### PR TITLE
Compute Segment Replication stats for SR backpressure.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Add GeoTile and GeoHash Grid aggregations on GeoShapes. ([#5589](https://github.com/opensearch-project/OpenSearch/pull/5589))
 - Disallow multiple data paths for search nodes ([#6427](https://github.com/opensearch-project/OpenSearch/pull/6427))
+- [Segment Replication] Add segment replication stats to NodeStats API ([#6520](https://github.com/opensearch-project/OpenSearch/pull/6520))
 
 ### Dependencies
 - Bump `org.apache.logging.log4j:log4j-core` from 2.18.0 to 2.20.0 ([#6490](https://github.com/opensearch-project/OpenSearch/pull/6490))

--- a/qa/smoke-test-http/src/test/java/org/opensearch/http/SegmentReplicationRestIT.java
+++ b/qa/smoke-test-http/src/test/java/org/opensearch/http/SegmentReplicationRestIT.java
@@ -63,7 +63,7 @@ public class SegmentReplicationRestIT extends HttpSmokeTestCase {
                 assertHitCount(client(node.getName()).prepareSearch("test_index").setSize(0).setPreference("_only_local").get(), 1);
             }
         });
-        Request statsRequest = new Request("GET", "/_nodes/stats/segment_replication?pretty");
+        Request statsRequest = new Request("GET", "/_nodes/stats/segment_replication_stats?pretty");
         final Response response = getRestClient().performRequest(statsRequest);
         logger.info("Node stats response\n{}", EntityUtils.toString(response.getEntity()));
         Map<String, Object> statsMap = XContentHelper.convertToMap(JsonXContent.jsonXContent, response.getEntity().getContent(),
@@ -88,8 +88,8 @@ public class SegmentReplicationRestIT extends HttpSmokeTestCase {
         XContentTestUtils.JsonMapView replica = new XContentTestUtils.JsonMapView((Map<String, Object>) shard1_replicas.get(0));
         Integer checkpoints_behind = replica.get("checkpoints_behind");
         assertEquals(0, checkpoints_behind.intValue());
-        assertNotNull(replica.get("current_replication_lag"));
-        assertNotNull(replica.get("last_completed_replication_lag"));
+        assertNotNull(replica.get("current_replication_time"));
+        assertNotNull(replica.get("last_completed_replication_time"));
         assertNotNull(replica.get("bytes_behind"));
     }
 }

--- a/qa/smoke-test-http/src/test/java/org/opensearch/http/SegmentReplicationRestIT.java
+++ b/qa/smoke-test-http/src/test/java/org/opensearch/http/SegmentReplicationRestIT.java
@@ -83,11 +83,12 @@ public class SegmentReplicationRestIT extends HttpSmokeTestCase {
         XContentTestUtils.JsonMapView shard1 = new XContentTestUtils.JsonMapView((Map<String, Object>) primary_values.get(0));
         Integer node1TotalLimitsRejections = shard1.get("rejected_requests");
         assertNotNull(node1TotalLimitsRejections);
-        List<Object> shard1_replicas = new ArrayList<>(((Map<Object, Object>) shard1.get("replicas")).values());
+        List<Object> shard1_replicas = shard1.get("replicas");
         assertEquals(1, shard1_replicas.size());
         XContentTestUtils.JsonMapView replica = new XContentTestUtils.JsonMapView((Map<String, Object>) shard1_replicas.get(0));
         Integer checkpoints_behind = replica.get("checkpoints_behind");
         assertEquals(0, checkpoints_behind.intValue());
+        assertNotNull(replica.get("node_id"));
         assertNotNull(replica.get("current_replication_time"));
         assertNotNull(replica.get("last_completed_replication_time"));
         assertNotNull(replica.get("bytes_behind"));

--- a/qa/smoke-test-http/src/test/java/org/opensearch/http/SegmentReplicationRestIT.java
+++ b/qa/smoke-test-http/src/test/java/org/opensearch/http/SegmentReplicationRestIT.java
@@ -1,0 +1,95 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.http;
+
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.opensearch.client.Node;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.test.XContentTestUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.opensearch.rest.RestStatus.CREATED;
+import static org.opensearch.rest.RestStatus.OK;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
+
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, supportsDedicatedMasters = false, numDataNodes = 2,
+    numClientNodes = 0)
+public class SegmentReplicationRestIT extends HttpSmokeTestCase {
+
+    @Override
+    protected Settings featureFlagSettings() {
+        return Settings.builder().put(super.featureFlagSettings()).put(FeatureFlags.REPLICATION_TYPE, "true").build();
+    }
+
+    @Override
+    protected boolean addMockInternalEngine() {
+        return false;
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testSegmentReplicationStats() throws Exception {
+        // create index.
+        Request createRequest = new Request("PUT", "/test_index");
+        createRequest.setJsonEntity("{\"settings\": {\"index\": {\"number_of_shards\": 1, \"number_of_replicas\": 1, " +
+            "\"replication\": {\"type\": \"SEGMENT\"}}}}");
+        final Response indexCreatedResponse = getRestClient().performRequest(createRequest);
+        assertEquals(indexCreatedResponse.getStatusLine().getStatusCode(), OK.getStatus());
+        ensureGreen("test_index");
+
+        //index a doc
+        Request successfulIndexingRequest = new Request("POST", "/test_index/_doc/");
+        successfulIndexingRequest.setJsonEntity("{\"foo\": \"bar\"}");
+        final Response indexSuccessFul = getRestClient().performRequest(successfulIndexingRequest);
+        assertEquals(indexSuccessFul.getStatusLine().getStatusCode(), CREATED.getStatus());
+
+        assertBusy(() -> {
+            // wait for SR to run.
+            for (Node node : getRestClient().getNodes()) {
+                assertHitCount(client(node.getName()).prepareSearch("test_index").setSize(0).setPreference("_only_local").get(), 1);
+            }
+        });
+        Request statsRequest = new Request("GET", "/_nodes/stats/segment_replication?pretty");
+        final Response response = getRestClient().performRequest(statsRequest);
+        logger.info("Node stats response\n{}", EntityUtils.toString(response.getEntity()));
+        Map<String, Object> statsMap = XContentHelper.convertToMap(JsonXContent.jsonXContent, response.getEntity().getContent(),
+            true);
+        List<Object> nodes = new ArrayList<>(((Map<Object, Object>) statsMap.get("nodes")).values());
+        assertEquals(2, nodes.size());
+        XContentTestUtils.JsonMapView node1 = new XContentTestUtils.JsonMapView((Map<String, Object>) nodes.get(0));
+        final Map<Object, Object> node1_map = node1.get("segment_replication");
+        Map<Object, Object> primaryNode_map = node1_map;
+        if (node1_map.isEmpty()) {
+            XContentTestUtils.JsonMapView node2 = new XContentTestUtils.JsonMapView((Map<String, Object>) nodes.get(1));
+            primaryNode_map = node2.get("segment_replication");
+        }
+        List<Object> primary_values = new ArrayList<>(primaryNode_map
+            .values());
+        assertEquals(1, primary_values.size());
+        XContentTestUtils.JsonMapView shard1 = new XContentTestUtils.JsonMapView((Map<String, Object>) primary_values.get(0));
+        Integer node1TotalLimitsRejections = shard1.get("rejected_requests");
+        assertNotNull(node1TotalLimitsRejections);
+        List<Object> shard1_replicas = new ArrayList<>(((Map<Object, Object>) shard1.get("replicas")).values());
+        assertEquals(1, shard1_replicas.size());
+        XContentTestUtils.JsonMapView replica = new XContentTestUtils.JsonMapView((Map<String, Object>) shard1_replicas.get(0));
+        Integer checkpoints_behind = replica.get("checkpoints_behind");
+        assertEquals(0, checkpoints_behind.intValue());
+        assertNotNull(replica.get("current_replication_lag"));
+        assertNotNull(replica.get("last_completed_replication_lag"));
+        assertNotNull(replica.get("bytes_behind"));
+    }
+}

--- a/qa/smoke-test-http/src/test/java/org/opensearch/http/SegmentReplicationRestIT.java
+++ b/qa/smoke-test-http/src/test/java/org/opensearch/http/SegmentReplicationRestIT.java
@@ -63,7 +63,7 @@ public class SegmentReplicationRestIT extends HttpSmokeTestCase {
                 assertHitCount(client(node.getName()).prepareSearch("test_index").setSize(0).setPreference("_only_local").get(), 1);
             }
         });
-        Request statsRequest = new Request("GET", "/_nodes/stats/segment_replication_stats?pretty");
+        Request statsRequest = new Request("GET", "/_nodes/stats/segment_replication?pretty");
         final Response response = getRestClient().performRequest(statsRequest);
         logger.info("Node stats response\n{}", EntityUtils.toString(response.getEntity()));
         Map<String, Object> statsMap = XContentHelper.convertToMap(JsonXContent.jsonXContent, response.getEntity().getContent(),

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -555,7 +555,7 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
             SegmentReplicationPerGroupStats groupStats = shardStats.get(primaryShard.shardId());
             Set<SegmentReplicationShardStats> replicaStats = groupStats.getReplicaStats();
             assertEquals(1, replicaStats.size());
-            assertEquals(replica.routingEntry().allocationId().getId(), replicaStats.stream().findFirst().get().getAllocationId());
+            assertEquals(replica.routingEntry().currentNodeId(), replicaStats.stream().findFirst().get().getNodeId());
 
             // assert replica node returns nothing.
             SegmentReplicationPressureService replicaNode_service = internalCluster().getInstance(
@@ -587,7 +587,7 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
             assertEquals(1, replicaNode_service.nodeStats().getShardStats().size());
             replicaStats = replicaNode_service.nodeStats().getShardStats().get(primaryShard.shardId()).getReplicaStats();
             assertEquals(1, replicaStats.size());
-            assertEquals(replica.routingEntry().allocationId().getId(), replicaStats.stream().findFirst().get().getAllocationId());
+            assertEquals(replica.routingEntry().currentNodeId(), replicaStats.stream().findFirst().get().getNodeId());
         }
     }
 }

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -522,12 +522,8 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
     }
 
     public void testSegmentReplicationStats() throws Exception {
-        final Settings settings = Settings.builder()
-            .put(indexSettings())
-            .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
-            .build();
         final String primaryNode = internalCluster().startNode();
-        createIndex(INDEX_NAME, settings);
+        createIndex(INDEX_NAME);
         final String replicaNode = internalCluster().startNode();
         ensureGreen(INDEX_NAME);
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodeStats.java
@@ -163,13 +163,6 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         }
         indexingPressureStats = in.readOptionalWriteable(IndexingPressureStats::new);
         shardIndexingPressureStats = in.readOptionalWriteable(ShardIndexingPressureStats::new);
-
-        if (in.getVersion().onOrAfter(Version.V_2_7_0)) {
-            segmentReplicationStats = in.readOptionalWriteable(SegmentReplicationStats::new);
-        } else {
-            segmentReplicationStats = null;
-        }
-
         if (in.getVersion().onOrAfter(Version.V_2_4_0)) {
             searchBackpressureStats = in.readOptionalWriteable(SearchBackpressureStats::new);
         } else {
@@ -190,6 +183,11 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
             fileCacheStats = in.readOptionalWriteable(FileCacheStats::new);
         } else {
             fileCacheStats = null;
+        }
+        if (in.getVersion().onOrAfter(Version.V_2_7_0) && FeatureFlags.isEnabled(FeatureFlags.REPLICATION_TYPE)) {
+            segmentReplicationStats = in.readOptionalWriteable(SegmentReplicationStats::new);
+        } else {
+            segmentReplicationStats = null;
         }
     }
 
@@ -398,10 +396,6 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         out.writeOptionalWriteable(indexingPressureStats);
         out.writeOptionalWriteable(shardIndexingPressureStats);
 
-        if (out.getVersion().onOrAfter(Version.V_2_7_0)) {
-            out.writeOptionalWriteable(segmentReplicationStats);
-        }
-
         if (out.getVersion().onOrAfter(Version.V_2_4_0)) {
             out.writeOptionalWriteable(searchBackpressureStats);
         }
@@ -413,6 +407,9 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         }
         if (out.getVersion().onOrAfter(Version.V_3_0_0) && FeatureFlags.isEnabled(FeatureFlags.SEARCHABLE_SNAPSHOT)) {
             out.writeOptionalWriteable(fileCacheStats);
+        }
+        if (out.getVersion().onOrAfter(Version.V_2_7_0) && FeatureFlags.isEnabled(FeatureFlags.REPLICATION_TYPE)) {
+            out.writeOptionalWriteable(segmentReplicationStats);
         }
     }
 
@@ -486,9 +483,6 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         if (getShardIndexingPressureStats() != null) {
             getShardIndexingPressureStats().toXContent(builder, params);
         }
-        if (getSegmentReplicationStats() != null) {
-            getSegmentReplicationStats().toXContent(builder, params);
-        }
         if (getSearchBackpressureStats() != null) {
             getSearchBackpressureStats().toXContent(builder, params);
         }
@@ -501,7 +495,9 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         if (getFileCacheStats() != null && FeatureFlags.isEnabled(FeatureFlags.SEARCHABLE_SNAPSHOT)) {
             getFileCacheStats().toXContent(builder, params);
         }
-
+        if (getSegmentReplicationStats() != null && FeatureFlags.isEnabled(FeatureFlags.REPLICATION_TYPE)) {
+            getSegmentReplicationStats().toXContent(builder, params);
+        }
         return builder;
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodeStats.java
@@ -46,6 +46,7 @@ import org.opensearch.core.xcontent.ToXContentFragment;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.discovery.DiscoveryStats;
 import org.opensearch.http.HttpStats;
+import org.opensearch.index.SegmentReplicationStats;
 import org.opensearch.index.stats.IndexingPressureStats;
 import org.opensearch.index.stats.ShardIndexingPressureStats;
 import org.opensearch.index.store.remote.filecache.FileCacheStats;
@@ -124,6 +125,9 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
     private ShardIndexingPressureStats shardIndexingPressureStats;
 
     @Nullable
+    private SegmentReplicationStats segmentReplicationStats;
+
+    @Nullable
     private SearchBackpressureStats searchBackpressureStats;
 
     @Nullable
@@ -159,6 +163,12 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         }
         indexingPressureStats = in.readOptionalWriteable(IndexingPressureStats::new);
         shardIndexingPressureStats = in.readOptionalWriteable(ShardIndexingPressureStats::new);
+
+        if (in.getVersion().onOrAfter(Version.V_2_7_0)) {
+            segmentReplicationStats = in.readOptionalWriteable(SegmentReplicationStats::new);
+        } else {
+            segmentReplicationStats = null;
+        }
 
         if (in.getVersion().onOrAfter(Version.V_2_4_0)) {
             searchBackpressureStats = in.readOptionalWriteable(SearchBackpressureStats::new);
@@ -202,6 +212,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         @Nullable ScriptCacheStats scriptCacheStats,
         @Nullable IndexingPressureStats indexingPressureStats,
         @Nullable ShardIndexingPressureStats shardIndexingPressureStats,
+        @Nullable SegmentReplicationStats segmentReplicationStats,
         @Nullable SearchBackpressureStats searchBackpressureStats,
         @Nullable ClusterManagerThrottlingStats clusterManagerThrottlingStats,
         @Nullable WeightedRoutingStats weightedRoutingStats,
@@ -225,6 +236,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         this.scriptCacheStats = scriptCacheStats;
         this.indexingPressureStats = indexingPressureStats;
         this.shardIndexingPressureStats = shardIndexingPressureStats;
+        this.segmentReplicationStats = segmentReplicationStats;
         this.searchBackpressureStats = searchBackpressureStats;
         this.clusterManagerThrottlingStats = clusterManagerThrottlingStats;
         this.weightedRoutingStats = weightedRoutingStats;
@@ -339,6 +351,11 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
     }
 
     @Nullable
+    public SegmentReplicationStats getSegmentReplicationStats() {
+        return segmentReplicationStats;
+    }
+
+    @Nullable
     public SearchBackpressureStats getSearchBackpressureStats() {
         return searchBackpressureStats;
     }
@@ -380,6 +397,10 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         out.writeOptionalWriteable(adaptiveSelectionStats);
         out.writeOptionalWriteable(indexingPressureStats);
         out.writeOptionalWriteable(shardIndexingPressureStats);
+
+        if (out.getVersion().onOrAfter(Version.V_2_7_0)) {
+            out.writeOptionalWriteable(segmentReplicationStats);
+        }
 
         if (out.getVersion().onOrAfter(Version.V_2_4_0)) {
             out.writeOptionalWriteable(searchBackpressureStats);
@@ -464,6 +485,9 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         }
         if (getShardIndexingPressureStats() != null) {
             getShardIndexingPressureStats().toXContent(builder, params);
+        }
+        if (getSegmentReplicationStats() != null) {
+            getSegmentReplicationStats().toXContent(builder, params);
         }
         if (getSearchBackpressureStats() != null) {
             getSearchBackpressureStats().toXContent(builder, params);

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodeStats.java
@@ -163,6 +163,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         }
         indexingPressureStats = in.readOptionalWriteable(IndexingPressureStats::new);
         shardIndexingPressureStats = in.readOptionalWriteable(ShardIndexingPressureStats::new);
+
         if (in.getVersion().onOrAfter(Version.V_2_4_0)) {
             searchBackpressureStats = in.readOptionalWriteable(SearchBackpressureStats::new);
         } else {

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodesStatsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodesStatsRequest.java
@@ -207,7 +207,7 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
         SCRIPT_CACHE("script_cache"),
         INDEXING_PRESSURE("indexing_pressure"),
         SHARD_INDEXING_PRESSURE("shard_indexing_pressure"),
-        SEGMENT_REPLICATION("segment_replication"),
+        SEGMENT_REPLICATION("segment_replication_stats"),
         SEARCH_BACKPRESSURE("search_backpressure"),
         CLUSTER_MANAGER_THROTTLING("cluster_manager_throttling"),
         WEIGHTED_ROUTING_STATS("weighted_routing"),

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodesStatsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodesStatsRequest.java
@@ -207,7 +207,7 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
         SCRIPT_CACHE("script_cache"),
         INDEXING_PRESSURE("indexing_pressure"),
         SHARD_INDEXING_PRESSURE("shard_indexing_pressure"),
-        SEGMENT_REPLICATION("segment_replication_stats"),
+        SEGMENT_REPLICATION("segment_replication"),
         SEARCH_BACKPRESSURE("search_backpressure"),
         CLUSTER_MANAGER_THROTTLING("cluster_manager_throttling"),
         WEIGHTED_ROUTING_STATS("weighted_routing"),

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodesStatsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodesStatsRequest.java
@@ -207,6 +207,7 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
         SCRIPT_CACHE("script_cache"),
         INDEXING_PRESSURE("indexing_pressure"),
         SHARD_INDEXING_PRESSURE("shard_indexing_pressure"),
+        SEGMENT_REPLICATION("segment_replication"),
         SEARCH_BACKPRESSURE("search_backpressure"),
         CLUSTER_MANAGER_THROTTLING("cluster_manager_throttling"),
         WEIGHTED_ROUTING_STATS("weighted_routing"),

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
@@ -119,6 +119,7 @@ public class TransportNodesStatsAction extends TransportNodesAction<
             NodesStatsRequest.Metric.SCRIPT_CACHE.containedIn(metrics),
             NodesStatsRequest.Metric.INDEXING_PRESSURE.containedIn(metrics),
             NodesStatsRequest.Metric.SHARD_INDEXING_PRESSURE.containedIn(metrics),
+            NodesStatsRequest.Metric.SEGMENT_REPLICATION.containedIn(metrics),
             NodesStatsRequest.Metric.SEARCH_BACKPRESSURE.containedIn(metrics),
             NodesStatsRequest.Metric.CLUSTER_MANAGER_THROTTLING.containedIn(metrics),
             NodesStatsRequest.Metric.WEIGHTED_ROUTING_STATS.containedIn(metrics),

--- a/server/src/main/java/org/opensearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -166,6 +166,7 @@ public class TransportClusterStatsAction extends TransportNodesAction<
             false,
             false,
             false,
+            false,
             false
         );
         List<ShardStats> shardsStats = new ArrayList<>();

--- a/server/src/main/java/org/opensearch/index/SegmentReplicationPerGroupStats.java
+++ b/server/src/main/java/org/opensearch/index/SegmentReplicationPerGroupStats.java
@@ -48,11 +48,11 @@ public class SegmentReplicationPerGroupStats implements Writeable, ToXContentFra
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.field("rejected_requests", rejectedRequestCount);
-        builder.startObject("replicas");
+        builder.startArray("replicas");
         for (SegmentReplicationShardStats stats : replicaStats) {
             stats.toXContent(builder, params);
         }
-        builder.endObject();
+        builder.endArray();
         return builder;
     }
 

--- a/server/src/main/java/org/opensearch/index/SegmentReplicationPerGroupStats.java
+++ b/server/src/main/java/org/opensearch/index/SegmentReplicationPerGroupStats.java
@@ -1,0 +1,69 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index;
+
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Set;
+
+/**
+ * Return Segment Replication stats for a Replication Group.
+ *
+ * @opensearch.internal
+ */
+public class SegmentReplicationPerGroupStats implements Writeable, ToXContentFragment {
+
+    private final Set<SegmentReplicationShardStats> replicaStats;
+    private final long rejectedRequestCount;
+
+    public SegmentReplicationPerGroupStats(Set<SegmentReplicationShardStats> replicaStats, long rejectedRequestCount) {
+        this.replicaStats = replicaStats;
+        this.rejectedRequestCount = rejectedRequestCount;
+    }
+
+    public SegmentReplicationPerGroupStats(StreamInput in) throws IOException {
+        this.replicaStats = in.readSet(SegmentReplicationShardStats::new);
+        this.rejectedRequestCount = in.readVLong();
+    }
+
+    public Set<SegmentReplicationShardStats> getReplicaStats() {
+        return replicaStats;
+    }
+
+    public long getRejectedRequestCount() {
+        return rejectedRequestCount;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.field("rejected_requests", rejectedRequestCount);
+        builder.startObject("replicas");
+        for (SegmentReplicationShardStats stats : replicaStats) {
+            stats.toXContent(builder, params);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeCollection(replicaStats);
+        out.writeVLong(rejectedRequestCount);
+    }
+
+    @Override
+    public String toString() {
+        return "SegmentReplicationPerGroupStats{" + "replicaStats=" + replicaStats + ", rejectedRequestCount=" + rejectedRequestCount + '}';
+    }
+}

--- a/server/src/main/java/org/opensearch/index/SegmentReplicationPressureService.java
+++ b/server/src/main/java/org/opensearch/index/SegmentReplicationPressureService.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index;
+
+import org.opensearch.index.shard.ShardId;
+import org.opensearch.indices.IndicesService;
+
+/**
+ * Service responsible for applying backpressure for lagging behind replicas when Segment Replication is enabled.
+ *
+ * @opensearch.internal
+ */
+public class SegmentReplicationPressureService {
+
+    private final IndicesService indicesService;
+    private final SegmentReplicationStatsTracker tracker;
+
+    public SegmentReplicationPressureService(IndicesService indexService) {
+        this.indicesService = indexService;
+        this.tracker = new SegmentReplicationStatsTracker(indicesService);
+    }
+
+    public void isSegrepLimitBreached(ShardId shardId) {
+        // TODO.
+    }
+
+    public SegmentReplicationStats nodeStats() {
+        return tracker.getStats();
+    }
+}

--- a/server/src/main/java/org/opensearch/index/SegmentReplicationShardStats.java
+++ b/server/src/main/java/org/opensearch/index/SegmentReplicationShardStats.java
@@ -1,0 +1,86 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index;
+
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.common.unit.ByteSizeValue;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+/**
+ * SegRep stats for a single shard.
+ *
+ * @opensearch.internal
+ */
+public class SegmentReplicationShardStats implements Writeable, ToXContentFragment {
+    private final String allocationId;
+    private final long checkpointsBehindCount;
+    private final long bytesBehindCount;
+    private final long currentReplicationLag;
+    private final long lastCompletedLag;
+
+    public SegmentReplicationShardStats(
+        String allocationId,
+        long checkpointsBehindCount,
+        long bytesBehindCount,
+        long currentReplicationLag,
+        long lastCompletedLag
+    ) {
+        this.allocationId = allocationId;
+        this.checkpointsBehindCount = checkpointsBehindCount;
+        this.bytesBehindCount = bytesBehindCount;
+        this.currentReplicationLag = currentReplicationLag;
+        this.lastCompletedLag = lastCompletedLag;
+    }
+
+    public SegmentReplicationShardStats(StreamInput in) throws IOException {
+        this.allocationId = in.readString();
+        this.checkpointsBehindCount = in.readVLong();
+        this.bytesBehindCount = in.readVLong();
+        this.currentReplicationLag = in.readVLong();
+        this.lastCompletedLag = in.readVLong();
+    }
+
+    public String getAllocationId() {
+        return allocationId;
+    }
+
+    public long getCheckpointsBehindCount() {
+        return checkpointsBehindCount;
+    }
+
+    public long getBytesBehindCount() {
+        return bytesBehindCount;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(allocationId);
+        builder.field("checkpoints_behind", checkpointsBehindCount);
+        builder.field("bytes_behind", new ByteSizeValue(bytesBehindCount).toString());
+        builder.field("current_replication_lag", new TimeValue(currentReplicationLag));
+        builder.field("last_completed_replication_lag", new TimeValue(lastCompletedLag));
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(allocationId);
+        out.writeVLong(checkpointsBehindCount);
+        out.writeVLong(bytesBehindCount);
+        out.writeVLong(currentReplicationLag);
+        out.writeVLong(lastCompletedLag);
+    }
+}

--- a/server/src/main/java/org/opensearch/index/SegmentReplicationShardStats.java
+++ b/server/src/main/java/org/opensearch/index/SegmentReplicationShardStats.java
@@ -88,7 +88,7 @@ public class SegmentReplicationShardStats implements Writeable, ToXContentFragme
     @Override
     public String toString() {
         return "SegmentReplicationShardStats{"
-            + "allocationId='"
+            + "nodeId='"
             + nodeId
             + '\''
             + ", checkpointsBehindCount="

--- a/server/src/main/java/org/opensearch/index/SegmentReplicationShardStats.java
+++ b/server/src/main/java/org/opensearch/index/SegmentReplicationShardStats.java
@@ -27,29 +27,29 @@ public class SegmentReplicationShardStats implements Writeable, ToXContentFragme
     private final String allocationId;
     private final long checkpointsBehindCount;
     private final long bytesBehindCount;
-    private final long currentReplicationLag;
-    private final long lastCompletedLag;
+    private final long currentReplicationTimeMillis;
+    private final long lastCompletedReplicationTimeMillis;
 
     public SegmentReplicationShardStats(
         String allocationId,
         long checkpointsBehindCount,
         long bytesBehindCount,
-        long currentReplicationLag,
-        long lastCompletedLag
+        long currentReplicationTimeMillis,
+        long lastCompletedReplicationTime
     ) {
         this.allocationId = allocationId;
         this.checkpointsBehindCount = checkpointsBehindCount;
         this.bytesBehindCount = bytesBehindCount;
-        this.currentReplicationLag = currentReplicationLag;
-        this.lastCompletedLag = lastCompletedLag;
+        this.currentReplicationTimeMillis = currentReplicationTimeMillis;
+        this.lastCompletedReplicationTimeMillis = lastCompletedReplicationTime;
     }
 
     public SegmentReplicationShardStats(StreamInput in) throws IOException {
         this.allocationId = in.readString();
         this.checkpointsBehindCount = in.readVLong();
         this.bytesBehindCount = in.readVLong();
-        this.currentReplicationLag = in.readVLong();
-        this.lastCompletedLag = in.readVLong();
+        this.currentReplicationTimeMillis = in.readVLong();
+        this.lastCompletedReplicationTimeMillis = in.readVLong();
     }
 
     public String getAllocationId() {
@@ -69,8 +69,8 @@ public class SegmentReplicationShardStats implements Writeable, ToXContentFragme
         builder.startObject(allocationId);
         builder.field("checkpoints_behind", checkpointsBehindCount);
         builder.field("bytes_behind", new ByteSizeValue(bytesBehindCount).toString());
-        builder.field("current_replication_lag", new TimeValue(currentReplicationLag));
-        builder.field("last_completed_replication_lag", new TimeValue(lastCompletedLag));
+        builder.field("current_replication_time", new TimeValue(currentReplicationTimeMillis));
+        builder.field("last_completed_replication_time", new TimeValue(lastCompletedReplicationTimeMillis));
         builder.endObject();
         return builder;
     }
@@ -80,7 +80,24 @@ public class SegmentReplicationShardStats implements Writeable, ToXContentFragme
         out.writeString(allocationId);
         out.writeVLong(checkpointsBehindCount);
         out.writeVLong(bytesBehindCount);
-        out.writeVLong(currentReplicationLag);
-        out.writeVLong(lastCompletedLag);
+        out.writeVLong(currentReplicationTimeMillis);
+        out.writeVLong(lastCompletedReplicationTimeMillis);
+    }
+
+    @Override
+    public String toString() {
+        return "SegmentReplicationShardStats{"
+            + "allocationId='"
+            + allocationId
+            + '\''
+            + ", checkpointsBehindCount="
+            + checkpointsBehindCount
+            + ", bytesBehindCount="
+            + bytesBehindCount
+            + ", currentReplicationLag="
+            + currentReplicationTimeMillis
+            + ", lastCompletedLag="
+            + lastCompletedReplicationTimeMillis
+            + '}';
     }
 }

--- a/server/src/main/java/org/opensearch/index/SegmentReplicationShardStats.java
+++ b/server/src/main/java/org/opensearch/index/SegmentReplicationShardStats.java
@@ -24,20 +24,20 @@ import java.io.IOException;
  * @opensearch.internal
  */
 public class SegmentReplicationShardStats implements Writeable, ToXContentFragment {
-    private final String allocationId;
+    private final String nodeId;
     private final long checkpointsBehindCount;
     private final long bytesBehindCount;
     private final long currentReplicationTimeMillis;
     private final long lastCompletedReplicationTimeMillis;
 
     public SegmentReplicationShardStats(
-        String allocationId,
+        String nodeId,
         long checkpointsBehindCount,
         long bytesBehindCount,
         long currentReplicationTimeMillis,
         long lastCompletedReplicationTime
     ) {
-        this.allocationId = allocationId;
+        this.nodeId = nodeId;
         this.checkpointsBehindCount = checkpointsBehindCount;
         this.bytesBehindCount = bytesBehindCount;
         this.currentReplicationTimeMillis = currentReplicationTimeMillis;
@@ -45,15 +45,15 @@ public class SegmentReplicationShardStats implements Writeable, ToXContentFragme
     }
 
     public SegmentReplicationShardStats(StreamInput in) throws IOException {
-        this.allocationId = in.readString();
+        this.nodeId = in.readString();
         this.checkpointsBehindCount = in.readVLong();
         this.bytesBehindCount = in.readVLong();
         this.currentReplicationTimeMillis = in.readVLong();
         this.lastCompletedReplicationTimeMillis = in.readVLong();
     }
 
-    public String getAllocationId() {
-        return allocationId;
+    public String getNodeId() {
+        return nodeId;
     }
 
     public long getCheckpointsBehindCount() {
@@ -66,7 +66,8 @@ public class SegmentReplicationShardStats implements Writeable, ToXContentFragme
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(allocationId);
+        builder.startObject();
+        builder.field("node_id", nodeId);
         builder.field("checkpoints_behind", checkpointsBehindCount);
         builder.field("bytes_behind", new ByteSizeValue(bytesBehindCount).toString());
         builder.field("current_replication_time", new TimeValue(currentReplicationTimeMillis));
@@ -77,7 +78,7 @@ public class SegmentReplicationShardStats implements Writeable, ToXContentFragme
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeString(allocationId);
+        out.writeString(nodeId);
         out.writeVLong(checkpointsBehindCount);
         out.writeVLong(bytesBehindCount);
         out.writeVLong(currentReplicationTimeMillis);
@@ -88,7 +89,7 @@ public class SegmentReplicationShardStats implements Writeable, ToXContentFragme
     public String toString() {
         return "SegmentReplicationShardStats{"
             + "allocationId='"
-            + allocationId
+            + nodeId
             + '\''
             + ", checkpointsBehindCount="
             + checkpointsBehindCount

--- a/server/src/main/java/org/opensearch/index/SegmentReplicationStats.java
+++ b/server/src/main/java/org/opensearch/index/SegmentReplicationStats.java
@@ -1,0 +1,72 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index;
+
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.shard.ShardId;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Segment Replication Stats.
+ *
+ * @opensearch.internal
+ */
+public class SegmentReplicationStats implements Writeable, ToXContentFragment {
+    @Override
+    public String toString() {
+        return "SegmentReplicationStats{" + "shardStats=" + shardStats + '}';
+    }
+
+    private final Map<ShardId, SegmentReplicationPerGroupStats> shardStats;
+
+    public SegmentReplicationStats(Map<ShardId, SegmentReplicationPerGroupStats> shardStats) {
+        this.shardStats = shardStats;
+    }
+
+    public SegmentReplicationStats(StreamInput in) throws IOException {
+        int shardEntries = in.readInt();
+        shardStats = new HashMap<>();
+        for (int i = 0; i < shardEntries; i++) {
+            ShardId shardId = new ShardId(in);
+            SegmentReplicationPerGroupStats groupStats = new SegmentReplicationPerGroupStats(in);
+            shardStats.put(shardId, groupStats);
+        }
+    }
+
+    public Map<ShardId, SegmentReplicationPerGroupStats> getShardStats() {
+        return shardStats;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject("segment_replication");
+        for (Map.Entry<ShardId, SegmentReplicationPerGroupStats> entry : shardStats.entrySet()) {
+            builder.startObject(entry.getKey().toString());
+            entry.getValue().toXContent(builder, params);
+            builder.endObject();
+        }
+        return builder.endObject();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeInt(shardStats.size());
+        for (Map.Entry<ShardId, SegmentReplicationPerGroupStats> entry : shardStats.entrySet()) {
+            entry.getKey().writeTo(out);
+            entry.getValue().writeTo(out);
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/index/SegmentReplicationStats.java
+++ b/server/src/main/java/org/opensearch/index/SegmentReplicationStats.java
@@ -25,10 +25,6 @@ import java.util.Map;
  * @opensearch.internal
  */
 public class SegmentReplicationStats implements Writeable, ToXContentFragment {
-    @Override
-    public String toString() {
-        return "SegmentReplicationStats{" + "shardStats=" + shardStats + '}';
-    }
 
     private final Map<ShardId, SegmentReplicationPerGroupStats> shardStats;
 
@@ -68,5 +64,10 @@ public class SegmentReplicationStats implements Writeable, ToXContentFragment {
             entry.getKey().writeTo(out);
             entry.getValue().writeTo(out);
         }
+    }
+
+    @Override
+    public String toString() {
+        return "SegmentReplicationStats{" + "shardStats=" + shardStats + '}';
     }
 }

--- a/server/src/main/java/org/opensearch/index/SegmentReplicationStatsTracker.java
+++ b/server/src/main/java/org/opensearch/index/SegmentReplicationStatsTracker.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index;
+
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.index.shard.ShardId;
+import org.opensearch.indices.IndicesService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Tracker responsible for computing SegmentReplicationStats.
+ *
+ * @opensearch.internal
+ */
+public class SegmentReplicationStatsTracker {
+
+    private final IndicesService indicesService;
+
+    public SegmentReplicationStatsTracker(IndicesService indicesService) {
+        this.indicesService = indicesService;
+    }
+
+    public SegmentReplicationStats getStats() {
+        Map<ShardId, SegmentReplicationPerGroupStats> stats = new HashMap<>();
+        for (IndexService indexShards : indicesService) {
+            for (IndexShard indexShard : indexShards) {
+                if (indexShard.indexSettings().isSegRepEnabled() && indexShard.routingEntry().primary()) {
+                    stats.putIfAbsent(
+                        indexShard.shardId(),
+                        new SegmentReplicationPerGroupStats(
+                            // TODO: Store rejected counts.
+                            indexShard.getReplicationStats(),
+                            0L
+                        )
+                    );
+                }
+            }
+        }
+        return new SegmentReplicationStats(stats);
+    }
+}

--- a/server/src/main/java/org/opensearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/opensearch/index/seqno/ReplicationTracker.java
@@ -1241,6 +1241,7 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
      * V2 - Set of {@link SegmentReplicationShardStats} per shard in this primary's replication group.
      */
     public synchronized Set<SegmentReplicationShardStats> getSegmentReplicationStats() {
+        assert indexSettings.isSegRepEnabled();
         final ReplicationCheckpoint lastPublishedCheckpoint = this.lastPublishedReplicationCheckpoint;
         if (primaryMode && lastPublishedCheckpoint != null) {
             return this.checkpoints.entrySet()

--- a/server/src/main/java/org/opensearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/opensearch/index/seqno/ReplicationTracker.java
@@ -1190,7 +1190,7 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
             });
             cps.lastCompletedReplicationLag = lastFinished.get();
         }
-        logger.info(
+        logger.trace(
             () -> new ParameterizedMessage(
                 "updated local knowledge for [{}] on the primary of the visible checkpoint from [{}] to [{}], active timers {}",
                 allocationId,
@@ -1222,7 +1222,7 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
                             replicationTimer.start();
                             return replicationTimer;
                         });
-                        logger.info(
+                        logger.trace(
                             () -> new ParameterizedMessage(
                                 "updated last published checkpoint to {} - timers [{}]",
                                 checkpoint,

--- a/server/src/main/java/org/opensearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/opensearch/index/seqno/ReplicationTracker.java
@@ -71,6 +71,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
@@ -1260,7 +1261,7 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
     ) {
         final Map<ReplicationCheckpoint, ReplicationTimer> checkpointTimers = checkpointState.checkpointTimers;
         return new SegmentReplicationShardStats(
-            allocationId,
+            Optional.ofNullable(this.routingTable.getByAllocationId(allocationId)).map(ShardRouting::currentNodeId).orElse("not assigned"),
             checkpointTimers.size(),
             checkpointState.visibleReplicationCheckpoint == null
                 ? latestCheckpointLength

--- a/server/src/main/java/org/opensearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/opensearch/index/seqno/ReplicationTracker.java
@@ -34,6 +34,7 @@ package org.opensearch.index.seqno;
 
 import com.carrotsearch.hppc.ObjectLongHashMap;
 import com.carrotsearch.hppc.ObjectLongMap;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.action.ActionListener;
@@ -48,14 +49,18 @@ import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.common.util.concurrent.ConcurrentCollections;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.gateway.WriteStateException;
 import org.opensearch.index.IndexSettings;
+import org.opensearch.index.SegmentReplicationShardStats;
 import org.opensearch.index.engine.SafeCommitInfo;
 import org.opensearch.index.shard.AbstractIndexShardComponent;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.shard.ReplicationGroup;
 import org.opensearch.index.shard.ShardId;
+import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
+import org.opensearch.indices.replication.common.ReplicationTimer;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -68,6 +73,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -242,6 +248,8 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
     private final double fileBasedRecoveryThreshold;
 
     private final Consumer<ReplicationGroup> onReplicationGroupUpdated;
+
+    private volatile ReplicationCheckpoint lastPublishedReplicationCheckpoint;
 
     /**
      * Get all retention leases tracked on this shard.
@@ -665,15 +673,15 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
     }
 
     /**
-     * The state of the lucene checkpoint
-     *
-     * @opensearch.internal
-     */
+    * The state of the lucene checkpoint
+    *
+    * @opensearch.internal
+    */
     public static class CheckpointState implements Writeable {
 
         /**
-         * the last local checkpoint information that we have for this shard. All operations up to this point are properly fsynced to disk.
-         */
+        * the last local checkpoint information that we have for this shard. All operations up to this point are properly fsynced to disk.
+        */
         long localCheckpoint;
 
         /**
@@ -699,12 +707,29 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
          */
         boolean replicated;
 
+        /**
+         * The currently searchable replication checkpoint.
+         */
+        ReplicationCheckpoint visibleReplicationCheckpoint;
+
+        /**
+         * Map of ReplicationCheckpoints to ReplicationTimers.  Timers are added as new checkpoints are published, and removed when
+         * the replica is caught up.
+         */
+        Map<ReplicationCheckpoint, ReplicationTimer> checkpointTimers;
+
+        /**
+         * The time it took to complete the most recent replication event.
+         */
+        long lastCompletedReplicationLag;
+
         public CheckpointState(long localCheckpoint, long globalCheckpoint, boolean inSync, boolean tracked, boolean replicated) {
             this.localCheckpoint = localCheckpoint;
             this.globalCheckpoint = globalCheckpoint;
             this.inSync = inSync;
             this.tracked = tracked;
             this.replicated = replicated;
+            this.checkpointTimers = ConcurrentCollections.newConcurrentMap();
         }
 
         public CheckpointState(StreamInput in) throws IOException {
@@ -1133,6 +1158,115 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
             );
         }
         assert invariant();
+    }
+
+    /**
+     * Update the local knowledge of the visible checkpoint for the specified allocation ID.
+     *
+     * This method will also stop timers for each shard and compute replication lag metrics.
+     *
+     * @param allocationId     the allocation ID to update the global checkpoint for
+     * @param visibleCheckpoint the visible checkpoint
+     */
+    public synchronized void updateVisibleCheckpointForShard(final String allocationId, final ReplicationCheckpoint visibleCheckpoint) {
+        assert indexSettings.isSegRepEnabled();
+        assert primaryMode;
+        assert handoffInProgress == false;
+        assert invariant();
+        final CheckpointState cps = checkpoints.get(allocationId);
+        assert !this.shardAllocationId.equals(allocationId) && cps != null;
+        if (cps.checkpointTimers.isEmpty() == false) {
+            // stop any timers for checkpoints up to the received cp and remove from cps.checkpointTimers.
+            // Compute the max lag from the set of completed timers.
+            final AtomicLong lastFinished = new AtomicLong(0L);
+            cps.checkpointTimers.entrySet().removeIf((entry) -> {
+                boolean result = visibleCheckpoint.equals(entry.getKey()) || visibleCheckpoint.isAheadOf(entry.getKey());
+                if (result) {
+                    final ReplicationTimer timer = entry.getValue();
+                    timer.stop();
+                    lastFinished.set(Math.max(lastFinished.get(), timer.time()));
+                }
+                return result;
+            });
+            cps.lastCompletedReplicationLag = lastFinished.get();
+        }
+        logger.info(
+            () -> new ParameterizedMessage(
+                "updated local knowledge for [{}] on the primary of the visible checkpoint from [{}] to [{}], active timers {}",
+                allocationId,
+                cps.visibleReplicationCheckpoint,
+                visibleCheckpoint,
+                cps.checkpointTimers.keySet()
+            )
+        );
+        cps.visibleReplicationCheckpoint = visibleCheckpoint;
+        assert invariant();
+    }
+
+    /**
+     * After a new checkpoint is published, start a timer for each replica to the checkpoint.
+     * @param checkpoint {@link ReplicationCheckpoint}
+     */
+    public synchronized void setLatestReplicationCheckpoint(ReplicationCheckpoint checkpoint) {
+        assert indexSettings.isSegRepEnabled();
+        assert primaryMode;
+        assert handoffInProgress == false;
+        if (checkpoint.equals(lastPublishedReplicationCheckpoint) == false) {
+            this.lastPublishedReplicationCheckpoint = checkpoint;
+            for (Map.Entry<String, CheckpointState> entry : checkpoints.entrySet()) {
+                if (entry.getKey().equals(this.shardAllocationId) == false) {
+                    final CheckpointState cps = entry.getValue();
+                    if (cps.inSync) {
+                        cps.checkpointTimers.computeIfAbsent(checkpoint, ignored -> {
+                            final ReplicationTimer replicationTimer = new ReplicationTimer();
+                            replicationTimer.start();
+                            return replicationTimer;
+                        });
+                        logger.info(
+                            () -> new ParameterizedMessage(
+                                "updated last published checkpoint to {} - timers [{}]",
+                                checkpoint,
+                                cps.checkpointTimers.keySet()
+                            )
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Fetch stats on segment replication.
+     * @return {@link Tuple} V1 - TimeValue in ms - mean replication lag for this primary to its entire group,
+     * V2 - Set of {@link SegmentReplicationShardStats} per shard in this primary's replication group.
+     */
+    public synchronized Set<SegmentReplicationShardStats> getSegmentReplicationStats() {
+        final ReplicationCheckpoint lastPublishedCheckpoint = this.lastPublishedReplicationCheckpoint;
+        if (primaryMode && lastPublishedCheckpoint != null) {
+            return this.checkpoints.entrySet()
+                .stream()
+                .filter(entry -> entry.getKey().equals(this.shardAllocationId) == false && entry.getValue().inSync)
+                .map(entry -> buildShardStats(lastPublishedCheckpoint.getLength(), entry.getKey(), entry.getValue()))
+                .collect(Collectors.toUnmodifiableSet());
+        }
+        return Collections.emptySet();
+    }
+
+    private SegmentReplicationShardStats buildShardStats(
+        final long latestCheckpointLength,
+        final String allocationId,
+        final CheckpointState checkpointState
+    ) {
+        final Map<ReplicationCheckpoint, ReplicationTimer> checkpointTimers = checkpointState.checkpointTimers;
+        return new SegmentReplicationShardStats(
+            allocationId,
+            checkpointTimers.size(),
+            checkpointState.visibleReplicationCheckpoint == null
+                ? latestCheckpointLength
+                : Math.max(latestCheckpointLength - checkpointState.visibleReplicationCheckpoint.getLength(), 0),
+            checkpointTimers.values().stream().mapToLong(ReplicationTimer::time).max().orElse(0),
+            checkpointState.lastCompletedReplicationLag
+        );
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/shard/CheckpointRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/CheckpointRefreshListener.java
@@ -41,7 +41,7 @@ public class CheckpointRefreshListener implements ReferenceManager.RefreshListen
     @Override
     public void afterRefresh(boolean didRefresh) throws IOException {
         if (didRefresh && shard.state() != IndexShardState.CLOSED && shard.getReplicationTracker().isPrimaryMode()) {
-            publisher.publish(shard);
+            publisher.publish(shard, shard.getLatestReplicationCheckpoint());
         }
     }
 }

--- a/server/src/main/java/org/opensearch/indices/replication/OngoingSegmentReplications.java
+++ b/server/src/main/java/org/opensearch/indices/replication/OngoingSegmentReplications.java
@@ -115,6 +115,10 @@ class OngoingSegmentReplications {
                 }
             });
             if (request.getFilesToFetch().isEmpty()) {
+                // before completion, alert the primary of the replica's state.
+                handler.getCopyState()
+                    .getShard()
+                    .updateVisibleCheckpointForShard(request.getTargetAllocationId(), handler.getCopyState().getCheckpoint());
                 wrappedListener.onResponse(new GetSegmentFilesResponse(Collections.emptyList()));
             } else {
                 handler.sendFiles(request, wrappedListener);

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceHandler.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceHandler.java
@@ -159,6 +159,7 @@ class SegmentReplicationSourceHandler {
 
             sendFileStep.whenComplete(r -> {
                 try {
+                    shard.updateVisibleCheckpointForShard(allocationId, copyState.getCheckpoint());
                     future.onResponse(new GetSegmentFilesResponse(List.of(storeFileMetadata)));
                 } finally {
                     IOUtils.close(resources);

--- a/server/src/main/java/org/opensearch/indices/replication/checkpoint/PublishCheckpointAction.java
+++ b/server/src/main/java/org/opensearch/indices/replication/checkpoint/PublishCheckpointAction.java
@@ -109,14 +109,13 @@ public class PublishCheckpointAction extends TransportReplicationAction<
     /**
      * Publish checkpoint request to shard
      */
-    final void publish(IndexShard indexShard) {
+    final void publish(IndexShard indexShard, ReplicationCheckpoint checkpoint) {
         long primaryTerm = indexShard.getPendingPrimaryTerm();
         final ThreadContext threadContext = threadPool.getThreadContext();
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
             // we have to execute under the system context so that if security is enabled the sync is authorized
             threadContext.markAsSystemContext();
-            PublishCheckpointRequest request = new PublishCheckpointRequest(indexShard.getLatestReplicationCheckpoint());
-            final ReplicationCheckpoint checkpoint = request.getCheckpoint();
+            PublishCheckpointRequest request = new PublishCheckpointRequest(checkpoint);
 
             final List<ShardRouting> replicationTargets = indexShard.getReplicationGroup().getReplicationTargets();
             for (ShardRouting replicationTarget : replicationTargets) {

--- a/server/src/main/java/org/opensearch/indices/replication/checkpoint/ReplicationCheckpoint.java
+++ b/server/src/main/java/org/opensearch/indices/replication/checkpoint/ReplicationCheckpoint.java
@@ -30,6 +30,7 @@ public class ReplicationCheckpoint implements Writeable, Comparable<ReplicationC
     private final long segmentsGen;
     private final long seqNo;
     private final long segmentInfosVersion;
+    private final long length;
 
     public static ReplicationCheckpoint empty(ShardId shardId) {
         return new ReplicationCheckpoint(shardId);
@@ -41,14 +42,20 @@ public class ReplicationCheckpoint implements Writeable, Comparable<ReplicationC
         segmentsGen = SequenceNumbers.NO_OPS_PERFORMED;
         seqNo = SequenceNumbers.NO_OPS_PERFORMED;
         segmentInfosVersion = SequenceNumbers.NO_OPS_PERFORMED;
+        length = 0L;
     }
 
     public ReplicationCheckpoint(ShardId shardId, long primaryTerm, long segmentsGen, long seqNo, long segmentInfosVersion) {
+        this(shardId, primaryTerm, segmentsGen, seqNo, segmentInfosVersion, 0L);
+    }
+
+    public ReplicationCheckpoint(ShardId shardId, long primaryTerm, long segmentsGen, long seqNo, long segmentInfosVersion, long length) {
         this.shardId = shardId;
         this.primaryTerm = primaryTerm;
         this.segmentsGen = segmentsGen;
         this.seqNo = seqNo;
         this.segmentInfosVersion = segmentInfosVersion;
+        this.length = length;
     }
 
     public ReplicationCheckpoint(StreamInput in) throws IOException {
@@ -57,6 +64,7 @@ public class ReplicationCheckpoint implements Writeable, Comparable<ReplicationC
         segmentsGen = in.readLong();
         seqNo = in.readLong();
         segmentInfosVersion = in.readLong();
+        length = in.readLong();
     }
 
     /**
@@ -90,6 +98,13 @@ public class ReplicationCheckpoint implements Writeable, Comparable<ReplicationC
     }
 
     /**
+     * @return The size in bytes of this checkpoint.
+     */
+    public long getLength() {
+        return length;
+    }
+
+    /**
      * Shard Id of primary shard.
      *
      * @return the Shard Id
@@ -105,6 +120,7 @@ public class ReplicationCheckpoint implements Writeable, Comparable<ReplicationC
         out.writeLong(segmentsGen);
         out.writeLong(seqNo);
         out.writeLong(segmentInfosVersion);
+        out.writeLong(length);
     }
 
     @Override
@@ -152,6 +168,8 @@ public class ReplicationCheckpoint implements Writeable, Comparable<ReplicationC
             + seqNo
             + ", version="
             + segmentInfosVersion
+            + ", size="
+            + length
             + '}';
     }
 }

--- a/server/src/main/java/org/opensearch/indices/replication/checkpoint/SegmentReplicationCheckpointPublisher.java
+++ b/server/src/main/java/org/opensearch/indices/replication/checkpoint/SegmentReplicationCheckpointPublisher.java
@@ -32,19 +32,22 @@ public class SegmentReplicationCheckpointPublisher {
         this.publishAction = Objects.requireNonNull(publishAction);
     }
 
-    public void publish(IndexShard indexShard) {
-        publishAction.publish(indexShard);
+    public void publish(IndexShard indexShard, ReplicationCheckpoint checkpoint) {
+        publishAction.publish(indexShard, checkpoint);
+        indexShard.onCheckpointPublished(checkpoint);
     }
 
     /**
      * Represents an action that is invoked to publish segment replication checkpoint to replica shard
      */
     public interface PublishAction {
-        void publish(IndexShard indexShard);
+        void publish(IndexShard indexShard, ReplicationCheckpoint checkpoint);
     }
 
     /**
      * NoOp Checkpoint publisher
      */
-    public static final SegmentReplicationCheckpointPublisher EMPTY = new SegmentReplicationCheckpointPublisher(indexShard -> {});
+    public static final SegmentReplicationCheckpointPublisher EMPTY = new SegmentReplicationCheckpointPublisher(
+        (indexShard, checkpoint) -> {}
+    );
 }

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -41,6 +41,7 @@ import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.cluster.routing.allocation.AwarenessReplicaBalance;
 import org.opensearch.index.IndexModule;
 import org.opensearch.index.IndexingPressureService;
+import org.opensearch.index.SegmentReplicationPressureService;
 import org.opensearch.indices.replication.SegmentReplicationSourceFactory;
 import org.opensearch.indices.replication.SegmentReplicationTargetService;
 import org.opensearch.indices.replication.SegmentReplicationSourceService;
@@ -857,6 +858,9 @@ public class Node implements Closeable {
                 SearchExecutionStatsCollector.makeWrapper(responseCollectorService)
             );
             final HttpServerTransport httpServerTransport = newHttpTransport(networkModule);
+            final SegmentReplicationPressureService segmentReplicationPressureService = new SegmentReplicationPressureService(
+                indicesService
+            );
             final IndexingPressureService indexingPressureService = new IndexingPressureService(settings, clusterService);
             // Going forward, IndexingPressureService will have required constructs for exposing listeners/interfaces for plugin
             // development. Then we can deprecate Getter and Setter for IndexingPressureService in ClusterService (#478).
@@ -967,6 +971,7 @@ public class Node implements Closeable {
                 responseCollectorService,
                 searchTransportService,
                 indexingPressureService,
+                segmentReplicationPressureService,
                 searchModule.getValuesSourceRegistry().getUsageService(),
                 searchBackpressureService,
                 nodeEnvironment
@@ -1028,6 +1033,7 @@ public class Node implements Closeable {
                 b.bind(AnalysisRegistry.class).toInstance(analysisModule.getAnalysisRegistry());
                 b.bind(IngestService.class).toInstance(ingestService);
                 b.bind(IndexingPressureService.class).toInstance(indexingPressureService);
+                b.bind(SegmentReplicationPressureService.class).toInstance(segmentReplicationPressureService);
                 b.bind(TaskResourceTrackingService.class).toInstance(taskResourceTrackingService);
                 b.bind(SearchBackpressureService.class).toInstance(searchBackpressureService);
                 b.bind(UsageService.class).toInstance(usageService);

--- a/server/src/main/java/org/opensearch/node/NodeService.java
+++ b/server/src/main/java/org/opensearch/node/NodeService.java
@@ -48,6 +48,7 @@ import org.opensearch.discovery.Discovery;
 import org.opensearch.env.NodeEnvironment;
 import org.opensearch.http.HttpServerTransport;
 import org.opensearch.index.IndexingPressureService;
+import org.opensearch.index.SegmentReplicationPressureService;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.breaker.CircuitBreakerService;
 import org.opensearch.ingest.IngestService;
@@ -83,6 +84,7 @@ public class NodeService implements Closeable {
     private final ResponseCollectorService responseCollectorService;
     private final SearchTransportService searchTransportService;
     private final IndexingPressureService indexingPressureService;
+    private final SegmentReplicationPressureService segmentReplicationPressureService;
     private final AggregationUsageService aggregationUsageService;
     private final SearchBackpressureService searchBackpressureService;
     private final ClusterService clusterService;
@@ -106,6 +108,7 @@ public class NodeService implements Closeable {
         ResponseCollectorService responseCollectorService,
         SearchTransportService searchTransportService,
         IndexingPressureService indexingPressureService,
+        SegmentReplicationPressureService segmentReplicationPressureService,
         AggregationUsageService aggregationUsageService,
         SearchBackpressureService searchBackpressureService,
         NodeEnvironment nodeEnvironment
@@ -125,6 +128,7 @@ public class NodeService implements Closeable {
         this.responseCollectorService = responseCollectorService;
         this.searchTransportService = searchTransportService;
         this.indexingPressureService = indexingPressureService;
+        this.segmentReplicationPressureService = segmentReplicationPressureService;
         this.aggregationUsageService = aggregationUsageService;
         this.searchBackpressureService = searchBackpressureService;
         this.clusterService = clusterService;
@@ -180,6 +184,7 @@ public class NodeService implements Closeable {
         boolean scriptCache,
         boolean indexingPressure,
         boolean shardIndexingPressure,
+        boolean segmentReplicationPressure,
         boolean searchBackpressure,
         boolean clusterManagerThrottling,
         boolean weightedRoutingStats,
@@ -206,6 +211,7 @@ public class NodeService implements Closeable {
             scriptCache ? scriptService.cacheStats() : null,
             indexingPressure ? this.indexingPressureService.nodeStats() : null,
             shardIndexingPressure ? this.indexingPressureService.shardStats(indices) : null,
+            segmentReplicationPressure ? this.segmentReplicationPressureService.nodeStats() : null,
             searchBackpressure ? this.searchBackpressureService.nodeStats() : null,
             clusterManagerThrottling ? this.clusterService.getClusterManagerService().getThrottlingStats() : null,
             weightedRoutingStats ? WeightedRoutingStats.getInstance() : null,

--- a/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -747,6 +747,7 @@ public class NodeStatsTests extends OpenSearchTestCase {
             null,
             null,
             null,
+            null,
             clusterManagerThrottlingStats,
             weightedRoutingStats,
             null

--- a/server/src/test/java/org/opensearch/cluster/DiskUsageTests.java
+++ b/server/src/test/java/org/opensearch/cluster/DiskUsageTests.java
@@ -189,6 +189,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
                 null,
                 null,
                 null,
+                null,
                 null
             ),
             new NodeStats(
@@ -213,6 +214,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
                 null,
                 null,
                 null,
+                null,
                 null
             ),
             new NodeStats(
@@ -224,6 +226,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
                 null,
                 null,
                 new FsInfo(0, null, node3FSInfo),
+                null,
                 null,
                 null,
                 null,
@@ -292,6 +295,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
                 null,
                 null,
                 null,
+                null,
                 null
             ),
             new NodeStats(
@@ -316,6 +320,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
                 null,
                 null,
                 null,
+                null,
                 null
             ),
             new NodeStats(
@@ -327,6 +332,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
                 null,
                 null,
                 new FsInfo(0, null, node3FSInfo),
+                null,
                 null,
                 null,
                 null,

--- a/server/src/test/java/org/opensearch/index/seqno/ReplicationTrackerTests.java
+++ b/server/src/test/java/org/opensearch/index/seqno/ReplicationTrackerTests.java
@@ -46,7 +46,10 @@ import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.set.Sets;
 import org.opensearch.index.IndexSettings;
+import org.opensearch.index.SegmentReplicationShardStats;
 import org.opensearch.index.shard.ShardId;
+import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
+import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.test.IndexSettingsModule;
 
 import java.io.IOException;
@@ -72,6 +75,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptySet;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REPLICATION_TYPE;
 import static org.opensearch.index.seqno.SequenceNumbers.NO_OPS_PERFORMED;
 import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 import static org.hamcrest.Matchers.equalTo;
@@ -1768,6 +1772,59 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
         );
         assertTrue(tracker.getTrackedLocalCheckpointForShard(newSyncingAllocationId.getId()).inSync);
         assertFalse(tracker.pendingInSync.contains(newSyncingAllocationId.getId()));
+    }
+
+    public void testSegmentReplicationCheckpointTracking() {
+        Settings settings = Settings.builder().put(SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT).build();
+        final long initialClusterStateVersion = randomNonNegativeLong();
+        final int numberOfActiveAllocationsIds = randomIntBetween(2, 16);
+        final int numberOfInitializingIds = randomIntBetween(2, 16);
+        final Tuple<Set<AllocationId>, Set<AllocationId>> activeAndInitializingAllocationIds = randomActiveAndInitializingAllocationIds(
+            numberOfActiveAllocationsIds,
+            numberOfInitializingIds
+        );
+        final Set<AllocationId> activeAllocationIds = activeAndInitializingAllocationIds.v1();
+        final Set<AllocationId> initializingIds = activeAndInitializingAllocationIds.v2();
+        AllocationId primaryId = activeAllocationIds.iterator().next();
+        IndexShardRoutingTable routingTable = routingTable(initializingIds, primaryId);
+        final ReplicationTracker tracker = newTracker(primaryId, settings);
+        tracker.updateFromClusterManager(initialClusterStateVersion, ids(activeAllocationIds), routingTable);
+        tracker.activatePrimaryMode(NO_OPS_PERFORMED);
+        assertThat(tracker.getReplicationGroup().getInSyncAllocationIds(), equalTo(ids(activeAllocationIds)));
+        assertThat(tracker.getReplicationGroup().getRoutingTable(), equalTo(routingTable));
+        assertTrue(activeAllocationIds.stream().allMatch(a -> tracker.getTrackedLocalCheckpointForShard(a.getId()).inSync));
+        // get insync ids, filter out the primary.
+        final Set<String> inSyncAllocationIds = tracker.getReplicationGroup()
+            .getInSyncAllocationIds()
+            .stream()
+            .filter(id -> tracker.shardAllocationId.equals(id) == false)
+            .collect(Collectors.toSet());
+
+        final ReplicationCheckpoint initialCheckpoint = new ReplicationCheckpoint(tracker.shardId(), 0L, 1, 0, 1, 0L);
+        final ReplicationCheckpoint secondCheckpoint = new ReplicationCheckpoint(tracker.shardId(), 0L, 2, 1, 2, 1L);
+        final ReplicationCheckpoint thirdCheckpoint = new ReplicationCheckpoint(tracker.shardId(), 0L, 2, 2, 3, 100L);
+
+        tracker.setLatestReplicationCheckpoint(initialCheckpoint);
+        tracker.setLatestReplicationCheckpoint(secondCheckpoint);
+        tracker.setLatestReplicationCheckpoint(thirdCheckpoint);
+
+        final Set<SegmentReplicationShardStats> groupStats = tracker.getSegmentReplicationStats();
+        assertEquals(inSyncAllocationIds.size(), groupStats.size());
+        for (SegmentReplicationShardStats shardStat : groupStats) {
+            assertEquals(3, shardStat.getCheckpointsBehindCount());
+            assertEquals(100L, shardStat.getBytesBehindCount());
+        }
+
+        // simulate replicas moved up to date.
+        final Map<String, ReplicationTracker.CheckpointState> checkpoints = tracker.checkpoints;
+        for (String id : inSyncAllocationIds) {
+            final ReplicationTracker.CheckpointState checkpointState = checkpoints.get(id);
+            assertEquals(3, checkpointState.checkpointTimers.size());
+            tracker.updateVisibleCheckpointForShard(id, initialCheckpoint);
+            assertEquals(2, checkpointState.checkpointTimers.size());
+            tracker.updateVisibleCheckpointForShard(id, thirdCheckpoint);
+            assertEquals(0, checkpointState.checkpointTimers.size());
+        }
     }
 
     public void testPrimaryContextHandoffWithRemoteTranslogEnabled() throws IOException {

--- a/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
@@ -259,7 +259,7 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
         refreshListener.afterRefresh(true);
 
         // verify checkpoint is published
-        verify(mock, times(1)).publish(any());
+        verify(mock, times(1)).publish(any(), any());
         closeShards(shard);
     }
 
@@ -281,7 +281,7 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
         refreshListener.afterRefresh(true);
 
         // verify checkpoint is not published
-        verify(mock, times(0)).publish(any());
+        verify(mock, times(0)).publish(any(), any());
         closeShards(shard);
     }
 

--- a/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationSourceHandlerTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationSourceHandlerTests.java
@@ -73,7 +73,7 @@ public class SegmentReplicationSourceHandlerTests extends IndexShardTestCase {
             chunkWriter,
             threadPool,
             copyState,
-            primary.routingEntry().allocationId().getId(),
+            replica.routingEntry().allocationId().getId(),
             5000,
             1
         );
@@ -111,7 +111,7 @@ public class SegmentReplicationSourceHandlerTests extends IndexShardTestCase {
             chunkWriter,
             threadPool,
             copyState,
-            primary.routingEntry().allocationId().getId(),
+            replica.routingEntry().allocationId().getId(),
             5000,
             1
         );
@@ -191,7 +191,7 @@ public class SegmentReplicationSourceHandlerTests extends IndexShardTestCase {
             chunkWriter,
             threadPool,
             copyState,
-            primary.routingEntry().allocationId().getId(),
+            replica.routingEntry().allocationId().getId(),
             5000,
             1
         );

--- a/test/framework/src/main/java/org/opensearch/cluster/MockInternalClusterInfoService.java
+++ b/test/framework/src/main/java/org/opensearch/cluster/MockInternalClusterInfoService.java
@@ -115,6 +115,7 @@ public class MockInternalClusterInfoService extends InternalClusterInfoService {
                 nodeStats.getScriptCacheStats(),
                 nodeStats.getIndexingPressureStats(),
                 nodeStats.getShardIndexingPressureStats(),
+                nodeStats.getSegmentReplicationStats(),
                 nodeStats.getSearchBackpressureStats(),
                 nodeStats.getClusterManagerThrottlingStats(),
                 nodeStats.getWeightedRoutingStats(),

--- a/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
@@ -2685,6 +2685,7 @@ public final class InternalTestCluster extends TestCluster {
                     false,
                     false,
                     false,
+                    false,
                     false
                 );
                 assertThat(


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR introduces new mechanisms to keep track of the current replicas within a replication group.  It is the first step in changes to add backpressure for lagging replicas when SR is enabled.  

- Adds new fields to CheckpointState inside a primary's ReplicationTracker to keep track of the following new metrics:
  - checkpointTimers - a map of ReplicationCheckpoint to a timer.  When the replica is caught up to at least that checkpoint, timers are stopped and removed.  Timers are added when the primary publishes a new checkpoint.  This allows us to compute the bytes behind and ongoing replication lag when requested.
  - visibleReplicationCheckpoint - the currently searchable checkpoint on the replica.
  - lastCompletedReplicationLag - lag for the most recently completed replication event.
- ReplicationTracker also has a new method `getSegmentReplicationStats` to fetch these stats per in-sync replica in addition to the amount of bytes the replica is behind.  In addition it returns the average replication lag for the whole group.
- The new stats are also added to NodeStats API.

Example Response:
```
    "oltX47ZFRfSMY9k5cef3eA" : {
      "timestamp" : 1677792047146,
      "name" : "node-2",
      "roles" : [
        "cluster_manager",
        "data",
        "ingest",
        "remote_cluster_client"
      ],
      "attributes" : {
        "shard_indexing_pressure_enabled" : "true"
      },
      "segment_replication" : {
        "[so][5]" : {
          "rejected_requests" : 0,
          "replicas" : {
            "syu-_SmoRmK1HrzuaoIBHQ" : {
              "checkpoints_behind" : 0,
              "bytes_behind" : "0b",
              "current_replication_lag" : "0s",
              "last_completed_replication_lag" : "273ms"
            }
          }
        },
        "[so][2]" : {
          "rejected_requests" : 0,
          "replicas" : {
            "x3BEIA9wQKGDfht4vXHUMA" : {
              "checkpoints_behind" : 0,
              "bytes_behind" : "0b",
              "current_replication_lag" : "0s",
              "last_completed_replication_lag" : "146ms"
            }
          }
        },
        "[so][8]" : {
          "rejected_requests" : 0,
          "replicas" : {
            "pkb-3tEOTJiRZQjlTV3VuQ" : {
              "checkpoints_behind" : 1,
              "bytes_behind" : "14.3mb",
              "current_replication_lag" : "385ms",
              "last_completed_replication_lag" : "300ms"
            }
          }
        }
      }
```


### Issues Resolved
closes #6388
related #4478 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
