### PR TITLE
[Segment Replication ]Remove state update of singleIndexWithSegmentReplicationDisabled in TransportSegmentReplicationStatsAction  Class

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationStatsIT.java
@@ -8,7 +8,6 @@
 
 package org.opensearch.indices.replication;
 
-import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.admin.indices.replication.SegmentReplicationStatsResponse;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
@@ -142,32 +141,6 @@ public class SegmentReplicationStatsIT extends SegmentReplicationBaseIT {
         );
         assertTrue(completedOnlyResponse.shardSegmentReplicationStates().get(INDEX_NAME).get(0).getIndex().recoveredFileCount() > 0);
         waitForAssertions.countDown();
-    }
-
-    public void testSegmentReplicationStatsResponseOnDocumentReplicationIndex() {
-        final String primaryNode = internalCluster().startNode();
-        prepareCreate(
-            INDEX_NAME,
-            Settings.builder().put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.DOCUMENT)
-
-        ).get();
-        ensureYellowAndNoInitializingShards(INDEX_NAME);
-        final String replicaNode = internalCluster().startNode();
-        ensureGreen(INDEX_NAME);
-
-        // index 10 docs
-        for (int i = 0; i < 10; i++) {
-            client().prepareIndex(INDEX_NAME).setId(Integer.toString(i)).setSource("field", "value" + i).execute().actionGet();
-        }
-        refresh(INDEX_NAME);
-        OpenSearchStatusException exception = assertThrows(
-            OpenSearchStatusException.class,
-            () -> client().admin().indices().prepareSegmentReplicationStats(INDEX_NAME).execute().actionGet()
-        );
-        // Verify exception message
-        String expectedMessage = "Segment Replication is not enabled on Index: test-idx-1";
-        assertEquals(expectedMessage, exception.getMessage());
-
     }
 
 }

--- a/server/src/main/java/org/opensearch/action/admin/indices/replication/TransportSegmentReplicationStatsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/replication/TransportSegmentReplicationStatsAction.java
@@ -8,7 +8,6 @@
 
 package org.opensearch.action.admin.indices.replication;
 
-import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.DefaultShardOperationFailedException;
 import org.opensearch.action.support.broadcast.node.TransportBroadcastByNodeAction;
@@ -27,7 +26,6 @@ import org.opensearch.index.shard.ShardId;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.replication.SegmentReplicationState;
 import org.opensearch.indices.replication.SegmentReplicationTargetService;
-import org.opensearch.rest.RestStatus;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
@@ -52,7 +50,6 @@ public class TransportSegmentReplicationStatsAction extends TransportBroadcastBy
 
     private final SegmentReplicationTargetService targetService;
     private final IndicesService indicesService;
-    private String singleIndexWithSegmentReplicationDisabled = null;
 
     @Inject
     public TransportSegmentReplicationStatsAction(
@@ -91,12 +88,6 @@ public class TransportSegmentReplicationStatsAction extends TransportBroadcastBy
         List<DefaultShardOperationFailedException> shardFailures,
         ClusterState clusterState
     ) {
-        // throw exception if API call is made on single index with segment replication disabled.
-        if (singleIndexWithSegmentReplicationDisabled != null) {
-            String index = singleIndexWithSegmentReplicationDisabled;
-            singleIndexWithSegmentReplicationDisabled = null;
-            throw new OpenSearchStatusException("Segment Replication is not enabled on Index: " + index, RestStatus.BAD_REQUEST);
-        }
         String[] shards = request.shards();
         Set<String> set = new HashSet<>();
         if (shards.length > 0) {
@@ -135,11 +126,6 @@ public class TransportSegmentReplicationStatsAction extends TransportBroadcastBy
         IndexShard indexShard = indexService.getShard(shardRouting.shardId().id());
         ShardId shardId = shardRouting.shardId();
 
-        // check if API call is made on single index with segment replication disabled.
-        if (request.indices().length == 1 && indexShard.indexSettings().isSegRepEnabled() == false) {
-            singleIndexWithSegmentReplicationDisabled = shardRouting.getIndexName();
-            return null;
-        }
         if (indexShard.indexSettings().isSegRepEnabled() == false || shardRouting.primary()) {
             return null;
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR fixes bug of _cat/segment_replication API giving incorrect results. TransportSegmentReplicationStatsAction  Class is a Singleton so we cannot do a global state update of singleIndexWithSegmentReplicationDisabled, which on concurrent request might incorrectly fail

### Issues Resolved
#5718 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
