### PR TITLE
Change default block size to 8MiB

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/SearchableSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/SearchableSnapshotIT.java
@@ -78,7 +78,7 @@ public final class SearchableSnapshotIT extends AbstractSnapshotIntegTestCase {
     private Settings.Builder chunkedRepositorySettings() {
         final Settings.Builder settings = Settings.builder();
         settings.put("location", randomRepoPath()).put("compress", randomBoolean());
-        settings.put("chunk_size", 2 << 13, ByteSizeUnit.BYTES);
+        settings.put("chunk_size", 2 << 23, ByteSizeUnit.BYTES);
         return settings;
     }
 

--- a/server/src/main/java/org/opensearch/index/store/remote/file/OnDemandBlockIndexInput.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/file/OnDemandBlockIndexInput.java
@@ -63,20 +63,13 @@ abstract class OnDemandBlockIndexInput extends IndexInput implements RandomAcces
      */
     protected final boolean isClone;
 
-    // Variables needed for block calculation and fetching logic
     /**
-     * Block size shift (default value is 13 = 8KB)
+     * Variables used for block calculation and fetching. blockSize must be a
+     * power of two, and is defined as 2^blockShiftSize. blockMask is defined
+     * as blockSize - 1 and is used to calculate the offset within a block.
      */
     protected final int blockSizeShift;
-
-    /**
-     * Fixed block size
-     */
     protected final int blockSize;
-
-    /**
-     * Block mask
-     */
     protected final int blockMask;
 
     /**
@@ -380,8 +373,8 @@ abstract class OnDemandBlockIndexInput extends IndexInput implements RandomAcces
     }
 
     public static class Builder {
-        // Block size shift (default value is 13 = 8KB)
-        public static final int DEFAULT_BLOCK_SIZE_SHIFT = 13;
+        // Block size shift (default value is 23 == 2^23 == 8MiB)
+        public static final int DEFAULT_BLOCK_SIZE_SHIFT = 23;
         public static final int DEFAULT_BLOCK_SIZE = 1 << DEFAULT_BLOCK_SIZE_SHIFT;;
 
         private String resourceDescription;

--- a/server/src/test/java/org/opensearch/env/NodeEnvironmentTests.java
+++ b/server/src/test/java/org/opensearch/env/NodeEnvironmentTests.java
@@ -591,7 +591,7 @@ public class NodeEnvironmentTests extends OpenSearchTestCase {
 
     public void testSearchFileCacheConfiguration() throws IOException {
         Settings searchRoleSettings = addRoles(buildEnvSettings(Settings.EMPTY), Set.of(DiscoveryNodeRole.SEARCH_ROLE));
-        ByteSizeValue cacheSize = new ByteSizeValue(100, ByteSizeUnit.MB);
+        ByteSizeValue cacheSize = new ByteSizeValue(16, ByteSizeUnit.GB);
         Settings searchRoleSettingsWithConfig = Settings.builder()
             .put(searchRoleSettings)
             .put(Node.NODE_SEARCH_CACHE_SIZE_SETTING.getKey(), cacheSize)

--- a/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheTests.java
@@ -213,8 +213,8 @@ public class FileCacheTests extends OpenSearchTestCase {
 
     public void testUsage() {
         // edge case, all Indexinput will be evicted as soon as they are put into file cache
-        FileCache fileCache = createFileCache(MEGA_BYTES);
-        fileCache.put(createPath("0"), new FakeIndexInput(8 * MEGA_BYTES));
+        FileCache fileCache = FileCacheFactory.createConcurrentLRUFileCache(16 * MEGA_BYTES, 1);
+        fileCache.put(createPath("0"), new FakeIndexInput(16 * MEGA_BYTES));
 
         CacheUsage expectedCacheUsage = new CacheUsage(0, 0);
         CacheUsage realCacheUsage = fileCache.usage();

--- a/server/src/test/java/org/opensearch/index/store/remote/utils/TransferManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/utils/TransferManagerTests.java
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.mock;
 
 @ThreadLeakFilters(filters = CleanerDaemonThreadLeakFilter.class)
 public class TransferManagerTests extends OpenSearchTestCase {
-    private final FileCache fileCache = FileCacheFactory.createConcurrentLRUFileCache(1024 * 1024, 8);
+    private final FileCache fileCache = FileCacheFactory.createConcurrentLRUFileCache(1024 * 1024 * 16, 1);
     private MMapDirectory directory;
     private BlobContainer blobContainer;
     private TransferManager transferManager;

--- a/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
@@ -218,7 +218,7 @@ public final class InternalTestCluster extends TestCluster {
         nodeAndClient.node.settings()
     );
 
-    private static final ByteSizeValue DEFAULT_SEARCH_CACHE_SIZE = new ByteSizeValue(100, ByteSizeUnit.MB);
+    private static final ByteSizeValue DEFAULT_SEARCH_CACHE_SIZE = new ByteSizeValue(2, ByteSizeUnit.GB);
 
     public static final int DEFAULT_LOW_NUM_CLUSTER_MANAGER_NODES = 1;
     public static final int DEFAULT_HIGH_NUM_CLUSTER_MANAGER_NODES = 3;


### PR DESCRIPTION
The current default of 8KiB is tiny, and with the current design of each block represented as a unique file on disk leads to an explosion of files for non-trivial data sizes. Also object stores are generally not optimized for fetching small bits of data.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
