### PR TITLE
[Banckport 2.x] Adding depth check in doc parser for deep nested document (#5199)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 ### Fixed
+- Added depth check in doc parser for deep nested document ([#5199](https://github.com/opensearch-project/OpenSearch/pull/5199))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/index/mapper/ParseContext.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ParseContext.java
@@ -38,6 +38,7 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.common.xcontent.XContentParser;
+import org.opensearch.OpenSearchParseException;
 import org.opensearch.index.IndexSettings;
 
 import java.util.ArrayList;
@@ -312,6 +313,36 @@ public abstract class ParseContext implements Iterable<ParseContext.Document> {
         public Collection<String> getIgnoredFields() {
             return in.getIgnoredFields();
         }
+
+        @Override
+        public void incrementFieldCurrentDepth() {
+            in.incrementFieldCurrentDepth();
+        }
+
+        @Override
+        public void decrementFieldCurrentDepth() {
+            in.decrementFieldCurrentDepth();
+        }
+
+        @Override
+        public void checkFieldDepthLimit() {
+            in.checkFieldDepthLimit();
+        }
+
+        @Override
+        public void incrementFieldArrayDepth() {
+            in.incrementFieldArrayDepth();
+        }
+
+        @Override
+        public void decrementFieldArrayDepth() {
+            in.decrementFieldArrayDepth();
+        }
+
+        @Override
+        public void checkFieldArrayDepthLimit() {
+            in.checkFieldArrayDepthLimit();
+        }
     }
 
     /**
@@ -345,6 +376,14 @@ public abstract class ParseContext implements Iterable<ParseContext.Document> {
 
         private long numNestedDocs;
 
+        private long currentFieldDepth;
+
+        private final long maxAllowedFieldDepth;
+
+        private long currentArrayDepth;
+
+        private final long maxAllowedArrayDepth;
+
         private final List<Mapper> dynamicMappers;
 
         private boolean docsReversed = false;
@@ -371,6 +410,10 @@ public abstract class ParseContext implements Iterable<ParseContext.Document> {
             this.dynamicMappers = new ArrayList<>();
             this.maxAllowedNumNestedDocs = indexSettings.getMappingNestedDocsLimit();
             this.numNestedDocs = 0L;
+            this.currentFieldDepth = 0L;
+            this.currentArrayDepth = 0L;
+            this.maxAllowedFieldDepth = indexSettings.getMappingDepthLimit();
+            this.maxAllowedArrayDepth = indexSettings.getMappingDepthLimit();
         }
 
         @Override
@@ -521,6 +564,60 @@ public abstract class ParseContext implements Iterable<ParseContext.Document> {
         @Override
         public Collection<String> getIgnoredFields() {
             return Collections.unmodifiableCollection(ignoredFields);
+        }
+
+        @Override
+        public void incrementFieldCurrentDepth() {
+            this.currentFieldDepth++;
+        }
+
+        @Override
+        public void decrementFieldCurrentDepth() {
+            if (this.currentFieldDepth > 0) {
+                this.currentFieldDepth--;
+            }
+        }
+
+        @Override
+        public void checkFieldDepthLimit() {
+            if (this.currentFieldDepth > maxAllowedFieldDepth) {
+                this.currentFieldDepth = 0;
+                throw new OpenSearchParseException(
+                    "The depth of the field has exceeded the allowed limit of ["
+                        + maxAllowedFieldDepth
+                        + "]."
+                        + " This limit can be set by changing the ["
+                        + MapperService.INDEX_MAPPING_DEPTH_LIMIT_SETTING.getKey()
+                        + "] index level setting."
+                );
+            }
+        }
+
+        @Override
+        public void incrementFieldArrayDepth() {
+            this.currentArrayDepth++;
+        }
+
+        @Override
+        public void decrementFieldArrayDepth() {
+            if (this.currentArrayDepth > 0) {
+                this.currentArrayDepth--;
+            }
+        }
+
+        @Override
+        public void checkFieldArrayDepthLimit() {
+            if (this.currentArrayDepth > maxAllowedArrayDepth) {
+                this.currentArrayDepth = 0;
+                throw new OpenSearchParseException(
+                    "The depth of the nested array field has exceeded the allowed limit of ["
+                        + maxAllowedArrayDepth
+                        + "]."
+                        + " This limit can be set by changing the ["
+                        + MapperService.INDEX_MAPPING_DEPTH_LIMIT_SETTING.getKey()
+                        + "] index level setting."
+                );
+            }
         }
     }
 
@@ -687,4 +784,17 @@ public abstract class ParseContext implements Iterable<ParseContext.Document> {
      * Get dynamic mappers created while parsing.
      */
     public abstract List<Mapper> getDynamicMappers();
+
+    public abstract void incrementFieldCurrentDepth();
+
+    public abstract void decrementFieldCurrentDepth();
+
+    public abstract void checkFieldDepthLimit();
+
+    public abstract void incrementFieldArrayDepth();
+
+    public abstract void decrementFieldArrayDepth();
+
+    public abstract void checkFieldArrayDepthLimit();
+
 }

--- a/server/src/test/java/org/opensearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/DocumentParserTests.java
@@ -1486,4 +1486,156 @@ public class DocumentParserTests extends MapperServiceTestCase {
         ParsedDocument doc = mapper.parse(source(b -> b.field("foo", "1234")));
         assertNull(doc.dynamicMappingsUpdate()); // no update since we reused the existing type
     }
+
+    public void testDocumentContainsDeepNestedFieldParsing() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {}));
+        ParsedDocument doc = mapper.parse(source(b -> {
+            b.startObject("inner1");
+            {
+                b.field("inner1_field1", "inner1_value1");
+                b.startObject("inner2");
+                {
+                    b.startObject("inner3");
+                    {
+                        b.field("inner3_field1", "inner3_value1");
+                        b.field("inner3_field2", "inner3_value2");
+                    }
+                    b.endObject();
+                }
+                b.endObject();
+            }
+            b.endObject();
+        }));
+
+        Mapping update = doc.dynamicMappingsUpdate();
+        assertNotNull(update); // dynamic mapping update
+
+        Mapper objMapper = update.root().getMapper("inner1");
+        Mapper inner1_field1_mapper = ((ObjectMapper) objMapper).getMapper("inner1_field1");
+        assertNotNull(inner1_field1_mapper);
+        Mapper inner2_mapper = ((ObjectMapper) objMapper).getMapper("inner2");
+        assertNotNull(inner2_mapper);
+        Mapper inner3_mapper = ((ObjectMapper) inner2_mapper).getMapper("inner3");
+        assertNotNull(inner3_mapper);
+        assertThat(doc.rootDoc().get("inner1.inner2.inner3.inner3_field1"), equalTo("inner3_value1"));
+    }
+
+    public void testDocumentContainsDeepNestedFieldParsingFail() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {}));
+        long depth_limit = MapperService.INDEX_MAPPING_DEPTH_LIMIT_SETTING.getDefault(Settings.EMPTY);
+        MapperParsingException e = expectThrows(MapperParsingException.class, () -> mapper.parse(source(b -> {
+            for (int i = 1; i <= depth_limit; i++) {
+                b.startObject("inner" + i);
+            }
+            b.field("inner_field", "inner_value");
+            for (int i = 1; i <= depth_limit; i++) {
+                b.endObject();
+            }
+        })));
+
+        // check that parsing succeeds with valid doc
+        // after throwing exception
+        ParsedDocument doc = mapper.parse(source(b -> {
+            b.startObject("inner1");
+            {
+                b.startObject("inner2");
+                {
+                    b.startObject("inner3");
+                    {
+                        b.field("inner3_field1", "inner3_value1");
+                    }
+                    b.endObject();
+                }
+                b.endObject();
+            }
+            b.endObject();
+        }));
+
+        Mapping update = doc.dynamicMappingsUpdate();
+        assertNotNull(update); // dynamic mapping update
+        Mapper objMapper = update.root().getMapper("inner1");
+        Mapper inner2_mapper = ((ObjectMapper) objMapper).getMapper("inner2");
+        assertNotNull(inner2_mapper);
+        Mapper inner3_mapper = ((ObjectMapper) inner2_mapper).getMapper("inner3");
+        assertNotNull(inner3_mapper);
+        assertThat(doc.rootDoc().get("inner1.inner2.inner3.inner3_field1"), equalTo("inner3_value1"));
+    }
+
+    public void testDocumentContainsDeepNestedFieldParsingShouldFail() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> { b.field("type", "nested"); }));
+        long depth_limit = MapperService.INDEX_MAPPING_DEPTH_LIMIT_SETTING.getDefault(Settings.EMPTY);
+        MapperParsingException e = expectThrows(MapperParsingException.class, () -> mapper.parse(source(b -> {
+            b.startObject("field");
+            b.startArray("inner");
+            for (int i = 1; i <= depth_limit; i++) {
+                b.startArray();
+            }
+            b.startArray().value(0).value(0).endArray();
+            for (int i = 1; i <= depth_limit; i++) {
+                b.endArray();
+            }
+            b.endArray();
+            b.endObject();
+        })));
+        // check parsing success for nested array within allowed depth limit
+        ParsedDocument doc = mapper.parse(source(b -> {
+            b.startObject("field");
+            b.startArray("inner");
+            for (int i = 1; i < depth_limit - 1; i++) {
+                b.startArray();
+            }
+            b.startArray().value(0).value(0).endArray();
+            for (int i = 1; i < depth_limit - 1; i++) {
+                b.endArray();
+            }
+            b.endArray();
+            b.endObject();
+        }
+
+        ));
+        Mapping update = doc.dynamicMappingsUpdate();
+        assertNotNull(update); // dynamic mapping update
+
+    }
+
+    // Test nesting upto max allowed depth with combination of nesting in object and array
+    // object -> array -> object -> array ....
+    public void testDocumentDeepNestedObjectAndArrayCombination() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {}));
+        long depth_limit = MapperService.INDEX_MAPPING_DEPTH_LIMIT_SETTING.getDefault(Settings.EMPTY);
+        MapperParsingException e = expectThrows(MapperParsingException.class, () -> mapper.parse(source(b -> {
+            for (int i = 1; i < depth_limit; i++) {
+                b.startArray("foo" + 1);
+                b.startObject();
+            }
+            b.startArray("bar");
+            b.startArray().value(0).value(0).endArray();
+            b.endArray();
+            for (int i = 1; i < depth_limit; i++) {
+                b.endObject();
+                b.endArray();
+            }
+        })));
+
+        // check parsing success for nested array within allowed depth limit
+        ParsedDocument doc = mapper.parse(source(b -> {
+            for (int i = 1; i < depth_limit - 1; i++) {
+                b.startArray("foo" + 1);
+                b.startObject();
+            }
+            b.startArray("bar");
+            b.startArray().value(0).value(0).endArray();
+            b.endArray();
+            for (int i = 1; i < depth_limit - 1; i++) {
+                b.endObject();
+                b.endArray();
+            }
+        }
+
+        ));
+        Mapping update = doc.dynamicMappingsUpdate();
+        assertNotNull(update); // dynamic mapping update
+
+    }
+
 }


### PR DESCRIPTION
* Adding depth check in doc parser for deep nested document

Fixing the issue (#5195)

Signed-off-by: Nikhil Kumar <nikhkumn@amazon.com>
(cherry picked from commit 950b86ae697d95db537e7809f2675ebdf2b0dc10)

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Added a depth level check within the document parser context. The depth level is incremented for each nested object parsing and decremented when parsing is done. If the depth level crosses a threshold, document parser throws a parsing exception and an error is returned in the response, stating the reason of the failure



### Issues Resolved
Closes issue (https://github.com/opensearch-project/OpenSearch/issues/5195)

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
