### PR TITLE
Add file cache restore logic

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/SearchableSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/SearchableSnapshotIT.java
@@ -24,7 +24,6 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.routing.GroupShardsIterator;
 import org.opensearch.cluster.routing.ShardIterator;
 import org.opensearch.cluster.routing.ShardRouting;
-import org.opensearch.common.collect.Map;
 import org.opensearch.common.io.PathUtils;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.ByteSizeUnit;
@@ -44,6 +43,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.contains;
@@ -388,6 +388,71 @@ public final class SearchableSnapshotIT extends AbstractSnapshotIntegTestCase {
         }
     }
 
+    public void testFileCacheStats() throws Exception {
+        final String snapshotName = "test-snap";
+        final String repoName = "test-repo";
+        final String indexName1 = "test-idx-1";
+        final Client client = client();
+        final int numNodes = 2;
+
+        internalCluster().ensureAtLeastNumDataNodes(numNodes);
+        createIndexWithDocsAndEnsureGreen(1, 100, indexName1);
+
+        createRepositoryWithSettings(null, repoName);
+        takeSnapshot(client, snapshotName, repoName, indexName1);
+        deleteIndicesAndEnsureGreen(client, indexName1);
+        assertAllNodesFileCacheEmpty();
+
+        internalCluster().ensureAtLeastNumSearchNodes(numNodes);
+        restoreSnapshotAndEnsureGreen(client, snapshotName, repoName);
+        assertNodesFileCacheNonEmpty(numNodes);
+    }
+
+    /**
+     * Tests file cache restore scenario for searchable snapshots by creating an index,
+     * taking a snapshot, restoring it as a searchable snapshot.
+     * It ensures file cache is restored post node restart.
+     */
+    public void testFileCacheRestore() throws Exception {
+        final String snapshotName = "test-snap";
+        final String repoName = "test-repo";
+        final String indexName = "test-idx";
+        final String restoredIndexName = indexName + "-copy";
+        // Keeping the replicas to 0 for reproducible cache results as shards can get reassigned otherwise
+        final int numReplicasIndex = 0;
+        final Client client = client();
+
+        internalCluster().ensureAtLeastNumDataNodes(numReplicasIndex + 1);
+        createIndexWithDocsAndEnsureGreen(numReplicasIndex, 100, indexName);
+
+        createRepositoryWithSettings(null, repoName);
+        takeSnapshot(client, snapshotName, repoName, indexName);
+        deleteIndicesAndEnsureGreen(client, indexName);
+
+        internalCluster().ensureAtLeastNumSearchNodes(numReplicasIndex + 1);
+        restoreSnapshotAndEnsureGreen(client, snapshotName, repoName);
+        assertDocCount(restoredIndexName, 100L);
+        assertIndexDirectoryDoesNotExist(restoredIndexName);
+
+        NodesStatsResponse preRestoreStats = client().admin().cluster().nodesStats(new NodesStatsRequest().all()).actionGet();
+        for (NodeStats nodeStats : preRestoreStats.getNodes()) {
+            if (nodeStats.getNode().isSearchNode()) {
+                internalCluster().restartNode(nodeStats.getNode().getName());
+            }
+        }
+
+        NodesStatsResponse postRestoreStats = client().admin().cluster().nodesStats(new NodesStatsRequest().all()).actionGet();
+        Map<String, NodeStats> preRestoreStatsMap = preRestoreStats.getNodesMap();
+        Map<String, NodeStats> postRestoreStatsMap = postRestoreStats.getNodesMap();
+        for (String node : postRestoreStatsMap.keySet()) {
+            NodeStats preRestoreStat = preRestoreStatsMap.get(node);
+            NodeStats postRestoreStat = postRestoreStatsMap.get(node);
+            if (preRestoreStat.getNode().isSearchNode()) {
+                assertEquals(preRestoreStat.getFileCacheStats().getUsed(), postRestoreStat.getFileCacheStats().getUsed());
+            }
+        }
+    }
+
     /**
      * Picks a shard out of the cluster state for each given index and asserts
      * that the 'index' directory does not exist in the node's file system.
@@ -424,26 +489,6 @@ public final class SearchableSnapshotIT extends AbstractSnapshotIntegTestCase {
                 MatcherAssert.assertThat("Expect file not to exist: " + file, Files.exists(file), is(false));
             }
         }
-    }
-
-    public void testFileCacheStats() throws Exception {
-        final String snapshotName = "test-snap";
-        final String repoName = "test-repo";
-        final String indexName1 = "test-idx-1";
-        final Client client = client();
-        final int numNodes = 2;
-
-        internalCluster().ensureAtLeastNumDataNodes(numNodes);
-        createIndexWithDocsAndEnsureGreen(1, 100, indexName1);
-
-        createRepositoryWithSettings(null, repoName);
-        takeSnapshot(client, snapshotName, repoName, indexName1);
-        deleteIndicesAndEnsureGreen(client, indexName1);
-        assertAllNodesFileCacheEmpty();
-
-        internalCluster().ensureAtLeastNumSearchNodes(numNodes);
-        restoreSnapshotAndEnsureGreen(client, snapshotName, repoName);
-        assertNodesFileCacheNonEmpty(numNodes);
     }
 
     private void assertAllNodesFileCacheEmpty() {

--- a/server/src/main/java/org/opensearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/opensearch/env/NodeEnvironment.java
@@ -410,7 +410,7 @@ public final class NodeEnvironment implements Closeable {
      * If the user doesn't configure the cache size, it fails if the node is a data + search node.
      * Else it configures the size to 80% of available capacity for a dedicated search node, if not explicitly defined.
      */
-    private void initializeFileCache(Settings settings) {
+    private void initializeFileCache(Settings settings) throws IOException {
         if (DiscoveryNode.isSearchNode(settings)) {
             long capacity = NODE_SEARCH_CACHE_SIZE_SETTING.get(settings).getBytes();
             FsInfo.Path info = ExceptionsHelper.catchAsRuntimeException(() -> FsProbe.getFSInfo(this.fileCacheNodePath));
@@ -435,6 +435,8 @@ public final class NodeEnvironment implements Closeable {
             capacity = Math.min(capacity, availableCapacity);
             fileCacheNodePath.fileCacheReservedSize = new ByteSizeValue(capacity, ByteSizeUnit.BYTES);
             this.fileCache = FileCacheFactory.createConcurrentLRUFileCache(capacity);
+            List<Path> fileCacheDataPaths = collectFileCacheDataPath(this.fileCacheNodePath);
+            this.fileCache.restoreFromDirectory(fileCacheDataPaths);
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCache.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCache.java
@@ -12,9 +12,16 @@ import org.opensearch.index.store.remote.utils.cache.CacheUsage;
 import org.opensearch.index.store.remote.utils.cache.RefCountedCache;
 import org.opensearch.index.store.remote.utils.cache.SegmentedCache;
 import org.opensearch.index.store.remote.utils.cache.stats.CacheStats;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
+
+import static org.opensearch.index.store.remote.directory.RemoteSnapshotDirectoryFactory.LOCAL_STORE_LOCATION;
 
 /**
  * File Cache (FC) is introduced to solve the problem that the local disk cannot hold
@@ -122,5 +129,38 @@ public class FileCache implements RefCountedCache<Path, CachedIndexInput> {
     @Override
     public CacheStats stats() {
         return theCache.stats();
+    }
+
+    /**
+     * Restores the file cache instance performing a folder scan of the
+     * {@link org.opensearch.index.store.remote.directory.RemoteSnapshotDirectoryFactory#LOCAL_STORE_LOCATION}
+     * directory within the provided file cache path.
+     */
+    public void restoreFromDirectory(List<Path> fileCacheDataPaths) {
+        fileCacheDataPaths.stream()
+            .filter(Files::isDirectory)
+            .map(path -> path.resolve(LOCAL_STORE_LOCATION))
+            .filter(Files::isDirectory)
+            .flatMap(dir -> {
+                try {
+                    return Files.list(dir);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(
+                        "Unable to process file cache directory. Please clear the file cache for node startup.",
+                        e
+                    );
+                }
+            })
+            .filter(Files::isRegularFile)
+            .forEach(path -> {
+                try {
+                    put(path.toAbsolutePath(), new FileCachedIndexInput.ClosedIndexInput(Files.size(path)));
+                } catch (IOException e) {
+                    throw new UncheckedIOException(
+                        "Unable to retrieve cache file details. Please clear the file cache for node startup.",
+                        e
+                    );
+                }
+            });
     }
 }

--- a/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCachedIndexInput.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCachedIndexInput.java
@@ -161,4 +161,61 @@ public class FileCachedIndexInput extends CachedIndexInput implements RandomAcce
     public boolean isClosed() {
         return closed;
     }
+
+    /**
+     * IndexInput instance which is utilized to fetch length for the input without opening the IndexInput.
+     */
+    public static class ClosedIndexInput extends CachedIndexInput {
+        private final long length;
+
+        public ClosedIndexInput(long length) {
+            super("ClosedIndexInput");
+            this.length = length;
+        }
+
+        @Override
+        public void close() throws IOException {
+            // No-Op
+        }
+
+        @Override
+        public long getFilePointer() {
+            throw new UnsupportedOperationException("ClosedIndexInput doesn't support getFilePointer().");
+        }
+
+        @Override
+        public void seek(long pos) throws IOException {
+            throw new UnsupportedOperationException("ClosedIndexInput doesn't support seek().");
+        }
+
+        @Override
+        public long length() {
+            return length;
+        }
+
+        @Override
+        public IndexInput slice(String sliceDescription, long offset, long length) throws IOException {
+            throw new UnsupportedOperationException("ClosedIndexInput couldn't be sliced.");
+        }
+
+        @Override
+        public byte readByte() throws IOException {
+            throw new UnsupportedOperationException("ClosedIndexInput doesn't support read.");
+        }
+
+        @Override
+        public void readBytes(byte[] b, int offset, int len) throws IOException {
+            throw new UnsupportedOperationException("ClosedIndexInput doesn't support read.");
+        }
+
+        @Override
+        public IndexInput clone() {
+            throw new UnsupportedOperationException("ClosedIndexInput cannot be cloned.");
+        }
+
+        @Override
+        public boolean isClosed() {
+            return true;
+        }
+    }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
- Add support to restore the file cache on node bootstrap

### Issues Resolved
- Resolves #5980 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
