### PR TITLE
[Extensions] Only store names of extension transport actions

### DIFF
--- a/server/src/main/java/org/opensearch/extensions/action/ExtensionTransportActionsHandler.java
+++ b/server/src/main/java/org/opensearch/extensions/action/ExtensionTransportActionsHandler.java
@@ -93,7 +93,7 @@ public class ExtensionTransportActionsHandler {
         logger.debug("Register Transport Actions request recieved {}", transportActionsRequest);
         DiscoveryExtensionNode extension = extensionIdMap.get(transportActionsRequest.getUniqueId());
         try {
-            for (String action : transportActionsRequest.getTransportActions().keySet()) {
+            for (String action : transportActionsRequest.getTransportActions()) {
                 registerAction(action, extension);
             }
         } catch (Exception e) {

--- a/server/src/test/java/org/opensearch/extensions/RegisterTransportActionsRequestTests.java
+++ b/server/src/test/java/org/opensearch/extensions/RegisterTransportActionsRequestTests.java
@@ -36,9 +36,6 @@ public class RegisterTransportActionsRequestTests extends OpenSearchTestCase {
     }
 
     public void testToString() {
-        assertEquals(
-            originalRequest.toString(),
-            "TransportActionsRequest{uniqueId=extension-uniqueId, actions={testAction=class org.opensearch.action.admin.indices.create.AutoCreateAction$TransportAction}}"
-        );
+        assertEquals(originalRequest.toString(), "TransportActionsRequest{uniqueId=extension-uniqueId, actions=[testAction]}");
     }
 }

--- a/server/src/test/java/org/opensearch/extensions/RegisterTransportActionsRequestTests.java
+++ b/server/src/test/java/org/opensearch/extensions/RegisterTransportActionsRequestTests.java
@@ -9,20 +9,19 @@
 package org.opensearch.extensions;
 
 import org.junit.Before;
-import org.opensearch.action.admin.indices.create.AutoCreateAction.TransportAction;
-import org.opensearch.common.collect.Map;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
+import java.util.Set;
 
 public class RegisterTransportActionsRequestTests extends OpenSearchTestCase {
     private RegisterTransportActionsRequest originalRequest;
 
     @Before
     public void setup() {
-        this.originalRequest = new RegisterTransportActionsRequest("extension-uniqueId", Map.of("testAction", TransportAction.class));
+        this.originalRequest = new RegisterTransportActionsRequest("extension-uniqueId", Set.of("testAction"));
     }
 
     public void testRegisterTransportActionsRequest() throws IOException {
@@ -31,7 +30,6 @@ public class RegisterTransportActionsRequestTests extends OpenSearchTestCase {
         StreamInput input = output.bytes().streamInput();
         RegisterTransportActionsRequest parsedRequest = new RegisterTransportActionsRequest(input);
         assertEquals(parsedRequest.getTransportActions(), originalRequest.getTransportActions());
-        assertEquals(parsedRequest.getTransportActions().get("testAction"), originalRequest.getTransportActions().get("testAction"));
         assertEquals(parsedRequest.getTransportActions().size(), originalRequest.getTransportActions().size());
         assertEquals(parsedRequest.hashCode(), originalRequest.hashCode());
         assertTrue(originalRequest.equals(parsedRequest));

--- a/server/src/test/java/org/opensearch/extensions/action/ExtensionTransportActionsHandlerTests.java
+++ b/server/src/test/java/org/opensearch/extensions/action/ExtensionTransportActionsHandlerTests.java
@@ -11,7 +11,6 @@ package org.opensearch.extensions.action;
 import org.junit.After;
 import org.junit.Before;
 import org.opensearch.Version;
-import org.opensearch.action.admin.indices.create.AutoCreateAction.TransportAction;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.io.stream.NamedWriteableRegistry;
@@ -151,10 +150,7 @@ public class ExtensionTransportActionsHandlerTests extends OpenSearchTestCase {
         );
 
         // Register Action
-        RegisterTransportActionsRequest registerRequest = new RegisterTransportActionsRequest(
-            "uniqueid1",
-            Set.of(action)
-        );
+        RegisterTransportActionsRequest registerRequest = new RegisterTransportActionsRequest("uniqueid1", Set.of(action));
         AcknowledgedResponse response = (AcknowledgedResponse) extensionTransportActionsHandler.handleRegisterTransportActionsRequest(
             registerRequest
         );

--- a/server/src/test/java/org/opensearch/extensions/action/ExtensionTransportActionsHandlerTests.java
+++ b/server/src/test/java/org/opensearch/extensions/action/ExtensionTransportActionsHandlerTests.java
@@ -39,6 +39,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.Collections.emptyMap;
@@ -118,7 +119,7 @@ public class ExtensionTransportActionsHandlerTests extends OpenSearchTestCase {
 
     public void testRegisterTransportActionsRequest() {
         String action = "test-action";
-        RegisterTransportActionsRequest request = new RegisterTransportActionsRequest("uniqueid1", Map.of(action, TransportAction.class));
+        RegisterTransportActionsRequest request = new RegisterTransportActionsRequest("uniqueid1", Set.of(action));
         AcknowledgedResponse response = (AcknowledgedResponse) extensionTransportActionsHandler.handleRegisterTransportActionsRequest(
             request
         );
@@ -152,7 +153,7 @@ public class ExtensionTransportActionsHandlerTests extends OpenSearchTestCase {
         // Register Action
         RegisterTransportActionsRequest registerRequest = new RegisterTransportActionsRequest(
             "uniqueid1",
-            Map.of(action, TransportAction.class)
+            Set.of(action)
         );
         AcknowledgedResponse response = (AcknowledgedResponse) extensionTransportActionsHandler.handleRegisterTransportActionsRequest(
             registerRequest


### PR DESCRIPTION
Companion PR: https://github.com/opensearch-project/opensearch-sdk-java/pull/524 
(PRs must be merged together, this one first.)

### Description

`o.o.extensions.RegisterTransportActionsRequest` was incorrectly attempting to store a map with a compiled class available only to the SDK and not to OpenSearch. 

This PR changes the request to track only the set of action names (exactly equivalent to the `.keySet()` of the prior map implementation), which was all that was being used by the handler anyway.

The SDK will maintain a map of name to actual compiled/executable action.

### Issues Resolved

[SDK #484](https://github.com/opensearch-project/opensearch-sdk-java/issues/484)

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
~- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~ (No change log, bug fix to prerelease feature.)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
