### PR TITLE
Remove the JUnit test framework workaround for JarHell issue, fixed in Gradle 8.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,6 @@ import org.gradle.plugins.ide.eclipse.model.AccessRule
 import org.gradle.plugins.ide.eclipse.model.EclipseJdt
 import org.gradle.plugins.ide.eclipse.model.SourceFolder
 import org.gradle.api.Project;
-import org.gradle.api.internal.tasks.testing.junit.JUnitTestFramework
 import org.gradle.process.ExecResult;
 
 import static org.opensearch.gradle.util.GradleUtils.maybeConfigure
@@ -76,19 +75,6 @@ allprojects {
   group = 'org.opensearch'
   version = VersionProperties.getOpenSearch()
   description = "OpenSearch subproject ${project.path}"
-
-  afterEvaluate {
-    project.tasks.withType(Test) { task ->
-      // This is so hacky: now, by default, test tasks uses JUnit framework and always includes 'junit'
-      // JARs from the Gradle distribution (no ways to override this behavior). It causes JAR hell on test 
-      // classpath, example of the report:
-      //
-      //  jar1: /home/ubuntu/.gradle/caches/modules-2/files-2.1/junit/junit/4.13.2/8ac9e16d933b6fb43bc7f576336b8f4d7eb5ba12/junit-4.13.2.jar
-      //  jar2: /home/ubuntu/.gradle/wrapper/dists/gradle-8.0-rc-1-all/2p8rgxxewg8l61n1p3vrzr9s8/gradle-8.0-rc-1/lib/junit-4.13.2.jar
-      // 
-      task.getTestFrameworkProperty().convention(getProviderFactory().provider(() -> new JUnitTestFramework(task, task.getFilter(), false)));
-    }
-  }
 }
 
 configure(allprojects - project(':distribution:archives:integ-test-zip')) {


### PR DESCRIPTION
### Description
Remove the JUnit test framework workaround for JarHell issue, fixed in Gradle 8.0.2

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
