### PR TITLE
fix compiler warning and base blob path case for searchable snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add GeoTile and GeoHash Grid aggregations on GeoShapes. ([#5589](https://github.com/opensearch-project/OpenSearch/pull/5589))
 - Disallow multiple data paths for search nodes ([#6427](https://github.com/opensearch-project/OpenSearch/pull/6427))
 - [Segment Replication] Allocation and rebalancing based on average primary shard count per index ([#6422](https://github.com/opensearch-project/OpenSearch/pull/6422))
+- Add 'base_path' setting to File System Repository ([#6558](https://github.com/opensearch-project/OpenSearch/pull/6558))
 
 ### Dependencies
 - Bump `org.apache.logging.log4j:log4j-core` from 2.18.0 to 2.20.0 ([#6490](https://github.com/opensearch-project/OpenSearch/pull/6490))
@@ -94,6 +95,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Added equals/hashcode for named DocValueFormat.DateTime inner class ([#6357](https://github.com/opensearch-project/OpenSearch/pull/6357))
+- Fixed bug for searchable snapshot to take 'base_path' of blob into account ([#6558](https://github.com/opensearch-project/OpenSearch/pull/6558))
 
 ### Security
 

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationAllocationIT.java
@@ -193,7 +193,7 @@ public class SegmentReplicationAllocationIT extends SegmentReplicationBaseIT {
 
     /**
      * Utility method which ensures cluster has balanced primary shard distribution across a single index.
-     * @throws Exception
+     * @throws Exception exception
      */
     private void verifyPerIndexPrimaryBalance() throws Exception {
         assertBusy(() -> {

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/SearchableSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/SearchableSnapshotIT.java
@@ -72,6 +72,7 @@ public final class SearchableSnapshotIT extends AbstractSnapshotIntegTestCase {
     protected Settings.Builder randomRepositorySettings() {
         final Settings.Builder settings = Settings.builder();
         settings.put("location", randomRepoPath()).put("compress", randomBoolean());
+        settings.put(FsRepository.BASE_PATH_SETTING.getKey(), "my_base_path");
         return settings;
     }
 

--- a/server/src/main/java/org/opensearch/index/store/remote/directory/RemoteSnapshotDirectoryFactory.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/directory/RemoteSnapshotDirectoryFactory.java
@@ -73,7 +73,8 @@ public final class RemoteSnapshotDirectoryFactory implements IndexStorePlugin.Di
         ShardPath localShardPath,
         BlobStoreRepository blobStoreRepository
     ) throws IOException {
-        final BlobPath blobPath = new BlobPath().add("indices")
+        final BlobPath blobPath = blobStoreRepository.basePath()
+            .add("indices")
             .add(IndexSettings.SEARCHABLE_SNAPSHOT_INDEX_ID.get(indexSettings.getSettings()))
             .add(Integer.toString(localShardPath.getShardId().getId()));
         final SnapshotId snapshotId = new SnapshotId(

--- a/server/src/main/java/org/opensearch/repositories/fs/FsRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/fs/FsRepository.java
@@ -36,6 +36,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.cluster.metadata.RepositoryMetadata;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.Strings;
 import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.common.blobstore.BlobStore;
 import org.opensearch.common.blobstore.fs.FsBlobStore;
@@ -98,6 +99,9 @@ public class FsRepository extends BlobStoreRepository {
         Property.NodeScope,
         Property.Deprecated
     );
+
+    public static final Setting<String> BASE_PATH_SETTING = Setting.simpleString("base_path");
+
     private final Environment environment;
 
     private ByteSizeValue chunkSize;
@@ -154,7 +158,12 @@ public class FsRepository extends BlobStoreRepository {
         } else {
             this.chunkSize = REPOSITORIES_CHUNK_SIZE_SETTING.get(environment.settings());
         }
-        this.basePath = BlobPath.cleanPath();
+        final String basePath = BASE_PATH_SETTING.get(metadata.settings());
+        if (Strings.hasLength(basePath)) {
+            this.basePath = new BlobPath().add(basePath);
+        } else {
+            this.basePath = BlobPath.cleanPath();
+        }
     }
 
     private static boolean calculateCompress(RepositoryMetadata metadata, Environment environment) {

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -162,7 +162,7 @@ public class RemoteSegmentStoreDirectoryTests extends OpenSearchTestCase {
      * Prepares metadata file bytes with header and footer
      * @param segmentFilesMap: actual metadata content
      * @return ByteArrayIndexInput: metadata file bytes with header and footer
-     * @throws IOException
+     * @throws IOException IOException
      */
     private ByteArrayIndexInput createMetadataFileBytes(Map<String, String> segmentFilesMap) throws IOException {
         BytesStreamOutput output = new BytesStreamOutput();

--- a/server/src/test/java/org/opensearch/repositories/fs/FsRepositoryTests.java
+++ b/server/src/test/java/org/opensearch/repositories/fs/FsRepositoryTests.java
@@ -104,6 +104,7 @@ public class FsRepositoryTests extends OpenSearchTestCase {
                 .put("location", repo)
                 .put("compress", randomBoolean())
                 .put("chunk_size", randomIntBetween(100, 1000), ByteSizeUnit.BYTES)
+                .put(FsRepository.BASE_PATH_SETTING.getKey(), "my_base_path")
                 .build();
 
             int numDocs = indexDocs(directory);


### PR DESCRIPTION
### Description
Fixing base blob path scenario for searchable snapshots
1. Adding base blob path configuration for FS directory
2. Add base blob path scenario in searchable snapshot tests and fix bug
3. Fix compiler warnings

### Issues Resolved
Closes #6557

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
