### PR TITLE
Implement Segment replication Backpressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add 'base_path' setting to File System Repository ([#6558](https://github.com/opensearch-project/OpenSearch/pull/6558))
 - Return success on DeletePits when no PITs exist. ([#6544](https://github.com/opensearch-project/OpenSearch/pull/6544))
 - Add node repurpose command for search nodes ([#6517](https://github.com/opensearch-project/OpenSearch/pull/6517))
+- [Segment Replication] Apply backpressure when replicas fall behind ([#6563](https://github.com/opensearch-project/OpenSearch/pull/6563))
 
 ### Dependencies
 - Bump `org.apache.logging.log4j:log4j-core` from 2.18.0 to 2.20.0 ([#6490](https://github.com/opensearch-project/OpenSearch/pull/6490))

--- a/server/src/internalClusterTest/java/org/opensearch/index/SegmentReplicationPressureIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/SegmentReplicationPressureIT.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright OpenSearch Contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.index;
+
+import org.opensearch.action.bulk.BulkItemResponse;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.UUIDs;
+import org.opensearch.common.lease.Releasable;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.concurrent.OpenSearchRejectedExecutionException;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.indices.replication.SegmentReplicationBaseIT;
+import org.opensearch.indices.replication.SegmentReplicationSourceService;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.rest.RestStatus;
+import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.test.transport.MockTransportService;
+import org.opensearch.transport.TransportService;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.Arrays.asList;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
+import static org.opensearch.index.SegmentReplicationPressureService.MAX_INDEXING_CHECKPOINTS;
+import static org.opensearch.index.SegmentReplicationPressureService.MAX_REPLICATION_TIME_SETTING;
+import static org.opensearch.index.SegmentReplicationPressureService.SEGMENT_REPLICATION_INDEXING_PRESSURE_ENABLED;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class SegmentReplicationPressureIT extends SegmentReplicationBaseIT {
+
+    private static final int MAX_CHECKPOINTS_BEHIND = 2;
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(SEGMENT_REPLICATION_INDEXING_PRESSURE_ENABLED.getKey(), true)
+            .put(MAX_REPLICATION_TIME_SETTING.getKey(), TimeValue.timeValueSeconds(1))
+            .put(MAX_INDEXING_CHECKPOINTS.getKey(), MAX_CHECKPOINTS_BEHIND)
+            .build();
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return asList(MockTransportService.TestPlugin.class);
+    }
+
+    public void testWritesRejected() throws Exception {
+        final String primaryNode = internalCluster().startNode();
+        createIndex(INDEX_NAME);
+        ensureYellowAndNoInitializingShards(INDEX_NAME);
+        final String replicaNode = internalCluster().startNode();
+        ensureGreen(INDEX_NAME);
+
+        final IndexShard primaryShard = getIndexShard(primaryNode, INDEX_NAME);
+        final List<String> replicaNodes = asList(replicaNode);
+        assertEqualSegmentInfosVersion(replicaNodes, primaryShard);
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicInteger totalDocs = new AtomicInteger(0);
+        try (final Releasable ignored = blockReplication(replicaNodes, latch)) {
+            Thread indexingThread = new Thread(() -> { totalDocs.getAndSet(indexUntilCheckpointCount()); });
+            indexingThread.start();
+            indexingThread.join();
+            latch.await();
+            // index again while we are stale.
+            assertBusy(() -> {
+                expectThrows(OpenSearchRejectedExecutionException.class, () -> {
+                    indexDoc();
+                    totalDocs.incrementAndGet();
+                });
+            });
+        }
+        refresh(INDEX_NAME);
+        // wait for the replicas to catch up after block is released.
+        waitForSearchableDocs(totalDocs.get(), replicaNodes.toArray(new String[] {}));
+
+        // index another doc showing there is no pressure enforced.
+        indexDoc();
+        waitForSearchableDocs(totalDocs.incrementAndGet(), replicaNodes.toArray(new String[] {}));
+        verifyStoreContent();
+    }
+
+    /**
+     * This test ensures that a replica can be added while the index is under write block.
+     * Ensuring that only write requests are blocked.
+     */
+    public void testAddReplicaWhileWritesBlocked() throws Exception {
+        final String primaryNode = internalCluster().startNode();
+        createIndex(INDEX_NAME);
+        ensureYellowAndNoInitializingShards(INDEX_NAME);
+        final String replicaNode = internalCluster().startNode();
+        ensureGreen(INDEX_NAME);
+
+        final IndexShard primaryShard = getIndexShard(primaryNode, INDEX_NAME);
+        final List<String> replicaNodes = new ArrayList<>();
+        replicaNodes.add(replicaNode);
+        assertEqualSegmentInfosVersion(replicaNodes, primaryShard);
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicInteger totalDocs = new AtomicInteger(0);
+        try (final Releasable ignored = blockReplication(replicaNodes, latch)) {
+            Thread indexingThread = new Thread(() -> { totalDocs.getAndSet(indexUntilCheckpointCount()); });
+            indexingThread.start();
+            indexingThread.join();
+            latch.await();
+            // index again while we are stale.
+            assertBusy(() -> {
+                expectThrows(OpenSearchRejectedExecutionException.class, () -> {
+                    indexDoc();
+                    totalDocs.incrementAndGet();
+                });
+            });
+            final String replica_2 = internalCluster().startNode();
+            assertAcked(
+                client().admin()
+                    .indices()
+                    .prepareUpdateSettings(INDEX_NAME)
+                    .setSettings(Settings.builder().put(SETTING_NUMBER_OF_REPLICAS, 2))
+            );
+            ensureGreen(INDEX_NAME);
+            replicaNodes.add(replica_2);
+            waitForSearchableDocs(totalDocs.get(), replica_2);
+        }
+        refresh(INDEX_NAME);
+        // wait for the replicas to catch up after block is released.
+        waitForSearchableDocs(totalDocs.get(), replicaNodes.toArray(new String[] {}));
+
+        // index another doc showing there is no pressure enforced.
+        indexDoc();
+        waitForSearchableDocs(totalDocs.incrementAndGet(), replicaNodes.toArray(new String[] {}));
+        verifyStoreContent();
+    }
+
+    public void testBelowReplicaLimit() throws Exception {
+        final Settings settings = Settings.builder().put(indexSettings()).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 3).build();
+        final String primaryNode = internalCluster().startNode();
+        createIndex(INDEX_NAME, settings);
+        ensureYellowAndNoInitializingShards(INDEX_NAME);
+        List<String> replicaNodes = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            replicaNodes.add(internalCluster().startNode());
+        }
+        ensureGreen(INDEX_NAME);
+
+        final IndexShard primaryShard = getIndexShard(primaryNode, INDEX_NAME);
+        assertEqualSegmentInfosVersion(replicaNodes, primaryShard);
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicInteger totalDocs = new AtomicInteger(0);
+        // only block a single replica, pressure should not get applied.
+        try (final Releasable ignored = blockReplication(replicaNodes.subList(0, 1), latch)) {
+            Thread indexingThread = new Thread(() -> totalDocs.getAndSet(indexUntilCheckpointCount()));
+            indexingThread.start();
+            indexingThread.join();
+            latch.await();
+            indexDoc();
+            totalDocs.incrementAndGet();
+            refresh(INDEX_NAME);
+        }
+        // index another doc showing there is no pressure enforced.
+        indexDoc();
+        refresh(INDEX_NAME);
+        waitForSearchableDocs(totalDocs.incrementAndGet(), replicaNodes.toArray(new String[] {}));
+        verifyStoreContent();
+    }
+
+    public void testBulkWritesRejected() throws Exception {
+        final String primaryNode = internalCluster().startNode();
+        createIndex(INDEX_NAME);
+        ensureYellowAndNoInitializingShards(INDEX_NAME);
+        final String replicaNode = internalCluster().startNode();
+        final String coordinator = internalCluster().startCoordinatingOnlyNode(Settings.EMPTY);
+        ensureGreen(INDEX_NAME);
+
+        final IndexShard primaryShard = getIndexShard(primaryNode, INDEX_NAME);
+        final List<String> replicaNodes = asList(replicaNode);
+        assertEqualSegmentInfosVersion(replicaNodes, primaryShard);
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        List<String> nodes = List.of(primaryNode, replicaNode, coordinator);
+
+        int docsPerBatch = randomIntBetween(1, 200);
+        int totalDocs = docsPerBatch * MAX_CHECKPOINTS_BEHIND;
+        try (final Releasable ignored = blockReplication(replicaNodes, latch)) {
+            Thread indexingThread = new Thread(() -> {
+                for (int i = 0; i < MAX_CHECKPOINTS_BEHIND + 1; i++) {
+                    executeBulkRequest(nodes, docsPerBatch);
+                    refresh(INDEX_NAME);
+                }
+            });
+            indexingThread.start();
+            indexingThread.join();
+            latch.await();
+            // try and index again while we are stale.
+            assertBusy(() -> { assertFailedRequests(executeBulkRequest(nodes, randomIntBetween(1, 200))); });
+        }
+        refresh(INDEX_NAME);
+        // wait for the replicas to catch up after block is released.
+        waitForSearchableDocs(totalDocs, replicaNodes.toArray(new String[] {}));
+
+        // index another doc showing there is no pressure enforced.
+        executeBulkRequest(nodes, totalDocs);
+        waitForSearchableDocs(totalDocs * 2L, replicaNodes.toArray(new String[] {}));
+        verifyStoreContent();
+    }
+
+    private BulkResponse executeBulkRequest(List<String> nodes, int docsPerBatch) {
+        final BulkRequest bulkRequest = new BulkRequest();
+        for (int j = 0; j < docsPerBatch; ++j) {
+            IndexRequest request = new IndexRequest(INDEX_NAME).id(UUIDs.base64UUID())
+                .source(Collections.singletonMap("key", randomAlphaOfLength(50)));
+            bulkRequest.add(request);
+        }
+        final BulkResponse bulkItemResponses = client(randomFrom(nodes)).bulk(bulkRequest).actionGet();
+        refresh(INDEX_NAME);
+        return bulkItemResponses;
+    }
+
+    /**
+     * Index and Refresh in batches to force checkpoints behind.
+     * Asserts that there are no stale replicas according to the primary until cp count is reached.
+     */
+    private int indexUntilCheckpointCount() {
+        int total = 0;
+        for (int i = 0; i < MAX_CHECKPOINTS_BEHIND; i++) {
+            final int numDocs = randomIntBetween(1, 100);
+            for (int j = 0; j < numDocs; ++j) {
+                indexDoc();
+            }
+            total += numDocs;
+            refresh(INDEX_NAME);
+        }
+        return total;
+    }
+
+    private void assertFailedRequests(BulkResponse response) {
+        assertTrue(Arrays.stream(response.getItems()).allMatch(BulkItemResponse::isFailed));
+        assertTrue(
+            Arrays.stream(response.getItems())
+                .map(BulkItemResponse::getFailure)
+                .allMatch((failure) -> failure.getStatus() == RestStatus.TOO_MANY_REQUESTS)
+        );
+    }
+
+    private void indexDoc() {
+        client().prepareIndex(INDEX_NAME).setId(UUIDs.base64UUID()).setSource("{}", "{}").get();
+    }
+
+    private void assertEqualSegmentInfosVersion(List<String> replicaNames, IndexShard primaryShard) {
+        for (String replicaName : replicaNames) {
+            final IndexShard replicaShard = getIndexShard(replicaName, INDEX_NAME);
+            assertEquals(
+                primaryShard.getLatestReplicationCheckpoint().getSegmentInfosVersion(),
+                replicaShard.getLatestReplicationCheckpoint().getSegmentInfosVersion()
+            );
+        }
+    }
+
+    private Releasable blockReplication(List<String> nodes, CountDownLatch latch) {
+        CountDownLatch pauseReplicationLatch = new CountDownLatch(nodes.size());
+        for (String node : nodes) {
+
+            MockTransportService mockTargetTransportService = ((MockTransportService) internalCluster().getInstance(
+                TransportService.class,
+                node
+            ));
+            mockTargetTransportService.addSendBehavior((connection, requestId, action, request, options) -> {
+                if (action.equals(SegmentReplicationSourceService.Actions.GET_SEGMENT_FILES)) {
+                    try {
+                        latch.countDown();
+                        pauseReplicationLatch.await();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+                connection.sendRequest(requestId, action, request, options);
+            });
+        }
+        return () -> {
+            while (pauseReplicationLatch.getCount() > 0) {
+                pauseReplicationLatch.countDown();
+            }
+        };
+    }
+}

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -39,6 +39,7 @@ import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.index.IndexModule;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.IndexingPressure;
+import org.opensearch.index.SegmentReplicationPressureService;
 import org.opensearch.index.ShardIndexingPressureMemoryManager;
 import org.opensearch.index.ShardIndexingPressureSettings;
 import org.opensearch.index.ShardIndexingPressureStore;
@@ -625,7 +626,11 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 SearchShardTaskSettings.SETTING_TOTAL_HEAP_PERCENT_THRESHOLD,
                 SearchBackpressureSettings.SETTING_CANCELLATION_RATIO,  // deprecated
                 SearchBackpressureSettings.SETTING_CANCELLATION_RATE,   // deprecated
-                SearchBackpressureSettings.SETTING_CANCELLATION_BURST   // deprecated
+                SearchBackpressureSettings.SETTING_CANCELLATION_BURST,   // deprecated
+                SegmentReplicationPressureService.SEGMENT_REPLICATION_INDEXING_PRESSURE_ENABLED,
+                SegmentReplicationPressureService.MAX_INDEXING_CHECKPOINTS,
+                SegmentReplicationPressureService.MAX_REPLICATION_TIME_SETTING,
+                SegmentReplicationPressureService.MAX_ALLOWED_STALE_SHARDS
             )
         )
     );

--- a/server/src/main/java/org/opensearch/index/SegmentReplicationPerGroupStats.java
+++ b/server/src/main/java/org/opensearch/index/SegmentReplicationPerGroupStats.java
@@ -1,0 +1,69 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index;
+
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Set;
+
+/**
+ * Return Segment Replication stats for a Replication Group.
+ *
+ * @opensearch.internal
+ */
+public class SegmentReplicationPerGroupStats implements Writeable, ToXContentFragment {
+
+    private final Set<SegmentReplicationShardStats> replicaStats;
+    private final long rejectedRequestCount;
+
+    public SegmentReplicationPerGroupStats(Set<SegmentReplicationShardStats> replicaStats, long rejectedRequestCount) {
+        this.replicaStats = replicaStats;
+        this.rejectedRequestCount = rejectedRequestCount;
+    }
+
+    public SegmentReplicationPerGroupStats(StreamInput in) throws IOException {
+        this.replicaStats = in.readSet(SegmentReplicationShardStats::new);
+        this.rejectedRequestCount = in.readVLong();
+    }
+
+    public Set<SegmentReplicationShardStats> getReplicaStats() {
+        return replicaStats;
+    }
+
+    public long getRejectedRequestCount() {
+        return rejectedRequestCount;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.field("rejected_requests", rejectedRequestCount);
+        builder.startArray("replicas");
+        for (SegmentReplicationShardStats stats : replicaStats) {
+            stats.toXContent(builder, params);
+        }
+        builder.endArray();
+        return builder;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeCollection(replicaStats);
+        out.writeVLong(rejectedRequestCount);
+    }
+
+    @Override
+    public String toString() {
+        return "SegmentReplicationPerGroupStats{" + "replicaStats=" + replicaStats + ", rejectedRequestCount=" + rejectedRequestCount + '}';
+    }
+}

--- a/server/src/main/java/org/opensearch/index/SegmentReplicationPressureService.java
+++ b/server/src/main/java/org/opensearch/index/SegmentReplicationPressureService.java
@@ -39,14 +39,14 @@ public class SegmentReplicationPressureService {
     private static final Logger logger = LogManager.getLogger(SegmentReplicationPressureService.class);
 
     public static final Setting<Boolean> SEGMENT_REPLICATION_INDEXING_PRESSURE_ENABLED = Setting.boolSetting(
-        "index.segrep.pressure.enabled",
+        "segrep.pressure.enabled",
         false,
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
 
     public static final Setting<Integer> MAX_INDEXING_CHECKPOINTS = Setting.intSetting(
-        "index.segrep.pressure.checkpoint.limit",
+        "segrep.pressure.checkpoint.limit",
         4,
         1,
         Setting.Property.Dynamic,
@@ -54,14 +54,14 @@ public class SegmentReplicationPressureService {
     );
 
     public static final Setting<TimeValue> MAX_REPLICATION_TIME_SETTING = Setting.positiveTimeSetting(
-        "index.segrep.pressure.time.limit",
+        "segrep.pressure.time.limit",
         TimeValue.timeValueMinutes(5),
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
 
     public static final Setting<Double> MAX_ALLOWED_STALE_SHARDS = Setting.doubleSetting(
-        "index.segrep.replica.stale.limit",
+        "segrep.pressure.replica.stale.limit",
         .5,
         0,
         1,

--- a/server/src/main/java/org/opensearch/index/SegmentReplicationPressureService.java
+++ b/server/src/main/java/org/opensearch/index/SegmentReplicationPressureService.java
@@ -21,7 +21,6 @@ import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.shard.ShardId;
 import org.opensearch.indices.IndicesService;
 
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -104,8 +103,8 @@ public class SegmentReplicationPressureService {
     }
 
     private void validateReplicationGroup(IndexShard shard) {
-        final Set<SegmentReplicationShardStats> replicaStatus = shard.getReplicationStats();
-        final List<SegmentReplicationShardStats> staleReplicas = getStaleReplicas(replicaStatus);
+        final Set<SegmentReplicationShardStats> replicaStats = shard.getReplicationStats();
+        final Set<SegmentReplicationShardStats> staleReplicas = getStaleReplicas(replicaStats);
         if (staleReplicas.isEmpty() == false) {
             // inSyncIds always considers the primary id, so filter it out.
             final float percentStale = staleReplicas.size() * 100f / (shard.getReplicationGroup().getInSyncAllocationIds().size() - 1);
@@ -121,11 +120,11 @@ public class SegmentReplicationPressureService {
         }
     }
 
-    private List<SegmentReplicationShardStats> getStaleReplicas(final Set<SegmentReplicationShardStats> replicas) {
+    private Set<SegmentReplicationShardStats> getStaleReplicas(final Set<SegmentReplicationShardStats> replicas) {
         return replicas.stream()
             .filter(entry -> entry.getCheckpointsBehindCount() > maxCheckpointsBehind)
             .filter(entry -> entry.getCurrentReplicationTimeMillis() > maxReplicationTime.millis())
-            .collect(Collectors.toList());
+            .collect(Collectors.toSet());
     }
 
     public SegmentReplicationStats nodeStats() {

--- a/server/src/main/java/org/opensearch/index/SegmentReplicationPressureService.java
+++ b/server/src/main/java/org/opensearch/index/SegmentReplicationPressureService.java
@@ -1,0 +1,155 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.concurrent.OpenSearchRejectedExecutionException;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.index.shard.ShardId;
+import org.opensearch.indices.IndicesService;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Service responsible for applying backpressure for lagging behind replicas when Segment Replication is enabled.
+ *
+ * @opensearch.internal
+ */
+public class SegmentReplicationPressureService {
+
+    private volatile boolean isSegmentReplicationBackpressureEnabled;
+    private volatile int maxCheckpointsBehind;
+    private volatile double maxAllowedStaleReplicas;
+    private volatile TimeValue maxReplicationTime;
+
+    private static final Logger logger = LogManager.getLogger(SegmentReplicationPressureService.class);
+
+    public static final Setting<Boolean> SEGMENT_REPLICATION_INDEXING_PRESSURE_ENABLED = Setting.boolSetting(
+        "index.segrep.pressure.enabled",
+        false,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    public static final Setting<Integer> MAX_INDEXING_CHECKPOINTS = Setting.intSetting(
+        "index.segrep.pressure.checkpoint.limit",
+        4,
+        1,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    public static final Setting<TimeValue> MAX_REPLICATION_TIME_SETTING = Setting.positiveTimeSetting(
+        "index.segrep.pressure.time.limit",
+        TimeValue.timeValueMinutes(5),
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    public static final Setting<Double> MAX_ALLOWED_STALE_SHARDS = Setting.doubleSetting(
+        "index.segrep.replica.stale.limit",
+        .5,
+        0,
+        1,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    private final IndicesService indicesService;
+    private final SegmentReplicationStatsTracker tracker;
+
+    @Inject
+    public SegmentReplicationPressureService(Settings settings, ClusterService clusterService, IndicesService indicesService) {
+        this.indicesService = indicesService;
+        this.tracker = new SegmentReplicationStatsTracker(this.indicesService);
+
+        final ClusterSettings clusterSettings = clusterService.getClusterSettings();
+        this.isSegmentReplicationBackpressureEnabled = SEGMENT_REPLICATION_INDEXING_PRESSURE_ENABLED.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(
+            SEGMENT_REPLICATION_INDEXING_PRESSURE_ENABLED,
+            this::setSegmentReplicationBackpressureEnabled
+        );
+
+        this.maxCheckpointsBehind = MAX_INDEXING_CHECKPOINTS.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(MAX_INDEXING_CHECKPOINTS, this::setMaxCheckpointsBehind);
+
+        this.maxReplicationTime = MAX_REPLICATION_TIME_SETTING.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(MAX_REPLICATION_TIME_SETTING, this::setMaxReplicationTime);
+
+        this.maxAllowedStaleReplicas = MAX_ALLOWED_STALE_SHARDS.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(MAX_ALLOWED_STALE_SHARDS, this::setMaxAllowedStaleReplicas);
+    }
+
+    public void isSegrepLimitBreached(ShardId shardId) {
+        final IndexService indexService = indicesService.indexService(shardId.getIndex());
+        final IndexShard shard = indexService.getShard(shardId.id());
+        if (isSegmentReplicationBackpressureEnabled && shard.indexSettings().isSegRepEnabled() && shard.routingEntry().primary()) {
+            validateReplicationGroup(shard);
+        }
+    }
+
+    private void validateReplicationGroup(IndexShard shard) {
+        final Set<SegmentReplicationShardStats> replicaStatus = shard.getReplicationStats();
+        final List<SegmentReplicationShardStats> staleReplicas = getStaleReplicas(replicaStatus);
+        if (staleReplicas.isEmpty() == false) {
+            // inSyncIds always considers the primary id, so filter it out.
+            final float percentStale = staleReplicas.size() * 100f / (shard.getReplicationGroup().getInSyncAllocationIds().size() - 1);
+            final double maxStaleLimit = maxAllowedStaleReplicas * 100f;
+            if (percentStale >= maxStaleLimit) {
+                tracker.incrementRejectionCount(shard.shardId());
+                logger.warn("Rejecting write requests for shard, stale shards [{}%] shards: {}", percentStale, staleReplicas);
+                throw new OpenSearchRejectedExecutionException(
+                    "rejected execution on primary shard: " + shard.shardId() + " Stale Replicas: " + staleReplicas + "]",
+                    false
+                );
+            }
+        }
+    }
+
+    private List<SegmentReplicationShardStats> getStaleReplicas(final Set<SegmentReplicationShardStats> replicas) {
+        return replicas.stream()
+            .filter(entry -> entry.getCheckpointsBehindCount() > maxCheckpointsBehind)
+            .filter(entry -> entry.getCurrentReplicationTimeMillis() > maxReplicationTime.millis())
+            .collect(Collectors.toList());
+    }
+
+    public SegmentReplicationStats nodeStats() {
+        return tracker.getStats();
+    }
+
+    public boolean isSegmentReplicationBackpressureEnabled() {
+        return isSegmentReplicationBackpressureEnabled;
+    }
+
+    public void setSegmentReplicationBackpressureEnabled(boolean segmentReplicationBackpressureEnabled) {
+        isSegmentReplicationBackpressureEnabled = segmentReplicationBackpressureEnabled;
+    }
+
+    public void setMaxCheckpointsBehind(int maxCheckpointsBehind) {
+        this.maxCheckpointsBehind = maxCheckpointsBehind;
+    }
+
+    public void setMaxAllowedStaleReplicas(double maxAllowedStaleReplicas) {
+        this.maxAllowedStaleReplicas = maxAllowedStaleReplicas;
+    }
+
+    public void setMaxReplicationTime(TimeValue maxReplicationTime) {
+        this.maxReplicationTime = maxReplicationTime;
+    }
+
+}

--- a/server/src/main/java/org/opensearch/index/SegmentReplicationShardStats.java
+++ b/server/src/main/java/org/opensearch/index/SegmentReplicationShardStats.java
@@ -1,0 +1,112 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index;
+
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.common.unit.ByteSizeValue;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+/**
+ * SegRep stats for a single shard.
+ *
+ * @opensearch.internal
+ */
+public class SegmentReplicationShardStats implements Writeable, ToXContentFragment {
+    private final String nodeId;
+    private final long checkpointsBehindCount;
+    private final long bytesBehindCount;
+    private final long currentReplicationTimeMillis;
+    private final long lastCompletedReplicationTimeMillis;
+
+    public SegmentReplicationShardStats(
+        String nodeId,
+        long checkpointsBehindCount,
+        long bytesBehindCount,
+        long currentReplicationTimeMillis,
+        long lastCompletedReplicationTime
+    ) {
+        this.nodeId = nodeId;
+        this.checkpointsBehindCount = checkpointsBehindCount;
+        this.bytesBehindCount = bytesBehindCount;
+        this.currentReplicationTimeMillis = currentReplicationTimeMillis;
+        this.lastCompletedReplicationTimeMillis = lastCompletedReplicationTime;
+    }
+
+    public SegmentReplicationShardStats(StreamInput in) throws IOException {
+        this.nodeId = in.readString();
+        this.checkpointsBehindCount = in.readVLong();
+        this.bytesBehindCount = in.readVLong();
+        this.currentReplicationTimeMillis = in.readVLong();
+        this.lastCompletedReplicationTimeMillis = in.readVLong();
+    }
+
+    public String getNodeId() {
+        return nodeId;
+    }
+
+    public long getCheckpointsBehindCount() {
+        return checkpointsBehindCount;
+    }
+
+    public long getBytesBehindCount() {
+        return bytesBehindCount;
+    }
+
+    public long getCurrentReplicationTimeMillis() {
+        return currentReplicationTimeMillis;
+    }
+
+    public long getLastCompletedReplicationTimeMillis() {
+        return lastCompletedReplicationTimeMillis;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("node_id", nodeId);
+        builder.field("checkpoints_behind", checkpointsBehindCount);
+        builder.field("bytes_behind", new ByteSizeValue(bytesBehindCount).toString());
+        builder.field("current_replication_time", new TimeValue(currentReplicationTimeMillis));
+        builder.field("last_completed_replication_time", new TimeValue(lastCompletedReplicationTimeMillis));
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(nodeId);
+        out.writeVLong(checkpointsBehindCount);
+        out.writeVLong(bytesBehindCount);
+        out.writeVLong(currentReplicationTimeMillis);
+        out.writeVLong(lastCompletedReplicationTimeMillis);
+    }
+
+    @Override
+    public String toString() {
+        return "SegmentReplicationShardStats{"
+            + "nodeId='"
+            + nodeId
+            + '\''
+            + ", checkpointsBehindCount="
+            + checkpointsBehindCount
+            + ", bytesBehindCount="
+            + bytesBehindCount
+            + ", currentReplicationLag="
+            + currentReplicationTimeMillis
+            + ", lastCompletedLag="
+            + lastCompletedReplicationTimeMillis
+            + '}';
+    }
+}

--- a/server/src/main/java/org/opensearch/index/SegmentReplicationStats.java
+++ b/server/src/main/java/org/opensearch/index/SegmentReplicationStats.java
@@ -1,0 +1,73 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index;
+
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.shard.ShardId;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Segment Replication Stats.
+ *
+ * @opensearch.internal
+ */
+public class SegmentReplicationStats implements Writeable, ToXContentFragment {
+
+    private final Map<ShardId, SegmentReplicationPerGroupStats> shardStats;
+
+    public SegmentReplicationStats(Map<ShardId, SegmentReplicationPerGroupStats> shardStats) {
+        this.shardStats = shardStats;
+    }
+
+    public SegmentReplicationStats(StreamInput in) throws IOException {
+        int shardEntries = in.readInt();
+        shardStats = new HashMap<>();
+        for (int i = 0; i < shardEntries; i++) {
+            ShardId shardId = new ShardId(in);
+            SegmentReplicationPerGroupStats groupStats = new SegmentReplicationPerGroupStats(in);
+            shardStats.put(shardId, groupStats);
+        }
+    }
+
+    public Map<ShardId, SegmentReplicationPerGroupStats> getShardStats() {
+        return shardStats;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject("segment_replication");
+        for (Map.Entry<ShardId, SegmentReplicationPerGroupStats> entry : shardStats.entrySet()) {
+            builder.startObject(entry.getKey().toString());
+            entry.getValue().toXContent(builder, params);
+            builder.endObject();
+        }
+        return builder.endObject();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeInt(shardStats.size());
+        for (Map.Entry<ShardId, SegmentReplicationPerGroupStats> entry : shardStats.entrySet()) {
+            entry.getKey().writeTo(out);
+            entry.getValue().writeTo(out);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "SegmentReplicationStats{" + "shardStats=" + shardStats + '}';
+    }
+}

--- a/server/src/main/java/org/opensearch/index/SegmentReplicationStatsTracker.java
+++ b/server/src/main/java/org/opensearch/index/SegmentReplicationStatsTracker.java
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index;
+
+import org.opensearch.common.util.concurrent.ConcurrentCollections;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.index.shard.ShardId;
+import org.opensearch.indices.IndicesService;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Tracker responsible for computing SegmentReplicationStats.
+ *
+ * @opensearch.internal
+ */
+public class SegmentReplicationStatsTracker {
+
+    private final IndicesService indicesService;
+    private Map<ShardId, AtomicInteger> rejectionCount;
+
+    public SegmentReplicationStatsTracker(IndicesService indicesService) {
+        this.indicesService = indicesService;
+        rejectionCount = ConcurrentCollections.newConcurrentMap();
+    }
+
+    public SegmentReplicationStats getStats() {
+        Map<ShardId, SegmentReplicationPerGroupStats> stats = new HashMap<>();
+        for (IndexService indexService : indicesService) {
+            for (IndexShard indexShard : indexService) {
+                if (indexShard.indexSettings().isSegRepEnabled() && indexShard.routingEntry().primary()) {
+                    stats.putIfAbsent(
+                        indexShard.shardId(),
+                        new SegmentReplicationPerGroupStats(
+                            indexShard.getReplicationStats(),
+                            Optional.ofNullable(rejectionCount.get(indexShard.shardId())).map(AtomicInteger::get).orElse(0)
+                        )
+                    );
+                }
+            }
+        }
+        return new SegmentReplicationStats(stats);
+    }
+
+    public void incrementRejectionCount(ShardId shardId) {
+        rejectionCount.compute(shardId, (k, v) -> {
+            if (v == null) {
+                return new AtomicInteger(1);
+            } else {
+                v.incrementAndGet();
+                return v;
+            }
+        });
+    }
+}

--- a/server/src/main/java/org/opensearch/index/shard/CheckpointRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/CheckpointRefreshListener.java
@@ -41,7 +41,7 @@ public class CheckpointRefreshListener implements ReferenceManager.RefreshListen
     @Override
     public void afterRefresh(boolean didRefresh) throws IOException {
         if (didRefresh && shard.state() != IndexShardState.CLOSED && shard.getReplicationTracker().isPrimaryMode()) {
-            publisher.publish(shard);
+            publisher.publish(shard, shard.getLatestReplicationCheckpoint());
         }
     }
 }

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -106,6 +106,7 @@ import org.opensearch.index.IndexModule;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.IndexSettings;
+import org.opensearch.index.SegmentReplicationShardStats;
 import org.opensearch.index.VersionType;
 import org.opensearch.index.cache.IndexCache;
 import org.opensearch.index.cache.bitset.ShardBitsetFilterCache;
@@ -1481,19 +1482,26 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         }
         // do not close the snapshot - caller will close it.
         final GatedCloseable<SegmentInfos> snapshot = getSegmentInfosSnapshot();
-        return Optional.ofNullable(snapshot.get())
-            .map(
-                segmentInfos -> new Tuple<>(
+        return Optional.ofNullable(snapshot.get()).map(segmentInfos -> {
+            try {
+                return new Tuple<>(
                     snapshot,
                     new ReplicationCheckpoint(
                         this.shardId,
                         getOperationPrimaryTerm(),
                         segmentInfos.getGeneration(),
-                        segmentInfos.getVersion()
+                        segmentInfos.getVersion(),
+                        // TODO: Update replicas to compute length from SegmentInfos. Replicas do not yet incref segments with
+                        // getSegmentInfosSnapshot, so computing length from SegmentInfos can cause issues.
+                        shardRouting.primary()
+                            ? store.getSegmentMetadataMap(segmentInfos).values().stream().mapToLong(StoreFileMetadata::length).sum()
+                            : store.stats(StoreStats.UNKNOWN_RESERVED_BYTES).getSizeInBytes()
                     )
-                )
-            )
-            .orElseGet(() -> new Tuple<>(new GatedCloseable<>(null, () -> {}), ReplicationCheckpoint.empty(shardId)));
+                );
+            } catch (IOException e) {
+                throw new OpenSearchException("Error Fetching SegmentInfos and latest checkpoint", e);
+            }
+        }).orElseGet(() -> new Tuple<>(new GatedCloseable<>(null, () -> {}), ReplicationCheckpoint.empty(shardId)));
     }
 
     /**
@@ -1733,6 +1741,10 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
      */
     public void resetToWriteableEngine() throws IOException, InterruptedException, TimeoutException {
         indexShardOperationPermits.blockOperations(30, TimeUnit.MINUTES, () -> { resetEngineToGlobalCheckpoint(); });
+    }
+
+    public void onCheckpointPublished(ReplicationCheckpoint checkpoint) {
+        replicationTracker.setLatestReplicationCheckpoint(checkpoint);
     }
 
     /**
@@ -2698,6 +2710,27 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         assert assertPrimaryMode();
         verifyNotClosed();
         replicationTracker.updateGlobalCheckpointForShard(allocationId, globalCheckpoint);
+    }
+
+    /**
+     * Update the local knowledge of the visible global checkpoint for the specified allocation ID.
+     *
+     * @param allocationId     the allocation ID to update the global checkpoint for
+     * @param visibleCheckpoint the visible checkpoint
+     */
+    public void updateVisibleCheckpointForShard(final String allocationId, final ReplicationCheckpoint visibleCheckpoint) {
+        assert assertPrimaryMode();
+        verifyNotClosed();
+        replicationTracker.updateVisibleCheckpointForShard(allocationId, visibleCheckpoint);
+    }
+
+    /**
+     * Fetch stats on segment replication.
+     * @return {@link Tuple} V1 - TimeValue in ms - mean replication lag for this primary to its entire group,
+     * V2 - Set of {@link SegmentReplicationShardStats} per shard in this primary's replication group.
+     */
+    public Set<SegmentReplicationShardStats> getReplicationStats() {
+        return replicationTracker.getSegmentReplicationStats();
     }
 
     /**

--- a/server/src/main/java/org/opensearch/indices/replication/OngoingSegmentReplications.java
+++ b/server/src/main/java/org/opensearch/indices/replication/OngoingSegmentReplications.java
@@ -121,6 +121,10 @@ class OngoingSegmentReplications {
                 }
             });
             if (request.getFilesToFetch().isEmpty()) {
+                // before completion, alert the primary of the replica's state.
+                handler.getCopyState()
+                    .getShard()
+                    .updateVisibleCheckpointForShard(request.getTargetAllocationId(), handler.getCopyState().getCheckpoint());
                 wrappedListener.onResponse(new GetSegmentFilesResponse(Collections.emptyList()));
             } else {
                 handler.sendFiles(request, wrappedListener);

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceHandler.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceHandler.java
@@ -159,6 +159,7 @@ class SegmentReplicationSourceHandler {
 
             sendFileStep.whenComplete(r -> {
                 try {
+                    shard.updateVisibleCheckpointForShard(allocationId, copyState.getCheckpoint());
                     future.onResponse(new GetSegmentFilesResponse(List.of(storeFileMetadata)));
                 } finally {
                     IOUtils.close(resources);

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
@@ -227,9 +227,10 @@ public class SegmentReplicationTargetService implements IndexEventListener {
                     public void onReplicationDone(SegmentReplicationState state) {
                         logger.trace(
                             () -> new ParameterizedMessage(
-                                "[shardId {}] [replication id {}] Replication complete, timing data: {}",
+                                "[shardId {}] [replication id {}] Replication complete to {}, timing data: {}",
                                 replicaShard.shardId().getId(),
                                 state.getReplicationId(),
+                                replicaShard.getLatestReplicationCheckpoint(),
                                 state.getTimingData()
                             )
                         );
@@ -402,9 +403,10 @@ public class SegmentReplicationTargetService implements IndexEventListener {
                     public void onReplicationDone(SegmentReplicationState state) {
                         logger.trace(
                             () -> new ParameterizedMessage(
-                                "[shardId {}] [replication id {}] Replication complete, timing data: {}",
+                                "[shardId {}] [replication id {}] Replication complete to {}, timing data: {}",
                                 indexShard.shardId().getId(),
                                 state.getReplicationId(),
+                                indexShard.getLatestReplicationCheckpoint(),
                                 state.getTimingData()
                             )
                         );

--- a/server/src/main/java/org/opensearch/indices/replication/checkpoint/PublishCheckpointAction.java
+++ b/server/src/main/java/org/opensearch/indices/replication/checkpoint/PublishCheckpointAction.java
@@ -109,14 +109,13 @@ public class PublishCheckpointAction extends TransportReplicationAction<
     /**
      * Publish checkpoint request to shard
      */
-    final void publish(IndexShard indexShard) {
+    final void publish(IndexShard indexShard, ReplicationCheckpoint checkpoint) {
         long primaryTerm = indexShard.getPendingPrimaryTerm();
         final ThreadContext threadContext = threadPool.getThreadContext();
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
             // we have to execute under the system context so that if security is enabled the sync is authorized
             threadContext.markAsSystemContext();
-            PublishCheckpointRequest request = new PublishCheckpointRequest(indexShard.getLatestReplicationCheckpoint());
-            final ReplicationCheckpoint checkpoint = request.getCheckpoint();
+            PublishCheckpointRequest request = new PublishCheckpointRequest(checkpoint);
 
             final List<ShardRouting> replicationTargets = indexShard.getReplicationGroup().getReplicationTargets();
             for (ShardRouting replicationTarget : replicationTargets) {

--- a/server/src/main/java/org/opensearch/indices/replication/checkpoint/ReplicationCheckpoint.java
+++ b/server/src/main/java/org/opensearch/indices/replication/checkpoint/ReplicationCheckpoint.java
@@ -29,6 +29,7 @@ public class ReplicationCheckpoint implements Writeable, Comparable<ReplicationC
     private final long primaryTerm;
     private final long segmentsGen;
     private final long segmentInfosVersion;
+    private final long length;
 
     public static ReplicationCheckpoint empty(ShardId shardId) {
         return new ReplicationCheckpoint(shardId);
@@ -39,13 +40,19 @@ public class ReplicationCheckpoint implements Writeable, Comparable<ReplicationC
         primaryTerm = SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
         segmentsGen = SequenceNumbers.NO_OPS_PERFORMED;
         segmentInfosVersion = SequenceNumbers.NO_OPS_PERFORMED;
+        length = 0L;
     }
 
     public ReplicationCheckpoint(ShardId shardId, long primaryTerm, long segmentsGen, long segmentInfosVersion) {
+        this(shardId, primaryTerm, segmentsGen, segmentInfosVersion, 0L);
+    }
+
+    public ReplicationCheckpoint(ShardId shardId, long primaryTerm, long segmentsGen, long segmentInfosVersion, long length) {
         this.shardId = shardId;
         this.primaryTerm = primaryTerm;
         this.segmentsGen = segmentsGen;
         this.segmentInfosVersion = segmentInfosVersion;
+        this.length = length;
     }
 
     public ReplicationCheckpoint(StreamInput in) throws IOException {
@@ -53,6 +60,7 @@ public class ReplicationCheckpoint implements Writeable, Comparable<ReplicationC
         primaryTerm = in.readLong();
         segmentsGen = in.readLong();
         segmentInfosVersion = in.readLong();
+        length = in.readLong();
     }
 
     /**
@@ -87,12 +95,20 @@ public class ReplicationCheckpoint implements Writeable, Comparable<ReplicationC
         return shardId;
     }
 
+    /**
+     * @return The size in bytes of this checkpoint.
+     */
+    public long getLength() {
+        return length;
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         shardId.writeTo(out);
         out.writeLong(primaryTerm);
         out.writeLong(segmentsGen);
         out.writeLong(segmentInfosVersion);
+        out.writeLong(length);
     }
 
     @Override
@@ -137,6 +153,8 @@ public class ReplicationCheckpoint implements Writeable, Comparable<ReplicationC
             + segmentsGen
             + ", version="
             + segmentInfosVersion
+            + ", size="
+            + length
             + '}';
     }
 }

--- a/server/src/main/java/org/opensearch/indices/replication/checkpoint/SegmentReplicationCheckpointPublisher.java
+++ b/server/src/main/java/org/opensearch/indices/replication/checkpoint/SegmentReplicationCheckpointPublisher.java
@@ -32,19 +32,22 @@ public class SegmentReplicationCheckpointPublisher {
         this.publishAction = Objects.requireNonNull(publishAction);
     }
 
-    public void publish(IndexShard indexShard) {
-        publishAction.publish(indexShard);
+    public void publish(IndexShard indexShard, ReplicationCheckpoint checkpoint) {
+        publishAction.publish(indexShard, checkpoint);
+        indexShard.onCheckpointPublished(checkpoint);
     }
 
     /**
      * Represents an action that is invoked to publish segment replication checkpoint to replica shard
      */
     public interface PublishAction {
-        void publish(IndexShard indexShard);
+        void publish(IndexShard indexShard, ReplicationCheckpoint checkpoint);
     }
 
     /**
      * NoOp Checkpoint publisher
      */
-    public static final SegmentReplicationCheckpointPublisher EMPTY = new SegmentReplicationCheckpointPublisher(indexShard -> {});
+    public static final SegmentReplicationCheckpointPublisher EMPTY = new SegmentReplicationCheckpointPublisher(
+        (indexShard, checkpoint) -> {}
+    );
 }

--- a/server/src/test/java/org/opensearch/action/bulk/TransportShardBulkActionTests.java
+++ b/server/src/test/java/org/opensearch/action/bulk/TransportShardBulkActionTests.java
@@ -69,6 +69,7 @@ import org.opensearch.index.Index;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.IndexingPressureService;
+import org.opensearch.index.SegmentReplicationPressureService;
 import org.opensearch.index.VersionType;
 import org.opensearch.index.engine.Engine;
 import org.opensearch.index.engine.VersionConflictEngineException;
@@ -1070,6 +1071,7 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
             mock(UpdateHelper.class),
             mock(ActionFilters.class),
             mock(IndexingPressureService.class),
+            mock(SegmentReplicationPressureService.class),
             mock(SystemIndices.class)
         );
         action.handlePrimaryTermValidationRequest(
@@ -1099,6 +1101,7 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
             mock(UpdateHelper.class),
             mock(ActionFilters.class),
             mock(IndexingPressureService.class),
+            mock(SegmentReplicationPressureService.class),
             mock(SystemIndices.class)
         );
         action.handlePrimaryTermValidationRequest(
@@ -1128,6 +1131,7 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
             mock(UpdateHelper.class),
             mock(ActionFilters.class),
             mock(IndexingPressureService.class),
+            mock(SegmentReplicationPressureService.class),
             mock(SystemIndices.class)
         );
         action.handlePrimaryTermValidationRequest(
@@ -1168,6 +1172,7 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
             mock(UpdateHelper.class),
             mock(ActionFilters.class),
             mock(IndexingPressureService.class),
+            mock(SegmentReplicationPressureService.class),
             mock(SystemIndices.class)
         );
     }

--- a/server/src/test/java/org/opensearch/index/SegmentReplicationPressureServiceTest.java
+++ b/server/src/test/java/org/opensearch/index/SegmentReplicationPressureServiceTest.java
@@ -1,0 +1,207 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index;
+
+import org.mockito.stubbing.Answer;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.concurrent.OpenSearchRejectedExecutionException;
+import org.opensearch.index.engine.NRTReplicationEngineFactory;
+import org.opensearch.index.replication.OpenSearchIndexLevelReplicationTestCase;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.index.shard.ShardId;
+import org.opensearch.indices.IndicesService;
+import org.opensearch.indices.replication.common.ReplicationType;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Arrays.asList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.index.SegmentReplicationPressureService.MAX_REPLICATION_TIME_SETTING;
+import static org.opensearch.index.SegmentReplicationPressureService.SEGMENT_REPLICATION_INDEXING_PRESSURE_ENABLED;
+
+public class SegmentReplicationPressureServiceTest extends OpenSearchIndexLevelReplicationTestCase {
+
+    private static final Settings settings = Settings.builder()
+        .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+        .put(SEGMENT_REPLICATION_INDEXING_PRESSURE_ENABLED.getKey(), true)
+        .put(MAX_REPLICATION_TIME_SETTING.getKey(), TimeValue.timeValueSeconds(5))
+        .build();
+
+    public void testIsSegrepLimitBreached() throws Exception {
+        try (ReplicationGroup shards = createGroup(1, settings, new NRTReplicationEngineFactory())) {
+            shards.startAll();
+            final IndexShard primaryShard = shards.getPrimary();
+            SegmentReplicationPressureService service = buildPressureService(settings, primaryShard);
+
+            indexInBatches(5, shards, primaryShard);
+
+            SegmentReplicationStats segmentReplicationStats = service.nodeStats();
+            Map<ShardId, SegmentReplicationPerGroupStats> shardStats = segmentReplicationStats.getShardStats();
+            assertEquals(1, shardStats.size());
+            SegmentReplicationPerGroupStats groupStats = shardStats.get(primaryShard.shardId());
+            assertEquals(0, groupStats.getRejectedRequestCount());
+            Set<SegmentReplicationShardStats> replicas = groupStats.getReplicaStats();
+            assertEquals(1, replicas.size());
+            SegmentReplicationShardStats replicaStats = replicas.stream().findFirst().get();
+            assertEquals(5, replicaStats.getCheckpointsBehindCount());
+
+            assertBusy(
+                () -> expectThrows(OpenSearchRejectedExecutionException.class, () -> service.isSegrepLimitBreached(primaryShard.shardId())),
+                30,
+                TimeUnit.SECONDS
+            );
+            assertBusy(
+                () -> expectThrows(OpenSearchRejectedExecutionException.class, () -> service.isSegrepLimitBreached(primaryShard.shardId())),
+                30,
+                TimeUnit.SECONDS
+            );
+
+            // let shard catch up
+            replicateSegments(primaryShard, shards.getReplicas());
+
+            segmentReplicationStats = service.nodeStats();
+            shardStats = segmentReplicationStats.getShardStats();
+            assertEquals(1, shardStats.size());
+            groupStats = shardStats.get(primaryShard.shardId());
+            assertEquals(2, groupStats.getRejectedRequestCount());
+            replicas = groupStats.getReplicaStats();
+            assertEquals(1, replicas.size());
+            replicaStats = replicas.stream().findFirst().get();
+            assertEquals(0, replicaStats.getCheckpointsBehindCount());
+
+            service.isSegrepLimitBreached(primaryShard.shardId());
+        }
+    }
+
+    public void testIsSegrepLimitBreached_onlyCheckpointLimitBreached() throws Exception {
+        final Settings settings = Settings.builder()
+            .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+            .put(SEGMENT_REPLICATION_INDEXING_PRESSURE_ENABLED.getKey(), true)
+            .build();
+
+        try (ReplicationGroup shards = createGroup(1, settings, new NRTReplicationEngineFactory())) {
+            shards.startAll();
+            final IndexShard primaryShard = shards.getPrimary();
+            SegmentReplicationPressureService service = buildPressureService(settings, primaryShard);
+
+            indexInBatches(5, shards, primaryShard);
+
+            Set<SegmentReplicationShardStats> replicationStats = primaryShard.getReplicationStats();
+            assertEquals(1, replicationStats.size());
+            SegmentReplicationShardStats shardStats = replicationStats.stream().findFirst().get();
+            assertEquals(5, shardStats.getCheckpointsBehindCount());
+
+            service.isSegrepLimitBreached(primaryShard.shardId());
+
+            replicateSegments(primaryShard, shards.getReplicas());
+            service.isSegrepLimitBreached(primaryShard.shardId());
+            final SegmentReplicationStats segmentReplicationStats = service.nodeStats();
+            assertEquals(0, segmentReplicationStats.getShardStats().get(primaryShard.shardId()).getRejectedRequestCount());
+        }
+    }
+
+    public void testIsSegrepLimitBreached_onlyTimeLimitBreached() throws Exception {
+        final Settings settings = Settings.builder()
+            .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+            .put(SEGMENT_REPLICATION_INDEXING_PRESSURE_ENABLED.getKey(), true)
+            .build();
+
+        try (ReplicationGroup shards = createGroup(1, settings, new NRTReplicationEngineFactory())) {
+            shards.startAll();
+            final IndexShard primaryShard = shards.getPrimary();
+            final SegmentReplicationPressureService service = buildPressureService(settings, primaryShard);
+
+            indexInBatches(1, shards, primaryShard);
+
+            assertBusy(() -> {
+                Set<SegmentReplicationShardStats> replicationStats = primaryShard.getReplicationStats();
+                assertEquals(1, replicationStats.size());
+                SegmentReplicationShardStats shardStats = replicationStats.stream().findFirst().get();
+                assertTrue(shardStats.getCurrentReplicationTimeMillis() > TimeValue.timeValueSeconds(5).millis());
+            });
+
+            service.isSegrepLimitBreached(primaryShard.shardId());
+            replicateSegments(primaryShard, shards.getReplicas());
+            service.isSegrepLimitBreached(primaryShard.shardId());
+            final SegmentReplicationStats segmentReplicationStats = service.nodeStats();
+            assertEquals(0, segmentReplicationStats.getShardStats().get(primaryShard.shardId()).getRejectedRequestCount());
+        }
+    }
+
+    public void testIsSegrepLimitBreached_underStaleNodeLimit() throws Exception {
+        try (ReplicationGroup shards = createGroup(3, settings, new NRTReplicationEngineFactory())) {
+            shards.startAll();
+            final IndexShard primaryShard = shards.getPrimary();
+            indexInBatches(5, shards, primaryShard);
+            SegmentReplicationPressureService service = buildPressureService(settings, primaryShard);
+
+            assertBusy(() -> {
+                Set<SegmentReplicationShardStats> replicationStats = primaryShard.getReplicationStats();
+                assertEquals(3, replicationStats.size());
+                SegmentReplicationShardStats shardStats = replicationStats.stream().findFirst().get();
+                assertTrue(shardStats.getCurrentReplicationTimeMillis() > TimeValue.timeValueSeconds(5).millis());
+            });
+
+            expectThrows(OpenSearchRejectedExecutionException.class, () -> service.isSegrepLimitBreached(primaryShard.shardId()));
+
+            SegmentReplicationStats segmentReplicationStats = service.nodeStats();
+            assertEquals(1, segmentReplicationStats.getShardStats().get(primaryShard.shardId()).getRejectedRequestCount());
+
+            // update one replica. 2/3 stale.
+            final List<IndexShard> replicas = shards.getReplicas();
+            replicateSegments(primaryShard, asList(replicas.get(0)));
+
+            expectThrows(OpenSearchRejectedExecutionException.class, () -> service.isSegrepLimitBreached(primaryShard.shardId()));
+
+            segmentReplicationStats = service.nodeStats();
+            assertEquals(2, segmentReplicationStats.getShardStats().get(primaryShard.shardId()).getRejectedRequestCount());
+
+            // update second replica - 1/3 stale - should not throw.
+            replicateSegments(primaryShard, asList(replicas.get(1)));
+            service.isSegrepLimitBreached(primaryShard.shardId());
+
+            // catch up all.
+            replicateSegments(primaryShard, shards.getReplicas());
+            service.isSegrepLimitBreached(primaryShard.shardId());
+        }
+    }
+
+    private int indexInBatches(int count, ReplicationGroup shards, IndexShard primaryShard) throws Exception {
+        int totalDocs = 0;
+        for (int i = 0; i < count; i++) {
+            int numDocs = randomIntBetween(100, 200);
+            totalDocs += numDocs;
+            shards.indexDocs(numDocs);
+            primaryShard.refresh("Test");
+        }
+        return totalDocs;
+    }
+
+    private SegmentReplicationPressureService buildPressureService(Settings settings, IndexShard primaryShard) {
+        IndicesService indicesService = mock(IndicesService.class);
+        IndexService indexService = mock(IndexService.class);
+        when(indicesService.iterator()).thenAnswer((Answer<Iterator<IndexService>>) invocation -> List.of(indexService).iterator());
+        when(indexService.iterator()).thenAnswer((Answer<Iterator<IndexShard>>) invocation -> List.of(primaryShard).iterator());
+        when(indicesService.indexService(primaryShard.shardId().getIndex())).thenReturn(indexService);
+        when(indexService.getShard(primaryShard.shardId().id())).thenReturn(primaryShard);
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS));
+
+        return new SegmentReplicationPressureService(settings, clusterService, indicesService);
+    }
+}

--- a/server/src/test/java/org/opensearch/index/SegmentReplicationPressureServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/SegmentReplicationPressureServiceTests.java
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.when;
 import static org.opensearch.index.SegmentReplicationPressureService.MAX_REPLICATION_TIME_SETTING;
 import static org.opensearch.index.SegmentReplicationPressureService.SEGMENT_REPLICATION_INDEXING_PRESSURE_ENABLED;
 
-public class SegmentReplicationPressureServiceTest extends OpenSearchIndexLevelReplicationTestCase {
+public class SegmentReplicationPressureServiceTests extends OpenSearchIndexLevelReplicationTestCase {
 
     private static final Settings settings = Settings.builder()
         .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)

--- a/server/src/test/java/org/opensearch/index/seqno/ReplicationTrackerTests.java
+++ b/server/src/test/java/org/opensearch/index/seqno/ReplicationTrackerTests.java
@@ -1800,9 +1800,9 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
             .filter(id -> tracker.shardAllocationId.equals(id) == false)
             .collect(Collectors.toSet());
 
-        final ReplicationCheckpoint initialCheckpoint = new ReplicationCheckpoint(tracker.shardId(), 0L, 1, 0, 1, 1L);
-        final ReplicationCheckpoint secondCheckpoint = new ReplicationCheckpoint(tracker.shardId(), 0L, 2, 1, 2, 50L);
-        final ReplicationCheckpoint thirdCheckpoint = new ReplicationCheckpoint(tracker.shardId(), 0L, 2, 2, 3, 100L);
+        final ReplicationCheckpoint initialCheckpoint = new ReplicationCheckpoint(tracker.shardId(), 0L, 1, 1, 1L);
+        final ReplicationCheckpoint secondCheckpoint = new ReplicationCheckpoint(tracker.shardId(), 0L, 2, 2, 50L);
+        final ReplicationCheckpoint thirdCheckpoint = new ReplicationCheckpoint(tracker.shardId(), 0L, 2, 3, 100L);
 
         tracker.setLatestReplicationCheckpoint(initialCheckpoint);
         tracker.setLatestReplicationCheckpoint(secondCheckpoint);

--- a/server/src/test/java/org/opensearch/index/seqno/ReplicationTrackerTests.java
+++ b/server/src/test/java/org/opensearch/index/seqno/ReplicationTrackerTests.java
@@ -46,7 +46,10 @@ import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.set.Sets;
 import org.opensearch.index.IndexSettings;
+import org.opensearch.index.SegmentReplicationShardStats;
 import org.opensearch.index.shard.ShardId;
+import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
+import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.test.IndexSettingsModule;
 
 import java.io.IOException;
@@ -72,6 +75,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptySet;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REPLICATION_TYPE;
 import static org.opensearch.index.seqno.SequenceNumbers.NO_OPS_PERFORMED;
 import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 import static org.hamcrest.Matchers.equalTo;
@@ -1768,6 +1772,78 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
         );
         assertTrue(tracker.getTrackedLocalCheckpointForShard(newSyncingAllocationId.getId()).inSync);
         assertFalse(tracker.pendingInSync.contains(newSyncingAllocationId.getId()));
+    }
+
+    public void testSegmentReplicationCheckpointTracking() {
+        Settings settings = Settings.builder().put(SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT).build();
+        final long initialClusterStateVersion = randomNonNegativeLong();
+        final int numberOfActiveAllocationsIds = randomIntBetween(2, 16);
+        final int numberOfInitializingIds = randomIntBetween(2, 16);
+        final Tuple<Set<AllocationId>, Set<AllocationId>> activeAndInitializingAllocationIds = randomActiveAndInitializingAllocationIds(
+            numberOfActiveAllocationsIds,
+            numberOfInitializingIds
+        );
+        final Set<AllocationId> activeAllocationIds = activeAndInitializingAllocationIds.v1();
+        final Set<AllocationId> initializingIds = activeAndInitializingAllocationIds.v2();
+        AllocationId primaryId = activeAllocationIds.iterator().next();
+        IndexShardRoutingTable routingTable = routingTable(initializingIds, primaryId);
+        final ReplicationTracker tracker = newTracker(primaryId, settings);
+        tracker.updateFromClusterManager(initialClusterStateVersion, ids(activeAllocationIds), routingTable);
+        tracker.activatePrimaryMode(NO_OPS_PERFORMED);
+        assertThat(tracker.getReplicationGroup().getInSyncAllocationIds(), equalTo(ids(activeAllocationIds)));
+        assertThat(tracker.getReplicationGroup().getRoutingTable(), equalTo(routingTable));
+        assertTrue(activeAllocationIds.stream().allMatch(a -> tracker.getTrackedLocalCheckpointForShard(a.getId()).inSync));
+        // get insync ids, filter out the primary.
+        final Set<String> inSyncAllocationIds = tracker.getReplicationGroup()
+            .getInSyncAllocationIds()
+            .stream()
+            .filter(id -> tracker.shardAllocationId.equals(id) == false)
+            .collect(Collectors.toSet());
+
+        final ReplicationCheckpoint initialCheckpoint = new ReplicationCheckpoint(tracker.shardId(), 0L, 1, 0, 1, 1L);
+        final ReplicationCheckpoint secondCheckpoint = new ReplicationCheckpoint(tracker.shardId(), 0L, 2, 1, 2, 50L);
+        final ReplicationCheckpoint thirdCheckpoint = new ReplicationCheckpoint(tracker.shardId(), 0L, 2, 2, 3, 100L);
+
+        tracker.setLatestReplicationCheckpoint(initialCheckpoint);
+        tracker.setLatestReplicationCheckpoint(secondCheckpoint);
+        tracker.setLatestReplicationCheckpoint(thirdCheckpoint);
+
+        Set<SegmentReplicationShardStats> groupStats = tracker.getSegmentReplicationStats();
+        assertEquals(inSyncAllocationIds.size(), groupStats.size());
+        for (SegmentReplicationShardStats shardStat : groupStats) {
+            assertEquals(3, shardStat.getCheckpointsBehindCount());
+            assertEquals(100L, shardStat.getBytesBehindCount());
+        }
+
+        // simulate replicas moved up to date.
+        final Map<String, ReplicationTracker.CheckpointState> checkpoints = tracker.checkpoints;
+        for (String id : inSyncAllocationIds) {
+            final ReplicationTracker.CheckpointState checkpointState = checkpoints.get(id);
+            assertEquals(3, checkpointState.checkpointTimers.size());
+            tracker.updateVisibleCheckpointForShard(id, initialCheckpoint);
+            assertEquals(2, checkpointState.checkpointTimers.size());
+        }
+
+        groupStats = tracker.getSegmentReplicationStats();
+        assertEquals(inSyncAllocationIds.size(), groupStats.size());
+        for (SegmentReplicationShardStats shardStat : groupStats) {
+            assertEquals(2, shardStat.getCheckpointsBehindCount());
+            assertEquals(99L, shardStat.getBytesBehindCount());
+        }
+
+        for (String id : inSyncAllocationIds) {
+            final ReplicationTracker.CheckpointState checkpointState = checkpoints.get(id);
+            assertEquals(2, checkpointState.checkpointTimers.size());
+            tracker.updateVisibleCheckpointForShard(id, thirdCheckpoint);
+            assertEquals(0, checkpointState.checkpointTimers.size());
+        }
+
+        groupStats = tracker.getSegmentReplicationStats();
+        assertEquals(inSyncAllocationIds.size(), groupStats.size());
+        for (SegmentReplicationShardStats shardStat : groupStats) {
+            assertEquals(0, shardStat.getCheckpointsBehindCount());
+            assertEquals(0L, shardStat.getBytesBehindCount());
+        }
     }
 
     public void testPrimaryContextHandoffWithRemoteTranslogEnabled() throws IOException {

--- a/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
@@ -258,7 +258,7 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
         refreshListener.afterRefresh(true);
 
         // verify checkpoint is published
-        verify(mock, times(1)).publish(any());
+        verify(mock, times(1)).publish(any(), any());
         closeShards(shard);
     }
 
@@ -280,7 +280,7 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
         refreshListener.afterRefresh(true);
 
         // verify checkpoint is not published
-        verify(mock, times(0)).publish(any());
+        verify(mock, times(0)).publish(any(), any());
         closeShards(shard);
     }
 

--- a/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationSourceHandlerTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationSourceHandlerTests.java
@@ -73,7 +73,7 @@ public class SegmentReplicationSourceHandlerTests extends IndexShardTestCase {
             chunkWriter,
             threadPool,
             copyState,
-            primary.routingEntry().allocationId().getId(),
+            replica.routingEntry().allocationId().getId(),
             5000,
             1
         );
@@ -111,7 +111,7 @@ public class SegmentReplicationSourceHandlerTests extends IndexShardTestCase {
             chunkWriter,
             threadPool,
             copyState,
-            primary.routingEntry().allocationId().getId(),
+            replica.routingEntry().allocationId().getId(),
             5000,
             1
         );
@@ -191,7 +191,7 @@ public class SegmentReplicationSourceHandlerTests extends IndexShardTestCase {
             chunkWriter,
             threadPool,
             copyState,
-            primary.routingEntry().allocationId().getId(),
+            replica.routingEntry().allocationId().getId(),
             5000,
             1
         );

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -169,6 +169,7 @@ import org.opensearch.gateway.MetaStateService;
 import org.opensearch.gateway.TransportNodesListGatewayStartedShards;
 import org.opensearch.index.Index;
 import org.opensearch.index.IndexingPressureService;
+import org.opensearch.index.SegmentReplicationPressureService;
 import org.opensearch.index.analysis.AnalysisRegistry;
 import org.opensearch.index.seqno.GlobalCheckpointSyncAction;
 import org.opensearch.index.seqno.RetentionLeaseSyncer;
@@ -1978,6 +1979,7 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                     new UpdateHelper(scriptService),
                     actionFilters,
                     new IndexingPressureService(settings, clusterService),
+                    new SegmentReplicationPressureService(settings, clusterService, mock(IndicesService.class)),
                     new SystemIndices(emptyMap())
                 );
                 actions.put(

--- a/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
@@ -1365,6 +1365,10 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
                             assertTrue(recoveryDiff.missing.isEmpty());
                             assertTrue(recoveryDiff.different.isEmpty());
                             assertEquals(recoveryDiff.identical.size(), primaryMetadata.size());
+                            primaryShard.updateVisibleCheckpointForShard(
+                                replica.routingEntry().allocationId().getId(),
+                                primaryShard.getLatestReplicationCheckpoint()
+                            );
                         } catch (Exception e) {
                             throw ExceptionsHelper.convertToRuntime(e);
                         } finally {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR is a re-cut of https://github.com/opensearch-project/OpenSearch/pull/6520 that includes implementing backpressure and removes the addition of these metrics to NodeStats API.  This is to make it easier to see in this PR how this will be used to implement pressure.  The metrics additions will be in a separate change.

This PR adds backpressure for index operations when Segment Replication is enabled.

This PR implements backpressure mechanisms for segment replication to prevent lagging
replicas from falling too far behind. Writes will be rejected under the following conditions:

1. More than half (default setting) of the replication group is 'stale'.  Defined by setting MAX_ALLOWED_STALE_SHARDS.
2. A replica is stale if it is behind more than MAX_INDEXING_CHECKPOINTS, default 4 AND its current replication lag is over
MAX_REPLICATION_TIME_SETTING, default 5 minutes.

This PR intentionally implements rejections only for index operations,
allowing other TransportWriteActions to succeed, TransportResyncReplicationAction and RetentionLeaseSyncAction.
Blocking these requests will fail recoveries as new nodes are added.

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/4478

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
