### PR TITLE
Fix to ensure fail open causes operations to complete. Also includes …

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/cluster/routing/WeightedRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/routing/WeightedRoutingIT.java
@@ -640,21 +640,17 @@ public class WeightedRoutingIT extends OpenSearchIntegTestCase {
 
         // Check cluster health for weighed in node when cluster manager is not discovered, health check should
         // return a response with 503 status code
-        assertThrows(ClusterManagerNotDiscoveredException.class, () -> client(nodes_in_zone_a.get(0)).admin()
-            .cluster()
-            .prepareHealth()
-            .setLocal(true)
-            .setEnsureNodeWeighedIn(true)
-            .get());
+        assertThrows(
+            ClusterManagerNotDiscoveredException.class,
+            () -> client(nodes_in_zone_a.get(0)).admin().cluster().prepareHealth().setLocal(true).setEnsureNodeWeighedIn(true).get()
+        );
 
         // Check cluster health for weighed away node when cluster manager is not discovered, health check should
         // return a response with 503 status code
-        assertThrows(ClusterManagerNotDiscoveredException.class, () -> client(nodes_in_zone_c.get(0)).admin()
-            .cluster()
-            .prepareHealth()
-            .setLocal(true)
-            .setEnsureNodeWeighedIn(true)
-            .get());
+        assertThrows(
+            ClusterManagerNotDiscoveredException.class,
+            () -> client(nodes_in_zone_c.get(0)).admin().cluster().prepareHealth().setLocal(true).setEnsureNodeWeighedIn(true).get()
+        );
         networkDisruption.stopDisrupting();
         Thread.sleep(1000);
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -62,6 +62,7 @@ import org.opensearch.common.inject.Inject;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.CollectionUtils;
+import org.opensearch.discovery.ClusterManagerNotDiscoveredException;
 import org.opensearch.discovery.Discovery;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.node.NodeClosedException;
@@ -281,7 +282,7 @@ public class TransportClusterHealthAction extends TransportClusterManagerNodeRea
             ClusterHealthResponse clusterHealthResponse = getResponse(request, currentState, waitCount, TimeoutState.OK);
             if (request.ensureNodeWeighedIn()) {
                 if (clusterHealthResponse.hasDiscoveredClusterManager() == false) {
-                    listener.onFailure(new NotClusterManagerException("cluster-manager not discovered"));
+                    listener.onFailure(new ClusterManagerNotDiscoveredException("cluster-manager not discovered"));
                 } else {
                     DiscoveryNode localNode = currentState.getNodes().getLocalNode();
                     // TODO: make this check more generic, check for node role instead

--- a/server/src/main/java/org/opensearch/action/fieldcaps/TransportFieldCapabilitiesIndexAction.java
+++ b/server/src/main/java/org/opensearch/action/fieldcaps/TransportFieldCapabilitiesIndexAction.java
@@ -266,7 +266,8 @@ public class TransportFieldCapabilitiesIndexAction extends HandledTransportActio
             if (shardsIt.size() == 0 || shardIndex >= shardsIt.size()) {
                 return null;
             }
-            ShardRouting next = FailAwareWeightedRouting.getInstance().findNext(shardsIt.get(shardIndex), clusterService.state(), failure);
+            ShardRouting next = FailAwareWeightedRouting.getInstance()
+                .findNext(shardsIt.get(shardIndex), clusterService.state(), failure, () -> ++shardIndex);
 
             if (next != null) {
                 return next;

--- a/server/src/main/java/org/opensearch/action/fieldcaps/TransportFieldCapabilitiesIndexAction.java
+++ b/server/src/main/java/org/opensearch/action/fieldcaps/TransportFieldCapabilitiesIndexAction.java
@@ -267,7 +267,7 @@ public class TransportFieldCapabilitiesIndexAction extends HandledTransportActio
                 return null;
             }
             ShardRouting next = FailAwareWeightedRouting.getInstance()
-                .findNext(shardsIt.get(shardIndex), clusterService.state(), failure, () -> ++shardIndex);
+                .findNext(shardsIt.get(shardIndex), clusterService.state(), failure, this::moveToNextShard);
 
             if (next != null) {
                 return next;

--- a/server/src/main/java/org/opensearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/opensearch/action/search/AbstractSearchAsyncAction.java
@@ -450,7 +450,8 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
         // we always add the shard failure for a specific shard instance
         // we do make sure to clean it on a successful response from a shard
         onShardFailure(shardIndex, shard, e);
-        SearchShardTarget nextShard = FailAwareWeightedRouting.getInstance().findNext(shardIt, clusterState, e);
+        SearchShardTarget nextShard = FailAwareWeightedRouting.getInstance()
+            .findNext(shardIt, clusterState, e, () -> totalOps.incrementAndGet());
 
         final boolean lastShard = nextShard == null;
         logger.debug(

--- a/server/src/main/java/org/opensearch/action/support/broadcast/TransportBroadcastAction.java
+++ b/server/src/main/java/org/opensearch/action/support/broadcast/TransportBroadcastAction.java
@@ -251,7 +251,8 @@ public abstract class TransportBroadcastAction<
             // we set the shard failure always, even if its the first in the replication group, and the next one
             // will work (it will just override it...)
             setFailure(shardIt, shardIndex, e);
-            ShardRouting nextShard = FailAwareWeightedRouting.getInstance().findNext(shardIt, clusterService.state(), e);
+            ShardRouting nextShard = FailAwareWeightedRouting.getInstance()
+                .findNext(shardIt, clusterService.state(), e, () -> counterOps.incrementAndGet());
 
             if (nextShard != null) {
                 if (e != null) {

--- a/server/src/main/java/org/opensearch/action/support/single/shard/TransportSingleShardAction.java
+++ b/server/src/main/java/org/opensearch/action/support/single/shard/TransportSingleShardAction.java
@@ -245,7 +245,8 @@ public abstract class TransportSingleShardAction<Request extends SingleShardRequ
                 lastFailure = currentFailure;
                 this.lastFailure = currentFailure;
             }
-            ShardRouting shardRouting = FailAwareWeightedRouting.getInstance().findNext(shardIt, clusterService.state(), currentFailure);
+            ShardRouting shardRouting = FailAwareWeightedRouting.getInstance()
+                .findNext(shardIt, clusterService.state(), currentFailure, () -> {});
 
             if (shardRouting == null) {
                 Exception failure = lastFailure;

--- a/server/src/main/java/org/opensearch/cluster/routing/FailAwareWeightedRouting.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/FailAwareWeightedRouting.java
@@ -62,7 +62,12 @@ public class FailAwareWeightedRouting {
      * @param shardIt Shard Iterator containing order in which shard copies for a shard need to be requested
      * @return the next shard copy
      */
-    public SearchShardTarget findNext(final SearchShardIterator shardIt, ClusterState clusterState, Exception exception) {
+    public SearchShardTarget findNext(
+        final SearchShardIterator shardIt,
+        ClusterState clusterState,
+        Exception exception,
+        Runnable onShardSkipped
+    ) {
         SearchShardTarget next = shardIt.nextOrNull();
         while (next != null && WeightedRoutingUtils.isWeighedAway(next.getNodeId(), clusterState)) {
             SearchShardTarget nextShard = next;
@@ -72,6 +77,7 @@ public class FailAwareWeightedRouting {
                 break;
             }
             next = shardIt.nextOrNull();
+            onShardSkipped.run();
         }
         return next;
     }
@@ -84,7 +90,7 @@ public class FailAwareWeightedRouting {
      * @param shardsIt Shard Iterator containing order in which shard copies for a shard need to be requested
      * @return the next shard copy
      */
-    public ShardRouting findNext(final ShardsIterator shardsIt, ClusterState clusterState, Exception exception) {
+    public ShardRouting findNext(final ShardsIterator shardsIt, ClusterState clusterState, Exception exception, Runnable onShardSkipped) {
         ShardRouting next = shardsIt.nextOrNull();
 
         while (next != null && WeightedRoutingUtils.isWeighedAway(next.currentNodeId(), clusterState)) {
@@ -95,6 +101,7 @@ public class FailAwareWeightedRouting {
                 break;
             }
             next = shardsIt.nextOrNull();
+            onShardSkipped.run();
         }
         return next;
     }

--- a/server/src/main/java/org/opensearch/cluster/routing/FailAwareWeightedRouting.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/FailAwareWeightedRouting.java
@@ -60,6 +60,9 @@ public class FailAwareWeightedRouting {
      * routing weight set to zero
      *
      * @param shardIt Shard Iterator containing order in which shard copies for a shard need to be requested
+     * @param clusterState The current cluster state
+     * @param exception The underlying search exception
+     * @param onShardSkipped The runnable to execute once a shard is skipped
      * @return the next shard copy
      */
     public SearchShardTarget findNext(
@@ -88,6 +91,9 @@ public class FailAwareWeightedRouting {
      * routing weight set to zero
      *
      * @param shardsIt Shard Iterator containing order in which shard copies for a shard need to be requested
+     * @param clusterState The current cluster state
+     * @param exception The underlying search exception
+     * @param onShardSkipped The runnable to execute once a shard is skipped
      * @return the next shard copy
      */
     public ShardRouting findNext(final ShardsIterator shardsIt, ClusterState clusterState, Exception exception, Runnable onShardSkipped) {


### PR DESCRIPTION
…a minor change to throw 503 on ensure_node_weighed_in

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
```
curl -XPOST "http://localhost:9200/my-knn-index-2/_search?pretty" -H 'Content-Type: application/json' -d'                                      
{
  "size": 2,
  "query": {
    "knn": {
      "my_vectorX": {
        "vector": [2, 3],
        "k": 2
      }
    }
  }
}'

Request with `illegal_argument_exception` gets stuck since the underlying operation is skipped and don't match the expected ops when zones are weighed away.
```


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
