### PR TITLE
[Segment Replication] Prevent segment replication for ineligible targets during recovery

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -12,6 +12,7 @@ import com.carrotsearch.randomizedtesting.RandomizedTest;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.client.Requests;
+import org.opensearch.cluster.health.ClusterHealthStatus;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.allocation.command.CancelAllocationCommand;
@@ -26,6 +27,7 @@ import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.transport.MockTransportService;
 import org.opensearch.transport.TransportService;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -282,6 +284,27 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
             refresh(INDEX_NAME);
             verifyStoreContent();
         }
+    }
+
+    /**
+     * This test verifies that segment replication does not fail for closed indices
+     */
+    public void testClosedIndices() {
+        internalCluster().startClusterManagerOnlyNode();
+        List<String> nodes = new ArrayList<>();
+        // start 1st node so that it contains the primary
+        nodes.add(internalCluster().startNode());
+        createIndex(INDEX_NAME, super.indexSettings());
+        ensureYellowAndNoInitializingShards(INDEX_NAME);
+        // start 2nd node so that it contains the replica
+        nodes.add(internalCluster().startNode());
+        ensureGreen(INDEX_NAME);
+
+        logger.info("--> Close index");
+        assertAcked(client().admin().indices().prepareClose(INDEX_NAME));
+
+        logger.info("--> waiting for allocation to have shards assigned");
+        waitForRelocation(ClusterHealthStatus.GREEN);
     }
 
     public void testCancellation() throws Exception {

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1509,15 +1509,15 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             logger.warn("Shard is in primary mode and cannot perform segment replication as a replica.");
             return false;
         }
-        if (this.routingEntry().primary()) {
-            logger.warn("Shard is marked as primary and cannot perform segment replication as a replica");
+        if (this.routingEntry().primary() && this.routingEntry().isRelocationTarget() == false) {
+            logger.warn("Shard is marked as primary but not relocating, so cannot perform segment replication");
             return false;
         }
         if (state().equals(IndexShardState.STARTED) == false
-            && (state() == IndexShardState.RECOVERING && shardRouting.state() == ShardRoutingState.INITIALIZING) == false) {
+            && ((state() == IndexShardState.RECOVERING || state() == IndexShardState.POST_RECOVERY) && shardRouting.state() == ShardRoutingState.INITIALIZING) == false) {
             logger.warn(
                 () -> new ParameterizedMessage(
-                    "Shard is not started or recovering {} {} and cannot perform segment replication as a replica",
+                    "Shard is not started or recovering {} {} and cannot perform segment replication",
                     state(),
                     shardRouting.state()
                 )

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1514,7 +1514,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             return false;
         }
         if (state().equals(IndexShardState.STARTED) == false
-            && ((state() == IndexShardState.RECOVERING || state() == IndexShardState.POST_RECOVERY) && shardRouting.state() == ShardRoutingState.INITIALIZING) == false) {
+            && ((state() == IndexShardState.RECOVERING || state() == IndexShardState.POST_RECOVERY)
+                && shardRouting.state() == ShardRoutingState.INITIALIZING) == false) {
             logger.warn(
                 () -> new ParameterizedMessage(
                     "Shard is not started or recovering {} {} and cannot perform segment replication",

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1514,7 +1514,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             return false;
         }
         if (state().equals(IndexShardState.STARTED) == false
-            && (state() == IndexShardState.POST_RECOVERY && shardRouting.state() == ShardRoutingState.INITIALIZING) == false) {
+            && (state() == IndexShardState.RECOVERING && shardRouting.state() == ShardRoutingState.INITIALIZING) == false) {
             logger.warn(
                 () -> new ParameterizedMessage(
                     "Shard is not started or recovering {} {} and cannot perform segment replication as a replica",

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
@@ -389,6 +389,11 @@ public class SegmentReplicationTargetService implements IndexEventListener {
         public void messageReceived(final ForceSyncRequest request, TransportChannel channel, Task task) throws Exception {
             assert indicesService != null;
             final IndexShard indexShard = indicesService.getShardOrNull(request.getShardId());
+            // Proceed with round of segment replication only when it is allowed
+            if (indexShard.isSegmentReplicationAllowed() == false) {
+                channel.sendResponse(TransportResponse.Empty.INSTANCE);
+                return;
+            }
             startReplication(
                 ReplicationCheckpoint.empty(request.getShardId()),
                 indexShard,


### PR DESCRIPTION
### Description
Prevent round of force segment replication during recovery for ineligible targets. This was identified for closed indices whose shards remain allocated to nodes with `NoOpEngine` type. 

Changes:
1. Change `IndexShardState.POST_RECOVERY` to  `IndexShardState.RECOVERING` inside `isSegmentReplicationAllowed` as segment replication is now performed during recovery finalization step as part of https://github.com/opensearch-project/OpenSearch/pull/5746
2. Use `isSegmentReplicationAllowed` inside force segment replication on target service.

### Issues Resolved
#6608 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
