### PR TITLE
[Backport] [2.x] Removed NOT_FOUND for empty results. (#6544)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Segment Replication] Allocation and rebalancing based on average primary shard count per index ([#6422](https://github.com/opensearch-project/OpenSearch/pull/6422))
 - The truncation limit of the OpenSearchJsonLayout logger is now configurable ([#6569](https://github.com/opensearch-project/OpenSearch/pull/6569))
 - Add 'base_path' setting to File System Repository ([#6558](https://github.com/opensearch-project/OpenSearch/pull/6558))
+- Return success on DeletePits when no PITs exist. ([#6544](https://github.com/opensearch-project/OpenSearch/pull/6544))
 
 ### Dependencies
 - Bump `org.apache.logging.log4j:log4j-core` from 2.18.0 to 2.20.0 ([#6490](https://github.com/opensearch-project/OpenSearch/pull/6490))

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/pit/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/pit/10_basic.yml
@@ -138,5 +138,7 @@
   - match: {pits.0.successful: true }
 
   - do:
-      catch: missing
-      delete_all_pits: { }
+      delete_all_pits: {}
+
+  - match: {pits: []}
+  - length: {pits: 0}

--- a/server/src/main/java/org/opensearch/action/search/DeletePitResponse.java
+++ b/server/src/main/java/org/opensearch/action/search/DeletePitResponse.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.opensearch.common.xcontent.ConstructingObjectParser.constructorArg;
-import static org.opensearch.rest.RestStatus.NOT_FOUND;
 import static org.opensearch.rest.RestStatus.OK;
 
 /**
@@ -57,7 +56,6 @@ public class DeletePitResponse extends ActionResponse implements StatusToXConten
      */
     @Override
     public RestStatus status() {
-        if (deletePitResults.isEmpty()) return NOT_FOUND;
         return OK;
     }
 

--- a/server/src/test/java/org/opensearch/search/DeletePitResponseTests.java
+++ b/server/src/test/java/org/opensearch/search/DeletePitResponseTests.java
@@ -43,7 +43,7 @@ public class DeletePitResponseTests extends OpenSearchTestCase {
     public void testDeletePitResponseToAndFromXContent() throws IOException {
         XContentType xContentType = randomFrom(XContentType.values());
         DeletePitResponse originalResponse = createDeletePitResponseTestItem();
-        ;
+
         BytesReference originalBytes = toShuffledXContent(originalResponse, xContentType, ToXContent.EMPTY_PARAMS, randomBoolean());
         DeletePitResponse parsedResponse;
         try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fix for the issue due to which 404 was returned when no PITs were present.
Backport to 2.x branch failed https://github.com/opensearch-project/OpenSearch/pull/6544

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/5938

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
