### PR TITLE
[Segment Replication] Fix flaky test testRelocateWhileContinuouslyIndexingAndWaitingForRefresh

### DIFF
--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -2998,6 +2998,9 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
      * @return the replication group
      */
     public ReplicationGroup getReplicationGroup() {
+        if (indexSettings.isSegRepEnabled() && replicationTracker.isPrimaryMode() == false) {
+            throw new OpenSearchException("shard is not in primary mode");
+        }
         assert assertPrimaryMode();
         verifyNotClosed();
         ReplicationGroup replicationGroup = replicationTracker.getReplicationGroup();

--- a/server/src/main/java/org/opensearch/indices/replication/checkpoint/PublishCheckpointAction.java
+++ b/server/src/main/java/org/opensearch/indices/replication/checkpoint/PublishCheckpointAction.java
@@ -118,7 +118,12 @@ public class PublishCheckpointAction extends TransportReplicationAction<
             PublishCheckpointRequest request = new PublishCheckpointRequest(indexShard.getLatestReplicationCheckpoint());
             final ReplicationCheckpoint checkpoint = request.getCheckpoint();
 
-            final List<ShardRouting> replicationTargets = indexShard.getReplicationGroup().getReplicationTargets();
+            final List<ShardRouting> replicationTargets;
+            try {
+                replicationTargets = indexShard.getReplicationGroup().getReplicationTargets();
+            } catch (OpenSearchException e) {
+                return;
+            }
             for (ShardRouting replicationTarget : replicationTargets) {
                 if (replicationTarget.primary()) {
                     continue;

--- a/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
@@ -12,6 +12,7 @@ import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.SegmentInfos;
 import org.junit.Assert;
 import org.opensearch.ExceptionsHelper;
+import org.opensearch.OpenSearchException;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.index.IndexRequest;
@@ -157,6 +158,14 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
         assertNotNull(segmentInfos);
         assertEquals(checkpoint.getSegmentInfosVersion(), segmentInfos.getVersion());
         assertEquals(checkpoint.getSegmentsGen(), segmentInfos.getGeneration());
+    }
+
+    public void testGetReplicationGroupOnReplica() throws IOException {
+        final IndexShard indexShard = newShard(false, settings);
+        OpenSearchException exception = assertThrows(OpenSearchException.class, () -> indexShard.getReplicationGroup());
+        String expectedMessage = "shard is not in primary mode";
+        assertEquals(expectedMessage, exception.getMessage());
+        closeShards(indexShard);
     }
 
     public void testIsSegmentReplicationAllowed_WrongEngineType() throws IOException {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR fixes the flaky Test failing in `SegmentReplicationRelocationIT.testRelocateWhileContinuouslyIndexingAndWaitingForRefresh`. This PR is the best effort to reduce flakiness.

### Issues Resolved
#6531 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
