### PR TITLE
Revert "[Segment Replication] Update RefreshPolicy.WAIT_UNTIL for rep…

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -27,6 +27,7 @@ import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.transport.MockTransportService;
 import org.opensearch.transport.TransportService;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -9,9 +9,6 @@
 package org.opensearch.indices.replication;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
-import org.opensearch.OpenSearchCorruptionException;
-import org.opensearch.action.ActionFuture;
-import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.client.Requests;
@@ -24,18 +21,15 @@ import org.opensearch.index.IndexModule;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.indices.recovery.FileChunkRequest;
 import org.opensearch.indices.replication.common.ReplicationType;
-import org.opensearch.rest.RestStatus;
 import org.opensearch.test.BackgroundIndexer;
 import org.opensearch.test.InternalTestCluster;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.transport.MockTransportService;
 import org.opensearch.transport.TransportService;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import static java.util.Arrays.asList;
 import static org.opensearch.index.query.QueryBuilders.matchQuery;
@@ -605,99 +599,4 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
             verifyStoreContent();
         }
     }
-
-    public void testWaitUntilRefresh() throws Exception {
-        final String primaryNode = internalCluster().startNode();
-        createIndex(INDEX_NAME);
-        ensureYellowAndNoInitializingShards(INDEX_NAME);
-        final String replicaNode = internalCluster().startNode();
-        ensureGreen(INDEX_NAME);
-        final int initialDocCount = scaledRandomIntBetween(6000, 7000);
-        final List<ActionFuture<IndexResponse>> pendingIndexResponses = new ArrayList<>();
-        IndexShard primaryShard = getIndexShard(primaryNode, INDEX_NAME);
-        IndexShard replicaShard = getIndexShard(replicaNode, INDEX_NAME);
-
-        for (int i = 0; i < initialDocCount; i++) {
-            pendingIndexResponses.add(
-                client().prepareIndex(INDEX_NAME)
-                    .setId(Integer.toString(i))
-                    .setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL)
-                    .setSource("field", "value" + i)
-                    .execute()
-            );
-        }
-        assertBusy(() -> {
-            assertTrue(pendingIndexResponses.stream().allMatch(response -> response.actionGet().status().equals(RestStatus.CREATED)));
-            assertEquals(primaryShard.getProcessedLocalCheckpoint(), replicaShard.getProcessedLocalCheckpoint());
-        }, 1, TimeUnit.MINUTES);
-        assertHitCount(client(primaryNode).prepareSearch(INDEX_NAME).setPreference("_only_local").setSize(0).get(), initialDocCount);
-        assertHitCount(client(replicaNode).prepareSearch(INDEX_NAME).setPreference("_only_local").setSize(0).get(), initialDocCount);
-    }
-
-    public void testWaitUntilWhenReplicaPromoted() throws Exception {
-        final String primaryNode = internalCluster().startNode();
-        createIndex(INDEX_NAME);
-        ensureYellowAndNoInitializingShards(INDEX_NAME);
-        final String replicaNode = internalCluster().startNode();
-        final CountDownLatch waitForReplication = new CountDownLatch(1);
-        // Mock transport service to add behaviour of throwing corruption exception during segment replication process.
-        MockTransportService mockTransportService = ((MockTransportService) internalCluster().getInstance(
-            TransportService.class,
-            primaryNode
-        ));
-        mockTransportService.addSendBehavior(
-            internalCluster().getInstance(TransportService.class, replicaNode),
-            (connection, requestId, action, request, options) -> {
-                if (action.equals(SegmentReplicationTargetService.Actions.FILE_CHUNK)) {
-                    try {
-                        waitForReplication.await();
-                    } catch (InterruptedException e) {
-                        throw new RuntimeException(e);
-                    }
-                    throw new OpenSearchCorruptionException("expected");
-                }
-                connection.sendRequest(requestId, action, request, options);
-            }
-        );
-        ensureGreen(INDEX_NAME);
-        final int initialDocCount = scaledRandomIntBetween(700, 5000);
-        final List<ActionFuture<IndexResponse>> pendingIndexResponses = new ArrayList<>();
-        for (int i = 0; i < initialDocCount; i++) {
-            pendingIndexResponses.add(
-                client().prepareIndex(INDEX_NAME)
-                    .setId(Integer.toString(i))
-                    .setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL)
-                    .setSource("field", "value" + i)
-                    .execute()
-            );
-        }
-        internalCluster().stopRandomNode(InternalTestCluster.nameFilter(primaryNode));
-        final ShardRouting replicaShardRouting = getShardRoutingForNodeName(replicaNode);
-        assertNotNull(replicaShardRouting);
-        waitForReplication.countDown();
-        assertBusy(() -> {
-            assertTrue(replicaShardRouting + " should be promoted as a primary", replicaShardRouting.primary());
-            client().admin().indices().prepareRefresh().execute().actionGet();
-            assertTrue(pendingIndexResponses.stream().allMatch(ActionFuture::isDone));
-        }, 1, TimeUnit.MINUTES);
-        int successfulDocCount = 0;
-        for (ActionFuture<IndexResponse> response : pendingIndexResponses) {
-            try {
-                IndexResponse indexResponse = response.actionGet();
-                successfulDocCount++;
-            } catch (Exception e) {
-                logger.trace("Failed to index Doc", e);
-            }
-        }
-        assertTrue(
-            client(replicaNode).prepareSearch(INDEX_NAME)
-                .setPreference("_only_local")
-                .setSize(0)
-                .get()
-                .getHits()
-                .getTotalHits().value >= successfulDocCount
-        );
-
-    }
-
 }

--- a/server/src/main/java/org/opensearch/action/resync/TransportResyncReplicationAction.java
+++ b/server/src/main/java/org/opensearch/action/resync/TransportResyncReplicationAction.java
@@ -169,7 +169,7 @@ public class TransportResyncReplicationAction extends TransportWriteAction<
     ) {
         ActionListener.completeWith(listener, () -> {
             Translog.Location location = performOnReplica(request, replica);
-            return new WriteReplicaResult<>(request, location, null, null, replica, logger);
+            return new WriteReplicaResult<>(request, location, null, replica, logger);
         });
     }
 

--- a/server/src/main/java/org/opensearch/index/engine/NRTReplicationEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/NRTReplicationEngine.java
@@ -309,22 +309,11 @@ public class NRTReplicationEngine extends Engine {
     }
 
     @Override
-    public void refresh(String source) throws EngineException {
-        maybeRefresh(source);
-    }
+    public void refresh(String source) throws EngineException {}
 
     @Override
     public boolean maybeRefresh(String source) throws EngineException {
-        try {
-            return readerManager.maybeRefresh();
-        } catch (IOException e) {
-            try {
-                failEngine("refresh failed source[" + source + "]", e);
-            } catch (Exception inner) {
-                e.addSuppressed(inner);
-            }
-            throw new RefreshFailedEngineException(shardId, e);
-        }
+        return false;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/engine/NRTReplicationReaderManager.java
+++ b/server/src/main/java/org/opensearch/index/engine/NRTReplicationReaderManager.java
@@ -51,10 +51,6 @@ public class NRTReplicationReaderManager extends OpenSearchReaderManager {
     @Override
     protected OpenSearchDirectoryReader refreshIfNeeded(OpenSearchDirectoryReader referenceToRefresh) throws IOException {
         Objects.requireNonNull(referenceToRefresh);
-        // checks if an actual refresh (change in segments) happened
-        if (unwrapStandardReader(referenceToRefresh).getSegmentInfos().version == currentInfos.version) {
-            return null;
-        }
         final List<LeafReader> subs = new ArrayList<>();
         final StandardDirectoryReader standardDirectoryReader = unwrapStandardReader(referenceToRefresh);
         for (LeafReaderContext ctx : standardDirectoryReader.leaves()) {

--- a/server/src/main/java/org/opensearch/index/seqno/RetentionLeaseSyncAction.java
+++ b/server/src/main/java/org/opensearch/index/seqno/RetentionLeaseSyncAction.java
@@ -202,7 +202,7 @@ public class RetentionLeaseSyncAction extends TransportWriteAction<
             Objects.requireNonNull(replica);
             replica.updateRetentionLeasesOnReplica(request.getRetentionLeases());
             replica.persistRetentionLeases();
-            return new WriteReplicaResult<>(request, null, null, null, replica, getLogger());
+            return new WriteReplicaResult<>(request, null, null, replica, getLogger());
         });
     }
 

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -3994,8 +3994,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             () -> refresh("too_many_listeners"),
             logger,
             threadPool.getThreadContext(),
-            externalRefreshMetric,
-            this::getProcessedLocalCheckpoint
+            externalRefreshMetric
         );
     }
 
@@ -4138,7 +4137,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         markSearcherAccessed(); // move the shard into non-search idle
         final Translog.Location location = pendingRefreshLocation.get();
         if (location != null) {
-            addRefreshListener(location, null, (b) -> {
+            addRefreshListener(location, (b) -> {
                 pendingRefreshLocation.compareAndSet(location, null);
                 listener.accept(true);
             });
@@ -4148,14 +4147,13 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     }
 
     /**
-     * Add a listener for refreshes. Only on Segment replication enabled replica shards we listen for maxSeqNo. In all other cases we listen for translog location
+     * Add a listener for refreshes.
      *
-     * @param location the translog location to listen for on a refresh
-     * @param maxSeqNo the Sequence Number to listen for on a refresh
+     * @param location the location to listen for
      * @param listener for the refresh. Called with true if registering the listener ran it out of slots and forced a refresh. Called with
      *        false otherwise.
      */
-    public void addRefreshListener(Translog.Location location, Long maxSeqNo, Consumer<Boolean> listener) {
+    public void addRefreshListener(Translog.Location location, Consumer<Boolean> listener) {
         final boolean readAllowed;
         if (isReadAllowed()) {
             readAllowed = true;
@@ -4168,11 +4166,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             }
         }
         if (readAllowed) {
-            if (indexSettings.isSegRepEnabled() && shardRouting.primary() == false) {
-                refreshListeners.addOrNotify(maxSeqNo, listener);
-            } else {
-                refreshListeners.addOrNotify(location, listener);
-            }
+            refreshListeners.addOrNotify(location, listener);
         } else {
             // we're not yet ready fo ready for reads, just ignore refresh cycles
             listener.accept(false);

--- a/server/src/test/java/org/opensearch/action/support/replication/TransportWriteActionForIndexingPressureTests.java
+++ b/server/src/test/java/org/opensearch/action/support/replication/TransportWriteActionForIndexingPressureTests.java
@@ -423,7 +423,7 @@ public class TransportWriteActionForIndexingPressureTests extends OpenSearchTest
 
         @Override
         protected void dispatchedShardOperationOnReplica(TestRequest request, IndexShard replica, ActionListener<ReplicaResult> listener) {
-            ActionListener.completeWith(listener, () -> new WriteReplicaResult<>(request, location, null, null, replica, logger));
+            ActionListener.completeWith(listener, () -> new WriteReplicaResult<>(request, location, null, replica, logger));
         }
 
     }

--- a/server/src/test/java/org/opensearch/action/support/replication/TransportWriteActionTests.java
+++ b/server/src/test/java/org/opensearch/action/support/replication/TransportWriteActionTests.java
@@ -161,7 +161,7 @@ public class TransportWriteActionTests extends OpenSearchTestCase {
             assertNotNull(listener.response);
             assertNull(listener.failure);
             verify(indexShard, never()).refresh(any());
-            verify(indexShard, never()).addRefreshListener(any(), any(), any());
+            verify(indexShard, never()).addRefreshListener(any(), any());
         }));
     }
 
@@ -177,7 +177,7 @@ public class TransportWriteActionTests extends OpenSearchTestCase {
         assertNotNull(listener.response);
         assertNull(listener.failure);
         verify(indexShard, never()).refresh(any());
-        verify(indexShard, never()).addRefreshListener(any(), any(), any());
+        verify(indexShard, never()).addRefreshListener(any(), any());
     }
 
     public void testPrimaryImmediateRefresh() throws Exception {
@@ -191,7 +191,7 @@ public class TransportWriteActionTests extends OpenSearchTestCase {
             assertNull(listener.failure);
             assertTrue(listener.response.forcedRefresh);
             verify(indexShard).refresh("refresh_flag_index");
-            verify(indexShard, never()).addRefreshListener(any(), any(), any());
+            verify(indexShard, never()).addRefreshListener(any(), any());
         }));
     }
 
@@ -207,7 +207,7 @@ public class TransportWriteActionTests extends OpenSearchTestCase {
         assertNotNull(listener.response);
         assertNull(listener.failure);
         verify(indexShard).refresh("refresh_flag_index");
-        verify(indexShard, never()).addRefreshListener(any(), any(), any());
+        verify(indexShard, never()).addRefreshListener(any(), any());
     }
 
     public void testPrimaryWaitForRefresh() throws Exception {
@@ -223,7 +223,7 @@ public class TransportWriteActionTests extends OpenSearchTestCase {
             @SuppressWarnings({ "unchecked", "rawtypes" })
             ArgumentCaptor<Consumer<Boolean>> refreshListener = ArgumentCaptor.forClass((Class) Consumer.class);
             verify(indexShard, never()).refresh(any());
-            verify(indexShard).addRefreshListener(any(), any(), refreshListener.capture());
+            verify(indexShard).addRefreshListener(any(), refreshListener.capture());
 
             // Now we can fire the listener manually and we'll get a response
             boolean forcedRefresh = randomBoolean();
@@ -247,7 +247,7 @@ public class TransportWriteActionTests extends OpenSearchTestCase {
         @SuppressWarnings({ "unchecked", "rawtypes" })
         ArgumentCaptor<Consumer<Boolean>> refreshListener = ArgumentCaptor.forClass((Class) Consumer.class);
         verify(indexShard, never()).refresh(any());
-        verify(indexShard).addRefreshListener(any(), any(), refreshListener.capture());
+        verify(indexShard).addRefreshListener(any(), refreshListener.capture());
 
         // Now we can fire the listener manually and we'll get a response
         boolean forcedRefresh = randomBoolean();
@@ -531,9 +531,9 @@ public class TransportWriteActionTests extends OpenSearchTestCase {
             ActionListener.completeWith(listener, () -> {
                 final WriteReplicaResult<TestRequest> replicaResult;
                 if (withDocumentFailureOnReplica) {
-                    replicaResult = new WriteReplicaResult<>(request, null, null, new RuntimeException("simulated"), replica, logger);
+                    replicaResult = new WriteReplicaResult<>(request, null, new RuntimeException("simulated"), replica, logger);
                 } else {
-                    replicaResult = new WriteReplicaResult<>(request, location, null, null, replica, logger);
+                    replicaResult = new WriteReplicaResult<>(request, location, null, replica, logger);
                 }
                 return replicaResult;
             });

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -3266,7 +3266,7 @@ public class IndexShardTests extends IndexShardTestCase {
         indexDoc(primary, "_doc", "0", "{\"foo\" : \"bar\"}");
         Consumer<IndexShard> assertListenerCalled = shard -> {
             AtomicBoolean called = new AtomicBoolean();
-            shard.addRefreshListener(null, null, b -> {
+            shard.addRefreshListener(null, b -> {
                 assertFalse(b);
                 called.set(true);
             });
@@ -4179,7 +4179,7 @@ public class IndexShardTests extends IndexShardTestCase {
         assertTrue(primary.scheduledRefresh());
         Engine.IndexResult doc = indexDoc(primary, "_doc", "1", "{\"foo\" : \"bar\"}");
         CountDownLatch latch = new CountDownLatch(1);
-        primary.addRefreshListener(doc.getTranslogLocation(), null, r -> latch.countDown());
+        primary.addRefreshListener(doc.getTranslogLocation(), r -> latch.countDown());
         assertEquals(1, latch.getCount());
         assertTrue(primary.getEngine().refreshNeeded());
         assertTrue(primary.scheduledRefresh());
@@ -4191,7 +4191,7 @@ public class IndexShardTests extends IndexShardTestCase {
 
         doc = indexDoc(primary, "_doc", "2", "{\"foo\" : \"bar\"}");
         CountDownLatch latch1 = new CountDownLatch(1);
-        primary.addRefreshListener(doc.getTranslogLocation(), null, r -> latch1.countDown());
+        primary.addRefreshListener(doc.getTranslogLocation(), r -> latch1.countDown());
         assertEquals(1, latch1.getCount());
         assertTrue(primary.getEngine().refreshNeeded());
         assertTrue(primary.scheduledRefresh());

--- a/server/src/test/java/org/opensearch/index/shard/RefreshListenersTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RefreshListenersTests.java
@@ -118,8 +118,7 @@ public class RefreshListenersTests extends OpenSearchTestCase {
             () -> engine.refresh("too-many-listeners"),
             logger,
             threadPool.getThreadContext(),
-            refreshMetric,
-            () -> 10L
+            refreshMetric
         );
 
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("index", Settings.EMPTY);
@@ -209,46 +208,6 @@ public class RefreshListenersTests extends OpenSearchTestCase {
         assertFalse(listener.forcedRefresh.get());
         listener.assertNoError();
         assertEquals(0, listeners.pendingCount());
-    }
-
-    public void testSeqNoRefreshListenersReleasedOnForceRefresh() throws IOException {
-        assertEquals(0, listeners.pendingCount());
-        Engine.IndexResult indexOne = index("1");
-        Engine.IndexResult indexTwo = index("2");
-        Engine.IndexResult indexThree = index("3");
-        DummyRefreshListener listenerOne = new DummyRefreshListener();
-        DummyRefreshListener listenerTwo = new DummyRefreshListener();
-        DummyRefreshListener listenerThree = new DummyRefreshListener();
-
-        // Add two listeners
-        listeners.addOrNotify(indexOne.getSeqNo(), listenerOne);
-        listeners.addOrNotify(indexTwo.getSeqNo(), listenerTwo);
-
-        // verify that two listeners are added successfully
-        assertEquals(2, listeners.pendingCount());
-
-        // now Force refresh which would fire all seqNO listeners and block addition of any new seqNo Listeners.
-        listeners.forceRefreshes();
-
-        // Add new listener and verify this listener is not added.
-        listeners.addOrNotify(indexThree.getSeqNo(), listenerThree);
-        assertEquals(0, listeners.pendingCount());
-
-    }
-
-    public void testSeqNoRefreshListener() throws IOException {
-        assertEquals(0, listeners.pendingCount());
-        Engine.IndexResult index = index("1");
-        DummyRefreshListener listener = new DummyRefreshListener();
-
-        // Add new listener
-        listeners.addOrNotify(index.getSeqNo(), listener);
-        assertEquals(1, listeners.pendingCount());
-
-        // Refresh and verify that listener is fired.
-        engine.refresh("test");
-        assertEquals(0, listeners.pendingCount());
-
     }
 
     public void testContextIsPreserved() throws IOException, InterruptedException {

--- a/test/framework/src/main/java/org/opensearch/action/support/replication/TransportWriteActionTestHelper.java
+++ b/test/framework/src/main/java/org/opensearch/action/support/replication/TransportWriteActionTestHelper.java
@@ -59,7 +59,7 @@ public abstract class TransportWriteActionTestHelper {
                 throw new AssertionError(ex);
             }
         };
-        new TransportWriteAction.AsyncAfterWriteAction(indexShard, request, location, null, writerResult, logger).run();
+        new TransportWriteAction.AsyncAfterWriteAction(indexShard, request, location, writerResult, logger).run();
         try {
             latch.await();
         } catch (InterruptedException e) {

--- a/test/framework/src/main/java/org/opensearch/index/replication/OpenSearchIndexLevelReplicationTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/replication/OpenSearchIndexLevelReplicationTestCase.java
@@ -73,7 +73,6 @@ import org.opensearch.cluster.routing.ShardRoutingHelper;
 import org.opensearch.cluster.routing.ShardRoutingState;
 import org.opensearch.cluster.routing.TestShardRouting;
 import org.opensearch.common.collect.Iterators;
-import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.lease.Releasable;
@@ -1022,11 +1021,10 @@ public abstract class OpenSearchIndexLevelReplicationTestCase extends IndexShard
             request
         );
         final Translog.Location location;
-        final Tuple<Translog.Location, Long> tuple;
         try (Releasable ignored = permitAcquiredFuture.actionGet()) {
-            tuple = TransportShardBulkAction.performOnReplica(request, replica);
+            location = TransportShardBulkAction.performOnReplica(request, replica);
         }
-        TransportWriteActionTestHelper.performPostWriteActions(replica, request, tuple.v1(), logger);
+        TransportWriteActionTestHelper.performPostWriteActions(replica, request, location, logger);
     }
 
     /**


### PR DESCRIPTION
…lica shards with segment replication enabled to wait for replica refresh (#6464)"

This reverts commit e8a4210b28ba7bf3c18b202b1958fd2100a8b330.

### Description
Reverts https://github.com/opensearch-project/OpenSearch/pull/6464 

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/6618

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
