### PR TITLE
Allow newer versions of IDEA to control test iterations

### DIFF
--- a/server/src/main/resources/org/opensearch/bootstrap/test-framework.policy
+++ b/server/src/main/resources/org/opensearch/bootstrap/test-framework.policy
@@ -128,9 +128,13 @@ grant codeBase "${codebase.httpasyncclient}" {
   permission java.net.NetPermission "getProxySelector";
 };
 
-
 grant codeBase "${codebase.junit-rt.jar}" {
   // allows IntelliJ IDEA JUnit test runner to control number of test iterations
+  permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
+};
+
+grant codeBase "${codebase.idea_rt.jar}" {
+  // allows IntelliJ IDEA (2022.3.3) JUnit test runner to control number of test iterations
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
 };
 


### PR DESCRIPTION
I'm a big user of the 'run until failure' option on the IDEA test runner for finding bugs. I just upgraded to the newest version of IDEA and it moved its JUnit runner, so we need a modified permission setting for that option to work.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
