### PR TITLE
Cancel in-flight search tasks due to search backpressure with 429 sta…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Change http code on create index API with bad input raising NotXContentException from 500 to 400 ([#4773](https://github.com/opensearch-project/OpenSearch/pull/4773))
 - Change http code for DecommissioningFailedException from 500 to 400 ([#5283](https://github.com/opensearch-project/OpenSearch/pull/5283))
 - Improve summary error message for invalid setting updates ([#4792](https://github.com/opensearch-project/OpenSearch/pull/4792))
+- Changed http code for in-flight search tasks cancelled due to search backpressure from 500 to 429 ([#6634](https://github.com/opensearch-project/OpenSearch/pull/6634))
 
 ### Deprecated
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/SearchCancellationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/SearchCancellationIT.java
@@ -51,6 +51,7 @@ import org.opensearch.action.support.WriteRequest;
 import org.opensearch.common.Strings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.concurrent.OpenSearchRejectedExecutionException;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.plugins.PluginsService;
@@ -209,7 +210,9 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
             final Throwable topFailureCause = searchFailure.getCause();
             assertTrue(
                 searchFailure.toString(),
-                topFailureCause instanceof TransportException || topFailureCause instanceof TaskCancelledException
+                topFailureCause instanceof TransportException
+                    || topFailureCause instanceof TaskCancelledException
+                    || topFailureCause instanceof OpenSearchRejectedExecutionException
             );
             if (topFailureCause instanceof TransportException) {
                 assertTrue(topFailureCause.getCause() instanceof TaskCancelledException);

--- a/server/src/main/java/org/opensearch/OpenSearchException.java
+++ b/server/src/main/java/org/opensearch/OpenSearchException.java
@@ -259,12 +259,12 @@ public class OpenSearchException extends RuntimeException implements ToXContentF
      */
     public RestStatus status() {
         Throwable cause = unwrapCause();
-        if (cause.getCause() instanceof TaskCancelledException
-            && ((TaskCancelledException) cause.getCause()).status() == RestStatus.TOO_MANY_REQUESTS) {
-            return ((TaskCancelledException) cause.getCause()).status();
-        } else if (cause == this) {
+        if (cause == this) {
             return RestStatus.INTERNAL_SERVER_ERROR;
         } else {
+            if (cause.getCause() != cause) {
+                return ExceptionsHelper.status(cause.getCause());
+            }
             return ExceptionsHelper.status(cause);
         }
     }

--- a/server/src/main/java/org/opensearch/search/backpressure/SearchBackpressureService.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/SearchBackpressureService.java
@@ -197,8 +197,9 @@ public class SearchBackpressureService extends AbstractLifecycleComponent implem
         }
 
         for (TaskCancellation taskCancellation : getTaskCancellations(cancellableTasks)) {
+            Class<? extends SearchBackpressureTask> taskType = getTaskType(taskCancellation.getTask());
             logger.debug(
-                "[{} mode] cancelling task [{}] due to high resource consumption [{}]",
+                "[{} mode] cancelling [{}] task with id [{}] due to high resource consumption [{}]",
                 mode.getName(),
                 taskCancellation.getTask().getId(),
                 taskCancellation.getReasonString()
@@ -207,8 +208,6 @@ public class SearchBackpressureService extends AbstractLifecycleComponent implem
             if (mode != SearchBackpressureMode.ENFORCED) {
                 continue;
             }
-
-            Class<? extends SearchBackpressureTask> taskType = getTaskType(taskCancellation.getTask());
 
             // Independently remove tokens from both token buckets.
             SearchBackpressureState searchBackpressureState = searchBackpressureStates.get(taskType);

--- a/server/src/main/java/org/opensearch/search/dfs/DfsPhase.java
+++ b/server/src/main/java/org/opensearch/search/dfs/DfsPhase.java
@@ -42,11 +42,12 @@ import org.apache.lucene.search.TermStatistics;
 import org.opensearch.common.collect.HppcMaps;
 import org.opensearch.search.internal.SearchContext;
 import org.opensearch.search.rescore.RescoreContext;
-import org.opensearch.tasks.TaskCancelledException;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.opensearch.tasks.TaskCancellationService.throwTaskCancelledException;
 
 /**
  * Dfs phase of a search request, used to make scoring 100% accurate by collecting additional info from each shard before the query phase.
@@ -64,7 +65,7 @@ public class DfsPhase {
                 @Override
                 public TermStatistics termStatistics(Term term, int docFreq, long totalTermFreq) throws IOException {
                     if (context.isCancelled()) {
-                        throw new TaskCancelledException("cancelled task with reason: " + context.getTask().getReasonCancelled());
+                        throwTaskCancelledException(context.getTask().getReasonCancelled());
                     }
                     TermStatistics ts = super.termStatistics(term, docFreq, totalTermFreq);
                     if (ts != null) {
@@ -76,7 +77,7 @@ public class DfsPhase {
                 @Override
                 public CollectionStatistics collectionStatistics(String field) throws IOException {
                     if (context.isCancelled()) {
-                        throw new TaskCancelledException("cancelled task with reason: " + context.getTask().getReasonCancelled());
+                        throwTaskCancelledException(context.getTask().getReasonCancelled());
                     }
                     CollectionStatistics cs = super.collectionStatistics(field);
                     if (cs != null) {

--- a/server/src/main/java/org/opensearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/opensearch/search/fetch/FetchPhase.java
@@ -71,7 +71,6 @@ import org.opensearch.search.fetch.subphase.InnerHitsPhase;
 import org.opensearch.search.internal.SearchContext;
 import org.opensearch.search.lookup.SearchLookup;
 import org.opensearch.search.lookup.SourceLookup;
-import org.opensearch.tasks.TaskCancelledException;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -86,6 +85,7 @@ import java.util.Set;
 import java.util.function.Function;
 
 import static java.util.Collections.emptyMap;
+import static org.opensearch.tasks.TaskCancellationService.throwTaskCancelledException;
 
 /**
  * Fetch phase of a search request, used to fetch the actual top matching documents to be returned to the client, identified
@@ -109,7 +109,7 @@ public class FetchPhase {
         }
 
         if (context.isCancelled()) {
-            throw new TaskCancelledException("cancelled task with reason: " + context.getTask().getReasonCancelled());
+            throwTaskCancelledException(context.getTask().getReasonCancelled());
         }
 
         if (context.docIdsToLoadSize() == 0) {
@@ -141,7 +141,7 @@ public class FetchPhase {
         boolean hasSequentialDocs = hasSequentialDocs(docs);
         for (int index = 0; index < context.docIdsToLoadSize(); index++) {
             if (context.isCancelled()) {
-                throw new TaskCancelledException("cancelled task with reason: " + context.getTask().getReasonCancelled());
+                throwTaskCancelledException(context.getTask().getReasonCancelled());
             }
             int docId = docs[index].docId;
             try {
@@ -184,7 +184,7 @@ public class FetchPhase {
             }
         }
         if (context.isCancelled()) {
-            throw new TaskCancelledException("cancelled task with reason: " + context.getTask().getReasonCancelled());
+            throwTaskCancelledException(context.getTask().getReasonCancelled());
         }
 
         TotalHits totalHits = context.queryResult().getTotalHits();

--- a/server/src/main/java/org/opensearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/opensearch/search/query/QueryPhase.java
@@ -64,7 +64,6 @@ import org.opensearch.search.profile.query.InternalProfileCollector;
 import org.opensearch.search.rescore.RescorePhase;
 import org.opensearch.search.sort.SortAndFormats;
 import org.opensearch.search.suggest.SuggestPhase;
-import org.opensearch.tasks.TaskCancelledException;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
@@ -77,6 +76,7 @@ import static org.opensearch.search.query.QueryCollectorContext.createFilteredCo
 import static org.opensearch.search.query.QueryCollectorContext.createMinScoreCollectorContext;
 import static org.opensearch.search.query.QueryCollectorContext.createMultiCollectorContext;
 import static org.opensearch.search.query.TopDocsCollectorContext.createTopDocsCollectorContext;
+import static org.opensearch.tasks.TaskCancellationService.throwTaskCancelledException;
 
 /**
  * Query phase of a search request, used to run the query and get back from each shard information about the matching documents
@@ -112,7 +112,7 @@ public class QueryPhase {
             cancellation = context.searcher().addQueryCancellation(() -> {
                 SearchShardTask task = context.getTask();
                 if (task != null && task.isCancelled()) {
-                    throw new TaskCancelledException("cancelled task with reason: " + task.getReasonCancelled());
+                    throwTaskCancelledException(context.getTask().getReasonCancelled());
                 }
             });
         } else {
@@ -253,7 +253,7 @@ public class QueryPhase {
                 searcher.addQueryCancellation(() -> {
                     SearchShardTask task = searchContext.getTask();
                     if (task != null && task.isCancelled()) {
-                        throw new TaskCancelledException("cancelled task with reason: " + task.getReasonCancelled());
+                        throwTaskCancelledException(task.getReasonCancelled());
                     }
                 });
             }

--- a/server/src/main/java/org/opensearch/tasks/TaskCancellationService.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskCancellationService.java
@@ -66,6 +66,7 @@ public class TaskCancellationService {
     public static final String BAN_PARENT_ACTION_NAME = "internal:admin/tasks/ban";
     public static final String REASON_PARENT_CANCELLED_HIGH_RESOURCE_CONSUMPTION =
         "The parent task was cancelled due to high resource consumption";
+    public static final String USAGE_EXCEEDED = "usage exceeded";
     private static final Logger logger = LogManager.getLogger(TaskCancellationService.class);
     private final TransportService transportService;
     private final TaskManager taskManager;
@@ -275,6 +276,6 @@ public class TaskCancellationService {
     }
 
     private static boolean isRejection(String reason) {
-        return (reason.contains("usage exceeded") || REASON_PARENT_CANCELLED_HIGH_RESOURCE_CONSUMPTION.equals(reason));
+        return (reason != null && (reason.contains(USAGE_EXCEEDED) || REASON_PARENT_CANCELLED_HIGH_RESOURCE_CONSUMPTION.equals(reason)));
     }
 }

--- a/server/src/main/java/org/opensearch/tasks/TaskCancelledException.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskCancelledException.java
@@ -32,6 +32,7 @@
 package org.opensearch.tasks;
 
 import org.opensearch.OpenSearchException;
+import org.opensearch.OpenSearchWrapperException;
 import org.opensearch.common.io.stream.StreamInput;
 
 import java.io.IOException;
@@ -41,10 +42,14 @@ import java.io.IOException;
  *
  * @opensearch.internal
  */
-public class TaskCancelledException extends OpenSearchException {
+public class TaskCancelledException extends OpenSearchException implements OpenSearchWrapperException {
 
     public TaskCancelledException(String msg) {
         super(msg);
+    }
+
+    public TaskCancelledException(Throwable cause) {
+        super(cause);
     }
 
     public TaskCancelledException(StreamInput in) throws IOException {

--- a/server/src/test/java/org/opensearch/action/admin/cluster/node/tasks/CancellableTasksTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/node/tasks/CancellableTasksTests.java
@@ -425,7 +425,7 @@ public class CancellableTasksTests extends TaskManagerTestCase {
         );
         assertThat(cancelledException.getMessage(), startsWith("Task cancelled before it started:"));
         CountDownLatch latch = new CountDownLatch(1);
-        taskManager.startBanOnChildrenNodes(parentTaskId.getId(), latch::countDown);
+        taskManager.startBanOnChildrenNodes(parentTaskId.getId(), null, latch::countDown);
         assertTrue("onChildTasksCompleted() is not invoked", latch.await(1, TimeUnit.SECONDS));
     }
 

--- a/server/src/test/java/org/opensearch/action/search/AbstractSearchAsyncActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/AbstractSearchAsyncActionTests.java
@@ -53,12 +53,14 @@ import org.opensearch.search.internal.InternalSearchResponse;
 import org.opensearch.search.internal.ShardSearchContextId;
 import org.opensearch.search.internal.ShardSearchRequest;
 import org.opensearch.search.query.QuerySearchResult;
+import org.opensearch.tasks.TaskId;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.Transport;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -158,7 +160,7 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
             new GroupShardsIterator<>(Arrays.asList(shards)),
             timeProvider,
             ClusterState.EMPTY_STATE,
-            null,
+            new SearchTask(1, "test", "test", () -> "Test", TaskId.EMPTY_TASK_ID, new HashMap<>()),
             results,
             request.getMaxConcurrentShardRequests(),
             SearchResponse.Clusters.EMPTY

--- a/server/src/test/java/org/opensearch/action/search/CanMatchPreFilterSearchPhaseTests.java
+++ b/server/src/test/java/org/opensearch/action/search/CanMatchPreFilterSearchPhaseTests.java
@@ -50,6 +50,7 @@ import org.opensearch.search.internal.ShardSearchRequest;
 import org.opensearch.search.sort.MinAndMax;
 import org.opensearch.search.sort.SortBuilders;
 import org.opensearch.search.sort.SortOrder;
+import org.opensearch.tasks.TaskId;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.Transport;
 
@@ -57,6 +58,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -128,7 +130,7 @@ public class CanMatchPreFilterSearchPhaseTests extends OpenSearchTestCase {
             shardsIter,
             timeProvider,
             ClusterState.EMPTY_STATE,
-            null,
+            new SearchTask(1, "test", "test", () -> "Test", TaskId.EMPTY_TASK_ID, new HashMap<>()),
             (iter) -> new SearchPhase("test") {
                 @Override
                 public void run() throws IOException {
@@ -219,7 +221,7 @@ public class CanMatchPreFilterSearchPhaseTests extends OpenSearchTestCase {
             shardsIter,
             timeProvider,
             ClusterState.EMPTY_STATE,
-            null,
+            new SearchTask(1, "test", "test", () -> "Test", TaskId.EMPTY_TASK_ID, new HashMap<>()),
             (iter) -> new SearchPhase("test") {
                 @Override
                 public void run() throws IOException {
@@ -300,7 +302,7 @@ public class CanMatchPreFilterSearchPhaseTests extends OpenSearchTestCase {
             shardsIter,
             timeProvider,
             ClusterState.EMPTY_STATE,
-            null,
+            new SearchTask(1, "test", "test", () -> "Test", TaskId.EMPTY_TASK_ID, new HashMap<>()),
             (iter) -> new AbstractSearchAsyncAction<SearchPhaseResult>("test", logger, transportService, (cluster, node) -> {
                 assert cluster == null : "cluster was not null: " + cluster;
                 return lookup.get(node);
@@ -314,7 +316,7 @@ public class CanMatchPreFilterSearchPhaseTests extends OpenSearchTestCase {
                 iter,
                 new TransportSearchAction.SearchTimeProvider(0, 0, () -> 0),
                 ClusterState.EMPTY_STATE,
-                null,
+                new SearchTask(1, "test", "test", () -> "Test", TaskId.EMPTY_TASK_ID, new HashMap<>()),
                 new ArraySearchPhaseResults<>(iter.size()),
                 randomIntBetween(1, 32),
                 SearchResponse.Clusters.EMPTY
@@ -420,7 +422,7 @@ public class CanMatchPreFilterSearchPhaseTests extends OpenSearchTestCase {
                 shardsIter,
                 timeProvider,
                 ClusterState.EMPTY_STATE,
-                null,
+                new SearchTask(1, "test", "test", () -> "Test", TaskId.EMPTY_TASK_ID, new HashMap<>()),
                 (iter) -> new SearchPhase("test") {
                     @Override
                     public void run() {
@@ -519,7 +521,7 @@ public class CanMatchPreFilterSearchPhaseTests extends OpenSearchTestCase {
                 shardsIter,
                 timeProvider,
                 ClusterState.EMPTY_STATE,
-                null,
+                new SearchTask(1, "test", "test", () -> "Test", TaskId.EMPTY_TASK_ID, new HashMap<>()),
                 (iter) -> new SearchPhase("test") {
                     @Override
                     public void run() {

--- a/server/src/test/java/org/opensearch/action/search/SearchAsyncActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchAsyncActionTests.java
@@ -50,6 +50,7 @@ import org.opensearch.search.SearchShardTarget;
 import org.opensearch.search.internal.AliasFilter;
 import org.opensearch.search.internal.InternalSearchResponse;
 import org.opensearch.search.internal.ShardSearchContextId;
+import org.opensearch.tasks.TaskId;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.Transport;
 import org.opensearch.transport.TransportException;
@@ -132,7 +133,7 @@ public class SearchAsyncActionTests extends OpenSearchTestCase {
             shardsIter,
             new TransportSearchAction.SearchTimeProvider(0, 0, () -> 0),
             ClusterState.EMPTY_STATE,
-            null,
+            new SearchTask(1, "test", "test", () -> "Test", TaskId.EMPTY_TASK_ID, new HashMap<>()),
             new ArraySearchPhaseResults<>(shardsIter.size()),
             request.getMaxConcurrentShardRequests(),
             SearchResponse.Clusters.EMPTY
@@ -250,7 +251,7 @@ public class SearchAsyncActionTests extends OpenSearchTestCase {
             shardsIter,
             new TransportSearchAction.SearchTimeProvider(0, 0, () -> 0),
             ClusterState.EMPTY_STATE,
-            null,
+            new SearchTask(1, "test", "test", () -> "Test", TaskId.EMPTY_TASK_ID, new HashMap<>()),
             new ArraySearchPhaseResults<>(shardsIter.size()),
             request.getMaxConcurrentShardRequests(),
             SearchResponse.Clusters.EMPTY
@@ -365,7 +366,7 @@ public class SearchAsyncActionTests extends OpenSearchTestCase {
             shardsIter,
             new TransportSearchAction.SearchTimeProvider(0, 0, () -> 0),
             ClusterState.EMPTY_STATE,
-            null,
+            new SearchTask(1, "test", "test", () -> "Test", TaskId.EMPTY_TASK_ID, new HashMap<>()),
             new ArraySearchPhaseResults<>(shardsIter.size()),
             request.getMaxConcurrentShardRequests(),
             SearchResponse.Clusters.EMPTY
@@ -487,7 +488,7 @@ public class SearchAsyncActionTests extends OpenSearchTestCase {
             shardsIter,
             new TransportSearchAction.SearchTimeProvider(0, 0, () -> 0),
             ClusterState.EMPTY_STATE,
-            null,
+            new SearchTask(1, "test", "test", () -> "Test", TaskId.EMPTY_TASK_ID, new HashMap<>()),
             new ArraySearchPhaseResults<>(shardsIter.size()),
             request.getMaxConcurrentShardRequests(),
             SearchResponse.Clusters.EMPTY
@@ -600,7 +601,7 @@ public class SearchAsyncActionTests extends OpenSearchTestCase {
             shardsIter,
             new TransportSearchAction.SearchTimeProvider(0, 0, () -> 0),
             ClusterState.EMPTY_STATE,
-            null,
+            new SearchTask(1, "test", "test", () -> "Test", TaskId.EMPTY_TASK_ID, new HashMap<>()),
             new ArraySearchPhaseResults<>(shardsIter.size()),
             request.getMaxConcurrentShardRequests(),
             SearchResponse.Clusters.EMPTY


### PR DESCRIPTION
### Description
* Added support for cancelling tasks with arbitrary status codes
* Modified search backpressure service to cancel tasks with 429 status code

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [X] New functionality includes testing.
  - [x] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
