### PR TITLE
[Segment Replication] Add global primary shard balance constraint during allocation

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/AllocationConstraints.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/AllocationConstraints.java
@@ -10,37 +10,29 @@ import org.opensearch.cluster.routing.allocation.allocator.ShardsBalancer;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Predicate;
 
-import static org.opensearch.cluster.routing.allocation.RebalanceConstraints.PREFER_PRIMARY_SHARD_BALANCE_NODE_BREACH_ID;
-import static org.opensearch.cluster.routing.allocation.RebalanceConstraints.isPrimaryShardsPerIndexPerNodeBreached;
+import static org.opensearch.cluster.routing.allocation.ConstraintTypes.CLUSTER_PRIMARY_SHARD_BALANCE_CONSTRAINT_ID;
+import static org.opensearch.cluster.routing.allocation.ConstraintTypes.INDEX_SHARD_PER_NODE_BREACH_CONSTRAINT_ID;
+import static org.opensearch.cluster.routing.allocation.ConstraintTypes.INDEX_PRIMARY_SHARD_BALANCE_CONSTRAINT_ID;
+import static org.opensearch.cluster.routing.allocation.ConstraintTypes.isIndexShardsPerNodeBreached;
+import static org.opensearch.cluster.routing.allocation.ConstraintTypes.isPerIndexPrimaryShardsPerNodeBreached;
+import static org.opensearch.cluster.routing.allocation.ConstraintTypes.isPrimaryShardsPerNodeBreached;
 
 /**
- * Allocation constraints specify conditions which, if breached, reduce the
- * priority of a node for receiving unassigned shard allocations.
+ * Allocation constraints specify conditions which, if breached, reduce the priority of a node for receiving unassigned
+ * shard allocations. Weight calculation in other scenarios like shard movement and re-balancing remain unaffected by
+ * this constraint.
  *
  * @opensearch.internal
  */
 public class AllocationConstraints {
-
-    /**
-     *
-     * This constraint is only applied for unassigned shards to avoid overloading a newly added node.
-     * Weight calculation in other scenarios like shard movement and re-balancing remain unaffected by this constraint.
-     */
-    public final static String INDEX_SHARD_PER_NODE_BREACH_CONSTRAINT_ID = "index.shard.breach.constraint";
     private Map<String, Constraint> constraints;
 
     public AllocationConstraints() {
         this.constraints = new HashMap<>();
-        this.constraints.putIfAbsent(
-            INDEX_SHARD_PER_NODE_BREACH_CONSTRAINT_ID,
-            new Constraint(INDEX_SHARD_PER_NODE_BREACH_CONSTRAINT_ID, isIndexShardsPerNodeBreached())
-        );
-        this.constraints.putIfAbsent(
-            PREFER_PRIMARY_SHARD_BALANCE_NODE_BREACH_ID,
-            new Constraint(PREFER_PRIMARY_SHARD_BALANCE_NODE_BREACH_ID, isPrimaryShardsPerIndexPerNodeBreached())
-        );
+        this.constraints.putIfAbsent(INDEX_SHARD_PER_NODE_BREACH_CONSTRAINT_ID, new Constraint(isIndexShardsPerNodeBreached()));
+        this.constraints.putIfAbsent(INDEX_PRIMARY_SHARD_BALANCE_CONSTRAINT_ID, new Constraint(isPerIndexPrimaryShardsPerNodeBreached()));
+        this.constraints.putIfAbsent(CLUSTER_PRIMARY_SHARD_BALANCE_CONSTRAINT_ID, new Constraint(isPrimaryShardsPerNodeBreached()));
     }
 
     public void updateAllocationConstraint(String constraint, boolean enable) {
@@ -50,27 +42,5 @@ public class AllocationConstraints {
     public long weight(ShardsBalancer balancer, BalancedShardsAllocator.ModelNode node, String index) {
         Constraint.ConstraintParams params = new Constraint.ConstraintParams(balancer, node, index);
         return params.weight(constraints);
-    }
-
-    /**
-     * Constraint to control number of shards of an index allocated on a single
-     * node.
-     *
-     * In current weight function implementation, when a node has significantly
-     * fewer shards than other nodes (e.g. during single new node addition or node
-     * replacement), its weight is much less than other nodes. All shard allocations
-     * at this time tend to land on the new node with skewed weight. This breaks
-     * index level balance in the cluster, by creating all shards of the same index
-     * on one node, often resulting in a hotspot on that node.
-     *
-     * This constraint is breached when balancer attempts to allocate more than
-     * average shards per index per node.
-     */
-    public static Predicate<Constraint.ConstraintParams> isIndexShardsPerNodeBreached() {
-        return (params) -> {
-            int currIndexShardsOnNode = params.getNode().numShards(params.getIndex());
-            int allowedIndexShardsPerNode = (int) Math.ceil(params.getBalancer().avgShardsPerNode(params.getIndex()));
-            return (currIndexShardsOnNode >= allowedIndexShardsPerNode);
-        };
     }
 }

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/Constraint.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/Constraint.java
@@ -12,8 +12,9 @@ import org.opensearch.cluster.routing.allocation.allocator.BalancedShardsAllocat
 import org.opensearch.cluster.routing.allocation.allocator.ShardsBalancer;
 
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Predicate;
+
+import static org.opensearch.cluster.routing.allocation.ConstraintTypes.CONSTRAINT_WEIGHT;
 
 /**
  * Defines a constraint useful to de-prioritize certain nodes as target of unassigned shards used in {@link AllocationConstraints} or
@@ -23,17 +24,11 @@ import java.util.function.Predicate;
  */
 public class Constraint implements Predicate<Constraint.ConstraintParams> {
 
-    public final static long CONSTRAINT_WEIGHT = 1000000L;
-
-    private String name;
-
     private boolean enable;
     private Predicate<ConstraintParams> predicate;
 
-    public Constraint(String name, Predicate<ConstraintParams> constraintPredicate) {
-        this.name = name;
+    public Constraint(Predicate<ConstraintParams> constraintPredicate) {
         this.predicate = constraintPredicate;
-        this.enable = false;
     }
 
     @Override
@@ -41,25 +36,8 @@ public class Constraint implements Predicate<Constraint.ConstraintParams> {
         return this.enable && predicate.test(constraintParams);
     }
 
-    public String getName() {
-        return name;
-    }
-
     public void setEnable(boolean enable) {
         this.enable = enable;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Constraint that = (Constraint) o;
-        return name.equals(that.name);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(name);
     }
 
     static class ConstraintParams {

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/ConstraintTypes.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/ConstraintTypes.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.routing.allocation;
+
+import java.util.function.Predicate;
+
+public class ConstraintTypes {
+    public final static long CONSTRAINT_WEIGHT = 1000000L;
+
+    /**
+     * Defines per index constraint which is breached when a node contains more than avg number of primary shards for an index
+     */
+    public final static String INDEX_PRIMARY_SHARD_BALANCE_CONSTRAINT_ID = "index.primary.shard.balance.constraint";
+
+    /**
+     * Defines a cluster constraint which is breached when a node contains more than avg primary shards across all indices
+     */
+    public final static String CLUSTER_PRIMARY_SHARD_BALANCE_CONSTRAINT_ID = "cluster.primary.shard.balance.constraint";
+
+    /**
+     * Defines an index constraint which is breached when a node contains more than avg number of shards for an index
+     */
+    public final static String INDEX_SHARD_PER_NODE_BREACH_CONSTRAINT_ID = "index.shard.count.constraint";
+
+    /**
+     * Constraint to control number of shards of an index allocated on a single
+     * node.
+     *
+     * In current weight function implementation, when a node has significantly
+     * fewer shards than other nodes (e.g. during single new node addition or node
+     * replacement), its weight is much less than other nodes. All shard allocations
+     * at this time tend to land on the new node with skewed weight. This breaks
+     * index level balance in the cluster, by creating all shards of the same index
+     * on one node, often resulting in a hotspot on that node.
+     *
+     * This constraint is breached when balancer attempts to allocate more than
+     * average shards per index per node.
+     */
+    public static Predicate<Constraint.ConstraintParams> isIndexShardsPerNodeBreached() {
+        return (params) -> {
+            int currIndexShardsOnNode = params.getNode().numShards(params.getIndex());
+            int allowedIndexShardsPerNode = (int) Math.ceil(params.getBalancer().avgShardsPerNode(params.getIndex()));
+            return (currIndexShardsOnNode >= allowedIndexShardsPerNode);
+        };
+    }
+
+    /**
+     * Defines a predicate which returns true when specific to an index, a node contains more than average number of primary
+     * shards. This constraint is used in weight calculation during allocation and rebalancing. When breached a high weight
+     * {@link ConstraintTypes#CONSTRAINT_WEIGHT} is assigned to node resulting in lesser chances of node being selected
+     * as allocation or rebalancing target
+     */
+    public static Predicate<Constraint.ConstraintParams> isPerIndexPrimaryShardsPerNodeBreached() {
+        return (params) -> {
+            int perIndexPrimaryShardCount = params.getNode().numPrimaryShards(params.getIndex());
+            int perIndexAllowedPrimaryShardCount = (int) Math.ceil(params.getBalancer().avgPrimaryShardsPerNode(params.getIndex()));
+            return perIndexPrimaryShardCount > perIndexAllowedPrimaryShardCount;
+        };
+    }
+
+    /**
+     * Defines a predicate which returns true when a node contains more than average number of primary shards. This
+     * constraint is used in weight calculation during allocation only. When breached a high weight {@link ConstraintTypes#CONSTRAINT_WEIGHT}
+     * is assigned to node resulting in lesser chances of node being selected as allocation target
+     */
+    public static Predicate<Constraint.ConstraintParams> isPrimaryShardsPerNodeBreached() {
+        return (params) -> {
+            int primaryShardCount = params.getNode().numPrimaryShards();
+            int allowedPrimaryShardCount = (int) Math.ceil(params.getBalancer().avgPrimaryShardsPerNode());
+            return primaryShardCount >= allowedPrimaryShardCount;
+        };
+    }
+}

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/ConstraintTypes.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/ConstraintTypes.java
@@ -10,6 +10,11 @@ package org.opensearch.cluster.routing.allocation;
 
 import java.util.function.Predicate;
 
+/**
+ * Defines different constraints definitions
+ *
+ * @opensearch.internal
+ */
 public class ConstraintTypes {
     public final static long CONSTRAINT_WEIGHT = 1000000L;
 

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/RebalanceConstraints.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/RebalanceConstraints.java
@@ -13,9 +13,9 @@ import org.opensearch.cluster.routing.allocation.allocator.ShardsBalancer;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Predicate;
 
-import static org.opensearch.cluster.routing.allocation.allocator.BalancedShardsAllocator.PREFER_PER_INDEX_PRIMARY_SHARD_BALANCE;
+import static org.opensearch.cluster.routing.allocation.ConstraintTypes.INDEX_PRIMARY_SHARD_BALANCE_CONSTRAINT_ID;
+import static org.opensearch.cluster.routing.allocation.ConstraintTypes.isPerIndexPrimaryShardsPerNodeBreached;
 
 /**
  * Constraints applied during rebalancing round; specify conditions which, if breached, reduce the
@@ -24,15 +24,12 @@ import static org.opensearch.cluster.routing.allocation.allocator.BalancedShards
  * @opensearch.internal
  */
 public class RebalanceConstraints {
-    public final static String PREFER_PRIMARY_SHARD_BALANCE_NODE_BREACH_ID = PREFER_PER_INDEX_PRIMARY_SHARD_BALANCE.getKey();
+
     private Map<String, Constraint> constraints;
 
     public RebalanceConstraints() {
         this.constraints = new HashMap<>();
-        this.constraints.putIfAbsent(
-            PREFER_PRIMARY_SHARD_BALANCE_NODE_BREACH_ID,
-            new Constraint(PREFER_PRIMARY_SHARD_BALANCE_NODE_BREACH_ID, isPrimaryShardsPerIndexPerNodeBreached())
-        );
+        this.constraints.putIfAbsent(INDEX_PRIMARY_SHARD_BALANCE_CONSTRAINT_ID, new Constraint(isPerIndexPrimaryShardsPerNodeBreached()));
     }
 
     public void updateRebalanceConstraint(String constraint, boolean enable) {
@@ -42,17 +39,5 @@ public class RebalanceConstraints {
     public long weight(ShardsBalancer balancer, BalancedShardsAllocator.ModelNode node, String index) {
         Constraint.ConstraintParams params = new Constraint.ConstraintParams(balancer, node, index);
         return params.weight(constraints);
-    }
-
-    /**
-     * When primary balance is preferred, add node constraint of average primary shards per node to give the node a
-     * higher weight resulting in lesser chances of being target of unassigned shard allocation or rebalancing target node
-     */
-    public static Predicate<Constraint.ConstraintParams> isPrimaryShardsPerIndexPerNodeBreached() {
-        return (params) -> {
-            int currPrimaryShardsOnNode = params.getNode().numPrimaryShards(params.getIndex());
-            int allowedPrimaryShardsPerNode = (int) Math.ceil(params.getBalancer().avgPrimaryShardsPerNode(params.getIndex()));
-            return currPrimaryShardsOnNode > allowedPrimaryShardsPerNode;
-        };
     }
 }

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancer.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancer.java
@@ -66,6 +66,8 @@ public class LocalShardsBalancer extends ShardsBalancer {
     private final float threshold;
     private final Metadata metadata;
     private final float avgShardsPerNode;
+
+    private final float avgPrimaryShardsPerNode;
     private final BalancedShardsAllocator.NodeSorter sorter;
     private final Set<RoutingNode> inEligibleTargetNode;
 
@@ -85,6 +87,9 @@ public class LocalShardsBalancer extends ShardsBalancer {
         this.routingNodes = allocation.routingNodes();
         this.metadata = allocation.metadata();
         avgShardsPerNode = ((float) metadata.getTotalNumberOfShards()) / routingNodes.size();
+        avgPrimaryShardsPerNode = (float) (StreamSupport.stream(metadata.spliterator(), false)
+            .mapToInt(IndexMetadata::getNumberOfShards)
+            .sum()) / routingNodes.size();
         nodes = Collections.unmodifiableMap(buildModelFromAssigned());
         sorter = newNodeSorter();
         inEligibleTargetNode = new HashSet<>();
@@ -109,6 +114,11 @@ public class LocalShardsBalancer extends ShardsBalancer {
     @Override
     public float avgPrimaryShardsPerNode(String index) {
         return ((float) metadata.index(index).getNumberOfShards()) / nodes.size();
+    }
+
+    @Override
+    public float avgPrimaryShardsPerNode() {
+        return avgPrimaryShardsPerNode;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/ShardsBalancer.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/ShardsBalancer.java
@@ -80,4 +80,11 @@ public abstract class ShardsBalancer {
         return Float.MAX_VALUE;
     }
 
+    /**
+     * Returns the average of primary shards per node
+     */
+    public float avgPrimaryShardsPerNode() {
+        return Float.MAX_VALUE;
+    }
+
 }

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -232,7 +232,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 AwarenessReplicaBalance.CLUSTER_ROUTING_ALLOCATION_AWARENESS_BALANCE_SETTING,
                 BalancedShardsAllocator.INDEX_BALANCE_FACTOR_SETTING,
                 BalancedShardsAllocator.SHARD_BALANCE_FACTOR_SETTING,
-                BalancedShardsAllocator.PREFER_PER_INDEX_PRIMARY_SHARD_BALANCE,
+                BalancedShardsAllocator.PREFER_PRIMARY_SHARD_BALANCE,
                 BalancedShardsAllocator.SHARD_MOVE_PRIMARY_FIRST_SETTING,
                 BalancedShardsAllocator.THRESHOLD_SETTING,
                 BreakerSettings.CIRCUIT_BREAKER_LIMIT_SETTING,

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/AllocationConstraintsTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/AllocationConstraintsTests.java
@@ -18,9 +18,10 @@ import org.opensearch.common.settings.Settings;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.opensearch.cluster.routing.allocation.AllocationConstraints.INDEX_SHARD_PER_NODE_BREACH_CONSTRAINT_ID;
-import static org.opensearch.cluster.routing.allocation.Constraint.CONSTRAINT_WEIGHT;
-import static org.opensearch.cluster.routing.allocation.RebalanceConstraints.PREFER_PRIMARY_SHARD_BALANCE_NODE_BREACH_ID;
+import static org.opensearch.cluster.routing.allocation.ConstraintTypes.CLUSTER_PRIMARY_SHARD_BALANCE_CONSTRAINT_ID;
+import static org.opensearch.cluster.routing.allocation.ConstraintTypes.CONSTRAINT_WEIGHT;
+import static org.opensearch.cluster.routing.allocation.ConstraintTypes.INDEX_SHARD_PER_NODE_BREACH_CONSTRAINT_ID;
+import static org.opensearch.cluster.routing.allocation.ConstraintTypes.INDEX_PRIMARY_SHARD_BALANCE_CONSTRAINT_ID;
 
 public class AllocationConstraintsTests extends OpenSearchAllocationTestCase {
 
@@ -36,7 +37,7 @@ public class AllocationConstraintsTests extends OpenSearchAllocationTestCase {
         settings.put(BalancedShardsAllocator.INDEX_BALANCE_FACTOR_SETTING.getKey(), indexBalanceFactor);
         settings.put(BalancedShardsAllocator.SHARD_BALANCE_FACTOR_SETTING.getKey(), shardBalance);
         settings.put(BalancedShardsAllocator.THRESHOLD_SETTING.getKey(), threshold);
-        settings.put(BalancedShardsAllocator.PREFER_PER_INDEX_PRIMARY_SHARD_BALANCE.getKey(), true);
+        settings.put(BalancedShardsAllocator.PREFER_PRIMARY_SHARD_BALANCE.getKey(), true);
 
         service.applySettings(settings.build());
 
@@ -45,7 +46,7 @@ public class AllocationConstraintsTests extends OpenSearchAllocationTestCase {
         assertEquals(threshold, allocator.getThreshold(), 0.01);
         assertEquals(true, allocator.getPreferPrimaryBalance());
 
-        settings.put(BalancedShardsAllocator.PREFER_PER_INDEX_PRIMARY_SHARD_BALANCE.getKey(), false);
+        settings.put(BalancedShardsAllocator.PREFER_PRIMARY_SHARD_BALANCE.getKey(), false);
         service.applySettings(settings.build());
         assertEquals(false, allocator.getPreferPrimaryBalance());
     }
@@ -76,40 +77,110 @@ public class AllocationConstraintsTests extends OpenSearchAllocationTestCase {
      * Test constraint evaluation logic when with different values of ConstraintMode
      * for IndexShardPerNode constraint satisfied and breached.
      */
-    public void testIndexPrimaryShardsPerNodeConstraint() {
+    public void testPerIndexPrimaryShardsConstraint() {
         ShardsBalancer balancer = mock(LocalShardsBalancer.class);
         BalancedShardsAllocator.ModelNode node = mock(BalancedShardsAllocator.ModelNode.class);
         AllocationConstraints constraints = new AllocationConstraints();
-        constraints.updateAllocationConstraint(PREFER_PRIMARY_SHARD_BALANCE_NODE_BREACH_ID, true);
+        constraints.updateAllocationConstraint(INDEX_PRIMARY_SHARD_BALANCE_CONSTRAINT_ID, true);
 
+        final String indexName = "test-index";
+        int perIndexPrimaryShardCount = 1;
+        float avgPerIndexPrimaryShardsPerNode = 2f;
+
+        when(balancer.avgPrimaryShardsPerNode(anyString())).thenReturn(avgPerIndexPrimaryShardsPerNode);
+        when(node.numPrimaryShards(anyString())).thenReturn(perIndexPrimaryShardCount);
+        when(node.getNodeId()).thenReturn("test-node");
+
+        assertEquals(0, constraints.weight(balancer, node, indexName));
+
+        perIndexPrimaryShardCount = 3;
+        when(node.numPrimaryShards(anyString())).thenReturn(perIndexPrimaryShardCount);
+        assertEquals(CONSTRAINT_WEIGHT, constraints.weight(balancer, node, indexName));
+
+        constraints.updateAllocationConstraint(INDEX_PRIMARY_SHARD_BALANCE_CONSTRAINT_ID, false);
+        assertEquals(0, constraints.weight(balancer, node, indexName));
+    }
+
+    /**
+     * Test constraint evaluation logic when per index primary shard count constraint is breached.
+     */
+    public void testGlobalPrimaryShardsConstraint() {
+        ShardsBalancer balancer = mock(LocalShardsBalancer.class);
+        BalancedShardsAllocator.ModelNode node = mock(BalancedShardsAllocator.ModelNode.class);
+        AllocationConstraints constraints = new AllocationConstraints();
+        constraints.updateAllocationConstraint(CLUSTER_PRIMARY_SHARD_BALANCE_CONSTRAINT_ID, true);
+
+        final String indexName = "test-index";
         int primaryShardCount = 1;
         float avgPrimaryShardsPerNode = 2f;
 
-        when(balancer.avgPrimaryShardsPerNode(anyString())).thenReturn(avgPrimaryShardsPerNode);
-        when(node.numPrimaryShards(anyString())).thenReturn(primaryShardCount);
+        when(balancer.avgPrimaryShardsPerNode()).thenReturn(avgPrimaryShardsPerNode);
+        when(node.numPrimaryShards()).thenReturn(primaryShardCount);
         when(node.getNodeId()).thenReturn("test-node");
 
-        assertEquals(0, constraints.weight(balancer, node, "index"));
+        assertEquals(0, constraints.weight(balancer, node, indexName));
 
         primaryShardCount = 3;
-        when(node.numPrimaryShards(anyString())).thenReturn(primaryShardCount);
-        assertEquals(CONSTRAINT_WEIGHT, constraints.weight(balancer, node, "index"));
+        when(node.numPrimaryShards()).thenReturn(primaryShardCount);
+        assertEquals(CONSTRAINT_WEIGHT, constraints.weight(balancer, node, indexName));
 
-        constraints.updateAllocationConstraint(PREFER_PRIMARY_SHARD_BALANCE_NODE_BREACH_ID, false);
-        assertEquals(0, constraints.weight(balancer, node, "index"));
+        constraints.updateAllocationConstraint(CLUSTER_PRIMARY_SHARD_BALANCE_CONSTRAINT_ID, false);
+        assertEquals(0, constraints.weight(balancer, node, indexName));
+    }
+
+    /**
+     * Test constraint evaluation logic when both per index and global primary shard count constraint is breached.
+     */
+    public void testPrimaryShardsConstraints() {
+        ShardsBalancer balancer = mock(LocalShardsBalancer.class);
+        BalancedShardsAllocator.ModelNode node = mock(BalancedShardsAllocator.ModelNode.class);
+        AllocationConstraints constraints = new AllocationConstraints();
+        constraints.updateAllocationConstraint(CLUSTER_PRIMARY_SHARD_BALANCE_CONSTRAINT_ID, true);
+        constraints.updateAllocationConstraint(INDEX_PRIMARY_SHARD_BALANCE_CONSTRAINT_ID, true);
+
+        final String indexName = "test-index";
+        int perIndexPrimaryShardCount = 1;
+        float avgPerIndexPrimaryShardCount = 2;
+        int primaryShardCount = 2;
+        float avgPrimaryShardsPerNode = 4;
+
+        when(balancer.avgPrimaryShardsPerNode(indexName)).thenReturn(avgPerIndexPrimaryShardCount);
+        when(node.numPrimaryShards(indexName)).thenReturn(perIndexPrimaryShardCount);
+        when(balancer.avgPrimaryShardsPerNode()).thenReturn(avgPrimaryShardsPerNode);
+        when(node.numPrimaryShards()).thenReturn(primaryShardCount);
+        when(node.getNodeId()).thenReturn("test-node");
+
+        assertEquals(0, constraints.weight(balancer, node, indexName));
+
+        // breaching global primary shard count but not per index primary shard count
+        primaryShardCount = 5;
+        when(node.numPrimaryShards()).thenReturn(primaryShardCount);
+        assertEquals(CONSTRAINT_WEIGHT, constraints.weight(balancer, node, indexName));
+
+        // when per index primary shard count constraint is also breached
+        perIndexPrimaryShardCount = 3;
+        when(node.numPrimaryShards(indexName)).thenReturn(perIndexPrimaryShardCount);
+        assertEquals(2 * CONSTRAINT_WEIGHT, constraints.weight(balancer, node, indexName));
+
+        // disable both constraints
+        constraints.updateAllocationConstraint(INDEX_PRIMARY_SHARD_BALANCE_CONSTRAINT_ID, false);
+        constraints.updateAllocationConstraint(CLUSTER_PRIMARY_SHARD_BALANCE_CONSTRAINT_ID, false);
+        assertEquals(0, constraints.weight(balancer, node, indexName));
     }
 
     /**
      * Test constraint evaluation logic when with different values of ConstraintMode
      * for IndexShardPerNode constraint satisfied and breached.
      */
-    public void testAllConstraint() {
+    public void testAllConstraints() {
         ShardsBalancer balancer = mock(LocalShardsBalancer.class);
         BalancedShardsAllocator.ModelNode node = mock(BalancedShardsAllocator.ModelNode.class);
         AllocationConstraints constraints = new AllocationConstraints();
         constraints.updateAllocationConstraint(INDEX_SHARD_PER_NODE_BREACH_CONSTRAINT_ID, true);
-        constraints.updateAllocationConstraint(PREFER_PRIMARY_SHARD_BALANCE_NODE_BREACH_ID, true);
+        constraints.updateAllocationConstraint(INDEX_PRIMARY_SHARD_BALANCE_CONSTRAINT_ID, true);
+        constraints.updateAllocationConstraint(CLUSTER_PRIMARY_SHARD_BALANCE_CONSTRAINT_ID, true);
 
+        final String indexName = "test-index";
         int shardCount = randomIntBetween(1, 500);
         int primaryShardCount = randomIntBetween(1, shardCount);
         float avgShardsPerNode = 1.0f + (random().nextFloat()) * 999.0f;
@@ -123,7 +194,7 @@ public class AllocationConstraintsTests extends OpenSearchAllocationTestCase {
 
         long expectedWeight = (shardCount >= avgShardsPerNode) ? CONSTRAINT_WEIGHT : 0;
         expectedWeight += primaryShardCount > avgPrimaryShardsPerNode ? CONSTRAINT_WEIGHT : 0;
-        assertEquals(expectedWeight, constraints.weight(balancer, node, "index"));
+        assertEquals(expectedWeight, constraints.weight(balancer, node, indexName));
     }
 
 }


### PR DESCRIPTION
### Description
This change is a follow up of https://github.com/opensearch-project/OpenSearch/pull/6422 where constraint based per index primary balance was introduced. This change adds a new constraint `isPrimaryShardsPerNodeBreached` which is marked breached if a node contains more than average number of primary shards across all indices. This is intentionally applied for allocation and will be applied for rebalancing as fast follow up tracked in https://github.com/opensearch-project/OpenSearch/issues/6642
 

### Issues Resolved
#6210 

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
