### PR TITLE
[Segment Replication] Mute segment replication pressure ITs

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/index/SegmentReplicationPressureIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/SegmentReplicationPressureIT.java
@@ -57,6 +57,7 @@ public class SegmentReplicationPressureIT extends SegmentReplicationBaseIT {
         return asList(MockTransportService.TestPlugin.class);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/6671")
     public void testWritesRejected() throws Exception {
         final String primaryNode = internalCluster().startNode();
         createIndex(INDEX_NAME);
@@ -97,6 +98,7 @@ public class SegmentReplicationPressureIT extends SegmentReplicationBaseIT {
      * This test ensures that a replica can be added while the index is under write block.
      * Ensuring that only write requests are blocked.
      */
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/6671")
     public void testAddReplicaWhileWritesBlocked() throws Exception {
         final String primaryNode = internalCluster().startNode();
         createIndex(INDEX_NAME);

--- a/server/src/main/java/org/opensearch/indices/replication/OngoingSegmentReplications.java
+++ b/server/src/main/java/org/opensearch/indices/replication/OngoingSegmentReplications.java
@@ -41,6 +41,8 @@ import java.util.stream.Collectors;
  * @opensearch.internal
  */
 class OngoingSegmentReplications {
+
+    private static final Logger logger = LogManager.getLogger(OngoingSegmentReplications.class);
     private final RecoverySettings recoverySettings;
     private final IndicesService indicesService;
     private final Map<ReplicationCheckpoint, CopyState> copyStateMap;
@@ -94,8 +96,6 @@ class OngoingSegmentReplications {
             return copyState;
         }
     }
-
-    private static final Logger logger = LogManager.getLogger(OngoingSegmentReplications.class);
 
     /**
      * Start sending files to the replica.
@@ -269,6 +269,9 @@ class OngoingSegmentReplications {
             .filter(predicate)
             .map(SegmentReplicationSourceHandler::getAllocationId)
             .collect(Collectors.toList());
+        if (allocationIds.size() == 0) {
+            return;
+        }
         logger.warn(() -> new ParameterizedMessage("Cancelling replications for allocationIds {}", allocationIds));
         for (String allocationId : allocationIds) {
             cancel(allocationId, reason);


### PR DESCRIPTION
### Description
Mute below two tests from `SegmentReplicationPressureIT` class.
1. testAddReplicaWhileWritesBlocked
2. testWritesRejected

This change also piggyback updating the logging condition inside `OngoingSegmentReplications` which create un-necessary noise on cluster state update events.

### Issues Related
#6671 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
