### PR TITLE
Fix shard allocation scenario with dedicated search nodes

### DIFF
--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/decider/TargetPoolAllocationDeciderTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/decider/TargetPoolAllocationDeciderTests.java
@@ -24,7 +24,7 @@ import java.util.Collections;
 import java.util.stream.Collectors;
 
 public class TargetPoolAllocationDeciderTests extends RemoteShardsBalancerBaseTestCase {
-    public void testTargetPoolAllocationDecisions() {
+    public void testTargetPoolHybridAllocationDecisions() {
         ClusterState clusterState = createInitialCluster(3, 3, 2, 2);
         AllocationService service = this.createRemoteCapableAllocationService();
         clusterState = allocateShardsAndBalance(clusterState, service);
@@ -107,6 +107,95 @@ public class TargetPoolAllocationDeciderTests extends RemoteShardsBalancerBaseTe
 
         // Verify only remote nodes are used for auto expand replica decision for remote index
         assertEquals(Decision.YES.type(), deciders.shouldAutoExpandToNode(localIdx, remoteCapableNode.node(), globalAllocation).type());
+        assertEquals(Decision.NO.type(), deciders.shouldAutoExpandToNode(remoteIdx, localOnlyNode.node(), globalAllocation).type());
+        assertEquals(Decision.YES.type(), deciders.shouldAutoExpandToNode(localIdx, localOnlyNode.node(), globalAllocation).type());
+        assertEquals(Decision.YES.type(), deciders.shouldAutoExpandToNode(remoteIdx, remoteCapableNode.node(), globalAllocation).type());
+    }
+
+    public void testTargetPoolDedicatedSearchNodeAllocationDecisions() {
+        ClusterState clusterState = createInitialCluster(3, 3, true, 2, 2);
+        AllocationService service = this.createRemoteCapableAllocationService();
+        clusterState = allocateShardsAndBalance(clusterState, service);
+
+        // Add an unassigned primary shard for force allocation checks
+        Metadata metadata = Metadata.builder(clusterState.metadata())
+            .put(IndexMetadata.builder("test_local_unassigned").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1))
+            .build();
+        RoutingTable routingTable = RoutingTable.builder(clusterState.routingTable())
+            .addAsNew(metadata.index("test_local_unassigned"))
+            .build();
+        clusterState = ClusterState.builder(clusterState).metadata(metadata).routingTable(routingTable).build();
+
+        // Add remote index unassigned primary
+        clusterState = createRemoteIndex(clusterState, "test_remote_unassigned");
+
+        RoutingNodes defaultRoutingNodes = clusterState.getRoutingNodes();
+        RoutingAllocation globalAllocation = getRoutingAllocation(clusterState, defaultRoutingNodes);
+
+        ShardRouting localShard = clusterState.routingTable()
+            .allShards(getIndexName(0, false))
+            .stream()
+            .filter(ShardRouting::primary)
+            .collect(Collectors.toList())
+            .get(0);
+        ShardRouting remoteShard = clusterState.routingTable()
+            .allShards(getIndexName(0, true))
+            .stream()
+            .filter(ShardRouting::primary)
+            .collect(Collectors.toList())
+            .get(0);
+        ShardRouting unassignedLocalShard = clusterState.routingTable()
+            .allShards("test_local_unassigned")
+            .stream()
+            .filter(ShardRouting::primary)
+            .collect(Collectors.toList())
+            .get(0);
+        ShardRouting unassignedRemoteShard = clusterState.routingTable()
+            .allShards("test_remote_unassigned")
+            .stream()
+            .filter(ShardRouting::primary)
+            .collect(Collectors.toList())
+            .get(0);
+        IndexMetadata localIdx = globalAllocation.metadata().getIndexSafe(localShard.index());
+        IndexMetadata remoteIdx = globalAllocation.metadata().getIndexSafe(remoteShard.index());
+        String localNodeId = LOCAL_NODE_PREFIX;
+        for (RoutingNode routingNode : globalAllocation.routingNodes()) {
+            if (routingNode.nodeId().startsWith(LOCAL_NODE_PREFIX)) {
+                localNodeId = routingNode.nodeId();
+                break;
+            }
+        }
+        String remoteNodeId = remoteShard.currentNodeId();
+        RoutingNode localOnlyNode = defaultRoutingNodes.node(localNodeId);
+        RoutingNode remoteCapableNode = defaultRoutingNodes.node(remoteNodeId);
+
+        AllocationDeciders deciders = new AllocationDeciders(Collections.singletonList(new TargetPoolAllocationDecider()));
+
+        // Incompatible Pools
+        assertEquals(Decision.NO.type(), deciders.canAllocate(remoteShard, localOnlyNode, globalAllocation).type());
+        assertEquals(Decision.NO.type(), deciders.canAllocate(remoteIdx, localOnlyNode, globalAllocation).type());
+        assertEquals(Decision.NO.type(), deciders.canForceAllocatePrimary(unassignedRemoteShard, localOnlyNode, globalAllocation).type());
+        // A dedicated search node should not accept local shards and indices.
+        assertEquals(Decision.NO.type(), deciders.canAllocate(localShard, remoteCapableNode, globalAllocation).type());
+        assertEquals(Decision.NO.type(), deciders.canAllocate(localIdx, remoteCapableNode, globalAllocation).type());
+        assertEquals(
+            Decision.NO.type(),
+            deciders.canForceAllocatePrimary(unassignedLocalShard, remoteCapableNode, globalAllocation).type()
+        );
+
+        // Compatible Pools
+        assertEquals(Decision.YES.type(), deciders.canAllocate(remoteShard, remoteCapableNode, globalAllocation).type());
+        assertEquals(Decision.YES.type(), deciders.canAllocate(remoteIdx, remoteCapableNode, globalAllocation).type());
+        assertEquals(Decision.YES.type(), deciders.canAllocate(localShard, localOnlyNode, globalAllocation).type());
+        assertEquals(Decision.YES.type(), deciders.canAllocate(localIdx, localOnlyNode, globalAllocation).type());
+        assertEquals(
+            Decision.YES.type(),
+            deciders.canForceAllocatePrimary(unassignedRemoteShard, remoteCapableNode, globalAllocation).type()
+        );
+        assertEquals(Decision.YES.type(), deciders.canForceAllocatePrimary(unassignedLocalShard, localOnlyNode, globalAllocation).type());
+
+        // Verify only compatible nodes are used for auto expand replica decision for remote index and local index
+        assertEquals(Decision.NO.type(), deciders.shouldAutoExpandToNode(localIdx, remoteCapableNode.node(), globalAllocation).type());
         assertEquals(Decision.NO.type(), deciders.shouldAutoExpandToNode(remoteIdx, localOnlyNode.node(), globalAllocation).type());
         assertEquals(Decision.YES.type(), deciders.shouldAutoExpandToNode(localIdx, localOnlyNode.node(), globalAllocation).type());
         assertEquals(Decision.YES.type(), deciders.shouldAutoExpandToNode(remoteIdx, remoteCapableNode.node(), globalAllocation).type());


### PR DESCRIPTION

### Description
- Fixes shard allocation for local indices and shards when the node is a dedicated `search` node

### Issues Resolved
- Resolves #6418 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
