### PR TITLE
Updated 1.3.9 release note to include latest version of Netty

### DIFF
--- a/release-notes/opensearch.release-notes-1.3.9.md
+++ b/release-notes/opensearch.release-notes-1.3.9.md
@@ -1,7 +1,7 @@
 ## 2022-03-15 Version 1.3.9 Release Notes
 
 ### Upgrades
-- Upgrade `Netty` from 4.1.86.Final to 4.1.87.Final ([#6130](https://github.com/opensearch-project/OpenSearch/pull/6130))
+- Upgrade Netty to 4.1.90.Final ([#6677](https://github.com/opensearch-project/OpenSearch/pull/6677)
 - Upgrade `Jackson` from 2.14.1 to 2.14.2 ([#6129](https://github.com/opensearch-project/OpenSearch/pull/6129))
 - Add support for ppc64le architecture ([#5459](https://github.com/opensearch-project/OpenSearch/pull/5459))
 - Upgrade `snakeyaml` from 1.33 to 2.0 ([#6511](https://github.com/opensearch-project/OpenSearch/pull/6511))


### PR DESCRIPTION
### Description
With the latest Netty [PR](https://github.com/opensearch-project/OpenSearch/pull/6684) merged to `1.3`. Updating the release doc to include the new version. Will backport this PR to `1.x` and `1.3`

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
