### PR TITLE
Add TopNSearchTasksLogger settings to Cluster Settings

### DIFF
--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -49,6 +49,7 @@ import org.opensearch.search.backpressure.settings.SearchShardTaskSettings;
 import org.opensearch.search.backpressure.settings.SearchTaskSettings;
 import org.opensearch.tasks.TaskManager;
 import org.opensearch.tasks.TaskResourceTrackingService;
+import org.opensearch.tasks.consumer.TopNSearchTasksLogger;
 import org.opensearch.watcher.ResourceWatcherService;
 import org.opensearch.action.admin.cluster.configuration.TransportAddVotingConfigExclusionsAction;
 import org.opensearch.action.admin.indices.close.TransportCloseIndexAction;
@@ -598,6 +599,8 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 IndexingPressure.MAX_INDEXING_BYTES,
                 TaskResourceTrackingService.TASK_RESOURCE_TRACKING_ENABLED,
                 TaskManager.TASK_RESOURCE_CONSUMERS_ENABLED,
+                TopNSearchTasksLogger.LOG_TOP_QUERIES_SIZE_SETTING,
+                TopNSearchTasksLogger.LOG_TOP_QUERIES_FREQUENCY_SETTING,
                 ClusterManagerTaskThrottler.THRESHOLD_SETTINGS,
 
                 // Settings related to search backpressure

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -49,6 +49,7 @@ import org.opensearch.extensions.NoopExtensionsManager;
 import org.opensearch.search.backpressure.SearchBackpressureService;
 import org.opensearch.search.backpressure.settings.SearchBackpressureSettings;
 import org.opensearch.tasks.TaskResourceTrackingService;
+import org.opensearch.tasks.consumer.TopNSearchTasksLogger;
 import org.opensearch.threadpool.RunnableTaskExecutionListener;
 import org.opensearch.index.store.RemoteSegmentStoreDirectoryFactory;
 import org.opensearch.watcher.ResourceWatcherService;
@@ -840,6 +841,8 @@ public class Node implements Closeable {
                 settingsModule.getClusterSettings(),
                 taskHeaders
             );
+            TopNSearchTasksLogger taskConsumer = new TopNSearchTasksLogger(settings, settingsModule.getClusterSettings());
+            transportService.getTaskManager().registerTaskResourceConsumer(taskConsumer);
             if (FeatureFlags.isEnabled(FeatureFlags.EXTENSIONS)) {
                 this.extensionsManager.initializeServicesAndRestHandler(
                     restController,

--- a/server/src/main/java/org/opensearch/search/backpressure/SearchBackpressureService.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/SearchBackpressureService.java
@@ -197,7 +197,7 @@ public class SearchBackpressureService extends AbstractLifecycleComponent implem
         }
 
         for (TaskCancellation taskCancellation : getTaskCancellations(cancellableTasks)) {
-            logger.debug(
+            logger.warn(
                 "[{} mode] cancelling task [{}] due to high resource consumption [{}]",
                 mode.getName(),
                 taskCancellation.getTask().getId(),

--- a/server/src/main/java/org/opensearch/tasks/consumer/TopNSearchTasksLogger.java
+++ b/server/src/main/java/org/opensearch/tasks/consumer/TopNSearchTasksLogger.java
@@ -105,7 +105,7 @@ public class TopNSearchTasksLogger implements Consumer<Task> {
         }
     }
 
-    void setLogTopQueriesSize(int topQueriesSize) {
+    private void setLogTopQueriesSize(int topQueriesSize) {
         this.topQueriesSize = topQueriesSize;
     }
 

--- a/server/src/main/java/org/opensearch/tasks/consumer/TopNSearchTasksLogger.java
+++ b/server/src/main/java/org/opensearch/tasks/consumer/TopNSearchTasksLogger.java
@@ -39,6 +39,8 @@ public class TopNSearchTasksLogger implements Consumer<Task> {
     public static final Setting<Integer> LOG_TOP_QUERIES_SIZE_SETTING = Setting.intSetting(
         LOG_TOP_QUERIES_SIZE,
         10,
+        1,
+        25,
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
@@ -46,6 +48,7 @@ public class TopNSearchTasksLogger implements Consumer<Task> {
     // frequency in which memory expensive search tasks are logged
     public static final Setting<TimeValue> LOG_TOP_QUERIES_FREQUENCY_SETTING = Setting.timeSetting(
         LOG_TOP_QUERIES_FREQUENCY,
+        TimeValue.timeValueSeconds(60L),
         TimeValue.timeValueSeconds(60L),
         Setting.Property.Dynamic,
         Setting.Property.NodeScope

--- a/server/src/main/java/org/opensearch/tasks/consumer/TopNSearchTasksLogger.java
+++ b/server/src/main/java/org/opensearch/tasks/consumer/TopNSearchTasksLogger.java
@@ -36,7 +36,7 @@ public class TopNSearchTasksLogger implements Consumer<Task> {
     private static final Logger SEARCH_TASK_DETAILS_LOGGER = LogManager.getLogger(TASK_DETAILS_LOG_PREFIX + ".search");
 
     // number of memory expensive search tasks that are logged
-    private static final Setting<Integer> LOG_TOP_QUERIES_SIZE_SETTING = Setting.intSetting(
+    public static final Setting<Integer> LOG_TOP_QUERIES_SIZE_SETTING = Setting.intSetting(
         LOG_TOP_QUERIES_SIZE,
         10,
         Setting.Property.Dynamic,
@@ -44,7 +44,7 @@ public class TopNSearchTasksLogger implements Consumer<Task> {
     );
 
     // frequency in which memory expensive search tasks are logged
-    private static final Setting<TimeValue> LOG_TOP_QUERIES_FREQUENCY_SETTING = Setting.timeSetting(
+    public static final Setting<TimeValue> LOG_TOP_QUERIES_FREQUENCY_SETTING = Setting.timeSetting(
         LOG_TOP_QUERIES_FREQUENCY,
         TimeValue.timeValueSeconds(60L),
         Setting.Property.Dynamic,

--- a/server/src/test/java/org/opensearch/tasks/consumer/TopNSearchTasksLoggerTests.java
+++ b/server/src/test/java/org/opensearch/tasks/consumer/TopNSearchTasksLoggerTests.java
@@ -12,12 +12,16 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LogEvent;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsResponse;
 import org.opensearch.action.search.SearchShardTask;
 import org.opensearch.common.logging.Loggers;
 import org.opensearch.common.logging.MockAppender;
+import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.tasks.ResourceStats;
 import org.opensearch.tasks.ResourceStatsType;
 import org.opensearch.tasks.ResourceUsageMetric;
@@ -26,8 +30,9 @@ import org.opensearch.test.OpenSearchSingleNodeTestCase;
 
 import java.util.Collections;
 
-import static org.opensearch.tasks.consumer.TopNSearchTasksLogger.LOG_TOP_QUERIES_FREQUENCY;
-import static org.opensearch.tasks.consumer.TopNSearchTasksLogger.LOG_TOP_QUERIES_SIZE;
+import static org.opensearch.tasks.consumer.TopNSearchTasksLogger.LOG_TOP_QUERIES_SIZE_SETTING;
+import static org.opensearch.tasks.consumer.TopNSearchTasksLogger.LOG_TOP_QUERIES_FREQUENCY_SETTING;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 
 public class TopNSearchTasksLoggerTests extends OpenSearchSingleNodeTestCase {
     static MockAppender appender;
@@ -42,6 +47,17 @@ public class TopNSearchTasksLoggerTests extends OpenSearchSingleNodeTestCase {
         Loggers.addAppender(searchLogger, appender);
     }
 
+    @After
+    public void cleanupAfterTest() {
+        assertAcked(
+            client().admin()
+                .cluster()
+                .prepareUpdateSettings()
+                .setPersistentSettings(Settings.builder().putNull("*"))
+                .setTransientSettings(Settings.builder().putNull("*"))
+        );
+    }
+
     @AfterClass
     public static void cleanup() {
         Loggers.removeAppender(searchLogger, appender);
@@ -49,8 +65,13 @@ public class TopNSearchTasksLoggerTests extends OpenSearchSingleNodeTestCase {
     }
 
     public void testLoggerWithTasks() {
-        final Settings settings = Settings.builder().put(LOG_TOP_QUERIES_SIZE, 1).put(LOG_TOP_QUERIES_FREQUENCY, "0ms").build();
-        topNSearchTasksLogger = new TopNSearchTasksLogger(settings);
+        final Settings settings = Settings.builder()
+            .put(LOG_TOP_QUERIES_SIZE_SETTING.getKey(), 1)
+            .put(LOG_TOP_QUERIES_FREQUENCY_SETTING.getKey(), "60s")
+            .build();
+        topNSearchTasksLogger = new TopNSearchTasksLogger(settings, null);
+        // This setting overrides is just for testing purpose
+        topNSearchTasksLogger.setTopQueriesLogFrequencyInNanos(TimeValue.timeValueMillis(0));
         generateTasks(5);
         LogEvent logEvent = appender.getLastEventAndReset();
         assertNotNull(logEvent);
@@ -59,20 +80,63 @@ public class TopNSearchTasksLoggerTests extends OpenSearchSingleNodeTestCase {
     }
 
     public void testLoggerWithoutTasks() {
-        final Settings settings = Settings.builder().put(LOG_TOP_QUERIES_SIZE, 1).put(LOG_TOP_QUERIES_FREQUENCY, "500ms").build();
-        topNSearchTasksLogger = new TopNSearchTasksLogger(settings);
+        final Settings settings = Settings.builder()
+            .put(LOG_TOP_QUERIES_SIZE_SETTING.getKey(), 1)
+            .put(LOG_TOP_QUERIES_FREQUENCY_SETTING.getKey(), "60s")
+            .build();
+        topNSearchTasksLogger = new TopNSearchTasksLogger(settings, null);
 
         assertNull(appender.getLastEventAndReset());
     }
 
     public void testLoggerWithHighFrequency() {
         // setting the frequency to a really large value and confirming that nothing gets written to log file.
-        final Settings settings = Settings.builder().put(LOG_TOP_QUERIES_SIZE, 1).put(LOG_TOP_QUERIES_FREQUENCY, "10m").build();
-        topNSearchTasksLogger = new TopNSearchTasksLogger(settings);
+        final Settings settings = Settings.builder()
+            .put(LOG_TOP_QUERIES_SIZE_SETTING.getKey(), 1)
+            .put(LOG_TOP_QUERIES_FREQUENCY_SETTING.getKey(), "10m")
+            .build();
+        topNSearchTasksLogger = new TopNSearchTasksLogger(settings, null);
         generateTasks(5);
         generateTasks(2);
 
         assertNull(appender.getLastEventAndReset());
+    }
+
+    public void testDynamicSettings() {
+        Settings settings = Settings.builder()
+            .put(LOG_TOP_QUERIES_SIZE_SETTING.getKey(), 1)
+            .put(LOG_TOP_QUERIES_FREQUENCY_SETTING.getKey(), "60s")
+            .build();
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        topNSearchTasksLogger = new TopNSearchTasksLogger(settings, clusterSettings);
+        settings = Settings.builder().put(LOG_TOP_QUERIES_SIZE_SETTING.getKey(), "10").build();
+        ClusterUpdateSettingsResponse response = client().admin().cluster().prepareUpdateSettings().setPersistentSettings(settings).get();
+        assertEquals(response.getPersistentSettings().get(LOG_TOP_QUERIES_SIZE_SETTING.getKey()), "10");
+
+        settings = Settings.builder().put(LOG_TOP_QUERIES_FREQUENCY_SETTING.getKey(), "100s").build();
+        response = client().admin().cluster().prepareUpdateSettings().setPersistentSettings(settings).get();
+        assertEquals(response.getPersistentSettings().get(LOG_TOP_QUERIES_FREQUENCY_SETTING.getKey()), "100s");
+    }
+
+    public void testMinMaxSettingValues() {
+        final Settings settings = Settings.builder()
+            .put(LOG_TOP_QUERIES_SIZE_SETTING.getKey(), 1)
+            .put(LOG_TOP_QUERIES_FREQUENCY_SETTING.getKey(), "60s")
+            .build();
+        topNSearchTasksLogger = new TopNSearchTasksLogger(settings, null);
+        final Settings sizeSetting = Settings.builder().put(LOG_TOP_QUERIES_SIZE_SETTING.getKey(), "50").build();
+        // request should fail as it crosses maximum defined value(25)
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> client().admin().cluster().prepareUpdateSettings().setPersistentSettings(sizeSetting).get()
+        );
+
+        final Settings freqSetting = Settings.builder().put(LOG_TOP_QUERIES_FREQUENCY_SETTING.getKey(), "30s").build();
+        // request should fail as it crosses minimum defined value(60s)
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> client().admin().cluster().prepareUpdateSettings().setPersistentSettings(freqSetting).get()
+        );
     }
 
     // generate search tasks and updates the topN search tasks logger consumer.


### PR DESCRIPTION
### Description
We introduced Task Resource Consumer to log task resource information at a specified interval as a part of https://github.com/opensearch-project/OpenSearch/pull/2293. However, newly introduced dynamic settings `cluster.task.consumers.top_n.size` and `cluster.task.consumers.top_n.frequency` are not registered under ClusterSettings.BUILT_IN_CLUSTER_SETTINGS and hence not recognised when trying to change the value. We need to register them in ClusterSettings.BUILT_IN_CLUSTER_SETTINGS to make them dynamic. Making this change to fix the issue.

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/6708

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
