### PR TITLE
Add configuration for custom block sized index inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Return success on DeletePits when no PITs exist. ([#6544](https://github.com/opensearch-project/OpenSearch/pull/6544))
 - Add node repurpose command for search nodes ([#6517](https://github.com/opensearch-project/OpenSearch/pull/6517))
 - [Segment Replication] Apply backpressure when replicas fall behind ([#6563](https://github.com/opensearch-project/OpenSearch/pull/6563))
+- Add index input block size configuration for searchable snapshots ([#6743](https://github.com/opensearch-project/OpenSearch/pull/6743))
 
 ### Dependencies
 - Bump `org.apache.logging.log4j:log4j-core` from 2.18.0 to 2.20.0 ([#6490](https://github.com/opensearch-project/OpenSearch/pull/6490))

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -43,6 +43,7 @@ import org.opensearch.index.SegmentReplicationPressureService;
 import org.opensearch.index.ShardIndexingPressureMemoryManager;
 import org.opensearch.index.ShardIndexingPressureSettings;
 import org.opensearch.index.ShardIndexingPressureStore;
+import org.opensearch.index.store.remote.directory.RemoteSnapshotDirectoryFactory;
 import org.opensearch.search.backpressure.settings.NodeDuressSettings;
 import org.opensearch.search.backpressure.settings.SearchBackpressureSettings;
 import org.opensearch.search.backpressure.settings.SearchShardTaskSettings;
@@ -644,7 +645,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
      */
     public static final Map<String, List<Setting>> FEATURE_FLAGGED_CLUSTER_SETTINGS = Map.of(
         FeatureFlags.SEARCHABLE_SNAPSHOT,
-        List.of(Node.NODE_SEARCH_CACHE_SIZE_SETTING)
+        List.of(Node.NODE_SEARCH_CACHE_SIZE_SETTING, RemoteSnapshotDirectoryFactory.SEARACHBLE_SNAPSHOT_BLOCK_SIZE_SETTING)
     );
 
 }

--- a/server/src/main/java/org/opensearch/index/store/remote/file/OnDemandBlockIndexInput.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/file/OnDemandBlockIndexInput.java
@@ -414,6 +414,15 @@ abstract class OnDemandBlockIndexInput extends IndexInput implements RandomAcces
             this.blockMask = blockSize - 1;
             return this;
         }
+
+        Builder blockSize(long blockSize) {
+            assert blockSize < 1L << 31 && blockSize > 0 : "invalid block size";
+            assert ((blockSize & (blockSize - 1)) == 0) : "block size must be a power of 2";
+            this.blockSize = (int) blockSize;
+            this.blockMask = this.blockSize - 1;
+            this.blockSizeShift = (int) (Math.log(this.blockSize) / Math.log(2));
+            return this;
+        }
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/store/remote/file/OnDemandBlockSnapshotIndexInput.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/file/OnDemandBlockSnapshotIndexInput.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.store.IndexInput;
+import org.opensearch.common.unit.ByteSizeValue;
 import org.opensearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot.FileInfo;
 import org.opensearch.index.store.remote.utils.BlobFetchRequest;
 import org.opensearch.index.store.remote.utils.TransferManager;
@@ -57,7 +58,12 @@ public class OnDemandBlockSnapshotIndexInput extends OnDemandBlockIndexInput {
      */
     protected final long originalFileSize;
 
-    public OnDemandBlockSnapshotIndexInput(FileInfo fileInfo, FSDirectory directory, TransferManager transferManager) {
+    public OnDemandBlockSnapshotIndexInput(
+        FileInfo fileInfo,
+        FSDirectory directory,
+        TransferManager transferManager,
+        ByteSizeValue blockSize
+    ) {
         this(
             "BlockedSnapshotIndexInput(path=\""
                 + directory.getDirectory().toString()
@@ -74,7 +80,8 @@ public class OnDemandBlockSnapshotIndexInput extends OnDemandBlockIndexInput {
             fileInfo.length(),
             false,
             directory,
-            transferManager
+            transferManager,
+            blockSize
         );
     }
 
@@ -85,10 +92,16 @@ public class OnDemandBlockSnapshotIndexInput extends OnDemandBlockIndexInput {
         long length,
         boolean isClone,
         FSDirectory directory,
-        TransferManager transferManager
+        TransferManager transferManager,
+        ByteSizeValue blockSize
     ) {
         this(
-            OnDemandBlockIndexInput.builder().resourceDescription(resourceDescription).isClone(isClone).offset(offset).length(length),
+            OnDemandBlockIndexInput.builder()
+                .blockSize(blockSize.getBytes())
+                .resourceDescription(resourceDescription)
+                .isClone(isClone)
+                .offset(offset)
+                .length(length),
             fileInfo,
             directory,
             transferManager

--- a/server/src/test/java/org/opensearch/index/store/remote/RemoteSnapshotDirectoryFactoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/RemoteSnapshotDirectoryFactoryTests.java
@@ -1,0 +1,117 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.store.remote;
+
+import org.junit.After;
+import org.junit.Before;
+import org.opensearch.Version;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.IndexScopedSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.settings.SettingsException;
+import org.opensearch.common.unit.ByteSizeUnit;
+import org.opensearch.common.unit.ByteSizeValue;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.shard.ShardId;
+import org.opensearch.index.shard.ShardPath;
+import org.opensearch.index.store.remote.directory.RemoteSnapshotDirectoryFactory;
+import org.opensearch.index.store.remote.filecache.FileCache;
+import org.opensearch.index.store.remote.filecache.FileCacheFactory;
+import org.opensearch.repositories.RepositoriesService;
+import org.opensearch.repositories.blobstore.BlobStoreRepository;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import static org.apache.lucene.tests.util.LuceneTestCase.createTempDir;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.index.IndexSettings.SEARCHABLE_SNAPSHOT_REPOSITORY;
+import static org.opensearch.index.store.remote.directory.RemoteSnapshotDirectoryFactory.SEARACHBLE_SNAPSHOT_BLOCK_SIZE_SETTING;
+
+public class RemoteSnapshotDirectoryFactoryTests extends OpenSearchTestCase {
+
+    private Supplier<RepositoriesService> repositoriesServiceSupplier;
+    private ThreadPool threadPool;
+    private RepositoriesService repositoriesService;
+    private FileCache remoteStoreFileCache;
+    private Path path;
+
+    private static final String REPO_NAME = "test_repo";
+    private static final String INDEX_NAME = "test_index";
+    private final static int GIGA_BYTES = 1024 * 1024 * 1024;
+    private final static int SHARD_ID = 0;
+
+    @Before
+    public void setup() throws IOException {
+        repositoriesServiceSupplier = mock(Supplier.class);
+        threadPool = new TestThreadPool("test");
+        repositoriesService = mock(RepositoriesService.class);
+        when(repositoriesServiceSupplier.get()).thenReturn(repositoriesService);
+        remoteStoreFileCache = FileCacheFactory.createConcurrentLRUFileCache(GIGA_BYTES, 1);
+        path = createTempDir("RemoteSnapshotDirectoryFactoryTests");
+    }
+
+    @After
+    public void teardown() {
+        threadPool.shutdown();
+    }
+
+    public void testNewDirectoryBlockException() {
+        RemoteSnapshotDirectoryFactory remoteSnapshotDirectoryFactory = new RemoteSnapshotDirectoryFactory(
+            repositoriesServiceSupplier,
+            threadPool,
+            remoteStoreFileCache
+        );
+        Settings repositorySettings = Settings.builder()
+            .put(SEARCHABLE_SNAPSHOT_REPOSITORY.getKey(), REPO_NAME)
+            .put(SEARACHBLE_SNAPSHOT_BLOCK_SIZE_SETTING.getKey(), new ByteSizeValue(3, ByteSizeUnit.MB))
+            .build();
+        BlobStoreRepository blobStoreRepository = mock(BlobStoreRepository.class);
+        when(repositoriesService.repository(eq(REPO_NAME))).thenReturn(blobStoreRepository);
+
+        IndexSettings settings = newIndexSettings(newIndexMeta(INDEX_NAME, repositorySettings), Settings.EMPTY);
+        ShardPath shardPath = new ShardPath(
+            false,
+            path.resolve(INDEX_NAME).resolve(String.valueOf(SHARD_ID)),
+            path.resolve(INDEX_NAME).resolve(String.valueOf(SHARD_ID)),
+            new ShardId(INDEX_NAME, INDEX_NAME, SHARD_ID)
+        );
+        assertThrows(SettingsException.class, () -> remoteSnapshotDirectoryFactory.newDirectory(settings, shardPath));
+    }
+
+    private IndexSettings newIndexSettings(IndexMetadata metadata, Settings nodeSettings, Setting<?>... settings) {
+        Set<Setting<?>> settingSet = new HashSet<>(IndexScopedSettings.BUILT_IN_INDEX_SETTINGS);
+        if (settings.length > 0) {
+            settingSet.addAll(Arrays.asList(settings));
+        }
+        return new IndexSettings(metadata, nodeSettings, new IndexScopedSettings(Settings.EMPTY, settingSet));
+    }
+
+    private IndexMetadata newIndexMeta(String name, Settings indexSettings) {
+        Settings build = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(indexSettings)
+            .build();
+        return IndexMetadata.builder(name).settings(build).build();
+    }
+
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
- Adds in a node level configuration `node.searchable_snapshot.block.size` to enable block size tuning at node level for searchable snapshots
- The configuration raises an exception if the block size is not defined as a power of 2 which is an internal constraint for the block manipulation logic

### Issues Resolved
Resolves #6480 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
