### PR TITLE
[Backport 2.x] [Segment Replication] Remove completed_only query parameter from _cat/segment_replication API

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segment_replication.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segment_replication.json
@@ -37,11 +37,6 @@
         "description":"If `true`, the response only includes ongoing segment replication events",
         "default":false
       },
-      "completed_only":{
-        "type":"boolean",
-        "description":"If `true`, the response only includes latest completed segment replication events",
-        "default":false
-      },
       "bytes":{
         "type":"enum",
         "description":"The unit in which to display byte values",

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationStatsIT.java
@@ -77,7 +77,7 @@ public class SegmentReplicationStatsIT extends SegmentReplicationBaseIT {
         }, 1, TimeUnit.MINUTES);
     }
 
-    public void testSegmentReplicationStatsResponseForActiveAndCompletedOnly() throws Exception {
+    public void testSegmentReplicationStatsResponseForActiveOnly() throws Exception {
         final String primaryNode = internalCluster().startNode();
         createIndex(INDEX_NAME);
         ensureYellowAndNoInitializingShards(INDEX_NAME);
@@ -140,25 +140,6 @@ public class SegmentReplicationStatsIT extends SegmentReplicationBaseIT {
             .getCurrentReplicationState()
             .getStage();
         assertEquals(SegmentReplicationState.Stage.GET_FILES, stage);
-
-        // verifying completed_only by checking if current stage is DONE
-        SegmentReplicationStatsResponse completedOnlyResponse = client().admin()
-            .indices()
-            .prepareSegmentReplicationStats(INDEX_NAME)
-            .setDetailed(true)
-            .setCompletedOnly(true)
-            .execute()
-            .actionGet();
-        assertEquals(completedOnlyResponse.getReplicationStats().size(), SHARD_COUNT);
-        perGroupStats = completedOnlyResponse.getReplicationStats().get(INDEX_NAME).get(0);
-        final SegmentReplicationState currentReplicationState = perGroupStats.getReplicaStats()
-            .stream()
-            .findFirst()
-            .get()
-            .getCurrentReplicationState();
-
-        assertEquals(SegmentReplicationState.Stage.DONE, currentReplicationState.getStage());
-        assertTrue(currentReplicationState.getIndex().recoveredFileCount() > 0);
         waitForAssertions.countDown();
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/replication/SegmentReplicationStatsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/replication/SegmentReplicationStatsRequest.java
@@ -24,10 +24,7 @@ import java.io.IOException;
 public class SegmentReplicationStatsRequest extends BroadcastRequest<SegmentReplicationStatsRequest> {
     private boolean detailed = false;       // Provides extra details in the response
     private boolean activeOnly = false;     // Only reports on active segment replication events
-
     private String[] shards = new String[0];
-
-    private boolean completedOnly = false;
 
     /**
      * Constructs a request for segment replication stats information for all shards
@@ -40,8 +37,6 @@ public class SegmentReplicationStatsRequest extends BroadcastRequest<SegmentRepl
         super(in);
         detailed = in.readBoolean();
         activeOnly = in.readBoolean();
-        completedOnly = in.readBoolean();
-
     }
 
     /**
@@ -92,25 +87,6 @@ public class SegmentReplicationStatsRequest extends BroadcastRequest<SegmentRepl
     }
 
     /**
-     * True if completedOnly flag is set, false otherwise. This value is false by default.
-     *
-     * @return  True if completedOnly flag is set, false otherwise
-     */
-    public boolean completedOnly() {
-        return completedOnly;
-    }
-
-    /**
-     * Set value of the completedOnly flag. If true, this request will only respond with
-     * latest completed segment replication event information.
-     *
-     * @param completedOnly   Whether or not to set the completedOnly flag.
-     */
-    public void completedOnly(boolean completedOnly) {
-        this.completedOnly = completedOnly;
-    }
-
-    /**
      * Contains list of shard id's if shards are passed, empty otherwise. Array is empty by default.
      *
      * @return  list of shard id's if shards are passed, empty otherwise
@@ -134,6 +110,5 @@ public class SegmentReplicationStatsRequest extends BroadcastRequest<SegmentRepl
         super.writeTo(out);
         out.writeBoolean(detailed);
         out.writeBoolean(activeOnly);
-        out.writeBoolean(completedOnly);
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/indices/replication/SegmentReplicationStatsRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/replication/SegmentReplicationStatsRequestBuilder.java
@@ -35,11 +35,6 @@ public class SegmentReplicationStatsRequestBuilder extends BroadcastOperationReq
         return this;
     }
 
-    public SegmentReplicationStatsRequestBuilder setCompletedOnly(boolean completedOnly) {
-        request.completedOnly(completedOnly);
-        return this;
-    }
-
     public SegmentReplicationStatsRequestBuilder shards(String... indices) {
         request.shards(indices);
         return this;

--- a/server/src/main/java/org/opensearch/action/admin/indices/replication/TransportSegmentReplicationStatsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/replication/TransportSegmentReplicationStatsAction.java
@@ -160,11 +160,6 @@ public class TransportSegmentReplicationStatsAction extends TransportBroadcastBy
         if (request.activeOnly()) {
             return new SegmentReplicationShardStatsResponse(targetService.getOngoingEventSegmentReplicationState(shardId));
         }
-
-        // return information about only latest completed segment replication events.
-        if (request.completedOnly()) {
-            return new SegmentReplicationShardStatsResponse(targetService.getlatestCompletedEventSegmentReplicationState(shardId));
-        }
         return new SegmentReplicationShardStatsResponse(targetService.getSegmentReplicationState(shardId));
     }
 

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestCatSegmentReplicationAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestCatSegmentReplicationAction.java
@@ -71,7 +71,6 @@ public class RestCatSegmentReplicationAction extends AbstractCatAction {
         segmentReplicationStatsRequest.detailed(request.paramAsBoolean("detailed", false));
         segmentReplicationStatsRequest.shards(Strings.splitStringByCommaToArray(request.param("shards")));
         segmentReplicationStatsRequest.activeOnly(request.paramAsBoolean("active_only", false));
-        segmentReplicationStatsRequest.completedOnly(request.paramAsBoolean("completed_only", false));
         segmentReplicationStatsRequest.indicesOptions(IndicesOptions.fromRequest(request, segmentReplicationStatsRequest.indicesOptions()));
 
         return channel -> client.admin()


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR backports #6725 to 2.x branch

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
