### PR TITLE
[Segment Replication] Handle update target cp for relocating primary

### DIFF
--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -2725,9 +2725,11 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
      * @param visibleCheckpoint the visible checkpoint
      */
     public void updateVisibleCheckpointForShard(final String allocationId, final ReplicationCheckpoint visibleCheckpoint) {
-        assert assertPrimaryMode();
-        verifyNotClosed();
-        replicationTracker.updateVisibleCheckpointForShard(allocationId, visibleCheckpoint);
+        // Update target replication checkpoint only when in active primary mode
+        if (shardRouting.primary() && replicationTracker.isPrimaryMode()) {
+            verifyNotClosed();
+            replicationTracker.updateVisibleCheckpointForShard(allocationId, visibleCheckpoint);
+        }
     }
 
     /**


### PR DESCRIPTION
### Description
As part of https://github.com/opensearch-project/OpenSearch/pull/6563, primary tracks the target replication checkpoint of target while responding `get_segment_files` call. But, during primary relocation this breaks as primary is not in active primary mode and fails `assertPrimaryMode()` assertion leading to test failures. During primary handoff, the target shard is [activated with primary context](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/index/seqno/ReplicationTracker.java#L1718).

Primary shard routing before and after relocation is started. 
```
[2023-03-20T14:19:20,164][INFO ][o.o.i.r.SegmentReplicationSourceService] [node_t7] --> oldRouting [test][44], node[FIVJG3pnRaa-irH_1SjJkg], [P], s[STARTED], a[id=o8B_jOT1QO-XF4JmOSGZLw]
[2023-03-20T14:19:20,164][INFO ][o.o.i.r.SegmentReplicationSourceService] [node_t7] --> newRouting [test][44], node[FIVJG3pnRaa-irH_1SjJkg], relocating [YhTm5x0BSe63RPmK4Wg0fg], [P], s[RELOCATING], a[id=o8B_jOT1QO-XF4JmOSGZLw, rId=ysSq8jpVQWK5HUL1Osbb3Q], expected_shard_size[230]
```

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/6740

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
