### PR TITLE
[Backport 2.x] Bump com.diffplug.spotless from 6.15.0 to 6.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `net.minidev:json-smart` from 2.4.8 to 2.4.9
 - Bump `com.google.protobuf:protobuf-java` from 3.22.0 to 3.22.2
 - Bump Netty to 4.1.90.Final ([#6677](https://github.com/opensearch-project/OpenSearch/pull/6677)
+- Bump `com.diffplug.spotless` from 6.15.0 to 6.17.0
 
 ### Changed
 - Require MediaType in Strings.toString API ([#6009](https://github.com/opensearch-project/OpenSearch/pull/6009))

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ plugins {
   id 'lifecycle-base'
   id 'opensearch.docker-support'
   id 'opensearch.global-build-info'
-  id "com.diffplug.spotless" version "6.15.0" apply false
+  id "com.diffplug.spotless" version "6.17.0" apply false
   id "org.gradle.test-retry" version "1.5.1" apply false
   id "test-report-aggregation"
   id 'jacoco-report-aggregation'

--- a/buildSrc/src/main/java/org/opensearch/gradle/docker/DockerSupportPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/docker/DockerSupportPlugin.java
@@ -56,13 +56,9 @@ public class DockerSupportPlugin implements Plugin<Project> {
 
         Provider<DockerSupportService> dockerSupportServiceProvider = project.getGradle()
             .getSharedServices()
-            .registerIfAbsent(
-                DOCKER_SUPPORT_SERVICE_NAME,
-                DockerSupportService.class,
-                spec -> spec.parameters(
-                    params -> { params.setExclusionsFile(new File(project.getRootDir(), DOCKER_ON_LINUX_EXCLUSIONS_FILE)); }
-                )
-            );
+            .registerIfAbsent(DOCKER_SUPPORT_SERVICE_NAME, DockerSupportService.class, spec -> spec.parameters(params -> {
+                params.setExclusionsFile(new File(project.getRootDir(), DOCKER_ON_LINUX_EXCLUSIONS_FILE));
+            }));
 
         // Ensure that if we are trying to run any DockerBuildTask tasks, we assert an available Docker installation exists
         project.getGradle().getTaskGraph().whenReady(graph -> {

--- a/buildSrc/src/main/java/org/opensearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
@@ -76,12 +76,9 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         project.getRootProject().getPluginManager().apply(GlobalBuildInfoPlugin.class);
-        BuildParams.getBwcVersions()
-            .forPreviousUnreleased(
-                (BwcVersions.UnreleasedVersionInfo unreleasedVersion) -> {
-                    configureBwcProject(project.project(unreleasedVersion.gradleProjectPath), unreleasedVersion);
-                }
-            );
+        BuildParams.getBwcVersions().forPreviousUnreleased((BwcVersions.UnreleasedVersionInfo unreleasedVersion) -> {
+            configureBwcProject(project.project(unreleasedVersion.gradleProjectPath), unreleasedVersion);
+        });
     }
 
     private void configureBwcProject(Project project, BwcVersions.UnreleasedVersionInfo versionInfo) {

--- a/buildSrc/src/main/java/org/opensearch/gradle/test/DistroTestPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/test/DistroTestPlugin.java
@@ -197,13 +197,9 @@ public class DistroTestPlugin implements Plugin<Project> {
 
             // windows boxes get windows distributions, and linux boxes get linux distributions
             if (isWindows(vmProject)) {
-                configureVMWrapperTasks(
-                    vmProject,
-                    windowsTestTasks,
-                    depsTasks,
-                    wrapperTask -> { vmLifecyleTasks.get(OpenSearchDistribution.Type.ARCHIVE).configure(t -> t.dependsOn(wrapperTask)); },
-                    vmDependencies
-                );
+                configureVMWrapperTasks(vmProject, windowsTestTasks, depsTasks, wrapperTask -> {
+                    vmLifecyleTasks.get(OpenSearchDistribution.Type.ARCHIVE).configure(t -> t.dependsOn(wrapperTask));
+                }, vmDependencies);
             } else {
                 for (Entry<OpenSearchDistribution.Type, List<TaskProvider<Test>>> entry : linuxTestTasks.entrySet()) {
                     OpenSearchDistribution.Type type = entry.getKey();

--- a/client/rest-high-level/src/main/java/org/opensearch/client/core/MainResponse.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/core/MainResponse.java
@@ -43,7 +43,9 @@ public class MainResponse {
     private static final ConstructingObjectParser<MainResponse, Void> PARSER = new ConstructingObjectParser<>(
         MainResponse.class.getName(),
         true,
-        args -> { return new MainResponse((String) args[0], (Version) args[1], (String) args[2], (String) args[3]); }
+        args -> {
+            return new MainResponse((String) args[0], (Version) args[1], (String) args[2], (String) args[3]);
+        }
     );
 
     static {

--- a/client/rest-high-level/src/main/java/org/opensearch/client/core/TermVectorsResponse.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/core/TermVectorsResponse.java
@@ -240,7 +240,9 @@ public class TermVectorsResponse {
             private static final ConstructingObjectParser<FieldStatistics, Void> PARSER = new ConstructingObjectParser<>(
                 "field_statistics",
                 true,
-                args -> { return new FieldStatistics((long) args[0], (int) args[1], (long) args[2]); }
+                args -> {
+                    return new FieldStatistics((long) args[0], (int) args[1], (long) args[2]);
+                }
             );
 
             static {
@@ -411,11 +413,9 @@ public class TermVectorsResponse {
 
         public static final class Token {
 
-            private static final ConstructingObjectParser<Token, Void> PARSER = new ConstructingObjectParser<>(
-                "token",
-                true,
-                args -> { return new Token((Integer) args[0], (Integer) args[1], (Integer) args[2], (String) args[3]); }
-            );
+            private static final ConstructingObjectParser<Token, Void> PARSER = new ConstructingObjectParser<>("token", true, args -> {
+                return new Token((Integer) args[0], (Integer) args[1], (Integer) args[2], (String) args[3]);
+            });
             static {
                 PARSER.declareInt(optionalConstructorArg(), new ParseField("start_offset"));
                 PARSER.declareInt(optionalConstructorArg(), new ParseField("end_offset"));

--- a/client/rest-high-level/src/test/java/org/opensearch/client/CrudIT.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/CrudIT.java
@@ -628,10 +628,9 @@ public class CrudIT extends OpenSearchRestHighLevelClientTestCase {
             assertEquals("index", indexResponse.getIndex());
             assertEquals("with_create_op_type", indexResponse.getId());
 
-            OpenSearchStatusException exception = expectThrows(
-                OpenSearchStatusException.class,
-                () -> { execute(indexRequest, highLevelClient()::index, highLevelClient()::indexAsync); }
-            );
+            OpenSearchStatusException exception = expectThrows(OpenSearchStatusException.class, () -> {
+                execute(indexRequest, highLevelClient()::index, highLevelClient()::indexAsync);
+            });
 
             assertEquals(RestStatus.CONFLICT, exception.status());
             assertEquals(

--- a/client/rest-high-level/src/test/java/org/opensearch/client/ReindexIT.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/ReindexIT.java
@@ -112,10 +112,9 @@ public class ReindexIT extends OpenSearchRestHighLevelClientTestCase {
             reindexRequest.setRefresh(true);
             reindexRequest.setRequireAlias(true);
 
-            OpenSearchStatusException exception = expectThrows(
-                OpenSearchStatusException.class,
-                () -> { execute(reindexRequest, highLevelClient()::reindex, highLevelClient()::reindexAsync); }
-            );
+            OpenSearchStatusException exception = expectThrows(OpenSearchStatusException.class, () -> {
+                execute(reindexRequest, highLevelClient()::reindex, highLevelClient()::reindexAsync);
+            });
             assertEquals(RestStatus.NOT_FOUND, exception.status());
             assertEquals(
                 "OpenSearch exception [type=index_not_found_exception, reason=no such index [dest] and [require_alias] request flag is [true] and [dest] is not an alias]",

--- a/client/rest-high-level/src/test/java/org/opensearch/client/RestHighLevelClientTests.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/RestHighLevelClientTests.java
@@ -427,13 +427,9 @@ public class RestHighLevelClientTests extends OpenSearchTestCase {
         {
             IOException ioe = expectThrows(
                 IOException.class,
-                () -> restHighLevelClient.performRequest(
-                    mainRequest,
-                    requestConverter,
-                    RequestOptions.DEFAULT,
-                    response -> { throw new IllegalStateException(); },
-                    Collections.emptySet()
-                )
+                () -> restHighLevelClient.performRequest(mainRequest, requestConverter, RequestOptions.DEFAULT, response -> {
+                    throw new IllegalStateException();
+                }, Collections.emptySet())
             );
             assertEquals(
                 "Unable to parse response body for Response{requestLine=GET / http/1.1, host=http://localhost:9200, "
@@ -575,13 +571,9 @@ public class RestHighLevelClientTests extends OpenSearchTestCase {
         when(restClient.performRequest(any(Request.class))).thenThrow(responseException);
         OpenSearchException openSearchException = expectThrows(
             OpenSearchException.class,
-            () -> restHighLevelClient.performRequest(
-                mainRequest,
-                requestConverter,
-                RequestOptions.DEFAULT,
-                response -> { throw new IllegalStateException(); },
-                Collections.singleton(404)
-            )
+            () -> restHighLevelClient.performRequest(mainRequest, requestConverter, RequestOptions.DEFAULT, response -> {
+                throw new IllegalStateException();
+            }, Collections.singleton(404))
         );
         assertEquals(RestStatus.NOT_FOUND, openSearchException.status());
         assertSame(responseException, openSearchException.getCause());
@@ -598,13 +590,9 @@ public class RestHighLevelClientTests extends OpenSearchTestCase {
         when(restClient.performRequest(any(Request.class))).thenThrow(responseException);
         OpenSearchException openSearchException = expectThrows(
             OpenSearchException.class,
-            () -> restHighLevelClient.performRequest(
-                mainRequest,
-                requestConverter,
-                RequestOptions.DEFAULT,
-                response -> { throw new IllegalStateException(); },
-                Collections.singleton(404)
-            )
+            () -> restHighLevelClient.performRequest(mainRequest, requestConverter, RequestOptions.DEFAULT, response -> {
+                throw new IllegalStateException();
+            }, Collections.singleton(404))
         );
         assertEquals(RestStatus.NOT_FOUND, openSearchException.status());
         assertSame(responseException, openSearchException.getSuppressed()[0]);

--- a/modules/analysis-common/src/test/java/org/opensearch/analysis/common/SynonymsAnalysisTests.java
+++ b/modules/analysis-common/src/test/java/org/opensearch/analysis/common/SynonymsAnalysisTests.java
@@ -244,10 +244,9 @@ public class SynonymsAnalysisTests extends OpenSearchTestCase {
             .build();
         IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("index", settings);
 
-        expectThrows(
-            IllegalArgumentException.class,
-            () -> { indexAnalyzers = createTestAnalysis(idxSettings, settings, new CommonAnalysisPlugin()).indexAnalyzers; }
-        );
+        expectThrows(IllegalArgumentException.class, () -> {
+            indexAnalyzers = createTestAnalysis(idxSettings, settings, new CommonAnalysisPlugin()).indexAnalyzers;
+        });
 
     }
 
@@ -308,7 +307,9 @@ public class SynonymsAnalysisTests extends OpenSearchTestCase {
                 IllegalArgumentException e = expectThrows(
                     IllegalArgumentException.class,
                     "Expected exception for factory " + tf.getName(),
-                    () -> { tf.get(idxSettings, null, tf.getName(), settings).getSynonymFilter(); }
+                    () -> {
+                        tf.get(idxSettings, null, tf.getName(), settings).getSynonymFilter();
+                    }
                 );
                 assertEquals(tf.getName(), "Token filter [" + tf.getName() + "] cannot be used to parse synonyms", e.getMessage());
             } else {

--- a/modules/geo/src/test/java/org/opensearch/geo/search/aggregations/bucket/geogrid/GeoGridAggregatorTestCase.java
+++ b/modules/geo/src/test/java/org/opensearch/geo/search/aggregations/bucket/geogrid/GeoGridAggregatorTestCase.java
@@ -123,7 +123,9 @@ public abstract class GeoGridAggregatorTestCase<T extends InternalGeoGridBucket>
             randomPrecision(),
             null,
             geoGrid -> { assertEquals(0, geoGrid.getBuckets().size()); },
-            iw -> { iw.addDocument(Collections.singleton(new LatLonDocValuesField(FIELD_NAME, 10D, 10D))); }
+            iw -> {
+                iw.addDocument(Collections.singleton(new LatLonDocValuesField(FIELD_NAME, 10D, 10D)));
+            }
         );
     }
 

--- a/modules/ingest-geoip/src/test/java/org/opensearch/ingest/geoip/IngestGeoIpPluginTests.java
+++ b/modules/ingest-geoip/src/test/java/org/opensearch/ingest/geoip/IngestGeoIpPluginTests.java
@@ -65,11 +65,9 @@ public class IngestGeoIpPluginTests extends OpenSearchTestCase {
         GeoIpCache cache = new GeoIpCache(1);
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> cache.putIfAbsent(
-                InetAddresses.forString("127.0.0.1"),
-                AbstractResponse.class,
-                ip -> { throw new IllegalArgumentException("bad"); }
-            )
+            () -> cache.putIfAbsent(InetAddresses.forString("127.0.0.1"), AbstractResponse.class, ip -> {
+                throw new IllegalArgumentException("bad");
+            })
         );
         assertEquals("bad", ex.getMessage());
     }

--- a/modules/lang-painless/src/test/java/org/opensearch/painless/DefBootstrapTests.java
+++ b/modules/lang-painless/src/test/java/org/opensearch/painless/DefBootstrapTests.java
@@ -157,21 +157,13 @@ public class DefBootstrapTests extends OpenSearchTestCase {
         map.put("a", "b");
         assertEquals(2, (int) handle.invokeExact((Object) map));
 
-        final IllegalArgumentException iae = expectThrows(
-            IllegalArgumentException.class,
-            () -> { Integer.toString((int) handle.invokeExact(new Object())); }
-        );
+        final IllegalArgumentException iae = expectThrows(IllegalArgumentException.class, () -> {
+            Integer.toString((int) handle.invokeExact(new Object()));
+        });
         assertEquals("dynamic method [java.lang.Object, size/0] not found", iae.getMessage());
-        assertTrue(
-            "Does not fail inside ClassValue.computeValue()",
-            Arrays.stream(iae.getStackTrace())
-                .anyMatch(
-                    e -> {
-                        return e.getMethodName().equals("computeValue")
-                            && e.getClassName().startsWith("org.opensearch.painless.DefBootstrap$PIC$");
-                    }
-                )
-        );
+        assertTrue("Does not fail inside ClassValue.computeValue()", Arrays.stream(iae.getStackTrace()).anyMatch(e -> {
+            return e.getMethodName().equals("computeValue") && e.getClassName().startsWith("org.opensearch.painless.DefBootstrap$PIC$");
+        }));
     }
 
     // test operators with null guards

--- a/modules/lang-painless/src/test/java/org/opensearch/painless/FunctionRefTests.java
+++ b/modules/lang-painless/src/test/java/org/opensearch/painless/FunctionRefTests.java
@@ -268,18 +268,16 @@ public class FunctionRefTests extends ScriptTestCase {
     }
 
     public void testMethodMissing() {
-        Exception e = expectScriptThrows(
-            IllegalArgumentException.class,
-            () -> { exec("List l = [2, 1]; l.sort(Integer::bogus); return l.get(0);"); }
-        );
+        Exception e = expectScriptThrows(IllegalArgumentException.class, () -> {
+            exec("List l = [2, 1]; l.sort(Integer::bogus); return l.get(0);");
+        });
         assertThat(e.getMessage(), containsString("function reference [Integer::bogus/2] matching [java.util.Comparator"));
     }
 
     public void testQualifiedMethodMissing() {
-        Exception e = expectScriptThrows(
-            IllegalArgumentException.class,
-            () -> { exec("List l = [2, 1]; l.sort(java.time.Instant::bogus); return l.get(0);", false); }
-        );
+        Exception e = expectScriptThrows(IllegalArgumentException.class, () -> {
+            exec("List l = [2, 1]; l.sort(java.time.Instant::bogus); return l.get(0);", false);
+        });
         assertThat(
             e.getMessage(),
             containsString("function reference [java.time.Instant::bogus/2] matching [java.util.Comparator, compare/2")
@@ -287,26 +285,23 @@ public class FunctionRefTests extends ScriptTestCase {
     }
 
     public void testClassMissing() {
-        Exception e = expectScriptThrows(
-            IllegalArgumentException.class,
-            () -> { exec("List l = [2, 1]; l.sort(Bogus::bogus); return l.get(0);", false); }
-        );
+        Exception e = expectScriptThrows(IllegalArgumentException.class, () -> {
+            exec("List l = [2, 1]; l.sort(Bogus::bogus); return l.get(0);", false);
+        });
         assertThat(e.getMessage(), endsWith("variable [Bogus] is not defined"));
     }
 
     public void testQualifiedClassMissing() {
-        Exception e = expectScriptThrows(
-            IllegalArgumentException.class,
-            () -> { exec("List l = [2, 1]; l.sort(org.joda.time.BogusDateTime::bogus); return l.get(0);", false); }
-        );
+        Exception e = expectScriptThrows(IllegalArgumentException.class, () -> {
+            exec("List l = [2, 1]; l.sort(org.joda.time.BogusDateTime::bogus); return l.get(0);", false);
+        });
         assertEquals("variable [org.joda.time.BogusDateTime] is not defined", e.getMessage());
     }
 
     public void testNotFunctionalInterface() {
-        IllegalArgumentException expected = expectScriptThrows(
-            IllegalArgumentException.class,
-            () -> { exec("List l = new ArrayList(); l.add(2); l.add(1); l.add(Integer::bogus); return l.get(0);"); }
-        );
+        IllegalArgumentException expected = expectScriptThrows(IllegalArgumentException.class, () -> {
+            exec("List l = new ArrayList(); l.add(2); l.add(1); l.add(Integer::bogus); return l.get(0);");
+        });
         assertThat(
             expected.getMessage(),
             containsString("cannot convert function reference [Integer::bogus] to a non-functional interface [def]")
@@ -314,17 +309,15 @@ public class FunctionRefTests extends ScriptTestCase {
     }
 
     public void testIncompatible() {
-        expectScriptThrows(
-            ClassCastException.class,
-            () -> { exec("List l = new ArrayList(); l.add(2); l.add(1); l.sort(String::startsWith); return l.get(0);"); }
-        );
+        expectScriptThrows(ClassCastException.class, () -> {
+            exec("List l = new ArrayList(); l.add(2); l.add(1); l.sort(String::startsWith); return l.get(0);");
+        });
     }
 
     public void testWrongArity() {
-        IllegalArgumentException expected = expectScriptThrows(
-            IllegalArgumentException.class,
-            () -> { exec("Optional.empty().orElseGet(String::startsWith);"); }
-        );
+        IllegalArgumentException expected = expectScriptThrows(IllegalArgumentException.class, () -> {
+            exec("Optional.empty().orElseGet(String::startsWith);");
+        });
         assertThat(
             expected.getMessage(),
             containsString("function reference [String::startsWith/0] matching [java.util.function.Supplier")
@@ -332,18 +325,16 @@ public class FunctionRefTests extends ScriptTestCase {
     }
 
     public void testWrongArityNotEnough() {
-        IllegalArgumentException expected = expectScriptThrows(
-            IllegalArgumentException.class,
-            () -> { exec("List l = new ArrayList(); l.add(2); l.add(1); l.sort(String::isEmpty);"); }
-        );
+        IllegalArgumentException expected = expectScriptThrows(IllegalArgumentException.class, () -> {
+            exec("List l = new ArrayList(); l.add(2); l.add(1); l.sort(String::isEmpty);");
+        });
         assertThat(expected.getMessage(), containsString("function reference [String::isEmpty/2] matching [java.util.Comparator"));
     }
 
     public void testWrongArityDef() {
-        IllegalArgumentException expected = expectScriptThrows(
-            IllegalArgumentException.class,
-            () -> { exec("def y = Optional.empty(); return y.orElseGet(String::startsWith);"); }
-        );
+        IllegalArgumentException expected = expectScriptThrows(IllegalArgumentException.class, () -> {
+            exec("def y = Optional.empty(); return y.orElseGet(String::startsWith);");
+        });
         assertThat(
             expected.getMessage(),
             containsString("function reference [String::startsWith/0] matching [java.util.function.Supplier")
@@ -351,38 +342,33 @@ public class FunctionRefTests extends ScriptTestCase {
     }
 
     public void testWrongArityNotEnoughDef() {
-        IllegalArgumentException expected = expectScriptThrows(
-            IllegalArgumentException.class,
-            () -> { exec("def l = new ArrayList(); l.add(2); l.add(1); l.sort(String::isEmpty);"); }
-        );
+        IllegalArgumentException expected = expectScriptThrows(IllegalArgumentException.class, () -> {
+            exec("def l = new ArrayList(); l.add(2); l.add(1); l.sort(String::isEmpty);");
+        });
         assertThat(expected.getMessage(), containsString("function reference [String::isEmpty/2] matching [java.util.Comparator"));
     }
 
     public void testReturnVoid() {
-        Throwable expected = expectScriptThrows(
-            ClassCastException.class,
-            () -> { exec("StringBuilder b = new StringBuilder(); List l = [1, 2]; l.stream().mapToLong(b::setLength).sum();"); }
-        );
+        Throwable expected = expectScriptThrows(ClassCastException.class, () -> {
+            exec("StringBuilder b = new StringBuilder(); List l = [1, 2]; l.stream().mapToLong(b::setLength).sum();");
+        });
         assertThat(expected.getMessage(), containsString("Cannot cast from [void] to [long]."));
     }
 
     public void testReturnVoidDef() {
-        Exception expected = expectScriptThrows(
-            LambdaConversionException.class,
-            () -> { exec("StringBuilder b = new StringBuilder(); def l = [1, 2]; l.stream().mapToLong(b::setLength);"); }
-        );
+        Exception expected = expectScriptThrows(LambdaConversionException.class, () -> {
+            exec("StringBuilder b = new StringBuilder(); def l = [1, 2]; l.stream().mapToLong(b::setLength);");
+        });
         assertThat(expected.getMessage(), containsString("lambda expects return type [long], but found return type [void]"));
 
-        expected = expectScriptThrows(
-            LambdaConversionException.class,
-            () -> { exec("def b = new StringBuilder(); def l = [1, 2]; l.stream().mapToLong(b::setLength);"); }
-        );
+        expected = expectScriptThrows(LambdaConversionException.class, () -> {
+            exec("def b = new StringBuilder(); def l = [1, 2]; l.stream().mapToLong(b::setLength);");
+        });
         assertThat(expected.getMessage(), containsString("lambda expects return type [long], but found return type [void]"));
 
-        expected = expectScriptThrows(
-            LambdaConversionException.class,
-            () -> { exec("def b = new StringBuilder(); List l = [1, 2]; l.stream().mapToLong(b::setLength);"); }
-        );
+        expected = expectScriptThrows(LambdaConversionException.class, () -> {
+            exec("def b = new StringBuilder(); List l = [1, 2]; l.stream().mapToLong(b::setLength);");
+        });
         assertThat(expected.getMessage(), containsString("lambda expects return type [long], but found return type [void]"));
     }
 }

--- a/modules/lang-painless/src/test/java/org/opensearch/painless/FunctionTests.java
+++ b/modules/lang-painless/src/test/java/org/opensearch/painless/FunctionTests.java
@@ -82,10 +82,9 @@ public class FunctionTests extends ScriptTestCase {
     }
 
     public void testDuplicates() {
-        Exception expected = expectScriptThrows(
-            IllegalArgumentException.class,
-            () -> { exec("void test(int x) {x = 2;} void test(def y) {y = 3;} test()"); }
-        );
+        Exception expected = expectScriptThrows(IllegalArgumentException.class, () -> {
+            exec("void test(int x) {x = 2;} void test(def y) {y = 3;} test()");
+        });
         assertThat(expected.getMessage(), containsString("found duplicate function"));
     }
 
@@ -108,23 +107,20 @@ public class FunctionTests extends ScriptTestCase {
 
     public void testReturnVoid() {
         assertEquals(null, exec("void test(StringBuilder b, int i) {b.setLength(i)} test(new StringBuilder(), 1)"));
-        Exception expected = expectScriptThrows(
-            IllegalArgumentException.class,
-            () -> { exec("int test(StringBuilder b, int i) {b.setLength(i)} test(new StringBuilder(), 1)"); }
-        );
+        Exception expected = expectScriptThrows(IllegalArgumentException.class, () -> {
+            exec("int test(StringBuilder b, int i) {b.setLength(i)} test(new StringBuilder(), 1)");
+        });
         assertEquals(
             "invalid function definition: " + "not all paths provide a return value for function [test] with [2] parameters",
             expected.getMessage()
         );
-        expected = expectScriptThrows(
-            ClassCastException.class,
-            () -> { exec("int test(StringBuilder b, int i) {return b.setLength(i)} test(new StringBuilder(), 1)"); }
-        );
+        expected = expectScriptThrows(ClassCastException.class, () -> {
+            exec("int test(StringBuilder b, int i) {return b.setLength(i)} test(new StringBuilder(), 1)");
+        });
         assertEquals("Cannot cast from [void] to [int].", expected.getMessage());
-        expected = expectScriptThrows(
-            ClassCastException.class,
-            () -> { exec("def test(StringBuilder b, int i) {return b.setLength(i)} test(new StringBuilder(), 1)"); }
-        );
+        expected = expectScriptThrows(ClassCastException.class, () -> {
+            exec("def test(StringBuilder b, int i) {return b.setLength(i)} test(new StringBuilder(), 1)");
+        });
         assertEquals("Cannot cast from [void] to [def].", expected.getMessage());
     }
 }

--- a/modules/lang-painless/src/test/java/org/opensearch/painless/GeneralCastTests.java
+++ b/modules/lang-painless/src/test/java/org/opensearch/painless/GeneralCastTests.java
@@ -293,14 +293,12 @@ public class GeneralCastTests extends ScriptTestCase {
     }
 
     public void testIllegalVoidCasts() {
-        expectScriptThrows(
-            IllegalArgumentException.class,
-            () -> { exec("def map = ['a': 1,'b': 2,'c': 3]; map.c = Collections.sort(new ArrayList(map.keySet()));"); }
-        );
-        expectScriptThrows(
-            IllegalArgumentException.class,
-            () -> { exec("Map map = ['a': 1,'b': 2,'c': 3]; def x = new HashMap(); x.put(1, map.clear());"); }
-        );
+        expectScriptThrows(IllegalArgumentException.class, () -> {
+            exec("def map = ['a': 1,'b': 2,'c': 3]; map.c = Collections.sort(new ArrayList(map.keySet()));");
+        });
+        expectScriptThrows(IllegalArgumentException.class, () -> {
+            exec("Map map = ['a': 1,'b': 2,'c': 3]; def x = new HashMap(); x.put(1, map.clear());");
+        });
     }
 
     public void testBoxedDefCalls() {

--- a/modules/lang-painless/src/test/java/org/opensearch/painless/LambdaTests.java
+++ b/modules/lang-painless/src/test/java/org/opensearch/painless/LambdaTests.java
@@ -173,28 +173,19 @@ public class LambdaTests extends ScriptTestCase {
     }
 
     public void testCapturesAreReadOnly() {
-        IllegalArgumentException expected = expectScriptThrows(
-            IllegalArgumentException.class,
-            () -> {
-                exec(
-                    "List l = new ArrayList(); l.add(1); l.add(1); " + "return l.stream().mapToInt(x -> { l = null; return x + 1 }).sum();"
-                );
-            }
-        );
+        IllegalArgumentException expected = expectScriptThrows(IllegalArgumentException.class, () -> {
+            exec("List l = new ArrayList(); l.add(1); l.add(1); " + "return l.stream().mapToInt(x -> { l = null; return x + 1 }).sum();");
+        });
         assertTrue(expected.getMessage().contains("is read-only"));
     }
 
     /** Lambda parameters shouldn't be able to mask a variable already in scope */
     public void testNoParamMasking() {
-        IllegalArgumentException expected = expectScriptThrows(
-            IllegalArgumentException.class,
-            () -> {
-                exec(
-                    "int x = 0; List l = new ArrayList(); l.add(1); l.add(1); "
-                        + "return l.stream().mapToInt(x -> { x += 1; return x }).sum();"
-                );
-            }
-        );
+        IllegalArgumentException expected = expectScriptThrows(IllegalArgumentException.class, () -> {
+            exec(
+                "int x = 0; List l = new ArrayList(); l.add(1); l.add(1); " + "return l.stream().mapToInt(x -> { x += 1; return x }).sum();"
+            );
+        });
         assertTrue(expected.getMessage().contains("already defined"));
     }
 
@@ -214,36 +205,30 @@ public class LambdaTests extends ScriptTestCase {
     }
 
     public void testWrongArity() {
-        IllegalArgumentException expected = expectScriptThrows(
-            IllegalArgumentException.class,
-            false,
-            () -> { exec("Optional.empty().orElseGet(x -> x);"); }
-        );
+        IllegalArgumentException expected = expectScriptThrows(IllegalArgumentException.class, false, () -> {
+            exec("Optional.empty().orElseGet(x -> x);");
+        });
         assertTrue(expected.getMessage().contains("Incorrect number of parameters"));
     }
 
     public void testWrongArityDef() {
-        IllegalArgumentException expected = expectScriptThrows(
-            IllegalArgumentException.class,
-            () -> { exec("def y = Optional.empty(); return y.orElseGet(x -> x);"); }
-        );
+        IllegalArgumentException expected = expectScriptThrows(IllegalArgumentException.class, () -> {
+            exec("def y = Optional.empty(); return y.orElseGet(x -> x);");
+        });
         assertTrue(expected.getMessage(), expected.getMessage().contains("due to an incorrect number of arguments"));
     }
 
     public void testWrongArityNotEnough() {
-        IllegalArgumentException expected = expectScriptThrows(
-            IllegalArgumentException.class,
-            false,
-            () -> { exec("List l = new ArrayList(); l.add(1); l.add(1); " + "return l.stream().mapToInt(() -> 5).sum();"); }
-        );
+        IllegalArgumentException expected = expectScriptThrows(IllegalArgumentException.class, false, () -> {
+            exec("List l = new ArrayList(); l.add(1); l.add(1); " + "return l.stream().mapToInt(() -> 5).sum();");
+        });
         assertTrue(expected.getMessage().contains("Incorrect number of parameters"));
     }
 
     public void testWrongArityNotEnoughDef() {
-        IllegalArgumentException expected = expectScriptThrows(
-            IllegalArgumentException.class,
-            () -> { exec("def l = new ArrayList(); l.add(1); l.add(1); " + "return l.stream().mapToInt(() -> 5).sum();"); }
-        );
+        IllegalArgumentException expected = expectScriptThrows(IllegalArgumentException.class, () -> {
+            exec("def l = new ArrayList(); l.add(1); l.add(1); " + "return l.stream().mapToInt(() -> 5).sum();");
+        });
         assertTrue(expected.getMessage(), expected.getMessage().contains("due to an incorrect number of arguments"));
     }
 
@@ -308,19 +293,17 @@ public class LambdaTests extends ScriptTestCase {
     }
 
     public void testReturnVoid() {
-        Throwable expected = expectScriptThrows(
-            ClassCastException.class,
-            () -> { exec("StringBuilder b = new StringBuilder(); List l = [1, 2]; l.stream().mapToLong(i -> b.setLength(i))"); }
-        );
+        Throwable expected = expectScriptThrows(ClassCastException.class, () -> {
+            exec("StringBuilder b = new StringBuilder(); List l = [1, 2]; l.stream().mapToLong(i -> b.setLength(i))");
+        });
         assertThat(expected.getMessage(), containsString("Cannot cast from [void] to [long]."));
     }
 
     public void testReturnVoidDef() {
         // If we can catch the error at compile time we do
-        Exception expected = expectScriptThrows(
-            ClassCastException.class,
-            () -> { exec("StringBuilder b = new StringBuilder(); def l = [1, 2]; l.stream().mapToLong(i -> b.setLength(i))"); }
-        );
+        Exception expected = expectScriptThrows(ClassCastException.class, () -> {
+            exec("StringBuilder b = new StringBuilder(); def l = [1, 2]; l.stream().mapToLong(i -> b.setLength(i))");
+        });
         assertThat(expected.getMessage(), containsString("Cannot cast from [void] to [def]."));
 
         // Otherwise we convert the void into a null

--- a/modules/lang-painless/src/test/java/org/opensearch/painless/OverloadTests.java
+++ b/modules/lang-painless/src/test/java/org/opensearch/painless/OverloadTests.java
@@ -38,20 +38,18 @@ public class OverloadTests extends ScriptTestCase {
     public void testMethod() {
         // assertEquals(2, exec("return 'abc123abc'.indexOf('c');"));
         // assertEquals(8, exec("return 'abc123abc'.indexOf('c', 3);"));
-        IllegalArgumentException expected = expectScriptThrows(
-            IllegalArgumentException.class,
-            () -> { exec("return 'abc123abc'.indexOf('c', 3, 'bogus');"); }
-        );
+        IllegalArgumentException expected = expectScriptThrows(IllegalArgumentException.class, () -> {
+            exec("return 'abc123abc'.indexOf('c', 3, 'bogus');");
+        });
         assertTrue(expected.getMessage().contains("[java.lang.String, indexOf/3]"));
     }
 
     public void testMethodDynamic() {
         assertEquals(2, exec("def x = 'abc123abc'; return x.indexOf('c');"));
         assertEquals(8, exec("def x = 'abc123abc'; return x.indexOf('c', 3);"));
-        IllegalArgumentException expected = expectScriptThrows(
-            IllegalArgumentException.class,
-            () -> { exec("def x = 'abc123abc'; return x.indexOf('c', 3, 'bogus');"); }
-        );
+        IllegalArgumentException expected = expectScriptThrows(IllegalArgumentException.class, () -> {
+            exec("def x = 'abc123abc'; return x.indexOf('c', 3, 'bogus');");
+        });
         assertTrue(expected.getMessage().contains("dynamic method [java.lang.String, indexOf/3] not found"));
     }
 

--- a/modules/lang-painless/src/test/java/org/opensearch/painless/StringTests.java
+++ b/modules/lang-painless/src/test/java/org/opensearch/painless/StringTests.java
@@ -182,11 +182,9 @@ public class StringTests extends ScriptTestCase {
         assertEquals('c', exec("String s = \"c\"; (char)s"));
         assertEquals('c', exec("String s = 'c'; (char)s"));
 
-        ClassCastException expected = expectScriptThrows(
-            ClassCastException.class,
-            false,
-            () -> { assertEquals("cc", exec("return (String)(char)\"cc\"")); }
-        );
+        ClassCastException expected = expectScriptThrows(ClassCastException.class, false, () -> {
+            assertEquals("cc", exec("return (String)(char)\"cc\""));
+        });
         assertTrue(expected.getMessage().contains("cannot cast java.lang.String with length not equal to one to char"));
 
         expected = expectScriptThrows(ClassCastException.class, false, () -> { assertEquals("cc", exec("return (String)(char)'cc'")); });

--- a/modules/lang-painless/src/test/java/org/opensearch/painless/WhenThingsGoWrongTests.java
+++ b/modules/lang-painless/src/test/java/org/opensearch/painless/WhenThingsGoWrongTests.java
@@ -57,10 +57,9 @@ public class WhenThingsGoWrongTests extends ScriptTestCase {
     public void testScriptStack() {
         for (String type : new String[] { "String", "def   " }) {
             // trigger NPE at line 1 of the script
-            ScriptException exception = expectThrows(
-                ScriptException.class,
-                () -> { exec(type + " x = null; boolean y = x.isEmpty();\n" + "return y;"); }
-            );
+            ScriptException exception = expectThrows(ScriptException.class, () -> {
+                exec(type + " x = null; boolean y = x.isEmpty();\n" + "return y;");
+            });
             // null deref at x.isEmpty(), the '.' is offset 30
             assertScriptElementColumn(30, exception);
             assertScriptStack(exception, "y = x.isEmpty();\n", "     ^---- HERE");
@@ -84,12 +83,9 @@ public class WhenThingsGoWrongTests extends ScriptTestCase {
             assertThat(exception.getCause(), instanceOf(NullPointerException.class));
 
             // trigger NPE at line 4 in script (inside conditional)
-            exception = expectThrows(
-                ScriptException.class,
-                () -> {
-                    exec(type + " x = null;\n" + "boolean y = false;\n" + "if (!y) {\n" + "  y = x.isEmpty();\n" + "}\n" + "return y;");
-                }
-            );
+            exception = expectThrows(ScriptException.class, () -> {
+                exec(type + " x = null;\n" + "boolean y = false;\n" + "if (!y) {\n" + "  y = x.isEmpty();\n" + "}\n" + "return y;");
+            });
             // null deref at x.isEmpty(), the '.' is offset 53
             assertScriptElementColumn(53, exception);
             assertScriptStack(exception, "y = x.isEmpty();\n}\n", "     ^---- HERE");
@@ -121,10 +117,9 @@ public class WhenThingsGoWrongTests extends ScriptTestCase {
     }
 
     public void testBogusParameter() {
-        IllegalArgumentException expected = expectThrows(
-            IllegalArgumentException.class,
-            () -> { exec("return 5;", null, Collections.singletonMap("bogusParameterKey", "bogusParameterValue"), true); }
-        );
+        IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> {
+            exec("return 5;", null, Collections.singletonMap("bogusParameterKey", "bogusParameterValue"), true);
+        });
         assertTrue(expected.getMessage().contains("Unrecognized compile-time parameter"));
     }
 
@@ -178,10 +173,9 @@ public class WhenThingsGoWrongTests extends ScriptTestCase {
     }
 
     public void testIllegalDynamicMethod() {
-        IllegalArgumentException expected = expectScriptThrows(
-            IllegalArgumentException.class,
-            () -> { exec("def x = 'test'; return x.getClass().toString()"); }
-        );
+        IllegalArgumentException expected = expectScriptThrows(IllegalArgumentException.class, () -> {
+            exec("def x = 'test'; return x.getClass().toString()");
+        });
         assertTrue(expected.getMessage().contains("dynamic method [java.lang.String, getClass/0] not found"));
     }
 

--- a/modules/lang-painless/src/test/java/org/opensearch/painless/WhitelistLoaderTests.java
+++ b/modules/lang-painless/src/test/java/org/opensearch/painless/WhitelistLoaderTests.java
@@ -47,19 +47,15 @@ public class WhitelistLoaderTests extends ScriptTestCase {
     public void testUnknownAnnotations() {
         Map<String, WhitelistAnnotationParser> parsers = new HashMap<>(WhitelistAnnotationParser.BASE_ANNOTATION_PARSERS);
 
-        RuntimeException expected = expectThrows(
-            RuntimeException.class,
-            () -> { WhitelistLoader.loadFromResourceFiles(Whitelist.class, parsers, "org.opensearch.painless.annotation.unknown"); }
-        );
+        RuntimeException expected = expectThrows(RuntimeException.class, () -> {
+            WhitelistLoader.loadFromResourceFiles(Whitelist.class, parsers, "org.opensearch.painless.annotation.unknown");
+        });
         assertEquals("invalid annotation: parser not found for [unknownAnnotation] [@unknownAnnotation]", expected.getCause().getMessage());
         assertEquals(IllegalArgumentException.class, expected.getCause().getClass());
 
-        expected = expectThrows(
-            RuntimeException.class,
-            () -> {
-                WhitelistLoader.loadFromResourceFiles(Whitelist.class, parsers, "org.opensearch.painless.annotation.unknown_with_options");
-            }
-        );
+        expected = expectThrows(RuntimeException.class, () -> {
+            WhitelistLoader.loadFromResourceFiles(Whitelist.class, parsers, "org.opensearch.painless.annotation.unknown_with_options");
+        });
         assertEquals(
             "invalid annotation: parser not found for [unknownAnootationWithMessage] [@unknownAnootationWithMessage[arg=\"arg value\"]]",
             expected.getCause().getMessage()

--- a/modules/percolator/src/internalClusterTest/java/org/opensearch/percolator/PercolatorQuerySearchIT.java
+++ b/modules/percolator/src/internalClusterTest/java/org/opensearch/percolator/PercolatorQuerySearchIT.java
@@ -436,10 +436,9 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
         client().admin().indices().prepareRefresh().get();
 
         logger.info("percolating empty doc with source disabled");
-        IllegalArgumentException e = expectThrows(
-            IllegalArgumentException.class,
-            () -> { client().prepareSearch().setQuery(new PercolateQueryBuilder("query", "test", "1", null, null, null)).get(); }
-        );
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> {
+            client().prepareSearch().setQuery(new PercolateQueryBuilder("query", "test", "1", null, null, null)).get();
+        });
         assertThat(e.getMessage(), containsString("source disabled"));
     }
 

--- a/modules/percolator/src/test/java/org/opensearch/percolator/PercolateQueryBuilderTests.java
+++ b/modules/percolator/src/test/java/org/opensearch/percolator/PercolateQueryBuilderTests.java
@@ -245,10 +245,9 @@ public class PercolateQueryBuilderTests extends AbstractQueryTestCase<PercolateQ
     }
 
     public void testRequiredParameters() {
-        IllegalArgumentException e = expectThrows(
-            IllegalArgumentException.class,
-            () -> { new PercolateQueryBuilder(null, new BytesArray("{}"), XContentType.JSON); }
-        );
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> {
+            new PercolateQueryBuilder(null, new BytesArray("{}"), XContentType.JSON);
+        });
         assertThat(e.getMessage(), equalTo("[field] is a required argument"));
 
         e = expectThrows(

--- a/modules/rank-eval/src/main/java/org/opensearch/index/rankeval/DiscountedCumulativeGain.java
+++ b/modules/rank-eval/src/main/java/org/opensearch/index/rankeval/DiscountedCumulativeGain.java
@@ -282,11 +282,9 @@ public class DiscountedCumulativeGain implements EvaluationMetric {
             return builder;
         }
 
-        private static final ConstructingObjectParser<Detail, Void> PARSER = new ConstructingObjectParser<>(
-            NAME,
-            true,
-            args -> { return new Detail((Double) args[0], (Double) args[1] != null ? (Double) args[1] : 0.0d, (Integer) args[2]); }
-        );
+        private static final ConstructingObjectParser<Detail, Void> PARSER = new ConstructingObjectParser<>(NAME, true, args -> {
+            return new Detail((Double) args[0], (Double) args[1] != null ? (Double) args[1] : 0.0d, (Integer) args[2]);
+        });
 
         static {
             PARSER.declareDouble(constructorArg(), DCG_FIELD);

--- a/modules/rank-eval/src/main/java/org/opensearch/index/rankeval/ExpectedReciprocalRank.java
+++ b/modules/rank-eval/src/main/java/org/opensearch/index/rankeval/ExpectedReciprocalRank.java
@@ -262,11 +262,9 @@ public class ExpectedReciprocalRank implements EvaluationMetric {
             return builder.field(UNRATED_FIELD.getPreferredName(), this.unratedDocs);
         }
 
-        private static final ConstructingObjectParser<Detail, Void> PARSER = new ConstructingObjectParser<>(
-            NAME,
-            true,
-            args -> { return new Detail((Integer) args[0]); }
-        );
+        private static final ConstructingObjectParser<Detail, Void> PARSER = new ConstructingObjectParser<>(NAME, true, args -> {
+            return new Detail((Integer) args[0]);
+        });
 
         static {
             PARSER.declareInt(constructorArg(), UNRATED_FIELD);

--- a/modules/rank-eval/src/main/java/org/opensearch/index/rankeval/MeanReciprocalRank.java
+++ b/modules/rank-eval/src/main/java/org/opensearch/index/rankeval/MeanReciprocalRank.java
@@ -219,11 +219,9 @@ public class MeanReciprocalRank implements EvaluationMetric {
             return builder.field(FIRST_RELEVANT_RANK_FIELD.getPreferredName(), firstRelevantRank);
         }
 
-        private static final ConstructingObjectParser<Detail, Void> PARSER = new ConstructingObjectParser<>(
-            NAME,
-            true,
-            args -> { return new Detail((Integer) args[0]); }
-        );
+        private static final ConstructingObjectParser<Detail, Void> PARSER = new ConstructingObjectParser<>(NAME, true, args -> {
+            return new Detail((Integer) args[0]);
+        });
 
         static {
             PARSER.declareInt(constructorArg(), FIRST_RELEVANT_RANK_FIELD);

--- a/modules/rank-eval/src/test/java/org/opensearch/index/rankeval/DiscountedCumulativeGainTests.java
+++ b/modules/rank-eval/src/test/java/org/opensearch/index/rankeval/DiscountedCumulativeGainTests.java
@@ -346,11 +346,9 @@ public class DiscountedCumulativeGainTests extends OpenSearchTestCase {
     }
 
     public void testEqualsAndHash() throws IOException {
-        checkEqualsAndHashCode(
-            createTestItem(),
-            original -> { return new DiscountedCumulativeGain(original.getNormalize(), original.getUnknownDocRating(), original.getK()); },
-            DiscountedCumulativeGainTests::mutateTestItem
-        );
+        checkEqualsAndHashCode(createTestItem(), original -> {
+            return new DiscountedCumulativeGain(original.getNormalize(), original.getUnknownDocRating(), original.getK());
+        }, DiscountedCumulativeGainTests::mutateTestItem);
     }
 
     private static DiscountedCumulativeGain mutateTestItem(DiscountedCumulativeGain original) {

--- a/modules/rank-eval/src/test/java/org/opensearch/index/rankeval/ExpectedReciprocalRankTests.java
+++ b/modules/rank-eval/src/test/java/org/opensearch/index/rankeval/ExpectedReciprocalRankTests.java
@@ -213,11 +213,9 @@ public class ExpectedReciprocalRankTests extends OpenSearchTestCase {
     }
 
     public void testEqualsAndHash() throws IOException {
-        checkEqualsAndHashCode(
-            createTestItem(),
-            original -> { return new ExpectedReciprocalRank(original.getMaxRelevance(), original.getUnknownDocRating(), original.getK()); },
-            ExpectedReciprocalRankTests::mutateTestItem
-        );
+        checkEqualsAndHashCode(createTestItem(), original -> {
+            return new ExpectedReciprocalRank(original.getMaxRelevance(), original.getUnknownDocRating(), original.getK());
+        }, ExpectedReciprocalRankTests::mutateTestItem);
     }
 
     private static ExpectedReciprocalRank mutateTestItem(ExpectedReciprocalRank original) {

--- a/modules/rank-eval/src/test/java/org/opensearch/index/rankeval/RatedDocumentTests.java
+++ b/modules/rank-eval/src/test/java/org/opensearch/index/rankeval/RatedDocumentTests.java
@@ -91,11 +91,9 @@ public class RatedDocumentTests extends OpenSearchTestCase {
     }
 
     public void testEqualsAndHash() throws IOException {
-        checkEqualsAndHashCode(
-            createRatedDocument(),
-            original -> { return new RatedDocument(original.getIndex(), original.getDocID(), original.getRating()); },
-            RatedDocumentTests::mutateTestItem
-        );
+        checkEqualsAndHashCode(createRatedDocument(), original -> {
+            return new RatedDocument(original.getIndex(), original.getDocID(), original.getRating());
+        }, RatedDocumentTests::mutateTestItem);
     }
 
     private static RatedDocument mutateTestItem(RatedDocument original) {

--- a/modules/reindex/src/test/java/org/opensearch/index/reindex/ClientScrollableHitSourceTests.java
+++ b/modules/reindex/src/test/java/org/opensearch/index/reindex/ClientScrollableHitSourceTests.java
@@ -105,10 +105,9 @@ public class ClientScrollableHitSourceTests extends OpenSearchTestCase {
 
     public void testRetryFail() {
         int retries = randomInt(10);
-        ExpectedException ex = expectThrows(
-            ExpectedException.class,
-            () -> { dotestBasicsWithRetry(retries, retries + 1, retries + 1, e -> { throw new ExpectedException(e); }); }
-        );
+        ExpectedException ex = expectThrows(ExpectedException.class, () -> {
+            dotestBasicsWithRetry(retries, retries + 1, retries + 1, e -> { throw new ExpectedException(e); });
+        });
         assertThat(ex.getCause(), instanceOf(OpenSearchRejectedExecutionException.class));
     }
 

--- a/plugins/analysis-icu/src/test/java/org/opensearch/index/analysis/IcuAnalyzerTests.java
+++ b/plugins/analysis-icu/src/test/java/org/opensearch/index/analysis/IcuAnalyzerTests.java
@@ -90,10 +90,9 @@ public class IcuAnalyzerTests extends BaseTokenStreamTestCase {
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT).put("mode", "wrong").build();
         IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("index", settings);
 
-        IllegalArgumentException e = expectThrows(
-            IllegalArgumentException.class,
-            () -> { new IcuAnalyzerProvider(idxSettings, null, "icu", settings); }
-        );
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> {
+            new IcuAnalyzerProvider(idxSettings, null, "icu", settings);
+        });
 
         assertThat(e.getMessage(), containsString("Unknown mode [wrong] in analyzer [icu], expected one of [compose, decompose]"));
 

--- a/plugins/repository-hdfs/src/test/java/org/opensearch/repositories/hdfs/HaHdfsFailoverTestSuiteIT.java
+++ b/plugins/repository-hdfs/src/test/java/org/opensearch/repositories/hdfs/HaHdfsFailoverTestSuiteIT.java
@@ -75,9 +75,9 @@ public class HaHdfsFailoverTestSuiteIT extends OpenSearchRestTestCase {
         String nn2Port = "10002";
         if (ports.length() > 0) {
             final Path path = PathUtils.get(ports);
-            final List<String> lines = AccessController.doPrivileged(
-                (PrivilegedExceptionAction<List<String>>) () -> { return Files.readAllLines(path); }
-            );
+            final List<String> lines = AccessController.doPrivileged((PrivilegedExceptionAction<List<String>>) () -> {
+                return Files.readAllLines(path);
+            });
             nn1Port = lines.get(0);
             nn2Port = lines.get(1);
         }

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/node/tasks/TasksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/node/tasks/TasksIT.java
@@ -510,14 +510,12 @@ public class TasksIT extends OpenSearchIntegTestCase {
             if (index != null) {
                 index.join();
             }
-            assertBusy(
-                () -> {
-                    assertEquals(
-                        emptyList(),
-                        client().admin().cluster().prepareListTasks().setActions("indices:data/write/index*").get().getTasks()
-                    );
-                }
-            );
+            assertBusy(() -> {
+                assertEquals(
+                    emptyList(),
+                    client().admin().cluster().prepareListTasks().setActions("indices:data/write/index*").get().getTasks()
+                );
+            });
         }
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/action/bulk/BulkWithUpdatesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/bulk/BulkWithUpdatesIT.java
@@ -105,18 +105,9 @@ public class BulkWithUpdatesIT extends OpenSearchIntegTestCase {
 
             scripts.put("ctx._source.field2 = 'value2'", vars -> srcScript(vars, source -> source.replace("field2", "value2")));
 
-            scripts.put(
-                "throw script exception on unknown var",
-                vars -> {
-                    throw new ScriptException(
-                        "message",
-                        null,
-                        Collections.emptyList(),
-                        "exception on unknown var",
-                        CustomScriptPlugin.NAME
-                    );
-                }
-            );
+            scripts.put("throw script exception on unknown var", vars -> {
+                throw new ScriptException("message", null, Collections.emptyList(), "exception on unknown var", CustomScriptPlugin.NAME);
+            });
 
             scripts.put("ctx.op = \"none\"", vars -> ((Map<String, Object>) vars.get("ctx")).put("op", "none"));
             scripts.put("ctx.op = \"delete\"", vars -> ((Map<String, Object>) vars.get("ctx")).put("op", "delete"));

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/metadata/TemplateUpgradeServiceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/metadata/TemplateUpgradeServiceIT.java
@@ -99,11 +99,9 @@ public class TemplateUpgradeServiceIT extends OpenSearchIntegTestCase {
             IndexNameExpressionResolver expressionResolver,
             Supplier<RepositoriesService> repositoriesServiceSupplier
         ) {
-            clusterService.getClusterSettings()
-                .addSettingsUpdateConsumer(
-                    UPDATE_TEMPLATE_DUMMY_SETTING,
-                    integer -> { logger.debug("the template dummy setting was updated to {}", integer); }
-                );
+            clusterService.getClusterSettings().addSettingsUpdateConsumer(UPDATE_TEMPLATE_DUMMY_SETTING, integer -> {
+                logger.debug("the template dummy setting was updated to {}", integer);
+            });
             return super.createComponents(
                 client,
                 clusterService,

--- a/server/src/internalClusterTest/java/org/opensearch/indexing/IndexActionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indexing/IndexActionIT.java
@@ -288,10 +288,9 @@ public class IndexActionIT extends OpenSearchIntegTestCase {
     }
 
     public void testDocumentWithBlankFieldName() {
-        MapperParsingException e = expectThrows(
-            MapperParsingException.class,
-            () -> { client().prepareIndex("test").setId("1").setSource("", "value1_2").execute().actionGet(); }
-        );
+        MapperParsingException e = expectThrows(MapperParsingException.class, () -> {
+            client().prepareIndex("test").setId("1").setSource("", "value1_2").execute().actionGet();
+        });
         assertThat(e.getMessage(), containsString("failed to parse"));
         assertThat(e.getRootCause().getMessage(), containsString("field name cannot be an empty string"));
     }

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationRelocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationRelocationIT.java
@@ -555,13 +555,8 @@ public class SegmentReplicationRelocationIT extends SegmentReplicationBaseIT {
 
         // Verify if all docs are present in replica after relocation, if new relocated primary doesn't flush after relocation the below
         // assert will fail.
-        assertBusy(
-            () -> {
-                assertHitCount(
-                    client(replicaNode).prepareSearch(INDEX_NAME).setPreference("_only_local").setSize(0).get(),
-                    initialDocCount
-                );
-            }
-        );
+        assertBusy(() -> {
+            assertHitCount(client(replicaNode).prepareSearch(INDEX_NAME).setPreference("_only_local").setSize(0).get(), initialDocCount);
+        });
     }
 }

--- a/server/src/internalClusterTest/java/org/opensearch/indices/settings/UpdateSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/settings/UpdateSettingsIT.java
@@ -136,11 +136,9 @@ public class UpdateSettingsIT extends OpenSearchIntegTestCase {
 
         @Override
         public void onIndexModule(IndexModule indexModule) {
-            indexModule.addSettingsUpdateConsumer(
-                DUMMY_SETTING,
-                (s) -> {},
-                (s) -> { if (s.equals("boom")) throw new IllegalArgumentException("this setting goes boom"); }
-            );
+            indexModule.addSettingsUpdateConsumer(DUMMY_SETTING, (s) -> {}, (s) -> {
+                if (s.equals("boom")) throw new IllegalArgumentException("this setting goes boom");
+            });
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/action/admin/cluster/settings/ClusterUpdateSettingsResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/settings/ClusterUpdateSettingsResponse.java
@@ -59,7 +59,9 @@ public class ClusterUpdateSettingsResponse extends AcknowledgedResponse {
     private static final ConstructingObjectParser<ClusterUpdateSettingsResponse, Void> PARSER = new ConstructingObjectParser<>(
         "cluster_update_settings_response",
         true,
-        args -> { return new ClusterUpdateSettingsResponse((boolean) args[0], (Settings) args[1], (Settings) args[2]); }
+        args -> {
+            return new ClusterUpdateSettingsResponse((boolean) args[0], (Settings) args[1], (Settings) args[2]);
+        }
     );
     static {
         declareAcknowledgedField(PARSER);

--- a/server/src/main/java/org/opensearch/action/admin/cluster/shards/routing/weighted/put/TransportAddWeightedRoutingAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/shards/routing/weighted/put/TransportAddWeightedRoutingAction.java
@@ -81,12 +81,9 @@ public class TransportAddWeightedRoutingAction extends TransportClusterManagerNo
         }
         weightedRoutingService.registerWeightedRoutingMetadata(
             request,
-            ActionListener.delegateFailure(
-                listener,
-                (delegatedListener, response) -> {
-                    delegatedListener.onResponse(new ClusterPutWeightedRoutingResponse(response.isAcknowledged()));
-                }
-            )
+            ActionListener.delegateFailure(listener, (delegatedListener, response) -> {
+                delegatedListener.onResponse(new ClusterPutWeightedRoutingResponse(response.isAcknowledged()));
+            })
         );
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/create/AutoCreateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/create/AutoCreateAction.java
@@ -132,7 +132,9 @@ public final class AutoCreateAction extends ActionType<CreateIndexResponse> {
                         new String[] { indexName },
                         ActiveShardCount.DEFAULT,
                         request.timeout(),
-                        shardsAcked -> { finalListener.onResponse(new CreateIndexResponse(true, shardsAcked, indexName)); },
+                        shardsAcked -> {
+                            finalListener.onResponse(new CreateIndexResponse(true, shardsAcked, indexName));
+                        },
                         finalListener::onFailure
                     );
                 } else {

--- a/server/src/main/java/org/opensearch/action/ingest/SimulateExecutionService.java
+++ b/server/src/main/java/org/opensearch/action/ingest/SimulateExecutionService.java
@@ -76,10 +76,9 @@ class SimulateExecutionService {
                 pipeline.getVersion(),
                 verbosePipelineProcessor
             );
-            ingestDocument.executePipeline(
-                verbosePipeline,
-                (result, e) -> { handler.accept(new SimulateDocumentVerboseResult(processorResultList), e); }
-            );
+            ingestDocument.executePipeline(verbosePipeline, (result, e) -> {
+                handler.accept(new SimulateDocumentVerboseResult(processorResultList), e);
+            });
         } else {
             ingestDocument.executePipeline(pipeline, (result, e) -> {
                 if (e == null) {

--- a/server/src/main/java/org/opensearch/action/search/SearchTransportService.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchTransportService.java
@@ -514,7 +514,9 @@ public class SearchTransportService {
             FREE_PIT_CONTEXT_ACTION_NAME,
             ThreadPool.Names.SAME,
             PitFreeContextsRequest::new,
-            (request, channel, task) -> { channel.sendResponse(searchService.freeReaderContextsIfFound(request.getContextIds())); }
+            (request, channel, task) -> {
+                channel.sendResponse(searchService.freeReaderContextsIfFound(request.getContextIds()));
+            }
         );
         TransportActionProxy.registerProxyAction(transportService, FREE_PIT_CONTEXT_ACTION_NAME, DeletePitResponse::new);
 

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateDataStreamService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateDataStreamService.java
@@ -100,7 +100,9 @@ public class MetadataCreateDataStreamService {
                     new String[] { firstBackingIndexName },
                     ActiveShardCount.DEFAULT,
                     request.masterNodeTimeout(),
-                    shardsAcked -> { finalListener.onResponse(new AcknowledgedResponse(true)); },
+                    shardsAcked -> {
+                        finalListener.onResponse(new AcknowledgedResponse(true));
+                    },
                     finalListener::onFailure
                 );
             } else {

--- a/server/src/main/java/org/opensearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/opensearch/cluster/service/MasterService.java
@@ -905,11 +905,9 @@ public class MasterService extends AbstractLifecycleComponent {
         );
         if (Assertions.ENABLED) {
             ClusterTasksResult<Object> finalClusterTasksResult = clusterTasksResult;
-            taskInputs.updateTasks.forEach(
-                updateTask -> {
-                    assert finalClusterTasksResult.executionResults.containsKey(updateTask.task) : "missing task result for " + updateTask;
-                }
-            );
+            taskInputs.updateTasks.forEach(updateTask -> {
+                assert finalClusterTasksResult.executionResults.containsKey(updateTask.task) : "missing task result for " + updateTask;
+            });
         }
 
         return clusterTasksResult;

--- a/server/src/main/java/org/opensearch/cluster/service/TaskBatcher.java
+++ b/server/src/main/java/org/opensearch/cluster/service/TaskBatcher.java
@@ -86,14 +86,9 @@ public abstract class TaskBatcher {
         try {
             // convert to an identity map to check for dups based on task identity
             final Map<Object, BatchedTask> tasksIdentity = tasks.stream()
-                .collect(
-                    Collectors.toMap(
-                        BatchedTask::getTask,
-                        Function.identity(),
-                        (a, b) -> { throw new IllegalStateException("cannot add duplicate task: " + a); },
-                        IdentityHashMap::new
-                    )
-                );
+                .collect(Collectors.toMap(BatchedTask::getTask, Function.identity(), (a, b) -> {
+                    throw new IllegalStateException("cannot add duplicate task: " + a);
+                }, IdentityHashMap::new));
             LinkedHashSet<BatchedTask> newTasks = new LinkedHashSet<>(tasks);
             tasksPerBatchingKey.merge(firstTask.batchingKey, newTasks, (existingTasks, updatedTasks) -> {
                 for (BatchedTask existing : existingTasks) {

--- a/server/src/main/java/org/opensearch/extensions/rest/RestSendToExtensionAction.java
+++ b/server/src/main/java/org/opensearch/extensions/rest/RestSendToExtensionAction.java
@@ -198,10 +198,9 @@ public class RestSendToExtensionAction extends BaseRestHandler {
             restExecuteOnExtensionResponse.getContent()
         );
         // No constructor that includes headers so we roll our own
-        restExecuteOnExtensionResponse.getHeaders()
-            .entrySet()
-            .stream()
-            .forEach(e -> { e.getValue().stream().forEach(v -> restResponse.addHeader(e.getKey(), v)); });
+        restExecuteOnExtensionResponse.getHeaders().entrySet().stream().forEach(e -> {
+            e.getValue().stream().forEach(v -> restResponse.addHeader(e.getKey(), v));
+        });
 
         return channel -> channel.sendResponse(restResponse);
     }

--- a/server/src/main/java/org/opensearch/index/IndexModule.java
+++ b/server/src/main/java/org/opensearch/index/IndexModule.java
@@ -635,7 +635,9 @@ public final class IndexModule {
             xContentRegistry,
             new SimilarityService(indexSettings, scriptService, similarities),
             mapperRegistry,
-            () -> { throw new UnsupportedOperationException("no index query shard context available"); },
+            () -> {
+                throw new UnsupportedOperationException("no index query shard context available");
+            },
             () -> false,
             scriptService
         );

--- a/server/src/main/java/org/opensearch/index/IndexSortConfig.java
+++ b/server/src/main/java/org/opensearch/index/IndexSortConfig.java
@@ -221,10 +221,9 @@ public final class IndexSortConfig {
             }
             IndexFieldData<?> fieldData;
             try {
-                fieldData = fieldDataLookup.apply(
-                    ft,
-                    () -> { throw new UnsupportedOperationException("index sorting not supported on runtime field [" + ft.name() + "]"); }
-                );
+                fieldData = fieldDataLookup.apply(ft, () -> {
+                    throw new UnsupportedOperationException("index sorting not supported on runtime field [" + ft.name() + "]");
+                });
             } catch (Exception e) {
                 throw new IllegalArgumentException("docvalues not found for index sort field:[" + sortSpec.field + "]", e);
             }

--- a/server/src/main/java/org/opensearch/index/IndexWarmer.java
+++ b/server/src/main/java/org/opensearch/index/IndexWarmer.java
@@ -166,7 +166,9 @@ public final class IndexWarmer {
                         IndexFieldData.Global<?> ifd = indexFieldDataService.getForField(
                             fieldType,
                             indexFieldDataService.index().getName(),
-                            () -> { throw new UnsupportedOperationException("search lookup not available when warming an index"); }
+                            () -> {
+                                throw new UnsupportedOperationException("search lookup not available when warming an index");
+                            }
                         );
                         IndexFieldData<?> global = ifd.loadGlobal(reader);
                         if (reader.leaves().isEmpty() == false) {

--- a/server/src/main/java/org/opensearch/index/analysis/AnalysisRegistry.java
+++ b/server/src/main/java/org/opensearch/index/analysis/AnalysisRegistry.java
@@ -648,7 +648,9 @@ public final class AnalysisRegistry implements Closeable {
                     charFilterFactoryFactories,
                     tokenizerFactoryFactories
                 ),
-                (k, v) -> { throw new IllegalStateException("already registered analyzer with name: " + entry.getKey()); }
+                (k, v) -> {
+                    throw new IllegalStateException("already registered analyzer with name: " + entry.getKey());
+                }
             );
         }
         for (Map.Entry<String, AnalyzerProvider<?>> entry : normalizerProviders.entrySet()) {

--- a/server/src/main/java/org/opensearch/index/translog/Translog.java
+++ b/server/src/main/java/org/opensearch/index/translog/Translog.java
@@ -2016,11 +2016,15 @@ public abstract class Translog extends AbstractIndexShardComponent implements In
             EMPTY_TRANSLOG_BUFFER_SIZE,
             minTranslogGeneration,
             initialGlobalCheckpoint,
-            () -> { throw new UnsupportedOperationException(); },
+            () -> {
+                throw new UnsupportedOperationException();
+            },
             () -> { throw new UnsupportedOperationException(); },
             primaryTerm,
             new TragicExceptionHolder(),
-            seqNo -> { throw new UnsupportedOperationException(); },
+            seqNo -> {
+                throw new UnsupportedOperationException();
+            },
             BigArrays.NON_RECYCLING_INSTANCE
         );
         writer.close();

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/DoubleValuesSource.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/DoubleValuesSource.java
@@ -152,11 +152,9 @@ class DoubleValuesSource extends SingleDimensionValuesSource<Double> {
         } else if (value instanceof Number) {
             afterValue = ((Number) value).doubleValue();
         } else {
-            afterValue = format.parseDouble(
-                value.toString(),
-                false,
-                () -> { throw new IllegalArgumentException("now() is not supported in [after] key"); }
-            );
+            afterValue = format.parseDouble(value.toString(), false, () -> {
+                throw new IllegalArgumentException("now() is not supported in [after] key");
+            });
         }
     }
 

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/LongValuesSource.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/LongValuesSource.java
@@ -170,11 +170,9 @@ public class LongValuesSource extends SingleDimensionValuesSource<Long> {
             afterValue = null;
         } else {
             // parse the value from a string in case it is a date or a formatted unsigned long.
-            afterValue = format.parseLong(
-                value.toString(),
-                false,
-                () -> { throw new IllegalArgumentException("now() is not supported in [after] key"); }
-            );
+            afterValue = format.parseLong(value.toString(), false, () -> {
+                throw new IllegalArgumentException("now() is not supported in [after] key");
+            });
         }
     }
 

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/DateHistogramAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/DateHistogramAggregator.java
@@ -162,34 +162,29 @@ class DateHistogramAggregator extends BucketsAggregator implements SizedBucketAg
 
     @Override
     public InternalAggregation[] buildAggregations(long[] owningBucketOrds) throws IOException {
-        return buildAggregationsForVariableBuckets(
-            owningBucketOrds,
-            bucketOrds,
-            (bucketValue, docCount, subAggregationResults) -> {
-                return new InternalDateHistogram.Bucket(bucketValue, docCount, keyed, formatter, subAggregationResults);
-            },
-            (owningBucketOrd, buckets) -> {
-                // the contract of the histogram aggregation is that shards must return buckets ordered by key in ascending order
-                CollectionUtil.introSort(buckets, BucketOrder.key(true).comparator());
+        return buildAggregationsForVariableBuckets(owningBucketOrds, bucketOrds, (bucketValue, docCount, subAggregationResults) -> {
+            return new InternalDateHistogram.Bucket(bucketValue, docCount, keyed, formatter, subAggregationResults);
+        }, (owningBucketOrd, buckets) -> {
+            // the contract of the histogram aggregation is that shards must return buckets ordered by key in ascending order
+            CollectionUtil.introSort(buckets, BucketOrder.key(true).comparator());
 
-                // value source will be null for unmapped fields
-                // Important: use `rounding` here, not `shardRounding`
-                InternalDateHistogram.EmptyBucketInfo emptyBucketInfo = minDocCount == 0
-                    ? new InternalDateHistogram.EmptyBucketInfo(rounding.withoutOffset(), buildEmptySubAggregations(), extendedBounds)
-                    : null;
-                return new InternalDateHistogram(
-                    name,
-                    buckets,
-                    order,
-                    minDocCount,
-                    rounding.offset(),
-                    emptyBucketInfo,
-                    formatter,
-                    keyed,
-                    metadata()
-                );
-            }
-        );
+            // value source will be null for unmapped fields
+            // Important: use `rounding` here, not `shardRounding`
+            InternalDateHistogram.EmptyBucketInfo emptyBucketInfo = minDocCount == 0
+                ? new InternalDateHistogram.EmptyBucketInfo(rounding.withoutOffset(), buildEmptySubAggregations(), extendedBounds)
+                : null;
+            return new InternalDateHistogram(
+                name,
+                buckets,
+                order,
+                minDocCount,
+                rounding.offset(),
+                emptyBucketInfo,
+                formatter,
+                keyed,
+                metadata()
+            );
+        });
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
@@ -444,7 +444,7 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                     && ordinalsValuesSource.supportsGlobalOrdinalsMapping()
                     &&
                 // we use the static COLLECT_SEGMENT_ORDS to allow tests to force specific optimizations
-                (COLLECT_SEGMENT_ORDS != null ? COLLECT_SEGMENT_ORDS.booleanValue() : ratio <= 0.5 && maxOrd <= 2048)) {
+                    (COLLECT_SEGMENT_ORDS != null ? COLLECT_SEGMENT_ORDS.booleanValue() : ratio <= 0.5 && maxOrd <= 2048)) {
                     /*
                      * We can use the low cardinality execution mode iff this aggregator:
                      *  - has no sub-aggregator AND

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/DerivativePipelineAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/DerivativePipelineAggregator.java
@@ -120,9 +120,9 @@ public class DerivativePipelineAggregator extends PipelineAggregator {
                 if (xAxisUnits != null) {
                     xDiff = (thisBucketKey.doubleValue() - lastBucketKey.doubleValue()) / xAxisUnits;
                 }
-                final List<InternalAggregation> aggs = StreamSupport.stream(bucket.getAggregations().spliterator(), false)
-                    .map((p) -> { return (InternalAggregation) p; })
-                    .collect(Collectors.toList());
+                final List<InternalAggregation> aggs = StreamSupport.stream(bucket.getAggregations().spliterator(), false).map((p) -> {
+                    return (InternalAggregation) p;
+                }).collect(Collectors.toList());
                 aggs.add(new InternalDerivative(name(), gradient, xDiff, formatter, metadata()));
                 Bucket newBucket = factory.createBucket(factory.getKey(bucket), bucket.getDocCount(), InternalAggregations.from(aggs));
                 newBuckets.add(newBucket);

--- a/server/src/test/java/org/opensearch/action/ActionListenerTests.java
+++ b/server/src/test/java/org/opensearch/action/ActionListenerTests.java
@@ -266,10 +266,9 @@ public class ActionListenerTests extends OpenSearchTestCase {
         assertThat(assertionError.getCause(), instanceOf(IllegalArgumentException.class));
         assertNull(exReference.get());
 
-        assertionError = expectThrows(
-            AssertionError.class,
-            () -> ActionListener.completeWith(listener, () -> { throw new IllegalArgumentException(); })
-        );
+        assertionError = expectThrows(AssertionError.class, () -> ActionListener.completeWith(listener, () -> {
+            throw new IllegalArgumentException();
+        }));
         assertThat(assertionError.getCause(), instanceOf(IllegalArgumentException.class));
         assertThat(exReference.get(), instanceOf(IllegalArgumentException.class));
     }

--- a/server/src/test/java/org/opensearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsActionTests.java
@@ -386,7 +386,9 @@ public class TransportAddVotingConfigExclusionsActionTests extends OpenSearchTes
                 Strings.EMPTY_ARRAY,
                 TimeValue.timeValueSeconds(30)
             ),
-            expectSuccess(e -> { countDownLatch.countDown(); })
+            expectSuccess(e -> {
+                countDownLatch.countDown();
+            })
         );
 
         assertTrue(countDownLatch.await(30, TimeUnit.SECONDS));
@@ -430,7 +432,9 @@ public class TransportAddVotingConfigExclusionsActionTests extends OpenSearchTes
             localNode,
             AddVotingConfigExclusionsAction.NAME,
             new AddVotingConfigExclusionsRequest("absent_node"),
-            expectSuccess(e -> { countDownLatch.countDown(); })
+            expectSuccess(e -> {
+                countDownLatch.countDown();
+            })
         );
 
         assertTrue(countDownLatch.await(30, TimeUnit.SECONDS));

--- a/server/src/test/java/org/opensearch/action/admin/indices/TransportAnalyzeActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/TransportAnalyzeActionTests.java
@@ -380,10 +380,9 @@ public class TransportAnalyzeActionTests extends OpenSearchTestCase {
 
     public void testGetFieldAnalyzerWithoutIndexAnalyzers() {
         AnalyzeAction.Request req = new AnalyzeAction.Request().field("field").text("text");
-        IllegalArgumentException e = expectThrows(
-            IllegalArgumentException.class,
-            () -> { TransportAnalyzeAction.analyze(req, registry, null, maxTokenCount); }
-        );
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> {
+            TransportAnalyzeAction.analyze(req, registry, null, maxTokenCount);
+        });
         assertEquals(e.getMessage(), "analysis based on a specific field requires an index");
     }
 

--- a/server/src/test/java/org/opensearch/action/admin/indices/create/CreateIndexRequestBuilderTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/create/CreateIndexRequestBuilderTests.java
@@ -74,10 +74,9 @@ public class CreateIndexRequestBuilderTests extends OpenSearchTestCase {
     public void testSetSource() throws IOException {
         CreateIndexRequestBuilder builder = new CreateIndexRequestBuilder(this.testClient, CreateIndexAction.INSTANCE);
 
-        OpenSearchParseException e = expectThrows(
-            OpenSearchParseException.class,
-            () -> { builder.setSource("{\"" + KEY + "\" : \"" + VALUE + "\"}", XContentType.JSON); }
-        );
+        OpenSearchParseException e = expectThrows(OpenSearchParseException.class, () -> {
+            builder.setSource("{\"" + KEY + "\" : \"" + VALUE + "\"}", XContentType.JSON);
+        });
         assertEquals(String.format(Locale.ROOT, "unknown key [%s] for create index", KEY), e.getMessage());
 
         builder.setSource("{\"settings\" : {\"" + KEY + "\" : \"" + VALUE + "\"}}", XContentType.JSON);

--- a/server/src/test/java/org/opensearch/action/admin/indices/get/GetIndexActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/get/GetIndexActionTests.java
@@ -109,7 +109,9 @@ public class GetIndexActionTests extends OpenSearchSingleNodeTestCase {
                     "index.refresh_interval should be set as we are including defaults",
                     defaultsResponse.getSetting(indexName, "index.refresh_interval")
                 ),
-                exception -> { throw new AssertionError(exception); }
+                exception -> {
+                    throw new AssertionError(exception);
+                }
             )
         );
     }
@@ -124,7 +126,9 @@ public class GetIndexActionTests extends OpenSearchSingleNodeTestCase {
                     "index.refresh_interval should be null as it was never set",
                     noDefaultsResponse.getSetting(indexName, "index.refresh_interval")
                 ),
-                exception -> { throw new AssertionError(exception); }
+                exception -> {
+                    throw new AssertionError(exception);
+                }
             )
         );
     }

--- a/server/src/test/java/org/opensearch/action/bulk/BulkRequestParserTests.java
+++ b/server/src/test/java/org/opensearch/action/bulk/BulkRequestParserTests.java
@@ -58,49 +58,19 @@ public class BulkRequestParserTests extends OpenSearchTestCase {
         }, req -> fail(), req -> fail());
         assertTrue(parsed.get());
 
-        parser.parse(
-            request,
-            "foo",
-            null,
-            null,
-            null,
-            true,
-            false,
-            XContentType.JSON,
-            indexRequest -> { assertTrue(indexRequest.isRequireAlias()); },
-            req -> fail(),
-            req -> fail()
-        );
+        parser.parse(request, "foo", null, null, null, true, false, XContentType.JSON, indexRequest -> {
+            assertTrue(indexRequest.isRequireAlias());
+        }, req -> fail(), req -> fail());
 
         request = new BytesArray("{ \"index\":{ \"_id\": \"bar\", \"require_alias\": true } }\n{}\n");
-        parser.parse(
-            request,
-            "foo",
-            null,
-            null,
-            null,
-            null,
-            false,
-            XContentType.JSON,
-            indexRequest -> { assertTrue(indexRequest.isRequireAlias()); },
-            req -> fail(),
-            req -> fail()
-        );
+        parser.parse(request, "foo", null, null, null, null, false, XContentType.JSON, indexRequest -> {
+            assertTrue(indexRequest.isRequireAlias());
+        }, req -> fail(), req -> fail());
 
         request = new BytesArray("{ \"index\":{ \"_id\": \"bar\", \"require_alias\": false } }\n{}\n");
-        parser.parse(
-            request,
-            "foo",
-            null,
-            null,
-            null,
-            true,
-            false,
-            XContentType.JSON,
-            indexRequest -> { assertFalse(indexRequest.isRequireAlias()); },
-            req -> fail(),
-            req -> fail()
-        );
+        parser.parse(request, "foo", null, null, null, true, false, XContentType.JSON, indexRequest -> {
+            assertFalse(indexRequest.isRequireAlias());
+        }, req -> fail(), req -> fail());
     }
 
     public void testDeleteRequest() throws IOException {
@@ -129,49 +99,19 @@ public class BulkRequestParserTests extends OpenSearchTestCase {
         }, req -> fail());
         assertTrue(parsed.get());
 
-        parser.parse(
-            request,
-            "foo",
-            null,
-            null,
-            null,
-            true,
-            false,
-            XContentType.JSON,
-            req -> fail(),
-            updateRequest -> { assertTrue(updateRequest.isRequireAlias()); },
-            req -> fail()
-        );
+        parser.parse(request, "foo", null, null, null, true, false, XContentType.JSON, req -> fail(), updateRequest -> {
+            assertTrue(updateRequest.isRequireAlias());
+        }, req -> fail());
 
         request = new BytesArray("{ \"update\":{ \"_id\": \"bar\", \"require_alias\": true } }\n{}\n");
-        parser.parse(
-            request,
-            "foo",
-            null,
-            null,
-            null,
-            null,
-            false,
-            XContentType.JSON,
-            req -> fail(),
-            updateRequest -> { assertTrue(updateRequest.isRequireAlias()); },
-            req -> fail()
-        );
+        parser.parse(request, "foo", null, null, null, null, false, XContentType.JSON, req -> fail(), updateRequest -> {
+            assertTrue(updateRequest.isRequireAlias());
+        }, req -> fail());
 
         request = new BytesArray("{ \"update\":{ \"_id\": \"bar\", \"require_alias\": false } }\n{}\n");
-        parser.parse(
-            request,
-            "foo",
-            null,
-            null,
-            null,
-            true,
-            false,
-            XContentType.JSON,
-            req -> fail(),
-            updateRequest -> { assertFalse(updateRequest.isRequireAlias()); },
-            req -> fail()
-        );
+        parser.parse(request, "foo", null, null, null, true, false, XContentType.JSON, req -> fail(), updateRequest -> {
+            assertFalse(updateRequest.isRequireAlias());
+        }, req -> fail());
     }
 
     public void testBarfOnLackOfTrailingNewline() {

--- a/server/src/test/java/org/opensearch/action/bulk/TransportBulkActionIndicesThatCannotBeCreatedTests.java
+++ b/server/src/test/java/org/opensearch/action/bulk/TransportBulkActionIndicesThatCannotBeCreatedTests.java
@@ -96,11 +96,9 @@ public class TransportBulkActionIndicesThatCannotBeCreatedTests extends OpenSear
         bulkRequest.add(new IndexRequest("can't"));
         bulkRequest.add(new DeleteRequest("do").version(0).versionType(VersionType.EXTERNAL));
         bulkRequest.add(new UpdateRequest("nothin", randomAlphaOfLength(5)));
-        indicesThatCannotBeCreatedTestCase(
-            new HashSet<>(Arrays.asList("no", "can't", "do", "nothin")),
-            bulkRequest,
-            index -> { throw new IndexNotFoundException("Can't make it because I say so"); }
-        );
+        indicesThatCannotBeCreatedTestCase(new HashSet<>(Arrays.asList("no", "can't", "do", "nothin")), bulkRequest, index -> {
+            throw new IndexNotFoundException("Can't make it because I say so");
+        });
     }
 
     public void testSomeFail() {

--- a/server/src/test/java/org/opensearch/action/bulk/TransportBulkActionIngestTests.java
+++ b/server/src/test/java/org/opensearch/action/bulk/TransportBulkActionIngestTests.java
@@ -302,11 +302,9 @@ public class TransportBulkActionIngestTests extends OpenSearchTestCase {
     public void testSingleItemBulkActionIngestSkipped() throws Exception {
         IndexRequest indexRequest = new IndexRequest("index").id("id");
         indexRequest.source(emptyMap());
-        singleItemBulkWriteAction.execute(
-            null,
-            indexRequest,
-            ActionListener.wrap(response -> {}, exception -> { throw new AssertionError(exception); })
-        );
+        singleItemBulkWriteAction.execute(null, indexRequest, ActionListener.wrap(response -> {}, exception -> {
+            throw new AssertionError(exception);
+        }));
         assertTrue(action.isExecuted);
         verifyNoInteractions(ingestService);
     }

--- a/server/src/test/java/org/opensearch/action/search/SearchAsyncActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchAsyncActionTests.java
@@ -317,7 +317,9 @@ public class SearchAsyncActionTests extends OpenSearchTestCase {
         AtomicReference<TestSearchResponse> response = new AtomicReference<>();
         ActionListener<SearchResponse> responseListener = ActionListener.wrap(
             searchResponse -> response.set((TestSearchResponse) searchResponse),
-            (e) -> { throw new AssertionError("unexpected", e); }
+            (e) -> {
+                throw new AssertionError("unexpected", e);
+            }
         );
         DiscoveryNode primaryNode = new DiscoveryNode("node_1", buildNewFakeTransportAddress(), Version.CURRENT);
         DiscoveryNode replicaNode = new DiscoveryNode("node_2", buildNewFakeTransportAddress(), Version.CURRENT);

--- a/server/src/test/java/org/opensearch/client/OriginSettingClientTests.java
+++ b/server/src/test/java/org/opensearch/client/OriginSettingClientTests.java
@@ -77,9 +77,8 @@ public class OriginSettingClientTests extends OpenSearchTestCase {
     }
 
     private <T> ActionListener<T> listenerThatAssertsOriginNotSet(ThreadContext threadContext) {
-        return ActionListener.wrap(
-            r -> { assertNull(threadContext.getTransient(ThreadContext.ACTION_ORIGIN_TRANSIENT_NAME)); },
-            e -> { fail("didn't expect to fail but: " + e); }
-        );
+        return ActionListener.wrap(r -> { assertNull(threadContext.getTransient(ThreadContext.ACTION_ORIGIN_TRANSIENT_NAME)); }, e -> {
+            fail("didn't expect to fail but: " + e);
+        });
     }
 }

--- a/server/src/test/java/org/opensearch/cluster/InternalClusterInfoServiceSchedulingTests.java
+++ b/server/src/test/java/org/opensearch/cluster/InternalClusterInfoServiceSchedulingTests.java
@@ -94,7 +94,9 @@ public class InternalClusterInfoServiceSchedulingTests extends OpenSearchTestCas
             "test",
             "clusterManagerService",
             threadPool,
-            r -> { fail("cluster-manager service should not run any tasks"); }
+            r -> {
+                fail("cluster-manager service should not run any tasks");
+            }
         );
 
         final ClusterService clusterService = new ClusterService(settings, clusterSettings, clusterManagerService, clusterApplierService);

--- a/server/src/test/java/org/opensearch/cluster/coordination/ClusterBootstrapServiceDeprecatedMasterTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/ClusterBootstrapServiceDeprecatedMasterTests.java
@@ -125,9 +125,9 @@ public class ClusterBootstrapServiceDeprecatedMasterTests extends OpenSearchTest
             settings.put(UNCONFIGURED_BOOTSTRAP_TIMEOUT_SETTING.getKey(), timeout + "ms");
         }
 
-        final AtomicReference<Supplier<Iterable<DiscoveryNode>>> discoveredNodesSupplier = new AtomicReference<>(
-            () -> { throw new AssertionError("should not be called yet"); }
-        );
+        final AtomicReference<Supplier<Iterable<DiscoveryNode>>> discoveredNodesSupplier = new AtomicReference<>(() -> {
+            throw new AssertionError("should not be called yet");
+        });
 
         final AtomicBoolean bootstrapped = new AtomicBoolean();
         ClusterBootstrapService clusterBootstrapService = new ClusterBootstrapService(
@@ -163,13 +163,9 @@ public class ClusterBootstrapServiceDeprecatedMasterTests extends OpenSearchTest
     }
 
     private void testDoesNothingWithSettings(Settings.Builder builder) {
-        ClusterBootstrapService clusterBootstrapService = new ClusterBootstrapService(
-            builder.build(),
-            transportService,
-            () -> { throw new AssertionError("should not be called"); },
-            () -> false,
-            vc -> { throw new AssertionError("should not be called"); }
-        );
+        ClusterBootstrapService clusterBootstrapService = new ClusterBootstrapService(builder.build(), transportService, () -> {
+            throw new AssertionError("should not be called");
+        }, () -> false, vc -> { throw new AssertionError("should not be called"); });
         transportService.start();
         clusterBootstrapService.scheduleUnconfiguredBootstrap();
         deterministicTaskQueue.runAllTasks();
@@ -182,7 +178,9 @@ public class ClusterBootstrapServiceDeprecatedMasterTests extends OpenSearchTest
                 transportService,
                 Collections::emptyList,
                 () -> false,
-                vc -> { throw new AssertionError("should not be called"); }
+                vc -> {
+                    throw new AssertionError("should not be called");
+                }
             );
         });
 
@@ -236,7 +234,9 @@ public class ClusterBootstrapServiceDeprecatedMasterTests extends OpenSearchTest
             transportService,
             () -> Stream.of(localNode, otherNode1, otherNode2).collect(Collectors.toList()),
             () -> false,
-            vc -> { throw new AssertionError("should not be called"); }
+            vc -> {
+                throw new AssertionError("should not be called");
+            }
         );
         assertWarnings(CLUSTER_SETTING_DEPRECATED_MESSAGE);
         transportService.start();
@@ -250,7 +250,9 @@ public class ClusterBootstrapServiceDeprecatedMasterTests extends OpenSearchTest
             transportService,
             () -> Stream.of(localNode, otherNode1, otherNode2).collect(Collectors.toList()),
             () -> false,
-            vc -> { throw new AssertionError("should not be called"); }
+            vc -> {
+                throw new AssertionError("should not be called");
+            }
         );
         assertWarnings(CLUSTER_SETTING_DEPRECATED_MESSAGE);
         transportService.start();
@@ -264,7 +266,9 @@ public class ClusterBootstrapServiceDeprecatedMasterTests extends OpenSearchTest
             transportService,
             () -> Stream.of(localNode, otherNode1, otherNode2).collect(Collectors.toList()),
             () -> false,
-            vc -> { throw new AssertionError("should not be called"); }
+            vc -> {
+                throw new AssertionError("should not be called");
+            }
         );
         assertWarnings(CLUSTER_SETTING_DEPRECATED_MESSAGE);
         transportService.start();

--- a/server/src/test/java/org/opensearch/cluster/coordination/ClusterBootstrapServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/ClusterBootstrapServiceTests.java
@@ -126,9 +126,9 @@ public class ClusterBootstrapServiceTests extends OpenSearchTestCase {
             settings.put(UNCONFIGURED_BOOTSTRAP_TIMEOUT_SETTING.getKey(), timeout + "ms");
         }
 
-        final AtomicReference<Supplier<Iterable<DiscoveryNode>>> discoveredNodesSupplier = new AtomicReference<>(
-            () -> { throw new AssertionError("should not be called yet"); }
-        );
+        final AtomicReference<Supplier<Iterable<DiscoveryNode>>> discoveredNodesSupplier = new AtomicReference<>(() -> {
+            throw new AssertionError("should not be called yet");
+        });
 
         final AtomicBoolean bootstrapped = new AtomicBoolean();
         ClusterBootstrapService clusterBootstrapService = new ClusterBootstrapService(
@@ -182,13 +182,9 @@ public class ClusterBootstrapServiceTests extends OpenSearchTestCase {
     }
 
     private void testDoesNothingWithSettings(Settings.Builder builder) {
-        ClusterBootstrapService clusterBootstrapService = new ClusterBootstrapService(
-            builder.build(),
-            transportService,
-            () -> { throw new AssertionError("should not be called"); },
-            () -> false,
-            vc -> { throw new AssertionError("should not be called"); }
-        );
+        ClusterBootstrapService clusterBootstrapService = new ClusterBootstrapService(builder.build(), transportService, () -> {
+            throw new AssertionError("should not be called");
+        }, () -> false, vc -> { throw new AssertionError("should not be called"); });
         transportService.start();
         clusterBootstrapService.scheduleUnconfiguredBootstrap();
         deterministicTaskQueue.runAllTasks();
@@ -201,7 +197,9 @@ public class ClusterBootstrapServiceTests extends OpenSearchTestCase {
                 transportService,
                 Collections::emptyList,
                 () -> false,
-                vc -> { throw new AssertionError("should not be called"); }
+                vc -> {
+                    throw new AssertionError("should not be called");
+                }
             );
         });
 
@@ -330,7 +328,9 @@ public class ClusterBootstrapServiceTests extends OpenSearchTestCase {
             transportService,
             Collections::emptyList,
             () -> true,
-            vc -> { throw new AssertionError("should not be called"); }
+            vc -> {
+                throw new AssertionError("should not be called");
+            }
         );
 
         transportService.start();
@@ -353,7 +353,9 @@ public class ClusterBootstrapServiceTests extends OpenSearchTestCase {
             transportService,
             () -> Stream.of(otherNode1).collect(Collectors.toList()),
             () -> false,
-            vc -> { throw new AssertionError("should not be called"); }
+            vc -> {
+                throw new AssertionError("should not be called");
+            }
         );
 
         transportService.start();
@@ -377,7 +379,9 @@ public class ClusterBootstrapServiceTests extends OpenSearchTestCase {
             transportService,
             () -> Stream.of(otherNode1, otherNode2).collect(Collectors.toList()),
             () -> false,
-            vc -> { throw new AssertionError("should not be called"); }
+            vc -> {
+                throw new AssertionError("should not be called");
+            }
         );
 
         transportService.start();
@@ -393,7 +397,9 @@ public class ClusterBootstrapServiceTests extends OpenSearchTestCase {
             transportService,
             () -> Stream.of(otherNode1, otherNode2).collect(Collectors.toList()),
             () -> true,
-            vc -> { throw new AssertionError("should not be called"); }
+            vc -> {
+                throw new AssertionError("should not be called");
+            }
         );
 
         transportService.start();
@@ -417,7 +423,9 @@ public class ClusterBootstrapServiceTests extends OpenSearchTestCase {
             transportService,
             () -> Stream.of(localNode, otherNode1, otherNode2).collect(Collectors.toList()),
             () -> false,
-            vc -> { throw new AssertionError("should not be called"); }
+            vc -> {
+                throw new AssertionError("should not be called");
+            }
         );
         transportService.start();
         clusterBootstrapService.onFoundPeersUpdated();
@@ -430,7 +438,9 @@ public class ClusterBootstrapServiceTests extends OpenSearchTestCase {
             transportService,
             () -> Stream.of(localNode, otherNode1, otherNode2).collect(Collectors.toList()),
             () -> false,
-            vc -> { throw new AssertionError("should not be called"); }
+            vc -> {
+                throw new AssertionError("should not be called");
+            }
         );
         transportService.start();
         clusterBootstrapService.onFoundPeersUpdated();
@@ -443,7 +453,9 @@ public class ClusterBootstrapServiceTests extends OpenSearchTestCase {
             transportService,
             () -> Stream.of(localNode, otherNode1, otherNode2).collect(Collectors.toList()),
             () -> false,
-            vc -> { throw new AssertionError("should not be called"); }
+            vc -> {
+                throw new AssertionError("should not be called");
+            }
         );
         transportService.start();
         clusterBootstrapService.scheduleUnconfiguredBootstrap();
@@ -484,7 +496,9 @@ public class ClusterBootstrapServiceTests extends OpenSearchTestCase {
             transportService,
             discoveredNodes::get,
             () -> false,
-            vc -> { throw new AssertionError("should not be called"); }
+            vc -> {
+                throw new AssertionError("should not be called");
+            }
         );
 
         transportService.start();
@@ -507,7 +521,9 @@ public class ClusterBootstrapServiceTests extends OpenSearchTestCase {
             transportService,
             discoveredNodes::get,
             () -> false,
-            vc -> { throw new AssertionError("should not be called"); }
+            vc -> {
+                throw new AssertionError("should not be called");
+            }
         );
 
         transportService.start();
@@ -593,7 +609,9 @@ public class ClusterBootstrapServiceTests extends OpenSearchTestCase {
             transportService,
             Collections::emptyList,
             () -> false,
-            vc -> { throw new AssertionError("should not be called"); }
+            vc -> {
+                throw new AssertionError("should not be called");
+            }
         );
 
         transportService.start();

--- a/server/src/test/java/org/opensearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/CoordinatorTests.java
@@ -1232,11 +1232,9 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
                     nodes.stream().map(ClusterNode::getLocalNode).map(DiscoveryNode::getId).collect(Collectors.toSet())
                 ) == false,
                 () -> randomSubsetOf(cluster.clusterNodes)
-            ).forEach(
-                cn -> cn.extraJoinValidators.add(
-                    (discoveryNode, clusterState) -> { throw new IllegalArgumentException("join validation failed"); }
-                )
-            );
+            ).forEach(cn -> cn.extraJoinValidators.add((discoveryNode, clusterState) -> {
+                throw new IllegalArgumentException("join validation failed");
+            }));
             cluster.bootstrapIfNecessary();
             cluster.runFor(10000, "failing join validation");
             assertTrue(cluster.clusterNodes.stream().allMatch(cn -> cn.getLastAppliedClusterState().version() == 0));

--- a/server/src/test/java/org/opensearch/cluster/coordination/FollowersCheckerTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/FollowersCheckerTests.java
@@ -132,7 +132,9 @@ public class FollowersCheckerTests extends OpenSearchTestCase {
             settings,
             transportService,
             fcr -> { assert false : fcr; },
-            (node, reason) -> { assert false : node; },
+            (node, reason) -> {
+                assert false : node;
+            },
             () -> new StatusInfo(StatusInfo.Status.HEALTHY, "healthy-info")
         );
 
@@ -705,7 +707,9 @@ public class FollowersCheckerTests extends OpenSearchTestCase {
             Settings.EMPTY,
             transportService,
             fcr -> { assert false : fcr; },
-            (node, reason) -> { assert false : node; },
+            (node, reason) -> {
+                assert false : node;
+            },
             () -> new StatusInfo(HEALTHY, "healthy-info")
         );
         followersChecker.setCurrentNodes(discoveryNodes);

--- a/server/src/test/java/org/opensearch/cluster/coordination/JoinHelperTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/JoinHelperTests.java
@@ -86,7 +86,9 @@ public class JoinHelperTests extends OpenSearchTestCase {
             transportService,
             () -> 0L,
             () -> null,
-            (joinRequest, joinCallback) -> { throw new AssertionError(); },
+            (joinRequest, joinCallback) -> {
+                throw new AssertionError();
+            },
             startJoinRequest -> { throw new AssertionError(); },
             Collections.emptyList(),
             (s, p, r) -> {},
@@ -220,20 +222,11 @@ public class JoinHelperTests extends OpenSearchTestCase {
             null,
             Collections.emptySet()
         );
-        new JoinHelper(
-            Settings.EMPTY,
-            null,
-            null,
-            transportService,
-            () -> 0L,
-            () -> localClusterState,
-            (joinRequest, joinCallback) -> { throw new AssertionError(); },
-            startJoinRequest -> { throw new AssertionError(); },
-            Collections.emptyList(),
-            (s, p, r) -> {},
-            null,
-            nodeCommissioned -> {}
-        ); // registers request handler
+        new JoinHelper(Settings.EMPTY, null, null, transportService, () -> 0L, () -> localClusterState, (joinRequest, joinCallback) -> {
+            throw new AssertionError();
+        }, startJoinRequest -> { throw new AssertionError(); }, Collections.emptyList(), (s, p, r) -> {}, null, nodeCommissioned -> {}); // registers
+                                                                                                                                         // request
+                                                                                                                                         // handler
         transportService.start();
         transportService.acceptIncomingRequests();
 
@@ -282,7 +275,9 @@ public class JoinHelperTests extends OpenSearchTestCase {
             transportService,
             () -> 0L,
             () -> null,
-            (joinRequest, joinCallback) -> { throw new AssertionError(); },
+            (joinRequest, joinCallback) -> {
+                throw new AssertionError();
+            },
             startJoinRequest -> { throw new AssertionError(); },
             Collections.emptyList(),
             (s, p, r) -> {},

--- a/server/src/test/java/org/opensearch/cluster/coordination/NodeJoinTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/NodeJoinTests.java
@@ -529,14 +529,9 @@ public class NodeJoinTests extends OpenSearchTestCase {
             )
         );
 
-        assertTrue(
-            MasterServiceTests.discoveryState(clusterManagerService)
-                .getVotingConfigExclusions()
-                .stream()
-                .anyMatch(
-                    exclusion -> { return "knownNodeName".equals(exclusion.getNodeName()) && "newNodeId".equals(exclusion.getNodeId()); }
-                )
-        );
+        assertTrue(MasterServiceTests.discoveryState(clusterManagerService).getVotingConfigExclusions().stream().anyMatch(exclusion -> {
+            return "knownNodeName".equals(exclusion.getNodeName()) && "newNodeId".equals(exclusion.getNodeId());
+        }));
     }
 
     private ClusterState buildStateWithVotingConfigExclusion(

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -735,9 +735,9 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
     }
 
     public void testAggregateSettingsAppliesSettingsFromTemplatesAndRequest() {
-        IndexTemplateMetadata templateMetadata = addMatchingTemplate(
-            builder -> { builder.settings(Settings.builder().put("template_setting", "value1")); }
-        );
+        IndexTemplateMetadata templateMetadata = addMatchingTemplate(builder -> {
+            builder.settings(Settings.builder().put("template_setting", "value1"));
+        });
         ImmutableOpenMap.Builder<String, IndexTemplateMetadata> templatesBuilder = ImmutableOpenMap.builder();
         templatesBuilder.put("template_1", templateMetadata);
         Metadata metadata = new Metadata.Builder().templates(templatesBuilder.build()).build();

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/FailedNodeRoutingTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/FailedNodeRoutingTests.java
@@ -188,8 +188,9 @@ public class FailedNodeRoutingTests extends OpenSearchAllocationTestCase {
             // Pick a random subset of primaries to fail
             List<FailedShard> shardsToFail = new ArrayList<>();
             List<ShardRouting> failedPrimaries = randomSubsetOf(primaries);
-            failedPrimaries.stream()
-                .forEach(sr -> { shardsToFail.add(new FailedShard(randomFrom(sr), "failed primary", new Exception(), randomBoolean())); });
+            failedPrimaries.stream().forEach(sr -> {
+                shardsToFail.add(new FailedShard(randomFrom(sr), "failed primary", new Exception(), randomBoolean()));
+            });
 
             logger.info("--> state before failing shards: {}", state);
             state = cluster.applyFailedShards(state, shardsToFail);

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/IndexShardConstraintDeciderOverlapTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/IndexShardConstraintDeciderOverlapTests.java
@@ -68,10 +68,10 @@ public class IndexShardConstraintDeciderOverlapTests extends OpenSearchAllocatio
         final ImmutableOpenMap<ClusterInfo.NodeAndPath, ClusterInfo.ReservedSpace> reservedSpace = new ImmutableOpenMap.Builder<
             ClusterInfo.NodeAndPath,
             ClusterInfo.ReservedSpace>().fPut(getNodeAndDevNullPath("node_0"), getReservedSpace())
-                .fPut(getNodeAndDevNullPath("node_1"), getReservedSpace())
-                .fPut(getNodeAndDevNullPath("node_2"), getReservedSpace())
-                .fPut(getNodeAndDevNullPath("high_watermark_node_0"), getReservedSpace())
-                .build();
+            .fPut(getNodeAndDevNullPath("node_1"), getReservedSpace())
+            .fPut(getNodeAndDevNullPath("node_2"), getReservedSpace())
+            .fPut(getNodeAndDevNullPath("high_watermark_node_0"), getReservedSpace())
+            .build();
         final ClusterInfo clusterInfo = new DevNullClusterInfo(usages, usages, shardSizes, reservedSpace);
         ClusterInfoService cis = () -> clusterInfo;
         allocation = createAllocationService(settings, cis);

--- a/server/src/test/java/org/opensearch/cluster/service/ClusterManagerTaskThrottlerTests.java
+++ b/server/src/test/java/org/opensearch/cluster/service/ClusterManagerTaskThrottlerTests.java
@@ -69,12 +69,9 @@ public class ClusterManagerTaskThrottlerTests extends OpenSearchTestCase {
 
     public void testDefaults() {
         ClusterSettings clusterSettings = new ClusterSettings(Settings.builder().build(), ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        ClusterManagerTaskThrottler throttler = new ClusterManagerTaskThrottler(
-            Settings.EMPTY,
-            clusterSettings,
-            () -> { return clusterService.getMasterService().getMinNodeVersion(); },
-            new ClusterManagerThrottlingStats()
-        );
+        ClusterManagerTaskThrottler throttler = new ClusterManagerTaskThrottler(Settings.EMPTY, clusterSettings, () -> {
+            return clusterService.getMasterService().getMinNodeVersion();
+        }, new ClusterManagerThrottlingStats());
         throttler.registerClusterManagerTask("put-mapping", true);
         throttler.registerClusterManagerTask("create-index", true);
         for (String key : throttler.THROTTLING_TASK_KEYS.keySet()) {
@@ -91,12 +88,9 @@ public class ClusterManagerTaskThrottlerTests extends OpenSearchTestCase {
         );
 
         ClusterSettings clusterSettings = new ClusterSettings(Settings.builder().build(), ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        ClusterManagerTaskThrottler throttler = new ClusterManagerTaskThrottler(
-            Settings.EMPTY,
-            clusterSettings,
-            () -> { return clusterService.getMasterService().getMinNodeVersion(); },
-            new ClusterManagerThrottlingStats()
-        );
+        ClusterManagerTaskThrottler throttler = new ClusterManagerTaskThrottler(Settings.EMPTY, clusterSettings, () -> {
+            return clusterService.getMasterService().getMinNodeVersion();
+        }, new ClusterManagerThrottlingStats());
         throttler.registerClusterManagerTask("put-mapping", true);
 
         // set some limit for update snapshot tasks
@@ -124,12 +118,9 @@ public class ClusterManagerTaskThrottlerTests extends OpenSearchTestCase {
         );
 
         ClusterSettings clusterSettings = new ClusterSettings(Settings.builder().build(), ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        ClusterManagerTaskThrottler throttler = new ClusterManagerTaskThrottler(
-            Settings.EMPTY,
-            clusterSettings,
-            () -> { return clusterService.getMasterService().getMinNodeVersion(); },
-            new ClusterManagerThrottlingStats()
-        );
+        ClusterManagerTaskThrottler throttler = new ClusterManagerTaskThrottler(Settings.EMPTY, clusterSettings, () -> {
+            return clusterService.getMasterService().getMinNodeVersion();
+        }, new ClusterManagerThrottlingStats());
         throttler.registerClusterManagerTask("put-mapping", false);
 
         // set some limit for update snapshot tasks
@@ -148,12 +139,9 @@ public class ClusterManagerTaskThrottlerTests extends OpenSearchTestCase {
         );
 
         ClusterSettings clusterSettings = new ClusterSettings(Settings.builder().build(), ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        ClusterManagerTaskThrottler throttler = new ClusterManagerTaskThrottler(
-            Settings.EMPTY,
-            clusterSettings,
-            () -> { return clusterService.getMasterService().getMinNodeVersion(); },
-            new ClusterManagerThrottlingStats()
-        );
+        ClusterManagerTaskThrottler throttler = new ClusterManagerTaskThrottler(Settings.EMPTY, clusterSettings, () -> {
+            return clusterService.getMasterService().getMinNodeVersion();
+        }, new ClusterManagerThrottlingStats());
         throttler.registerClusterManagerTask("put-mapping", true);
 
         // set some limit for put-mapping tasks
@@ -181,12 +169,9 @@ public class ClusterManagerTaskThrottlerTests extends OpenSearchTestCase {
         Settings initialSettings = Settings.builder()
             .put("cluster_manager.throttling.thresholds.put-mapping.value", put_mapping_threshold_value)
             .build();
-        ClusterManagerTaskThrottler throttler = new ClusterManagerTaskThrottler(
-            initialSettings,
-            clusterSettings,
-            () -> { return clusterService.getMasterService().getMinNodeVersion(); },
-            new ClusterManagerThrottlingStats()
-        );
+        ClusterManagerTaskThrottler throttler = new ClusterManagerTaskThrottler(initialSettings, clusterSettings, () -> {
+            return clusterService.getMasterService().getMinNodeVersion();
+        }, new ClusterManagerThrottlingStats());
         throttler.registerClusterManagerTask("put-mapping", true);
 
         // assert that limit is applied on throttler
@@ -202,12 +187,9 @@ public class ClusterManagerTaskThrottlerTests extends OpenSearchTestCase {
         );
 
         ClusterSettings clusterSettings = new ClusterSettings(Settings.builder().build(), ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        ClusterManagerTaskThrottler throttler = new ClusterManagerTaskThrottler(
-            Settings.EMPTY,
-            clusterSettings,
-            () -> { return clusterService.getMasterService().getMinNodeVersion(); },
-            new ClusterManagerThrottlingStats()
-        );
+        ClusterManagerTaskThrottler throttler = new ClusterManagerTaskThrottler(Settings.EMPTY, clusterSettings, () -> {
+            return clusterService.getMasterService().getMinNodeVersion();
+        }, new ClusterManagerThrottlingStats());
 
         // set some limit for update snapshot tasks
         int newLimit = randomIntBetween(1, 10);
@@ -224,12 +206,9 @@ public class ClusterManagerTaskThrottlerTests extends OpenSearchTestCase {
         );
 
         ClusterSettings clusterSettings = new ClusterSettings(Settings.builder().build(), ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        ClusterManagerTaskThrottler throttler = new ClusterManagerTaskThrottler(
-            Settings.EMPTY,
-            clusterSettings,
-            () -> { return clusterService.getMasterService().getMinNodeVersion(); },
-            new ClusterManagerThrottlingStats()
-        );
+        ClusterManagerTaskThrottler throttler = new ClusterManagerTaskThrottler(Settings.EMPTY, clusterSettings, () -> {
+            return clusterService.getMasterService().getMinNodeVersion();
+        }, new ClusterManagerThrottlingStats());
         throttler.registerClusterManagerTask("put-mapping", true);
 
         // set some limit for update snapshot tasks
@@ -254,12 +233,9 @@ public class ClusterManagerTaskThrottlerTests extends OpenSearchTestCase {
         );
 
         ClusterSettings clusterSettings = new ClusterSettings(Settings.builder().build(), ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        ClusterManagerTaskThrottler throttler = new ClusterManagerTaskThrottler(
-            Settings.EMPTY,
-            clusterSettings,
-            () -> { return clusterService.getMasterService().getMinNodeVersion(); },
-            new ClusterManagerThrottlingStats()
-        );
+        ClusterManagerTaskThrottler throttler = new ClusterManagerTaskThrottler(Settings.EMPTY, clusterSettings, () -> {
+            return clusterService.getMasterService().getMinNodeVersion();
+        }, new ClusterManagerThrottlingStats());
         throttler.registerClusterManagerTask("put-mapping", true);
 
         Settings newSettings = Settings.builder().put("cluster_manager.throttling.thresholds.put-mapping.values", -5).build();
@@ -268,12 +244,9 @@ public class ClusterManagerTaskThrottlerTests extends OpenSearchTestCase {
 
     public void testUpdateLimit() {
         ClusterSettings clusterSettings = new ClusterSettings(Settings.builder().build(), ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        ClusterManagerTaskThrottler throttler = new ClusterManagerTaskThrottler(
-            Settings.EMPTY,
-            clusterSettings,
-            () -> { return clusterService.getMasterService().getMinNodeVersion(); },
-            new ClusterManagerThrottlingStats()
-        );
+        ClusterManagerTaskThrottler throttler = new ClusterManagerTaskThrottler(Settings.EMPTY, clusterSettings, () -> {
+            return clusterService.getMasterService().getMinNodeVersion();
+        }, new ClusterManagerThrottlingStats());
         throttler.registerClusterManagerTask("put-mapping", true);
 
         throttler.updateLimit("test", 5);
@@ -306,12 +279,9 @@ public class ClusterManagerTaskThrottlerTests extends OpenSearchTestCase {
         ClusterManagerThrottlingStats throttlingStats = new ClusterManagerThrottlingStats();
         String taskKey = "test";
         ClusterSettings clusterSettings = new ClusterSettings(Settings.builder().build(), ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        ClusterManagerTaskThrottler throttler = new ClusterManagerTaskThrottler(
-            Settings.EMPTY,
-            clusterSettings,
-            () -> { return clusterService.getMasterService().getMinNodeVersion(); },
-            throttlingStats
-        );
+        ClusterManagerTaskThrottler throttler = new ClusterManagerTaskThrottler(Settings.EMPTY, clusterSettings, () -> {
+            return clusterService.getMasterService().getMinNodeVersion();
+        }, throttlingStats);
         ClusterManagerTaskThrottler.ThrottlingKey throttlingKey = throttler.registerClusterManagerTask(taskKey, false);
 
         // adding limit directly in thresholds
@@ -339,12 +309,9 @@ public class ClusterManagerTaskThrottlerTests extends OpenSearchTestCase {
         Settings initialSettings = Settings.builder()
             .put("cluster_manager.throttling.thresholds.put-mapping.value", put_mapping_threshold_value)
             .build();
-        ClusterManagerTaskThrottler throttler = new ClusterManagerTaskThrottler(
-            initialSettings,
-            clusterSettings,
-            () -> { return clusterService.getMasterService().getMinNodeVersion(); },
-            throttlingStats
-        );
+        ClusterManagerTaskThrottler throttler = new ClusterManagerTaskThrottler(initialSettings, clusterSettings, () -> {
+            return clusterService.getMasterService().getMinNodeVersion();
+        }, throttlingStats);
         ClusterManagerTaskThrottler.ThrottlingKey throttlingKey = throttler.registerClusterManagerTask("put-mapping", true);
 
         // verifying adding more tasks then threshold passes
@@ -370,12 +337,9 @@ public class ClusterManagerTaskThrottlerTests extends OpenSearchTestCase {
         ClusterManagerThrottlingStats throttlingStats = new ClusterManagerThrottlingStats();
         String taskKey = "test";
         ClusterSettings clusterSettings = new ClusterSettings(Settings.builder().build(), ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        ClusterManagerTaskThrottler throttler = new ClusterManagerTaskThrottler(
-            Settings.EMPTY,
-            clusterSettings,
-            () -> { return clusterService.getMasterService().getMinNodeVersion(); },
-            throttlingStats
-        );
+        ClusterManagerTaskThrottler throttler = new ClusterManagerTaskThrottler(Settings.EMPTY, clusterSettings, () -> {
+            return clusterService.getMasterService().getMinNodeVersion();
+        }, throttlingStats);
         ClusterManagerTaskThrottler.ThrottlingKey throttlingKey = throttler.registerClusterManagerTask(taskKey, true);
 
         throttler.updateLimit(taskKey, 5);

--- a/server/src/test/java/org/opensearch/common/geo/GeoJsonSerializationTests.java
+++ b/server/src/test/java/org/opensearch/common/geo/GeoJsonSerializationTests.java
@@ -102,7 +102,9 @@ public class GeoJsonSerializationTests extends OpenSearchTestCase {
         AbstractXContentTestCase.xContentTester(
             this::createParser,
             () -> new GeometryWrapper(instanceSupplier.get()),
-            (geometryWrapper, xContentBuilder) -> { geometryWrapper.toXContent(xContentBuilder, ToXContent.EMPTY_PARAMS); },
+            (geometryWrapper, xContentBuilder) -> {
+                geometryWrapper.toXContent(xContentBuilder, ToXContent.EMPTY_PARAMS);
+            },
             GeometryWrapper::fromXContent
         ).supportsUnknownFields(true).test();
     }

--- a/server/src/test/java/org/opensearch/common/settings/SettingTests.java
+++ b/server/src/test/java/org/opensearch/common/settings/SettingTests.java
@@ -367,13 +367,9 @@ public class SettingTests extends OpenSearchTestCase {
     }
 
     public void testValidatorForFilteredStringSetting() {
-        final Setting<String> filteredStringSetting = new Setting<>(
-            "foo.bar",
-            "foobar",
-            Function.identity(),
-            value -> { throw new SettingsException("validate always fails"); },
-            Property.Filtered
-        );
+        final Setting<String> filteredStringSetting = new Setting<>("foo.bar", "foobar", Function.identity(), value -> {
+            throw new SettingsException("validate always fails");
+        }, Property.Filtered);
 
         final Settings settings = Settings.builder().put(filteredStringSetting.getKey(), filteredStringSetting.getKey() + " value").build();
         final IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> filteredStringSetting.get(settings));
@@ -1628,16 +1624,14 @@ public class SettingTests extends OpenSearchTestCase {
             validator
         );
 
-        IllegalArgumentException illegal = expectThrows(
-            IllegalArgumentException.class,
-            () -> { updater.getValue(Settings.builder().put("prefix.foo.suffix", 5).put("abc", 2).build(), Settings.EMPTY); }
-        );
+        IllegalArgumentException illegal = expectThrows(IllegalArgumentException.class, () -> {
+            updater.getValue(Settings.builder().put("prefix.foo.suffix", 5).put("abc", 2).build(), Settings.EMPTY);
+        });
         assertEquals("foo and 2 can't go together", illegal.getMessage());
 
-        illegal = expectThrows(
-            IllegalArgumentException.class,
-            () -> { updater.getValue(Settings.builder().put("prefix.bar.suffix", 6).put("abc", 3).build(), Settings.EMPTY); }
-        );
+        illegal = expectThrows(IllegalArgumentException.class, () -> {
+            updater.getValue(Settings.builder().put("prefix.bar.suffix", 6).put("abc", 3).build(), Settings.EMPTY);
+        });
         assertEquals("no bar", illegal.getMessage());
 
         Settings s = updater.getValue(

--- a/server/src/test/java/org/opensearch/common/settings/SettingsTests.java
+++ b/server/src/test/java/org/opensearch/common/settings/SettingsTests.java
@@ -606,19 +606,17 @@ public class SettingsTests extends OpenSearchTestCase {
 
     public void testIndentation() throws Exception {
         String yaml = "/org/opensearch/common/settings/loader/indentation-settings.yml";
-        OpenSearchParseException e = expectThrows(
-            OpenSearchParseException.class,
-            () -> { Settings.builder().loadFromStream(yaml, getClass().getResourceAsStream(yaml), false); }
-        );
+        OpenSearchParseException e = expectThrows(OpenSearchParseException.class, () -> {
+            Settings.builder().loadFromStream(yaml, getClass().getResourceAsStream(yaml), false);
+        });
         assertTrue(e.getMessage(), e.getMessage().contains("malformed"));
     }
 
     public void testIndentationWithExplicitDocumentStart() throws Exception {
         String yaml = "/org/opensearch/common/settings/loader/indentation-with-explicit-document-start-settings.yml";
-        OpenSearchParseException e = expectThrows(
-            OpenSearchParseException.class,
-            () -> { Settings.builder().loadFromStream(yaml, getClass().getResourceAsStream(yaml), false); }
-        );
+        OpenSearchParseException e = expectThrows(OpenSearchParseException.class, () -> {
+            Settings.builder().loadFromStream(yaml, getClass().getResourceAsStream(yaml), false);
+        });
         assertTrue(e.getMessage(), e.getMessage().contains("malformed"));
     }
 

--- a/server/src/test/java/org/opensearch/discovery/DiscoveryModuleTests.java
+++ b/server/src/test/java/org/opensearch/discovery/DiscoveryModuleTests.java
@@ -218,10 +218,9 @@ public class DiscoveryModuleTests extends OpenSearchTestCase {
     }
 
     public void testLazyConstructionSeedsProvider() {
-        DummyHostsProviderPlugin plugin = () -> Collections.singletonMap(
-            "custom",
-            () -> { throw new AssertionError("created hosts provider which was not selected"); }
-        );
+        DummyHostsProviderPlugin plugin = () -> Collections.singletonMap("custom", () -> {
+            throw new AssertionError("created hosts provider which was not selected");
+        });
         newModule(Settings.EMPTY, Collections.singletonList(plugin));
     }
 

--- a/server/src/test/java/org/opensearch/gateway/GatewayMetaStateTests.java
+++ b/server/src/test/java/org/opensearch/gateway/GatewayMetaStateTests.java
@@ -114,9 +114,9 @@ public class GatewayMetaStateTests extends OpenSearchTestCase {
 
     public void testIndexTemplateValidation() {
         Metadata metadata = randomMetadata();
-        MetadataUpgrader metadataUpgrader = new MetadataUpgrader(
-            Collections.singletonList(customs -> { throw new IllegalStateException("template is incompatible"); })
-        );
+        MetadataUpgrader metadataUpgrader = new MetadataUpgrader(Collections.singletonList(customs -> {
+            throw new IllegalStateException("template is incompatible");
+        }));
         String message = expectThrows(
             IllegalStateException.class,
             () -> GatewayMetaState.upgradeMetadata(metadata, new MockMetadataIndexUpgradeService(false), metadataUpgrader)

--- a/server/src/test/java/org/opensearch/index/IndexSettingsTests.java
+++ b/server/src/test/java/org/opensearch/index/IndexSettingsTests.java
@@ -100,8 +100,9 @@ public class IndexSettingsTests extends OpenSearchTestCase {
         Setting<Integer> integerSetting = Setting.intSetting("index.test.setting.int", -1, Property.Dynamic, Property.IndexScope);
         IndexMetadata metadata = newIndexMeta("index", theSettings);
         IndexSettings settings = newIndexSettings(newIndexMeta("index", theSettings), Settings.EMPTY, integerSetting);
-        settings.getScopedSettings()
-            .addSettingsUpdateConsumer(integerSetting, integer::set, (i) -> { if (i == 42) throw new AssertionError("boom"); });
+        settings.getScopedSettings().addSettingsUpdateConsumer(integerSetting, integer::set, (i) -> {
+            if (i == 42) throw new AssertionError("boom");
+        });
 
         assertEquals(version, settings.getIndexVersionCreated());
         assertEquals("0xdeadbeef", settings.getUUID());
@@ -654,15 +655,15 @@ public class IndexSettingsTests extends OpenSearchTestCase {
     }
 
     public void testArchiveBrokenIndexSettings() {
-        Settings settings = IndexScopedSettings.DEFAULT_SCOPED_SETTINGS.archiveUnknownOrInvalidSettings(
-            Settings.EMPTY,
-            e -> { assert false : "should not have been invoked, no unknown settings"; },
-            (e, ex) -> { assert false : "should not have been invoked, no invalid settings"; }
-        );
+        Settings settings = IndexScopedSettings.DEFAULT_SCOPED_SETTINGS.archiveUnknownOrInvalidSettings(Settings.EMPTY, e -> {
+            assert false : "should not have been invoked, no unknown settings";
+        }, (e, ex) -> { assert false : "should not have been invoked, no invalid settings"; });
         assertSame(settings, Settings.EMPTY);
         settings = IndexScopedSettings.DEFAULT_SCOPED_SETTINGS.archiveUnknownOrInvalidSettings(
             Settings.builder().put("index.refresh_interval", "-200").build(),
-            e -> { assert false : "should not have been invoked, no invalid settings"; },
+            e -> {
+                assert false : "should not have been invoked, no invalid settings";
+            },
             (e, ex) -> {
                 assertThat(e.getKey(), equalTo("index.refresh_interval"));
                 assertThat(e.getValue(), equalTo("-200"));
@@ -673,11 +674,9 @@ public class IndexSettingsTests extends OpenSearchTestCase {
         assertNull(settings.get("index.refresh_interval"));
 
         Settings prevSettings = settings; // no double archive
-        settings = IndexScopedSettings.DEFAULT_SCOPED_SETTINGS.archiveUnknownOrInvalidSettings(
-            prevSettings,
-            e -> { assert false : "should not have been invoked, no unknown settings"; },
-            (e, ex) -> { assert false : "should not have been invoked, no invalid settings"; }
-        );
+        settings = IndexScopedSettings.DEFAULT_SCOPED_SETTINGS.archiveUnknownOrInvalidSettings(prevSettings, e -> {
+            assert false : "should not have been invoked, no unknown settings";
+        }, (e, ex) -> { assert false : "should not have been invoked, no invalid settings"; });
         assertSame(prevSettings, settings);
 
         settings = IndexScopedSettings.DEFAULT_SCOPED_SETTINGS.archiveUnknownOrInvalidSettings(

--- a/server/src/test/java/org/opensearch/index/analysis/AnalysisRegistryTests.java
+++ b/server/src/test/java/org/opensearch/index/analysis/AnalysisRegistryTests.java
@@ -475,13 +475,10 @@ public class AnalysisRegistryTests extends OpenSearchTestCase {
             .build();
         IndexSettings exceptionSettings = IndexSettingsModule.newIndexSettings("index", indexSettings);
 
-        IllegalArgumentException e = expectThrows(
-            IllegalArgumentException.class,
-            () -> {
-                new AnalysisModule(TestEnvironment.newEnvironment(settings), singletonList(plugin)).getAnalysisRegistry()
-                    .build(exceptionSettings);
-            }
-        );
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> {
+            new AnalysisModule(TestEnvironment.newEnvironment(settings), singletonList(plugin)).getAnalysisRegistry()
+                .build(exceptionSettings);
+        });
         assertEquals("Cannot use token filter [exception]", e.getMessage());
 
     }

--- a/server/src/test/java/org/opensearch/index/analysis/AnalysisTests.java
+++ b/server/src/test/java/org/opensearch/index/analysis/AnalysisTests.java
@@ -124,15 +124,9 @@ public class AnalysisTests extends OpenSearchTestCase {
             writer.write('\n');
         }
         Environment env = TestEnvironment.newEnvironment(nodeSettings);
-        RuntimeException ex = expectThrows(
-            RuntimeException.class,
-            () -> Analysis.parseWordList(
-                env,
-                nodeSettings,
-                "foo.bar",
-                s -> { throw new RuntimeException("Error while parsing rule = " + s); }
-            )
-        );
+        RuntimeException ex = expectThrows(RuntimeException.class, () -> Analysis.parseWordList(env, nodeSettings, "foo.bar", s -> {
+            throw new RuntimeException("Error while parsing rule = " + s);
+        }));
         assertEquals("Line [1]: Error while parsing rule = abcd", ex.getMessage());
     }
 
@@ -146,15 +140,9 @@ public class AnalysisTests extends OpenSearchTestCase {
         }
         Settings nodeSettings = Settings.builder().put("foo.bar_path", dict).put(Environment.PATH_HOME_SETTING.getKey(), home).build();
         Environment env = TestEnvironment.newEnvironment(nodeSettings);
-        RuntimeException ex = expectThrows(
-            RuntimeException.class,
-            () -> Analysis.parseWordList(
-                env,
-                nodeSettings,
-                "foo.bar",
-                s -> { throw new RuntimeException("Error while parsing rule = " + s); }
-            )
-        );
+        RuntimeException ex = expectThrows(RuntimeException.class, () -> Analysis.parseWordList(env, nodeSettings, "foo.bar", s -> {
+            throw new RuntimeException("Error while parsing rule = " + s);
+        }));
         assertEquals("Line [1]: Invalid rule", ex.getMessage());
     }
 }

--- a/server/src/test/java/org/opensearch/index/engine/CompletionStatsCacheTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/CompletionStatsCacheTests.java
@@ -59,9 +59,9 @@ public class CompletionStatsCacheTests extends OpenSearchTestCase {
 
     public void testExceptionsAreNotCached() {
         final AtomicInteger openCount = new AtomicInteger();
-        final CompletionStatsCache completionStatsCache = new CompletionStatsCache(
-            () -> { throw new OpenSearchException("simulated " + openCount.incrementAndGet()); }
-        );
+        final CompletionStatsCache completionStatsCache = new CompletionStatsCache(() -> {
+            throw new OpenSearchException("simulated " + openCount.incrementAndGet());
+        });
 
         assertThat(expectThrows(OpenSearchException.class, completionStatsCache::get).getMessage(), equalTo("simulated 1"));
         assertThat(expectThrows(OpenSearchException.class, completionStatsCache::get).getMessage(), equalTo("simulated 2"));

--- a/server/src/test/java/org/opensearch/index/fielddata/IndexFieldDataServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/fielddata/IndexFieldDataServiceTests.java
@@ -327,10 +327,9 @@ public class IndexFieldDataServiceTests extends OpenSearchSingleNodeTestCase {
             if (ft.hasDocValues()) {
                 ifds.getForField(ft, "test", () -> { throw new UnsupportedOperationException(); }); // no exception
             } else {
-                IllegalArgumentException e = expectThrows(
-                    IllegalArgumentException.class,
-                    () -> ifds.getForField(ft, "test", () -> { throw new UnsupportedOperationException(); })
-                );
+                IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> ifds.getForField(ft, "test", () -> {
+                    throw new UnsupportedOperationException();
+                }));
                 assertThat(e.getMessage(), containsString("doc values"));
             }
         } finally {

--- a/server/src/test/java/org/opensearch/index/mapper/IdFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/IdFieldMapperTests.java
@@ -114,10 +114,9 @@ public class IdFieldMapperTests extends OpenSearchSingleNodeTestCase {
             .setTransientSettings(Settings.builder().put(IndicesService.INDICES_ID_FIELD_DATA_ENABLED_SETTING.getKey(), false))
             .get();
         try {
-            IllegalArgumentException exc = expectThrows(
-                IllegalArgumentException.class,
-                () -> ft.fielddataBuilder("test", () -> { throw new UnsupportedOperationException(); }).build(null, null)
-            );
+            IllegalArgumentException exc = expectThrows(IllegalArgumentException.class, () -> ft.fielddataBuilder("test", () -> {
+                throw new UnsupportedOperationException();
+            }).build(null, null));
             assertThat(exc.getMessage(), containsString(IndicesService.INDICES_ID_FIELD_DATA_ENABLED_SETTING.getKey()));
             assertFalse(ft.isAggregatable());
         } finally {

--- a/server/src/test/java/org/opensearch/index/mapper/MapperServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/MapperServiceTests.java
@@ -340,10 +340,9 @@ public class MapperServiceTests extends OpenSearchSingleNodeTestCase {
             )
         );
 
-        IllegalArgumentException e = expectThrows(
-            IllegalArgumentException.class,
-            () -> { mapperService.merge("type", mappingUpdate, updateOrPreflight()); }
-        );
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> {
+            mapperService.merge("type", mappingUpdate, updateOrPreflight());
+        });
 
         assertEquals("Field name [" + testString + "] is longer than the limit of [" + maxFieldNameLength + "] characters", e.getMessage());
     }
@@ -371,10 +370,9 @@ public class MapperServiceTests extends OpenSearchSingleNodeTestCase {
             )
         );
 
-        IllegalArgumentException e = expectThrows(
-            IllegalArgumentException.class,
-            () -> { mapperService.merge("type", mapping, updateOrPreflight()); }
-        );
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> {
+            mapperService.merge("type", mapping, updateOrPreflight());
+        });
 
         assertEquals("Field name [" + testString + "] is longer than the limit of [" + maxFieldNameLength + "] characters", e.getMessage());
     }
@@ -406,10 +404,9 @@ public class MapperServiceTests extends OpenSearchSingleNodeTestCase {
             )
         );
 
-        IllegalArgumentException e = expectThrows(
-            IllegalArgumentException.class,
-            () -> { mapperService.merge("type", mapping, updateOrPreflight()); }
-        );
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> {
+            mapperService.merge("type", mapping, updateOrPreflight());
+        });
 
         assertEquals("Field name [" + testString + "] is longer than the limit of [" + maxFieldNameLength + "] characters", e.getMessage());
     }

--- a/server/src/test/java/org/opensearch/index/mapper/NumberFieldTypeTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/NumberFieldTypeTests.java
@@ -553,10 +553,9 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
 
         // Create an index writer configured with the same index sort.
         NumberFieldType fieldType = new NumberFieldType("field", type);
-        IndexNumericFieldData fielddata = (IndexNumericFieldData) fieldType.fielddataBuilder(
-            "index",
-            () -> { throw new UnsupportedOperationException(); }
-        ).build(null, null);
+        IndexNumericFieldData fielddata = (IndexNumericFieldData) fieldType.fielddataBuilder("index", () -> {
+            throw new UnsupportedOperationException();
+        }).build(null, null);
         SortField sortField = fielddata.sortField(null, MultiValueMode.MIN, null, randomBoolean());
 
         IndexWriterConfig writerConfig = new IndexWriterConfig();

--- a/server/src/test/java/org/opensearch/index/mapper/ObjectMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/ObjectMapperTests.java
@@ -443,10 +443,9 @@ public class ObjectMapperTests extends OpenSearchSingleNodeTestCase {
         );
 
         // Empty name not allowed in index created after 5.0
-        IllegalArgumentException e = expectThrows(
-            IllegalArgumentException.class,
-            () -> { createIndex("test").mapperService().documentMapperParser().parse("", new CompressedXContent(mapping)); }
-        );
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> {
+            createIndex("test").mapperService().documentMapperParser().parse("", new CompressedXContent(mapping));
+        });
         assertThat(e.getMessage(), containsString("name cannot be empty string"));
     }
 

--- a/server/src/test/java/org/opensearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/TextFieldMapperTests.java
@@ -501,10 +501,9 @@ public class TextFieldMapperTests extends MapperTestCase {
 
     public void testFielddata() throws IOException {
         MapperService disabledMapper = createMapperService(fieldMapping(this::minimalMapping));
-        Exception e = expectThrows(
-            IllegalArgumentException.class,
-            () -> disabledMapper.fieldType("field").fielddataBuilder("test", () -> { throw new UnsupportedOperationException(); })
-        );
+        Exception e = expectThrows(IllegalArgumentException.class, () -> disabledMapper.fieldType("field").fielddataBuilder("test", () -> {
+            throw new UnsupportedOperationException();
+        }));
         assertThat(e.getMessage(), containsString("Text fields are not optimised for operations that require per-document field data"));
 
         MapperService enabledMapper = createMapperService(fieldMapping(b -> b.field("type", "text").field("fielddata", true)));

--- a/server/src/test/java/org/opensearch/index/query/InnerHitBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/InnerHitBuilderTests.java
@@ -237,12 +237,9 @@ public class InnerHitBuilderTests extends OpenSearchTestCase {
         });
         modifiers.add(() -> {
             if (randomBoolean()) {
-                copy.setScriptFields(
-                    randomValueOtherThan(
-                        copy.getScriptFields(),
-                        () -> { return new HashSet<>(randomListStuff(16, InnerHitBuilderTests::randomScript)); }
-                    )
-                );
+                copy.setScriptFields(randomValueOtherThan(copy.getScriptFields(), () -> {
+                    return new HashSet<>(randomListStuff(16, InnerHitBuilderTests::randomScript));
+                }));
             } else {
                 SearchSourceBuilder.ScriptField script = randomScript();
                 copy.addScriptField(script.fieldName(), script.script());

--- a/server/src/test/java/org/opensearch/index/search/MultiMatchQueryTests.java
+++ b/server/src/test/java/org/opensearch/index/search/MultiMatchQueryTests.java
@@ -111,12 +111,9 @@ public class MultiMatchQueryTests extends OpenSearchSingleNodeTestCase {
     }
 
     public void testCrossFieldMultiMatchQuery() throws IOException {
-        QueryShardContext queryShardContext = indexService.newQueryShardContext(
-            randomInt(20),
-            null,
-            () -> { throw new UnsupportedOperationException(); },
-            null
-        );
+        QueryShardContext queryShardContext = indexService.newQueryShardContext(randomInt(20), null, () -> {
+            throw new UnsupportedOperationException();
+        }, null);
         queryShardContext.setAllowUnmappedFields(true);
         for (float tieBreaker : new float[] { 0.0f, 0.5f }) {
             Query parsedQuery = multiMatchQuery("banon").field("name.first", 2)
@@ -141,14 +138,9 @@ public class MultiMatchQueryTests extends OpenSearchSingleNodeTestCase {
         Term[] terms = new Term[] { new Term("foo", "baz"), new Term("bar", "baz") };
         float[] boosts = new float[] { 2, 3 };
         Query expected = BlendedTermQuery.dismaxBlendedQuery(terms, boosts, 1.0f);
-        Query actual = MultiMatchQuery.blendTerm(
-            indexService.newQueryShardContext(randomInt(20), null, () -> { throw new UnsupportedOperationException(); }, null),
-            new BytesRef("baz"),
-            null,
-            1f,
-            false,
-            Arrays.asList(new FieldAndBoost(ft1, 2), new FieldAndBoost(ft2, 3))
-        );
+        Query actual = MultiMatchQuery.blendTerm(indexService.newQueryShardContext(randomInt(20), null, () -> {
+            throw new UnsupportedOperationException();
+        }, null), new BytesRef("baz"), null, 1f, false, Arrays.asList(new FieldAndBoost(ft1, 2), new FieldAndBoost(ft2, 3)));
         assertEquals(expected, actual);
     }
 
@@ -160,14 +152,9 @@ public class MultiMatchQueryTests extends OpenSearchSingleNodeTestCase {
         Term[] terms = new Term[] { new Term("foo", "baz"), new Term("bar", "baz") };
         float[] boosts = new float[] { 200, 30 };
         Query expected = BlendedTermQuery.dismaxBlendedQuery(terms, boosts, 1.0f);
-        Query actual = MultiMatchQuery.blendTerm(
-            indexService.newQueryShardContext(randomInt(20), null, () -> { throw new UnsupportedOperationException(); }, null),
-            new BytesRef("baz"),
-            null,
-            1f,
-            false,
-            Arrays.asList(new FieldAndBoost(ft1, 2), new FieldAndBoost(ft2, 3))
-        );
+        Query actual = MultiMatchQuery.blendTerm(indexService.newQueryShardContext(randomInt(20), null, () -> {
+            throw new UnsupportedOperationException();
+        }, null), new BytesRef("baz"), null, 1f, false, Arrays.asList(new FieldAndBoost(ft1, 2), new FieldAndBoost(ft2, 3)));
         assertEquals(expected, actual);
     }
 
@@ -188,14 +175,9 @@ public class MultiMatchQueryTests extends OpenSearchSingleNodeTestCase {
             ),
             1f
         );
-        Query actual = MultiMatchQuery.blendTerm(
-            indexService.newQueryShardContext(randomInt(20), null, () -> { throw new UnsupportedOperationException(); }, null),
-            new BytesRef("baz"),
-            null,
-            1f,
-            true,
-            Arrays.asList(new FieldAndBoost(ft1, 2), new FieldAndBoost(ft2, 3))
-        );
+        Query actual = MultiMatchQuery.blendTerm(indexService.newQueryShardContext(randomInt(20), null, () -> {
+            throw new UnsupportedOperationException();
+        }, null), new BytesRef("baz"), null, 1f, true, Arrays.asList(new FieldAndBoost(ft1, 2), new FieldAndBoost(ft2, 3)));
         assertEquals(expected, actual);
     }
 
@@ -208,14 +190,9 @@ public class MultiMatchQueryTests extends OpenSearchSingleNodeTestCase {
         };
         expectThrows(
             IllegalArgumentException.class,
-            () -> MultiMatchQuery.blendTerm(
-                indexService.newQueryShardContext(randomInt(20), null, () -> { throw new UnsupportedOperationException(); }, null),
-                new BytesRef("baz"),
-                null,
-                1f,
-                false,
-                Arrays.asList(new FieldAndBoost(ft, 1))
-            )
+            () -> MultiMatchQuery.blendTerm(indexService.newQueryShardContext(randomInt(20), null, () -> {
+                throw new UnsupportedOperationException();
+            }, null), new BytesRef("baz"), null, 1f, false, Arrays.asList(new FieldAndBoost(ft, 1)))
         );
     }
 
@@ -232,24 +209,16 @@ public class MultiMatchQueryTests extends OpenSearchSingleNodeTestCase {
         Query expectedDisjunct1 = BlendedTermQuery.dismaxBlendedQuery(terms, boosts, 1.0f);
         Query expectedDisjunct2 = new BoostQuery(new MatchAllDocsQuery(), 3);
         Query expected = new DisjunctionMaxQuery(Arrays.asList(expectedDisjunct2, expectedDisjunct1), 1.0f);
-        Query actual = MultiMatchQuery.blendTerm(
-            indexService.newQueryShardContext(randomInt(20), null, () -> { throw new UnsupportedOperationException(); }, null),
-            new BytesRef("baz"),
-            null,
-            1f,
-            false,
-            Arrays.asList(new FieldAndBoost(ft1, 2), new FieldAndBoost(ft2, 3))
-        );
+        Query actual = MultiMatchQuery.blendTerm(indexService.newQueryShardContext(randomInt(20), null, () -> {
+            throw new UnsupportedOperationException();
+        }, null), new BytesRef("baz"), null, 1f, false, Arrays.asList(new FieldAndBoost(ft1, 2), new FieldAndBoost(ft2, 3)));
         assertEquals(expected, actual);
     }
 
     public void testMultiMatchCrossFieldsWithSynonyms() throws IOException {
-        QueryShardContext queryShardContext = indexService.newQueryShardContext(
-            randomInt(20),
-            null,
-            () -> { throw new UnsupportedOperationException(); },
-            null
-        );
+        QueryShardContext queryShardContext = indexService.newQueryShardContext(randomInt(20), null, () -> {
+            throw new UnsupportedOperationException();
+        }, null);
 
         MultiMatchQuery parser = new MultiMatchQuery(queryShardContext);
         parser.setAnalyzer(new MockSynonymAnalyzer());
@@ -279,12 +248,9 @@ public class MultiMatchQueryTests extends OpenSearchSingleNodeTestCase {
     }
 
     public void testMultiMatchCrossFieldsWithSynonymsPhrase() throws IOException {
-        QueryShardContext queryShardContext = indexService.newQueryShardContext(
-            randomInt(20),
-            null,
-            () -> { throw new UnsupportedOperationException(); },
-            null
-        );
+        QueryShardContext queryShardContext = indexService.newQueryShardContext(randomInt(20), null, () -> {
+            throw new UnsupportedOperationException();
+        }, null);
         MultiMatchQuery parser = new MultiMatchQuery(queryShardContext);
         parser.setAnalyzer(new MockSynonymAnalyzer());
         Map<String, Float> fieldNames = new HashMap<>();
@@ -345,12 +311,9 @@ public class MultiMatchQueryTests extends OpenSearchSingleNodeTestCase {
                 .endObject()
         );
         mapperService.merge("type", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
-        QueryShardContext queryShardContext = indexService.newQueryShardContext(
-            randomInt(20),
-            null,
-            () -> { throw new UnsupportedOperationException(); },
-            null
-        );
+        QueryShardContext queryShardContext = indexService.newQueryShardContext(randomInt(20), null, () -> {
+            throw new UnsupportedOperationException();
+        }, null);
         MultiMatchQuery parser = new MultiMatchQuery(queryShardContext);
         Map<String, Float> fieldNames = new HashMap<>();
         fieldNames.put("field", 1.0f);

--- a/server/src/test/java/org/opensearch/index/shard/GlobalCheckpointListenersTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/GlobalCheckpointListenersTests.java
@@ -625,11 +625,9 @@ public class GlobalCheckpointListenersTests extends OpenSearchTestCase {
         }).when(mockLogger).warn(any(String.class), any(RuntimeException.class));
         final GlobalCheckpointListeners globalCheckpointListeners = new GlobalCheckpointListeners(shardId, scheduler, mockLogger);
         final TimeValue timeout = TimeValue.timeValueMillis(randomIntBetween(1, 50));
-        globalCheckpointListeners.add(
-            NO_OPS_PERFORMED,
-            maybeMultipleInvocationProtectingListener((g, e) -> { throw new RuntimeException("failure"); }),
-            timeout
-        );
+        globalCheckpointListeners.add(NO_OPS_PERFORMED, maybeMultipleInvocationProtectingListener((g, e) -> {
+            throw new RuntimeException("failure");
+        }), timeout);
         latch.await();
         final ArgumentCaptor<String> message = ArgumentCaptor.forClass(String.class);
         final ArgumentCaptor<RuntimeException> t = ArgumentCaptor.forClass(RuntimeException.class);

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardOperationPermitsTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardOperationPermitsTests.java
@@ -226,18 +226,12 @@ public class IndexShardOperationPermitsTests extends OpenSearchTestCase {
 
     public void testBlockIfClosed() {
         permits.close();
-        expectThrows(
-            IndexShardClosedException.class,
-            () -> permits.blockOperations(randomInt(10), TimeUnit.MINUTES, () -> { throw new IllegalArgumentException("fake error"); })
-        );
-        expectThrows(
-            IndexShardClosedException.class,
-            () -> permits.asyncBlockOperations(
-                wrap(() -> { throw new IllegalArgumentException("fake error"); }),
-                randomInt(10),
-                TimeUnit.MINUTES
-            )
-        );
+        expectThrows(IndexShardClosedException.class, () -> permits.blockOperations(randomInt(10), TimeUnit.MINUTES, () -> {
+            throw new IllegalArgumentException("fake error");
+        }));
+        expectThrows(IndexShardClosedException.class, () -> permits.asyncBlockOperations(wrap(() -> {
+            throw new IllegalArgumentException("fake error");
+        }), randomInt(10), TimeUnit.MINUTES));
     }
 
     public void testOperationsDelayedIfBlock() throws ExecutionException, InterruptedException, TimeoutException {

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -2113,11 +2113,9 @@ public class IndexShardTests extends IndexShardTestCase {
         IndexShardTestCase.updateRoutingEntry(shard, routing);
         ReplicationFailedException segRepException = expectThrows(
             ReplicationFailedException.class,
-            () -> shard.relocated(
-                routing.getTargetRelocatingShard().allocationId().getId(),
-                primaryContext -> {},
-                () -> { throw new ReplicationFailedException("Segment replication failed"); }
-            )
+            () -> shard.relocated(routing.getTargetRelocatingShard().allocationId().getId(), primaryContext -> {}, () -> {
+                throw new ReplicationFailedException("Segment replication failed");
+            })
         );
         assertTrue(segRepException.getMessage().equals("Segment replication failed"));
         closeShards(shard);
@@ -2900,11 +2898,9 @@ public class IndexShardTests extends IndexShardTestCase {
             new NoneCircuitBreakerService(),
             shard.mapperService()
         );
-        IndexFieldData.Global ifd = indexFieldDataService.getForField(
-            foo,
-            "test",
-            () -> { throw new UnsupportedOperationException("search lookup not available"); }
-        );
+        IndexFieldData.Global ifd = indexFieldDataService.getForField(foo, "test", () -> {
+            throw new UnsupportedOperationException("search lookup not available");
+        });
         FieldDataStats before = shard.fieldData().stats("foo");
         assertThat(before.getMemorySizeInBytes(), equalTo(0L));
         FieldDataStats after = null;

--- a/server/src/test/java/org/opensearch/index/shard/SearchOperationListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/SearchOperationListenerTests.java
@@ -138,7 +138,9 @@ public class SearchOperationListenerTests extends OpenSearchTestCase {
         SearchOperationListener throwingListener = (SearchOperationListener) Proxy.newProxyInstance(
             SearchOperationListener.class.getClassLoader(),
             new Class[] { SearchOperationListener.class },
-            (a, b, c) -> { throw new RuntimeException(); }
+            (a, b, c) -> {
+                throw new RuntimeException();
+            }
         );
         int throwingListeners = 0;
         final List<SearchOperationListener> indexingOperationListeners = new ArrayList<>(Arrays.asList(listener, listener));

--- a/server/src/test/java/org/opensearch/index/similarity/ScriptedSimilarityTests.java
+++ b/server/src/test/java/org/opensearch/index/similarity/ScriptedSimilarityTests.java
@@ -111,10 +111,9 @@ public class ScriptedSimilarityTests extends OpenSearchTestCase {
                 ) {
 
                     StackTraceElement[] stackTraceElements = Thread.currentThread().getStackTrace();
-                    if (Arrays.stream(stackTraceElements)
-                        .anyMatch(
-                            ste -> { return ste.getClassName().endsWith(".TermScorer") && ste.getMethodName().equals("score"); }
-                        ) == false) {
+                    if (Arrays.stream(stackTraceElements).anyMatch(ste -> {
+                        return ste.getClassName().endsWith(".TermScorer") && ste.getMethodName().equals("score");
+                    }) == false) {
                         // this might happen when computing max scores
                         return Float.MAX_VALUE;
                     }
@@ -210,10 +209,9 @@ public class ScriptedSimilarityTests extends OpenSearchTestCase {
                 ) {
 
                     StackTraceElement[] stackTraceElements = Thread.currentThread().getStackTrace();
-                    if (Arrays.stream(stackTraceElements)
-                        .anyMatch(
-                            ste -> { return ste.getClassName().endsWith(".TermScorer") && ste.getMethodName().equals("score"); }
-                        ) == false) {
+                    if (Arrays.stream(stackTraceElements).anyMatch(ste -> {
+                        return ste.getClassName().endsWith(".TermScorer") && ste.getMethodName().equals("score");
+                    }) == false) {
                         // this might happen when computing max scores
                         return Float.MAX_VALUE;
                     }

--- a/server/src/test/java/org/opensearch/index/translog/listener/TranslogListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/listener/TranslogListenerTests.java
@@ -98,7 +98,9 @@ public class TranslogListenerTests extends OpenSearchTestCase {
         TranslogEventListener throwingListener = (TranslogEventListener) Proxy.newProxyInstance(
             TranslogEventListener.class.getClassLoader(),
             new Class[] { TranslogEventListener.class },
-            (a, b, c) -> { throw new RuntimeException(); }
+            (a, b, c) -> {
+                throw new RuntimeException();
+            }
         );
 
         final List<TranslogEventListener> translogEventListeners = new LinkedList<>(Arrays.asList(listener, throwingListener, listener));

--- a/server/src/test/java/org/opensearch/indices/recovery/PeerRecoveryTargetServiceTests.java
+++ b/server/src/test/java/org/opensearch/indices/recovery/PeerRecoveryTargetServiceTests.java
@@ -148,7 +148,9 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
                             r.content(),
                             r.lastChunk(),
                             r.totalTranslogOps(),
-                            ActionListener.wrap(ignored -> {}, e -> { throw new AssertionError(e); })
+                            ActionListener.wrap(ignored -> {}, e -> {
+                                throw new AssertionError(e);
+                            })
                         );
                     }
                 } catch (Exception e) {

--- a/server/src/test/java/org/opensearch/indices/replication/SegmentFileTransferHandlerTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/SegmentFileTransferHandlerTests.java
@@ -245,16 +245,13 @@ public class SegmentFileTransferHandlerTests extends IndexShardTestCase {
         );
 
         doNothing().when(shard).failShard(anyString(), any());
-        assertThrows(
-            CorruptIndexException.class,
-            () -> {
-                handler.handleErrorOnSendFiles(
-                    shard.store(),
-                    new CorruptIndexException("test", "test"),
-                    new StoreFileMetadata[] { SEGMENTS_FILE }
-                );
-            }
-        );
+        assertThrows(CorruptIndexException.class, () -> {
+            handler.handleErrorOnSendFiles(
+                shard.store(),
+                new CorruptIndexException("test", "test"),
+                new StoreFileMetadata[] { SEGMENTS_FILE }
+            );
+        });
 
         verify(shard, times(1)).failShard(any(), any());
     }

--- a/server/src/test/java/org/opensearch/ingest/CompoundProcessorTests.java
+++ b/server/src/test/java/org/opensearch/ingest/CompoundProcessorTests.java
@@ -75,9 +75,9 @@ public class CompoundProcessorTests extends OpenSearchTestCase {
     public void testSingleProcessor() throws Exception {
         LongSupplier relativeTimeProvider = mock(LongSupplier.class);
         when(relativeTimeProvider.getAsLong()).thenReturn(0L, TimeUnit.MILLISECONDS.toNanos(1));
-        TestProcessor processor = new TestProcessor(
-            ingestDocument -> { assertStats(0, ingestDocument.getFieldValue("compoundProcessor", CompoundProcessor.class), 1, 0, 0, 0); }
-        );
+        TestProcessor processor = new TestProcessor(ingestDocument -> {
+            assertStats(0, ingestDocument.getFieldValue("compoundProcessor", CompoundProcessor.class), 1, 0, 0, 0);
+        });
         CompoundProcessor compoundProcessor = new CompoundProcessor(relativeTimeProvider, processor);
         ingestDocument.setFieldValue("compoundProcessor", compoundProcessor); // ugly hack to assert current count = 1
         assertThat(compoundProcessor.getProcessors().size(), equalTo(1));

--- a/server/src/test/java/org/opensearch/ingest/ConditionalProcessorTests.java
+++ b/server/src/test/java/org/opensearch/ingest/ConditionalProcessorTests.java
@@ -164,11 +164,9 @@ public class ConditionalProcessorTests extends OpenSearchTestCase {
     }
 
     public void testPrecompiledError() {
-        ScriptService scriptService = MockScriptService.singleContext(
-            IngestConditionalScript.CONTEXT,
-            code -> { throw new ScriptException("bad script", new ParseException("error", 0), List.of(), "", "lang", null); },
-            Map.of()
-        );
+        ScriptService scriptService = MockScriptService.singleContext(IngestConditionalScript.CONTEXT, code -> {
+            throw new ScriptException("bad script", new ParseException("error", 0), List.of(), "", "lang", null);
+        }, Map.of());
         Script script = new Script(ScriptType.INLINE, "lang", "foo", Map.of());
         ScriptException e = expectThrows(ScriptException.class, () -> new ConditionalProcessor(null, null, script, scriptService, null));
         assertThat(e.getMessage(), equalTo("bad script"));

--- a/server/src/test/java/org/opensearch/ingest/PipelineProcessorTests.java
+++ b/server/src/test/java/org/opensearch/ingest/PipelineProcessorTests.java
@@ -172,25 +172,16 @@ public class PipelineProcessorTests extends OpenSearchTestCase {
             pipeline2Id,
             null,
             null,
-            new CompoundProcessor(
-                true,
-                Arrays.asList(
-                    new TestProcessor(ingestDocument -> { ingestDocument.setFieldValue(key1, randomInt()); }),
-                    pipeline2Processor
-                ),
-                Collections.emptyList()
-            ),
+            new CompoundProcessor(true, Arrays.asList(new TestProcessor(ingestDocument -> {
+                ingestDocument.setFieldValue(key1, randomInt());
+            }), pipeline2Processor), Collections.emptyList()),
             relativeTimeProvider
         );
         relativeTimeProvider = mock(LongSupplier.class);
         when(relativeTimeProvider.getAsLong()).thenReturn(0L, TimeUnit.MILLISECONDS.toNanos(2));
-        Pipeline pipeline3 = new Pipeline(
-            pipeline3Id,
-            null,
-            null,
-            new CompoundProcessor(new TestProcessor(ingestDocument -> { throw new RuntimeException("error"); })),
-            relativeTimeProvider
-        );
+        Pipeline pipeline3 = new Pipeline(pipeline3Id, null, null, new CompoundProcessor(new TestProcessor(ingestDocument -> {
+            throw new RuntimeException("error");
+        })), relativeTimeProvider);
         when(ingestService.getPipeline(pipeline1Id)).thenReturn(pipeline1);
         when(ingestService.getPipeline(pipeline2Id)).thenReturn(pipeline2);
         when(ingestService.getPipeline(pipeline3Id)).thenReturn(pipeline3);

--- a/server/src/test/java/org/opensearch/ingest/TrackingResultProcessorTests.java
+++ b/server/src/test/java/org/opensearch/ingest/TrackingResultProcessorTests.java
@@ -280,14 +280,17 @@ public class TrackingResultProcessorTests extends OpenSearchTestCase {
             new HashMap<>(ScriptModule.CORE_CONTEXTS)
         );
 
-        CompoundProcessor compoundProcessor = new CompoundProcessor(
-            new TestProcessor(ingestDocument -> { ingestDocument.setFieldValue(key1, randomInt()); }),
+        CompoundProcessor compoundProcessor = new CompoundProcessor(new TestProcessor(ingestDocument -> {
+            ingestDocument.setFieldValue(key1, randomInt());
+        }),
             new ConditionalProcessor(
                 randomAlphaOfLength(10),
                 null,
                 new Script(ScriptType.INLINE, Script.DEFAULT_SCRIPT_LANG, scriptName, Collections.emptyMap()),
                 scriptService,
-                new TestProcessor(ingestDocument -> { ingestDocument.setFieldValue(key2, randomInt()); })
+                new TestProcessor(ingestDocument -> {
+                    ingestDocument.setFieldValue(key2, randomInt());
+                })
             ),
             new TestProcessor(ingestDocument -> { ingestDocument.setFieldValue(key3, randomInt()); })
         );
@@ -331,16 +334,11 @@ public class TrackingResultProcessorTests extends OpenSearchTestCase {
         String key2 = randomAlphaOfLength(10);
         String key3 = randomAlphaOfLength(10);
 
-        Pipeline pipeline = new Pipeline(
-            pipelineId,
-            null,
-            null,
-            new CompoundProcessor(
-                new TestProcessor(ingestDocument -> { ingestDocument.setFieldValue(key1, randomInt()); }),
-                new TestProcessor(ingestDocument -> { ingestDocument.setFieldValue(key2, randomInt()); }),
-                new TestProcessor(ingestDocument -> { ingestDocument.setFieldValue(key3, randomInt()); })
-            )
-        );
+        Pipeline pipeline = new Pipeline(pipelineId, null, null, new CompoundProcessor(new TestProcessor(ingestDocument -> {
+            ingestDocument.setFieldValue(key1, randomInt());
+        }), new TestProcessor(ingestDocument -> { ingestDocument.setFieldValue(key2, randomInt()); }), new TestProcessor(ingestDocument -> {
+            ingestDocument.setFieldValue(key3, randomInt());
+        })));
         when(ingestService.getPipeline(pipelineId)).thenReturn(pipeline);
 
         PipelineProcessor pipelineProcessor = factory.create(Collections.emptyMap(), null, null, pipelineConfig);
@@ -406,29 +404,24 @@ public class TrackingResultProcessorTests extends OpenSearchTestCase {
             new HashMap<>(ScriptModule.CORE_CONTEXTS)
         );
 
-        Pipeline pipeline1 = new Pipeline(
-            pipelineId1,
-            null,
-            null,
-            new CompoundProcessor(
-                new TestProcessor(ingestDocument -> { ingestDocument.setFieldValue(key1, randomInt()); }),
-                new ConditionalProcessor(
-                    randomAlphaOfLength(10),
-                    null,
-                    new Script(ScriptType.INLINE, Script.DEFAULT_SCRIPT_LANG, scriptName, Collections.emptyMap()),
-                    scriptService,
-                    factory.create(Collections.emptyMap(), "pipeline1", null, pipelineConfig2)
-                ),
-                new TestProcessor(ingestDocument -> { ingestDocument.setFieldValue(key3, randomInt()); })
-            )
-        );
+        Pipeline pipeline1 = new Pipeline(pipelineId1, null, null, new CompoundProcessor(new TestProcessor(ingestDocument -> {
+            ingestDocument.setFieldValue(key1, randomInt());
+        }),
+            new ConditionalProcessor(
+                randomAlphaOfLength(10),
+                null,
+                new Script(ScriptType.INLINE, Script.DEFAULT_SCRIPT_LANG, scriptName, Collections.emptyMap()),
+                scriptService,
+                factory.create(Collections.emptyMap(), "pipeline1", null, pipelineConfig2)
+            ),
+            new TestProcessor(ingestDocument -> {
+                ingestDocument.setFieldValue(key3, randomInt());
+            })
+        ));
 
-        Pipeline pipeline2 = new Pipeline(
-            pipelineId2,
-            null,
-            null,
-            new CompoundProcessor(new TestProcessor(ingestDocument -> { ingestDocument.setFieldValue(key2, randomInt()); }))
-        );
+        Pipeline pipeline2 = new Pipeline(pipelineId2, null, null, new CompoundProcessor(new TestProcessor(ingestDocument -> {
+            ingestDocument.setFieldValue(key2, randomInt());
+        })));
 
         when(ingestService.getPipeline(pipelineId1)).thenReturn(pipeline1);
         when(ingestService.getPipeline(pipelineId2)).thenReturn(pipeline2);
@@ -503,29 +496,24 @@ public class TrackingResultProcessorTests extends OpenSearchTestCase {
             new HashMap<>(ScriptModule.CORE_CONTEXTS)
         );
 
-        Pipeline pipeline1 = new Pipeline(
-            pipelineId1,
-            null,
-            null,
-            new CompoundProcessor(
-                new TestProcessor(ingestDocument -> { ingestDocument.setFieldValue(key1, randomInt()); }),
-                new ConditionalProcessor(
-                    randomAlphaOfLength(10),
-                    null,
-                    new Script(ScriptType.INLINE, Script.DEFAULT_SCRIPT_LANG, scriptName, Collections.emptyMap()),
-                    scriptService,
-                    factory.create(Collections.emptyMap(), null, null, pipelineConfig2)
-                ),
-                new TestProcessor(ingestDocument -> { ingestDocument.setFieldValue(key3, randomInt()); })
-            )
-        );
+        Pipeline pipeline1 = new Pipeline(pipelineId1, null, null, new CompoundProcessor(new TestProcessor(ingestDocument -> {
+            ingestDocument.setFieldValue(key1, randomInt());
+        }),
+            new ConditionalProcessor(
+                randomAlphaOfLength(10),
+                null,
+                new Script(ScriptType.INLINE, Script.DEFAULT_SCRIPT_LANG, scriptName, Collections.emptyMap()),
+                scriptService,
+                factory.create(Collections.emptyMap(), null, null, pipelineConfig2)
+            ),
+            new TestProcessor(ingestDocument -> {
+                ingestDocument.setFieldValue(key3, randomInt());
+            })
+        ));
 
-        Pipeline pipeline2 = new Pipeline(
-            pipelineId2,
-            null,
-            null,
-            new CompoundProcessor(new TestProcessor(ingestDocument -> { ingestDocument.setFieldValue(key2, randomInt()); }))
-        );
+        Pipeline pipeline2 = new Pipeline(pipelineId2, null, null, new CompoundProcessor(new TestProcessor(ingestDocument -> {
+            ingestDocument.setFieldValue(key2, randomInt());
+        })));
 
         when(ingestService.getPipeline(pipelineId1)).thenReturn(pipeline1);
         when(ingestService.getPipeline(pipelineId2)).thenReturn(pipeline2);
@@ -579,20 +567,18 @@ public class TrackingResultProcessorTests extends OpenSearchTestCase {
         String key2 = randomAlphaOfLength(10);
         String key3 = randomAlphaOfLength(10);
 
-        Pipeline pipeline = new Pipeline(
-            pipelineId,
-            null,
-            null,
+        Pipeline pipeline = new Pipeline(pipelineId, null, null, new CompoundProcessor(new TestProcessor(ingestDocument -> {
+            ingestDocument.setFieldValue(key1, randomInt());
+        }),
             new CompoundProcessor(
-                new TestProcessor(ingestDocument -> { ingestDocument.setFieldValue(key1, randomInt()); }),
-                new CompoundProcessor(
-                    false,
-                    Collections.singletonList(new TestProcessor(ingestDocument -> { throw exception; })),
-                    Collections.singletonList(new TestProcessor(ingestDocument -> { ingestDocument.setFieldValue(key2, randomInt()); }))
-                ),
-                new TestProcessor(ingestDocument -> { ingestDocument.setFieldValue(key3, randomInt()); })
-            )
-        );
+                false,
+                Collections.singletonList(new TestProcessor(ingestDocument -> { throw exception; })),
+                Collections.singletonList(new TestProcessor(ingestDocument -> {
+                    ingestDocument.setFieldValue(key2, randomInt());
+                }))
+            ),
+            new TestProcessor(ingestDocument -> { ingestDocument.setFieldValue(key3, randomInt()); })
+        ));
         when(ingestService.getPipeline(pipelineId)).thenReturn(pipeline);
 
         PipelineProcessor pipelineProcessor = factory.create(Collections.emptyMap(), null, null, pipelineConfig);
@@ -650,7 +636,9 @@ public class TrackingResultProcessorTests extends OpenSearchTestCase {
             null,
             new CompoundProcessor(
                 new TestProcessor(ingestDocument -> ingestDocument.setFieldValue(key1, randomInt())),
-                new TestProcessor(ingestDocument -> { throw exception; })
+                new TestProcessor(ingestDocument -> {
+                    throw exception;
+                })
             )
         );
         when(ingestService.getPipeline(pipelineId)).thenReturn(pipeline);
@@ -730,12 +718,9 @@ public class TrackingResultProcessorTests extends OpenSearchTestCase {
 
         String key1 = randomAlphaOfLength(10);
         PipelineProcessor pipelineProcessor = factory.create(Collections.emptyMap(), null, null, pipelineConfig);
-        Pipeline pipeline = new Pipeline(
-            pipelineId,
-            null,
-            null,
-            new CompoundProcessor(new TestProcessor(ingestDocument -> { ingestDocument.setFieldValue(key1, randomInt()); }))
-        );
+        Pipeline pipeline = new Pipeline(pipelineId, null, null, new CompoundProcessor(new TestProcessor(ingestDocument -> {
+            ingestDocument.setFieldValue(key1, randomInt());
+        })));
         when(ingestService.getPipeline(pipelineId)).thenReturn(pipeline);
 
         // calls the same pipeline twice

--- a/server/src/test/java/org/opensearch/lucene/misc/search/similarity/LegacyBM25SimilarityTests.java
+++ b/server/src/test/java/org/opensearch/lucene/misc/search/similarity/LegacyBM25SimilarityTests.java
@@ -36,10 +36,9 @@ import org.apache.lucene.search.similarities.Similarity;
 public class LegacyBM25SimilarityTests extends BaseSimilarityTestCase {
 
     public void testIllegalK1() {
-        IllegalArgumentException expected = expectThrows(
-            IllegalArgumentException.class,
-            () -> { new LegacyBM25Similarity(Float.POSITIVE_INFINITY, 0.75f); }
-        );
+        IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> {
+            new LegacyBM25Similarity(Float.POSITIVE_INFINITY, 0.75f);
+        });
         assertTrue(expected.getMessage().contains("illegal k1 value"));
 
         expected = expectThrows(IllegalArgumentException.class, () -> { new LegacyBM25Similarity(-1, 0.75f); });

--- a/server/src/test/java/org/opensearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/opensearch/plugins/PluginsServiceTests.java
@@ -922,10 +922,9 @@ public class PluginsServiceTests extends OpenSearchTestCase {
         class TestExtension implements TestExtensionPoint {
             private TestExtension() {}
         }
-        IllegalStateException e = expectThrows(
-            IllegalStateException.class,
-            () -> { PluginsService.createExtension(TestExtension.class, TestExtensionPoint.class, plugin); }
-        );
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> {
+            PluginsService.createExtension(TestExtension.class, TestExtensionPoint.class, plugin);
+        });
 
         assertThat(
             e,
@@ -950,10 +949,9 @@ public class PluginsServiceTests extends OpenSearchTestCase {
 
             }
         }
-        IllegalStateException e = expectThrows(
-            IllegalStateException.class,
-            () -> { PluginsService.createExtension(TestExtension.class, TestExtensionPoint.class, plugin); }
-        );
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> {
+            PluginsService.createExtension(TestExtension.class, TestExtensionPoint.class, plugin);
+        });
 
         assertThat(
             e,
@@ -971,10 +969,9 @@ public class PluginsServiceTests extends OpenSearchTestCase {
 
     public void testBadSingleParameterConstructor() {
         TestPlugin plugin = new TestPlugin();
-        IllegalStateException e = expectThrows(
-            IllegalStateException.class,
-            () -> { PluginsService.createExtension(BadSingleParameterConstructorExtension.class, TestExtensionPoint.class, plugin); }
-        );
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> {
+            PluginsService.createExtension(BadSingleParameterConstructorExtension.class, TestExtensionPoint.class, plugin);
+        });
 
         assertThat(
             e,
@@ -996,10 +993,9 @@ public class PluginsServiceTests extends OpenSearchTestCase {
 
     public void testTooManyParametersExtensionConstructors() {
         TestPlugin plugin = new TestPlugin();
-        IllegalStateException e = expectThrows(
-            IllegalStateException.class,
-            () -> { PluginsService.createExtension(TooManyParametersConstructorExtension.class, TestExtensionPoint.class, plugin); }
-        );
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> {
+            PluginsService.createExtension(TooManyParametersConstructorExtension.class, TestExtensionPoint.class, plugin);
+        });
 
         assertThat(
             e,
@@ -1019,10 +1015,9 @@ public class PluginsServiceTests extends OpenSearchTestCase {
 
     public void testThrowingConstructor() {
         TestPlugin plugin = new TestPlugin();
-        IllegalStateException e = expectThrows(
-            IllegalStateException.class,
-            () -> { PluginsService.createExtension(ThrowingConstructorExtension.class, TestExtensionPoint.class, plugin); }
-        );
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> {
+            PluginsService.createExtension(ThrowingConstructorExtension.class, TestExtensionPoint.class, plugin);
+        });
 
         assertThat(
             e,

--- a/server/src/test/java/org/opensearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/opensearch/rest/RestControllerTests.java
@@ -118,11 +118,9 @@ public class RestControllerTests extends OpenSearchTestCase {
                 new BytesRestResponse(RestStatus.OK, BytesRestResponse.TEXT_CONTENT_TYPE, BytesArray.EMPTY)
             )
         );
-        restController.registerHandler(
-            RestRequest.Method.GET,
-            "/error",
-            (request, channel, client) -> { throw new IllegalArgumentException("test error"); }
-        );
+        restController.registerHandler(RestRequest.Method.GET, "/error", (request, channel, client) -> {
+            throw new IllegalArgumentException("test error");
+        });
 
         httpServerTransport.start();
     }

--- a/server/src/test/java/org/opensearch/script/ScriptServiceTests.java
+++ b/server/src/test/java/org/opensearch/script/ScriptServiceTests.java
@@ -391,10 +391,9 @@ public class ScriptServiceTests extends OpenSearchTestCase {
         assertNull(scriptMetadata.getStoredScript("_id"));
 
         ScriptMetadata errorMetadata = scriptMetadata;
-        ResourceNotFoundException e = expectThrows(
-            ResourceNotFoundException.class,
-            () -> { ScriptMetadata.deleteStoredScript(errorMetadata, "_id"); }
-        );
+        ResourceNotFoundException e = expectThrows(ResourceNotFoundException.class, () -> {
+            ScriptMetadata.deleteStoredScript(errorMetadata, "_id");
+        });
         assertEquals("stored script [_id] does not exist and cannot be deleted", e.getMessage());
     }
 
@@ -425,24 +424,17 @@ public class ScriptServiceTests extends OpenSearchTestCase {
     public void testMaxSizeLimit() throws Exception {
         buildScriptService(Settings.builder().put(ScriptService.SCRIPT_MAX_SIZE_IN_BYTES.getKey(), 4).build());
         scriptService.compile(new Script(ScriptType.INLINE, "test", "1+1", Collections.emptyMap()), randomFrom(contexts.values()));
-        IllegalArgumentException iae = expectThrows(
-            IllegalArgumentException.class,
-            () -> {
-                scriptService.compile(
-                    new Script(ScriptType.INLINE, "test", "10+10", Collections.emptyMap()),
-                    randomFrom(contexts.values())
-                );
-            }
-        );
+        IllegalArgumentException iae = expectThrows(IllegalArgumentException.class, () -> {
+            scriptService.compile(new Script(ScriptType.INLINE, "test", "10+10", Collections.emptyMap()), randomFrom(contexts.values()));
+        });
         assertEquals("exceeded max allowed inline script size in bytes [4] with size [5] for script [10+10]", iae.getMessage());
         clusterSettings.applySettings(Settings.builder().put(ScriptService.SCRIPT_MAX_SIZE_IN_BYTES.getKey(), 6).build());
         scriptService.compile(new Script(ScriptType.INLINE, "test", "10+10", Collections.emptyMap()), randomFrom(contexts.values()));
         clusterSettings.applySettings(Settings.builder().put(ScriptService.SCRIPT_MAX_SIZE_IN_BYTES.getKey(), 5).build());
         scriptService.compile(new Script(ScriptType.INLINE, "test", "10+10", Collections.emptyMap()), randomFrom(contexts.values()));
-        iae = expectThrows(
-            IllegalArgumentException.class,
-            () -> { clusterSettings.applySettings(Settings.builder().put(ScriptService.SCRIPT_MAX_SIZE_IN_BYTES.getKey(), 2).build()); }
-        );
+        iae = expectThrows(IllegalArgumentException.class, () -> {
+            clusterSettings.applySettings(Settings.builder().put(ScriptService.SCRIPT_MAX_SIZE_IN_BYTES.getKey(), 2).build());
+        });
         assertEquals(
             "script.max_size_in_bytes cannot be set to [2], stored script [test1] exceeds the new value with a size of [3]",
             iae.getMessage()
@@ -537,10 +529,9 @@ public class ScriptServiceTests extends OpenSearchTestCase {
 
         assertEquals(ScriptService.SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING.get(s), ScriptService.USE_CONTEXT_RATE_VALUE);
 
-        IllegalArgumentException illegal = expectThrows(
-            IllegalArgumentException.class,
-            () -> { ScriptService.SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getAsMap(s); }
-        );
+        IllegalArgumentException illegal = expectThrows(IllegalArgumentException.class, () -> {
+            ScriptService.SCRIPT_MAX_COMPILATIONS_RATE_SETTING.getAsMap(s);
+        });
 
         assertEquals("parameter must contain a positive integer and a timevalue, i.e. 10/1m, but was [use-context]", illegal.getMessage());
         assertSettingDeprecationsAndWarnings(new Setting<?>[] { SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING });

--- a/server/src/test/java/org/opensearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/opensearch/search/SearchServiceTests.java
@@ -740,13 +740,9 @@ public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
     public static class FailOnRewriteQueryPlugin extends Plugin implements SearchPlugin {
         @Override
         public List<QuerySpec<?>> getQueries() {
-            return singletonList(
-                new QuerySpec<>(
-                    "fail_on_rewrite_query",
-                    FailOnRewriteQueryBuilder::new,
-                    parseContext -> { throw new UnsupportedOperationException("No query parser for this plugin"); }
-                )
-            );
+            return singletonList(new QuerySpec<>("fail_on_rewrite_query", FailOnRewriteQueryBuilder::new, parseContext -> {
+                throw new UnsupportedOperationException("No query parser for this plugin");
+            }));
         }
     }
 

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/composite/CompositeAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/composite/CompositeAggregatorTests.java
@@ -89,7 +89,9 @@ public class CompositeAggregatorTests extends BaseCompositeAggregatorTestCase {
             Arrays.asList(new MatchAllDocsQuery(), new DocValuesFieldExistsQuery("keyword")),
             dataset,
             () -> new CompositeAggregationBuilder("name", Arrays.asList(new TermsValuesSourceBuilder("unmapped").field("unmapped"))),
-            (result) -> { assertEquals(0, result.getBuckets().size()); }
+            (result) -> {
+                assertEquals(0, result.getBuckets().size());
+            }
         );
 
         testSearchCase(
@@ -114,7 +116,9 @@ public class CompositeAggregatorTests extends BaseCompositeAggregatorTestCase {
                 "name",
                 Arrays.asList(new TermsValuesSourceBuilder("unmapped").field("unmapped").missingBucket(true))
             ).aggregateAfter(Collections.singletonMap("unmapped", null)),
-            (result) -> { assertEquals(0, result.getBuckets().size()); }
+            (result) -> {
+                assertEquals(0, result.getBuckets().size());
+            }
         );
 
         testSearchCase(
@@ -127,7 +131,9 @@ public class CompositeAggregatorTests extends BaseCompositeAggregatorTestCase {
                     new TermsValuesSourceBuilder("unmapped").field("unmapped")
                 )
             ),
-            (result) -> { assertEquals(0, result.getBuckets().size()); }
+            (result) -> {
+                assertEquals(0, result.getBuckets().size());
+            }
         );
 
         testSearchCase(

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/histogram/NumericHistogramAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/histogram/NumericHistogramAggregatorTests.java
@@ -303,10 +303,9 @@ public class NumericHistogramAggregatorTests extends AggregatorTestCase {
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
 
-                expectThrows(
-                    IllegalArgumentException.class,
-                    () -> { searchAndReduce(searcher, new MatchAllDocsQuery(), aggBuilder, keywordField("field")); }
-                );
+                expectThrows(IllegalArgumentException.class, () -> {
+                    searchAndReduce(searcher, new MatchAllDocsQuery(), aggBuilder, keywordField("field"));
+                });
             }
         }
 

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/histogram/VariableWidthHistogramAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/histogram/VariableWidthHistogramAggregatorTests.java
@@ -543,7 +543,9 @@ public class VariableWidthHistogramAggregatorTests extends AggregatorTestCase {
                 List.of(),
                 true,
                 aggregation -> aggregation.field(NUMERIC_FIELD).setNumBuckets(2).setShardSize(2),
-                histogram -> { fail(); }
+                histogram -> {
+                    fail();
+                }
             )
         );
         assertThat(e.getMessage(), equalTo("3/4 of shard_size must be at least buckets but was [1<2] for [_name]"));
@@ -571,7 +573,9 @@ public class VariableWidthHistogramAggregatorTests extends AggregatorTestCase {
                 List.of(),
                 true,
                 aggregation -> aggregation.field(NUMERIC_FIELD).setInitialBuffer(1),
-                histogram -> { fail(); }
+                histogram -> {
+                    fail();
+                }
             )
         );
         assertThat(e.getMessage(), equalTo("initial_buffer must be at least buckets but was [1<10] for [_name]"));

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/range/DateRangeAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/range/DateRangeAggregatorTests.java
@@ -220,13 +220,9 @@ public class DateRangeAggregatorTests extends AggregatorTestCase {
 
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
-            () -> testCase(
-                aggregationBuilder,
-                new MatchAllDocsQuery(),
-                iw -> { iw.addDocument(singleton(new SortedSetDocValuesField("string", new BytesRef("foo")))); },
-                range -> fail("Should have thrown exception"),
-                fieldType
-            )
+            () -> testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+                iw.addDocument(singleton(new SortedSetDocValuesField("string", new BytesRef("foo"))));
+            }, range -> fail("Should have thrown exception"), fieldType)
         );
         assertEquals("Field [not_a_number] of type [keyword] is not supported for aggregation [date_range]", e.getMessage());
     }

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/range/RangeAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/range/RangeAggregatorTests.java
@@ -245,13 +245,9 @@ public class RangeAggregatorTests extends AggregatorTestCase {
 
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
-            () -> testCase(
-                aggregationBuilder,
-                new MatchAllDocsQuery(),
-                iw -> { iw.addDocument(singleton(new SortedSetDocValuesField("string", new BytesRef("foo")))); },
-                range -> fail("Should have thrown exception"),
-                fieldType
-            )
+            () -> testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+                iw.addDocument(singleton(new SortedSetDocValuesField("string", new BytesRef("foo"))));
+            }, range -> fail("Should have thrown exception"), fieldType)
         );
         assertEquals("Field [not_a_number] of type [keyword] is not supported for aggregation [range]", e.getMessage());
     }

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregationBuilderTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregationBuilderTests.java
@@ -91,10 +91,9 @@ public class MultiTermsAggregationBuilderTests extends BaseAggregationTestCase<M
     }
 
     public void testInvalidTermsParams() {
-        IllegalArgumentException exception = expectThrows(
-            IllegalArgumentException.class,
-            () -> { new MultiTermsAggregationBuilder("_name").terms(Collections.singletonList(randomFieldConfig())); }
-        );
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> {
+            new MultiTermsAggregationBuilder("_name").terms(Collections.singletonList(randomFieldConfig()));
+        });
         assertEquals(
             "multi term aggregation must has at least 2 terms. Found [1] in [_name] Use terms aggregation for single term aggregation",
             exception.getMessage()

--- a/server/src/test/java/org/opensearch/search/aggregations/metrics/HDRPercentilesAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/metrics/HDRPercentilesAggregatorTests.java
@@ -113,16 +113,9 @@ public class HDRPercentilesAggregatorTests extends AggregatorTestCase {
         MappedFieldType fieldType = new RangeFieldMapper.RangeFieldType(fieldName, RangeType.DOUBLE);
         RangeFieldMapper.Range range = new RangeFieldMapper.Range(RangeType.DOUBLE, 1.0D, 5.0D, true, true);
         BytesRef encodedRange = RangeType.DOUBLE.encodeRanges(Collections.singleton(range));
-        expectThrows(
-            IllegalArgumentException.class,
-            () -> testCase(
-                new DocValuesFieldExistsQuery(fieldName),
-                iw -> { iw.addDocument(singleton(new BinaryDocValuesField(fieldName, encodedRange))); },
-                hdr -> {},
-                fieldType,
-                fieldName
-            )
-        );
+        expectThrows(IllegalArgumentException.class, () -> testCase(new DocValuesFieldExistsQuery(fieldName), iw -> {
+            iw.addDocument(singleton(new BinaryDocValuesField(fieldName, encodedRange)));
+        }, hdr -> {}, fieldType, fieldName));
     }
 
     public void testNoMatchingField() throws IOException {

--- a/server/src/test/java/org/opensearch/search/aggregations/metrics/MinAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/metrics/MinAggregatorTests.java
@@ -302,13 +302,9 @@ public class MinAggregatorTests extends AggregatorTestCase {
 
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
-            () -> testCase(
-                aggregationBuilder,
-                new MatchAllDocsQuery(),
-                iw -> { iw.addDocument(singleton(new SortedSetDocValuesField("string", new BytesRef("foo")))); },
-                (Consumer<InternalMin>) min -> { fail("Should have thrown exception"); },
-                fieldType
-            )
+            () -> testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+                iw.addDocument(singleton(new SortedSetDocValuesField("string", new BytesRef("foo"))));
+            }, (Consumer<InternalMin>) min -> { fail("Should have thrown exception"); }, fieldType)
         );
         assertEquals("Field [not_a_number] of type [keyword] is not supported for aggregation [min]", e.getMessage());
     }

--- a/server/src/test/java/org/opensearch/search/aggregations/metrics/ScriptedMetricAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/metrics/ScriptedMetricAggregatorTests.java
@@ -593,12 +593,9 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
             .mapScript(MAP_SCRIPT)
             .combineScript(COMBINE_SCRIPT)
             .reduceScript(REDUCE_SCRIPT);
-        testCase(
-            aggregationBuilder,
-            new MatchAllDocsQuery(),
-            iw -> { iw.addDocument(new Document()); },
-            (InternalScriptedMetric r) -> { assertEquals(1, r.aggregation()); }
-        );
+        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> { iw.addDocument(new Document()); }, (InternalScriptedMetric r) -> {
+            assertEquals(1, r.aggregation());
+        });
     }
 
     public void testAsSubAgg() throws IOException {

--- a/server/src/test/java/org/opensearch/search/suggest/SuggestBuilderTests.java
+++ b/server/src/test/java/org/opensearch/search/suggest/SuggestBuilderTests.java
@@ -102,11 +102,9 @@ public class SuggestBuilderTests extends OpenSearchTestCase {
     public void testEqualsAndHashcode() throws IOException {
         for (int runs = 0; runs < NUMBER_OF_RUNS; runs++) {
             // explicit about type parameters, see: https://bugs.eclipse.org/bugs/show_bug.cgi?id=481649
-            EqualsHashCodeTestUtils.<SuggestBuilder>checkEqualsAndHashCode(
-                randomSuggestBuilder(),
-                original -> { return copyWriteable(original, namedWriteableRegistry, SuggestBuilder::new); },
-                this::createMutation
-            );
+            EqualsHashCodeTestUtils.<SuggestBuilder>checkEqualsAndHashCode(randomSuggestBuilder(), original -> {
+                return copyWriteable(original, namedWriteableRegistry, SuggestBuilder::new);
+            }, this::createMutation);
         }
     }
 

--- a/server/src/test/java/org/opensearch/transport/TransportActionProxyTests.java
+++ b/server/src/test/java/org/opensearch/transport/TransportActionProxyTests.java
@@ -168,12 +168,9 @@ public class TransportActionProxyTests extends OpenSearchTestCase {
         });
         TransportActionProxy.registerProxyAction(serviceB, "internal:test", SimpleTestResponse::new);
         serviceB.connectToNode(nodeC);
-        serviceC.registerRequestHandler(
-            "internal:test",
-            ThreadPool.Names.SAME,
-            SimpleTestRequest::new,
-            (request, channel, task) -> { throw new OpenSearchException("greetings from TS_C"); }
-        );
+        serviceC.registerRequestHandler("internal:test", ThreadPool.Names.SAME, SimpleTestRequest::new, (request, channel, task) -> {
+            throw new OpenSearchException("greetings from TS_C");
+        });
         TransportActionProxy.registerProxyAction(serviceC, "internal:test", SimpleTestResponse::new);
 
         CountDownLatch latch = new CountDownLatch(1);

--- a/server/src/test/java/org/opensearch/transport/TransportServiceHandshakeTests.java
+++ b/server/src/test/java/org/opensearch/transport/TransportServiceHandshakeTests.java
@@ -218,10 +218,9 @@ public class TransportServiceHandshakeTests extends OpenSearchTestCase {
             emptySet(),
             handleB.discoveryNode.getVersion()
         );
-        ConnectTransportException ex = expectThrows(
-            ConnectTransportException.class,
-            () -> { handleA.transportService.connectToNode(discoveryNode, TestProfiles.LIGHT_PROFILE); }
-        );
+        ConnectTransportException ex = expectThrows(ConnectTransportException.class, () -> {
+            handleA.transportService.connectToNode(discoveryNode, TestProfiles.LIGHT_PROFILE);
+        });
         assertThat(ex.getMessage(), containsString("unexpected remote node"));
         assertFalse(handleA.transportService.nodeConnected(discoveryNode));
     }

--- a/test/framework/src/main/java/org/opensearch/index/mapper/MapperServiceTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/mapper/MapperServiceTestCase.java
@@ -155,7 +155,9 @@ public abstract class MapperServiceTestCase extends OpenSearchTestCase {
             xContentRegistry(),
             similarityService,
             mapperRegistry,
-            () -> { throw new UnsupportedOperationException(); },
+            () -> {
+                throw new UnsupportedOperationException();
+            },
             () -> true,
             scriptService
         );
@@ -249,9 +251,9 @@ public abstract class MapperServiceTestCase extends OpenSearchTestCase {
             inv -> mapperService.simpleMatchToFullName(inv.getArguments()[0].toString())
         );
         when(queryShardContext.allowExpensiveQueries()).thenReturn(true);
-        when(queryShardContext.lookup()).thenReturn(
-            new SearchLookup(mapperService, (ft, s) -> { throw new UnsupportedOperationException("search lookup not available"); })
-        );
+        when(queryShardContext.lookup()).thenReturn(new SearchLookup(mapperService, (ft, s) -> {
+            throw new UnsupportedOperationException("search lookup not available");
+        }));
         return queryShardContext;
     }
 }

--- a/test/framework/src/main/java/org/opensearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/mapper/MapperTestCase.java
@@ -286,22 +286,22 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
         throws IOException {
 
         BiFunction<MappedFieldType, Supplier<SearchLookup>, IndexFieldData<?>> fieldDataLookup = (mft, lookupSource) -> mft
-            .fielddataBuilder("test", () -> { throw new UnsupportedOperationException(); })
+            .fielddataBuilder("test", () -> {
+                throw new UnsupportedOperationException();
+            })
             .build(new IndexFieldDataCache.None(), new NoneCircuitBreakerService());
         SetOnce<List<?>> result = new SetOnce<>();
-        withLuceneIndex(
-            mapperService,
-            iw -> { iw.addDocument(mapperService.documentMapper().parse(source(b -> b.field(ft.name(), sourceValue))).rootDoc()); },
-            iw -> {
-                SearchLookup lookup = new SearchLookup(mapperService, fieldDataLookup);
-                ValueFetcher valueFetcher = new DocValueFetcher(format, lookup.doc().getForField(ft));
-                IndexSearcher searcher = newSearcher(iw);
-                LeafReaderContext context = searcher.getIndexReader().leaves().get(0);
-                lookup.source().setSegmentAndDocument(context, 0);
-                valueFetcher.setNextReader(context);
-                result.set(valueFetcher.fetchValues(lookup.source()));
-            }
-        );
+        withLuceneIndex(mapperService, iw -> {
+            iw.addDocument(mapperService.documentMapper().parse(source(b -> b.field(ft.name(), sourceValue))).rootDoc());
+        }, iw -> {
+            SearchLookup lookup = new SearchLookup(mapperService, fieldDataLookup);
+            ValueFetcher valueFetcher = new DocValueFetcher(format, lookup.doc().getForField(ft));
+            IndexSearcher searcher = newSearcher(iw);
+            LeafReaderContext context = searcher.getIndexReader().leaves().get(0);
+            lookup.source().setSegmentAndDocument(context, 0);
+            valueFetcher.setNextReader(context);
+            result.set(valueFetcher.fetchValues(lookup.source()));
+        });
         return result.get();
     }
 

--- a/test/framework/src/main/java/org/opensearch/index/replication/OpenSearchIndexLevelReplicationTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/replication/OpenSearchIndexLevelReplicationTestCase.java
@@ -237,7 +237,9 @@ public abstract class OpenSearchIndexLevelReplicationTestCase extends IndexShard
             (shardId, primaryAllocationId, primaryTerm, retentionLeases) -> syncRetentionLeases(
                 shardId,
                 retentionLeases,
-                ActionListener.wrap(r -> {}, e -> { throw new AssertionError("failed to background sync retention lease", e); })
+                ActionListener.wrap(r -> {}, e -> {
+                    throw new AssertionError("failed to background sync retention lease", e);
+                })
             )
         );
 

--- a/test/framework/src/main/java/org/opensearch/index/seqno/RetentionLeaseUtils.java
+++ b/test/framework/src/main/java/org/opensearch/index/seqno/RetentionLeaseUtils.java
@@ -53,13 +53,8 @@ public class RetentionLeaseUtils {
         return retentionLeases.leases()
             .stream()
             .filter(l -> ReplicationTracker.PEER_RECOVERY_RETENTION_LEASE_SOURCE.equals(l.source()) == false)
-            .collect(
-                Collectors.toMap(
-                    RetentionLease::id,
-                    Function.identity(),
-                    (o1, o2) -> { throw new AssertionError("unexpectedly merging " + o1 + " and " + o2); },
-                    LinkedHashMap::new
-                )
-            );
+            .collect(Collectors.toMap(RetentionLease::id, Function.identity(), (o1, o2) -> {
+                throw new AssertionError("unexpectedly merging " + o1 + " and " + o2);
+            }, LinkedHashMap::new));
     }
 }

--- a/test/framework/src/main/java/org/opensearch/test/AbstractBuilderTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/AbstractBuilderTestCase.java
@@ -369,12 +369,9 @@ public abstract class AbstractBuilderTestCase extends OpenSearchTestCase {
             boolean registerType
         ) throws IOException {
             this.nowInMillis = nowInMillis;
-            Environment env = InternalSettingsPreparer.prepareEnvironment(
-                nodeSettings,
-                emptyMap(),
-                null,
-                () -> { throw new AssertionError("node.name must be set"); }
-            );
+            Environment env = InternalSettingsPreparer.prepareEnvironment(nodeSettings, emptyMap(), null, () -> {
+                throw new AssertionError("node.name must be set");
+            });
             PluginsService pluginsService;
             pluginsService = new PluginsService(nodeSettings, null, env.modulesFile(), env.pluginsFile(), plugins);
 

--- a/test/framework/src/main/java/org/opensearch/test/AbstractQueryTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/AbstractQueryTestCase.java
@@ -732,7 +732,8 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
                 .getPreferredName();
         } else {
             rewrite = randomFrom(QueryParsers.TOP_TERMS, QueryParsers.TOP_TERMS_BOOST, QueryParsers.TOP_TERMS_BLENDED_FREQS)
-                .getPreferredName() + "1";
+                .getPreferredName()
+                + "1";
         }
         return rewrite;
     }

--- a/test/framework/src/main/java/org/opensearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/transport/AbstractSimpleTransportTestCase.java
@@ -2109,7 +2109,9 @@ public abstract class AbstractSimpleTransportTestCase extends OpenSearchTestCase
             "internal:action1",
             randomFrom(ThreadPool.Names.SAME, ThreadPool.Names.GENERIC),
             TestRequest::new,
-            (request, message, task) -> { throw new AssertionError("boom"); }
+            (request, message, task) -> {
+                throw new AssertionError("boom");
+            }
         );
         expectThrows(
             IllegalArgumentException.class,
@@ -2117,7 +2119,9 @@ public abstract class AbstractSimpleTransportTestCase extends OpenSearchTestCase
                 "internal:action1",
                 randomFrom(ThreadPool.Names.SAME, ThreadPool.Names.GENERIC),
                 TestRequest::new,
-                (request, message, task) -> { throw new AssertionError("boom"); }
+                (request, message, task) -> {
+                    throw new AssertionError("boom");
+                }
             )
         );
 
@@ -2125,7 +2129,9 @@ public abstract class AbstractSimpleTransportTestCase extends OpenSearchTestCase
             "internal:action1",
             randomFrom(ThreadPool.Names.SAME, ThreadPool.Names.GENERIC),
             TestRequest::new,
-            (request, message, task) -> { throw new AssertionError("boom"); }
+            (request, message, task) -> {
+                throw new AssertionError("boom");
+            }
         );
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
- Backports #6751  to `2.x`

### Issues Resolved
- N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
