### PR TITLE
[Backport 2.x] Bump org.apache.zookeeper:zookeeper from 3.8.0 to 3.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `com.google.protobuf:protobuf-java` from 3.22.0 to 3.22.2
 - Bump Netty to 4.1.90.Final ([#6677](https://github.com/opensearch-project/OpenSearch/pull/6677)
 - Bump `com.diffplug.spotless` from 6.15.0 to 6.17.0
+- Bump `org.apache.zookeeper:zookeeper` from 3.8.0 to 3.8.1
 
 ### Changed
 - Require MediaType in Strings.toString API ([#6009](https://github.com/opensearch-project/OpenSearch/pull/6009))

--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -55,7 +55,7 @@ dependencies {
   api "com.google.protobuf:protobuf-java:3.21.9"
   api "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
   api 'org.eclipse.jetty:jetty-server:9.4.49.v20220914'
-  api 'org.apache.zookeeper:zookeeper:3.8.0'
+  api 'org.apache.zookeeper:zookeeper:3.8.1'
   api "org.apache.commons:commons-text:1.10.0"
   api "commons-net:commons-net:3.9.0"
   runtimeOnly "com.google.guava:guava:${versions.guava}"


### PR DESCRIPTION
### Description
Backport of https://github.com/opensearch-project/OpenSearch/pull/6754

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
