### PR TITLE
[Segment Replication] Handling resource close

### DIFF
--- a/server/src/main/java/org/opensearch/indices/recovery/RecoveryTarget.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/RecoveryTarget.java
@@ -109,11 +109,6 @@ public class RecoveryTarget extends ReplicationTarget implements RecoveryTargetH
         return new RecoveryTarget(indexShard, sourceNode, listener);
     }
 
-    public IndexShard indexShard() {
-        ensureRefCount();
-        return indexShard;
-    }
-
     public String source() {
         return sourceNode.toString();
     }

--- a/server/src/main/java/org/opensearch/indices/replication/OngoingSegmentReplications.java
+++ b/server/src/main/java/org/opensearch/indices/replication/OngoingSegmentReplications.java
@@ -80,7 +80,7 @@ class OngoingSegmentReplications {
         } else {
             // From the checkpoint's shard ID, fetch the IndexShard
             ShardId shardId = checkpoint.getShardId();
-            final IndexService indexService = indicesService.indexService(shardId.getIndex());
+            final IndexService indexService = indicesService.indexServiceSafe(shardId.getIndex());
             final IndexShard indexShard = indexService.getShard(shardId.id());
             // build the CopyState object and cache it before returning
             final CopyState copyState = new CopyState(checkpoint, indexShard);

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTarget.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTarget.java
@@ -18,6 +18,7 @@ import org.apache.lucene.store.ByteBuffersDataInput;
 import org.apache.lucene.store.ByteBuffersIndexInput;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.opensearch.ExceptionsHelper;
+import org.opensearch.OpenSearchException;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.StepListener;
 import org.opensearch.common.UUIDs;
@@ -251,7 +252,7 @@ public class SegmentReplicationTarget extends ReplicationTarget {
                 );
                 fail(rfe, true);
                 throw rfe;
-            } catch (IllegalStateException ex) {
+            } catch (OpenSearchException ex) {
                 /*
                  Ignore closed replication target as it can happen due to index shard closed event in a separate thread.
                  In such scenario, ignore the exception

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
@@ -395,7 +395,7 @@ public class SegmentReplicationTargetService implements IndexEventListener {
             assert indicesService != null;
             final IndexShard indexShard = indicesService.getShardOrNull(request.getShardId());
             // Proceed with round of segment replication only when it is allowed
-            if (indexShard.getReplicationEngine().isEmpty()) {
+            if (indexShard == null || indexShard.getReplicationEngine().isEmpty()) {
                 logger.info("Ignore force segment replication sync as it is not allowed");
                 channel.sendResponse(TransportResponse.Empty.INSTANCE);
                 return;

--- a/server/src/main/java/org/opensearch/indices/replication/common/ReplicationTarget.java
+++ b/server/src/main/java/org/opensearch/indices/replication/common/ReplicationTarget.java
@@ -11,6 +11,7 @@ package org.opensearch.indices.replication.common;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.store.RateLimiter;
 import org.opensearch.ExceptionsHelper;
+import org.opensearch.OpenSearchException;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.support.ChannelActionListener;
 import org.opensearch.common.CheckedFunction;
@@ -186,7 +187,7 @@ public abstract class ReplicationTarget extends AbstractRefCounted {
 
     protected void ensureRefCount() {
         if (refCount() <= 0) {
-            throw new IllegalStateException(
+            throw new OpenSearchException(
                 "ReplicationTarget is used but it's refcount is 0. Probably a mismatch between incRef/decRef calls"
             );
         }

--- a/server/src/main/java/org/opensearch/indices/replication/common/ReplicationTarget.java
+++ b/server/src/main/java/org/opensearch/indices/replication/common/ReplicationTarget.java
@@ -186,7 +186,7 @@ public abstract class ReplicationTarget extends AbstractRefCounted {
 
     protected void ensureRefCount() {
         if (refCount() <= 0) {
-            throw new ReplicationFailedException(
+            throw new IllegalStateException(
                 "ReplicationTarget is used but it's refcount is 0. Probably a mismatch between incRef/decRef calls"
             );
         }

--- a/server/src/test/java/org/opensearch/indices/replication/OngoingSegmentReplicationsTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/OngoingSegmentReplicationsTests.java
@@ -76,7 +76,7 @@ public class OngoingSegmentReplicationsTests extends IndexShardTestCase {
         // This mirrors the creation of the ReplicationCheckpoint inside CopyState
         testCheckpoint = new ReplicationCheckpoint(testShardId, primary.getOperationPrimaryTerm(), 0L, 0L);
         IndexService mockIndexService = mock(IndexService.class);
-        when(mockIndicesService.indexService(testShardId.getIndex())).thenReturn(mockIndexService);
+        when(mockIndicesService.indexServiceSafe(testShardId.getIndex())).thenReturn(mockIndexService);
         when(mockIndexService.getShard(testShardId.id())).thenReturn(primary);
 
         TransportService transportService = mock(TransportService.class);

--- a/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationSourceServiceTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationSourceServiceTests.java
@@ -51,7 +51,7 @@ public class SegmentReplicationSourceServiceTests extends OpenSearchTestCase {
         ShardId testShardId = mockIndexShard.shardId();
         IndicesService mockIndicesService = mock(IndicesService.class);
         IndexService mockIndexService = mock(IndexService.class);
-        when(mockIndicesService.indexService(testShardId.getIndex())).thenReturn(mockIndexService);
+        when(mockIndicesService.indexServiceSafe(testShardId.getIndex())).thenReturn(mockIndexService);
         when(mockIndexService.getShard(testShardId.id())).thenReturn(mockIndexShard);
 
         // This mirrors the creation of the ReplicationCheckpoint inside CopyState


### PR DESCRIPTION
### Description
Changes
1. Store decRef handling. Inside finalize step, sometimes the call to fetch [store](https://github.com/opensearch-project/OpenSearch/blob/f40fa82e3667825fd0ba8d4bb17b6959ff7cc4f1/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTarget.java#L218) reference fails due to various reasons (ReplicationTarget refCounts to 0 - segrep cancelleation, store already closed - close/delete index etc). This results in skipping the incRef() on ontained store reference. The subsequent call to [decRef](https://github.com/opensearch-project/OpenSearch/blob/f40fa82e3667825fd0ba8d4bb17b6959ff7cc4f1/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTarget.java#L262) inside finalize block thus results in extra decRef call on store object, causing failures in store references outside of segrep (index deletion, read store etc).

2. Handle closed shard. When shard is already closed (delete index/close index), the call to obtain [store reference](https://github.com/opensearch-project/OpenSearch/blob/f40fa82e3667825fd0ba8d4bb17b6959ff7cc4f1/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTarget.java#L218) fails as [resources are released](https://github.com/opensearch-project/OpenSearch/blob/f40fa82e3667825fd0ba8d4bb17b6959ff7cc4f1/server/src/main/java/org/opensearch/indices/replication/common/ReplicationTarget.java#L181) by event listeners. We check for event cancellation before every step on target but it is not sufficient. The propose change here is to catch such exceptions and handle them gracefully.

3. Obtain safe reference of IndexService while results in `IndexNotFoundException` for deleted/closed indices. This is better than null pointer exception. Will raise a separate for handling on target and not fail segment replication and thus recovery.  

4. Changes ReplicationFailedException to OpenSearchException on ReplicationTarget which closely resembles to situation when target is already decRef'ed (closed).

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/6776

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
