### PR TITLE
[Segment Replication] Mute testAllocationWithDisruption flaky test

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationAllocationIT.java
@@ -169,6 +169,7 @@ public class SegmentReplicationAllocationIT extends SegmentReplicationBaseIT {
      * Similar to testSingleIndexShardAllocation test but creates multiple indices, multiple node adding in and getting
      * removed. The test asserts post each such event that primary shard distribution is balanced across single index.
      */
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/6565")
     public void testAllocationWithDisruption() throws Exception {
         internalCluster().startClusterManagerOnlyNode();
         final int maxReplicaCount = 2;


### PR DESCRIPTION
### Description
Mutes `testAllocationWithDisruption` test until it is fixed. Tracked in https://github.com/opensearch-project/OpenSearch/issues/6565

### Issues Releted
https://github.com/opensearch-project/OpenSearch/issues/6565

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
