### PR TITLE
[BUG] Hello World sample validator reverses logic

### DIFF
--- a/server/src/main/java/org/opensearch/common/settings/Setting.java
+++ b/server/src/main/java/org/opensearch/common/settings/Setting.java
@@ -1256,11 +1256,22 @@ public class Setting<T> implements ToXContentObject {
     public static class RegexValidator implements Writeable, Validator<String> {
         private Pattern pattern;
 
+        private boolean isMatching = true;
+
         /**
          * @param regex A regular expression containing the only valid input for this setting.
          */
         public RegexValidator(String regex) {
             this.pattern = Pattern.compile(regex);
+        }
+
+        /**
+         * @param regex A regular expression containing the only valid input for this setting.
+         * @param isMatching this is a boolean switching between "fail, if it matches" or "fail, if it doesn't match".
+         */
+        public RegexValidator(String regex, boolean isMatching) {
+            this.pattern = Pattern.compile(regex);
+            this.isMatching = isMatching;
         }
 
         public RegexValidator(StreamInput in) throws IOException {
@@ -1273,8 +1284,14 @@ public class Setting<T> implements ToXContentObject {
 
         @Override
         public void validate(String value) {
-            if (!pattern.matcher(value).matches()) {
-                throw new IllegalArgumentException("Setting [" + value + "] does not match regex [" + pattern.pattern() + "]");
+            if (isMatching){
+                if (!pattern.matcher(value).matches()) {
+                    throw new IllegalArgumentException("Setting must not contain [" + pattern.pattern() + "]");
+                }
+            }else {
+                if (pattern.matcher(value).matches()) {
+                    throw new IllegalArgumentException("Setting must not contain [" + pattern.pattern() + "]");
+                }
             }
         }
 


### PR DESCRIPTION
### Description
[Update the validator to take a boolean parameter switching between "fail if it matches" or "fail if it doesn't match". This provides the most flexibility.]

### Issues Resolved
[https://github.com/opensearch-project/opensearch-sdk-java/issues/591]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
