### PR TITLE
[Remote Store] Add file details to recoveryState while downloading segments from remote store

### DIFF
--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -4388,9 +4388,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
      * @throws IOException if exception occurs while reading segments from remote store
      */
     public void syncSegmentsFromRemoteSegmentStore(boolean overrideLocal, boolean refreshLevelSegmentSync) throws IOException {
-        if (recoveryState.getStage() != RecoveryState.Stage.INDEX) {
-            return;
-        }
+        assert recoveryState.getStage() == RecoveryState.Stage.INDEX: "Shard recovery should be in INDEX stage";
         assert indexSettings.isRemoteStoreEnabled();
         logger.info("Downloading segments from remote segment store");
         assert remoteStore.directory() instanceof FilterDirectory : "Store.directory is not an instance of FilterDirectory";

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -4416,6 +4416,14 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             for (String file : uploadedSegments.keySet()) {
                 long checksum = Long.parseLong(uploadedSegments.get(file).getChecksum());
                 if (overrideLocal || localDirectoryContains(storeDirectory, file, checksum) == false) {
+                    recoveryState.getIndex().addFileDetail(file, uploadedSegments.get(file).getLength(), false);
+                } else {
+                    recoveryState.getIndex().addFileDetail(file, uploadedSegments.get(file).getLength(), true);
+                }
+            }
+            for (String file : uploadedSegments.keySet()) {
+                long checksum = Long.parseLong(uploadedSegments.get(file).getChecksum());
+                if (overrideLocal || localDirectoryContains(storeDirectory, file, checksum) == false) {
                     if (localSegmentFiles.contains(file)) {
                         storeDirectory.deleteFile(file);
                     }

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -4388,7 +4388,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
      * @throws IOException if exception occurs while reading segments from remote store
      */
     public void syncSegmentsFromRemoteSegmentStore(boolean overrideLocal, boolean refreshLevelSegmentSync) throws IOException {
-        assert recoveryState.getStage() == RecoveryState.Stage.INDEX: "Shard recovery should be in INDEX stage";
+        assert recoveryState.getStage() == RecoveryState.Stage.INDEX : "Shard recovery should be in INDEX stage";
         assert indexSettings.isRemoteStoreEnabled();
         logger.info("Downloading segments from remote segment store");
         assert remoteStore.directory() instanceof FilterDirectory : "Store.directory is not an instance of FilterDirectory";

--- a/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
@@ -74,7 +74,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;

--- a/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
@@ -74,6 +74,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
@@ -268,7 +269,9 @@ final class StoreRecovery {
             in.copyFrom(new FilterDirectory(from) {
                 @Override
                 public IndexInput openInput(String name, IOContext context) throws IOException {
-                    index.addFileDetail(dest, l, false);
+                    if (index.getFileDetails(dest) == null) {
+                        index.addFileDetail(dest, l, false);
+                    }
                     copies.set(true);
                     final IndexInput input = in.openInput(name, context);
                     return new IndexInput("StatsDirectoryWrapper(" + input.toString() + ")") {
@@ -311,7 +314,7 @@ final class StoreRecovery {
                     };
                 }
             }, src, dest, context);
-            if (copies.get() == false) {
+            if (copies.get() == false && index.getFileDetails(dest) == null) {
                 index.addFileDetail(dest, l, true); // hardlinked - we treat it as reused since the file was already somewhat there
             } else {
                 assert index.getFileDetails(dest) != null : "File [" + dest + "] has no file details";

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -17,6 +17,7 @@ import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.opensearch.common.UUIDs;
+import org.opensearch.common.blobstore.BlobMetadata;
 import org.opensearch.index.store.remote.metadata.RemoteSegmentMetadata;
 import org.opensearch.common.io.VersionedCodecStreamWrapper;
 import org.opensearch.index.store.remote.metadata.RemoteSegmentMetadataHandler;
@@ -276,6 +277,9 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory {
      */
     @Override
     public long fileLength(String name) throws IOException {
+        if (segmentsUploadedToRemoteStore.containsKey(name)) {
+            return segmentsUploadedToRemoteStore.get(name).getLength();
+        }
         String remoteFilename = getExistingRemoteFilename(name);
         if (remoteFilename != null) {
             return remoteDataDirectory.fileLength(remoteFilename);

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -150,25 +150,31 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory {
         private final String originalFilename;
         private final String uploadedFilename;
         private final String checksum;
+        private final long length;
 
-        UploadedSegmentMetadata(String originalFilename, String uploadedFilename, String checksum) {
+        UploadedSegmentMetadata(String originalFilename, String uploadedFilename, String checksum, long length) {
             this.originalFilename = originalFilename;
             this.uploadedFilename = uploadedFilename;
             this.checksum = checksum;
+            this.length = length;
         }
 
         @Override
         public String toString() {
-            return String.join(SEPARATOR, originalFilename, uploadedFilename, checksum);
+            return String.join(SEPARATOR, originalFilename, uploadedFilename, checksum, String.valueOf(length));
         }
 
         public String getChecksum() {
             return this.checksum;
         }
 
+        public long getLength() {
+            return this.length;
+        }
+
         public static UploadedSegmentMetadata fromString(String uploadedFilename) {
             String[] values = uploadedFilename.split(SEPARATOR);
-            return new UploadedSegmentMetadata(values[0], values[1], values[2]);
+            return new UploadedSegmentMetadata(values[0], values[1], values[2], Long.parseLong(values[3]));
         }
     }
 
@@ -314,7 +320,7 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory {
         }
         remoteDataDirectory.copyFrom(from, src, remoteFilename, context);
         String checksum = getChecksumOfLocalFile(from, src);
-        UploadedSegmentMetadata segmentMetadata = new UploadedSegmentMetadata(src, remoteFilename, checksum);
+        UploadedSegmentMetadata segmentMetadata = new UploadedSegmentMetadata(src, remoteFilename, checksum, from.fileLength(src));
         segmentsUploadedToRemoteStore.put(src, segmentMetadata);
     }
 

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -17,7 +17,6 @@ import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.opensearch.common.UUIDs;
-import org.opensearch.common.blobstore.BlobMetadata;
 import org.opensearch.index.store.remote.metadata.RemoteSegmentMetadata;
 import org.opensearch.common.io.VersionedCodecStreamWrapper;
 import org.opensearch.index.store.remote.metadata.RemoteSegmentMetadataHandler;

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -64,16 +64,17 @@ public class RemoteSegmentStoreDirectoryTests extends OpenSearchTestCase {
         RemoteSegmentStoreDirectory.UploadedSegmentMetadata metadata = new RemoteSegmentStoreDirectory.UploadedSegmentMetadata(
             "abc",
             "pqr",
-            "123456"
+            "123456",
+            1234
         );
-        assertEquals("abc::pqr::123456", metadata.toString());
+        assertEquals("abc::pqr::123456::1234", metadata.toString());
     }
 
     public void testUploadedSegmentMetadataFromString() {
         RemoteSegmentStoreDirectory.UploadedSegmentMetadata metadata = RemoteSegmentStoreDirectory.UploadedSegmentMetadata.fromString(
-            "_0.cfe::_0.cfe__uuidxyz::4567"
+            "_0.cfe::_0.cfe__uuidxyz::4567::372000"
         );
-        assertEquals("_0.cfe::_0.cfe__uuidxyz::4567", metadata.toString());
+        assertEquals("_0.cfe::_0.cfe__uuidxyz::4567::372000", metadata.toString());
     }
 
     public void testGetMetadataFilename() {
@@ -141,9 +142,42 @@ public class RemoteSegmentStoreDirectoryTests extends OpenSearchTestCase {
     private Map<String, String> getDummyMetadata(String prefix, int commitGeneration) {
         Map<String, String> metadata = new HashMap<>();
 
-        metadata.put(prefix + ".cfe", prefix + ".cfe::" + prefix + ".cfe__" + UUIDs.base64UUID() + "::" + randomIntBetween(1000, 5000));
-        metadata.put(prefix + ".cfs", prefix + ".cfs::" + prefix + ".cfs__" + UUIDs.base64UUID() + "::" + randomIntBetween(1000, 5000));
-        metadata.put(prefix + ".si", prefix + ".si::" + prefix + ".si__" + UUIDs.base64UUID() + "::" + randomIntBetween(1000, 5000));
+        metadata.put(
+            prefix + ".cfe",
+            prefix
+                + ".cfe::"
+                + prefix
+                + ".cfe__"
+                + UUIDs.base64UUID()
+                + "::"
+                + randomIntBetween(1000, 5000)
+                + "::"
+                + randomIntBetween(512000, 1024000)
+        );
+        metadata.put(
+            prefix + ".cfs",
+            prefix
+                + ".cfs::"
+                + prefix
+                + ".cfs__"
+                + UUIDs.base64UUID()
+                + "::"
+                + randomIntBetween(1000, 5000)
+                + "::"
+                + randomIntBetween(512000, 1024000)
+        );
+        metadata.put(
+            prefix + ".si",
+            prefix
+                + ".si::"
+                + prefix
+                + ".si__"
+                + UUIDs.base64UUID()
+                + "::"
+                + randomIntBetween(1000, 5000)
+                + "::"
+                + randomIntBetween(512000, 1024000)
+        );
         metadata.put(
             "segments_" + commitGeneration,
             "segments_"
@@ -154,6 +188,8 @@ public class RemoteSegmentStoreDirectoryTests extends OpenSearchTestCase {
                 + UUIDs.base64UUID()
                 + "::"
                 + randomIntBetween(1000, 5000)
+                + "::"
+                + randomIntBetween(1024, 5120)
         );
         return metadata;
     }
@@ -376,8 +412,8 @@ public class RemoteSegmentStoreDirectoryTests extends OpenSearchTestCase {
         );
 
         Map<String, String> metadata = new HashMap<>();
-        metadata.put("_0.cfe", "_0.cfe::_0.cfe__" + UUIDs.base64UUID() + "::1234");
-        metadata.put("_0.cfs", "_0.cfs::_0.cfs__" + UUIDs.base64UUID() + "::2345");
+        metadata.put("_0.cfe", "_0.cfe::_0.cfe__" + UUIDs.base64UUID() + "::1234::512");
+        metadata.put("_0.cfs", "_0.cfs::_0.cfs__" + UUIDs.base64UUID() + "::2345::1024");
 
         when(remoteMetadataDirectory.openInput("metadata__1__5__abc", IOContext.DEFAULT)).thenReturn(createMetadataFileBytes(metadata));
 
@@ -390,7 +426,7 @@ public class RemoteSegmentStoreDirectoryTests extends OpenSearchTestCase {
             UnsupportedOperationException.class,
             () -> uploadedSegmentMetadataMap.put(
                 "_100.si",
-                new RemoteSegmentStoreDirectory.UploadedSegmentMetadata("_100.si", "_100.si__uuid1", "1234")
+                new RemoteSegmentStoreDirectory.UploadedSegmentMetadata("_100.si", "_100.si__uuid1", "1234", 500)
             )
         );
 
@@ -531,8 +567,8 @@ public class RemoteSegmentStoreDirectoryTests extends OpenSearchTestCase {
         );
 
         Map<String, String> metadata = new HashMap<>();
-        metadata.put("_0.cfe", "_0.cfe::_0.cfe__" + UUIDs.base64UUID() + "::1234");
-        metadata.put("_0.cfs", "_0.cfs::_0.cfs__" + UUIDs.base64UUID() + "::2345");
+        metadata.put("_0.cfe", "_0.cfe::_0.cfe__" + UUIDs.base64UUID() + "::1234::512");
+        metadata.put("_0.cfs", "_0.cfs::_0.cfs__" + UUIDs.base64UUID() + "::2345::1024");
 
         BytesStreamOutput output = new BytesStreamOutput();
         IndexOutput indexOutput = new OutputStreamIndexOutput("segment metadata", "metadata output stream", output, 4096);

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -286,7 +286,7 @@ public class RemoteSegmentStoreDirectoryTests extends OpenSearchTestCase {
         assertThrows(IOException.class, () -> remoteSegmentStoreDirectory.deleteFile("_0.si"));
     }
 
-    public void testFileLenght() throws IOException {
+    public void testFileLength() throws IOException {
         populateMetadata();
         remoteSegmentStoreDirectory.init();
 
@@ -295,9 +295,7 @@ public class RemoteSegmentStoreDirectoryTests extends OpenSearchTestCase {
 
         assertTrue(uploadedSegments.containsKey("_0.si"));
 
-        when(remoteDataDirectory.fileLength(startsWith("_0.si"))).thenReturn(1234L);
-
-        assertEquals(1234L, remoteSegmentStoreDirectory.fileLength("_0.si"));
+        assertEquals(uploadedSegments.get("_0.si").getLength(), remoteSegmentStoreDirectory.fileLength("_0.si"));
     }
 
     public void testFileLenghtNoSuchFile() throws IOException {

--- a/server/src/test/java/org/opensearch/index/store/remote/metadata/RemoteSegmentMetadataHandlerTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/metadata/RemoteSegmentMetadataHandlerTests.java
@@ -59,11 +59,27 @@ public class RemoteSegmentMetadataHandlerTests extends OpenSearchTestCase {
         String prefix = "_0";
         expectedOutput.put(
             prefix + ".cfe",
-            prefix + ".cfe::" + prefix + ".cfe__" + UUIDs.base64UUID() + "::" + randomIntBetween(1000, 5000)
+            prefix
+                + ".cfe::"
+                + prefix
+                + ".cfe__"
+                + UUIDs.base64UUID()
+                + "::"
+                + randomIntBetween(1000, 5000)
+                + "::"
+                + randomIntBetween(1024, 2048)
         );
         expectedOutput.put(
             prefix + ".cfs",
-            prefix + ".cfs::" + prefix + ".cfs__" + UUIDs.base64UUID() + "::" + randomIntBetween(1000, 5000)
+            prefix
+                + ".cfs::"
+                + prefix
+                + ".cfs__"
+                + UUIDs.base64UUID()
+                + "::"
+                + randomIntBetween(1000, 5000)
+                + "::"
+                + randomIntBetween(1024, 2048)
         );
         return expectedOutput;
     }


### PR DESCRIPTION
### Description
- `_cat/recovery` API provide details of progress of recovery. This helps in getting insight especially when shards are bigger in size.
- While restoring remote store backed index, entry is created but there is no data shown under `_cat/recovery`.
- This feature request adds the support of tracking segment download progress.

### Issues Resolved
- https://github.com/opensearch-project/OpenSearch/issues/6821

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
