### PR TITLE
Remove patch version check for plugin compatibility

### DIFF
--- a/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/InstallPluginCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/InstallPluginCommandTests.java
@@ -881,7 +881,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
         Tuple<Path, Environment> env = createEnv(fs, temp);
         Path pluginDir = createPluginDir(temp);
         Version coreVersion = Version.CURRENT;
-        Version pluginVersion = VersionUtils.getVersion(coreVersion.major, coreVersion.minor, (byte)(coreVersion.revision + 1));
+        Version pluginVersion = VersionUtils.getVersion(coreVersion.major, coreVersion.minor, (byte) (coreVersion.revision + 1));
         // Plugin explicitly specifies semVer range compatibility so patch version is not checked
         String pluginZip = createPlugin("fake", pluginDir, pluginVersion, "is.semVer.range.compatible", "true").toUri().toURL().toString();
         skipJarHellCommand.execute(terminal, Collections.singletonList(pluginZip), false, env.v2());
@@ -892,9 +892,12 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
         Tuple<Path, Environment> env = createEnv(fs, temp);
         Path pluginDir = createPluginDir(temp);
         Version coreVersion = Version.CURRENT;
-        Version pluginVersion = VersionUtils.getVersion(coreVersion.major, coreVersion.minor, (byte)(coreVersion.revision + 1));
+        Version pluginVersion = VersionUtils.getVersion(coreVersion.major, coreVersion.minor, (byte) (coreVersion.revision + 1));
         String pluginZip = createPlugin("fake", pluginDir, pluginVersion).toUri().toURL().toString();
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> skipJarHellCommand.execute(terminal, Collections.singletonList(pluginZip), false, env.v2()));
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> skipJarHellCommand.execute(terminal, Collections.singletonList(pluginZip), false, env.v2())
+        );
         assertThat(e.getMessage(), containsString("Plugin [fake] was built for OpenSearch version"));
     }
 
@@ -902,9 +905,12 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
         Tuple<Path, Environment> env = createEnv(fs, temp);
         Path pluginDir = createPluginDir(temp);
         Version coreVersion = Version.CURRENT;
-        Version pluginVersion = VersionUtils.getVersion(coreVersion.major, (byte)(coreVersion.minor + 1), coreVersion.revision);
+        Version pluginVersion = VersionUtils.getVersion(coreVersion.major, (byte) (coreVersion.minor + 1), coreVersion.revision);
         String pluginZip = createPlugin("fake", pluginDir, pluginVersion).toUri().toURL().toString();
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> skipJarHellCommand.execute(terminal, Collections.singletonList(pluginZip), false, env.v2()));
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> skipJarHellCommand.execute(terminal, Collections.singletonList(pluginZip), false, env.v2())
+        );
         assertThat(e.getMessage(), containsString("Plugin [fake] was built for OpenSearch version"));
     }
 

--- a/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/InstallPluginCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/InstallPluginCommandTests.java
@@ -877,18 +877,20 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
         assertThat(e.getMessage(), containsString("Unknown plugin unknown_plugin"));
     }
 
-    public void testInstallPluginDifferingInPatchVersionAllowed() throws Exception {
+    public void testInstallPluginWithDifferentPatchVersionIfPluginOptsIn() throws Exception {
         Tuple<Path, Environment> env = createEnv(fs, temp);
         Path pluginDir = createPluginDir(temp);
         Version coreVersion = Version.CURRENT;
         Version pluginVersion = VersionUtils.getVersion(coreVersion.major, coreVersion.minor, (byte) (coreVersion.revision + 1));
-        // Plugin explicitly specifies semVer range compatibility so patch version is not checked
-        String pluginZip = createPlugin("fake", pluginDir, pluginVersion, "is.semVer.range.compatible", "true").toUri().toURL().toString();
+        // Plugin explicitly specifies compatibility across patch versions
+        String pluginZip = createPlugin("fake", pluginDir, pluginVersion, "compatible.across.patch.versions", "true").toUri()
+            .toURL()
+            .toString();
         skipJarHellCommand.execute(terminal, Collections.singletonList(pluginZip), false, env.v2());
         assertThat(terminal.getOutput(), containsString("100%"));
     }
 
-    public void testInstallPluginDifferingInPatchVersionNotAllowed() throws Exception {
+    public void testInstallPluginWithDifferentPatchVersionNotAllowedByDefault() throws Exception {
         Tuple<Path, Environment> env = createEnv(fs, temp);
         Path pluginDir = createPluginDir(temp);
         Version coreVersion = Version.CURRENT;

--- a/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/ListPluginsCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/ListPluginsCommandTests.java
@@ -173,7 +173,7 @@ public class ListPluginsCommandTests extends OpenSearchTestCase {
                 "Extended Plugins: []",
                 " * Classname: org.fake",
                 "Folder name: custom-folder",
-                "SemVer Range Compatible: false"
+                "Compatible across patch versions: false"
             ),
             terminal.getOutput()
         );
@@ -197,7 +197,7 @@ public class ListPluginsCommandTests extends OpenSearchTestCase {
                 "Extended Plugins: []",
                 " * Classname: org.fake",
                 "Folder name: custom-folder",
-                "SemVer Range Compatible: false"
+                "Compatible across patch versions: false"
             ),
             terminal.getOutput()
         );
@@ -222,7 +222,7 @@ public class ListPluginsCommandTests extends OpenSearchTestCase {
                 "Extended Plugins: []",
                 " * Classname: org.fake",
                 "Folder name: custom-folder",
-                "SemVer Range Compatible: false",
+                "Compatible across patch versions: false",
                 "fake_plugin2",
                 "- Plugin information:",
                 "Name: fake_plugin2",
@@ -234,7 +234,7 @@ public class ListPluginsCommandTests extends OpenSearchTestCase {
                 "Extended Plugins: []",
                 " * Classname: org.fake2",
                 "Folder name: custom-folder",
-                "SemVer Range Compatible: false"
+                "Compatible across patch versions: false"
             ),
             terminal.getOutput()
         );

--- a/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/ListPluginsCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/ListPluginsCommandTests.java
@@ -172,7 +172,8 @@ public class ListPluginsCommandTests extends OpenSearchTestCase {
                 "Native Controller: false",
                 "Extended Plugins: []",
                 " * Classname: org.fake",
-                "Folder name: custom-folder"
+                "Folder name: custom-folder",
+                "SemVer Range Compatible: false"
             ),
             terminal.getOutput()
         );
@@ -195,7 +196,8 @@ public class ListPluginsCommandTests extends OpenSearchTestCase {
                 "Native Controller: true",
                 "Extended Plugins: []",
                 " * Classname: org.fake",
-                "Folder name: custom-folder"
+                "Folder name: custom-folder",
+                "SemVer Range Compatible: false"
             ),
             terminal.getOutput()
         );
@@ -220,6 +222,7 @@ public class ListPluginsCommandTests extends OpenSearchTestCase {
                 "Extended Plugins: []",
                 " * Classname: org.fake",
                 "Folder name: custom-folder",
+                "SemVer Range Compatible: false",
                 "fake_plugin2",
                 "- Plugin information:",
                 "Name: fake_plugin2",
@@ -230,7 +233,8 @@ public class ListPluginsCommandTests extends OpenSearchTestCase {
                 "Native Controller: false",
                 "Extended Plugins: []",
                 " * Classname: org.fake2",
-                "Folder name: custom-folder"
+                "Folder name: custom-folder",
+                "SemVer Range Compatible: false"
             ),
             terminal.getOutput()
         );

--- a/server/src/main/java/org/opensearch/plugins/PluginInfo.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginInfo.java
@@ -254,7 +254,6 @@ public class PluginInfo implements Writeable, ToXContentObject {
 
         final String isSemVerRangeCompatibleValue = propsMap.remove("is.semVer.range.compatible");
         final boolean isSemVerRangeCompatible = getBooleanProperty("is.semVer.range.compatible", isSemVerRangeCompatibleValue, false);
-        ;
 
         if (propsMap.isEmpty() == false) {
             throw new IllegalArgumentException("Unknown properties in plugin descriptor: " + propsMap.keySet());

--- a/server/src/main/java/org/opensearch/plugins/PluginInfo.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginInfo.java
@@ -75,7 +75,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
     private final String customFolderName;
     private final List<String> extendedPlugins;
     private final boolean hasNativeController;
-    private final boolean isSemVerRangeCompatible;
+    private final boolean compatibleAcrossPatchVersions;
 
     /**
      * Construct plugin info.
@@ -89,7 +89,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
      * @param customFolderName          the custom folder name for the plugin
      * @param extendedPlugins           other plugins this plugin extends through SPI
      * @param hasNativeController       whether or not the plugin has a native controller
-     * @param isSemVerRangeCompatible   whether or not the plugin specifies a semVer range of compatible versions
+     * @param compatibleAcrossPatchVersions   whether or not the plugin is compatible across patch versions
      */
     public PluginInfo(
         String name,
@@ -101,7 +101,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
         String customFolderName,
         List<String> extendedPlugins,
         boolean hasNativeController,
-        boolean isSemVerRangeCompatible
+        boolean compatibleAcrossPatchVersions
     ) {
         this.name = name;
         this.description = description;
@@ -112,7 +112,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
         this.customFolderName = customFolderName;
         this.extendedPlugins = Collections.unmodifiableList(extendedPlugins);
         this.hasNativeController = hasNativeController;
-        this.isSemVerRangeCompatible = isSemVerRangeCompatible;
+        this.compatibleAcrossPatchVersions = compatibleAcrossPatchVersions;
     }
 
     /**
@@ -126,7 +126,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
      * @param classname                 the entry point to the plugin
      * @param extendedPlugins           other plugins this plugin extends through SPI
      * @param hasNativeController       whether or not the plugin has a native controller
-     * @param isSemVerRangeCompatible   whether or not the plugin specifies a semVer range of compatible versions
+     * @param compatibleAcrossPatchVersions   whether or not the plugin is compatible with all patch versions
      */
     public PluginInfo(
         String name,
@@ -137,7 +137,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
         String classname,
         List<String> extendedPlugins,
         boolean hasNativeController,
-        boolean isSemVerRangeCompatible
+        boolean compatibleAcrossPatchVersions
     ) {
         this(
             name,
@@ -149,7 +149,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
             null /* customFolderName */,
             extendedPlugins,
             hasNativeController,
-            isSemVerRangeCompatible
+            compatibleAcrossPatchVersions
         );
     }
 
@@ -169,7 +169,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
         this.customFolderName = in.readString();
         this.extendedPlugins = in.readStringList();
         this.hasNativeController = in.readBoolean();
-        this.isSemVerRangeCompatible = in.readBoolean();
+        this.compatibleAcrossPatchVersions = in.readBoolean();
     }
 
     @Override
@@ -187,7 +187,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
         }
         out.writeStringCollection(extendedPlugins);
         out.writeBoolean(hasNativeController);
-        out.writeBoolean(isSemVerRangeCompatible);
+        out.writeBoolean(compatibleAcrossPatchVersions);
     }
 
     /**
@@ -252,8 +252,12 @@ public class PluginInfo implements Writeable, ToXContentObject {
         final String hasNativeControllerValue = propsMap.remove("has.native.controller");
         final boolean hasNativeController = getBooleanProperty("has.native.controller", hasNativeControllerValue, false);
 
-        final String isSemVerRangeCompatibleValue = propsMap.remove("is.semVer.range.compatible");
-        final boolean isSemVerRangeCompatible = getBooleanProperty("is.semVer.range.compatible", isSemVerRangeCompatibleValue, false);
+        final String compatibleAcrossPatchVersionsValue = propsMap.remove("compatible.across.patch.versions");
+        final boolean compatibleAcrossPatchVersions = getBooleanProperty(
+            "compatible.across.patch.versions",
+            compatibleAcrossPatchVersionsValue,
+            false
+        );
 
         if (propsMap.isEmpty() == false) {
             throw new IllegalArgumentException("Unknown properties in plugin descriptor: " + propsMap.keySet());
@@ -269,7 +273,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
             customFolderName,
             extendedPlugins,
             hasNativeController,
-            isSemVerRangeCompatible
+            compatibleAcrossPatchVersions
         );
     }
 
@@ -377,11 +381,11 @@ public class PluginInfo implements Writeable, ToXContentObject {
     }
 
     /**
-     * Whether or not the plugin specifies a semVer range of compatible versions.
-     * @return {@code true} if the plugin specifies a semVer range of compatible versions, {@code false} otherwise.
+     * Whether or not the plugin is compatible with all patch versions for given opensearch version
+     * @return {@code true} if the plugin is compatible with all patch versions, {@code false} otherwise.
      */
-    public boolean isSemVerRangeCompatible() {
-        return isSemVerRangeCompatible;
+    public boolean compatibleAcrossPatchVersions() {
+        return compatibleAcrossPatchVersions;
     }
 
     /**
@@ -406,7 +410,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
             builder.field("custom_foldername", customFolderName);
             builder.field("extended_plugins", extendedPlugins);
             builder.field("has_native_controller", hasNativeController);
-            builder.field("is_semVer_range_compatible", isSemVerRangeCompatible);
+            builder.field("compatible_across_patch_versions", compatibleAcrossPatchVersions);
         }
         builder.endObject();
 
@@ -477,8 +481,8 @@ public class PluginInfo implements Writeable, ToXContentObject {
             .append(customFolderName)
             .append("\n")
             .append(prefix)
-            .append("SemVer Range Compatible: ")
-            .append(isSemVerRangeCompatible);
+            .append("Compatible across patch versions: ")
+            .append(compatibleAcrossPatchVersions);
         return information.toString();
     }
 }

--- a/server/src/main/java/org/opensearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginsService.java
@@ -410,8 +410,8 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
      */
     static boolean isPluginVersionCompatible(final PluginInfo pluginInfo, final Version coreVersion) {
         final Version pluginVersion = pluginInfo.getOpenSearchVersion();
-        if (pluginInfo.isSemVerRangeCompatible()) {
-            // Ignore patch version if plugin is specifying semVer range compatibility
+        if (pluginInfo.compatibleAcrossPatchVersions()) {
+            // Ignore patch version if plugin is compatible across patch versions
             return pluginVersion.major == coreVersion.major && pluginVersion.minor == coreVersion.minor;
         }
         return pluginVersion.equals(coreVersion);

--- a/server/src/main/java/org/opensearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginsService.java
@@ -387,7 +387,7 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
      * Verify the given plugin is compatible with the current OpenSearch installation.
      */
     static void verifyCompatibility(PluginInfo info) {
-        if (info.getOpenSearchVersion().equals(Version.CURRENT) == false) {
+        if (!isPluginVersionCompatibile(info.getOpenSearchVersion(), Version.CURRENT)) {
             throw new IllegalArgumentException(
                 "Plugin ["
                     + info.getName()
@@ -399,6 +399,16 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
             );
         }
         JarHell.checkJavaVersion(info.getName(), info.getJavaVersion());
+    }
+
+    /**
+     * This method checks if plugin was built with a version that is compatible with core's version.
+     * @param pluginVersion OS version plugin was built with
+     * @param coreVersion Core version
+     * @return true if plugin's version is compatible with core, false otherwise
+     */
+    static boolean isPluginVersionCompatibile(final Version pluginVersion, final Version coreVersion) {
+        return pluginVersion.major == coreVersion.major && pluginVersion.minor == coreVersion.minor;
     }
 
     static void checkForFailedPluginRemovals(final Path pluginsDirectory) throws IOException {

--- a/server/src/main/java/org/opensearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginsService.java
@@ -149,6 +149,7 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
                 pluginClass.getName(),
                 null,
                 Collections.emptyList(),
+                false,
                 false
             );
             if (logger.isTraceEnabled()) {
@@ -387,7 +388,7 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
      * Verify the given plugin is compatible with the current OpenSearch installation.
      */
     static void verifyCompatibility(PluginInfo info) {
-        if (!isPluginVersionCompatibile(info.getOpenSearchVersion(), Version.CURRENT)) {
+        if (!isPluginVersionCompatible(info, Version.CURRENT)) {
             throw new IllegalArgumentException(
                 "Plugin ["
                     + info.getName()
@@ -403,12 +404,17 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
 
     /**
      * This method checks if plugin was built with a version that is compatible with core's version.
-     * @param pluginVersion OS version plugin was built with
+     * @param pluginInfo {@code PluginInfo} to fetch plugin properties
      * @param coreVersion Core version
      * @return true if plugin's version is compatible with core, false otherwise
      */
-    static boolean isPluginVersionCompatibile(final Version pluginVersion, final Version coreVersion) {
-        return pluginVersion.major == coreVersion.major && pluginVersion.minor == coreVersion.minor;
+    static boolean isPluginVersionCompatible(final PluginInfo pluginInfo, final Version coreVersion) {
+        final Version pluginVersion = pluginInfo.getOpenSearchVersion();
+        if (pluginInfo.isSemVerRangeCompatible()) {
+            // Ignore patch version if plugin is specifying semVer range compatibility
+            return pluginVersion.major == coreVersion.major && pluginVersion.minor == coreVersion.minor;
+        }
+        return pluginVersion.equals(coreVersion);
     }
 
     static void checkForFailedPluginRemovals(final Path pluginsDirectory) throws IOException {

--- a/server/src/test/java/org/opensearch/nodesinfo/NodeInfoStreamingTests.java
+++ b/server/src/test/java/org/opensearch/nodesinfo/NodeInfoStreamingTests.java
@@ -179,6 +179,7 @@ public class NodeInfoStreamingTests extends OpenSearchTestCase {
                         randomAlphaOfLengthBetween(3, 10),
                         name,
                         Collections.emptyList(),
+                        randomBoolean(),
                         randomBoolean()
                     )
                 );
@@ -197,6 +198,7 @@ public class NodeInfoStreamingTests extends OpenSearchTestCase {
                         randomAlphaOfLengthBetween(3, 10),
                         name,
                         Collections.emptyList(),
+                        randomBoolean(),
                         randomBoolean()
                     )
                 );

--- a/server/src/test/java/org/opensearch/plugins/PluginInfoTests.java
+++ b/server/src/test/java/org/opensearch/plugins/PluginInfoTests.java
@@ -75,6 +75,7 @@ public class PluginInfoTests extends OpenSearchTestCase {
         assertEquals("1.0", info.getVersion());
         assertEquals("FakePlugin", info.getClassname());
         assertThat(info.getExtendedPlugins(), empty());
+        assertEquals(info.isSemVerRangeCompatible(), false);
     }
 
     public void testReadFromPropertiesWithFolderNameAndVersionAfter() throws Exception {
@@ -287,6 +288,52 @@ public class PluginInfoTests extends OpenSearchTestCase {
         assertThat(info.getExtendedPlugins(), empty());
     }
 
+    public void testReadFromPropertiesSemVerRangeCompatible() throws Exception {
+        Path pluginDir = createTempDir().resolve("fake-plugin");
+        PluginTestUtil.writePluginProperties(
+            pluginDir,
+            "description",
+            "fake desc",
+            "name",
+            "my_plugin",
+            "version",
+            "1.0",
+            "opensearch.version",
+            Version.CURRENT.toString(),
+            "java.version",
+            System.getProperty("java.specification.version"),
+            "classname",
+            "FakePlugin",
+            "is.semVer.range.compatible",
+            "true"
+        );
+        PluginInfo info = PluginInfo.readFromProperties(pluginDir);
+        assertEquals(true, info.isSemVerRangeCompatible());
+    }
+
+    public void testReadFromPropertiesSemVerRangeNotCompatible() throws Exception {
+        Path pluginDir = createTempDir().resolve("fake-plugin");
+        PluginTestUtil.writePluginProperties(
+            pluginDir,
+            "description",
+            "fake desc",
+            "name",
+            "my_plugin",
+            "version",
+            "1.0",
+            "opensearch.version",
+            Version.CURRENT.toString(),
+            "java.version",
+            System.getProperty("java.specification.version"),
+            "classname",
+            "FakePlugin",
+            "is.semVer.range.compatible",
+            "false"
+        );
+        PluginInfo info = PluginInfo.readFromProperties(pluginDir);
+        assertEquals(false, info.isSemVerRangeCompatible());
+    }
+
     public void testSerialize() throws Exception {
         PluginInfo info = new PluginInfo(
             "c",
@@ -297,6 +344,7 @@ public class PluginInfoTests extends OpenSearchTestCase {
             "dummyclass",
             "c",
             Collections.singletonList("foo"),
+            randomBoolean(),
             randomBoolean()
         );
         BytesStreamOutput output = new BytesStreamOutput();
@@ -310,11 +358,71 @@ public class PluginInfoTests extends OpenSearchTestCase {
 
     public void testPluginListSorted() {
         List<PluginInfo> plugins = new ArrayList<>();
-        plugins.add(new PluginInfo("c", "foo", "dummy", Version.CURRENT, "1.8", "dummyclass", Collections.emptyList(), randomBoolean()));
-        plugins.add(new PluginInfo("b", "foo", "dummy", Version.CURRENT, "1.8", "dummyclass", Collections.emptyList(), randomBoolean()));
-        plugins.add(new PluginInfo("e", "foo", "dummy", Version.CURRENT, "1.8", "dummyclass", Collections.emptyList(), randomBoolean()));
-        plugins.add(new PluginInfo("a", "foo", "dummy", Version.CURRENT, "1.8", "dummyclass", Collections.emptyList(), randomBoolean()));
-        plugins.add(new PluginInfo("d", "foo", "dummy", Version.CURRENT, "1.8", "dummyclass", Collections.emptyList(), randomBoolean()));
+        plugins.add(
+            new PluginInfo(
+                "c",
+                "foo",
+                "dummy",
+                Version.CURRENT,
+                "1.8",
+                "dummyclass",
+                Collections.emptyList(),
+                randomBoolean(),
+                randomBoolean()
+            )
+        );
+        plugins.add(
+            new PluginInfo(
+                "b",
+                "foo",
+                "dummy",
+                Version.CURRENT,
+                "1.8",
+                "dummyclass",
+                Collections.emptyList(),
+                randomBoolean(),
+                randomBoolean()
+            )
+        );
+        plugins.add(
+            new PluginInfo(
+                "e",
+                "foo",
+                "dummy",
+                Version.CURRENT,
+                "1.8",
+                "dummyclass",
+                Collections.emptyList(),
+                randomBoolean(),
+                randomBoolean()
+            )
+        );
+        plugins.add(
+            new PluginInfo(
+                "a",
+                "foo",
+                "dummy",
+                Version.CURRENT,
+                "1.8",
+                "dummyclass",
+                Collections.emptyList(),
+                randomBoolean(),
+                randomBoolean()
+            )
+        );
+        plugins.add(
+            new PluginInfo(
+                "d",
+                "foo",
+                "dummy",
+                Version.CURRENT,
+                "1.8",
+                "dummyclass",
+                Collections.emptyList(),
+                randomBoolean(),
+                randomBoolean()
+            )
+        );
         PluginsAndModules pluginsInfo = new PluginsAndModules(plugins, Collections.emptyList());
 
         final List<PluginInfo> infos = pluginsInfo.getPluginInfos();

--- a/server/src/test/java/org/opensearch/plugins/PluginInfoTests.java
+++ b/server/src/test/java/org/opensearch/plugins/PluginInfoTests.java
@@ -75,7 +75,7 @@ public class PluginInfoTests extends OpenSearchTestCase {
         assertEquals("1.0", info.getVersion());
         assertEquals("FakePlugin", info.getClassname());
         assertThat(info.getExtendedPlugins(), empty());
-        assertEquals(info.isSemVerRangeCompatible(), false);
+        assertEquals(info.compatibleAcrossPatchVersions(), false);
     }
 
     public void testReadFromPropertiesWithFolderNameAndVersionAfter() throws Exception {
@@ -288,7 +288,7 @@ public class PluginInfoTests extends OpenSearchTestCase {
         assertThat(info.getExtendedPlugins(), empty());
     }
 
-    public void testReadFromPropertiesSemVerRangeCompatible() throws Exception {
+    public void testReadFromPropertiesPluginCompatibleAcrossPatchVersions() throws Exception {
         Path pluginDir = createTempDir().resolve("fake-plugin");
         PluginTestUtil.writePluginProperties(
             pluginDir,
@@ -304,14 +304,14 @@ public class PluginInfoTests extends OpenSearchTestCase {
             System.getProperty("java.specification.version"),
             "classname",
             "FakePlugin",
-            "is.semVer.range.compatible",
+            "compatible.across.patch.versions",
             "true"
         );
         PluginInfo info = PluginInfo.readFromProperties(pluginDir);
-        assertEquals(true, info.isSemVerRangeCompatible());
+        assertEquals(true, info.compatibleAcrossPatchVersions());
     }
 
-    public void testReadFromPropertiesSemVerRangeNotCompatible() throws Exception {
+    public void testReadFromPropertiesPluginNotCompatibleAcrossPatchVersions() throws Exception {
         Path pluginDir = createTempDir().resolve("fake-plugin");
         PluginTestUtil.writePluginProperties(
             pluginDir,
@@ -327,11 +327,11 @@ public class PluginInfoTests extends OpenSearchTestCase {
             System.getProperty("java.specification.version"),
             "classname",
             "FakePlugin",
-            "is.semVer.range.compatible",
+            "compatible.across.patch.versions",
             "false"
         );
         PluginInfo info = PluginInfo.readFromProperties(pluginDir);
-        assertEquals(false, info.isSemVerRangeCompatible());
+        assertEquals(false, info.compatibleAcrossPatchVersions());
     }
 
     public void testSerialize() throws Exception {

--- a/server/src/test/java/org/opensearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/opensearch/plugins/PluginsServiceTests.java
@@ -790,8 +790,8 @@ public class PluginsServiceTests extends OpenSearchTestCase {
         assertThat(e.getMessage(), containsString("was built for OpenSearch version 6.0.0"));
     }
 
-    public void testPluginCompatibleWhenSemVerRangeNotSpecified() throws Exception {
-        // When semVer range is not specified, plugin is required to have same version as the core (Version.CURRENT)
+    public void testPluginCompatibilityDefaultBehavior() throws Exception {
+        // Plugin is required to have same version as the core (Version.CURRENT)
         PluginInfo info = new PluginInfo(
             "my_plugin",
             "desc",
@@ -806,8 +806,8 @@ public class PluginsServiceTests extends OpenSearchTestCase {
         PluginsService.verifyCompatibility(info);
     }
 
-    public void testPluginIncompatibleWhenSemVerRangeNotSpecified() throws Exception {
-        // When semVer range is not specified, differing patch version is not allowed
+    public void testPluginIncompatibleIfPatchVersionMismatches() throws Exception {
+        // Differing patch version is not allowed by default
         Version coreVersion = Version.CURRENT;
         Version pluginVersion = VersionUtils.getVersion(coreVersion.major, coreVersion.minor, (byte) (coreVersion.revision + 1));
         PluginInfo info = new PluginInfo(
@@ -825,34 +825,64 @@ public class PluginsServiceTests extends OpenSearchTestCase {
         assertThat(e.getMessage(), containsString("was built for OpenSearch version"));
     }
 
-    public void testPluginCompatibilityWhenSemVerRangeSpecified() {
+    public void testPluginCompatibilityWhenPluginOptsIntoPatchVersionVariability() {
         // Compatible plugin and core versions
-        assertTrue(PluginsService.isPluginVersionCompatible(getSemverCompatiblePluginInfoForVersion("1.0.0"), Version.fromString("1.0.0")));
-        assertTrue(PluginsService.isPluginVersionCompatible(getSemverCompatiblePluginInfoForVersion("1.0.0"), Version.fromString("1.0.1")));
-        assertTrue(PluginsService.isPluginVersionCompatible(getSemverCompatiblePluginInfoForVersion("1.0.1"), Version.fromString("1.0.0")));
+        assertTrue(
+            PluginsService.isPluginVersionCompatible(
+                getPluginInfoWithCompatibilityAcrossPatchVersions("1.0.0"),
+                Version.fromString("1.0.0")
+            )
+        );
+        assertTrue(
+            PluginsService.isPluginVersionCompatible(
+                getPluginInfoWithCompatibilityAcrossPatchVersions("1.0.0"),
+                Version.fromString("1.0.1")
+            )
+        );
+        assertTrue(
+            PluginsService.isPluginVersionCompatible(
+                getPluginInfoWithCompatibilityAcrossPatchVersions("1.0.1"),
+                Version.fromString("1.0.0")
+            )
+        );
 
         // Incompatible plugin and core versions
         // Different minor versions
         assertFalse(
-            PluginsService.isPluginVersionCompatible(getSemverCompatiblePluginInfoForVersion("1.0.0"), Version.fromString("1.1.0"))
+            PluginsService.isPluginVersionCompatible(
+                getPluginInfoWithCompatibilityAcrossPatchVersions("1.0.0"),
+                Version.fromString("1.1.0")
+            )
         );
         assertFalse(
-            PluginsService.isPluginVersionCompatible(getSemverCompatiblePluginInfoForVersion("1.1.0"), Version.fromString("1.0.0"))
+            PluginsService.isPluginVersionCompatible(
+                getPluginInfoWithCompatibilityAcrossPatchVersions("1.1.0"),
+                Version.fromString("1.0.0")
+            )
         );
         // Different major versions
         assertFalse(
-            PluginsService.isPluginVersionCompatible(getSemverCompatiblePluginInfoForVersion("1.0.0"), Version.fromString("2.0.0"))
+            PluginsService.isPluginVersionCompatible(
+                getPluginInfoWithCompatibilityAcrossPatchVersions("1.0.0"),
+                Version.fromString("2.0.0")
+            )
         );
         assertFalse(
-            PluginsService.isPluginVersionCompatible(getSemverCompatiblePluginInfoForVersion("2.0.0"), Version.fromString("1.0.0"))
+            PluginsService.isPluginVersionCompatible(
+                getPluginInfoWithCompatibilityAcrossPatchVersions("2.0.0"),
+                Version.fromString("1.0.0")
+            )
         );
         // Different major and minor versions
         assertFalse(
-            PluginsService.isPluginVersionCompatible(getSemverCompatiblePluginInfoForVersion("1.2.0"), Version.fromString("2.1.0"))
+            PluginsService.isPluginVersionCompatible(
+                getPluginInfoWithCompatibilityAcrossPatchVersions("1.2.0"),
+                Version.fromString("2.1.0")
+            )
         );
     }
 
-    private PluginInfo getSemverCompatiblePluginInfoForVersion(String version) {
+    private PluginInfo getPluginInfoWithCompatibilityAcrossPatchVersions(String version) {
         return new PluginInfo(
             "my_plugin",
             "desc",

--- a/server/src/test/java/org/opensearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/opensearch/plugins/PluginsServiceTests.java
@@ -293,7 +293,17 @@ public class PluginsServiceTests extends OpenSearchTestCase {
 
     public void testSortBundlesCycleSelfReference() throws Exception {
         Path pluginDir = createTempDir();
-        PluginInfo info = new PluginInfo("foo", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.singletonList("foo"), false);
+        PluginInfo info = new PluginInfo(
+            "foo",
+            "desc",
+            "1.0",
+            Version.CURRENT,
+            "1.8",
+            "MyPlugin",
+            Collections.singletonList("foo"),
+            false,
+            false
+        );
         PluginsService.Bundle bundle = new PluginsService.Bundle(info, pluginDir);
         IllegalStateException e = expectThrows(
             IllegalStateException.class,
@@ -305,7 +315,17 @@ public class PluginsServiceTests extends OpenSearchTestCase {
     public void testSortBundlesCycle() throws Exception {
         Path pluginDir = createTempDir();
         Set<PluginsService.Bundle> bundles = new LinkedHashSet<>(); // control iteration order, so we get know the beginning of the cycle
-        PluginInfo info = new PluginInfo("foo", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Arrays.asList("bar", "other"), false);
+        PluginInfo info = new PluginInfo(
+            "foo",
+            "desc",
+            "1.0",
+            Version.CURRENT,
+            "1.8",
+            "MyPlugin",
+            Arrays.asList("bar", "other"),
+            false,
+            false
+        );
         bundles.add(new PluginsService.Bundle(info, pluginDir));
         PluginInfo info2 = new PluginInfo(
             "bar",
@@ -315,6 +335,7 @@ public class PluginsServiceTests extends OpenSearchTestCase {
             "1.8",
             "MyPlugin",
             Collections.singletonList("baz"),
+            false,
             false
         );
         bundles.add(new PluginsService.Bundle(info2, pluginDir));
@@ -326,10 +347,21 @@ public class PluginsServiceTests extends OpenSearchTestCase {
             "1.8",
             "MyPlugin",
             Collections.singletonList("foo"),
+            false,
             false
         );
         bundles.add(new PluginsService.Bundle(info3, pluginDir));
-        PluginInfo info4 = new PluginInfo("other", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.emptyList(), false);
+        PluginInfo info4 = new PluginInfo(
+            "other",
+            "desc",
+            "1.0",
+            Version.CURRENT,
+            "1.8",
+            "MyPlugin",
+            Collections.emptyList(),
+            false,
+            false
+        );
         bundles.add(new PluginsService.Bundle(info4, pluginDir));
 
         IllegalStateException e = expectThrows(IllegalStateException.class, () -> PluginsService.sortBundles(bundles));
@@ -338,7 +370,7 @@ public class PluginsServiceTests extends OpenSearchTestCase {
 
     public void testSortBundlesSingle() throws Exception {
         Path pluginDir = createTempDir();
-        PluginInfo info = new PluginInfo("foo", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.emptyList(), false);
+        PluginInfo info = new PluginInfo("foo", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.emptyList(), false, false);
         PluginsService.Bundle bundle = new PluginsService.Bundle(info, pluginDir);
         List<PluginsService.Bundle> sortedBundles = PluginsService.sortBundles(Collections.singleton(bundle));
         assertThat(sortedBundles, Matchers.contains(bundle));
@@ -347,13 +379,13 @@ public class PluginsServiceTests extends OpenSearchTestCase {
     public void testSortBundlesNoDeps() throws Exception {
         Path pluginDir = createTempDir();
         Set<PluginsService.Bundle> bundles = new LinkedHashSet<>(); // control iteration order
-        PluginInfo info1 = new PluginInfo("foo", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.emptyList(), false);
+        PluginInfo info1 = new PluginInfo("foo", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.emptyList(), false, false);
         PluginsService.Bundle bundle1 = new PluginsService.Bundle(info1, pluginDir);
         bundles.add(bundle1);
-        PluginInfo info2 = new PluginInfo("bar", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.emptyList(), false);
+        PluginInfo info2 = new PluginInfo("bar", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.emptyList(), false, false);
         PluginsService.Bundle bundle2 = new PluginsService.Bundle(info2, pluginDir);
         bundles.add(bundle2);
-        PluginInfo info3 = new PluginInfo("baz", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.emptyList(), false);
+        PluginInfo info3 = new PluginInfo("baz", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.emptyList(), false, false);
         PluginsService.Bundle bundle3 = new PluginsService.Bundle(info3, pluginDir);
         bundles.add(bundle3);
         List<PluginsService.Bundle> sortedBundles = PluginsService.sortBundles(bundles);
@@ -362,7 +394,17 @@ public class PluginsServiceTests extends OpenSearchTestCase {
 
     public void testSortBundlesMissingDep() throws Exception {
         Path pluginDir = createTempDir();
-        PluginInfo info = new PluginInfo("foo", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.singletonList("dne"), false);
+        PluginInfo info = new PluginInfo(
+            "foo",
+            "desc",
+            "1.0",
+            Version.CURRENT,
+            "1.8",
+            "MyPlugin",
+            Collections.singletonList("dne"),
+            false,
+            false
+        );
         PluginsService.Bundle bundle = new PluginsService.Bundle(info, pluginDir);
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
@@ -374,7 +416,17 @@ public class PluginsServiceTests extends OpenSearchTestCase {
     public void testSortBundlesCommonDep() throws Exception {
         Path pluginDir = createTempDir();
         Set<PluginsService.Bundle> bundles = new LinkedHashSet<>(); // control iteration order
-        PluginInfo info1 = new PluginInfo("grandparent", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.emptyList(), false);
+        PluginInfo info1 = new PluginInfo(
+            "grandparent",
+            "desc",
+            "1.0",
+            Version.CURRENT,
+            "1.8",
+            "MyPlugin",
+            Collections.emptyList(),
+            false,
+            false
+        );
         PluginsService.Bundle bundle1 = new PluginsService.Bundle(info1, pluginDir);
         bundles.add(bundle1);
         PluginInfo info2 = new PluginInfo(
@@ -385,6 +437,7 @@ public class PluginsServiceTests extends OpenSearchTestCase {
             "1.8",
             "MyPlugin",
             Collections.singletonList("common"),
+            false,
             false
         );
         PluginsService.Bundle bundle2 = new PluginsService.Bundle(info2, pluginDir);
@@ -397,6 +450,7 @@ public class PluginsServiceTests extends OpenSearchTestCase {
             "1.8",
             "MyPlugin",
             Collections.singletonList("common"),
+            false,
             false
         );
         PluginsService.Bundle bundle3 = new PluginsService.Bundle(info3, pluginDir);
@@ -409,6 +463,7 @@ public class PluginsServiceTests extends OpenSearchTestCase {
             "1.8",
             "MyPlugin",
             Collections.singletonList("grandparent"),
+            false,
             false
         );
         PluginsService.Bundle bundle4 = new PluginsService.Bundle(info4, pluginDir);
@@ -420,7 +475,7 @@ public class PluginsServiceTests extends OpenSearchTestCase {
     public void testSortBundlesAlreadyOrdered() throws Exception {
         Path pluginDir = createTempDir();
         Set<PluginsService.Bundle> bundles = new LinkedHashSet<>(); // control iteration order
-        PluginInfo info1 = new PluginInfo("dep", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.emptyList(), false);
+        PluginInfo info1 = new PluginInfo("dep", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.emptyList(), false, false);
         PluginsService.Bundle bundle1 = new PluginsService.Bundle(info1, pluginDir);
         bundles.add(bundle1);
         PluginInfo info2 = new PluginInfo(
@@ -431,6 +486,7 @@ public class PluginsServiceTests extends OpenSearchTestCase {
             "1.8",
             "MyPlugin",
             Collections.singletonList("dep"),
+            false,
             false
         );
         PluginsService.Bundle bundle2 = new PluginsService.Bundle(info2, pluginDir);
@@ -498,6 +554,7 @@ public class PluginsServiceTests extends OpenSearchTestCase {
             "1.8",
             "MyPlugin",
             Collections.singletonList("dep"),
+            false,
             false
         );
         PluginsService.Bundle bundle = new PluginsService.Bundle(info1, pluginDir);
@@ -527,6 +584,7 @@ public class PluginsServiceTests extends OpenSearchTestCase {
             "1.8",
             "MyPlugin",
             Arrays.asList("dep1", "dep2"),
+            false,
             false
         );
         PluginsService.Bundle bundle = new PluginsService.Bundle(info1, pluginDir);
@@ -546,7 +604,17 @@ public class PluginsServiceTests extends OpenSearchTestCase {
         Path pluginDir = createTempDir();
         Path pluginJar = pluginDir.resolve("plugin.jar");
         makeJar(pluginJar, Level.class);
-        PluginInfo info1 = new PluginInfo("myplugin", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.emptyList(), false);
+        PluginInfo info1 = new PluginInfo(
+            "myplugin",
+            "desc",
+            "1.0",
+            Version.CURRENT,
+            "1.8",
+            "MyPlugin",
+            Collections.emptyList(),
+            false,
+            false
+        );
         PluginsService.Bundle bundle = new PluginsService.Bundle(info1, pluginDir);
         IllegalStateException e = expectThrows(
             IllegalStateException.class,
@@ -574,6 +642,7 @@ public class PluginsServiceTests extends OpenSearchTestCase {
             "1.8",
             "MyPlugin",
             Collections.singletonList("dep"),
+            false,
             false
         );
         PluginsService.Bundle bundle = new PluginsService.Bundle(info1, pluginDir);
@@ -607,6 +676,7 @@ public class PluginsServiceTests extends OpenSearchTestCase {
             "1.8",
             "MyPlugin",
             Arrays.asList("dep1", "dep2"),
+            false,
             false
         );
         PluginsService.Bundle bundle = new PluginsService.Bundle(info1, pluginDir);
@@ -640,6 +710,7 @@ public class PluginsServiceTests extends OpenSearchTestCase {
             "1.8",
             "MyPlugin",
             Arrays.asList("dep1", "dep2"),
+            false,
             false
         );
         PluginsService.Bundle bundle = new PluginsService.Bundle(info1, pluginDir);
@@ -712,35 +783,87 @@ public class PluginsServiceTests extends OpenSearchTestCase {
             "1.8",
             "FakePlugin",
             Collections.emptyList(),
+            false,
             false
         );
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginsService.verifyCompatibility(info));
         assertThat(e.getMessage(), containsString("was built for OpenSearch version 6.0.0"));
     }
 
-    public void testPluginDifferingWithCoreForPatchVersion() throws Exception {
-        // Validate that a plugin is allowed to have a different patch version than core
-        Version coreVersion = Version.CURRENT;
-        Version pluginVersion = VersionUtils.getVersion(coreVersion.major, coreVersion.minor, (byte)(coreVersion.revision + 1)); 
-        PluginInfo info = new PluginInfo("my_plugin", "desc", "1.0", pluginVersion, "1.8", "FakePlugin", Collections.emptyList(), false);
+    public void testPluginCompatibleWhenSemVerRangeNotSpecified() throws Exception {
+        // When semVer range is not specified, plugin is required to have same version as the core (Version.CURRENT)
+        PluginInfo info = new PluginInfo(
+            "my_plugin",
+            "desc",
+            "1.0",
+            Version.CURRENT,
+            "1.8",
+            "FakePlugin",
+            Collections.emptyList(),
+            false,
+            false
+        );
         PluginsService.verifyCompatibility(info);
     }
 
-    public void testIsPluginVersionCompatibile() {
+    public void testPluginIncompatibleWhenSemVerRangeNotSpecified() throws Exception {
+        // When semVer range is not specified, differing patch version is not allowed
+        Version coreVersion = Version.CURRENT;
+        Version pluginVersion = VersionUtils.getVersion(coreVersion.major, coreVersion.minor, (byte) (coreVersion.revision + 1));
+        PluginInfo info = new PluginInfo(
+            "my_plugin",
+            "desc",
+            "1.0",
+            pluginVersion,
+            "1.8",
+            "FakePlugin",
+            Collections.emptyList(),
+            false,
+            false
+        );
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginsService.verifyCompatibility(info));
+        assertThat(e.getMessage(), containsString("was built for OpenSearch version"));
+    }
+
+    public void testPluginCompatibilityWhenSemVerRangeSpecified() {
         // Compatible plugin and core versions
-        assertTrue(PluginsService.isPluginVersionCompatibile(Version.fromString("1.0.0"), Version.fromString("1.0.0")));
-        assertTrue(PluginsService.isPluginVersionCompatibile(Version.fromString("1.0.0"), Version.fromString("1.0.1")));
-        assertTrue(PluginsService.isPluginVersionCompatibile(Version.fromString("1.0.1"), Version.fromString("1.0.0")));
+        assertTrue(PluginsService.isPluginVersionCompatible(getSemverCompatiblePluginInfoForVersion("1.0.0"), Version.fromString("1.0.0")));
+        assertTrue(PluginsService.isPluginVersionCompatible(getSemverCompatiblePluginInfoForVersion("1.0.0"), Version.fromString("1.0.1")));
+        assertTrue(PluginsService.isPluginVersionCompatible(getSemverCompatiblePluginInfoForVersion("1.0.1"), Version.fromString("1.0.0")));
 
         // Incompatible plugin and core versions
         // Different minor versions
-        assertFalse(PluginsService.isPluginVersionCompatibile(Version.fromString("1.0.0"), Version.fromString("1.1.0")));
-        assertFalse(PluginsService.isPluginVersionCompatibile(Version.fromString("1.1.0"), Version.fromString("1.0.0")));
+        assertFalse(
+            PluginsService.isPluginVersionCompatible(getSemverCompatiblePluginInfoForVersion("1.0.0"), Version.fromString("1.1.0"))
+        );
+        assertFalse(
+            PluginsService.isPluginVersionCompatible(getSemverCompatiblePluginInfoForVersion("1.1.0"), Version.fromString("1.0.0"))
+        );
         // Different major versions
-        assertFalse(PluginsService.isPluginVersionCompatibile(Version.fromString("1.0.0"), Version.fromString("2.0.0")));
-        assertFalse(PluginsService.isPluginVersionCompatibile(Version.fromString("2.0.0"), Version.fromString("1.0.0")));
+        assertFalse(
+            PluginsService.isPluginVersionCompatible(getSemverCompatiblePluginInfoForVersion("1.0.0"), Version.fromString("2.0.0"))
+        );
+        assertFalse(
+            PluginsService.isPluginVersionCompatible(getSemverCompatiblePluginInfoForVersion("2.0.0"), Version.fromString("1.0.0"))
+        );
         // Different major and minor versions
-        assertFalse(PluginsService.isPluginVersionCompatibile(Version.fromString("1.2.0"), Version.fromString("2.1.0")));
+        assertFalse(
+            PluginsService.isPluginVersionCompatible(getSemverCompatiblePluginInfoForVersion("1.2.0"), Version.fromString("2.1.0"))
+        );
+    }
+
+    private PluginInfo getSemverCompatiblePluginInfoForVersion(String version) {
+        return new PluginInfo(
+            "my_plugin",
+            "desc",
+            "1.0",
+            Version.fromString(version),
+            "1.8",
+            "FakePlugin",
+            Collections.emptyList(),
+            false,
+            true
+        );
     }
 
     public void testIncompatibleJavaVersion() throws Exception {
@@ -752,6 +875,7 @@ public class PluginsServiceTests extends OpenSearchTestCase {
             "1000000",
             "FakePlugin",
             Collections.emptyList(),
+            false,
             false
         );
         IllegalStateException e = expectThrows(IllegalStateException.class, () -> PluginsService.verifyCompatibility(info));
@@ -917,7 +1041,10 @@ public class PluginsServiceTests extends OpenSearchTestCase {
         TestExtensiblePlugin extensiblePlugin = new TestExtensiblePlugin();
         PluginsService.loadExtensions(
             Collections.singletonList(
-                Tuple.tuple(new PluginInfo("extensible", null, null, null, null, null, Collections.emptyList(), false), extensiblePlugin)
+                Tuple.tuple(
+                    new PluginInfo("extensible", null, null, null, null, null, Collections.emptyList(), false, false),
+                    extensiblePlugin
+                )
             )
         );
 
@@ -928,9 +1055,12 @@ public class PluginsServiceTests extends OpenSearchTestCase {
         TestPlugin testPlugin = new TestPlugin();
         PluginsService.loadExtensions(
             Arrays.asList(
-                Tuple.tuple(new PluginInfo("extensible", null, null, null, null, null, Collections.emptyList(), false), extensiblePlugin),
                 Tuple.tuple(
-                    new PluginInfo("test", null, null, null, null, null, Collections.singletonList("extensible"), false),
+                    new PluginInfo("extensible", null, null, null, null, null, Collections.emptyList(), false, false),
+                    extensiblePlugin
+                ),
+                Tuple.tuple(
+                    new PluginInfo("test", null, null, null, null, null, Collections.singletonList("extensible"), false, false),
                     testPlugin
                 )
             )

--- a/server/src/test/java/org/opensearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/opensearch/plugins/PluginsServiceTests.java
@@ -47,6 +47,7 @@ import org.opensearch.env.TestEnvironment;
 import org.opensearch.index.IndexModule;
 import org.opensearch.test.MockLogAppender;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.VersionUtils;
 import org.hamcrest.Matchers;
 
 import java.io.IOException;
@@ -715,6 +716,19 @@ public class PluginsServiceTests extends OpenSearchTestCase {
         );
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginsService.verifyCompatibility(info));
         assertThat(e.getMessage(), containsString("was built for OpenSearch version 6.0.0"));
+    }
+
+    public void testPluginDifferingWithCoreForPatchVersion() throws Exception {
+        // Get a version for plugin to use that is just before the core's version.
+        // We will use the plugin version for test only if it differs in patch version
+        Version pluginVersion = VersionUtils.getPreviousVersion(Version.CURRENT);
+        if (pluginVersion.major != Version.CURRENT.major || pluginVersion.minor != Version.CURRENT.minor) {
+            // Cannot fail the test as there is no version that differs with core's patch version
+            // but has the same major and minor version as core. Not a valid test in that case.
+            return;
+        }
+        PluginInfo info = new PluginInfo("my_plugin", "desc", "1.0", pluginVersion, "1.8", "FakePlugin", Collections.emptyList(), false);
+        PluginsService.verifyCompatibility(info);
     }
 
     public void testIncompatibleJavaVersion() throws Exception {

--- a/server/src/test/java/org/opensearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/opensearch/plugins/PluginsServiceTests.java
@@ -719,16 +719,28 @@ public class PluginsServiceTests extends OpenSearchTestCase {
     }
 
     public void testPluginDifferingWithCoreForPatchVersion() throws Exception {
-        // Get a version for plugin to use that is just before the core's version.
-        // We will use the plugin version for test only if it differs in patch version
-        Version pluginVersion = VersionUtils.getPreviousVersion(Version.CURRENT);
-        if (pluginVersion.major != Version.CURRENT.major || pluginVersion.minor != Version.CURRENT.minor) {
-            // Cannot fail the test as there is no version that differs with core's patch version
-            // but has the same major and minor version as core. Not a valid test in that case.
-            return;
-        }
+        // Validate that a plugin is allowed to have a different patch version than core
+        Version coreVersion = Version.CURRENT;
+        Version pluginVersion = VersionUtils.getVersion(coreVersion.major, coreVersion.minor, (byte)(coreVersion.revision + 1)); 
         PluginInfo info = new PluginInfo("my_plugin", "desc", "1.0", pluginVersion, "1.8", "FakePlugin", Collections.emptyList(), false);
         PluginsService.verifyCompatibility(info);
+    }
+
+    public void testIsPluginVersionCompatibile() {
+        // Compatible plugin and core versions
+        assertTrue(PluginsService.isPluginVersionCompatibile(Version.fromString("1.0.0"), Version.fromString("1.0.0")));
+        assertTrue(PluginsService.isPluginVersionCompatibile(Version.fromString("1.0.0"), Version.fromString("1.0.1")));
+        assertTrue(PluginsService.isPluginVersionCompatibile(Version.fromString("1.0.1"), Version.fromString("1.0.0")));
+
+        // Incompatible plugin and core versions
+        // Different minor versions
+        assertFalse(PluginsService.isPluginVersionCompatibile(Version.fromString("1.0.0"), Version.fromString("1.1.0")));
+        assertFalse(PluginsService.isPluginVersionCompatibile(Version.fromString("1.1.0"), Version.fromString("1.0.0")));
+        // Different major versions
+        assertFalse(PluginsService.isPluginVersionCompatibile(Version.fromString("1.0.0"), Version.fromString("2.0.0")));
+        assertFalse(PluginsService.isPluginVersionCompatibile(Version.fromString("2.0.0"), Version.fromString("1.0.0")));
+        // Different major and minor versions
+        assertFalse(PluginsService.isPluginVersionCompatibile(Version.fromString("1.2.0"), Version.fromString("2.1.0")));
     }
 
     public void testIncompatibleJavaVersion() throws Exception {

--- a/test/framework/src/main/java/org/opensearch/test/VersionUtils.java
+++ b/test/framework/src/main/java/org/opensearch/test/VersionUtils.java
@@ -237,6 +237,16 @@ public class VersionUtils {
     }
 
     /**
+     * Returns a {@link Version} with a given major, minor and revision version.
+     * Build version is skipped for the sake of simplicity.
+     */
+    public static Version getVersion(byte major, byte minor, byte revision) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(major).append('.').append(minor).append('.').append(revision);
+        return Version.fromString(sb.toString());
+    }
+
+    /**
      * Returns the released {@link Version} before the {@link Version#CURRENT}
      * where the minor version is less than the currents minor version.
      */


### PR DESCRIPTION
Signed-off-by: Abhilasha Seth <abseth@amazon.com>

### Description
As a first step towards supporting semVer range of compatible versions for plugins, we are starting with relaxing the patch version check (for default compatibility range). 

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/1707

### Check List
- [ ] New functionality includes testing.
  - [X] New tests pass
- [ ] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
