### PR TITLE
[Search Profile] Time in seconds in addition to nanoseconds

### DIFF
--- a/server/src/main/java/org/opensearch/search/profile/ProfileResult.java
+++ b/server/src/main/java/org/opensearch/search/profile/ProfileResult.java
@@ -70,6 +70,7 @@ public final class ProfileResult implements Writeable, ToXContentObject {
     static final ParseField DEBUG = new ParseField("debug");
     static final ParseField NODE_TIME = new ParseField("time");
     static final ParseField NODE_TIME_RAW = new ParseField("time_in_nanos");
+    static final ParseField NODE_TIME_SECONDS = new ParseField("time_in_seconds");
     static final ParseField CHILDREN = new ParseField("children");
 
     private final String type;
@@ -170,6 +171,7 @@ public final class ProfileResult implements Writeable, ToXContentObject {
             builder.field(NODE_TIME.getPreferredName(), new TimeValue(getTime(), TimeUnit.NANOSECONDS).toString());
         }
         builder.field(NODE_TIME_RAW.getPreferredName(), getTime());
+        builder.field(NODE_TIME_SECONDS.getPreferredName(), (double) getTime() / 1_000_000_000);
         builder.field(BREAKDOWN.getPreferredName(), breakdown);
         if (false == debug.isEmpty()) {
             builder.field(DEBUG.getPreferredName(), debug);

--- a/server/src/main/java/org/opensearch/search/profile/query/CollectorResult.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/CollectorResult.java
@@ -71,6 +71,7 @@ public class CollectorResult implements ToXContentObject, Writeable {
     private static final ParseField REASON = new ParseField("reason");
     private static final ParseField TIME = new ParseField("time");
     private static final ParseField TIME_NANOS = new ParseField("time_in_nanos");
+    private static final ParseField NODE_TIME_SECONDS = new ParseField("time_in_seconds");
     private static final ParseField CHILDREN = new ParseField("children");
 
     /**
@@ -163,7 +164,7 @@ public class CollectorResult implements ToXContentObject, Writeable {
             builder.field(TIME.getPreferredName(), new TimeValue(getTime(), TimeUnit.NANOSECONDS).toString());
         }
         builder.field(TIME_NANOS.getPreferredName(), getTime());
-
+        builder.field(NODE_TIME_SECONDS.getPreferredName(), (double) getTime() / 1_000_000_000);
         if (!children.isEmpty()) {
             builder = builder.startArray(CHILDREN.getPreferredName());
             for (CollectorResult child : children) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

Currently the profile API responds with only nanoseconds, `time_in_nanos`. When debugging large queries (especially nested and pipeline aggregations) that run for several seconds, with just the `time_in_nanos` information, it quite difficult to make out if a particular aggregator took, for example, 15 seconds OR 1.5 seconds or 0.15 seconds. The number of digits in nanosecond makes it difficult for human eyes, especially when scrolling over 1000s of lines in the `profile` response, for just a single shard.

This may not be a problem for an experienced pair of eye but for new users it could be.

### Issues Resolved

https://github.com/opensearch-project/OpenSearch/issues/6843

This PR adds a `time_in_seconds` to make it easy on the human eyes to read and digest the information (without having to count the number of digits in the `time_in_nanos`, each time). 

Ideally, a "Search Profile UI" like in the latest versions of Kibana would be the best way to analyse the run time. And the `time_in_seconds` or `time_in_ms` can be calculated from the `nanos` on the UI layer. Until then, should should help. I'm open to making changes based on suggestions.

This is how the response with `time_in_seconds` would look like,

![time_in_seconds](https://user-images.githubusercontent.com/32518356/227992757-e1339192-5625-46dd-a2fb-9f8991928c18.png)

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
