### PR TITLE
[Segment Replication] Fix flaky tests in SegmentReplicationPressureIT

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/index/SegmentReplicationPressureIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/SegmentReplicationPressureIT.java
@@ -17,6 +17,7 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.OpenSearchRejectedExecutionException;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.indices.replication.SegmentReplicationBaseIT;
+import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.rest.RestStatus;
 import org.opensearch.test.OpenSearchIntegTestCase;
@@ -53,11 +54,23 @@ public class SegmentReplicationPressureIT extends SegmentReplicationBaseIT {
     }
 
     @Override
+    public Settings indexSettings() {
+        // we want to control refreshes
+        return Settings.builder()
+            .put(super.indexSettings())
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, SHARD_COUNT)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, REPLICA_COUNT)
+            .put(IndexModule.INDEX_QUERY_CACHE_ENABLED_SETTING.getKey(), false)
+            .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+            .put("index.refresh_interval", -1)
+            .build();
+    }
+
+    @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         return asList(MockTransportService.TestPlugin.class);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/6671")
     public void testWritesRejected() throws Exception {
         final String primaryNode = internalCluster().startNode();
         createIndex(INDEX_NAME);
@@ -76,6 +89,10 @@ public class SegmentReplicationPressureIT extends SegmentReplicationBaseIT {
             indexingThread.start();
             indexingThread.join();
             latch.await();
+
+            indexDoc();
+            totalDocs.incrementAndGet();
+            refresh(INDEX_NAME);
             // index again while we are stale.
             assertBusy(() -> {
                 expectThrows(OpenSearchRejectedExecutionException.class, () -> {
@@ -90,6 +107,7 @@ public class SegmentReplicationPressureIT extends SegmentReplicationBaseIT {
 
         // index another doc showing there is no pressure enforced.
         indexDoc();
+        refresh(INDEX_NAME);
         waitForSearchableDocs(totalDocs.incrementAndGet(), replicaNodes.toArray(new String[] {}));
         verifyStoreContent();
     }
@@ -98,7 +116,6 @@ public class SegmentReplicationPressureIT extends SegmentReplicationBaseIT {
      * This test ensures that a replica can be added while the index is under write block.
      * Ensuring that only write requests are blocked.
      */
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/6671")
     public void testAddReplicaWhileWritesBlocked() throws Exception {
         final String primaryNode = internalCluster().startNode();
         createIndex(INDEX_NAME);
@@ -118,6 +135,9 @@ public class SegmentReplicationPressureIT extends SegmentReplicationBaseIT {
             indexingThread.start();
             indexingThread.join();
             latch.await();
+            indexDoc();
+            totalDocs.incrementAndGet();
+            refresh(INDEX_NAME);
             // index again while we are stale.
             assertBusy(() -> {
                 expectThrows(OpenSearchRejectedExecutionException.class, () -> {
@@ -142,6 +162,7 @@ public class SegmentReplicationPressureIT extends SegmentReplicationBaseIT {
 
         // index another doc showing there is no pressure enforced.
         indexDoc();
+        refresh(INDEX_NAME);
         waitForSearchableDocs(totalDocs.incrementAndGet(), replicaNodes.toArray(new String[] {}));
         verifyStoreContent();
     }
@@ -258,7 +279,7 @@ public class SegmentReplicationPressureIT extends SegmentReplicationBaseIT {
     }
 
     private void indexDoc() {
-        client().prepareIndex(INDEX_NAME).setId(UUIDs.base64UUID()).setSource("{}", "{}").get();
+        client().prepareIndex(INDEX_NAME).setId(UUIDs.base64UUID()).setSource("{}", "{}").execute().actionGet();
     }
 
     private void assertEqualSegmentInfosVersion(List<String> replicaNames, IndexShard primaryShard) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
In the previous tests for segmentReplicationPressureIT, the tests covered situations where it expected replicas to be stale and fail behind. However, it didn't take automatic background refreshes that take place at a refresh interval into account. Therefore, in certain situations where we expected the replica to be only 1 or 2 checkpoints behind due to indexing docs, it was actually 3 or 4 checkpoints behind due to checkpoints being sent on automatic refresh as well. 

This caused all the replicas to turn stale and the tests to fail intermittently. By turning off the automatic refresh, we now control when we expect the refreshes to take place which fixes the issue. Ran the tests over 2000 times to check with no failures. 

### Issues Resolved
Resolves #6671 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
