### PR TITLE
[Extensions] Update ExtensionRestResponse to handle RestRequest object

### DIFF
--- a/server/src/main/java/org/opensearch/extensions/rest/ExtensionRestResponse.java
+++ b/server/src/main/java/org/opensearch/extensions/rest/ExtensionRestResponse.java
@@ -11,6 +11,7 @@ package org.opensearch.extensions.rest;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.RestStatus;
 
 import java.util.List;
@@ -32,7 +33,7 @@ public class ExtensionRestResponse extends BytesRestResponse {
      * @param status  The REST status.
      * @param builder  The builder for the response.
      */
-    public ExtensionRestResponse(ExtensionRestRequest request, RestStatus status, XContentBuilder builder) {
+    public ExtensionRestResponse(RestRequest request, RestStatus status, XContentBuilder builder) {
         super(status, builder);
         this.consumedParams = request.consumedParams();
         this.contentConsumed = request.isContentConsumed();
@@ -45,7 +46,7 @@ public class ExtensionRestResponse extends BytesRestResponse {
      * @param status  The REST status.
      * @param content  A plain text response string.
      */
-    public ExtensionRestResponse(ExtensionRestRequest request, RestStatus status, String content) {
+    public ExtensionRestResponse(RestRequest request, RestStatus status, String content) {
         super(status, content);
         this.consumedParams = request.consumedParams();
         this.contentConsumed = request.isContentConsumed();
@@ -59,7 +60,7 @@ public class ExtensionRestResponse extends BytesRestResponse {
      * @param contentType  The content type of the response string.
      * @param content  A response string.
      */
-    public ExtensionRestResponse(ExtensionRestRequest request, RestStatus status, String contentType, String content) {
+    public ExtensionRestResponse(RestRequest request, RestStatus status, String contentType, String content) {
         super(status, contentType, content);
         this.consumedParams = request.consumedParams();
         this.contentConsumed = request.isContentConsumed();
@@ -73,7 +74,7 @@ public class ExtensionRestResponse extends BytesRestResponse {
      * @param contentType  The content type of the response bytes.
      * @param content  Response bytes.
      */
-    public ExtensionRestResponse(ExtensionRestRequest request, RestStatus status, String contentType, byte[] content) {
+    public ExtensionRestResponse(RestRequest request, RestStatus status, String contentType, byte[] content) {
         super(status, contentType, content);
         this.consumedParams = request.consumedParams();
         this.contentConsumed = request.isContentConsumed();
@@ -87,7 +88,7 @@ public class ExtensionRestResponse extends BytesRestResponse {
      * @param contentType  The content type of the response bytes.
      * @param content  Response bytes.
      */
-    public ExtensionRestResponse(ExtensionRestRequest request, RestStatus status, String contentType, BytesReference content) {
+    public ExtensionRestResponse(RestRequest request, RestStatus status, String contentType, BytesReference content) {
         super(status, contentType, content);
         this.consumedParams = request.consumedParams();
         this.contentConsumed = request.isContentConsumed();

--- a/server/src/main/java/org/opensearch/rest/RestRequest.java
+++ b/server/src/main/java/org/opensearch/rest/RestRequest.java
@@ -382,7 +382,7 @@ public class RestRequest implements ToXContent.Params {
      *
      * @return the list of currently consumed parameters.
      */
-    List<String> consumedParams() {
+    public List<String> consumedParams() {
         return new ArrayList<>(consumedParams);
     }
 

--- a/server/src/test/java/org/opensearch/extensions/rest/ExtensionRestResponseTests.java
+++ b/server/src/test/java/org/opensearch/extensions/rest/ExtensionRestResponseTests.java
@@ -11,11 +11,18 @@ package org.opensearch.extensions.rest;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import org.opensearch.common.bytes.BytesArray;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.http.HttpRequest;
+import org.opensearch.http.HttpResponse;
+import org.opensearch.http.HttpRequest.HttpVersion;
 import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.RestStatus;
 import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -38,15 +45,63 @@ public class ExtensionRestResponseTests extends OpenSearchTestCase {
         testBytes = new byte[] { 1, 2 };
     }
 
-    private ExtensionRestRequest generateTestRequest() {
-        ExtensionRestRequest request = new ExtensionRestRequest(
-            Method.GET,
-            "/foo",
-            Collections.emptyMap(),
-            null,
-            new BytesArray("Text Content"),
-            null
-        );
+    private RestRequest generateTestRequest() {
+        RestRequest request = RestRequest.request(null, new HttpRequest() {
+
+            @Override
+            public Method method() {
+                return Method.GET;
+            }
+
+            @Override
+            public String uri() {
+                return "/foo";
+            }
+
+            @Override
+            public BytesReference content() {
+                return new BytesArray("Text Content");
+            }
+
+            @Override
+            public Map<String, List<String>> getHeaders() {
+                return Collections.emptyMap();
+            }
+
+            @Override
+            public List<String> strictCookies() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public HttpVersion protocolVersion() {
+                return null;
+            }
+
+            @Override
+            public HttpRequest removeHeader(String header) {
+                // we don't use
+                return null;
+            }
+
+            @Override
+            public HttpResponse createResponse(RestStatus status, BytesReference content) {
+                return null;
+            }
+
+            @Override
+            public Exception getInboundException() {
+                return null;
+            }
+
+            @Override
+            public void release() {}
+
+            @Override
+            public HttpRequest releaseAndCopy() {
+                return null;
+            }
+        }, null);
         // consume params "foo" and "bar"
         request.param("foo");
         request.param("bar");
@@ -60,7 +115,7 @@ public class ExtensionRestResponseTests extends OpenSearchTestCase {
         builder.startObject();
         builder.field("status", ACCEPTED);
         builder.endObject();
-        ExtensionRestRequest request = generateTestRequest();
+        RestRequest request = generateTestRequest();
         ExtensionRestResponse response = new ExtensionRestResponse(request, OK, builder);
 
         assertEquals(OK, response.status());
@@ -73,7 +128,7 @@ public class ExtensionRestResponseTests extends OpenSearchTestCase {
     }
 
     public void testConstructorWithPlainText() {
-        ExtensionRestRequest request = generateTestRequest();
+        RestRequest request = generateTestRequest();
         ExtensionRestResponse response = new ExtensionRestResponse(request, OK, testText);
 
         assertEquals(OK, response.status());
@@ -86,7 +141,7 @@ public class ExtensionRestResponseTests extends OpenSearchTestCase {
     }
 
     public void testConstructorWithText() {
-        ExtensionRestRequest request = generateTestRequest();
+        RestRequest request = generateTestRequest();
         ExtensionRestResponse response = new ExtensionRestResponse(request, OK, TEXT_CONTENT_TYPE, testText);
 
         assertEquals(OK, response.status());
@@ -100,7 +155,7 @@ public class ExtensionRestResponseTests extends OpenSearchTestCase {
     }
 
     public void testConstructorWithByteArray() {
-        ExtensionRestRequest request = generateTestRequest();
+        RestRequest request = generateTestRequest();
         ExtensionRestResponse response = new ExtensionRestResponse(request, OK, OCTET_CONTENT_TYPE, testBytes);
 
         assertEquals(OK, response.status());
@@ -113,7 +168,7 @@ public class ExtensionRestResponseTests extends OpenSearchTestCase {
     }
 
     public void testConstructorWithBytesReference() {
-        ExtensionRestRequest request = generateTestRequest();
+        RestRequest request = generateTestRequest();
         ExtensionRestResponse response = new ExtensionRestResponse(
             request,
             OK,


### PR DESCRIPTION
Companion PRs (this one must be merged first of three):
 - SDK: https://github.com/opensearch-project/opensearch-sdk-java/pull/623
 - AD: https://github.com/opensearch-project/anomaly-detection/pull/848

### Description

Extensions do not use all the internal components of a `RestRequest` and initial implementation double-purposed the `ExtensionsRestRequest` object used in transport as the object that Extensions would need to handle.  However, increasing use of the methods on this object are ending up duplicating a lot of code.  It makes a lot more sense to just recreate a `RestRequest` object from the parameters passed in this request.

While this is marked api, it is only used behind feature-flagged code and will not break any BWC.

### Issues Resolved

Part of [SDK #431](https://github.com/opensearch-project/opensearch-sdk-java/issues/431).

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
