### PR TITLE
[Backport] [1.x] fix for updating version numbers for deprecation messages (#4719)

### DIFF
--- a/modules/ingest-user-agent/src/main/java/org/opensearch/ingest/useragent/UserAgentProcessor.java
+++ b/modules/ingest-user-agent/src/main/java/org/opensearch/ingest/useragent/UserAgentProcessor.java
@@ -346,7 +346,7 @@ public class UserAgentProcessor extends AbstractProcessor {
                 deprecationLogger.deprecate(
                     "ecs_false_non_common_schema",
                     "setting [ecs] to false for non-common schema "
-                        + "format is deprecated and will be removed in 8.0, set to true or remove to use the non-deprecated format"
+                        + "format is deprecated and will be removed in 3.0, set to true or remove to use the non-deprecated format"
                 );
             }
 

--- a/modules/ingest-user-agent/src/yamlRestTest/resources/rest-api-spec/test/ingest-useragent/20_useragent_processor.yml
+++ b/modules/ingest-user-agent/src/yamlRestTest/resources/rest-api-spec/test/ingest-useragent/20_useragent_processor.yml
@@ -87,7 +87,7 @@
 
   - do:
       allowed_warnings:
-        - "setting [ecs] to false for non-common schema format is deprecated and will be removed in 8.0, set to true or remove to use the non-deprecated format"
+        - "setting [ecs] to false for non-common schema format is deprecated and will be removed in 3.0, set to true or remove to use the non-deprecated format"
         - "the [os_major] property is deprecated for the user-agent processor"
       ingest.put_pipeline:
         id: "my_pipeline"

--- a/plugins/mapper-annotated-text/src/internalClusterTest/java/org/opensearch/index/mapper/annotatedtext/AnnotatedTextFieldMapperTests.java
+++ b/plugins/mapper-annotated-text/src/internalClusterTest/java/org/opensearch/index/mapper/annotatedtext/AnnotatedTextFieldMapperTests.java
@@ -99,7 +99,7 @@ public class AnnotatedTextFieldMapperTests extends MapperTestCase {
 
     @Override
     protected void assertParseMaximalWarnings() {
-        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 8.0");
+        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 3.0");
     }
 
     @Override

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/30_copy_settings.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/30_copy_settings.yml
@@ -49,7 +49,7 @@
             index.number_of_replicas: 0
             index.merge.scheduler.max_thread_count: 2
       allowed_warnings:
-        - "parameter [copy_settings] is deprecated and will be removed in 8.0.0"
+        - "parameter [copy_settings] is deprecated and will be removed in 3.0.0"
 
   - do:
       cluster.health:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/30_copy_settings.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/30_copy_settings.yml
@@ -51,8 +51,7 @@
             index.number_of_shards: 2
             index.merge.scheduler.max_thread_count: 2
       allowed_warnings:
-        - "parameter [copy_settings] is deprecated and will be removed in 8.0.0"
-
+        - "parameter [copy_settings] is deprecated and will be removed in 3.0.0"
 
   - do:
       cluster.health:

--- a/server/src/main/java/org/opensearch/index/mapper/ParametrizedFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ParametrizedFieldMapper.java
@@ -694,7 +694,7 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
                 if (Objects.equals("boost", propName)) {
                     deprecationLogger.deprecate(
                         "boost_" + name,
-                        "Parameter [boost] on field [{}] is deprecated and will be removed in 8.0",
+                        "Parameter [boost] on field [{}] is deprecated and will be removed in 3.0",
                         name
                     );
                 }

--- a/server/src/main/java/org/opensearch/index/mapper/TypeParsers.java
+++ b/server/src/main/java/org/opensearch/index/mapper/TypeParsers.java
@@ -150,7 +150,7 @@ public class TypeParsers {
                 builder.boost(nodeFloatValue(propNode));
                 deprecationLogger.deprecate(
                     "boost_" + name,
-                    "Parameter [boost] on field [{}] is deprecated and will be removed in 8.0",
+                    "Parameter [boost] on field [{}] is deprecated and will be removed in 3.0",
                     name
                 );
                 iterator.remove();

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestResizeHandler.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestResizeHandler.java
@@ -85,7 +85,7 @@ public abstract class RestResizeHandler extends BaseRestHandler {
             }
             deprecationLogger.deprecate(
                 "resize_deprecated_parameter",
-                "parameter [copy_settings] is deprecated and will be removed in 8.0.0"
+                "parameter [copy_settings] is deprecated and will be removed in 3.0.0"
             );
         }
         resizeRequest.setCopySettings(copySettings);

--- a/server/src/test/java/org/opensearch/index/mapper/BooleanFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/BooleanFieldMapperTests.java
@@ -62,7 +62,7 @@ public class BooleanFieldMapperTests extends MapperTestCase {
 
     @Override
     protected void assertParseMaximalWarnings() {
-        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 8.0");
+        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 3.0");
     }
 
     protected void registerParameters(ParameterChecker checker) throws IOException {

--- a/server/src/test/java/org/opensearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/DateFieldMapperTests.java
@@ -84,7 +84,7 @@ public class DateFieldMapperTests extends MapperTestCase {
 
     @Override
     protected void assertParseMaximalWarnings() {
-        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 8.0");
+        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 3.0");
     }
 
     public void testDefaults() throws Exception {

--- a/server/src/test/java/org/opensearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/KeywordFieldMapperTests.java
@@ -173,7 +173,7 @@ public class KeywordFieldMapperTests extends MapperTestCase {
 
     @Override
     protected void assertParseMaximalWarnings() {
-        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 8.0");
+        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 3.0");
     }
 
     protected void registerParameters(ParameterChecker checker) throws IOException {
@@ -309,7 +309,7 @@ public class KeywordFieldMapperTests extends MapperTestCase {
     public void testBoost() throws IOException {
         MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "keyword").field("boost", 2f)));
         assertThat(mapperService.fieldType("field").boost(), equalTo(2f));
-        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 8.0");
+        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 3.0");
     }
 
     public void testEnableNorms() throws IOException {

--- a/server/src/test/java/org/opensearch/index/mapper/RangeFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/RangeFieldMapperTests.java
@@ -97,7 +97,7 @@ public class RangeFieldMapperTests extends AbstractNumericFieldMapperTestCase {
 
     @Override
     protected void assertParseMaximalWarnings() {
-        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 8.0");
+        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 3.0");
     }
 
     protected void registerParameters(ParameterChecker checker) throws IOException {

--- a/server/src/test/java/org/opensearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/TextFieldMapperTests.java
@@ -102,7 +102,7 @@ public class TextFieldMapperTests extends MapperTestCase {
 
     @Override
     protected void assertParseMaximalWarnings() {
-        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 8.0");
+        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 3.0");
     }
 
     public final void testExistsQueryIndexDisabled() throws IOException {

--- a/server/src/test/java/org/opensearch/rest/action/admin/indices/RestResizeHandlerTests.java
+++ b/server/src/test/java/org/opensearch/rest/action/admin/indices/RestResizeHandlerTests.java
@@ -84,7 +84,7 @@ public class RestResizeHandlerTests extends OpenSearchTestCase {
             );
             assertThat(e, hasToString(containsString("parameter [copy_settings] can not be explicitly set to [false]")));
         } else {
-            String expectedWarning = "parameter [copy_settings] is deprecated and will be removed in 8.0.0";
+            String expectedWarning = "parameter [copy_settings] is deprecated and will be removed in 3.0.0";
             handler.prepareRequest(request, mock(NodeClient.class));
             if (("".equals(copySettings) || "true".equals(copySettings)) && !assertedWarnings.contains(expectedWarning)) {
                 assertWarnings(expectedWarning);

--- a/test/framework/src/main/java/org/opensearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/mapper/MapperTestCase.java
@@ -274,7 +274,7 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
         }));
         String type = typeName();
         String[] warnings = new String[] {
-            "Parameter [boost] on field [field] is deprecated and will be removed in 8.0",
+            "Parameter [boost] on field [field] is deprecated and will be removed in 3.0",
             "Parameter [boost] has no effect on type [" + type + "] and will be removed in future" };
         allowedWarnings(warnings);
     }


### PR DESCRIPTION
Backport 16797d658125a8c28ddf49413222f30675352dd6 from #4719 to `1.x`