### PR TITLE
Fixing SortField comparison to use equals instead of reference equality

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/260_sort_mixed.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/260_sort_mixed.yml
@@ -1,0 +1,71 @@
+"search across indices with mixed long and double numeric types":
+  - skip:
+      version: " - 2.6.99"
+      reason: relies on numeric sort optimization that landed in 2.7.0 only
+
+  - do:
+      indices.create:
+        index: test_1
+        body:
+          settings:
+            number_of_shards: "1"
+            number_of_replicas: "0"
+          mappings:
+            properties:
+              counter:
+                type: long
+
+  - do:
+      indices.create:
+        index: test_2
+        body:
+          settings:
+            number_of_shards: "1"
+            number_of_replicas: "0"
+          mappings:
+            properties:
+              counter:
+                type: double
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - index:
+              _index: test_1
+          - counter: 223372036854775800
+          - index:
+              _index: test_2
+          - counter: 1223372036854775800.23
+          - index:
+              _index: test_2
+          - counter: 184.4
+
+  - do:
+      search:
+        index: test_*
+        rest_total_hits_as_int: true
+        body:
+          sort: [{ counter: desc }]
+  - match: { hits.total: 3 }
+  - length: { hits.hits: 3 }
+  - match: { hits.hits.0._index: test_2 }
+  - match: { hits.hits.0._source.counter: 1223372036854775800.23 }
+  - match: { hits.hits.0.sort: [1223372036854775800.23] }
+  - match: { hits.hits.1._index: test_1 }
+  - match: { hits.hits.1._source.counter: 223372036854775800 }
+  - match: { hits.hits.1.sort: [223372036854775800] }
+
+  - do:
+      search:
+        index: test_*
+        rest_total_hits_as_int: true
+        body:
+          sort: [{ counter: asc }]
+  - match: { hits.total: 3 }
+  - length: { hits.hits: 3 }
+  - match: { hits.hits.0._index: test_2 }
+  - match: { hits.hits.0._source.counter: 184.4 }
+  - match: { hits.hits.0.sort: [184.4] }
+  - match: { hits.hits.1._index: test_1 }
+  - match: { hits.hits.1._source.counter: 223372036854775800 }
+  - match: { hits.hits.1.sort: [223372036854775800] }

--- a/server/src/main/java/org/opensearch/action/search/SearchPhaseController.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchPhaseController.java
@@ -635,7 +635,7 @@ public final class SearchPhaseController {
      */
     private static boolean isSortWideningRequired(TopFieldDocs[] topFieldDocs, int sortFieldindex) {
         for (int i = 0; i < topFieldDocs.length - 1; i++) {
-            if (topFieldDocs[i].fields[sortFieldindex] != topFieldDocs[i + 1].fields[sortFieldindex]) {
+            if (!topFieldDocs[i].fields[sortFieldindex].equals(topFieldDocs[i + 1].fields[sortFieldindex])) {
                 return true;
             }
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fixing SortField comparison to use equals instead of reference equality

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
