### PR TITLE
Fix testCacheFilesAreClosedAfterUse for Searchable Snapshots

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/SearchableSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/SearchableSnapshotIT.java
@@ -35,10 +35,15 @@ import org.opensearch.index.store.remote.filecache.FileCacheStats;
 import org.opensearch.monitor.fs.FsInfo;
 import org.opensearch.repositories.fs.FsRepository;
 
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
@@ -537,34 +542,68 @@ public final class SearchableSnapshotIT extends AbstractSnapshotIntegTestCase {
         assertAllNodesFileCacheEmpty();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/6888")
-    public void testCacheFilesAreClosedAfterUse() throws Exception {
-        final int numReplicasIndex = randomIntBetween(1, 4);
+    /**
+     * Test scenario that checks the cache folder location on search nodes for the restored index on snapshot restoration
+     * and ensures the index folder is cleared on all nodes post index deletion
+     */
+    public void testCacheIndexFilesClearedOnDelete() throws Exception {
+        final int numReplicas = randomIntBetween(1, 4);
+        final int numShards = numReplicas + 1;
         final String indexName = "test-idx";
         final String restoredIndexName = indexName + "-copy";
         final String repoName = "test-repo";
         final String snapshotName = "test-snap";
         final Client client = client();
 
-        internalCluster().ensureAtLeastNumSearchAndDataNodes(numReplicasIndex + 1);
-        createIndexWithDocsAndEnsureGreen(1, 100, indexName);
+        internalCluster().ensureAtLeastNumSearchAndDataNodes(numShards);
+        createIndexWithDocsAndEnsureGreen(numReplicas, 100, indexName);
         createRepositoryWithSettings(null, repoName);
         takeSnapshot(client, snapshotName, repoName, indexName);
         restoreSnapshotAndEnsureGreen(client, snapshotName, repoName);
         assertDocCount(restoredIndexName, 100L);
 
+        // The index count will be 1 since there is only a single restored index "test-idx-copy"
+        assertCacheDirectoryReplicaAndIndexCount(numShards, 1);
+
         // The local cache files should be closed by deleting the restored index
         deleteIndicesAndEnsureGreen(client, restoredIndexName);
 
         logger.info("--> validate cache file path is deleted");
-        // Get path of cache files
-        final NodeEnvironment nodeEnv = internalCluster().getInstance(NodeEnvironment.class);
-        Path fileCachePath = nodeEnv.fileCacheNodePath().fileCachePath;
+        // The index count will be 0 since the only restored index "test-idx-copy" was deleted
+        assertCacheDirectoryReplicaAndIndexCount(numShards, 0);
+        logger.info("--> validated that the cache file path doesn't exist");
+    }
 
-        if (Files.exists(fileCachePath)) {
-            fail("Cache file path isn't deleted.");
-        } else {
-            logger.info("--> validated that the cache file path doesn't exist");
+    /**
+     * Asserts the cache folder count to match the number of shards and the number of indices within the cache folder
+     * as provided.
+     * @param numCacheFolderCount total number of cache folders that should exist for the test case
+     * @param numIndexCount total number of index folder locations that should exist within the cache folder
+     */
+    private void assertCacheDirectoryReplicaAndIndexCount(int numCacheFolderCount, int numIndexCount) throws IOException {
+        // Get the available NodeEnvironment instances
+        Iterable<NodeEnvironment> nodeEnvironments = internalCluster().getInstances(NodeEnvironment.class);
+
+        // Filter out search NodeEnvironment(s) since FileCache is initialized only on search nodes and
+        // collect the path for all the cache locations on search nodes.
+        List<Path> searchNodeFileCachePaths = StreamSupport.stream(nodeEnvironments.spliterator(), false)
+            .filter(nodeEnv -> nodeEnv.fileCache() != null)
+            .map(nodeEnv -> nodeEnv.fileCacheNodePath().fileCachePath)
+            .collect(Collectors.toList());
+
+        // Walk through the cache directory on nodes
+        for (Path fileCachePath : searchNodeFileCachePaths) {
+            assertTrue(Files.exists(fileCachePath));
+            assertTrue(Files.isDirectory(fileCachePath));
+            try (DirectoryStream<Path> cachePathStream = Files.newDirectoryStream(fileCachePath)) {
+                Path nodeLockIdPath = cachePathStream.iterator().next();
+                assertTrue(Files.isDirectory(nodeLockIdPath));
+                try (Stream<Path> dataPathStream = Files.list(nodeLockIdPath)) {
+                    assertEquals(numIndexCount, dataPathStream.count());
+                }
+            }
         }
+        // Verifies if all the shards (primary and replica) have been deleted
+        assertEquals(numCacheFolderCount, searchNodeFileCachePaths.size());
     }
 }


### PR DESCRIPTION
### Description
- Fixes `testCacheFilesAreClosedAfterUse` to check all the `search` nodes for cache locations
- There are two checks - one which happens after restore and another which happens after deletions
- Ensures that the index exists on cache when restored and cache folder for the location is cleared when index is deleted

### Issues Resolved
- Resolves #6888 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
