### PR TITLE
Avoid negative memory result in IndicesQueryCache stats calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix 'org.apache.hc.core5.http.ParseException: Invalid protocol version' under JDK 16+ ([#4827](https://github.com/opensearch-project/OpenSearch/pull/4827))
 - Fix compression support for h2c protocol ([#4944](https://github.com/opensearch-project/OpenSearch/pull/4944))
 - Support OpenSSL Provider with default Netty allocator ([#5460](https://github.com/opensearch-project/OpenSearch/pull/5460))
+- Avoid negative memory result in IndicesQueryCache stats calculation ([#6917](https://github.com/opensearch-project/OpenSearch/pull/6917))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/indices/IndicesQueryCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesQueryCache.java
@@ -128,13 +128,17 @@ public class IndicesQueryCache implements QueryCache, Closeable {
 
         // We also have some shared ram usage that we try to distribute to
         // proportionally to their number of cache entries of each shard
-        long totalSize = 0;
-        for (QueryCacheStats s : stats.values()) {
-            totalSize += s.getCacheSize();
+        if (stats.isEmpty()) {
+            shardStats.add(new QueryCacheStats(sharedRamBytesUsed, 0, 0, 0, 0));
+        } else {
+            long totalSize = 0;
+            for (QueryCacheStats s : stats.values()) {
+                totalSize += s.getCacheSize();
+            }
+            final double weight = totalSize == 0 ? 1d / stats.size() : ((double) shardStats.getCacheSize()) / totalSize;
+            final long additionalRamBytesUsed = Math.round(weight * sharedRamBytesUsed);
+            shardStats.add(new QueryCacheStats(additionalRamBytesUsed, 0, 0, 0, 0));
         }
-        final double weight = totalSize == 0 ? 1d / stats.size() : ((double) shardStats.getCacheSize()) / totalSize;
-        final long additionalRamBytesUsed = Math.round(weight * sharedRamBytesUsed);
-        shardStats.add(new QueryCacheStats(additionalRamBytesUsed, 0, 0, 0, 0));
         return shardStats;
     }
 

--- a/server/src/test/java/org/opensearch/indices/IndicesQueryCacheTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndicesQueryCacheTests.java
@@ -192,7 +192,7 @@ public class IndicesQueryCacheTests extends OpenSearchTestCase {
         assertEquals(0L, stats.getCacheCount());
         assertEquals(0L, stats.getHitCount());
         assertEquals(0L, stats.getMissCount());
-        assertEquals(0L, stats.getMemorySizeInBytes());
+        assertTrue(stats.getMemorySizeInBytes() >= 0L);
 
         cache.close(); // this triggers some assertions
     }

--- a/server/src/test/java/org/opensearch/indices/IndicesQueryCacheTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndicesQueryCacheTests.java
@@ -152,7 +152,7 @@ public class IndicesQueryCacheTests extends OpenSearchTestCase {
         assertEquals(1L, stats.getCacheCount());
         assertEquals(0L, stats.getHitCount());
         assertEquals(1L, stats.getMissCount());
-        assertTrue(stats.getMemorySizeInBytes() >= 0L);
+        assertTrue(stats.getMemorySizeInBytes() > 0L && stats.getMemorySizeInBytes() < Long.MAX_VALUE);
 
         for (int i = 1; i < 20; ++i) {
             assertEquals(1, s.count(new DummyQuery(i)));
@@ -163,7 +163,7 @@ public class IndicesQueryCacheTests extends OpenSearchTestCase {
         assertEquals(20L, stats.getCacheCount());
         assertEquals(0L, stats.getHitCount());
         assertEquals(20L, stats.getMissCount());
-        assertTrue(stats.getMemorySizeInBytes() >= 0L);
+        assertTrue(stats.getMemorySizeInBytes() > 0L && stats.getMemorySizeInBytes() < Long.MAX_VALUE);
 
         s.count(new DummyQuery(10));
 
@@ -172,7 +172,7 @@ public class IndicesQueryCacheTests extends OpenSearchTestCase {
         assertEquals(20L, stats.getCacheCount());
         assertEquals(1L, stats.getHitCount());
         assertEquals(20L, stats.getMissCount());
-        assertTrue(stats.getMemorySizeInBytes() >= 0L);
+        assertTrue(stats.getMemorySizeInBytes() > 0L && stats.getMemorySizeInBytes() < Long.MAX_VALUE);
 
         IOUtils.close(r, dir);
 
@@ -182,7 +182,7 @@ public class IndicesQueryCacheTests extends OpenSearchTestCase {
         assertEquals(20L, stats.getCacheCount());
         assertEquals(1L, stats.getHitCount());
         assertEquals(20L, stats.getMissCount());
-        assertTrue(stats.getMemorySizeInBytes() >= 0L);
+        assertTrue(stats.getMemorySizeInBytes() > 0L && stats.getMemorySizeInBytes() < Long.MAX_VALUE);
 
         cache.onClose(shard);
 
@@ -192,7 +192,7 @@ public class IndicesQueryCacheTests extends OpenSearchTestCase {
         assertEquals(0L, stats.getCacheCount());
         assertEquals(0L, stats.getHitCount());
         assertEquals(0L, stats.getMissCount());
-        assertTrue(stats.getMemorySizeInBytes() >= 0L);
+        assertTrue(stats.getMemorySizeInBytes() >= 0L && stats.getMemorySizeInBytes() < Long.MAX_VALUE);
 
         cache.close(); // this triggers some assertions
     }
@@ -233,12 +233,14 @@ public class IndicesQueryCacheTests extends OpenSearchTestCase {
         assertEquals(1L, stats1.getCacheCount());
         assertEquals(0L, stats1.getHitCount());
         assertEquals(1L, stats1.getMissCount());
+        assertTrue(stats1.getMemorySizeInBytes() >= 0L && stats1.getMemorySizeInBytes() < Long.MAX_VALUE);
 
         QueryCacheStats stats2 = cache.getStats(shard2);
         assertEquals(0L, stats2.getCacheSize());
         assertEquals(0L, stats2.getCacheCount());
         assertEquals(0L, stats2.getHitCount());
         assertEquals(0L, stats2.getMissCount());
+        assertTrue(stats2.getMemorySizeInBytes() >= 0L && stats2.getMemorySizeInBytes() < Long.MAX_VALUE);
 
         assertEquals(1, s2.count(new DummyQuery(0)));
 
@@ -247,12 +249,14 @@ public class IndicesQueryCacheTests extends OpenSearchTestCase {
         assertEquals(1L, stats1.getCacheCount());
         assertEquals(0L, stats1.getHitCount());
         assertEquals(1L, stats1.getMissCount());
+        assertTrue(stats1.getMemorySizeInBytes() >= 0L && stats1.getMemorySizeInBytes() < Long.MAX_VALUE);
 
         stats2 = cache.getStats(shard2);
         assertEquals(1L, stats2.getCacheSize());
         assertEquals(1L, stats2.getCacheCount());
         assertEquals(0L, stats2.getHitCount());
         assertEquals(1L, stats2.getMissCount());
+        assertTrue(stats2.getMemorySizeInBytes() >= 0L && stats2.getMemorySizeInBytes() < Long.MAX_VALUE);
 
         for (int i = 0; i < 20; ++i) {
             assertEquals(1, s2.count(new DummyQuery(i)));
@@ -263,12 +267,14 @@ public class IndicesQueryCacheTests extends OpenSearchTestCase {
         assertEquals(1L, stats1.getCacheCount());
         assertEquals(0L, stats1.getHitCount());
         assertEquals(1L, stats1.getMissCount());
+        assertTrue(stats1.getMemorySizeInBytes() >= 0L && stats1.getMemorySizeInBytes() < Long.MAX_VALUE);
 
         stats2 = cache.getStats(shard2);
         assertEquals(10L, stats2.getCacheSize());
         assertEquals(20L, stats2.getCacheCount());
         assertEquals(1L, stats2.getHitCount());
         assertEquals(20L, stats2.getMissCount());
+        assertTrue(stats2.getMemorySizeInBytes() >= 0L && stats2.getMemorySizeInBytes() < Long.MAX_VALUE);
 
         IOUtils.close(r1, dir1);
 
@@ -278,12 +284,14 @@ public class IndicesQueryCacheTests extends OpenSearchTestCase {
         assertEquals(1L, stats1.getCacheCount());
         assertEquals(0L, stats1.getHitCount());
         assertEquals(1L, stats1.getMissCount());
+        assertTrue(stats1.getMemorySizeInBytes() >= 0L && stats1.getMemorySizeInBytes() < Long.MAX_VALUE);
 
         stats2 = cache.getStats(shard2);
         assertEquals(10L, stats2.getCacheSize());
         assertEquals(20L, stats2.getCacheCount());
         assertEquals(1L, stats2.getHitCount());
         assertEquals(20L, stats2.getMissCount());
+        assertTrue(stats2.getMemorySizeInBytes() >= 0L && stats2.getMemorySizeInBytes() < Long.MAX_VALUE);
 
         cache.onClose(shard1);
 
@@ -293,12 +301,14 @@ public class IndicesQueryCacheTests extends OpenSearchTestCase {
         assertEquals(0L, stats1.getCacheCount());
         assertEquals(0L, stats1.getHitCount());
         assertEquals(0L, stats1.getMissCount());
+        assertTrue(stats1.getMemorySizeInBytes() >= 0L && stats1.getMemorySizeInBytes() < Long.MAX_VALUE);
 
         stats2 = cache.getStats(shard2);
         assertEquals(10L, stats2.getCacheSize());
         assertEquals(20L, stats2.getCacheCount());
         assertEquals(1L, stats2.getHitCount());
         assertEquals(20L, stats2.getMissCount());
+        assertTrue(stats2.getMemorySizeInBytes() >= 0L && stats2.getMemorySizeInBytes() < Long.MAX_VALUE);
 
         IOUtils.close(r2, dir2);
         cache.onClose(shard2);
@@ -309,12 +319,14 @@ public class IndicesQueryCacheTests extends OpenSearchTestCase {
         assertEquals(0L, stats1.getCacheCount());
         assertEquals(0L, stats1.getHitCount());
         assertEquals(0L, stats1.getMissCount());
+        assertTrue(stats1.getMemorySizeInBytes() >= 0L && stats1.getMemorySizeInBytes() < Long.MAX_VALUE);
 
         stats2 = cache.getStats(shard2);
         assertEquals(0L, stats2.getCacheSize());
         assertEquals(0L, stats2.getCacheCount());
         assertEquals(0L, stats2.getHitCount());
         assertEquals(0L, stats2.getMissCount());
+        assertTrue(stats2.getMemorySizeInBytes() >= 0L && stats2.getMemorySizeInBytes() < Long.MAX_VALUE);
 
         cache.close(); // this triggers some assertions
     }

--- a/server/src/test/java/org/opensearch/indices/IndicesQueryCacheTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndicesQueryCacheTests.java
@@ -143,6 +143,7 @@ public class IndicesQueryCacheTests extends OpenSearchTestCase {
         assertEquals(0L, stats.getCacheCount());
         assertEquals(0L, stats.getHitCount());
         assertEquals(0L, stats.getMissCount());
+        assertEquals(0L, stats.getMemorySizeInBytes());
 
         assertEquals(1, s.count(new DummyQuery(0)));
 
@@ -151,6 +152,7 @@ public class IndicesQueryCacheTests extends OpenSearchTestCase {
         assertEquals(1L, stats.getCacheCount());
         assertEquals(0L, stats.getHitCount());
         assertEquals(1L, stats.getMissCount());
+        assertTrue(stats.getMemorySizeInBytes() >= 0L);
 
         for (int i = 1; i < 20; ++i) {
             assertEquals(1, s.count(new DummyQuery(i)));
@@ -161,6 +163,7 @@ public class IndicesQueryCacheTests extends OpenSearchTestCase {
         assertEquals(20L, stats.getCacheCount());
         assertEquals(0L, stats.getHitCount());
         assertEquals(20L, stats.getMissCount());
+        assertTrue(stats.getMemorySizeInBytes() >= 0L);
 
         s.count(new DummyQuery(10));
 
@@ -169,6 +172,7 @@ public class IndicesQueryCacheTests extends OpenSearchTestCase {
         assertEquals(20L, stats.getCacheCount());
         assertEquals(1L, stats.getHitCount());
         assertEquals(20L, stats.getMissCount());
+        assertTrue(stats.getMemorySizeInBytes() >= 0L);
 
         IOUtils.close(r, dir);
 
@@ -178,6 +182,7 @@ public class IndicesQueryCacheTests extends OpenSearchTestCase {
         assertEquals(20L, stats.getCacheCount());
         assertEquals(1L, stats.getHitCount());
         assertEquals(20L, stats.getMissCount());
+        assertTrue(stats.getMemorySizeInBytes() >= 0L);
 
         cache.onClose(shard);
 
@@ -187,6 +192,7 @@ public class IndicesQueryCacheTests extends OpenSearchTestCase {
         assertEquals(0L, stats.getCacheCount());
         assertEquals(0L, stats.getHitCount());
         assertEquals(0L, stats.getMissCount());
+        assertEquals(0L, stats.getMemorySizeInBytes());
 
         cache.close(); // this triggers some assertions
     }


### PR DESCRIPTION
### Description

In the edge case where shardStats is an empty map (caused by removing the last document from an index through a means other than clearing the index), the stats map is also empty. However this case also leads to divide-by-zero calculation which gives a weight of `Double.POSITIVE_INFINITY`.  This rounds to `Long.MAX_VALUE` for additionalRamBytesUsed for the shard.

Then later in calculating total memory, the max long value is added to other fields, resulting in overflow.

### Issues Resolved

Fixes #4474

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
