### PR TITLE
[Backport] [1.3] fix for updating version numbers for deprecation messages (SyncedFlushService)

### DIFF
--- a/server/src/main/java/org/opensearch/indices/flush/SyncedFlushService.java
+++ b/server/src/main/java/org/opensearch/indices/flush/SyncedFlushService.java
@@ -96,7 +96,7 @@ public class SyncedFlushService implements IndexEventListener {
     private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(logger.getName());
 
     public static final String SYNCED_FLUSH_DEPRECATION_MESSAGE =
-        "Synced flush is deprecated and will be removed in 8.0. Use flush at _/flush or /{index}/_flush instead.";
+        "Synced flush is deprecated and will be removed in 3.0. Use flush at _/flush or /{index}/_flush instead.";
 
     private static final String PRE_SYNCED_FLUSH_ACTION_NAME = "internal:indices/flush/synced/pre";
     private static final String SYNCED_FLUSH_ACTION_NAME = "internal:indices/flush/synced/sync";


### PR DESCRIPTION
Followup on 35e6389be49654fed8acb09af51f68b51d889f55 since `SyncedFlushService` was removed in `2.x` and later