### PR TITLE
[Backport] [1.3] fix for updating version numbers for deprecation messages (tests)

### DIFF
--- a/client/rest-high-level/src/test/java/org/opensearch/client/documentation/IndicesClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/documentation/IndicesClientDocumentationIT.java
@@ -1033,7 +1033,7 @@ public class IndicesClientDocumentationIT extends OpenSearchRestHighLevelClientT
 
             // tag::flush-synced-execute
             SyncedFlushResponse flushSyncedResponse = client.indices().flushSynced(request, expectWarnings(
-                "Synced flush is deprecated and will be removed in 8.0. Use flush at _/flush or /{index}/_flush instead."
+                "Synced flush is deprecated and will be removed in 3.0. Use flush at _/flush or /{index}/_flush instead."
             ));
             // end::flush-synced-execute
 
@@ -1079,7 +1079,7 @@ public class IndicesClientDocumentationIT extends OpenSearchRestHighLevelClientT
 
             // tag::flush-synced-execute-async
             client.indices().flushSyncedAsync(request, expectWarnings(
-                "Synced flush is deprecated and will be removed in 8.0. Use flush at _/flush or /{index}/_flush instead."
+                "Synced flush is deprecated and will be removed in 3.0. Use flush at _/flush or /{index}/_flush instead."
             ), listener); // <1>
             // end::flush-synced-execute-async
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.flush/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.flush/10_basic.yml
@@ -17,7 +17,7 @@
         wait_for_status: green
   - do:
       allowed_warnings:
-        - Synced flush is deprecated and will be removed in 8.0. Use flush at _/flush or /{index}/_flush instead.
+        - Synced flush is deprecated and will be removed in 3.0. Use flush at _/flush or /{index}/_flush instead.
       indices.flush_synced:
         index: testing
 


### PR DESCRIPTION
Missed that Gradle check was unstable, fixing tests for https://github.com/opensearch-project/OpenSearch/pull/6918