### PR TITLE
Include all file cache access in privileged section

### DIFF
--- a/server/src/test/java/org/opensearch/index/store/remote/utils/TransferManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/utils/TransferManagerTests.java
@@ -10,7 +10,6 @@ package org.opensearch.index.store.remote.utils;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -158,7 +157,7 @@ public class TransferManagerTests extends OpenSearchTestCase {
     public void testDownloadFails() throws Exception {
         doThrow(new IOException("Expected test exception")).when(blobContainer).readBlob(eq("failure-blob"), anyLong(), anyLong());
         expectThrows(
-            UncheckedIOException.class,
+            IOException.class,
             () -> transferManager.fetchBlob(
                 BlobFetchRequest.builder()
                     .blobName("failure-blob")


### PR DESCRIPTION
This expands on #6914 a bit to include the full cache access. Adding an entry to the cache can result in an eviction, and the subsequent file deletion needs the elevated permissions as well.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
