### PR TITLE
Fix sort in case of different numeric field types between indices

### DIFF
--- a/server/src/main/java/org/opensearch/action/search/SearchPhaseController.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchPhaseController.java
@@ -615,14 +615,13 @@ public final class SearchPhaseController {
         final SortField[] newFields = new SortField[firstTopDocFields.length];
 
         for (int i = 0; i < firstTopDocFields.length; i++) {
-            if (firstTopDocFields[i] instanceof SortedNumericSortField && isSortWideningRequired(topFieldDocs, i)) {
-                final SortedNumericSortField delegate = (SortedNumericSortField) firstTopDocFields[i];
-                newFields[i] = new SortedWiderNumericSortField(
-                    delegate.getField(),
-                    delegate.getNumericType(),
-                    delegate.getReverse(),
-                    delegate.getSelector()
-                );
+            final SortField delegate = firstTopDocFields[i];
+            final SortField.Type type = delegate instanceof SortedNumericSortField
+                ? ((SortedNumericSortField) delegate).getNumericType()
+                : delegate.getType();
+
+            if (SortedWiderNumericSortField.isTypeSupported(type) && isSortWideningRequired(topFieldDocs, i)) {
+                newFields[i] = new SortedWiderNumericSortField(delegate.getField(), type, delegate.getReverse());
             } else {
                 newFields[i] = firstTopDocFields[i];
             }

--- a/server/src/main/java/org/opensearch/search/sort/SortedWiderNumericSortField.java
+++ b/server/src/main/java/org/opensearch/search/sort/SortedWiderNumericSortField.java
@@ -16,8 +16,7 @@ package org.opensearch.search.sort;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.FieldComparator;
 import org.apache.lucene.search.LeafFieldComparator;
-import org.apache.lucene.search.SortedNumericSelector;
-import org.apache.lucene.search.SortedNumericSortField;
+import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.comparators.NumericComparator;
 
 import java.io.IOException;
@@ -28,7 +27,7 @@ import java.io.IOException;
  *
  * @opensearch.internal
  */
-public class SortedWiderNumericSortField extends SortedNumericSortField {
+public class SortedWiderNumericSortField extends SortField {
     /**
      * Creates a sort, possibly in reverse, specifying how the sort value from the document's set is
      * selected.
@@ -36,10 +35,9 @@ public class SortedWiderNumericSortField extends SortedNumericSortField {
      * @param field    Name of field to sort by. Must not be null.
      * @param type     Type of values
      * @param reverse  True if natural order should be reversed.
-     * @param selector custom selector type for choosing the sort value from the set.
      */
-    public SortedWiderNumericSortField(String field, Type type, boolean reverse, SortedNumericSelector.Type selector) {
-        super(field, type, reverse, selector);
+    public SortedWiderNumericSortField(String field, Type type, boolean reverse) {
+        super(field, type, reverse);
     }
 
     /**
@@ -83,5 +81,24 @@ public class SortedWiderNumericSortField extends SortedNumericSortField {
                 }
             }
         };
+    }
+
+    /**
+     * The only below types would be considered for widening during merging topDocs results for sort,
+     * This will support indices having different Numeric types to be sorted together.
+     * @param type
+     * @return
+     */
+    public static boolean isTypeSupported(Type type) {
+        // Only below 4 numeric types supported as of now for widened merge
+        switch (type) {
+            case INT:
+            case LONG:
+            case FLOAT:
+            case DOUBLE:
+                return true;
+            default:
+                return false;
+        }
     }
 }

--- a/server/src/main/java/org/opensearch/search/sort/SortedWiderNumericSortField.java
+++ b/server/src/main/java/org/opensearch/search/sort/SortedWiderNumericSortField.java
@@ -86,8 +86,8 @@ public class SortedWiderNumericSortField extends SortField {
     /**
      * The only below types would be considered for widening during merging topDocs results for sort,
      * This will support indices having different Numeric types to be sorted together.
-     * @param type
-     * @return
+     * @param type SortField.Type
+     * @return returns true if type is supported for widened numeric comparisons
      */
     public static boolean isTypeSupported(Type type) {
         // Only below 4 numeric types supported as of now for widened merge

--- a/server/src/main/java/org/opensearch/search/sort/SortedWiderNumericSortField.java
+++ b/server/src/main/java/org/opensearch/search/sort/SortedWiderNumericSortField.java
@@ -16,7 +16,7 @@ package org.opensearch.search.sort;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.FieldComparator;
 import org.apache.lucene.search.LeafFieldComparator;
-import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.SortedNumericSortField;
 import org.apache.lucene.search.comparators.NumericComparator;
 
 import java.io.IOException;
@@ -27,7 +27,7 @@ import java.io.IOException;
  *
  * @opensearch.internal
  */
-public class SortedWiderNumericSortField extends SortField {
+public class SortedWiderNumericSortField extends SortedNumericSortField {
     /**
      * Creates a sort, possibly in reverse, specifying how the sort value from the document's set is
      * selected.


### PR DESCRIPTION
### Description
There was a regression after merging #6424. Basically, we lost ability to merge different numeric types sort results.
i.e. if Index-1 has field mapping Int, but Index-2 has field mapping Long, earlier it was supported to sort across these two indices. That's the exact problem we tried to solve in #6424, but that worked only on single node cluster. For multi node clusters, since SortedNumericSortField is getting serialized as SortField only, while merging results from different shards, we are not able to determine correctly if wider numeric type should be applied or not.
This PR fixes that.

This issue is caught by @reta while adding integ tests for this scenario #6901 . Huge thanks to reta for it.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
