### PR TITLE
Don't register destructiveDistroTest.docker twice

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/test/DistroTestPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/test/DistroTestPlugin.java
@@ -119,8 +119,8 @@ public class DistroTestPlugin implements Plugin<Project> {
             TaskProvider<?> depsTask = project.getTasks().register(taskname + "#deps");
             depsTask.configure(t -> t.dependsOn(distribution, examplePlugin));
             depsTasks.put(taskname, depsTask);
-            // TODO - suppressing failure temporarily where duplicate tasks are created for docker.
-            try {
+            // Avoid duplicate tasks such as docker registered in lifecycleTasks
+            if (project.getTasksByName(taskname, false).isEmpty()) {
                 TaskProvider<Test> destructiveTask = configureTestTask(project, taskname, distribution, t -> {
                     t.onlyIf(t2 -> distribution.isDocker() == false || dockerSupport.get().getDockerAvailability().isAvailable);
                     addSysprop(t, DISTRIBUTION_SYSPROP, distribution::getFilepath);
@@ -134,8 +134,6 @@ public class DistroTestPlugin implements Plugin<Project> {
                 }
                 destructiveDistroTest.configure(t -> t.dependsOn(destructiveTask));
                 lifecycleTasks.get(distribution.getType()).configure(t -> t.dependsOn(destructiveTask));
-            } catch (Exception ex) {
-                System.out.println(ex.getMessage());
             }
 
             if ((distribution.getType() == OpenSearchDistribution.Type.DEB || distribution.getType() == OpenSearchDistribution.Type.RPM)


### PR DESCRIPTION
### Description

The `destructiveDistroTest.docker` task was already registered here:
https://github.com/opensearch-project/OpenSearch/blob/c85d33e2e487242eb5ad60b64567ca2ec14fc88f/buildSrc/src/main/java/org/opensearch/gradle/test/DistroTestPlugin.java#L245

Which is called here:
https://github.com/opensearch-project/OpenSearch/blob/c85d33e2e487242eb5ad60b64567ca2ec14fc88f/buildSrc/src/main/java/org/opensearch/gradle/test/DistroTestPlugin.java#L107

Which causes duplicate registration here:
https://github.com/opensearch-project/OpenSearch/blob/c85d33e2e487242eb5ad60b64567ca2ec14fc88f/buildSrc/src/main/java/org/opensearch/gradle/test/DistroTestPlugin.java#L124

This fixes the `TODO` by adding a test whether a task is already registered in place of the exception catch/warning.

### Issues Resolved

Fixes #1640 (you're welcome).

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
