### PR TITLE
Validate checksum in footer separately for segment metadata files

### DIFF
--- a/server/src/main/java/org/opensearch/common/io/VersionedCodecStreamWrapper.java
+++ b/server/src/main/java/org/opensearch/common/io/VersionedCodecStreamWrapper.java
@@ -11,7 +11,6 @@ package org.opensearch.common.io;
 import java.io.IOException;
 
 import org.apache.lucene.codecs.CodecUtil;
-import org.apache.lucene.store.BufferedChecksumIndexInput;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
@@ -47,10 +46,9 @@ public class VersionedCodecStreamWrapper<T> {
      * @return stream content parsed into {@link T}
      */
     public T readStream(IndexInput indexInput) throws IOException {
-        ChecksumIndexInput checksumIndexInput = new BufferedChecksumIndexInput(indexInput);
-        int readStreamVersion = checkHeader(checksumIndexInput);
-        T content = getHandlerForVersion(readStreamVersion).readContent(checksumIndexInput);
-        checkFooter(checksumIndexInput);
+        CodecUtil.checksumEntireFile(indexInput);
+        int readStreamVersion = checkHeader(indexInput);
+        T content = getHandlerForVersion(readStreamVersion).readContent(indexInput);
         return content;
     }
 

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -17,6 +17,7 @@ import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.opensearch.common.UUIDs;
+import org.opensearch.common.lucene.store.ByteArrayIndexInput;
 import org.opensearch.index.store.remote.metadata.RemoteSegmentMetadata;
 import org.opensearch.common.io.VersionedCodecStreamWrapper;
 import org.opensearch.index.store.remote.metadata.RemoteSegmentMetadataHandler;
@@ -135,7 +136,9 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory {
 
     private Map<String, UploadedSegmentMetadata> readMetadataFile(String metadataFilename) throws IOException {
         try (IndexInput indexInput = remoteMetadataDirectory.openInput(metadataFilename, IOContext.DEFAULT)) {
-            RemoteSegmentMetadata metadata = metadataStreamWrapper.readStream(indexInput);
+            byte[] metadataBytes = new byte[(int) indexInput.length()];
+            indexInput.readBytes(metadataBytes, 0, (int) indexInput.length());
+            RemoteSegmentMetadata metadata = metadataStreamWrapper.readStream(new ByteArrayIndexInput(metadataFilename, metadataBytes));
             return metadata.getMetadata();
         }
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
While reading segment metadata files, we validate header and footer. Currently, reading the footer was failing intermittently. We are reading the footer separately now to avoid issues. 

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/6824

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
