### PR TITLE
Upgrade test fixture Ubunutu from 14.04 to 18.04

### DIFF
--- a/test/fixtures/krb5kdc-fixture/Dockerfile
+++ b/test/fixtures/krb5kdc-fixture/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 RUN apt update -y
 RUN apt upgrade -y
 ADD . /fixture


### PR DESCRIPTION

### Description
- Upgrades Ubuntu for test fixture `krb5kdc-fixture` from 14.04 to 18.04
- The change worked successfully for a local docker build post upgrade
```
Successfully built a861bf2dc4b0
'<unknown> Dockerfile: test/fixtures/krb5kdc-fixture/Dockerfile' has been deployed successfully.
```

### Issues Resolved
- Helps moving https://github.com/opensearch-project/opensearch-build/issues/3358 forward

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
