### PR TITLE
feat: allow overwrite opensearch home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Change http code on create index API with bad input raising NotXContentException from 500 to 400 ([#4773](https://github.com/opensearch-project/OpenSearch/pull/4773))
 - Change http code for DecommissioningFailedException from 500 to 400 ([#5283](https://github.com/opensearch-project/OpenSearch/pull/5283))
 - Improve summary error message for invalid setting updates ([#4792](https://github.com/opensearch-project/OpenSearch/pull/4792))
+- Changed `opensearch-env` to respect already set `OPENSEARCH_HOME` environment variable ([#6956](https://github.com/opensearch-project/OpenSearch/pull/6956/))
 
 ### Deprecated
 

--- a/distribution/src/bin/opensearch-env
+++ b/distribution/src/bin/opensearch-env
@@ -28,18 +28,20 @@ while [ -h "$SCRIPT" ] ; do
   fi
 done
 
-# determine OpenSearch home; to do this, we strip from the path until we find
-# bin, and then strip bin (there is an assumption here that there is no nested
-# directory under bin also named bin)
-OPENSEARCH_HOME=`dirname "$SCRIPT"`
+if [[ -z "$OPENSEARCH_HOME" ]]; then
+  # determine OpenSearch home; to do this, we strip from the path until we find
+  # bin, and then strip bin (there is an assumption here that there is no nested
+  # directory under bin also named bin)
+  OPENSEARCH_HOME=`dirname "$SCRIPT"`
 
-# now make OPENSEARCH_HOME absolute
-OPENSEARCH_HOME=`cd "$OPENSEARCH_HOME"; pwd`
+  # now make OPENSEARCH_HOME absolute
+  OPENSEARCH_HOME=`cd "$OPENSEARCH_HOME"; pwd`
 
-while [ "`basename "$OPENSEARCH_HOME"`" != "bin" ]; do
+  while [ "`basename "$OPENSEARCH_HOME"`" != "bin" ]; do
+    OPENSEARCH_HOME=`dirname "$OPENSEARCH_HOME"`
+  done
   OPENSEARCH_HOME=`dirname "$OPENSEARCH_HOME"`
-done
-OPENSEARCH_HOME=`dirname "$OPENSEARCH_HOME"`
+fi
 
 # now set the classpath
 OPENSEARCH_CLASSPATH="$OPENSEARCH_HOME/lib/*"

--- a/distribution/src/bin/opensearch-env.bat
+++ b/distribution/src/bin/opensearch-env.bat
@@ -3,15 +3,17 @@ set SCRIPT=%0
 rem determine OpenSearch home; to do this, we strip from the path until we
 rem find bin, and then strip bin (there is an assumption here that there is no
 rem nested directory under bin also named bin)
-for %%I in (%SCRIPT%) do set OPENSEARCH_HOME=%%~dpI
+if not defined OPENSEARCH_HOME (
+  for %%I in (%SCRIPT%) do set OPENSEARCH_HOME=%%~dpI
 
-:opensearch_home_loop
-for %%I in ("%OPENSEARCH_HOME:~1,-1%") do set DIRNAME=%%~nxI
-if not "%DIRNAME%" == "bin" (
+  :opensearch_home_loop
+  for %%I in ("%OPENSEARCH_HOME:~1,-1%") do set DIRNAME=%%~nxI
+  if not "%DIRNAME%" == "bin" (
+    for %%I in ("%OPENSEARCH_HOME%..") do set OPENSEARCH_HOME=%%~dpfI
+    goto opensearch_home_loop
+  )
   for %%I in ("%OPENSEARCH_HOME%..") do set OPENSEARCH_HOME=%%~dpfI
-  goto opensearch_home_loop
 )
-for %%I in ("%OPENSEARCH_HOME%..") do set OPENSEARCH_HOME=%%~dpfI
 
 rem now set the classpath
 set OPENSEARCH_CLASSPATH=!OPENSEARCH_HOME!\lib\*


### PR DESCRIPTION
### Description
Right now it is not possible to set a fixed OPENSEARCH_HOME directory.

This is required for Nix packaging as the OpenSearch files lives inside the nix store (/nix/store/random-string-opensearch/bin/opensearch). [Therefore we needed to patch this to allow us to set a custom directory.](https://github.com/NixOS/nixpkgs/blob/master/pkgs/servers/search/opensearch/opensearch-home-fix.patch) 

If you need maybe more background to understand we setup a own empty Opensearch home and symlink required files: https://github.com/NixOS/nixpkgs/blob/fc46a9d1e2b30321a2497e413eb1562c9cfda5b6/nixos/modules/services/search/opensearch.nix#L185-L217


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
