### PR TITLE
[Remote Store] Support to emit multiple streams for a file content each responsible for processing a specific part of the file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Remove 'cluster_manager' role attachment when using 'node.master' deprecated setting ([#6331](https://github.com/opensearch-project/OpenSearch/pull/6331))
 - Add new cluster settings to ignore weighted round-robin routing and fallback to default behaviour. ([#6834](https://github.com/opensearch-project/OpenSearch/pull/6834))
 - Add experimental support for ZSTD compression. ([#3577](https://github.com/opensearch-project/OpenSearch/pull/3577))
+- [Remote Store] Support to emit multiple streams for a file content each responsible for processing a specific part of the file ([#6977](https://github.com/opensearch-project/OpenSearch/pull/6977))
 
 ### Dependencies
 - Bump `org.apache.logging.log4j:log4j-core` from 2.18.0 to 2.20.0 ([#6490](https://github.com/opensearch-project/OpenSearch/pull/6490))

--- a/server/src/main/java/org/opensearch/common/Stream.java
+++ b/server/src/main/java/org/opensearch/common/Stream.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common;
+
+import java.io.InputStream;
+
+/**
+ * Model composed of an input stream, the total content length and offset
+ */
+public class Stream {
+
+    private final InputStream inputStream;
+    private final long contentLength;
+    private final long offset;
+
+    /**
+     * Construct a new stream object
+     *
+     * @param inputStream The input stream that is to be encapsulated
+     * @param contentLength The total content length that is to be read from the stream
+     * @param offset The offset pointer that this stream reads from in the file
+     */
+    public Stream(InputStream inputStream, long contentLength, long offset) {
+        this.inputStream = inputStream;
+        this.contentLength = contentLength;
+        this.offset = offset;
+    }
+
+    /**
+     * @return The input stream this object is reading from
+     */
+    public InputStream getInputStream() {
+        return inputStream;
+    }
+
+    /**
+     * @return The total length of the content that has to be read from this stream
+     */
+    public long getContentLength() {
+        return contentLength;
+    }
+
+    /**
+     * @return The offset pointer in the file that this stream is reading from
+     */
+    public long getOffset() {
+        return offset;
+    }
+}

--- a/server/src/main/java/org/opensearch/common/StreamProvider.java
+++ b/server/src/main/java/org/opensearch/common/StreamProvider.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common;
+
+import java.io.IOException;
+
+/**
+ * StreamProvider is used to supply streams to vendor plugins using <code>StreamProvider#provideStream</code>
+ */
+public class StreamProvider {
+
+    private final TransferPartStreamSupplier streamSupplier;
+    private final long partSize;
+    private final long lastPartSize;
+    private final int numOfParts;
+
+    /**
+     * Construct a new StreamProvider object
+     *
+     * @param streamSupplier An implementation of TransferPartStreamSupplier which will be called when provideStreams is called
+     * @param partSize Size of all parts apart from the last one
+     * @param lastPartSize Size of the last part
+     * @param numOfParts Total number of parts
+     */
+    public StreamProvider(TransferPartStreamSupplier streamSupplier, long partSize, long lastPartSize, int numOfParts) {
+        this.streamSupplier = streamSupplier;
+        this.partSize = partSize;
+        this.lastPartSize = lastPartSize;
+        this.numOfParts = numOfParts;
+    }
+
+    /**
+     * @param partNumber The index of the part
+     * @return A stream reference to the part requested
+     */
+    public Stream provideStream(int partNumber) throws IOException {
+        long position = partSize * partNumber;
+        long size = (partNumber == numOfParts - 1) ? lastPartSize : partSize;
+        return streamSupplier.supply(partNumber, size, position);
+    }
+}

--- a/server/src/main/java/org/opensearch/common/TransferPartStreamSupplier.java
+++ b/server/src/main/java/org/opensearch/common/TransferPartStreamSupplier.java
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common;
+
+import java.io.IOException;
+
+/**
+ * TransferPartStreamSupplier is used to supply streams to specific parts of a file based on
+ * the partNo, size and position (the offset in the file)
+ */
+public interface TransferPartStreamSupplier {
+    Stream supply(int partNo, long size, long position) throws IOException;
+}

--- a/server/src/main/java/org/opensearch/common/blobstore/stream/StreamContext.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/stream/StreamContext.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.blobstore.stream;
+
+import org.opensearch.common.StreamProvider;
+
+/**
+ * StreamContext encapsulates all the data required for uploading multiple streams
+ */
+public class StreamContext {
+
+    private final StreamProvider streamProvider;
+    private final int numberOfParts;
+
+    /**
+     * Construct a new StreamContext object
+     *
+     * @param streamProvider A stream provider to provide a stream for a given part number.
+     * @param numberOfParts Number of parts of the content referenced by equivalent number of streams.
+     */
+    public StreamContext(StreamProvider streamProvider, int numberOfParts) {
+        this.streamProvider = streamProvider;
+        this.numberOfParts = numberOfParts;
+    }
+
+    /**
+     * @return The stream iterable for the current upload
+     */
+    public StreamProvider getStreamProvider() {
+        return streamProvider;
+    }
+
+    /**
+     * @return The number of parts in current upload
+     */
+    public int getNumberOfParts() {
+        return numberOfParts;
+    }
+}

--- a/server/src/main/java/org/opensearch/common/blobstore/stream/package-info.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/stream/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/** Abstractions for stream based file transfers */
+package org.opensearch.common.blobstore.stream;

--- a/server/src/main/java/org/opensearch/common/blobstore/stream/write/StreamContextSupplier.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/stream/write/StreamContextSupplier.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.blobstore.stream.write;
+
+import org.opensearch.common.blobstore.stream.StreamContext;
+
+/**
+ * Will return the <code>StreamContext</code> to the caller given the part size
+ */
+public interface StreamContextSupplier {
+
+    /**
+     * @param partSize The size of a single part to be uploaded
+     * @return The <code>StreamContext</code> based on the part size provided
+     */
+    StreamContext supplyStreamContext(long partSize);
+}

--- a/server/src/main/java/org/opensearch/common/blobstore/stream/write/WriteContext.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/stream/write/WriteContext.java
@@ -1,0 +1,90 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.blobstore.stream.write;
+
+import org.opensearch.common.blobstore.stream.StreamContext;
+import org.opensearch.common.blobstore.transfer.UploadFinalizer;
+
+/**
+ * WriteContext is used to encapsulate all data needed by <code>BlobContainer#writeStreams</code>
+ */
+public class WriteContext {
+
+    private final String fileName;
+    private final StreamContextSupplier streamContextSupplier;
+    private final long fileSize;
+    private final boolean failIfAlreadyExists;
+    private final WritePriority writePriority;
+    private final UploadFinalizer uploadFinalizer;
+
+    /**
+     * Construct a new WriteContext object
+     *
+     * @param fileName The name of the file being uploaded
+     * @param streamContextSupplier A supplier that will provide StreamContext to the plugin
+     * @param fileSize The total size of the file being uploaded
+     * @param failIfAlreadyExists A boolean to fail the upload is the file exists
+     * @param writePriority The <code>WritePriority</code> of this upload
+     */
+    public WriteContext(
+        String fileName,
+        StreamContextSupplier streamContextSupplier,
+        long fileSize,
+        boolean failIfAlreadyExists,
+        WritePriority writePriority,
+        UploadFinalizer uploadFinalizer
+    ) {
+        this.fileName = fileName;
+        this.streamContextSupplier = streamContextSupplier;
+        this.fileSize = fileSize;
+        this.failIfAlreadyExists = failIfAlreadyExists;
+        this.writePriority = writePriority;
+        this.uploadFinalizer = uploadFinalizer;
+    }
+
+    /**
+     * @return The file name
+     */
+    public String getFileName() {
+        return fileName;
+    }
+
+    /**
+     * @return The boolean representing whether to fail the file upload if it exists
+     */
+    public boolean isFailIfAlreadyExists() {
+        return failIfAlreadyExists;
+    }
+
+    /**
+     * @param partSize The size of a single part to be uploaded
+     * @return The stream context which will be used by the plugin to initialize streams from the file
+     */
+    public StreamContext getStreamContext(long partSize) {
+        return streamContextSupplier.supplyStreamContext(partSize);
+    }
+
+    /**
+     * @return The total size of the file
+     */
+    public long getFileSize() {
+        return fileSize;
+    }
+
+    /**
+     * @return The <code>WritePriority</code> of the upload
+     */
+    public WritePriority getWritePriority() {
+        return writePriority;
+    }
+
+    public UploadFinalizer getUploadFinalizer() {
+        return uploadFinalizer;
+    }
+}

--- a/server/src/main/java/org/opensearch/common/blobstore/stream/write/WritePriority.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/stream/write/WritePriority.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.blobstore.stream.write;
+
+/**
+ * WritePriority for upload
+ */
+public enum WritePriority {
+    NORMAL,
+    HIGH
+}

--- a/server/src/main/java/org/opensearch/common/blobstore/stream/write/package-info.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/stream/write/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/** Abstractions for stream based file writes */
+package org.opensearch.common.blobstore.stream.write;

--- a/server/src/main/java/org/opensearch/common/blobstore/transfer/RemoteTransferContainer.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/transfer/RemoteTransferContainer.java
@@ -1,0 +1,249 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.blobstore.transfer;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.opensearch.common.SetOnce;
+import org.opensearch.common.Stream;
+import org.opensearch.common.StreamProvider;
+import org.opensearch.common.TransferPartStreamSupplier;
+import org.opensearch.common.blobstore.stream.StreamContext;
+import org.opensearch.common.blobstore.stream.write.WriteContext;
+import org.opensearch.common.blobstore.stream.write.WritePriority;
+import org.opensearch.common.blobstore.transfer.stream.OffsetRangeFileInputStream;
+import org.opensearch.common.blobstore.transfer.stream.OffsetRangeIndexInputStream;
+import org.opensearch.common.blobstore.transfer.stream.ResettableCheckedInputStream;
+import org.opensearch.index.translog.ChannelFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Objects;
+
+/**
+ * RemoteTransferContainer is an encapsulation for managing transfers for translog and segment files.
+ */
+public class RemoteTransferContainer implements Closeable {
+
+    private Path localFile;
+    private Directory directory;
+    private IOContext ioContext;
+    private int numberOfParts;
+    private long partSize;
+    private long lastPartSize;
+
+    private final long contentLength;
+    private final SetOnce<ResettableCheckedInputStream[]> inputStreams = new SetOnce<>();
+    private final String localFileName;
+    private final String remoteFileName;
+    private final boolean failTransferIfFileExists;
+    private final WritePriority writePriority;
+
+    private static final Logger log = LogManager.getLogger(RemoteTransferContainer.class);
+
+    /**
+     * Construct a new RemoteTransferContainer object using {@link Path} reference to the file.
+     *
+     * @param localFile A {@link Path} reference to the local file
+     * @param localFileName Name of the local file
+     * @param remoteFileName Name of the remote file
+     * @param failTransferIfFileExists A boolean to determine if upload has to be failed if file exists
+     * @param writePriority The {@link WritePriority} of current upload
+     * @throws IOException If opening file channel to the local file fails
+     */
+    public RemoteTransferContainer(
+        Path localFile,
+        String localFileName,
+        String remoteFileName,
+        boolean failTransferIfFileExists,
+        WritePriority writePriority
+    ) throws IOException {
+        this.localFileName = localFileName;
+        this.remoteFileName = remoteFileName;
+        this.localFile = localFile;
+        this.failTransferIfFileExists = failTransferIfFileExists;
+        this.writePriority = writePriority;
+
+        ChannelFactory channelFactory = FileChannel::open;
+        localFile.getFileSystem().provider();
+        try (FileChannel channel = channelFactory.open(localFile, StandardOpenOption.READ)) {
+            this.contentLength = channel.size();
+        }
+    }
+
+    /**
+     * @param directory The directory which contains the local file
+     * @param ioContext The {@link IOContext} which will be used to open {@link IndexInput} to the file
+     * @param localFileName Name of the local file
+     * @param remoteFileName Name of the remote file
+     * @param failTransferIfFileExists A boolean to determine if upload has to be failed if file exists
+     * @param writePriority The {@link WritePriority} of current upload
+     * @throws IOException If opening {@link IndexInput} on local file fails
+     */
+    public RemoteTransferContainer(
+        Directory directory,
+        IOContext ioContext,
+        String localFileName,
+        String remoteFileName,
+        boolean failTransferIfFileExists,
+        WritePriority writePriority
+    ) throws IOException {
+        this.localFileName = localFileName;
+        this.remoteFileName = remoteFileName;
+        this.directory = directory;
+        this.failTransferIfFileExists = failTransferIfFileExists;
+        try (IndexInput indexInput = directory.openInput(this.localFileName, ioContext)) {
+            this.contentLength = indexInput.length();
+        }
+        this.ioContext = ioContext;
+        this.writePriority = writePriority;
+    }
+
+    /**
+     * @return The {@link  WriteContext} for the current upload
+     */
+    public WriteContext createWriteContext() {
+        return new WriteContext(
+            remoteFileName,
+            this::supplyStreamContext,
+            contentLength,
+            failTransferIfFileExists,
+            writePriority,
+            this::finalizeUpload
+        );
+    }
+
+    /**
+     * @param partSize Part sizes of all parts apart from the last one, which is determined internally
+     * @return The {@link StreamContext} object that will be used by the vendor plugin to retrieve streams
+     */
+    public StreamContext supplyStreamContext(long partSize) {
+        try {
+            return this.openMultipartStreams(partSize);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private StreamContext openMultipartStreams(long partSize) throws IOException {
+        if (inputStreams.get() != null) {
+            throw new IOException("Multi-part streams are already created.");
+        }
+
+        this.partSize = partSize;
+        this.lastPartSize = (contentLength % partSize) != 0 ? contentLength % partSize : partSize;
+        this.numberOfParts = (int) ((contentLength % partSize) == 0 ? contentLength / partSize : (contentLength / partSize) + 1);
+        ResettableCheckedInputStream[] streams = new ResettableCheckedInputStream[numberOfParts];
+        inputStreams.set(streams);
+
+        return new StreamContext(new StreamProvider(getTransferPartStreamSupplier(), partSize, lastPartSize, numberOfParts), numberOfParts);
+    }
+
+    private TransferPartStreamSupplier getTransferPartStreamSupplier() {
+        return ((partNo, size, position) -> {
+            assert inputStreams.get() != null : "expected inputStreams to be initialised";
+            if (localFile != null) {
+                return getMultiPartStreamSupplierForFile(partNo, size, position).get();
+            } else {
+                return getMultiPartStreamSupplierForIndexInput(partNo, size, position).get();
+            }
+        });
+    }
+
+    interface LocalStreamSupplier<Stream> {
+        Stream get() throws IOException;
+    }
+
+    private LocalStreamSupplier<Stream> getMultiPartStreamSupplierForFile(final int streamIdx, final long size, final long position) {
+        return () -> {
+            try {
+                OffsetRangeFileInputStream offsetRangeInputStream = new OffsetRangeFileInputStream(localFile, size, position);
+                ResettableCheckedInputStream checkedInputStream = new ResettableCheckedInputStream(
+                    offsetRangeInputStream,
+                    localFileName,
+                    () -> {
+                        try {
+                            return offsetRangeInputStream.getFileChannel().position();
+                        } catch (IOException e) {
+                            log.error("Error getting position of file channel", e);
+                        }
+                        return null;
+                    }
+                );
+                Objects.requireNonNull(inputStreams.get())[streamIdx] = checkedInputStream;
+
+                return new Stream(checkedInputStream, size, position);
+            } catch (IOException e) {
+                log.error("Failed to create input stream", e);
+                throw e;
+            }
+        };
+    }
+
+    private LocalStreamSupplier<Stream> getMultiPartStreamSupplierForIndexInput(final int streamIdx, final long size, final long position) {
+        return () -> {
+            try {
+                IndexInput indexInput = directory.openInput(localFileName, ioContext);
+                OffsetRangeIndexInputStream offsetRangeInputStream = new OffsetRangeIndexInputStream(indexInput, size, position);
+                ResettableCheckedInputStream checkedInputStream = new ResettableCheckedInputStream(
+                    offsetRangeInputStream,
+                    localFileName,
+                    indexInput::getFilePointer
+                );
+                Objects.requireNonNull(inputStreams.get())[streamIdx] = checkedInputStream;
+
+                return new Stream(checkedInputStream, size, position);
+            } catch (IOException e) {
+                log.error("Failed to create input stream", e);
+                throw e;
+            }
+        };
+    }
+
+    private void finalizeUpload(boolean uploadSuccessful) {}
+
+    /**
+     * @return The total content length of current upload
+     */
+    public long getContentLength() {
+        return contentLength;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (inputStreams.get() == null) {
+            log.warn("Input streams cannot be closed since they are not yet set for multi stream upload");
+            return;
+        }
+
+        boolean closeStreamException = false;
+        for (InputStream is : Objects.requireNonNull(inputStreams.get())) {
+            try {
+                if (is != null) {
+                    is.close();
+                }
+            } catch (IOException ex) {
+                closeStreamException = true;
+                // Attempting to close all streams first before throwing exception.
+                log.error("Multipart stream failed to close ", ex);
+            }
+        }
+
+        if (closeStreamException) {
+            throw new IOException("Closure of some of the multi-part streams failed.");
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/common/blobstore/transfer/UploadFinalizer.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/transfer/UploadFinalizer.java
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.blobstore.transfer;
+
+/**
+ * UploadFinalizer is an interface with support for a method that will be called once upload is complete
+ */
+public interface UploadFinalizer {
+    void accept(boolean uploadSuccess);
+}

--- a/server/src/main/java/org/opensearch/common/blobstore/transfer/package-info.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/transfer/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/** Contains transfer related utilities for {@link org.opensearch.common.blobstore.BlobContainer} */
+package org.opensearch.common.blobstore.transfer;

--- a/server/src/main/java/org/opensearch/common/blobstore/transfer/stream/OffsetRangeFileInputStream.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/transfer/stream/OffsetRangeFileInputStream.java
@@ -1,0 +1,119 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.blobstore.transfer.stream;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+/**
+ * OffsetRangeFileInputStream extends InputStream to read from a specified offset using FileChannel
+ */
+public class OffsetRangeFileInputStream extends InputStream {
+    private final InputStream inputStream;
+    private final FileChannel fileChannel;
+
+    private final long actualSizeToRead;
+    // This is the maximum position till stream is to be read. If read methods exceed maxPos then bytes are read
+    // till maxPos. If no byte is left after maxPos, then -1 is returned from read methods.
+    private final long limit;
+    // Position in stream from which read will start.
+    private long counter = 0;
+
+    private long markPointer;
+    private long markCounter;
+
+    /**
+     * Construct a new OffsetRangeFileInputStream object
+     *
+     * @param path Path to the file
+     * @param size Number of bytes that need to be read from specified <code>position</code>
+     * @param position Position from where the read needs to start
+     * @throws IOException When <code>FileChannel#position</code> operation fails
+     */
+    public OffsetRangeFileInputStream(Path path, long size, long position) throws IOException {
+        fileChannel = FileChannel.open(path, StandardOpenOption.READ);
+        fileChannel.position(position);
+        inputStream = Channels.newInputStream(fileChannel);
+        long totalLength = fileChannel.size();
+        this.counter = 0;
+        this.limit = size;
+        if ((totalLength - position) > limit) {
+            actualSizeToRead = limit;
+        } else {
+            actualSizeToRead = totalLength - position;
+        }
+    }
+
+    public FileChannel getFileChannel() {
+        return fileChannel;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        if (b == null) {
+            throw new NullPointerException();
+        } else if (off < 0 || len < 0 || len > b.length - off) {
+            throw new IndexOutOfBoundsException();
+        }
+        if (fileChannel.position() >= fileChannel.size()) {
+            return -1;
+        }
+        if (fileChannel.position() + len > fileChannel.size()) {
+            len = (int) (fileChannel.size() - fileChannel.position());
+        }
+        if (counter + len > limit) {
+            len = (int) (limit - counter);
+        }
+        if (len <= 0) {
+            return -1;
+        }
+
+        inputStream.read(b, off, len);
+        counter += len;
+        return len;
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (counter++ >= limit) {
+            return -1;
+        }
+        return (fileChannel.position() < fileChannel.size()) ? (inputStream.read() & 0xff) : -1;
+    }
+
+    @Override
+    public boolean markSupported() {
+        return true;
+    }
+
+    @Override
+    public synchronized void mark(int readlimit) {
+        try {
+            markPointer = fileChannel.position();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        markCounter = counter;
+    }
+
+    @Override
+    public synchronized void reset() throws IOException {
+        fileChannel.position(markPointer);
+        counter = markCounter;
+    }
+
+    @Override
+    public void close() throws IOException {
+        inputStream.close();
+    }
+}

--- a/server/src/main/java/org/opensearch/common/blobstore/transfer/stream/OffsetRangeIndexInputStream.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/transfer/stream/OffsetRangeIndexInputStream.java
@@ -1,0 +1,69 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.blobstore.transfer.stream;
+
+import org.apache.lucene.store.IndexInput;
+import org.opensearch.common.lucene.store.InputStreamIndexInput;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * OffsetRangeIndexInputStream extends InputStream to read from a specified offset using IndexInput
+ */
+public class OffsetRangeIndexInputStream extends InputStream {
+
+    private final InputStreamIndexInput inputStreamIndexInput;
+    private final IndexInput indexInput;
+
+    /**
+     * Construct a new OffsetRangeIndexInputStream object
+     *
+     * @param indexInput IndexInput opened on the file to read from
+     * @param maxLen The maximum length to read from specified <code>position</code>
+     * @param position Position from where read needs to start
+     * @throws IOException When <code>IndexInput#seek</code> operation fails
+     */
+    public OffsetRangeIndexInputStream(IndexInput indexInput, long maxLen, long position) throws IOException {
+        indexInput.seek(position);
+        this.indexInput = indexInput;
+        this.inputStreamIndexInput = new InputStreamIndexInput(indexInput, maxLen);
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        return inputStreamIndexInput.read(b, off, len);
+    }
+
+    @Override
+    public int read() throws IOException {
+        return inputStreamIndexInput.read();
+    }
+
+    @Override
+    public boolean markSupported() {
+        return inputStreamIndexInput.markSupported();
+    }
+
+    @Override
+    public synchronized void mark(int readlimit) {
+        inputStreamIndexInput.mark(readlimit);
+    }
+
+    @Override
+    public synchronized void reset() throws IOException {
+        inputStreamIndexInput.reset();
+    }
+
+    @Override
+    public void close() throws IOException {
+        inputStreamIndexInput.close();
+        indexInput.close();
+    }
+}

--- a/server/src/main/java/org/opensearch/common/blobstore/transfer/stream/ResettableCheckedInputStream.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/transfer/stream/ResettableCheckedInputStream.java
@@ -1,0 +1,110 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.blobstore.transfer.stream;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.function.Supplier;
+
+/**
+ * ResettableCheckedInputStream is a modified implementation of {@link java.util.zip.CheckedInputStream} that supports
+ * mark and reset and modifies the file checksum during mark and reset calls.
+ */
+public class ResettableCheckedInputStream extends FilterInputStream {
+
+    private final long startPos;
+    private final String file;
+    private final Supplier<Long> posSupplier;
+
+    /**
+     * Creates a new ResettableCheckedInputStream object
+     *
+     * @param in The underlying input stream
+     * @param file Name of the file
+     * @param posSupplier A supplier to fetch the current position of the file pointer
+     */
+    public ResettableCheckedInputStream(InputStream in, String file, Supplier<Long> posSupplier) {
+        super(in);
+        this.startPos = posSupplier.get();
+        this.file = file;
+        this.posSupplier = posSupplier;
+    }
+
+    /**
+     * Reads a byte. Will block if no input is available.
+     * @return the byte read, or -1 if the end of the stream is reached.
+     * @exception IOException if an I/O error has occurred
+     */
+    public int read() throws IOException {
+        byte[] buffer = new byte[1];
+        int len = read(buffer, 0, 1);
+        if (len == -1) {
+            return -1;
+        }
+        return buffer[0];
+    }
+
+    /**
+     * Reads into an array of bytes. If <code>len</code> is not zero, the method
+     * blocks until some input is available; otherwise, no
+     * bytes are read and <code>0</code> is returned.
+     * @param buf the buffer into which the data is read
+     * @param off the start offset in the destination array <code>b</code>
+     * @param len the maximum number of bytes read
+     * @return    the actual number of bytes read, or -1 if the end
+     *            of the stream is reached.
+     * @exception  NullPointerException If <code>buf</code> is <code>null</code>.
+     * @exception  IndexOutOfBoundsException If <code>off</code> is negative,
+     * <code>len</code> is negative, or <code>len</code> is greater than
+     * <code>buf.length - off</code>
+     * @exception IOException if an I/O error has occurred
+     */
+    public int read(byte[] buf, int off, int len) throws IOException {
+        return in.read(buf, off, len);
+    }
+
+    /**
+     * Skips specified number of bytes of input.
+     * @param n the number of bytes to skip
+     * @return the actual number of bytes skipped
+     * @exception IOException if an I/O error has occurred
+     */
+    public long skip(long n) throws IOException {
+        byte[] buf = new byte[512];
+        long total = 0;
+        while (total < n) {
+            long len = n - total;
+            len = read(buf, 0, len < buf.length ? (int) len : buf.length);
+            if (len == -1) {
+                return total;
+            }
+            total += len;
+        }
+        return total;
+    }
+
+    @Override
+    public synchronized void mark(int readlimit) {
+        super.mark(readlimit);
+    }
+
+    @Override
+    public synchronized void reset() throws IOException {
+        if (startPos == posSupplier.get()) {
+            return;
+        }
+        super.reset();
+    }
+
+    @Override
+    public void close() throws IOException {
+        super.close();
+    }
+}

--- a/server/src/main/java/org/opensearch/common/blobstore/transfer/stream/package-info.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/transfer/stream/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/** Contains encapsulations to create streams for part uploads */
+package org.opensearch.common.blobstore.transfer.stream;

--- a/server/src/test/java/org/opensearch/common/blobstore/transfer/RemoteTransferContainerTests.java
+++ b/server/src/test/java/org/opensearch/common/blobstore/transfer/RemoteTransferContainerTests.java
@@ -1,0 +1,144 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.blobstore.transfer;
+
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.NIOFSDirectory;
+import org.junit.Before;
+import org.opensearch.common.Stream;
+import org.opensearch.common.blobstore.stream.StreamContext;
+import org.opensearch.common.blobstore.stream.write.WritePriority;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+public class RemoteTransferContainerTests extends OpenSearchTestCase {
+
+    private static final int TEST_FILE_SIZE_BYTES = 128;
+
+    private Path testFile;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        testFile = createTempFile();
+        Files.write(testFile, randomByteArrayOfLength(TEST_FILE_SIZE_BYTES), StandardOpenOption.APPEND);
+    }
+
+    public void testSupplyStreamContextForPathDivisibleParts() throws IOException, InterruptedException {
+        try (
+            RemoteTransferContainer remoteTransferContainer = new RemoteTransferContainer(
+                testFile,
+                testFile.getFileName().toString(),
+                testFile.getFileName().toString(),
+                true,
+                WritePriority.HIGH
+            )
+        ) {
+            testSupplyStreamContext(remoteTransferContainer, 16, 16, 8);
+        }
+    }
+
+    public void testSupplyStreamContextForDirectoryDivisibleParts() throws IOException, InterruptedException {
+        try (
+            RemoteTransferContainer remoteTransferContainer = new RemoteTransferContainer(
+                new NIOFSDirectory(testFile.getParent()),
+                IOContext.DEFAULT,
+                testFile.getFileName().toString(),
+                testFile.getFileName().toString(),
+                true,
+                WritePriority.HIGH
+            )
+        ) {
+            testSupplyStreamContext(remoteTransferContainer, 16, 16, 8);
+        }
+    }
+
+    public void testSupplyStreamContextForPathNonDivisibleParts() throws IOException, InterruptedException {
+        try (
+            RemoteTransferContainer remoteTransferContainer = new RemoteTransferContainer(
+                testFile,
+                testFile.getFileName().toString(),
+                testFile.getFileName().toString(),
+                true,
+                WritePriority.HIGH
+            )
+        ) {
+            testSupplyStreamContext(remoteTransferContainer, 10, 8, 13);
+        }
+    }
+
+    public void testSupplyStreamContextForDirectoryNonDivisibleParts() throws IOException, InterruptedException {
+        try (
+            RemoteTransferContainer remoteTransferContainer = new RemoteTransferContainer(
+                new NIOFSDirectory(testFile.getParent()),
+                IOContext.DEFAULT,
+                testFile.getFileName().toString(),
+                testFile.getFileName().toString(),
+                true,
+                WritePriority.HIGH
+            )
+        ) {
+            testSupplyStreamContext(remoteTransferContainer, 10, 8, 13);
+        }
+    }
+
+    private void testSupplyStreamContext(
+        RemoteTransferContainer remoteTransferContainer,
+        long partSize,
+        long lastPartSize,
+        int expectedPartCount
+    ) throws InterruptedException {
+        StreamContext streamContext = remoteTransferContainer.supplyStreamContext(partSize);
+        int partCount = streamContext.getNumberOfParts();
+        assertEquals(expectedPartCount, partCount);
+        Thread[] threads = new Thread[partCount];
+        long totalContentLength = remoteTransferContainer.getContentLength();
+        assert partSize * (partCount - 1) + lastPartSize == totalContentLength
+            : "part sizes and last part size don't add up to total content length";
+        logger.info("partSize: {}, lastPartSize: {}, partCount: {}", partSize, lastPartSize, streamContext.getNumberOfParts());
+        for (int partIdx = 0; partIdx < partCount; partIdx++) {
+            int finalPartIdx = partIdx;
+            long expectedPartSize = (partIdx == partCount - 1) ? lastPartSize : partSize;
+            long expectedOffset = partIdx * partSize;
+            threads[partIdx] = new Thread(() -> {
+                try {
+                    Stream stream = streamContext.getStreamProvider().provideStream(finalPartIdx);
+                    assertEquals(expectedPartSize, stream.getContentLength());
+                    assertEquals(expectedOffset, stream.getOffset());
+                } catch (IOException e) {
+                    fail("IOException during stream creation");
+                }
+            });
+            threads[partIdx].start();
+        }
+        for (int i = 0; i < partCount; i++) {
+            threads[i].join();
+        }
+    }
+
+    public void testSupplyStreamContextCalledTwice() throws IOException {
+        try (
+            RemoteTransferContainer remoteTransferContainer = new RemoteTransferContainer(
+                testFile,
+                testFile.getFileName().toString(),
+                testFile.getFileName().toString(),
+                true,
+                WritePriority.HIGH
+            )
+        ) {
+            remoteTransferContainer.supplyStreamContext(16);
+            assertThrows(RuntimeException.class, () -> remoteTransferContainer.supplyStreamContext(16));
+        }
+    }
+}

--- a/server/src/test/java/org/opensearch/common/blobstore/transfer/stream/OffsetRangeFileInputStreamTests.java
+++ b/server/src/test/java/org/opensearch/common/blobstore/transfer/stream/OffsetRangeFileInputStreamTests.java
@@ -1,0 +1,27 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.blobstore.transfer.stream;
+
+import java.io.IOException;
+
+public class OffsetRangeFileInputStreamTests extends ResettableCheckedInputStreamBaseTest {
+
+    @Override
+    protected InputStreamContainer provideInputStreamContainer(int offset, long size) throws IOException {
+        OffsetRangeFileInputStream offsetRangeFileInputStream = new OffsetRangeFileInputStream(testFile, size, offset);
+        return new InputStreamContainer(offsetRangeFileInputStream, () -> {
+            try {
+                return offsetRangeFileInputStream.getFileChannel().position();
+            } catch (IOException e) {
+                fail("IOException while fetching fileChannel position");
+            }
+            return null;
+        });
+    }
+}

--- a/server/src/test/java/org/opensearch/common/blobstore/transfer/stream/OffsetRangeIndexInputStreamTests.java
+++ b/server/src/test/java/org/opensearch/common/blobstore/transfer/stream/OffsetRangeIndexInputStreamTests.java
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.blobstore.transfer.stream;
+
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.NIOFSDirectory;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+
+public class OffsetRangeIndexInputStreamTests extends ResettableCheckedInputStreamBaseTest {
+
+    private Directory directory;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        directory = new NIOFSDirectory(testFile.getParent());
+    }
+
+    @Override
+    protected InputStreamContainer provideInputStreamContainer(int offset, long size) throws IOException {
+        IndexInput indexInput = directory.openInput(testFile.getFileName().toString(), IOContext.DEFAULT);
+        return new InputStreamContainer(new OffsetRangeIndexInputStream(indexInput, size, offset), indexInput::getFilePointer);
+    }
+
+    @Override
+    @After
+    public void tearDown() throws Exception {
+        directory.close();
+        super.tearDown();
+    }
+}

--- a/server/src/test/java/org/opensearch/common/blobstore/transfer/stream/ResettableCheckedInputStreamBaseTest.java
+++ b/server/src/test/java/org/opensearch/common/blobstore/transfer/stream/ResettableCheckedInputStreamBaseTest.java
@@ -1,0 +1,202 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.blobstore.transfer.stream;
+
+import org.junit.After;
+import org.junit.Before;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.function.Supplier;
+
+public abstract class ResettableCheckedInputStreamBaseTest extends OpenSearchTestCase {
+
+    private static final int TEST_FILE_SIZE_BYTES = 10;
+
+    private final byte[] bytesToWrite = randomByteArrayOfLength(TEST_FILE_SIZE_BYTES);
+    protected Path testFile;
+    private ResettableCheckedInputStream[] resettableCheckedInputStreams;
+
+    static class InputStreamContainer {
+        private final InputStream inputStream;
+        private final Supplier<Long> inputStreamPosSupplier;
+
+        public InputStreamContainer(InputStream inputStream, Supplier<Long> inputStreamPosSupplier) {
+            this.inputStream = inputStream;
+            this.inputStreamPosSupplier = inputStreamPosSupplier;
+        }
+
+        public InputStream getInputStream() {
+            return inputStream;
+        }
+
+        public Supplier<Long> getInputStreamPosSupplier() {
+            return inputStreamPosSupplier;
+        }
+    }
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        testFile = createTempFile();
+        Files.write(testFile, bytesToWrite, StandardOpenOption.TRUNCATE_EXISTING);
+    }
+
+    protected abstract InputStreamContainer provideInputStreamContainer(int offset, long size) throws IOException;
+
+    public void testReadSingleByte() throws IOException, InterruptedException {
+        final int nParallelReads = 10;
+        Thread[] threads = new Thread[nParallelReads];
+        resettableCheckedInputStreams = new ResettableCheckedInputStream[nParallelReads];
+        for (int readIdx = 0; readIdx < nParallelReads; readIdx++) {
+            int offset = randomInt(TEST_FILE_SIZE_BYTES - 1);
+            InputStreamContainer inputStreamContainer = provideInputStreamContainer(offset, 1);
+            ResettableCheckedInputStream resettableCheckedInputStream = new ResettableCheckedInputStream(
+                inputStreamContainer.getInputStream(),
+                testFile.getFileName().toString(),
+                inputStreamContainer.getInputStreamPosSupplier()
+            );
+            resettableCheckedInputStreams[readIdx] = resettableCheckedInputStream;
+            threads[readIdx] = new Thread(() -> {
+                try {
+                    assertEquals(bytesToWrite[offset], resettableCheckedInputStream.read());
+                } catch (IOException e) {
+                    fail("Failure while reading single byte from offset stream");
+                }
+            });
+            threads[readIdx].start();
+        }
+        for (Thread thread : threads) {
+            thread.join();
+        }
+    }
+
+    public void testReadMultipleBytes() throws IOException, InterruptedException {
+        final int nParallelReads = 10;
+        Thread[] threads = new Thread[nParallelReads];
+        resettableCheckedInputStreams = new ResettableCheckedInputStream[nParallelReads];
+        for (int readIdx = 0; readIdx < nParallelReads; readIdx++) {
+            int readByteCount = randomInt(TEST_FILE_SIZE_BYTES - 1) + 1;
+            int offset = randomInt(TEST_FILE_SIZE_BYTES - readByteCount);
+            InputStreamContainer inputStreamContainer = provideInputStreamContainer(offset, readByteCount);
+            ResettableCheckedInputStream resettableCheckedInputStream = new ResettableCheckedInputStream(
+                inputStreamContainer.getInputStream(),
+                testFile.getFileName().toString(),
+                inputStreamContainer.getInputStreamPosSupplier()
+            );
+            resettableCheckedInputStreams[readIdx] = resettableCheckedInputStream;
+            threads[readIdx] = new Thread(() -> {
+                try {
+                    byte[] buffer = new byte[readByteCount];
+                    int bytesRead = resettableCheckedInputStream.read(buffer, 0, readByteCount);
+                    assertEquals(readByteCount, bytesRead);
+                    for (int bufferIdx = 0; bufferIdx < readByteCount; bufferIdx++) {
+                        assertEquals(bytesToWrite[offset + bufferIdx], buffer[bufferIdx]);
+                    }
+                } catch (IOException e) {
+                    fail("Failure while reading bytes from offset stream");
+                }
+            });
+            threads[readIdx].start();
+        }
+        for (Thread thread : threads) {
+            thread.join();
+        }
+    }
+
+    public void testMarkAndReset() throws IOException, InterruptedException {
+        final int nParallelReads = 100;
+        Thread[] threads = new Thread[nParallelReads];
+        resettableCheckedInputStreams = new ResettableCheckedInputStream[nParallelReads];
+        for (int readIdx = 0; readIdx < nParallelReads; readIdx++) {
+            int readByteCount = randomInt(TEST_FILE_SIZE_BYTES - 1) + 1;
+            int offset = randomInt(TEST_FILE_SIZE_BYTES - readByteCount);
+            InputStreamContainer inputStreamContainer = provideInputStreamContainer(offset, readByteCount);
+            ResettableCheckedInputStream resettableCheckedInputStream = new ResettableCheckedInputStream(
+                inputStreamContainer.getInputStream(),
+                testFile.getFileName().toString(),
+                inputStreamContainer.getInputStreamPosSupplier()
+            );
+            resettableCheckedInputStreams[readIdx] = resettableCheckedInputStream;
+            int finalRunIdx = readIdx;
+            threads[readIdx] = new Thread(() -> {
+                try {
+                    boolean streamMarked = false;
+                    long streamMarkPosition = -1;
+                    for (int byteIdx = 0; byteIdx < readByteCount - 1; byteIdx++) {
+                        resettableCheckedInputStream.read();
+                        if (!streamMarked && randomBoolean()) {
+                            streamMarked = true;
+                            streamMarkPosition = inputStreamContainer.getInputStreamPosSupplier().get();
+                            resettableCheckedInputStream.mark(readByteCount);
+                        }
+                    }
+                    if (!streamMarked) {
+                        streamMarkPosition = inputStreamContainer.getInputStreamPosSupplier().get();
+                        resettableCheckedInputStream.mark(readByteCount);
+                    }
+                    resettableCheckedInputStream.reset();
+                    assertEquals(bytesToWrite[(int) streamMarkPosition], resettableCheckedInputStream.read());
+                } catch (IOException e) {
+                    fail("Failure while reading bytes from offset stream");
+                }
+            });
+            threads[readIdx].start();
+        }
+        for (Thread thread : threads) {
+            thread.join();
+        }
+    }
+
+    public void testReadAfterSkip() throws IOException {
+        InputStreamContainer inputStreamContainer = provideInputStreamContainer(0, TEST_FILE_SIZE_BYTES);
+        ResettableCheckedInputStream resettableCheckedInputStream = new ResettableCheckedInputStream(
+            inputStreamContainer.getInputStream(),
+            testFile.getFileName().toString(),
+            inputStreamContainer.getInputStreamPosSupplier()
+        );
+        resettableCheckedInputStreams = new ResettableCheckedInputStream[] { resettableCheckedInputStream };
+
+        long skipBytes = randomLongBetween(1, TEST_FILE_SIZE_BYTES - 1);
+        long actualBytesSkipped = resettableCheckedInputStream.skip(skipBytes);
+        assertEquals(skipBytes, actualBytesSkipped);
+        assertEquals(bytesToWrite[(int) skipBytes], resettableCheckedInputStream.read());
+    }
+
+    public void testReadLastByte() throws IOException {
+        InputStreamContainer inputStreamContainer = provideInputStreamContainer(0, TEST_FILE_SIZE_BYTES);
+        ResettableCheckedInputStream resettableCheckedInputStream = new ResettableCheckedInputStream(
+            inputStreamContainer.getInputStream(),
+            testFile.getFileName().toString(),
+            inputStreamContainer.getInputStreamPosSupplier()
+        );
+        resettableCheckedInputStreams = new ResettableCheckedInputStream[] { resettableCheckedInputStream };
+
+        long skipBytes = TEST_FILE_SIZE_BYTES;
+        long actualBytesSkipped = resettableCheckedInputStream.skip(skipBytes);
+        assertEquals(skipBytes, actualBytesSkipped);
+        assertEquals(-1, resettableCheckedInputStream.read());
+    }
+
+    @Override
+    @After
+    public void tearDown() throws Exception {
+        for (ResettableCheckedInputStream resettableCheckedInputStream : resettableCheckedInputStreams) {
+            if (resettableCheckedInputStream != null) {
+                resettableCheckedInputStream.close();
+            }
+        }
+        super.tearDown();
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
- Offset based `InputStream` extensions to emit stream from a specific part of a file, which starts reading from a specific position and ensures that maximum length of content read doesn't exceed a specified limit. `OffsetRangeFileInputStream` achieves this for File objects, while `OffsetRangeIndexInputStream` achieves this for lucene's IndexInput construct
- `RemoteTransferContainer` has utilities to open streams to specific parts of the file based on the type as mentioned in the previous point. It also manages post upload tasks by implementing an `UploadFinalizer`.
- `ResettableCheckedInputStream` allows for individual parts to be reset through mark and reset in the event of upload failures

### Issues Resolved
- #6980 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
