### PR TITLE
[Segment Replication] Fix flaky testReplicaHasDiffFilesThanPrimary test

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -745,7 +745,8 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
             refresh(INDEX_NAME);
         }
         // Refresh, this should trigger round of segment replication
-        assertBusy(() -> { assertDocCounts(docCount, replicaNode); });
+        waitForSearchableDocs(docCount, primaryNode, replicaNode);
+        verifyStoreContent();
         final IndexShard replicaAfterFailure = getIndexShard(replicaNode, INDEX_NAME);
         assertNotEquals(replicaAfterFailure.routingEntry().allocationId().getId(), replicaShard.routingEntry().allocationId().getId());
     }

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -737,6 +737,7 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
 
         final SegmentInfos segmentInfos = SegmentInfos.readLatestCommit(replicaShard.store().directory());
         replicaShard.finalizeReplication(segmentInfos);
+        ensureYellow(INDEX_NAME);
 
         final int docCount = scaledRandomIntBetween(10, 200);
         for (int i = 0; i < docCount; i++) {


### PR DESCRIPTION
### Description
Fixes the flakyness of this test by waiting for cluster to process the replica shard failure. Without this wait, doc ingestion & shard cancellation run in parallel. The test also uses existing utilities used for doc count assertion which waits for a longer time i.e. `1 minute`.  Ran test with fix 100 times without failure. 

### Issues Resolved
Resolves https://github.com/opensearch-project/OpenSearch/issues/6885

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
