### PR TITLE
Use per-key latch to wait on file downloads

### DIFF
--- a/server/src/test/java/org/opensearch/index/store/remote/utils/TransferManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/utils/TransferManagerTests.java
@@ -12,6 +12,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -176,6 +177,45 @@ public class TransferManagerTests extends OpenSearchTestCase {
         );
         MatcherAssert.assertThat(fileCache.usage().activeUsage(), equalTo(0L));
         MatcherAssert.assertThat(fileCache.usage().usage(), equalTo(0L));
+    }
+
+    public void testFetchesToDifferentBlobsDoNotBlockOnEachOther() throws Exception {
+        // Mock a call for a blob that will block until the latch is released,
+        // then start the fetch for that blob on a separate thread
+        final CountDownLatch latch = new CountDownLatch(1);
+        doAnswer(i -> {
+            latch.await();
+            return new ByteArrayInputStream(createData());
+        }).when(blobContainer).readBlob(eq("blocking-blob"), anyLong(), anyLong());
+        final Thread blockingThread = new Thread(
+            () -> {
+                try {
+                    transferManager.fetchBlob(
+                        BlobFetchRequest.builder()
+                            .blobName("blocking-blob")
+                            .position(0)
+                            .fileName("blocking-file")
+                            .directory(directory)
+                            .length(EIGHT_MB)
+                            .build()
+                    );
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        );
+        blockingThread.start();
+
+        // Assert that a different blob can be fetched and will not block on the other blob
+        try (IndexInput i = fetchBlobWithName("file")) {
+            assertIndexInputIsFunctional(i);
+            MatcherAssert.assertThat(fileCache.usage().activeUsage(), equalTo((long) EIGHT_MB));
+        }
+
+        assertTrue(blockingThread.isAlive());
+        latch.countDown();
+        blockingThread.join(5_000);
+        assertFalse(blockingThread.isAlive());
     }
 
     private IndexInput fetchBlobWithName(String blobname) throws IOException {


### PR DESCRIPTION
The lock that guards `FileCache.compute` is per-cache-segment, and therefore means unrelated keys can get stuck waiting for one another. This refactors the code to do the download outside of the cache operation, and uses a per-key latch mechanism to ensure that only requests for the exact same blob will block on each other.

See [this issue][1] for details about the cache implementation. I think it is possible to re-work the cache so that locking would be much more precise and this change would not be necessary. However, that is a bigger change potentially with other tradeoffs, so I think this fix is a reasonable thing to do now.

[1]: https://github.com/opensearch-project/OpenSearch/issues/6225#issuecomment-1496337366

### Issues Resolved

Closes #7031 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
