### PR TITLE
Change port number for disconnected remote host to accomadate for Win…

### DIFF
--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/90_remote.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/90_remote.yml
@@ -390,14 +390,12 @@
         refresh: true
 
   - do:
-      # sometimes IIS is listening on port 0. In that case we fail in other ways and this test isn't useful.
-      # make sure to stop any local webservers if running this test locally otherwise an s_s_l handshake exception may occur
       catch: /connect_exception|IIS Windows Server/
       reindex:
         body:
           source:
             remote:
-              host: http://127.0.0.1:0
+              host: http://127.0.0.1:54321
             index: source
           dest:
             index: dest


### PR DESCRIPTION
…dows platform execution

### Description
- Uses a port number other than 0 to connect to a non existent cluster to ensure no conflicts on Windows platform

### Issues Resolved
- Resolves #5930 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
