### PR TITLE
[Segment Replication] Fix SearchableSnapshotIT tests failing with segment replication enabled indices

### DIFF
--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -930,11 +930,11 @@ public class IndicesService extends AbstractLifecycleComponent
             .filter(maybe -> Objects.requireNonNull(maybe).isPresent())
             .collect(Collectors.toList());
         if (engineFactories.isEmpty()) {
-            if (idxSettings.isSegRepEnabled()) {
-                return new NRTReplicationEngineFactory();
-            }
             if (idxSettings.isRemoteSnapshot()) {
                 return config -> new ReadOnlyEngine(config, new SeqNoStats(0, 0, 0), new TranslogStats(), true, Function.identity(), false);
+            }
+            if (idxSettings.isSegRepEnabled()) {
+                return new NRTReplicationEngineFactory();
             }
             return new InternalEngineFactory();
         } else if (engineFactories.size() == 1) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
When we are restoring snapshot with storage type as REMOTE_SNAPSHOT we should use ReadOnlyEngine. But currectly we are wiring up a NRTReplicationEngineFactor instead of `ReadOnlyEngine`.

 This PR moves up the `isRemoteSnapshot()` check on index setting before we check if `isSegRepEnabled()`.  This way be wire `ReadOnlyEngine` when using remote snapshot.

### Issues Resolved
Resolves #7034 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
