### PR TITLE
[Segment Replication] Cancellation check before send files to prevent…

### DIFF
--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceHandler.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceHandler.java
@@ -136,7 +136,7 @@ class SegmentReplicationSourceHandler {
                     timer.time()
                 );
             };
-
+            cancellableThreads.checkForCancel();
             final IndexShardRoutingTable routingTable = shard.getReplicationGroup().getRoutingTable();
             ShardRouting targetShardRouting = routingTable.getByAllocationId(request.getTargetAllocationId());
             if (targetShardRouting == null) {


### PR DESCRIPTION
… segrep round

### Description
Cancel segment replication when shard not in primary mode. This ensures that shards not in primary mode and cancelled on source by respective event listeners should not proceed with next steps on segment replication.

### Issues Resolved
Resolves https://github.com/opensearch-project/OpenSearch/issues/6778


### Alternative
Run sequential code block inside cancellableThreads.execute() which can be interrupted on shard changes. This will need little more refactoring and thought around resource handling (close operations etc), we can take this up as follow up. 


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
