### PR TITLE
[Segment Replication] Close writer on segment replication cancellation

### DIFF
--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTarget.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTarget.java
@@ -292,5 +292,6 @@ public class SegmentReplicationTarget extends ReplicationTarget {
     protected void onCancel(String reason) {
         cancellableThreads.cancel(reason);
         source.cancel();
+        multiFileWriter.close();
     }
 }


### PR DESCRIPTION
### Description
Close MultiFileWriter on segment replication cancellation. 

This bug appears rarely and happen during failover where promoted replica [cleans up](https://github.com/opensearch-project/OpenSearch/blob/0db20d99d4e06ddb261429466a8072501cc15941/server/src/main/java/org/opensearch/index/store/Store.java#L948) its store while having multiple file copy operations in progress. The clean up deletes temporary replication files which conflict with one of file copy thread's validation. Existing cancellation skips writer close as target ref count does not goes to `0` when there are multiple file copy operations is in progress. Target is [inc'ref](https://github.com/opensearch-project/OpenSearch/blob/0db20d99d4e06ddb261429466a8072501cc15941/server/src/main/java/org/opensearch/indices/replication/common/ReplicationCollection.java#L153) with every file chunk handler but during cancellation the target is dec'ref once and thus [closeInternal](https://github.com/opensearch-project/OpenSearch/blob/0db20d99d4e06ddb261429466a8072501cc15941/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTarget.java#L80) action (which closes writer) on target is [prevented](https://github.com/opensearch-project/OpenSearch/blob/0db20d99d4e06ddb261429466a8072501cc15941/libs/common/src/main/java/org/opensearch/common/util/concurrent/AbstractRefCounted.java#L78).

#### Timeline from one failing test
node_t2 is started as replica which performs segrep with older primary on node_t1.

```
[2023-04-07T19:10:23,524][INFO ][o.o.i.r.SegmentReplicationTarget] [node_t2] [test-idx-1][0] [31206] Replication diff for checkpoint ReplicationCheckpoint{shardId=[test-idx-1][0], primaryTerm=1, segmentsGen=3, version=11, size=93731, codec=Lucene95} RecoveryDiff{identical=[], different=[], missing=[name [_1.cfs], length [56235], checksum [1vl1wuo], writtenBy [9.6.0], name [_0.cfe], length [479], checksum [1gnw71m], writtenBy [9.6.0], name [_0.si], length [318], checksum [97u0s0], writtenBy [9.6.0], name [_1.cfe], length [479], checksum [qmaym9], writtenBy [9.6.0], name [_1.si], length [318], checksum [1bqh7cs], writtenBy [9.6.0], name [_0.cfs], length [35902], checksum [vzl70q], writtenBy [9.6.0]]}
```
Meanwhile older primary is stopped which promotes node_t2 as new primary. During node_t2 promotion, engine is [reset](https://github.com/opensearch-project/OpenSearch/blob/0db20d99d4e06ddb261429466a8072501cc15941/server/src/main/java/org/opensearch/index/shard/IndexShard.java#L663), where replica commit its latest processed checkpoint, followed by store [clean up](https://github.com/opensearch-project/OpenSearch/blob/0db20d99d4e06ddb261429466a8072501cc15941/server/src/main/java/org/opensearch/index/store/Store.java#L948). This clean up deletes all files not referenced in latest commit on store and clean up deletes the temporary replication files.
```
[2023-04-07T19:10:23,657][INFO ][i.s.deletes              ] [node_t2][test-idx-1][0] [31196] After commit: delete file replication.teSJpKFuT-6pgtOxNsffsA._0.cfe
[2023-04-07T19:10:23,658][INFO ][i.s.deletes              ] [node_t2][test-idx-1][0] [31196] After commit: delete file replication.teSJpKFuT-6pgtOxNsffsA._0.cfs
[2023-04-07T19:10:23,658][INFO ][i.s.deletes              ] [node_t2][test-idx-1][0] [31196] After commit: delete file replication.teSJpKFuT-6pgtOxNsffsA._0.si
[2023-04-07T19:10:23,659][INFO ][i.s.deletes              ] [node_t2][test-idx-1][0] [31196] After commit: delete file replication.teSJpKFuT-6pgtOxNsffsA._1.cfe
[2023-04-07T19:10:23,659][INFO ][i.s.deletes              ] [node_t2][test-idx-1][0] [31196] After commit: delete file replication.teSJpKFuT-6pgtOxNsffsA._1.cfs
```
The on-going replication process on replica is not aware of this clean up and thus fails while validating post file copy.
```
[2023-04-07T19:10:23,663][INFO ][o.o.i.r.SegmentReplicationTarget] [node_t2] [test-idx-1][0] [31206] --> Failure reported, current list of files [segments_5, write.lock]
java.lang.AssertionError: expected: [replication.teSJpKFuT-6pgtOxNsffsA._1.cfs] in [segments_5, write.lock]
...
```

#### Test
The test does not fail in 2k iterations locally, it fails after 2k success runs for a different reason. Created https://github.com/opensearch-project/OpenSearch/issues/7063 to track this.

### Issues Resolved
Resolves #6762

### Alternatives Considered
1. `ensureOpen.run()` inside innerWriteFileChunk method. It wouldn't work as target doesn't goes down to `0`.
2. https://github.com/opensearch-project/OpenSearch/pull/7044 prevents store clean up with store commit. This fix is still needed as it performs important clean up of IndexOutput objects post writer close.
3. Don't incref target with every chunk handler. 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
