### PR TITLE
[Extensions] Handle Deprecated and Replaced Routes in Extension Rest Handlers

### DIFF
--- a/server/src/main/java/org/opensearch/extensions/rest/RegisterRestActionsRequest.java
+++ b/server/src/main/java/org/opensearch/extensions/rest/RegisterRestActionsRequest.java
@@ -25,16 +25,19 @@ import java.util.Objects;
 public class RegisterRestActionsRequest extends TransportRequest {
     private String uniqueId;
     private List<String> restActions;
+    private List<String> deprecatedRestActions;
 
-    public RegisterRestActionsRequest(String uniqueId, List<String> restActions) {
+    public RegisterRestActionsRequest(String uniqueId, List<String> restActions, List<String> deprecatedRestActions) {
         this.uniqueId = uniqueId;
         this.restActions = new ArrayList<>(restActions);
+        this.deprecatedRestActions = new ArrayList<>(deprecatedRestActions);
     }
 
     public RegisterRestActionsRequest(StreamInput in) throws IOException {
         super(in);
         uniqueId = in.readString();
         restActions = in.readStringList();
+        deprecatedRestActions = in.readStringList();
     }
 
     @Override
@@ -42,6 +45,7 @@ public class RegisterRestActionsRequest extends TransportRequest {
         super.writeTo(out);
         out.writeString(uniqueId);
         out.writeStringCollection(restActions);
+        out.writeStringCollection(deprecatedRestActions);
     }
 
     public String getUniqueId() {
@@ -49,12 +53,22 @@ public class RegisterRestActionsRequest extends TransportRequest {
     }
 
     public List<String> getRestActions() {
-        return new ArrayList<>(restActions);
+        return List.copyOf(restActions);
+    }
+
+    public List<String> getDeprecatedRestActions() {
+        return List.copyOf(deprecatedRestActions);
     }
 
     @Override
     public String toString() {
-        return "RestActionsRequest{uniqueId=" + uniqueId + ", restActions=" + restActions + "}";
+        return "RestActionsRequest{uniqueId="
+            + uniqueId
+            + ", restActions="
+            + restActions
+            + ", deprecatedRestActions="
+            + deprecatedRestActions
+            + "}";
     }
 
     @Override
@@ -62,11 +76,13 @@ public class RegisterRestActionsRequest extends TransportRequest {
         if (this == obj) return true;
         if (obj == null || getClass() != obj.getClass()) return false;
         RegisterRestActionsRequest that = (RegisterRestActionsRequest) obj;
-        return Objects.equals(uniqueId, that.uniqueId) && Objects.equals(restActions, that.restActions);
+        return Objects.equals(uniqueId, that.uniqueId)
+            && Objects.equals(restActions, that.restActions)
+            && Objects.equals(deprecatedRestActions, that.deprecatedRestActions);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(uniqueId, restActions);
+        return Objects.hash(uniqueId, restActions, deprecatedRestActions);
     }
 }

--- a/server/src/main/java/org/opensearch/extensions/rest/RestSendToExtensionAction.java
+++ b/server/src/main/java/org/opensearch/extensions/rest/RestSendToExtensionAction.java
@@ -60,6 +60,7 @@ public class RestSendToExtensionAction extends BaseRestHandler {
     };
 
     private final List<Route> routes;
+    private final List<DeprecatedRoute> deprecatedRoutes;
     private final String pathPrefix;
     private final DiscoveryExtensionNode discoveryExtensionNode;
     private final TransportService transportService;
@@ -80,12 +81,13 @@ public class RestSendToExtensionAction extends BaseRestHandler {
         TransportService transportService
     ) {
         this.pathPrefix = "/_extensions/_" + restActionsRequest.getUniqueId();
+        RestRequest.Method method;
+        String path;
+
         List<Route> restActionsAsRoutes = new ArrayList<>();
         for (String restAction : restActionsRequest.getRestActions()) {
-            RestRequest.Method method;
-            String path;
+            int delim = restAction.indexOf(' ');
             try {
-                int delim = restAction.indexOf(' ');
                 method = RestRequest.Method.valueOf(restAction.substring(0, delim));
                 path = pathPrefix + restAction.substring(delim).trim();
             } catch (IndexOutOfBoundsException | IllegalArgumentException e) {
@@ -95,6 +97,25 @@ public class RestSendToExtensionAction extends BaseRestHandler {
             restActionsAsRoutes.add(new Route(method, path));
         }
         this.routes = unmodifiableList(restActionsAsRoutes);
+
+        List<DeprecatedRoute> restActionsAsDeprecatedRoutes = new ArrayList<>();
+        // Iterate in pairs of route / deprecation message
+        List<String> deprecatedActions = restActionsRequest.getDeprecatedRestActions();
+        for (int i = 0; i < deprecatedActions.size() - 1; i += 2) {
+            String restAction = deprecatedActions.get(i);
+            String message = deprecatedActions.get(i + 1);
+            int delim = restAction.indexOf(' ');
+            try {
+                method = RestRequest.Method.valueOf(restAction.substring(0, delim));
+                path = pathPrefix + restAction.substring(delim).trim();
+            } catch (IndexOutOfBoundsException | IllegalArgumentException e) {
+                throw new IllegalArgumentException(restAction + " does not begin with a valid REST method");
+            }
+            logger.info("Registering: " + method + " " + path + " with deprecation message " + message);
+            restActionsAsDeprecatedRoutes.add(new DeprecatedRoute(method, path, message));
+        }
+        this.deprecatedRoutes = unmodifiableList(restActionsAsDeprecatedRoutes);
+
         this.discoveryExtensionNode = discoveryExtensionNode;
         this.transportService = transportService;
     }
@@ -107,6 +128,11 @@ public class RestSendToExtensionAction extends BaseRestHandler {
     @Override
     public List<Route> routes() {
         return this.routes;
+    }
+
+    @Override
+    public List<DeprecatedRoute> deprecatedRoutes() {
+        return this.deprecatedRoutes;
     }
 
     public Map<String, List<String>> filterHeaders(Map<String, List<String>> headers, Set<String> allowList, Set<String> denyList) {

--- a/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
+++ b/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
@@ -471,7 +471,8 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
 
         String uniqueIdStr = "uniqueid1";
         List<String> actionsList = List.of("GET /foo", "PUT /bar", "POST /baz");
-        RegisterRestActionsRequest registerActionsRequest = new RegisterRestActionsRequest(uniqueIdStr, actionsList);
+        List<String> deprecatedActionsList = List.of("GET /deprecated/foo", "It's deprecated!");
+        RegisterRestActionsRequest registerActionsRequest = new RegisterRestActionsRequest(uniqueIdStr, actionsList, deprecatedActionsList);
         TransportResponse response = extensionsManager.getRestActionsRequestHandler()
             .handleRegisterRestActionsRequest(registerActionsRequest);
         assertEquals(AcknowledgedResponse.class, response.getClass());
@@ -501,7 +502,22 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
 
         String uniqueIdStr = "uniqueid1";
         List<String> actionsList = List.of("FOO /foo", "PUT /bar", "POST /baz");
-        RegisterRestActionsRequest registerActionsRequest = new RegisterRestActionsRequest(uniqueIdStr, actionsList);
+        List<String> deprecatedActionsList = List.of("GET /deprecated/foo", "It's deprecated!");
+        RegisterRestActionsRequest registerActionsRequest = new RegisterRestActionsRequest(uniqueIdStr, actionsList, deprecatedActionsList);
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> extensionsManager.getRestActionsRequestHandler().handleRegisterRestActionsRequest(registerActionsRequest)
+        );
+    }
+
+    public void testHandleRegisterRestActionsRequestWithInvalidDeprecatedMethod() throws Exception {
+        ExtensionsManager extensionsManager = new ExtensionsManager(settings, extensionDir);
+        initialize(extensionsManager);
+
+        String uniqueIdStr = "uniqueid1";
+        List<String> actionsList = List.of("GET /foo", "PUT /bar", "POST /baz");
+        List<String> deprecatedActionsList = List.of("FOO /deprecated/foo", "It's deprecated!");
+        RegisterRestActionsRequest registerActionsRequest = new RegisterRestActionsRequest(uniqueIdStr, actionsList, deprecatedActionsList);
         expectThrows(
             IllegalArgumentException.class,
             () -> extensionsManager.getRestActionsRequestHandler().handleRegisterRestActionsRequest(registerActionsRequest)
@@ -513,7 +529,21 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
         initialize(extensionsManager);
         String uniqueIdStr = "uniqueid1";
         List<String> actionsList = List.of("GET", "PUT /bar", "POST /baz");
-        RegisterRestActionsRequest registerActionsRequest = new RegisterRestActionsRequest(uniqueIdStr, actionsList);
+        List<String> deprecatedActionsList = List.of("GET /deprecated/foo", "It's deprecated!");
+        RegisterRestActionsRequest registerActionsRequest = new RegisterRestActionsRequest(uniqueIdStr, actionsList, deprecatedActionsList);
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> extensionsManager.getRestActionsRequestHandler().handleRegisterRestActionsRequest(registerActionsRequest)
+        );
+    }
+
+    public void testHandleRegisterRestActionsRequestWithInvalidDeprecatedUri() throws Exception {
+        ExtensionsManager extensionsManager = new ExtensionsManager(settings, extensionDir);
+        initialize(extensionsManager);
+        String uniqueIdStr = "uniqueid1";
+        List<String> actionsList = List.of("GET /foo", "PUT /bar", "POST /baz");
+        List<String> deprecatedActionsList = List.of("GET", "It's deprecated!");
+        RegisterRestActionsRequest registerActionsRequest = new RegisterRestActionsRequest(uniqueIdStr, actionsList, deprecatedActionsList);
         expectThrows(
             IllegalArgumentException.class,
             () -> extensionsManager.getRestActionsRequestHandler().handleRegisterRestActionsRequest(registerActionsRequest)

--- a/server/src/test/java/org/opensearch/extensions/rest/RegisterRestActionsTests.java
+++ b/server/src/test/java/org/opensearch/extensions/rest/RegisterRestActionsTests.java
@@ -20,13 +20,16 @@ public class RegisterRestActionsTests extends OpenSearchTestCase {
     public void testRegisterRestActionsRequest() throws Exception {
         String uniqueIdStr = "uniqueid1";
         List<String> expected = List.of("GET /foo", "PUT /bar", "POST /baz");
-        RegisterRestActionsRequest registerRestActionsRequest = new RegisterRestActionsRequest(uniqueIdStr, expected);
+        List<String> expectedDeprecated = List.of("GET /deprecated/foo", "It's deprecated");
+        RegisterRestActionsRequest registerRestActionsRequest = new RegisterRestActionsRequest(uniqueIdStr, expected, expectedDeprecated);
 
         assertEquals(uniqueIdStr, registerRestActionsRequest.getUniqueId());
         List<String> restActions = registerRestActionsRequest.getRestActions();
+        List<String> deprecatedRestActions = registerRestActionsRequest.getDeprecatedRestActions();
         assertEquals(expected.size(), restActions.size());
         assertTrue(restActions.containsAll(expected));
         assertTrue(expected.containsAll(restActions));
+        assertTrue(expectedDeprecated.containsAll(deprecatedRestActions));
 
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             registerRestActionsRequest.writeTo(out);
@@ -36,9 +39,11 @@ public class RegisterRestActionsTests extends OpenSearchTestCase {
 
                 assertEquals(uniqueIdStr, registerRestActionsRequest.getUniqueId());
                 restActions = registerRestActionsRequest.getRestActions();
+                deprecatedRestActions = registerRestActionsRequest.getDeprecatedRestActions();
                 assertEquals(expected.size(), restActions.size());
                 assertTrue(restActions.containsAll(expected));
                 assertTrue(expected.containsAll(restActions));
+                assertTrue(expectedDeprecated.containsAll(deprecatedRestActions));
             }
         }
     }

--- a/server/src/test/java/org/opensearch/extensions/rest/RestSendToExtensionActionTests.java
+++ b/server/src/test/java/org/opensearch/extensions/rest/RestSendToExtensionActionTests.java
@@ -99,7 +99,8 @@ public class RestSendToExtensionActionTests extends OpenSearchTestCase {
     public void testRestSendToExtensionAction() throws Exception {
         RegisterRestActionsRequest registerRestActionRequest = new RegisterRestActionsRequest(
             "uniqueid1",
-            List.of("GET /foo", "PUT /bar", "POST /baz")
+            List.of("GET /foo", "PUT /bar", "POST /baz"),
+            List.of("GET /deprecated/foo", "It's deprecated!")
         );
         RestSendToExtensionAction restSendToExtensionAction = new RestSendToExtensionAction(
             registerRestActionRequest,
@@ -129,7 +130,8 @@ public class RestSendToExtensionActionTests extends OpenSearchTestCase {
     public void testRestSendToExtensionActionFilterHeaders() throws Exception {
         RegisterRestActionsRequest registerRestActionRequest = new RegisterRestActionsRequest(
             "uniqueid1",
-            List.of("GET /foo", "PUT /bar", "POST /baz")
+            List.of("GET /foo", "PUT /bar", "POST /baz"),
+            List.of("GET /deprecated/foo", "It's deprecated!")
         );
         RestSendToExtensionAction restSendToExtensionAction = new RestSendToExtensionAction(
             registerRestActionRequest,
@@ -155,7 +157,20 @@ public class RestSendToExtensionActionTests extends OpenSearchTestCase {
     public void testRestSendToExtensionActionBadMethod() throws Exception {
         RegisterRestActionsRequest registerRestActionRequest = new RegisterRestActionsRequest(
             "uniqueid1",
-            List.of("/foo", "PUT /bar", "POST /baz")
+            List.of("/foo", "PUT /bar", "POST /baz"),
+            List.of("GET /deprecated/foo", "It's deprecated!")
+        );
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> new RestSendToExtensionAction(registerRestActionRequest, discoveryExtensionNode, transportService)
+        );
+    }
+
+    public void testRestSendToExtensionActionBadDeprecatedMethod() throws Exception {
+        RegisterRestActionsRequest registerRestActionRequest = new RegisterRestActionsRequest(
+            "uniqueid1",
+            List.of("GET /foo", "PUT /bar", "POST /baz"),
+            List.of("/deprecated/foo", "It's deprecated!")
         );
         expectThrows(
             IllegalArgumentException.class,
@@ -166,7 +181,20 @@ public class RestSendToExtensionActionTests extends OpenSearchTestCase {
     public void testRestSendToExtensionActionMissingUri() throws Exception {
         RegisterRestActionsRequest registerRestActionRequest = new RegisterRestActionsRequest(
             "uniqueid1",
-            List.of("GET", "PUT /bar", "POST /baz")
+            List.of("GET", "PUT /bar", "POST /baz"),
+            List.of("GET /deprecated/foo", "It's deprecated!")
+        );
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> new RestSendToExtensionAction(registerRestActionRequest, discoveryExtensionNode, transportService)
+        );
+    }
+
+    public void testRestSendToExtensionActionMissingDeprecatedUri() throws Exception {
+        RegisterRestActionsRequest registerRestActionRequest = new RegisterRestActionsRequest(
+            "uniqueid1",
+            List.of("GET /foo", "PUT /bar", "POST /baz"),
+            List.of("GET", "It's deprecated!")
         );
         expectThrows(
             IllegalArgumentException.class,


### PR DESCRIPTION
Companion PR on SDK: https://github.com/opensearch-project/opensearch-sdk-java/pull/666

### Description

Adds the ability to handle Deprecated and Replaced Routes to the ExtensionRestHandler.  This will permit (nearly) identical syntax for plugin migration, and provide backwards compatibility to extension users.
 - Routes were already registered.
 - Deprecated routes are just a wrapper around Routes, which add a log message.
 - Replaced routes are a fancy user interface to simultaneously register Routes and Deprecated Routes.

The OpenSearch integration adds a new list to the existing registration request.  In addition to the method and path sent for routes, deprecated routes have a deprecationMessage included.  This is included in a separate list where the message immediately follows the method/path.

### Issues Resolved

Fixes [SDK #665](https://github.com/opensearch-project/opensearch-sdk-java/issues/665)

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
