### PR TITLE
Removed duplicated 'nodeId' in cache path #7059

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/SearchableSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/SearchableSnapshotIT.java
@@ -36,7 +36,6 @@ import org.opensearch.node.Node;
 import org.opensearch.repositories.fs.FsRepository;
 
 import java.io.IOException;
-import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -595,12 +594,8 @@ public final class SearchableSnapshotIT extends AbstractSnapshotIntegTestCase {
         for (Path fileCachePath : searchNodeFileCachePaths) {
             assertTrue(Files.exists(fileCachePath));
             assertTrue(Files.isDirectory(fileCachePath));
-            try (DirectoryStream<Path> cachePathStream = Files.newDirectoryStream(fileCachePath)) {
-                Path nodeLockIdPath = cachePathStream.iterator().next();
-                assertTrue(Files.isDirectory(nodeLockIdPath));
-                try (Stream<Path> dataPathStream = Files.list(nodeLockIdPath)) {
-                    assertEquals(numIndexCount, dataPathStream.count());
-                }
+            try (Stream<Path> dataPathStream = Files.list(fileCachePath)) {
+                assertEquals(numIndexCount, dataPathStream.count());
             }
         }
         // Verifies if all the shards (primary and replica) have been deleted

--- a/server/src/main/java/org/opensearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/opensearch/env/NodeEnvironment.java
@@ -1307,9 +1307,7 @@ public final class NodeEnvironment implements Closeable {
      * @param shardId shard to resolve the path to
      */
     public Path resolveFileCacheLocation(final Path fileCachePath, final ShardId shardId) {
-        return fileCachePath.resolve(Integer.toString(nodeLockId))
-            .resolve(shardId.getIndex().getUUID())
-            .resolve(Integer.toString(shardId.id()));
+        return fileCachePath.resolve(shardId.getIndex().getUUID()).resolve(Integer.toString(shardId.id()));
     }
 
     /**

--- a/server/src/main/java/org/opensearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/opensearch/env/NodeEnvironment.java
@@ -1247,22 +1247,17 @@ public final class NodeEnvironment implements Closeable {
      * The returned paths will point to the shard data folder.
      */
     public static List<Path> collectFileCacheDataPath(NodePath fileCacheNodePath) throws IOException {
+        // Structure is: <file cache path>/<index uuid>/<shard id>/...
         List<Path> indexSubPaths = new ArrayList<>();
         Path fileCachePath = fileCacheNodePath.fileCachePath;
         if (Files.isDirectory(fileCachePath)) {
-            try (DirectoryStream<Path> nodeStream = Files.newDirectoryStream(fileCachePath)) {
-                for (Path nodePath : nodeStream) {
-                    if (Files.isDirectory(nodePath)) {
-                        try (DirectoryStream<Path> indexStream = Files.newDirectoryStream(nodePath)) {
-                            for (Path indexPath : indexStream) {
-                                if (Files.isDirectory(indexPath)) {
-                                    try (Stream<Path> shardStream = Files.list(indexPath)) {
-                                        shardStream.filter(NodeEnvironment::isShardPath)
-                                            .map(Path::toAbsolutePath)
-                                            .forEach(indexSubPaths::add);
-                                    }
-                                }
-                            }
+            try (DirectoryStream<Path> indexStream = Files.newDirectoryStream(fileCachePath)) {
+                for (Path indexPath : indexStream) {
+                    if (Files.isDirectory(indexPath)) {
+                        try (Stream<Path> shardStream = Files.list(indexPath)) {
+                            shardStream.filter(NodeEnvironment::isShardPath)
+                                .map(Path::toAbsolutePath)
+                                .forEach(indexSubPaths::add);
                         }
                     }
                 }

--- a/server/src/main/java/org/opensearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/opensearch/env/NodeEnvironment.java
@@ -1255,9 +1255,7 @@ public final class NodeEnvironment implements Closeable {
                 for (Path indexPath : indexStream) {
                     if (Files.isDirectory(indexPath)) {
                         try (Stream<Path> shardStream = Files.list(indexPath)) {
-                            shardStream.filter(NodeEnvironment::isShardPath)
-                                .map(Path::toAbsolutePath)
-                                .forEach(indexSubPaths::add);
+                            shardStream.filter(NodeEnvironment::isShardPath).map(Path::toAbsolutePath).forEach(indexSubPaths::add);
                         }
                     }
                 }

--- a/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCacheCleaner.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCacheCleaner.java
@@ -91,9 +91,7 @@ public class FileCacheCleaner implements IndexEventListener {
     ) {
         if (isRemoteSnapshot(indexSettings.getSettings())
             && reason == IndicesClusterStateService.AllocatedIndices.IndexRemovalReason.DELETED) {
-            final Path indexCachePath = nodeEnvironment.fileCacheNodePath().fileCachePath.resolve(
-                Integer.toString(nodeEnvironment.getNodeLockId())
-            ).resolve(index.getUUID());
+            final Path indexCachePath = nodeEnvironment.fileCacheNodePath().fileCachePath.resolve(index.getUUID());
             if (Files.exists(indexCachePath)) {
                 try {
                     IOUtils.rm(indexCachePath);

--- a/server/src/test/java/org/opensearch/env/NodeRepurposeCommandTests.java
+++ b/server/src/test/java/org/opensearch/env/NodeRepurposeCommandTests.java
@@ -391,7 +391,7 @@ public class NodeRepurposeCommandTests extends OpenSearchTestCase {
 
             if (cacheMode) {
                 Path cachePath = env.fileCacheNodePath().fileCachePath;
-                cachePath = cachePath.resolve(String.valueOf(env.getNodeLockId())).resolve(INDEX.getUUID());
+                cachePath = cachePath.resolve(INDEX.getUUID());
                 for (int i = 0; i < shardCount; ++i) {
                     Files.createDirectories(cachePath.resolve(Integer.toString(shardDataDirNumber)));
                     shardDataDirNumber += randomIntBetween(1, 10);

--- a/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheCleanerTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheCleanerTests.java
@@ -92,8 +92,7 @@ public class FileCacheCleanerTests extends OpenSearchTestCase {
     }
 
     public void testIndexRemoved() {
-        final Path indexCachePath = env.fileCacheNodePath().fileCachePath.resolve(Integer.toString(env.getNodeLockId()))
-            .resolve(SHARD_0.getIndex().getUUID());
+        final Path indexCachePath = env.fileCacheNodePath().fileCachePath.resolve(SHARD_0.getIndex().getUUID());
         assertTrue(Files.exists(indexCachePath));
 
         cleaner.beforeIndexShardDeleted(SHARD_0, SETTINGS);

--- a/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheTests.java
@@ -54,9 +54,8 @@ public class FileCacheTests extends OpenSearchTestCase {
     }
 
     @SuppressForbidden(reason = "creating a test file for cache")
-    private void createFile(String nodeId, String indexName, String shardId, String fileName) throws IOException {
+    private void createFile(String indexName, String shardId, String fileName) throws IOException {
         Path folderPath = path.resolve(NodeEnvironment.CACHE_FOLDER)
-            .resolve(nodeId)
             .resolve(indexName)
             .resolve(shardId)
             .resolve(RemoteSnapshotDirectoryFactory.LOCAL_STORE_LOCATION);
@@ -266,10 +265,9 @@ public class FileCacheTests extends OpenSearchTestCase {
     }
 
     public void testCacheRestore() throws IOException {
-        String nodeId = "0";
         String indexName = "test-index";
         String shardId = "0";
-        createFile(nodeId, indexName, shardId, "test.0");
+        createFile(indexName, shardId, "test.0");
         FileCache fileCache = createFileCache(GIGA_BYTES);
         assertEquals(0, fileCache.usage().usage());
         Path fileCachePath = path.resolve(NodeEnvironment.CACHE_FOLDER).resolve(indexName).resolve(shardId);

--- a/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheTests.java
@@ -272,7 +272,7 @@ public class FileCacheTests extends OpenSearchTestCase {
         createFile(nodeId, indexName, shardId, "test.0");
         FileCache fileCache = createFileCache(GIGA_BYTES);
         assertEquals(0, fileCache.usage().usage());
-        Path fileCachePath = path.resolve(NodeEnvironment.CACHE_FOLDER).resolve(nodeId).resolve(indexName).resolve(shardId);
+        Path fileCachePath = path.resolve(NodeEnvironment.CACHE_FOLDER).resolve(indexName).resolve(shardId);
         fileCache.restoreFromDirectory(List.of(fileCachePath));
         assertTrue(fileCache.usage().usage() > 0);
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
So in this issue, i removed the duplicate <node-lock-id> that was present in the cache path generated.

### Issues Resolved
Closes #7059

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
