### PR TITLE
[Extensions] Add ClusterStateRequest parameter to cluster state transport request

### DIFF
--- a/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
@@ -32,7 +32,7 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.OpenSearchException;
 import org.opensearch.Version;
 import org.opensearch.action.ActionModule;
-import org.opensearch.action.admin.cluster.state.ClusterStateResponse;
+import org.opensearch.action.admin.cluster.state.ClusterStateRequest;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.cluster.ClusterSettingsResponse;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -246,8 +246,8 @@ public class ExtensionsManager {
             ThreadPool.Names.GENERIC,
             false,
             false,
-            ExtensionRequest::new,
-            ((request, channel, task) -> channel.sendResponse(handleExtensionRequest(request)))
+            ClusterStateRequest::new,
+            ((request, channel, task) -> channel.sendResponse(extensionTransportActionsHandler.handleClusterStateRequest(request)))
         );
         transportService.registerRequestHandler(
             REQUEST_EXTENSION_CLUSTER_SETTINGS,
@@ -436,8 +436,6 @@ public class ExtensionsManager {
      */
     TransportResponse handleExtensionRequest(ExtensionRequest extensionRequest) throws Exception {
         switch (extensionRequest.getRequestType()) {
-            case REQUEST_EXTENSION_CLUSTER_STATE:
-                return new ClusterStateResponse(clusterService.getClusterName(), clusterService.state(), false);
             case REQUEST_EXTENSION_CLUSTER_SETTINGS:
                 return new ClusterSettingsResponse(clusterService);
             case REQUEST_EXTENSION_ENVIRONMENT_SETTINGS:

--- a/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
+++ b/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
@@ -42,7 +42,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.opensearch.Version;
 import org.opensearch.action.ActionModule;
-import org.opensearch.action.admin.cluster.state.ClusterStateResponse;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.cluster.ClusterSettingsResponse;
 import org.opensearch.env.EnvironmentSettingsResponse;
@@ -523,9 +522,6 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
     public void testHandleExtensionRequest() throws Exception {
         ExtensionsManager extensionsManager = new ExtensionsManager(settings, extensionDir);
         initialize(extensionsManager);
-
-        ExtensionRequest clusterStateRequest = new ExtensionRequest(ExtensionsManager.RequestType.REQUEST_EXTENSION_CLUSTER_STATE);
-        assertEquals(ClusterStateResponse.class, extensionsManager.handleExtensionRequest(clusterStateRequest).getClass());
 
         ExtensionRequest clusterSettingRequest = new ExtensionRequest(ExtensionsManager.RequestType.REQUEST_EXTENSION_CLUSTER_SETTINGS);
         assertEquals(ClusterSettingsResponse.class, extensionsManager.handleExtensionRequest(clusterSettingRequest).getClass());

--- a/server/src/test/java/org/opensearch/extensions/action/ExtensionTransportActionsHandlerTests.java
+++ b/server/src/test/java/org/opensearch/extensions/action/ExtensionTransportActionsHandlerTests.java
@@ -13,8 +13,8 @@ import org.junit.Before;
 import org.opensearch.Version;
 import org.opensearch.action.ActionModule;
 import org.opensearch.action.ActionModule.DynamicActionRegistry;
+import org.opensearch.action.admin.cluster.state.ClusterStateAction;
 import org.opensearch.action.admin.cluster.state.ClusterStateRequest;
-import org.opensearch.action.admin.cluster.state.ClusterStateResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -45,7 +45,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import static java.util.Collections.emptyMap;
@@ -97,7 +102,7 @@ public class ExtensionTransportActionsHandlerTests extends OpenSearchTestCase {
             Version.fromString("3.0.0"),
             Collections.emptyList()
         );
-        client = new NoOpNodeClient(this.getTestName());
+        client = spy(new NoOpNodeClient(this.getTestName()));
         ActionModule mockActionModule = mock(ActionModule.class);
         DynamicActionRegistry dynamicActionRegistry = new DynamicActionRegistry();
         dynamicActionRegistry.registerUnmodifiableActionMap(Collections.emptyMap());
@@ -181,9 +186,8 @@ public class ExtensionTransportActionsHandlerTests extends OpenSearchTestCase {
 
     public void testHandleClusterStateRequest() throws Exception {
         ClusterStateRequest clusterStateRequest = new ClusterStateRequest().all();
-        assertEquals(
-            ClusterStateResponse.class,
-            extensionTransportActionsHandler.handleClusterStateRequest(clusterStateRequest).getClass()
-        );
+        // The client is no-op so doesn't actually execute this request, but we can verify it's called
+        extensionTransportActionsHandler.handleClusterStateRequest(clusterStateRequest);
+        verify(client, times(1)).execute(eq(ClusterStateAction.INSTANCE), eq(clusterStateRequest), any());
     }
 }

--- a/server/src/test/java/org/opensearch/extensions/action/ExtensionTransportActionsHandlerTests.java
+++ b/server/src/test/java/org/opensearch/extensions/action/ExtensionTransportActionsHandlerTests.java
@@ -13,6 +13,8 @@ import org.junit.Before;
 import org.opensearch.Version;
 import org.opensearch.action.ActionModule;
 import org.opensearch.action.ActionModule.DynamicActionRegistry;
+import org.opensearch.action.admin.cluster.state.ClusterStateRequest;
+import org.opensearch.action.admin.cluster.state.ClusterStateResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -175,5 +177,13 @@ public class ExtensionTransportActionsHandlerTests extends OpenSearchTestCase {
         assertTrue(response.getStatus());
 
         expectThrows(NodeNotConnectedException.class, () -> extensionTransportActionsHandler.sendTransportRequestToExtension(request));
+    }
+
+    public void testHandleClusterStateRequest() throws Exception {
+        ClusterStateRequest clusterStateRequest = new ClusterStateRequest().all();
+        assertEquals(
+            ClusterStateResponse.class,
+            extensionTransportActionsHandler.handleClusterStateRequest(clusterStateRequest).getClass()
+        );
     }
 }


### PR DESCRIPTION
Companion PR on SDK: https://github.com/opensearch-project/opensearch-sdk-java/pull/668

### Description

Adds the ability to send a `ClusterStateRequest` parameter when requesting Cluster State, to limit the values returned (and reduce transport bandwidth).  To get the old behavior, use `new ClusterStateRequest().all()` as the parameter.

### Issues Resolved

Fixes [SDK #354](https://github.com/opensearch-project/opensearch-sdk-java/issues/354)

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
