### PR TITLE
Do not delete entire index cache on shard removal

### DIFF
--- a/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCacheCleaner.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCacheCleaner.java
@@ -11,13 +11,16 @@ package org.opensearch.index.store.remote.filecache;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.opensearch.common.io.FileSystemUtils;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.env.NodeEnvironment;
+import org.opensearch.index.Index;
 import org.opensearch.index.IndexModule;
+import org.opensearch.index.IndexSettings;
 import org.opensearch.index.shard.IndexEventListener;
 import org.opensearch.index.shard.ShardId;
 import org.opensearch.index.shard.ShardPath;
+import org.opensearch.indices.cluster.IndicesClusterStateService;
 
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
@@ -52,19 +55,56 @@ public class FileCacheCleaner implements IndexEventListener {
     @Override
     public void beforeIndexShardDeleted(ShardId shardId, Settings settings) {
         try {
-            String storeType = settings.get(IndexModule.INDEX_STORE_TYPE_SETTING.getKey());
-            if (IndexModule.Type.REMOTE_SNAPSHOT.match(storeType)) {
-                ShardPath shardPath = ShardPath.loadFileCachePath(nodeEnvironment, shardId);
-                Path localStorePath = shardPath.getDataPath().resolve(LOCAL_STORE_LOCATION);
+            if (isRemoteSnapshot(settings)) {
+                final ShardPath shardPath = ShardPath.loadFileCachePath(nodeEnvironment, shardId);
+                final Path localStorePath = shardPath.getDataPath().resolve(LOCAL_STORE_LOCATION);
                 try (DirectoryStream<Path> ds = Files.newDirectoryStream(localStorePath)) {
                     for (Path subPath : ds) {
                         fileCache.remove(subPath.toRealPath());
                     }
                 }
-                FileSystemUtils.deleteSubDirectories(shardPath.getRootDataPath());
             }
         } catch (IOException ioe) {
-            log.error(() -> new ParameterizedMessage("Error removing items from cache during shard deletion {})", shardId), ioe);
+            log.error(() -> new ParameterizedMessage("Error removing items from cache during shard deletion {}", shardId), ioe);
         }
+    }
+
+    @Override
+    public void afterIndexShardDeleted(ShardId shardId, Settings settings) {
+        if (isRemoteSnapshot(settings)) {
+            final Path path = ShardPath.loadFileCachePath(nodeEnvironment, shardId).getDataPath();
+            try {
+                if (Files.exists(path)) {
+                    IOUtils.rm(path);
+                }
+            } catch (IOException e) {
+                log.error(() -> new ParameterizedMessage("Failed to delete cache path for shard {}", shardId), e);
+            }
+        }
+    }
+
+    @Override
+    public void afterIndexRemoved(
+        Index index,
+        IndexSettings indexSettings,
+        IndicesClusterStateService.AllocatedIndices.IndexRemovalReason reason
+    ) {
+        if (isRemoteSnapshot(indexSettings.getSettings())
+            && reason == IndicesClusterStateService.AllocatedIndices.IndexRemovalReason.DELETED) {
+            final Path indexCachePath = nodeEnvironment.fileCacheNodePath().fileCachePath.resolve(
+                Integer.toString(nodeEnvironment.getNodeLockId())
+            ).resolve(index.getUUID());
+            if (Files.exists(indexCachePath)) {
+                try {
+                    IOUtils.rm(indexCachePath);
+                } catch (IOException e) {
+                    log.error(() -> new ParameterizedMessage("Failed to delete cache path for index {}", index), e);
+                }
+            }
+        }
+    }
+
+    private static boolean isRemoteSnapshot(Settings settings) {
+        return IndexModule.Type.REMOTE_SNAPSHOT.match(settings.get(IndexModule.INDEX_STORE_TYPE_SETTING.getKey()));
     }
 }

--- a/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheCleanerTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheCleanerTests.java
@@ -1,0 +1,111 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.store.remote.filecache;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hamcrest.MatcherAssert;
+import org.junit.After;
+import org.junit.Before;
+import org.opensearch.Version;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.breaker.CircuitBreaker;
+import org.opensearch.common.breaker.NoopCircuitBreaker;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.env.NodeEnvironment;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.shard.ShardId;
+import org.opensearch.index.shard.ShardPath;
+import org.opensearch.indices.cluster.IndicesClusterStateService;
+import org.opensearch.test.OpenSearchTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.opensearch.index.store.remote.directory.RemoteSnapshotDirectoryFactory.LOCAL_STORE_LOCATION;
+
+public class FileCacheCleanerTests extends OpenSearchTestCase {
+    private static final ShardId SHARD_0 = new ShardId("index", "uuid-0", 0);
+    private static final ShardId SHARD_1 = new ShardId("index", "uuid-1", 0);
+    private static final Settings SETTINGS = Settings.builder()
+        .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+        .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
+        .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+        .put("index.store.type", "remote_snapshot")
+        .build();
+    private static final IndexSettings INDEX_SETTINGS = new IndexSettings(
+        IndexMetadata.builder("index").settings(SETTINGS).build(),
+        SETTINGS
+    );
+
+    private final FileCache fileCache = FileCacheFactory.createConcurrentLRUFileCache(
+        1024 * 1024 * 1024,
+        1,
+        new NoopCircuitBreaker(CircuitBreaker.REQUEST)
+    );
+    private final Map<ShardId, Path> files = new HashMap<>();
+    private NodeEnvironment env;
+    private FileCacheCleaner cleaner;
+
+    @Before
+    public void setUpFileCache() throws IOException {
+        env = newNodeEnvironment(SETTINGS);
+        cleaner = new FileCacheCleaner(env, fileCache);
+        files.put(SHARD_0, addFile(fileCache, env, SHARD_0));
+        files.put(SHARD_1, addFile(fileCache, env, SHARD_1));
+        MatcherAssert.assertThat(fileCache.size(), equalTo(2L));
+    }
+
+    private static Path addFile(FileCache fileCache, NodeEnvironment env, ShardId shardId) throws IOException {
+        final ShardPath shardPath = ShardPath.loadFileCachePath(env, shardId);
+        final Path localStorePath = shardPath.getDataPath().resolve(LOCAL_STORE_LOCATION);
+        Files.createDirectories(localStorePath);
+        final Path file = Files.createFile(localStorePath.resolve("file"));
+        fileCache.put(file, new FileCachedIndexInput.ClosedIndexInput(1024));
+        return file;
+    }
+
+    @After
+    public void tearDownFileCache() {
+        env.close();
+    }
+
+    public void testShardRemoved() {
+        final Path cachePath = ShardPath.loadFileCachePath(env, SHARD_0).getDataPath();
+        assertTrue(Files.exists(cachePath));
+
+        cleaner.beforeIndexShardDeleted(SHARD_0, SETTINGS);
+        MatcherAssert.assertThat(fileCache.size(), equalTo(1L));
+        assertNull(fileCache.get(files.get(SHARD_0)));
+        assertFalse(Files.exists(files.get(SHARD_0)));
+        assertTrue(Files.exists(files.get(SHARD_1)));
+        cleaner.afterIndexShardDeleted(SHARD_0, SETTINGS);
+        assertFalse(Files.exists(cachePath));
+    }
+
+    public void testIndexRemoved() {
+        final Path indexCachePath = env.fileCacheNodePath().fileCachePath.resolve(Integer.toString(env.getNodeLockId()))
+            .resolve(SHARD_0.getIndex().getUUID());
+        assertTrue(Files.exists(indexCachePath));
+
+        cleaner.beforeIndexShardDeleted(SHARD_0, SETTINGS);
+        cleaner.afterIndexShardDeleted(SHARD_0, SETTINGS);
+        cleaner.beforeIndexShardDeleted(SHARD_1, SETTINGS);
+        cleaner.afterIndexShardDeleted(SHARD_1, SETTINGS);
+        cleaner.afterIndexRemoved(
+            SHARD_0.getIndex(),
+            INDEX_SETTINGS,
+            IndicesClusterStateService.AllocatedIndices.IndexRemovalReason.DELETED
+        );
+        MatcherAssert.assertThat(fileCache.size(), equalTo(0L));
+        assertFalse(Files.exists(indexCachePath));
+    }
+}


### PR DESCRIPTION
The cleaner was too aggresive with cleaning up the cache and would delete the entire index directory within the cache when a shard was removed. This is not correct when multiple shards for a given index are on the same node.

### Issues Resolved
Closes #6996

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
