### PR TITLE
[Backport] [2.x] Bump org.gradle.test-retry from 1.5.1 to 1.5.2 (#7067)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add `com.github.luben:zstd-jni:1.5.4-1` ([#3577](https://github.com/opensearch-project/OpenSearch/pull/3577))
 - Bump: Netty from 4.1.90.Final to 4.1.91.Final , ASM 9.4 to ASM 9.5, ByteBuddy 1.14.2 to 1.14.3 ([#6981](https://github.com/opensearch-project/OpenSearch/pull/6981))
 - Bump `com.azure:azure-storage-blob` from 12.15.0 to 12.21.1
+- Bump `org.gradle.test-retry` from 1.5.1 to 1.5.2
 
 ### Changed
 - Require MediaType in Strings.toString API ([#6009](https://github.com/opensearch-project/OpenSearch/pull/6009))

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ plugins {
   id 'opensearch.docker-support'
   id 'opensearch.global-build-info'
   id "com.diffplug.spotless" version "6.17.0" apply false
-  id "org.gradle.test-retry" version "1.5.1" apply false
+  id "org.gradle.test-retry" version "1.5.2" apply false
   id "test-report-aggregation"
   id 'jacoco-report-aggregation'
 }


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/7067 to `2.x`