### PR TITLE
[Backport] [1.3] Bump org.gradle.test-retry from 1.5.1 to 1.5.2 (#7067)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Dependencies
 - Bump: Netty from 4.1.90.Final to 4.1.91.Final , ASM 9.4 to ASM 9.5, ByteBuddy 1.14.2 to 1.14.3 ([#6981](https://github.com/opensearch-project/OpenSearch/pull/6981))
+- Bump `org.gradle.test-retry` from 1.5.1 to 1.5.2
 
 ### Changed
 ### Deprecated

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ plugins {
   id 'opensearch.docker-support'
   id 'opensearch.global-build-info'
   id "com.diffplug.spotless" version "6.3.0" apply false
-  id "org.gradle.test-retry" version "1.4.1" apply false
+  id "org.gradle.test-retry" version "1.5.2" apply false
 }
 
 apply from: 'gradle/build-complete.gradle'


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/7067 to `1.3`