### PR TITLE
Ensure path is set before trying to parse using %~nxI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix compression support for h2c protocol ([#4944](https://github.com/opensearch-project/OpenSearch/pull/4944))
 - Support OpenSSL Provider with default Netty allocator ([#5460](https://github.com/opensearch-project/OpenSearch/pull/5460))
 - Avoid negative memory result in IndicesQueryCache stats calculation ([#6917](https://github.com/opensearch-project/OpenSearch/pull/6917))
+- Fixed incorrect path causing start up failure ([#7079](https://github.com/opensearch-project/OpenSearch/pull/7079))
 
 ### Security
 

--- a/distribution/src/bin/opensearch-env.bat
+++ b/distribution/src/bin/opensearch-env.bat
@@ -1,18 +1,22 @@
 set SCRIPT=%0
 
+for %%I in (opensearch.bat) do (
+    set "OPENSEARCH_HOME=%%~dpI"
+)
+
 rem determine OpenSearch home; to do this, we strip from the path until we
 rem find bin, and then strip bin (there is an assumption here that there is no
 rem nested directory under bin also named bin)
 if not defined OPENSEARCH_HOME (
-  for %%I in (%SCRIPT%) do set OPENSEARCH_HOME=%%~dpI
+    for %%I in (%0) do set OPENSEARCH_HOME=%%~dpI
 
-  :opensearch_home_loop
-  for %%I in ("%OPENSEARCH_HOME:~1,-1%") do set DIRNAME=%%~nxI
-  if not "%DIRNAME%" == "bin" (
+    :opensearch_home_loop
+    for %%I in ("%OPENSEARCH_HOME:~1,-1%") do set DIRNAME=%%~nxI
+    if not "%DIRNAME%" == "bin" (
+        for %%I in ("%OPENSEARCH_HOME%..") do set OPENSEARCH_HOME=%%~dpfI
+        goto opensearch_home_loop
+    )
     for %%I in ("%OPENSEARCH_HOME%..") do set OPENSEARCH_HOME=%%~dpfI
-    goto opensearch_home_loop
-  )
-  for %%I in ("%OPENSEARCH_HOME%..") do set OPENSEARCH_HOME=%%~dpfI
 )
 
 rem now set the classpath
@@ -43,10 +47,10 @@ if "%1" == "nojava" (
 
 rem comparing to empty string makes this equivalent to bash -v check on env var
 rem and allows to effectively force use of the bundled jdk when launching OpenSearch
-rem by setting OPENSEARCH_JAVA_HOME= and JAVA_HOME= 
+rem by setting OPENSEARCH_JAVA_HOME= and JAVA_HOME=
 if not "%OPENSEARCH_JAVA_HOME%" == "" (
   set "JAVA=%OPENSEARCH_JAVA_HOME%\bin\java.exe"
-  set JAVA_TYPE=OPENSEARCH_JAVA_HOME 
+  set JAVA_TYPE=OPENSEARCH_JAVA_HOME
 ) else if not "%JAVA_HOME%" == "" (
   set "JAVA=%JAVA_HOME%\bin\java.exe"
   set JAVA_TYPE=JAVA_HOME


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Resolve the issue seen as a result of #6956.

### Issues Resolved
[Security](https://github.com/opensearch-project/security/issues/2657) and [Job Scheduler](https://github.com/opensearch-project/job-scheduler/pull/360) failures amongst other repos.

### Check List
- [ ] ~New functionality includes testing.~
  - [ ] ~All tests pass~
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
