### PR TITLE
[Backport] [1.3] Bump org.apache.hadoop:hadoop-minicluster from 3.3.4 to 3.3.5 in /test/fixtures/hdfs-fixture (#7070)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Dependencies
 - Bump: Netty from 4.1.90.Final to 4.1.91.Final , ASM 9.4 to ASM 9.5, ByteBuddy 1.14.2 to 1.14.3 ([#6981](https://github.com/opensearch-project/OpenSearch/pull/6981))
 - Bump `org.gradle.test-retry` from 1.5.1 to 1.5.2
+- Bump `org.apache.hadoop:hadoop-minicluster` from 3.3.4 to 3.3.5
 
 ### Changed
 ### Deprecated

--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -31,7 +31,7 @@
 apply plugin: 'opensearch.java'
 
 dependencies {
-  api("org.apache.hadoop:hadoop-minicluster:3.3.4") {
+  api("org.apache.hadoop:hadoop-minicluster:3.3.5") {
     exclude module: 'websocket-client'
     exclude module: 'jettison'
   }


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/7070 to `1.3`