### PR TITLE
Dependabot/gradle/plugins/repository gcs/com.google.cloud google cloud storage 2.20.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `org.apache.zookeeper:zookeeper` from 3.8.0 to 3.8.1
 - Bump `net.minidev:json-smart` from 2.4.8 to 2.4.10
 - Bump `org.apache.maven:maven-model` from 3.8.6 to 3.9.1
+- Bump `com.google.cloud:google-cloud-storage` from 1.113.1 to 2.21.0 in /plugins/repository-gcs ([#6835](https://github.com/opensearch-project/OpenSearch/pull/6835))
 
 ### Changed
 - [CCR] Add getHistoryOperationsFromTranslog method to fetch the history snapshot from translogs ([#3948](https://github.com/opensearch-project/OpenSearch/pull/3948))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `org.apache.zookeeper:zookeeper` from 3.8.0 to 3.8.1
 - Bump `net.minidev:json-smart` from 2.4.8 to 2.4.10
 - Bump `org.apache.maven:maven-model` from 3.8.6 to 3.9.1
-- Bump `com.google.cloud:google-cloud-storage` from 1.113.1 to 2.21.0 in /plugins/repository-gcs ([#6835](https://github.com/opensearch-project/OpenSearch/pull/6835))
+- Bump `com.google.cloud:google-cloud-storage` from 1.113.1 to 2.20.2 in /plugins/repository-gcs ([#6835](https://github.com/opensearch-project/OpenSearch/pull/6835))
 
 ### Changed
 - [CCR] Add getHistoryOperationsFromTranslog method to fetch the history snapshot from translogs ([#3948](https://github.com/opensearch-project/OpenSearch/pull/3948))

--- a/plugins/repository-gcs/build.gradle
+++ b/plugins/repository-gcs/build.gradle
@@ -84,6 +84,8 @@ dependencies {
   api 'io.opencensus:opencensus-contrib-http-util:0.31.1'
   api 'com.google.apis:google-api-services-storage:v1-rev20220608-1.32.1'
 
+  compileOnly 'org.checkerframework:checker-qual:3.32.0'
+
   testImplementation project(':test:fixtures:gcs-fixture')
 }
 


### PR DESCRIPTION

### Description
Adds this PR to changelog and updates `plugins/repository-gcs/build.gradle` to user checker-qual 3.32.0 when compiling to prevent RequireNonNull error



### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
