### PR TITLE
Fix file cache active usage on restore

### DIFF
--- a/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCache.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCache.java
@@ -172,6 +172,7 @@ public class FileCache implements RefCountedCache<Path, CachedIndexInput> {
             .forEach(path -> {
                 try {
                     put(path.toAbsolutePath(), new FileCachedIndexInput.ClosedIndexInput(Files.size(path)));
+                    decRef(path.toAbsolutePath());
                 } catch (IOException e) {
                     throw new UncheckedIOException(
                         "Unable to retrieve cache file details. Please clear the file cache for node startup.",

--- a/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheTests.java
@@ -273,6 +273,7 @@ public class FileCacheTests extends OpenSearchTestCase {
         Path fileCachePath = path.resolve(NodeEnvironment.CACHE_FOLDER).resolve(indexName).resolve(shardId);
         fileCache.restoreFromDirectory(List.of(fileCachePath));
         assertTrue(fileCache.usage().usage() > 0);
+        assertEquals(0, fileCache.usage().activeUsage());
     }
 
     private void putAndDecRef(FileCache cache, int path, long indexInputSize) {


### PR DESCRIPTION
### Description
- Fixes improper ref count for objects within file cache on cache restore

### Issues Resolved
- Resolves #7097 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
