### PR TITLE
GlobalAggregation with profile option enabled returns incorrect result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed bug for searchable snapshot to take 'base_path' of blob into account ([#6558](https://github.com/opensearch-project/OpenSearch/pull/6558))
 - Fix fuzziness validation ([#5805](https://github.com/opensearch-project/OpenSearch/pull/5805))
 - Fix GetSnapshots to not return non-existent snapshots with ignore_unavailable=true ([#6839](https://github.com/opensearch-project/OpenSearch/pull/6839))
+- Fix GlobalAggregation with profile option enabled returns incorrect result ([#7114](https://github.com/opensearch-project/OpenSearch/pull/7114))
 
 ### Security
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/GlobalIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/GlobalIT.java
@@ -83,10 +83,19 @@ public class GlobalIT extends OpenSearchIntegTestCase {
         ensureSearchable();
     }
 
-    public void testWithStatsSubAggregator() throws Exception {
+    public void testWithStatsSubAggregatorAndProfileEnabled() throws Exception {
+        testWithStatsSubAggregator(true);
+    }
+
+    public void testWithStatsSubAggregatorAndProfileDisabled() throws Exception {
+        testWithStatsSubAggregator(false);
+    }
+
+    private void testWithStatsSubAggregator(boolean profileEnabled) throws Exception {
         SearchResponse response = client().prepareSearch("idx")
             .setQuery(QueryBuilders.termQuery("tag", "tag1"))
             .addAggregation(global("global").subAggregation(stats("value_stats").field("value")))
+            .setProfile(profileEnabled)
             .get();
 
         assertSearchResponse(response);


### PR DESCRIPTION
### Description
For the case when profile is enabled the check for GlobalAggregator operator will fail as it gets wrapped in the Profiling Aggregator. To fix this the check considers both the cases with profile enabled/disabled and verifies if the unwrapped aggregator instance is of Global type or not.

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/7088

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
