### PR TITLE
[Remote Store] Add Lock Manager in Remote Segment Store to persist da…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add new cluster settings to ignore weighted round-robin routing and fallback to default behaviour. ([#6834](https://github.com/opensearch-project/OpenSearch/pull/6834))
 - Add experimental support for ZSTD compression. ([#3577](https://github.com/opensearch-project/OpenSearch/pull/3577))
 - [Segment Replication] Add point in time and scroll query compatibility. ([#6644](https://github.com/opensearch-project/OpenSearch/pull/6644))
+- [Remote Store] Add Lock Manager in Remote Segment Store to persist data([#6787](https://github.com/opensearch-project/OpenSearch/pull/6787))
 
 ### Dependencies
 - Bump `org.apache.logging.log4j:log4j-core` from 2.18.0 to 2.20.0 ([#6490](https://github.com/opensearch-project/OpenSearch/pull/6490))

--- a/server/src/main/java/org/opensearch/index/store/RemoteDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteDirectory.java
@@ -35,7 +35,7 @@ import java.util.Set;
  */
 public class RemoteDirectory extends Directory {
 
-    private final BlobContainer blobContainer;
+    protected final BlobContainer blobContainer;
 
     public RemoteDirectory(BlobContainer blobContainer) {
         this.blobContainer = blobContainer;

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -21,7 +21,9 @@ import org.opensearch.common.lucene.store.ByteArrayIndexInput;
 import org.opensearch.index.store.remote.metadata.RemoteSegmentMetadata;
 import org.opensearch.common.io.VersionedCodecStreamWrapper;
 import org.opensearch.index.store.remote.metadata.RemoteSegmentMetadataHandler;
+import org.opensearch.index.store.lockmanager.RemoteStoreMDShardLockManager;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.NoSuchFileException;
 import java.util.Collection;
@@ -57,6 +59,8 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory {
     public static final MetadataFilenameUtils.MetadataFilenameComparator METADATA_FILENAME_COMPARATOR =
         new MetadataFilenameUtils.MetadataFilenameComparator();
 
+    public static final String METADATA_FILENAME_PREFIX = MetadataFilenameUtils.METADATA_PREFIX;
+
     /**
      * remoteDataDirectory is used to store segment files at path: cluster_UUID/index_UUID/shardId/segments/data
      */
@@ -65,6 +69,8 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory {
      * remoteMetadataDirectory is used to store metadata files at path: cluster_UUID/index_UUID/shardId/segments/metadata
      */
     private final RemoteDirectory remoteMetadataDirectory;
+
+    private final RemoteStoreMDShardLockManager mdLockManager;
 
     /**
      * To prevent explosion of refresh metadata files, we replace refresh files for the given primary term and generation
@@ -87,10 +93,12 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory {
 
     private static final Logger logger = LogManager.getLogger(RemoteSegmentStoreDirectory.class);
 
-    public RemoteSegmentStoreDirectory(RemoteDirectory remoteDataDirectory, RemoteDirectory remoteMetadataDirectory) throws IOException {
+    public RemoteSegmentStoreDirectory(RemoteDirectory remoteDataDirectory, RemoteDirectory remoteMetadataDirectory,
+                                       RemoteStoreMDShardLockManager mdLockManager) throws IOException {
         super(remoteDataDirectory);
         this.remoteDataDirectory = remoteDataDirectory;
         this.remoteMetadataDirectory = remoteMetadataDirectory;
+        this.mdLockManager = mdLockManager;
         init();
     }
 
@@ -317,7 +325,32 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory {
         }
     }
 
-    public void copyFrom(Directory from, String src, String dest, IOContext context, boolean useCommonSuffix) throws IOException {
+    public void acquireLock(long primaryTerm, long generation, String resourceID) throws IOException {
+        Optional<String> metadataFile = getMetadataFileForCommit(primaryTerm, generation);
+        if (metadataFile.isEmpty()) {
+            String errorString = "Metadata file is not present for given primary term "
+                + primaryTerm + " and generation " + generation;
+            throw new FileNotFoundException(errorString);
+        }
+        mdLockManager.acquire(mdLockManager.getLockInfoBuilder().withMetadataFile(metadataFile.get())
+            .withResourceId(resourceID).build());
+    }
+
+    // Visible for testing
+    Optional<String> getMetadataFileForCommit(long primaryTerm, long generation) throws IOException {
+        Collection<String> metadataFiles = remoteMetadataDirectory.listFilesByPrefix(
+            MetadataFilenameUtils.METADATA_PREFIX);
+
+        return metadataFiles.stream().filter(
+            file -> (
+                MetadataFilenameUtils.getPrimaryTerm(
+                    file.split(MetadataFilenameUtils.SEPARATOR)) == primaryTerm
+                    && MetadataFilenameUtils.getGeneration(
+                    file.split(MetadataFilenameUtils.SEPARATOR)) == generation)).findAny();
+    }
+
+    public void copyFrom(Directory from, String src, String dest, IOContext context, boolean useCommonSuffix,
+                         String checksum) throws IOException {
         String remoteFilename;
         if (useCommonSuffix) {
             remoteFilename = dest + SEGMENT_NAME_UUID_SEPARATOR + this.commonFilenameSuffix;
@@ -325,9 +358,15 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory {
             remoteFilename = getNewRemoteSegmentFilename(dest);
         }
         remoteDataDirectory.copyFrom(from, src, remoteFilename, context);
-        String checksum = getChecksumOfLocalFile(from, src);
         UploadedSegmentMetadata segmentMetadata = new UploadedSegmentMetadata(src, remoteFilename, checksum, from.fileLength(src));
         segmentsUploadedToRemoteStore.put(src, segmentMetadata);
+    }
+    public void copyFrom(Directory from, String src, String dest, IOContext context, boolean useCommonSuffix) throws IOException {
+        copyFrom(from, src, dest, context, useCommonSuffix, getChecksumOfLocalFile(from, src));
+    }
+
+    public static long getCommitGenerationFromMdFile(String mdFile) {
+        return MetadataFilenameUtils.getGeneration(mdFile.split(MetadataFilenameUtils.SEPARATOR));
     }
 
     /**
@@ -406,6 +445,20 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory {
     // Visible for testing
     public Map<String, UploadedSegmentMetadata> getSegmentsUploadedToRemoteStore() {
         return Collections.unmodifiableMap(this.segmentsUploadedToRemoteStore);
+    }
+
+    public Map<String, UploadedSegmentMetadata> getSegmentsUploadedToRemoteStore(long primaryTerm, long generation)
+        throws IOException {
+        Optional<String> metadataFile = getMetadataFileForCommit(primaryTerm, generation);
+
+        if (metadataFile.isEmpty()) {
+            String errorString = "Metadata file is not present for given primary term "
+                + primaryTerm + " and generation " + generation;
+            throw new FileNotFoundException(errorString);
+        }
+        Map<String, UploadedSegmentMetadata> segmentsUploadedToRemoteStore = new ConcurrentHashMap<>(
+            readMetadataFile(metadataFile.get()));
+        return Collections.unmodifiableMap(segmentsUploadedToRemoteStore);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryFactory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryFactory.java
@@ -13,6 +13,8 @@ import org.opensearch.common.blobstore.BlobContainer;
 import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.shard.ShardPath;
+import org.opensearch.index.store.lockmanager.RemoteStoreMDLockManagerFactory;
+import org.opensearch.index.store.lockmanager.RemoteStoreMDShardLockManager;
 import org.opensearch.plugins.IndexStorePlugin;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.repositories.Repository;
@@ -38,17 +40,25 @@ public class RemoteSegmentStoreDirectoryFactory implements IndexStorePlugin.Dire
     @Override
     public Directory newDirectory(IndexSettings indexSettings, ShardPath path) throws IOException {
         String repositoryName = indexSettings.getRemoteStoreRepository();
+        String indexUUID = indexSettings.getIndex().getUUID();
+        String shardId = String.valueOf(path.getShardId().getId());
+        return newDirectory(repositoryName, indexUUID, shardId);
+    }
+
+    public Directory newDirectory(String repositoryName, String indexUUID, String shardId) throws IOException {
         try (Repository repository = repositoriesService.get().repository(repositoryName)) {
             assert repository instanceof BlobStoreRepository : "repository should be instance of BlobStoreRepository";
             BlobPath commonBlobPath = ((BlobStoreRepository) repository).basePath();
-            commonBlobPath = commonBlobPath.add(indexSettings.getIndex().getUUID())
-                .add(String.valueOf(path.getShardId().getId()))
+            commonBlobPath = commonBlobPath.add(indexUUID)
+                .add(shardId)
                 .add("segments");
 
             RemoteDirectory dataDirectory = createRemoteDirectory(repository, commonBlobPath, "data");
-            RemoteDirectory metadataDirectory = createRemoteDirectory(repository, commonBlobPath, "metadata");
+            RemoteDirectory metadataDirectory = createRemoteDirectory(repository, commonBlobPath,"metadata");
+            RemoteStoreMDShardLockManager mdLockManager = RemoteStoreMDLockManagerFactory.newLockManager(
+                repositoriesService.get(), repositoryName, indexUUID, shardId);
 
-            return new RemoteSegmentStoreDirectory(dataDirectory, metadataDirectory);
+            return new RemoteSegmentStoreDirectory(dataDirectory, metadataDirectory, mdLockManager);
         } catch (RepositoryMissingException e) {
             throw new IllegalArgumentException("Repository should be created before creating index with remote_store enabled setting", e);
         }

--- a/server/src/main/java/org/opensearch/index/store/lockmanager/FileBasedMDIndexLockManager.java
+++ b/server/src/main/java/org/opensearch/index/store/lockmanager/FileBasedMDIndexLockManager.java
@@ -1,0 +1,153 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.store.lockmanager;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.Lock;
+import org.opensearch.common.Nullable;
+import org.opensearch.index.store.RemoteDirectory;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A Lock Manager Class for Index Level Lock
+ * @opensearch.internal
+ */
+public class FileBasedMDIndexLockManager implements RemoteStoreMDIndexLockManager {
+    private static final Logger logger = LogManager.getLogger(RemoteStoreMDIndexLockManager.class);
+    private final RemoteDirectory lockDirectory;
+    public FileBasedMDIndexLockManager(RemoteDirectory lockDirectory) {
+        this.lockDirectory = lockDirectory;
+    }
+
+    @Override
+    public void acquire(RemoteStoreMDIndexLockManager.IndexLockInfo lockInfo) throws IOException {
+        try (IndexOutput indexOutput = lockDirectory.createOutput(lockInfo.getLockName(), IOContext.DEFAULT)) {
+            lockInfo.writeLockContent(indexOutput);
+        }
+    }
+
+    @Override
+    public void release(String fileName) throws IOException {
+        lockDirectory.deleteFile(fileName);
+    }
+
+    @Override
+    public IndexLockFileInfo readLockData(String lockName) throws IOException {
+        try (IndexInput indexInput = lockDirectory.openInput(lockName, IOContext.DEFAULT)) {
+            return IndexLockFileInfo.getLockFileInfoFromIndexInput(indexInput);
+        }
+    }
+
+    @Override
+    public IndexLockInfo.LockInfoBuilder getLockInfoBuilder() {
+        return new IndexLockFileInfo.LockInfoBuilder();
+    }
+
+    public Boolean isLockExpiredForResource(String resourceId) throws IOException {
+        IndexLockFileInfo lockFileData = readLockData(IndexLockFileInfo.generateLockFileName(resourceId));
+        if (lockFileData.getExpiryTime() != null) {
+            Instant currentInstantInUTC = Instant.now().atZone(ZoneOffset.UTC).toInstant();
+            return Instant.parse(lockFileData.getExpiryTime()).compareTo(currentInstantInUTC) > 0;
+        }
+        return false;
+    }
+
+    static class IndexLockFileInfo implements RemoteStoreMDIndexLockManager.IndexLockInfo {
+        private String resourceId;
+        private String expiryTime = null;
+
+        private void setResourceId(String resourceId) {
+            this.resourceId = resourceId;
+        }
+
+        private void setExpiryTimeFromTTL(String ttl) {
+            if (!Objects.equals(ttl, RemoteStoreLockManagerUtils.NO_TTL)) {
+                setExpiryTime(Instant.now().atZone(ZoneOffset.UTC).plusDays(Long.parseLong(ttl)).toInstant().toString());
+            }
+        }
+
+        private void setExpiryTime(String expiryTime) {
+            this.expiryTime = expiryTime;
+        }
+
+        public String getExpiryTime() {
+            return this.expiryTime;
+        }
+
+        public String getResourceId() {
+            return resourceId;
+        }
+
+        static IndexLockFileInfo getLockFileInfoFromIndexInput(IndexInput indexInput) throws IOException {
+            Map<String, String> lockData = indexInput.readMapOfStrings();
+            IndexLockFileInfo indexLockFileInfo = new IndexLockFileInfo();
+            indexLockFileInfo.setResourceId(lockData.get(RemoteStoreLockManagerUtils.RESOURCE_ID));
+            indexLockFileInfo.setExpiryTime(lockData.get(RemoteStoreLockManagerUtils.LOCK_EXPIRY_TIME));
+            return indexLockFileInfo;
+        }
+
+        static String generateLockFileName(String resourceID) {
+            return resourceID + RemoteStoreLockManagerUtils.LOCK_FILE_EXTENSION;
+        }
+
+        static String getResourceIDFromLockFile(String lockFile) {
+            return lockFile.replace(RemoteStoreLockManagerUtils.LOCK_FILE_EXTENSION, "");
+        }
+        static Map<String, String> getLockData(String resourceID, String expiry_time) {
+            Map<String, String> lockFileData = new HashMap<>();
+            lockFileData.put(RemoteStoreLockManagerUtils.RESOURCE_ID, resourceID);
+            if (expiry_time != null) {
+                lockFileData.put(RemoteStoreLockManagerUtils.LOCK_EXPIRY_TIME, expiry_time);
+            }
+            return lockFileData;
+        }
+        @Override
+        public String getLockName() {
+            return generateLockFileName(this.resourceId);
+        }
+
+        @Override
+        public void writeLockContent(IndexOutput indexOutput) throws IOException {
+            indexOutput.writeMapOfStrings(getLockData(resourceId, expiryTime));
+        }
+        static class LockInfoBuilder implements RemoteStoreMDIndexLockManager.IndexLockInfo.LockInfoBuilder {
+            private final IndexLockFileInfo lockFileInfo;
+
+            LockInfoBuilder() {
+                this.lockFileInfo = new IndexLockFileInfo();
+            }
+            @Override
+            public LockInfoBuilder withTTL(String ttl) {
+                lockFileInfo.setExpiryTimeFromTTL(ttl);
+                return this;
+            }
+
+            @Override
+            public LockInfoBuilder withResourceId(String resourceId) {
+                lockFileInfo.setResourceId(resourceId);
+                return this;
+            }
+
+            @Override
+            public IndexLockFileInfo build() {
+                return lockFileInfo;
+            }
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/index/store/lockmanager/FileBasedMDShardLockManager.java
+++ b/server/src/main/java/org/opensearch/index/store/lockmanager/FileBasedMDShardLockManager.java
@@ -1,0 +1,141 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.store.lockmanager;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.opensearch.index.store.RemoteDirectory;
+
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * A Lock Manager Class for Shard Level Lock {@code RemoteLockDirectory}.
+ * @opensearch.internal
+ */
+public class FileBasedMDShardLockManager implements RemoteStoreMDShardLockManager  {
+
+    private static final Logger logger = LogManager.getLogger(FileBasedMDShardLockManager.class);
+    protected final RemoteDirectory lockDirectory;
+
+    public FileBasedMDShardLockManager(RemoteDirectory lockDirectory) {
+        this.lockDirectory = lockDirectory;
+    }
+
+    @Override
+    public void acquire(RemoteStoreMDShardLockManager.ShardLockInfo lockInfo) throws IOException {
+        try (IndexOutput indexOutput = lockDirectory.createOutput(lockInfo.getLockName(), IOContext.DEFAULT)) {
+            lockInfo.writeLockContent(indexOutput);
+        }
+    }
+
+    @Override
+    public void release(String fileName) throws IOException {
+        lockDirectory.deleteFile(fileName);
+    }
+
+    @Override
+    public ShardLockFileInfo readLockData(String lockName) throws IOException {
+        try (IndexInput indexInput = lockDirectory.openInput(lockName, IOContext.DEFAULT)) {
+            return ShardLockFileInfo.getLockFileInfoFromIndexInput(indexInput);
+        }
+    }
+
+    @Override
+    public ShardLockFileInfo.LockInfoBuilder getLockInfoBuilder() {
+        return new ShardLockFileInfo.LockInfoBuilder();
+    }
+
+    static class ShardLockFileInfo implements RemoteStoreMDShardLockManager.ShardLockInfo {
+        private String metadataFile;
+        private String resourceId;
+
+        public String getResourceId() {
+            return resourceId;
+        }
+
+        public String getMetadataFile() {
+            return metadataFile;
+        }
+
+        private void setMetadataFile(String metadataFile) {
+            this.metadataFile = metadataFile;
+        }
+
+        private void setResourceId(String resourceId) {
+            this.resourceId = resourceId;
+        }
+
+        static String getResourceIDfromLockFile(String lockFile) {
+            return lockFile.split(RemoteStoreLockManagerUtils.SEPARATOR)[1].replace(RemoteStoreLockManagerUtils.LOCK_FILE_EXTENSION, "");
+        }
+
+        static Map<String, String> getLockData(String metadataFile, String resourceId) {
+            Map<String, String> lockFileData = new HashMap<>();
+            lockFileData.put(RemoteStoreLockManagerUtils.RESOURCE_ID, resourceId);
+            lockFileData.put(RemoteStoreLockManagerUtils.METADATA_FILE_NAME, metadataFile);
+            return lockFileData;
+        }
+
+        static ShardLockFileInfo getLockFileInfoFromIndexInput(IndexInput indexInput) throws IOException {
+            Map<String, String> lockData = indexInput.readMapOfStrings();
+            ShardLockFileInfo shardLockFileInfo = new ShardLockFileInfo();
+            shardLockFileInfo.setMetadataFile(lockData.get(RemoteStoreLockManagerUtils.METADATA_FILE_NAME));
+            shardLockFileInfo.setResourceId(lockData.get(RemoteStoreLockManagerUtils.RESOURCE_ID));
+            return shardLockFileInfo;
+        }
+
+        static String generateLockFileName(String mdFile, String resourceID) {
+            return String.join(RemoteStoreLockManagerUtils.SEPARATOR, mdFile, resourceID)
+                + RemoteStoreLockManagerUtils.LOCK_FILE_EXTENSION;
+        }
+
+        @Override
+        public String getLockName() {
+            return generateLockFileName(metadataFile, resourceId);
+        }
+
+        public String getMetadataFileNameFromLockFile(String lockFile) {
+            return lockFile.split(RemoteStoreLockManagerUtils.SEPARATOR)[0];
+        }
+
+        @Override
+        public void writeLockContent(IndexOutput indexOutput) throws IOException {
+            indexOutput.writeMapOfStrings(getLockData(this.metadataFile, this.resourceId));
+        }
+
+        static class LockInfoBuilder implements RemoteStoreMDShardLockManager.ShardLockInfo.LockInfoBuilder {
+            private final ShardLockFileInfo lockFileInfo;
+            LockInfoBuilder() {
+                this.lockFileInfo = new ShardLockFileInfo();
+            }
+
+            @Override
+            public LockInfoBuilder withMetadataFile(String metadataFile) {
+                lockFileInfo.setMetadataFile(metadataFile);
+                return this;
+            }
+
+            @Override
+            public LockInfoBuilder withResourceId(String resourceId) {
+                lockFileInfo.setResourceId(resourceId);
+                return this;
+            }
+
+            public ShardLockFileInfo build() {
+                return lockFileInfo;
+            }
+
+        }
+
+    }
+}

--- a/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteBufferedIndexOutput.java
+++ b/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteBufferedIndexOutput.java
@@ -1,0 +1,111 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.store.lockmanager;
+
+import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.OutputStreamIndexOutput;
+import org.opensearch.common.blobstore.BlobContainer;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.index.store.RemoteIndexOutput;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.sql.Blob;
+
+/**
+ * Class for output to a file in a {@link RemoteBufferedOutputDirectory}. Used for all output operations to the remote store.
+ * @see RemoteBufferedOutputDirectory
+ *
+ * @opensearch.internal
+ */
+public class RemoteBufferedIndexOutput extends RemoteIndexOutput {
+    private final BlobContainer blobContainer;
+    private final BytesStreamOutput out;
+    private final OutputStreamIndexOutput indexOutputBuffer;
+    // visible for testing
+    static final int BUFFER_SIZE = 4096;
+
+    public RemoteBufferedIndexOutput(String name, BlobContainer blobContainer, int bufferSize) {
+        super(name, blobContainer);
+        this.blobContainer = blobContainer;
+        out = new BytesStreamOutput();
+        indexOutputBuffer = new OutputStreamIndexOutput(
+            name,
+            name,
+            out,
+            bufferSize
+        );
+    }
+    public RemoteBufferedIndexOutput(String name, BlobContainer blobContainer) {
+        this(name, blobContainer, BUFFER_SIZE);
+    }
+
+    // Visible for testing
+    RemoteBufferedIndexOutput(String name, BlobContainer blobContainer,BytesStreamOutput out,
+                              OutputStreamIndexOutput indexOutputBuffer) {
+        super(name, blobContainer);
+        this.blobContainer = blobContainer;
+        this.out = out;
+        this.indexOutputBuffer = indexOutputBuffer;
+    }
+
+    @Override
+    public void copyBytes(DataInput input, long numBytes) throws IOException {
+        indexOutputBuffer.copyBytes(input, numBytes);
+    }
+
+    /**
+     * when we trigger close() to close the stream, we will first flush the buffer to output stream and then write all
+     * data to blob container and close the output stream.
+     *
+     */
+    @Override
+    public void close() throws IOException {
+        indexOutputBuffer.close();
+        try (final BytesStreamOutput outStream = out; InputStream stream = out.bytes().streamInput()) {
+            blobContainer.writeBlob(getName(), stream, out.bytes().length(), false);
+        }
+    }
+
+    /**
+     * This method will write Bytes to the stream we are maintaining.
+     *
+     */
+    @Override
+    public void writeByte(byte b) throws IOException {
+        indexOutputBuffer.writeByte(b);
+    }
+
+    /**
+     * This method will write a byte array to the stream we are maintaining.
+     *
+     */
+    @Override
+    public void writeBytes(byte[] byteArray, int offset, int length) throws IOException {
+        indexOutputBuffer.writeBytes(byteArray,offset, length);
+    }
+
+    /**
+     * This method will return the file pointer to the current position in the stream.
+     *
+     */
+    @Override
+    public long getFilePointer() {
+        return indexOutputBuffer.getFilePointer();
+    }
+
+    /**
+     * This method will return checksum
+     *
+     */
+    @Override
+    public long getChecksum() throws IOException {
+        return indexOutputBuffer.getChecksum();
+    }
+}

--- a/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteBufferedOutputDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteBufferedOutputDirectory.java
@@ -1,0 +1,31 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.store.lockmanager;
+
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexOutput;
+import org.opensearch.common.blobstore.BlobContainer;
+import org.opensearch.index.store.RemoteDirectory;
+
+/**
+ * A {@code RemoteBufferedOutputDirectory} is an extension of Remote Directory where creation of new files are allowed.
+ * A remoteDirectory contains only files (no sub-folder hierarchy).
+ *
+ * @opensearch.internal
+ */
+public class RemoteBufferedOutputDirectory extends RemoteDirectory {
+    public RemoteBufferedOutputDirectory(BlobContainer blobContainer) {
+        super(blobContainer);
+    }
+
+    @Override
+    public IndexOutput createOutput(String name, IOContext context) {
+        return new RemoteBufferedIndexOutput(name, this.blobContainer);
+    }
+}

--- a/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreLockManagerUtils.java
+++ b/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreLockManagerUtils.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.store.lockmanager;
+
+/**
+ * Utility class for remote store lock manager,
+ * right now only have constants defined, we can add methods as well here in the future.
+ * @opensearch.internal
+ */
+public class RemoteStoreLockManagerUtils {
+    static final String METADATA_FILE_NAME = "MD File Name";
+    static final String SEPARATOR = "__";
+    static final String LOCK_FILE_EXTENSION = ".lock";
+    static final String RESOURCE_ID = "Resource ID";
+    public static final String NO_TTL = "-1";
+    static final String LOCK_EXPIRY_TIME = "Lock Expiry Time";
+}

--- a/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreMDIndexLockManager.java
+++ b/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreMDIndexLockManager.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.store.lockmanager;
+
+import org.apache.lucene.store.IndexOutput;
+
+import java.io.IOException;
+
+/**
+ * An Interface that defines Index Level Remote Store MD Lock Manager.
+ * @opensearch.internal
+ */
+public interface RemoteStoreMDIndexLockManager {
+    /**
+     * Method to acquire index level lock.
+     */
+    public void acquire(IndexLockInfo lockInfo) throws IOException;
+    /**
+     * Method to release index level lock.
+     */
+    public void release(String lockName) throws IOException;
+    /**
+     * Method to get Index Lock Info Builder.
+     */
+    IndexLockInfo.LockInfoBuilder getLockInfoBuilder();
+    /**
+     * Method to read index level lock data.
+     */
+    public IndexLockInfo readLockData(String lockName) throws IOException;
+    /**
+     * An Interface that defines the info needed to be present in a Index Level Lock.
+     */
+    public interface IndexLockInfo {
+        /**
+         * Index Level Lock Name.
+         */
+        public String getLockName();
+        /**
+         * Method to write data in lock.
+         */
+        public void writeLockContent(IndexOutput indexOutput) throws IOException;
+        /**
+         * An Interface that defines a Lock Info Builder
+         */
+        public static interface LockInfoBuilder {
+            /**
+             * Method to set TTL in Index Level Lock.
+             */
+            public LockInfoBuilder withTTL(String ttl);
+            /**
+             * Method to set Resource Id in Index Level Lock.
+             */
+            public LockInfoBuilder withResourceId(String resourceId);
+            /**
+             * Method to build Lock Info Instance.
+             */
+            public IndexLockInfo build();
+        }
+
+    }
+}

--- a/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreMDLockManagerFactory.java
+++ b/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreMDLockManagerFactory.java
@@ -1,0 +1,86 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.store.lockmanager;
+
+import org.opensearch.common.blobstore.BlobContainer;
+import org.opensearch.common.blobstore.BlobPath;
+import org.opensearch.repositories.RepositoriesService;
+import org.opensearch.repositories.Repository;
+import org.opensearch.repositories.RepositoryMissingException;
+import org.opensearch.repositories.blobstore.BlobStoreRepository;
+import org.opensearch.index.store.RemoteDirectory;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+
+/**
+ * Factory for remote store lock manager
+ *
+ * @opensearch.internal
+ */
+public class RemoteStoreMDLockManagerFactory {
+    private final Supplier<RepositoriesService> repositoriesService;
+    public RemoteStoreMDLockManagerFactory(Supplier<RepositoriesService> repositoriesService) {
+        this.repositoriesService = repositoriesService;
+    }
+
+    public RemoteStoreMDShardLockManager newLockManager(String repositoryName, String indexUUID,
+                                                        String shardId) throws IOException {
+        return newLockManager(repositoriesService.get(), repositoryName, indexUUID, shardId);
+    }
+
+    public static RemoteStoreMDShardLockManager newLockManager(RepositoriesService repositoriesService,
+                                                               String repositoryName,
+                                                               String indexUUID,
+                                                               String shardId) throws IOException {
+        try (Repository repository = repositoriesService.repository(repositoryName)) {
+            assert repository instanceof BlobStoreRepository : "repository should be instance of BlobStoreRepository";
+            BlobPath shardLevelBlobPath = ((BlobStoreRepository) repository).basePath().add(indexUUID)
+                .add(shardId).add("segments");
+            RemoteDirectory shardMDLockDirectory = createRemoteBufferedOutputDirectory(repository, shardLevelBlobPath,
+                "lock_files");
+
+            return new FileBasedMDShardLockManager(shardMDLockDirectory);
+        } catch (RepositoryMissingException e) {
+            throw new IllegalArgumentException("Repository should be present to acquire/release lock", e);
+        }
+    }
+
+    public RemoteStoreMDIndexLockManager newLockManager(String repositoryName, String indexUUID) throws IOException {
+        return newLockManager(repositoriesService.get(), repositoryName, indexUUID);
+    }
+
+    public static RemoteStoreMDIndexLockManager newLockManager(RepositoriesService repositoriesService, String repositoryName,
+                                                        String indexUUID) throws IOException {
+        try (Repository repository = repositoriesService.repository(repositoryName)) {
+            assert repository instanceof BlobStoreRepository : "repository should be instance of BlobStoreRepository";
+            BlobPath indexLevelBlobPath = ((BlobStoreRepository) repository).basePath().add(indexUUID);
+            RemoteDirectory indexMDLockDirectory = createRemoteBufferedOutputDirectory(repository, indexLevelBlobPath,
+                "resource_lock_files");
+
+            return new FileBasedMDIndexLockManager(indexMDLockDirectory);
+        } catch (RepositoryMissingException e) {
+            throw new IllegalArgumentException("Repository should be present to acquire/release lock", e);
+        }
+    }
+
+    private RemoteDirectory createRemoteDirectory(Repository repository, BlobPath commonBlobPath, String extention) {
+        BlobPath extendedPath = commonBlobPath.add(extention);
+        BlobContainer dataBlobContainer = ((BlobStoreRepository) repository).blobStore().blobContainer(extendedPath);
+        return new RemoteDirectory(dataBlobContainer);
+    }
+
+    private static RemoteBufferedOutputDirectory createRemoteBufferedOutputDirectory(Repository repository,
+                                                                                     BlobPath commonBlobPath,
+                                                                                     String extention) {
+        BlobPath extendedPath = commonBlobPath.add(extention);
+        BlobContainer dataBlobContainer = ((BlobStoreRepository) repository).blobStore().blobContainer(extendedPath);
+        return new RemoteBufferedOutputDirectory(dataBlobContainer);
+    }
+}

--- a/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreMDShardLockManager.java
+++ b/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreMDShardLockManager.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.store.lockmanager;
+
+import org.apache.lucene.store.IndexOutput;
+
+import java.io.IOException;
+
+/**
+ * An Interface that defines Shard Level Remote Store MD Lock Manager.
+ * @opensearch.internal
+ */
+public interface RemoteStoreMDShardLockManager {
+    /**
+     * Method to acquire Shard level lock.
+     */
+    public void acquire(ShardLockInfo lockInfo) throws IOException;
+    /**
+     * Method to release Shard level lock.
+     */
+    public void release(String lockName) throws IOException;
+    /**
+     * Method to get Shard Lock Info Builder.
+     */
+    ShardLockInfo.LockInfoBuilder getLockInfoBuilder();
+    /**
+     * Method to read Shard level lock data.
+     */
+    public ShardLockInfo readLockData(String lockName) throws IOException;
+    /**
+     * An Interface that defines the info needed to be present in a Shard Level Lock.
+     */
+    public interface ShardLockInfo {
+        /**
+         * Shard Level Lock Name.
+         */
+        String getLockName();
+        /**
+         * Method to write data in lock.
+         */
+        public void writeLockContent(IndexOutput indexOutput) throws IOException;
+        /**
+         * An Interface that defines a Lock Info Builder
+         */
+        public static interface LockInfoBuilder {
+            /**
+             * Method to set Metadata File in Shard Level Lock.
+             */
+            public LockInfoBuilder withMetadataFile(String metadataFile);
+            /**
+             * Method to set Resource Id in Shard Level Lock.
+             */
+            public LockInfoBuilder withResourceId(String resourceId);
+            /**
+             * Method to build Lock Info Instance.
+             */
+            public ShardLockInfo build();
+        }
+
+    }
+}

--- a/server/src/main/java/org/opensearch/index/store/lockmanager/package-info.java
+++ b/server/src/main/java/org/opensearch/index/store/lockmanager/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Package containing classes for remote segment store md lock manager
+ */
+package org.opensearch.index.store.lockmanager;

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryFactoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryFactoryTests.java
@@ -72,13 +72,14 @@ public class RemoteSegmentStoreDirectoryFactoryTests extends OpenSearchTestCase 
         try (Directory directory = remoteSegmentStoreDirectoryFactory.newDirectory(indexSettings, shardPath)) {
             assertTrue(directory instanceof RemoteSegmentStoreDirectory);
             ArgumentCaptor<BlobPath> blobPathCaptor = ArgumentCaptor.forClass(BlobPath.class);
-            verify(blobStore, times(2)).blobContainer(blobPathCaptor.capture());
+            verify(blobStore, times(3)).blobContainer(blobPathCaptor.capture());
             List<BlobPath> blobPaths = blobPathCaptor.getAllValues();
             assertEquals("base_path/uuid_1/0/segments/data/", blobPaths.get(0).buildAsString());
             assertEquals("base_path/uuid_1/0/segments/metadata/", blobPaths.get(1).buildAsString());
+            assertEquals("base_path/uuid_1/0/segments/lock_files/", blobPaths.get(2).buildAsString());
 
             verify(blobContainer).listBlobsByPrefix(RemoteSegmentStoreDirectory.MetadataFilenameUtils.METADATA_PREFIX);
-            verify(repositoriesService).repository("remote_store_repository");
+            verify(repositoriesService, times(2)).repository("remote_store_repository");
         }
     }
 

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -23,32 +23,23 @@ import org.opensearch.common.UUIDs;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.lucene.store.ByteArrayIndexInput;
+import org.opensearch.index.store.lockmanager.FileBasedMDShardLockManager;
 import org.opensearch.index.store.remote.metadata.RemoteSegmentMetadata;
+import org.opensearch.index.store.lockmanager.RemoteStoreMDShardLockManager;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.NoSuchFileException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.startsWith;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class RemoteSegmentStoreDirectoryTests extends OpenSearchTestCase {
     private RemoteDirectory remoteDataDirectory;
     private RemoteDirectory remoteMetadataDirectory;
+    private RemoteStoreMDShardLockManager mdLockManager;
 
     private RemoteSegmentStoreDirectory remoteSegmentStoreDirectory;
 
@@ -56,8 +47,9 @@ public class RemoteSegmentStoreDirectoryTests extends OpenSearchTestCase {
     public void setup() throws IOException {
         remoteDataDirectory = mock(RemoteDirectory.class);
         remoteMetadataDirectory = mock(RemoteDirectory.class);
+        mdLockManager = mock(RemoteStoreMDShardLockManager.class);
 
-        remoteSegmentStoreDirectory = new RemoteSegmentStoreDirectory(remoteDataDirectory, remoteMetadataDirectory);
+        remoteSegmentStoreDirectory = new RemoteSegmentStoreDirectory(remoteDataDirectory, remoteMetadataDirectory, mdLockManager);
     }
 
     public void testUploadedSegmentMetadataToString() {
@@ -343,6 +335,76 @@ public class RemoteSegmentStoreDirectoryTests extends OpenSearchTestCase {
         when(remoteDataDirectory.openInput(startsWith("_0.si"), eq(IOContext.DEFAULT))).thenThrow(new IOException("Error"));
 
         assertThrows(IOException.class, () -> remoteSegmentStoreDirectory.openInput("_0.si", IOContext.DEFAULT));
+    }
+
+    public void testAcquireLock() throws IOException {
+        populateMetadata();
+        remoteSegmentStoreDirectory.init();
+        String mdFile = "xyz";
+        String resourceId = "test-resource";
+        long testPrimaryTerm = 1;
+        long testGeneration = 5;
+
+        RemoteStoreMDShardLockManager.ShardLockInfo.LockInfoBuilder infoBuilder = mock(RemoteStoreMDShardLockManager.ShardLockInfo.LockInfoBuilder.class);
+        when(infoBuilder.withMetadataFile(any())).thenReturn(infoBuilder);
+        when(infoBuilder.withResourceId(any())).thenReturn(infoBuilder);
+        when(infoBuilder.build()).thenReturn(mock(RemoteStoreMDShardLockManager.ShardLockInfo.class));
+        when(mdLockManager.getLockInfoBuilder()).thenReturn(infoBuilder);
+
+        remoteSegmentStoreDirectory.acquireLock(testPrimaryTerm, testGeneration, resourceId);
+        verify(mdLockManager).acquire(any());
+    }
+
+    public void testAcquireLockNoSuchFile() throws IOException {
+        populateMetadata();
+        remoteSegmentStoreDirectory.init();
+        String mdFile = "xyz";
+        String testResourceId = "test-resource";
+        long testPrimaryTerm = 2;
+        long testGeneration = 3;
+
+        assertThrows(FileNotFoundException.class, () -> remoteSegmentStoreDirectory.acquireLock(testPrimaryTerm,
+            testGeneration, testResourceId));
+    }
+
+    public void testGetMetadataFileForCommit() throws IOException {
+        long testPrimaryTerm = 2;
+        long testGeneration = 3;
+        List<String> metadataFiles = List.of("metadata__1__5__abc", "metadata__" + testPrimaryTerm + "__" + testGeneration + "__pqr", "metadata__2__1__zxv");
+        when(remoteMetadataDirectory.listFilesByPrefix(RemoteSegmentStoreDirectory.MetadataFilenameUtils.METADATA_PREFIX)).thenReturn(
+            metadataFiles
+        );
+
+        Optional<String> output = remoteSegmentStoreDirectory.getMetadataFileForCommit(testPrimaryTerm, testGeneration);
+        assertTrue(output.isPresent());
+        assertEquals("metadata__"+ testPrimaryTerm + "__" + testGeneration + "__pqr", output.get());
+
+    }
+
+    public void testGetSegmentsUploadedToRemoteStore() throws IOException {
+        long testPrimaryTerm = 1;
+        long testGeneration = 5;
+
+        List<String> metadataFiles = List.of("metadata__1__5__abc", "metadata__1__6__pqr", "metadata__2__1__zxv");
+        when(remoteMetadataDirectory.listFilesByPrefix(RemoteSegmentStoreDirectory.MetadataFilenameUtils.METADATA_PREFIX)).thenReturn(
+            metadataFiles
+        );
+
+        Map<String, Map<String, String>> metadataFilenameContentMapping = Map.of(
+            "metadata__1__5__abc",
+            getDummyMetadata("_0", 5),
+            "metadata__1__6__pqr",
+            getDummyMetadata("_0", 6),
+            "metadata__2__1__zxv",
+            getDummyMetadata("_0", 1)
+        );
+
+        when(remoteMetadataDirectory.openInput("metadata__1__5__abc", IOContext.DEFAULT)).thenReturn(
+            createMetadataFileBytes(metadataFilenameContentMapping.get("metadata__1__5__abc"))
+        );
+
+        assert(remoteSegmentStoreDirectory.getSegmentsUploadedToRemoteStore(testPrimaryTerm, testGeneration)
+            .containsKey("segments_5"));
     }
 
     public void testCopyFrom() throws IOException {

--- a/server/src/test/java/org/opensearch/index/store/lockmanager/FileBasedMDIndexLockManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/store/lockmanager/FileBasedMDIndexLockManagerTests.java
@@ -1,0 +1,83 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.store.lockmanager;
+
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.junit.Before;
+import org.opensearch.index.store.RemoteDirectory;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
+
+public class FileBasedMDIndexLockManagerTests extends OpenSearchTestCase {
+
+    private RemoteDirectory lockDirectory;
+    private FileBasedMDIndexLockManager fileBasedMDIndexLockManager;
+    @Before
+    public void setup() throws IOException {
+        lockDirectory = mock(RemoteBufferedOutputDirectory.class);
+
+        fileBasedMDIndexLockManager = new FileBasedMDIndexLockManager(lockDirectory);
+    }
+
+    public void testAcquire() throws IOException {
+
+        String testLockName = "testLock";
+        IndexOutput indexOutput = mock(IndexOutput.class);
+        when(lockDirectory.createOutput(eq(testLockName), eq(IOContext.DEFAULT))).thenReturn(indexOutput);
+
+        RemoteStoreMDIndexLockManager.IndexLockInfo lockInfoMock = mock(FileBasedMDIndexLockManager
+            .IndexLockFileInfo.class);
+        when(lockInfoMock.getLockName()).thenReturn(testLockName);
+
+        fileBasedMDIndexLockManager.acquire(lockInfoMock);
+        verify(lockInfoMock).writeLockContent(any());
+
+    }
+
+    public void testRelease() throws IOException {
+        String testLockName = "testLock";
+
+        fileBasedMDIndexLockManager.release(testLockName);
+        verify(lockDirectory).deleteFile(testLockName);
+    }
+
+    public void testReadLockData() throws IOException {
+        String testLockName = "testLock";
+
+        String testExpiryTime = Instant.now().toString();
+        String resourceId = "testResourceId";
+
+        IndexInput indexInput = mock(IndexInput.class);
+        when(lockDirectory.openInput(eq(testLockName), eq(IOContext.DEFAULT))).thenReturn(indexInput);
+
+        Map<String, String> lockDataMock = new java.util.HashMap<>();
+        lockDataMock.put(RemoteStoreLockManagerUtils.LOCK_EXPIRY_TIME, testExpiryTime);
+        lockDataMock.put(RemoteStoreLockManagerUtils.RESOURCE_ID, resourceId);
+        when(indexInput.readMapOfStrings()).thenReturn(lockDataMock);
+
+        FileBasedMDIndexLockManager.IndexLockFileInfo output = fileBasedMDIndexLockManager.readLockData(testLockName);
+        assertEquals(output.getResourceId(), resourceId);
+        assertEquals(output.getExpiryTime(), testExpiryTime);
+    }
+
+    public void testGetLockInfoBuilder() {
+        assert(fileBasedMDIndexLockManager.getLockInfoBuilder().getClass().getName().equals(
+            FileBasedMDIndexLockManager.IndexLockFileInfo.LockInfoBuilder.class.getName()));
+    }
+}

--- a/server/src/test/java/org/opensearch/index/store/lockmanager/FileBasedMDShardLockManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/store/lockmanager/FileBasedMDShardLockManagerTests.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.store.lockmanager;
+
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.junit.Before;
+import org.opensearch.index.store.RemoteDirectory;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+public class FileBasedMDShardLockManagerTests extends OpenSearchTestCase {
+
+    private RemoteDirectory lockDirectory;
+    private FileBasedMDShardLockManager fileBasedMDShardLockManager;
+    @Before
+    public void setup() throws IOException {
+        lockDirectory = mock(RemoteBufferedOutputDirectory.class);
+
+        fileBasedMDShardLockManager = new FileBasedMDShardLockManager(lockDirectory);
+    }
+
+    public void testAcquire() throws IOException {
+
+        String testLockName = "testLock";
+        IndexOutput indexOutput = mock(IndexOutput.class);
+        when(lockDirectory.createOutput(eq(testLockName), eq(IOContext.DEFAULT))).thenReturn(indexOutput);
+
+        RemoteStoreMDShardLockManager.ShardLockInfo lockInfoMock = mock(FileBasedMDShardLockManager.ShardLockFileInfo.class);
+        when(lockInfoMock.getLockName()).thenReturn(testLockName);
+
+        fileBasedMDShardLockManager.acquire(lockInfoMock);
+        verify(lockInfoMock).writeLockContent(any());
+
+    }
+
+    public void testRelease() throws IOException {
+        String testLockName = "testLock";
+
+        fileBasedMDShardLockManager.release(testLockName);
+        verify(lockDirectory).deleteFile(testLockName);
+    }
+
+    public void testReadLockData() throws IOException {
+        String testLockName = "testLock";
+
+        String testMDFileName = "testMDFile";
+        String resourceId = "testResourceId";
+
+        IndexInput indexInput = mock(IndexInput.class);
+        when(lockDirectory.openInput(eq(testLockName), eq(IOContext.DEFAULT))).thenReturn(indexInput);
+
+        Map<String, String> lockDataMock = new java.util.HashMap<>();
+        lockDataMock.put(RemoteStoreLockManagerUtils.METADATA_FILE_NAME, testMDFileName);
+        lockDataMock.put(RemoteStoreLockManagerUtils.RESOURCE_ID, resourceId);
+        when(indexInput.readMapOfStrings()).thenReturn(lockDataMock);
+
+        FileBasedMDShardLockManager.ShardLockFileInfo output = fileBasedMDShardLockManager.readLockData(testLockName);
+        assertEquals(output.getMetadataFile(), testMDFileName);
+        assertEquals(output.getResourceId(), resourceId);
+    }
+
+    public void testGetLockInfoBuilder() {
+        assert(fileBasedMDShardLockManager.getLockInfoBuilder().getClass().getName().equals(
+            FileBasedMDShardLockManager.ShardLockFileInfo.LockInfoBuilder.class.getName()));
+    }
+}

--- a/server/src/test/java/org/opensearch/index/store/lockmanager/RemoteBufferedIndexOutputTests.java
+++ b/server/src/test/java/org/opensearch/index/store/lockmanager/RemoteBufferedIndexOutputTests.java
@@ -1,0 +1,71 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.store.lockmanager;
+
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.OutputStreamIndexOutput;
+import org.junit.Before;
+import org.opensearch.common.blobstore.BlobContainer;
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+public class RemoteBufferedIndexOutputTests extends OpenSearchTestCase {
+
+    private static final String FILENAME = "segment_1";
+
+    private BlobContainer blobContainer;
+
+    private BytesStreamOutput out;
+
+    private OutputStreamIndexOutput indexOutputBuffer;
+
+    private RemoteBufferedIndexOutput remoteBufferedIndexOutput;
+
+    @Before
+    public void setup() {
+        blobContainer = mock(BlobContainer.class);
+        out = mock(BytesStreamOutput.class);
+        indexOutputBuffer = mock(OutputStreamIndexOutput.class);
+
+        remoteBufferedIndexOutput = new RemoteBufferedIndexOutput(FILENAME, blobContainer, out, indexOutputBuffer);
+    }
+
+    public void testCopyBytes() throws IOException {
+        IndexInput indexInput = mock(IndexInput.class);
+        remoteBufferedIndexOutput.copyBytes(indexInput, 100);
+
+        verify(indexOutputBuffer).copyBytes(eq(indexInput), eq(100L));
+    }
+
+    public void testCopyBytesException() throws IOException {
+        IndexInput indexInput = mock(IndexInput.class);
+        doThrow(new IOException("Test Induced Failure")).when(indexOutputBuffer).copyBytes(eq(indexInput), eq(100L));
+
+        assertThrows(IOException.class, () -> remoteBufferedIndexOutput.copyBytes(indexInput, 100));
+    }
+
+    public void testClose() throws IOException {
+        BytesReference mockBytesReference = mock(BytesReference.class);
+        when(out.bytes()).thenReturn(mockBytesReference);
+        when(mockBytesReference.streamInput()).thenReturn(mock(StreamInput.class));
+
+        remoteBufferedIndexOutput.close();
+        verify(blobContainer).writeBlob(eq(FILENAME), any(StreamInput.class), anyLong(), eq(false));
+        verify(indexOutputBuffer).close();
+        verify(out).close();
+    }
+}

--- a/server/src/test/java/org/opensearch/index/store/lockmanager/RemoteBufferedOutputDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/lockmanager/RemoteBufferedOutputDirectoryTests.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.store.lockmanager;
+
+import org.apache.lucene.store.IOContext;
+import org.junit.Before;
+import org.opensearch.common.blobstore.BlobContainer;
+import org.opensearch.test.OpenSearchTestCase;
+
+import static org.mockito.Mockito.mock;
+
+public class RemoteBufferedOutputDirectoryTests extends OpenSearchTestCase {
+
+    private BlobContainer blobContainer;
+    private RemoteBufferedOutputDirectory remoteBufferedOutputDirectory;
+
+    @Before
+    public void setup() {
+        blobContainer = mock(BlobContainer.class);
+        remoteBufferedOutputDirectory = new RemoteBufferedOutputDirectory(blobContainer);
+    }
+
+    public void testCreateOutput() {
+        String testBlobName = "testBlob";
+        assert(remoteBufferedOutputDirectory.createOutput(testBlobName, IOContext.DEFAULT)
+            instanceof RemoteBufferedIndexOutput);
+
+
+    }
+}

--- a/server/src/test/java/org/opensearch/index/store/lockmanager/RemoteStoreMDLockManagerFactoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/lockmanager/RemoteStoreMDLockManagerFactoryTests.java
@@ -1,0 +1,99 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.store.lockmanager;
+
+import org.junit.Before;
+import org.mockito.ArgumentCaptor;
+import org.opensearch.common.blobstore.BlobContainer;
+import org.opensearch.common.blobstore.BlobPath;
+import org.opensearch.common.blobstore.BlobStore;
+import org.opensearch.repositories.RepositoriesService;
+import org.opensearch.repositories.blobstore.BlobStoreRepository;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+
+public class RemoteStoreMDLockManagerFactoryTests extends OpenSearchTestCase {
+
+    private Supplier<RepositoriesService> repositoriesServiceSupplier;
+    private RepositoriesService repositoriesService;
+    private RemoteStoreMDLockManagerFactory remoteStoreMDLockManagerFactory;
+    @Before
+    public void setup() throws IOException {
+        repositoriesServiceSupplier = mock(Supplier.class);
+        repositoriesService = mock(RepositoriesService.class);
+        when(repositoriesServiceSupplier.get()).thenReturn(repositoriesService);
+        remoteStoreMDLockManagerFactory = new RemoteStoreMDLockManagerFactory(repositoriesServiceSupplier);
+    }
+
+    public void testNewLockManagerShard() throws IOException {
+
+        String testRepository = "testRepository";
+        String testIndexUUID = "testIndexUUID";
+        String testShardId = "testShardId";
+
+        BlobStoreRepository repository = mock(BlobStoreRepository.class);
+        BlobStore blobStore = mock(BlobStore.class);
+        BlobContainer blobContainer = mock(BlobContainer.class);
+        when(repository.blobStore()).thenReturn(blobStore);
+        when(repository.basePath()).thenReturn(new BlobPath().add("base_path"));
+        when(blobStore.blobContainer(any())).thenReturn(blobContainer);
+        when(blobContainer.listBlobs()).thenReturn(Collections.emptyMap());
+
+        when(repositoriesService.repository(testRepository)).thenReturn(repository);
+
+        RemoteStoreMDShardLockManager lockManager = remoteStoreMDLockManagerFactory.newLockManager(testRepository,
+            testIndexUUID, testShardId);
+
+        assertTrue(lockManager instanceof FileBasedMDShardLockManager);
+        ArgumentCaptor<BlobPath> blobPathCaptor = ArgumentCaptor.forClass(BlobPath.class);
+        verify(blobStore, times(1)).blobContainer(blobPathCaptor.capture());
+        List<BlobPath> blobPaths = blobPathCaptor.getAllValues();
+        assertEquals("base_path/" + testIndexUUID + "/" + testShardId + "/segments/lock_files/",
+            blobPaths.get(0).buildAsString());
+
+        verify(repositoriesService).repository(testRepository);
+    }
+
+    public void testNewLockManagerIndex() throws IOException {
+
+        String testRepository = "testRepository";
+        String testIndexUUID = "testIndexUUID";
+
+        BlobStoreRepository repository = mock(BlobStoreRepository.class);
+        BlobStore blobStore = mock(BlobStore.class);
+        BlobContainer blobContainer = mock(BlobContainer.class);
+        when(repository.blobStore()).thenReturn(blobStore);
+        when(repository.basePath()).thenReturn(new BlobPath().add("base_path"));
+        when(blobStore.blobContainer(any())).thenReturn(blobContainer);
+        when(blobContainer.listBlobs()).thenReturn(Collections.emptyMap());
+
+        when(repositoriesService.repository(testRepository)).thenReturn(repository);
+
+        RemoteStoreMDIndexLockManager lockManager = remoteStoreMDLockManagerFactory.newLockManager(testRepository,
+            testIndexUUID);
+
+        assertTrue(lockManager instanceof FileBasedMDIndexLockManager);
+        ArgumentCaptor<BlobPath> blobPathCaptor = ArgumentCaptor.forClass(BlobPath.class);
+        verify(blobStore, times(1)).blobContainer(blobPathCaptor.capture());
+        List<BlobPath> blobPaths = blobPathCaptor.getAllValues();
+        assertEquals("base_path/" + testIndexUUID + "/resource_lock_files/", blobPaths.get(0).buildAsString());
+
+        verify(repositoriesService).repository(testRepository);
+    }
+
+
+}

--- a/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
@@ -95,10 +95,7 @@ import org.opensearch.index.seqno.RetentionLeaseSyncer;
 import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.index.similarity.SimilarityService;
 import org.opensearch.index.snapshots.IndexShardSnapshotStatus;
-import org.opensearch.index.store.RemoteDirectory;
-import org.opensearch.index.store.RemoteSegmentStoreDirectory;
-import org.opensearch.index.store.Store;
-import org.opensearch.index.store.StoreFileMetadata;
+import org.opensearch.index.store.*;
 import org.opensearch.index.translog.InternalTranslogFactory;
 import org.opensearch.index.translog.RemoteBlobStoreInternalTranslogFactory;
 import org.opensearch.index.translog.Translog;
@@ -632,7 +629,7 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
         ShardPath remoteShardPath = new ShardPath(false, remoteNodePath.resolve(shardId), remoteNodePath.resolve(shardId), shardId);
         RemoteDirectory dataDirectory = newRemoteDirectory(remoteShardPath.resolveIndex());
         RemoteDirectory metadataDirectory = newRemoteDirectory(remoteShardPath.resolveIndex());
-        RemoteSegmentStoreDirectory remoteSegmentStoreDirectory = new RemoteSegmentStoreDirectory(dataDirectory, metadataDirectory);
+        RemoteSegmentStoreDirectory remoteSegmentStoreDirectory = new RemoteSegmentStoreDirectory(dataDirectory, metadataDirectory, null);
         return createStore(shardId, new IndexSettings(metadata, nodeSettings), remoteSegmentStoreDirectory);
     }
 


### PR DESCRIPTION
…ta for longer duration.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Changes for Lock Manager in Remote Segment Store to keep data for longer duration and prevent their deletion from Remote Store Side GC.  
Manually Tested Feature End to end on an opensearch cluster.

Previous Draft PR: https://github.com/opensearch-project/OpenSearch/pull/6787

## TODO:
ITs

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/6691
https://github.com/opensearch-project/OpenSearch/issues/6688


### Check List
- [Yes ] New functionality includes testing.
  - [] All tests pass
- [ Yes] New functionality has been documented.
  - [ Yes] New functionality has javadoc added
- [Yes ] Commits are signed per the DCO using --signoff
- [Yes ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
