### PR TITLE
[Extensions] Increased visibility of BaseRestHandler’s `unrecognized` method using a new public `unrecognizedStrings` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Refactor] XContent base classes from xcontent to core library ([#5902](https://github.com/opensearch-project/OpenSearch/pull/5902))
 - Changed `opensearch-env` to respect already set `OPENSEARCH_HOME` environment variable ([#6956](https://github.com/opensearch-project/OpenSearch/pull/6956/))
 - Added a new field type: flat_object ([#6507](https://github.com/opensearch-project/OpenSearch/pull/6507))
+- Changed the method definition of `unregnized method` in BaseRestHandler and added a new method `unrecognizedStrings method` ([#7125])(https://github.com/opensearch-project/OpenSearch/pull/7125)
 
 ### Deprecated
 - Map, List, and Set in org.opensearch.common.collect ([#6609](https://github.com/opensearch-project/OpenSearch/pull/6609))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,7 +122,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Refactor] XContent base classes from xcontent to core library ([#5902](https://github.com/opensearch-project/OpenSearch/pull/5902))
 - Changed `opensearch-env` to respect already set `OPENSEARCH_HOME` environment variable ([#6956](https://github.com/opensearch-project/OpenSearch/pull/6956/))
 - Added a new field type: flat_object ([#6507](https://github.com/opensearch-project/OpenSearch/pull/6507))
-- Increased visibility of BaseRestHandler’s `unrecognized` method using a new public `unrecognizedString` method. ([#7125](https://github.com/opensearch-project/OpenSearch/pull/7125))
+- Increased visibility of BaseRestHandler’s `unrecognized` method using a new public `unrecognizedStrings` method. ([#7125](https://github.com/opensearch-project/OpenSearch/pull/7125))
 
 ### Deprecated
 - Map, List, and Set in org.opensearch.common.collect ([#6609](https://github.com/opensearch-project/OpenSearch/pull/6609))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,7 +122,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Refactor] XContent base classes from xcontent to core library ([#5902](https://github.com/opensearch-project/OpenSearch/pull/5902))
 - Changed `opensearch-env` to respect already set `OPENSEARCH_HOME` environment variable ([#6956](https://github.com/opensearch-project/OpenSearch/pull/6956/))
 - Added a new field type: flat_object ([#6507](https://github.com/opensearch-project/OpenSearch/pull/6507))
-- Changed the method definition of `unregnized method` in BaseRestHandler and added a new method `unrecognizedStrings method` ([#7125])(https://github.com/opensearch-project/OpenSearch/pull/7125)
+- Increased visibility of BaseRestHandler’s `unrecognized` method using a new public `unrecognizedString` method. ([#7125])(https://github.com/opensearch-project/OpenSearch/pull/7125)
 
 ### Deprecated
 - Map, List, and Set in org.opensearch.common.collect ([#6609](https://github.com/opensearch-project/OpenSearch/pull/6609))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,7 +122,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Refactor] XContent base classes from xcontent to core library ([#5902](https://github.com/opensearch-project/OpenSearch/pull/5902))
 - Changed `opensearch-env` to respect already set `OPENSEARCH_HOME` environment variable ([#6956](https://github.com/opensearch-project/OpenSearch/pull/6956/))
 - Added a new field type: flat_object ([#6507](https://github.com/opensearch-project/OpenSearch/pull/6507))
-- Increased visibility of BaseRestHandler’s `unrecognized` method using a new public `unrecognizedString` method. ([#7125])(https://github.com/opensearch-project/OpenSearch/pull/7125)
+- Increased visibility of BaseRestHandler’s `unrecognized` method using a new public `unrecognizedString` method. ([#7125](https://github.com/opensearch-project/OpenSearch/pull/7125))
 
 ### Deprecated
 - Map, List, and Set in org.opensearch.common.collect ([#6609](https://github.com/opensearch-project/OpenSearch/pull/6609))

--- a/server/src/main/java/org/opensearch/rest/BaseRestHandler.java
+++ b/server/src/main/java/org/opensearch/rest/BaseRestHandler.java
@@ -173,6 +173,15 @@ public abstract class BaseRestHandler implements RestHandler {
         return message.toString();
     }
 
+    /**
+     * Returns a String message of the detail of any unrecognized error occurred. The string is intended for use in error messages to be returned to the user.
+     *
+     * @param request The request that caused the exception
+     * @param invalids Strings from the request which were unable to be understood.
+     * @param candidates A set of words that are most likely to be the valid strings determined invalid, to be suggested to the user.
+     * @param detail The parameter contains the details of the exception.
+     * @return a String that contains the message.
+     */
     protected final String unrecognized(
         final RestRequest request,
         final Set<String> invalids,

--- a/server/src/main/java/org/opensearch/rest/BaseRestHandler.java
+++ b/server/src/main/java/org/opensearch/rest/BaseRestHandler.java
@@ -128,7 +128,7 @@ public abstract class BaseRestHandler implements RestHandler {
         action.accept(channel);
     }
 
-    protected final String unrecognized(
+    public static String unrecognizedStrings(
         final RestRequest request,
         final Set<String> invalids,
         final Set<String> candidates,
@@ -171,6 +171,15 @@ public abstract class BaseRestHandler implements RestHandler {
         }
 
         return message.toString();
+    }
+
+    protected final String unrecognized(
+        final RestRequest request,
+        final Set<String> invalids,
+        final Set<String> candidates,
+        final String detail
+    ) {
+        return unrecognizedStrings(request, invalids, candidates, detail);
     }
 
     /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
BaseRestExtensionHandler in opensearch-sdk needs to use unrecognized method of BaseRestHandler. Therefore to follow DRY principle I have added a new method unrecognizedStrings in BaseRestHandler and then copied the definition of current unrecognized method in it. Then I called unrecognizedString method from unrecognized method. 

From BaseRestExtensionHandler I will just call the unrecognizedMethod. This change is done so that if in future there is some change in unrecognized method then it reflects for extensions also.


### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
