### PR TITLE
[Refactor] ClusterInfo to use j.util.Map instead of ImmutableOpenMap

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/cluster/ClusterInfoServiceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/ClusterInfoServiceIT.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.cluster;
 
-import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.ActionRequest;
@@ -47,7 +46,6 @@ import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.allocation.decider.EnableAllocationDecider;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Strings;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.index.IndexService;
@@ -69,6 +67,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -174,24 +173,24 @@ public class ClusterInfoServiceIT extends OpenSearchIntegTestCase {
         infoService.setUpdateFrequency(TimeValue.timeValueMillis(200));
         ClusterInfo info = infoService.refresh();
         assertNotNull("info should not be null", info);
-        ImmutableOpenMap<String, DiskUsage> leastUsages = info.getNodeLeastAvailableDiskUsages();
-        ImmutableOpenMap<String, DiskUsage> mostUsages = info.getNodeMostAvailableDiskUsages();
-        ImmutableOpenMap<String, Long> shardSizes = info.shardSizes;
+        final Map<String, DiskUsage> leastUsages = info.getNodeLeastAvailableDiskUsages();
+        final Map<String, DiskUsage> mostUsages = info.getNodeMostAvailableDiskUsages();
+        final Map<String, Long> shardSizes = info.shardSizes;
         assertNotNull(leastUsages);
         assertNotNull(shardSizes);
         assertThat("some usages are populated", leastUsages.values().size(), Matchers.equalTo(2));
         assertThat("some shard sizes are populated", shardSizes.values().size(), greaterThan(0));
-        for (ObjectCursor<DiskUsage> usage : leastUsages.values()) {
-            logger.info("--> usage: {}", usage.value);
-            assertThat("usage has be retrieved", usage.value.getFreeBytes(), greaterThan(0L));
+        for (Map.Entry<String, DiskUsage> usage : leastUsages.entrySet()) {
+            logger.info("--> usage: {}", usage.getValue());
+            assertThat("usage has be retrieved", usage.getValue().getFreeBytes(), greaterThan(0L));
         }
-        for (ObjectCursor<DiskUsage> usage : mostUsages.values()) {
-            logger.info("--> usage: {}", usage.value);
-            assertThat("usage has be retrieved", usage.value.getFreeBytes(), greaterThan(0L));
+        for (DiskUsage usage : mostUsages.values()) {
+            logger.info("--> usage: {}", usage);
+            assertThat("usage has be retrieved", usage.getFreeBytes(), greaterThan(0L));
         }
-        for (ObjectCursor<Long> size : shardSizes.values()) {
-            logger.info("--> shard size: {}", size.value);
-            assertThat("shard size is greater than 0", size.value, greaterThanOrEqualTo(0L));
+        for (Long size : shardSizes.values()) {
+            logger.info("--> shard size: {}", size);
+            assertThat("shard size is greater than 0", size, greaterThanOrEqualTo(0L));
         }
         ClusterService clusterService = internalTestCluster.getInstance(ClusterService.class, internalTestCluster.getClusterManagerName());
         ClusterState state = clusterService.state();

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
@@ -573,7 +573,7 @@ public class DiskThresholdDeciderIT extends OpenSearchIntegTestCase {
         // if the nodes were all under the low watermark already (but unbalanced) then a change in the disk usage doesn't trigger a reroute
         // even though it's now possible to achieve better balance, so we have to do an explicit reroute. TODO fix this?
         if (StreamSupport.stream(clusterInfoService.getClusterInfo().getNodeMostAvailableDiskUsages().values().spliterator(), false)
-            .allMatch(cur -> cur.value.getFreeBytes() > WATERMARK_BYTES)) {
+            .allMatch(cur -> cur.getFreeBytes() > WATERMARK_BYTES)) {
             assertAcked(client().admin().cluster().prepareReroute());
         }
 

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitor.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitor.java
@@ -32,8 +32,6 @@
 
 package org.opensearch.cluster.routing.allocation;
 
-import com.carrotsearch.hppc.ObjectLookupContainer;
-import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
@@ -53,7 +51,6 @@ import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.allocation.decider.DiskThresholdDecider;
 import org.opensearch.common.Priority;
 import org.opensearch.common.Strings;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.set.Sets;
@@ -61,6 +58,7 @@ import org.opensearch.common.util.set.Sets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -134,7 +132,7 @@ public class DiskThresholdMonitor {
             return;
         }
 
-        final ImmutableOpenMap<String, DiskUsage> usages = info.getNodeLeastAvailableDiskUsages();
+        final Map<String, DiskUsage> usages = info.getNodeLeastAvailableDiskUsages();
         if (usages == null) {
             logger.trace("skipping monitor as no disk usage information is available");
             checkFinished();
@@ -148,7 +146,7 @@ public class DiskThresholdMonitor {
         final long currentTimeMillis = currentTimeMillisSupplier.getAsLong();
 
         // Clean up nodes that have been removed from the cluster
-        final ObjectLookupContainer<String> nodes = usages.keys();
+        final Set<String> nodes = usages.keySet();
         cleanUpRemovedNodes(nodes, nodesOverLowThreshold);
         cleanUpRemovedNodes(nodes, nodesOverHighThreshold);
         cleanUpRemovedNodes(nodes, nodesOverHighThresholdAndRelocating);
@@ -161,9 +159,9 @@ public class DiskThresholdMonitor {
 
         final List<DiskUsage> usagesOverHighThreshold = new ArrayList<>();
 
-        for (final ObjectObjectCursor<String, DiskUsage> entry : usages) {
-            final String node = entry.key;
-            final DiskUsage usage = entry.value;
+        for (final Map.Entry<String, DiskUsage> entry : usages.entrySet()) {
+            final String node = entry.getKey();
+            final DiskUsage usage = entry.getValue();
             final RoutingNode routingNode = routingNodes.node(node);
 
             if (usage.getFreeBytes() < diskThresholdSettings.getFreeBytesThresholdFloodStage().getBytes()
@@ -401,7 +399,7 @@ public class DiskThresholdMonitor {
 
     private void markNodesMissingUsageIneligibleForRelease(
         RoutingNodes routingNodes,
-        ImmutableOpenMap<String, DiskUsage> usages,
+        Map<String, DiskUsage> usages,
         Set<String> indicesToMarkIneligibleForAutoRelease
     ) {
         for (RoutingNode routingNode : routingNodes) {
@@ -459,7 +457,7 @@ public class DiskThresholdMonitor {
             .execute(ActionListener.map(wrappedListener, r -> null));
     }
 
-    private static void cleanUpRemovedNodes(ObjectLookupContainer<String> nodesToKeep, Set<String> nodesToCleanUp) {
+    private static void cleanUpRemovedNodes(Set<String> nodesToKeep, Set<String> nodesToCleanUp) {
         for (String node : nodesToCleanUp) {
             if (nodesToKeep.contains(node) == false) {
                 nodesToCleanUp.remove(node);

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.cluster.routing.allocation.decider;
 
-import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.Version;
@@ -49,7 +48,6 @@ import org.opensearch.cluster.routing.ShardRoutingState;
 import org.opensearch.cluster.routing.allocation.DiskThresholdSettings;
 import org.opensearch.cluster.routing.allocation.RoutingAllocation;
 import org.opensearch.common.Strings;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
@@ -59,6 +57,7 @@ import org.opensearch.index.shard.ShardId;
 import org.opensearch.snapshots.SnapshotShardSizeInfo;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.opensearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING;
@@ -168,7 +167,7 @@ public class DiskThresholdDecider extends AllocationDecider {
     @Override
     public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
         ClusterInfo clusterInfo = allocation.clusterInfo();
-        ImmutableOpenMap<String, DiskUsage> usages = clusterInfo.getNodeMostAvailableDiskUsages();
+        Map<String, DiskUsage> usages = clusterInfo.getNodeMostAvailableDiskUsages();
         final Decision decision = earlyTerminate(allocation, usages);
         if (decision != null) {
             return decision;
@@ -424,7 +423,7 @@ public class DiskThresholdDecider extends AllocationDecider {
             throw new IllegalArgumentException("Shard [" + shardRouting + "] is not allocated on node: [" + node.nodeId() + "]");
         }
         final ClusterInfo clusterInfo = allocation.clusterInfo();
-        final ImmutableOpenMap<String, DiskUsage> usages = clusterInfo.getNodeLeastAvailableDiskUsages();
+        final Map<String, DiskUsage> usages = clusterInfo.getNodeLeastAvailableDiskUsages();
         final Decision decision = earlyTerminate(allocation, usages);
         if (decision != null) {
             return decision;
@@ -520,7 +519,7 @@ public class DiskThresholdDecider extends AllocationDecider {
     private DiskUsageWithRelocations getDiskUsage(
         RoutingNode node,
         RoutingAllocation allocation,
-        ImmutableOpenMap<String, DiskUsage> usages,
+        final Map<String, DiskUsage> usages,
         boolean subtractLeavingShards
     ) {
         DiskUsage usage = usages.get(node.nodeId());
@@ -566,15 +565,15 @@ public class DiskThresholdDecider extends AllocationDecider {
      * @param usages Map of nodeId to DiskUsage for all known nodes
      * @return DiskUsage representing given node using the average disk usage
      */
-    DiskUsage averageUsage(RoutingNode node, ImmutableOpenMap<String, DiskUsage> usages) {
+    DiskUsage averageUsage(RoutingNode node, final Map<String, DiskUsage> usages) {
         if (usages.size() == 0) {
             return new DiskUsage(node.nodeId(), node.node().getName(), "_na_", 0, 0);
         }
         long totalBytes = 0;
         long freeBytes = 0;
-        for (ObjectCursor<DiskUsage> du : usages.values()) {
-            totalBytes += du.value.getTotalBytes();
-            freeBytes += du.value.getFreeBytes();
+        for (DiskUsage du : usages.values()) {
+            totalBytes += du.getTotalBytes();
+            freeBytes += du.getFreeBytes();
         }
         return new DiskUsage(node.nodeId(), node.node().getName(), "_na_", totalBytes / usages.size(), freeBytes / usages.size());
     }
@@ -598,7 +597,7 @@ public class DiskThresholdDecider extends AllocationDecider {
         return newUsage.getFreeDiskAsPercentage();
     }
 
-    private Decision earlyTerminate(RoutingAllocation allocation, ImmutableOpenMap<String, DiskUsage> usages) {
+    private Decision earlyTerminate(RoutingAllocation allocation, final Map<String, DiskUsage> usages) {
         // Always allow allocation if the decider is disabled
         if (diskThresholdSettings.isEnabled() == false) {
             return allocation.decision(Decision.YES, NAME, "the disk threshold decider is disabled");

--- a/server/src/test/java/org/opensearch/cluster/ClusterInfoTests.java
+++ b/server/src/test/java/org/opensearch/cluster/ClusterInfoTests.java
@@ -34,10 +34,12 @@ package org.opensearch.cluster;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.ShardRoutingState;
 import org.opensearch.cluster.routing.TestShardRouting;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.index.shard.ShardId;
 import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class ClusterInfoTests extends OpenSearchTestCase {
 
@@ -60,9 +62,9 @@ public class ClusterInfoTests extends OpenSearchTestCase {
         assertEquals(clusterInfo.reservedSpace, result.reservedSpace);
     }
 
-    private static ImmutableOpenMap<String, DiskUsage> randomDiskUsage() {
+    private static Map<String, DiskUsage> randomDiskUsage() {
         int numEntries = randomIntBetween(0, 128);
-        ImmutableOpenMap.Builder<String, DiskUsage> builder = ImmutableOpenMap.builder(numEntries);
+        final Map<String, DiskUsage> builder = new HashMap<>(numEntries);
         for (int i = 0; i < numEntries; i++) {
             String key = randomAlphaOfLength(32);
             DiskUsage diskUsage = new DiskUsage(
@@ -74,34 +76,34 @@ public class ClusterInfoTests extends OpenSearchTestCase {
             );
             builder.put(key, diskUsage);
         }
-        return builder.build();
+        return builder;
     }
 
-    private static ImmutableOpenMap<String, Long> randomShardSizes() {
+    private static Map<String, Long> randomShardSizes() {
         int numEntries = randomIntBetween(0, 128);
-        ImmutableOpenMap.Builder<String, Long> builder = ImmutableOpenMap.builder(numEntries);
+        final Map<String, Long> builder = new HashMap<>(numEntries);
         for (int i = 0; i < numEntries; i++) {
             String key = randomAlphaOfLength(32);
             long shardSize = randomIntBetween(0, Integer.MAX_VALUE);
             builder.put(key, shardSize);
         }
-        return builder.build();
+        return builder;
     }
 
-    private static ImmutableOpenMap<ShardRouting, String> randomRoutingToDataPath() {
+    private static Map<ShardRouting, String> randomRoutingToDataPath() {
         int numEntries = randomIntBetween(0, 128);
-        ImmutableOpenMap.Builder<ShardRouting, String> builder = ImmutableOpenMap.builder(numEntries);
+        final Map<ShardRouting, String> builder = new HashMap<>(numEntries);
         for (int i = 0; i < numEntries; i++) {
             ShardId shardId = new ShardId(randomAlphaOfLength(32), randomAlphaOfLength(32), randomIntBetween(0, Integer.MAX_VALUE));
             ShardRouting shardRouting = TestShardRouting.newShardRouting(shardId, null, randomBoolean(), ShardRoutingState.UNASSIGNED);
             builder.put(shardRouting, randomAlphaOfLength(32));
         }
-        return builder.build();
+        return builder;
     }
 
-    private static ImmutableOpenMap<ClusterInfo.NodeAndPath, ClusterInfo.ReservedSpace> randomReservedSpace() {
+    private static Map<ClusterInfo.NodeAndPath, ClusterInfo.ReservedSpace> randomReservedSpace() {
         int numEntries = randomIntBetween(0, 128);
-        ImmutableOpenMap.Builder<ClusterInfo.NodeAndPath, ClusterInfo.ReservedSpace> builder = ImmutableOpenMap.builder(numEntries);
+        final Map<ClusterInfo.NodeAndPath, ClusterInfo.ReservedSpace> builder = new HashMap<>(numEntries);
         for (int i = 0; i < numEntries; i++) {
             final ClusterInfo.NodeAndPath key = new ClusterInfo.NodeAndPath(randomAlphaOfLength(10), randomAlphaOfLength(10));
             final ClusterInfo.ReservedSpace.Builder valueBuilder = new ClusterInfo.ReservedSpace.Builder();
@@ -111,7 +113,7 @@ public class ClusterInfoTests extends OpenSearchTestCase {
             }
             builder.put(key, valueBuilder.build());
         }
-        return builder.build();
+        return builder;
     }
 
 }

--- a/server/src/test/java/org/opensearch/cluster/DiskUsageTests.java
+++ b/server/src/test/java/org/opensearch/cluster/DiskUsageTests.java
@@ -41,7 +41,6 @@ import org.opensearch.cluster.routing.RecoverySource.PeerRecoverySource;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.ShardRoutingHelper;
 import org.opensearch.cluster.routing.UnassignedInfo;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.index.Index;
 import org.opensearch.index.shard.ShardId;
 import org.opensearch.index.shard.ShardPath;
@@ -53,6 +52,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
@@ -137,9 +137,8 @@ public class DiskUsageTests extends OpenSearchTestCase {
         ShardStats[] stats = new ShardStats[] {
             new ShardStats(test_0, new ShardPath(false, test0Path, test0Path, test_0.shardId()), commonStats0, null, null, null),
             new ShardStats(test_1, new ShardPath(false, test1Path, test1Path, test_1.shardId()), commonStats1, null, null, null) };
-        ImmutableOpenMap.Builder<String, Long> shardSizes = ImmutableOpenMap.builder();
-        ImmutableOpenMap.Builder<ShardRouting, String> routingToPath = ImmutableOpenMap.builder();
-        ClusterState state = ClusterState.builder(new ClusterName("blarg")).version(0).build();
+        final Map<String, Long> shardSizes = new HashMap<>();
+        final Map<ShardRouting, String> routingToPath = new HashMap<>();
         InternalClusterInfoService.buildShardLevelInfo(logger, stats, shardSizes, routingToPath, new HashMap<>());
         assertEquals(2, shardSizes.size());
         assertTrue(shardSizes.containsKey(ClusterInfo.shardIdentifierFromRouting(test_0)));
@@ -155,8 +154,8 @@ public class DiskUsageTests extends OpenSearchTestCase {
     }
 
     public void testFillDiskUsage() {
-        ImmutableOpenMap.Builder<String, DiskUsage> newLeastAvaiableUsages = ImmutableOpenMap.builder();
-        ImmutableOpenMap.Builder<String, DiskUsage> newMostAvaiableUsages = ImmutableOpenMap.builder();
+        final Map<String, DiskUsage> newLeastAvaiableUsages = new HashMap<>();
+        final Map<String, DiskUsage> newMostAvaiableUsages = new HashMap<>();
         FsInfo.Path[] node1FSInfo = new FsInfo.Path[] {
             new FsInfo.Path("/middle", "/dev/sda", 100, 90, 80),
             new FsInfo.Path("/least", "/dev/sdb", 200, 190, 70),
@@ -258,8 +257,8 @@ public class DiskUsageTests extends OpenSearchTestCase {
     }
 
     public void testFillDiskUsageSomeInvalidValues() {
-        ImmutableOpenMap.Builder<String, DiskUsage> newLeastAvailableUsages = ImmutableOpenMap.builder();
-        ImmutableOpenMap.Builder<String, DiskUsage> newMostAvailableUsages = ImmutableOpenMap.builder();
+        final Map<String, DiskUsage> newLeastAvailableUsages = new HashMap<>();
+        final Map<String, DiskUsage> newMostAvailableUsages = new HashMap<>();
         FsInfo.Path[] node1FSInfo = new FsInfo.Path[] {
             new FsInfo.Path("/middle", "/dev/sda", 100, 90, 80),
             new FsInfo.Path("/least", "/dev/sdb", -1, -1, -1),

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitorTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitorTests.java
@@ -49,7 +49,6 @@ import org.opensearch.cluster.routing.RoutingNode;
 import org.opensearch.cluster.routing.RoutingTable;
 import org.opensearch.cluster.routing.ShardRoutingState;
 import org.opensearch.common.Priority;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.shard.ShardId;
@@ -58,7 +57,9 @@ import org.opensearch.test.junit.annotations.TestLogging;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -137,19 +138,19 @@ public class DiskThresholdMonitorTests extends OpenSearchAllocationTestCase {
             }
         };
 
-        ImmutableOpenMap.Builder<String, DiskUsage> builder = ImmutableOpenMap.builder();
+        Map<String, DiskUsage> builder = new HashMap<>();
         builder.put("node1", new DiskUsage("node1", "node1", "/foo/bar", 100, 4));
         builder.put("node2", new DiskUsage("node2", "node2", "/foo/bar", 100, 30));
-        monitor.onNewInfo(clusterInfo(builder.build()));
+        monitor.onNewInfo(clusterInfo(builder));
         assertFalse(reroute.get());
         assertEquals(new HashSet<>(Arrays.asList("test_1", "test_2")), indices.get());
 
         indices.set(null);
-        builder = ImmutableOpenMap.builder();
+        builder = new HashMap<>();
         builder.put("node1", new DiskUsage("node1", "node1", "/foo/bar", 100, 4));
         builder.put("node2", new DiskUsage("node2", "node2", "/foo/bar", 100, 5));
         currentTime.addAndGet(randomLongBetween(60001, 120000));
-        monitor.onNewInfo(clusterInfo(builder.build()));
+        monitor.onNewInfo(clusterInfo(builder));
         assertTrue(reroute.get());
         assertEquals(new HashSet<>(Arrays.asList("test_1", "test_2")), indices.get());
         IndexMetadata indexMetadata = IndexMetadata.builder(clusterState.metadata().index("test_2"))
@@ -200,10 +201,10 @@ public class DiskThresholdMonitorTests extends OpenSearchAllocationTestCase {
 
         indices.set(null);
         reroute.set(false);
-        builder = ImmutableOpenMap.builder();
+        builder = new HashMap<>();
         builder.put("node1", new DiskUsage("node1", "node1", "/foo/bar", 100, 4));
         builder.put("node2", new DiskUsage("node2", "node2", "/foo/bar", 100, 5));
-        monitor.onNewInfo(clusterInfo(builder.build()));
+        monitor.onNewInfo(clusterInfo(builder));
         assertTrue(reroute.get());
         assertEquals(Collections.singleton("test_1"), indices.get());
     }
@@ -232,16 +233,13 @@ public class DiskThresholdMonitorTests extends OpenSearchAllocationTestCase {
             }
         };
 
-        final ImmutableOpenMap.Builder<String, DiskUsage> allDisksOkBuilder;
-        allDisksOkBuilder = ImmutableOpenMap.builder();
-        allDisksOkBuilder.put("node1", new DiskUsage("node1", "node1", "/foo/bar", 100, 50));
-        allDisksOkBuilder.put("node2", new DiskUsage("node2", "node2", "/foo/bar", 100, 50));
-        final ImmutableOpenMap<String, DiskUsage> allDisksOk = allDisksOkBuilder.build();
+        final Map<String, DiskUsage> allDisksOk = new HashMap<>();
+        allDisksOk.put("node1", new DiskUsage("node1", "node1", "/foo/bar", 100, 50));
+        allDisksOk.put("node2", new DiskUsage("node2", "node2", "/foo/bar", 100, 50));
 
-        final ImmutableOpenMap.Builder<String, DiskUsage> oneDiskAboveWatermarkBuilder = ImmutableOpenMap.builder();
-        oneDiskAboveWatermarkBuilder.put("node1", new DiskUsage("node1", "node1", "/foo/bar", 100, between(5, 9)));
-        oneDiskAboveWatermarkBuilder.put("node2", new DiskUsage("node2", "node2", "/foo/bar", 100, 50));
-        final ImmutableOpenMap<String, DiskUsage> oneDiskAboveWatermark = oneDiskAboveWatermarkBuilder.build();
+        final Map<String, DiskUsage> oneDiskAboveWatermark = new HashMap<>();
+        oneDiskAboveWatermark.put("node1", new DiskUsage("node1", "node1", "/foo/bar", 100, between(5, 9)));
+        oneDiskAboveWatermark.put("node2", new DiskUsage("node2", "node2", "/foo/bar", 100, 50));
 
         // should not reroute when all disks are ok
         currentTime.addAndGet(randomLongBetween(0, 120000));
@@ -308,12 +306,11 @@ public class DiskThresholdMonitorTests extends OpenSearchAllocationTestCase {
         assertNull(listenerReference.get());
 
         // should reroute again when one disk has reserved space that pushes it over the high watermark
-        final ImmutableOpenMap.Builder<ClusterInfo.NodeAndPath, ClusterInfo.ReservedSpace> builder = ImmutableOpenMap.builder(1);
-        builder.put(
+        final Map<ClusterInfo.NodeAndPath, ClusterInfo.ReservedSpace> reservedSpaces = new HashMap<>(1);
+        reservedSpaces.put(
             new ClusterInfo.NodeAndPath("node1", "/foo/bar"),
             new ClusterInfo.ReservedSpace.Builder().add(new ShardId("baz", "quux", 0), between(41, 100)).build()
         );
-        final ImmutableOpenMap<ClusterInfo.NodeAndPath, ClusterInfo.ReservedSpace> reservedSpaces = builder.build();
 
         currentTime.addAndGet(
             randomLongBetween(
@@ -324,7 +321,6 @@ public class DiskThresholdMonitorTests extends OpenSearchAllocationTestCase {
         monitor.onNewInfo(clusterInfo(allDisksOk, reservedSpaces));
         assertNotNull(listenerReference.get());
         listenerReference.getAndSet(null).onResponse(null);
-
     }
 
     public void testAutoReleaseIndices() {
@@ -348,19 +344,17 @@ public class DiskThresholdMonitorTests extends OpenSearchAllocationTestCase {
         );
         assertThat(clusterState.getRoutingTable().shardsWithState(ShardRoutingState.STARTED).size(), equalTo(8));
 
-        final ImmutableOpenMap.Builder<ClusterInfo.NodeAndPath, ClusterInfo.ReservedSpace> reservedSpacesBuilder = ImmutableOpenMap
-            .builder();
+        final Map<ClusterInfo.NodeAndPath, ClusterInfo.ReservedSpace> reservedSpaces = new HashMap<>();
         final int reservedSpaceNode1 = between(0, 10);
-        reservedSpacesBuilder.put(
+        reservedSpaces.put(
             new ClusterInfo.NodeAndPath("node1", "/foo/bar"),
             new ClusterInfo.ReservedSpace.Builder().add(new ShardId("", "", 0), reservedSpaceNode1).build()
         );
         final int reservedSpaceNode2 = between(0, 10);
-        reservedSpacesBuilder.put(
+        reservedSpaces.put(
             new ClusterInfo.NodeAndPath("node2", "/foo/bar"),
             new ClusterInfo.ReservedSpace.Builder().add(new ShardId("", "", 0), reservedSpaceNode2).build()
         );
-        ImmutableOpenMap<ClusterInfo.NodeAndPath, ClusterInfo.ReservedSpace> reservedSpaces = reservedSpacesBuilder.build();
 
         DiskThresholdMonitor monitor = new DiskThresholdMonitor(
             Settings.EMPTY,
@@ -392,20 +386,20 @@ public class DiskThresholdMonitorTests extends OpenSearchAllocationTestCase {
         };
         indicesToMarkReadOnly.set(null);
         indicesToRelease.set(null);
-        ImmutableOpenMap.Builder<String, DiskUsage> builder = ImmutableOpenMap.builder();
+        Map<String, DiskUsage> builder = new HashMap<>();
         builder.put("node1", new DiskUsage("node1", "node1", "/foo/bar", 100, between(0, 4)));
         builder.put("node2", new DiskUsage("node2", "node2", "/foo/bar", 100, between(0, 4)));
-        monitor.onNewInfo(clusterInfo(builder.build(), reservedSpaces));
+        monitor.onNewInfo(clusterInfo(builder, reservedSpaces));
         assertEquals(new HashSet<>(Arrays.asList("test_1", "test_2")), indicesToMarkReadOnly.get());
         assertNull(indicesToRelease.get());
 
         // Reserved space is ignored when applying block
         indicesToMarkReadOnly.set(null);
         indicesToRelease.set(null);
-        builder = ImmutableOpenMap.builder();
+        builder = new HashMap<>();
         builder.put("node1", new DiskUsage("node1", "node1", "/foo/bar", 100, between(5, 90)));
         builder.put("node2", new DiskUsage("node2", "node2", "/foo/bar", 100, between(5, 90)));
-        monitor.onNewInfo(clusterInfo(builder.build(), reservedSpaces));
+        monitor.onNewInfo(clusterInfo(builder, reservedSpaces));
         assertNull(indicesToMarkReadOnly.get());
         assertNull(indicesToRelease.get());
 
@@ -454,66 +448,66 @@ public class DiskThresholdMonitorTests extends OpenSearchAllocationTestCase {
         // When free disk on any of node1 or node2 goes below 5% flood watermark, then apply index block on indices not having the block
         indicesToMarkReadOnly.set(null);
         indicesToRelease.set(null);
-        builder = ImmutableOpenMap.builder();
+        builder = new HashMap<>();
         builder.put("node1", new DiskUsage("node1", "node1", "/foo/bar", 100, between(0, 100)));
         builder.put("node2", new DiskUsage("node2", "node2", "/foo/bar", 100, between(0, 4)));
-        monitor.onNewInfo(clusterInfo(builder.build(), reservedSpaces));
+        monitor.onNewInfo(clusterInfo(builder, reservedSpaces));
         assertThat(indicesToMarkReadOnly.get(), contains("test_1"));
         assertNull(indicesToRelease.get());
 
         // When free disk on node1 and node2 goes above 10% high watermark then release index block, ignoring reserved space
         indicesToMarkReadOnly.set(null);
         indicesToRelease.set(null);
-        builder = ImmutableOpenMap.builder();
+        builder = new HashMap<>();
         builder.put("node1", new DiskUsage("node1", "node1", "/foo/bar", 100, between(10, 100)));
         builder.put("node2", new DiskUsage("node2", "node2", "/foo/bar", 100, between(10, 100)));
-        monitor.onNewInfo(clusterInfo(builder.build(), reservedSpaces));
+        monitor.onNewInfo(clusterInfo(builder, reservedSpaces));
         assertNull(indicesToMarkReadOnly.get());
         assertThat(indicesToRelease.get(), contains("test_2"));
 
         // When no usage information is present for node2, we don't release the block
         indicesToMarkReadOnly.set(null);
         indicesToRelease.set(null);
-        builder = ImmutableOpenMap.builder();
+        builder = new HashMap<>();
         builder.put("node1", new DiskUsage("node1", "node1", "/foo/bar", 100, between(0, 4)));
-        monitor.onNewInfo(clusterInfo(builder.build()));
+        monitor.onNewInfo(clusterInfo(builder));
         assertThat(indicesToMarkReadOnly.get(), contains("test_1"));
         assertNull(indicesToRelease.get());
 
         // When disk usage on one node is between the high and flood-stage watermarks, nothing changes
         indicesToMarkReadOnly.set(null);
         indicesToRelease.set(null);
-        builder = ImmutableOpenMap.builder();
+        builder = new HashMap<>();
         builder.put("node1", new DiskUsage("node1", "node1", "/foo/bar", 100, between(5, 9)));
         builder.put("node2", new DiskUsage("node2", "node2", "/foo/bar", 100, between(5, 100)));
         if (randomBoolean()) {
             builder.put("node3", new DiskUsage("node3", "node3", "/foo/bar", 100, between(0, 100)));
         }
-        monitor.onNewInfo(clusterInfo(builder.build()));
+        monitor.onNewInfo(clusterInfo(builder));
         assertNull(indicesToMarkReadOnly.get());
         assertNull(indicesToRelease.get());
 
         // When disk usage on one node is missing and the other is below the high watermark, nothing changes
         indicesToMarkReadOnly.set(null);
         indicesToRelease.set(null);
-        builder = ImmutableOpenMap.builder();
+        builder = new HashMap<>();
         builder.put("node1", new DiskUsage("node1", "node1", "/foo/bar", 100, between(5, 100)));
         if (randomBoolean()) {
             builder.put("node3", new DiskUsage("node3", "node3", "/foo/bar", 100, between(0, 100)));
         }
-        monitor.onNewInfo(clusterInfo(builder.build()));
+        monitor.onNewInfo(clusterInfo(builder));
         assertNull(indicesToMarkReadOnly.get());
         assertNull(indicesToRelease.get());
 
         // When disk usage on one node is missing and the other is above the flood-stage watermark, affected indices are blocked
         indicesToMarkReadOnly.set(null);
         indicesToRelease.set(null);
-        builder = ImmutableOpenMap.builder();
+        builder = new HashMap<>();
         builder.put("node1", new DiskUsage("node1", "node1", "/foo/bar", 100, between(0, 4)));
         if (randomBoolean()) {
             builder.put("node3", new DiskUsage("node3", "node3", "/foo/bar", 100, between(0, 100)));
         }
-        monitor.onNewInfo(clusterInfo(builder.build()));
+        monitor.onNewInfo(clusterInfo(builder));
         assertThat(indicesToMarkReadOnly.get(), contains("test_1"));
         assertNull(indicesToRelease.get());
     }
@@ -565,22 +559,18 @@ public class DiskThresholdMonitorTests extends OpenSearchAllocationTestCase {
             }
         };
 
-        final ImmutableOpenMap.Builder<String, DiskUsage> allDisksOkBuilder;
-        allDisksOkBuilder = ImmutableOpenMap.builder();
-        allDisksOkBuilder.put("node1", new DiskUsage("node1", "node1", "/foo/bar", 100, between(15, 100)));
-        final ImmutableOpenMap<String, DiskUsage> allDisksOk = allDisksOkBuilder.build();
+        final Map<String, DiskUsage> allDisksOk;
+        allDisksOk = new HashMap<>();
+        allDisksOk.put("node1", new DiskUsage("node1", "node1", "/foo/bar", 100, between(15, 100)));
 
-        final ImmutableOpenMap.Builder<String, DiskUsage> aboveLowWatermarkBuilder = ImmutableOpenMap.builder();
-        aboveLowWatermarkBuilder.put("node1", new DiskUsage("node1", "node1", "/foo/bar", 100, between(10, 14)));
-        final ImmutableOpenMap<String, DiskUsage> aboveLowWatermark = aboveLowWatermarkBuilder.build();
+        final Map<String, DiskUsage> aboveLowWatermark = new HashMap<>();
+        aboveLowWatermark.put("node1", new DiskUsage("node1", "node1", "/foo/bar", 100, between(10, 14)));
 
-        final ImmutableOpenMap.Builder<String, DiskUsage> aboveHighWatermarkBuilder = ImmutableOpenMap.builder();
-        aboveHighWatermarkBuilder.put("node1", new DiskUsage("node1", "node1", "/foo/bar", 100, between(5, 9)));
-        final ImmutableOpenMap<String, DiskUsage> aboveHighWatermark = aboveHighWatermarkBuilder.build();
+        final Map<String, DiskUsage> aboveHighWatermark = new HashMap<>();
+        aboveHighWatermark.put("node1", new DiskUsage("node1", "node1", "/foo/bar", 100, between(5, 9)));
 
-        final ImmutableOpenMap.Builder<String, DiskUsage> aboveFloodStageWatermarkBuilder = ImmutableOpenMap.builder();
-        aboveFloodStageWatermarkBuilder.put("node1", new DiskUsage("node1", "node1", "/foo/bar", 100, between(0, 4)));
-        final ImmutableOpenMap<String, DiskUsage> aboveFloodStageWatermark = aboveFloodStageWatermarkBuilder.build();
+        final Map<String, DiskUsage> aboveFloodStageWatermark = new HashMap<>();
+        aboveFloodStageWatermark.put("node1", new DiskUsage("node1", "node1", "/foo/bar", 100, between(0, 4)));
 
         assertNoLogging(monitor, allDisksOk);
 
@@ -727,13 +717,12 @@ public class DiskThresholdMonitorTests extends OpenSearchAllocationTestCase {
             }
         };
 
-        ImmutableOpenMap.Builder<String, DiskUsage> builder = ImmutableOpenMap.builder();
-        monitor.onNewInfo(clusterInfo(builder.build()));
+        final Map<String, DiskUsage> builder = new HashMap<>();
+        monitor.onNewInfo(clusterInfo(builder));
         assertTrue(countBlocksCalled.get() == 0);
     }
 
-    private void assertNoLogging(DiskThresholdMonitor monitor, ImmutableOpenMap<String, DiskUsage> diskUsages)
-        throws IllegalAccessException {
+    private void assertNoLogging(DiskThresholdMonitor monitor, final Map<String, DiskUsage> diskUsages) throws IllegalAccessException {
         try (MockLogAppender mockAppender = MockLogAppender.createForLoggers(LogManager.getLogger(DiskThresholdMonitor.class))) {
             mockAppender.addExpectation(
                 new MockLogAppender.UnseenEventExpectation(
@@ -760,26 +749,26 @@ public class DiskThresholdMonitorTests extends OpenSearchAllocationTestCase {
         }
     }
 
-    private void assertRepeatedWarningMessages(DiskThresholdMonitor monitor, ImmutableOpenMap<String, DiskUsage> diskUsages, String message)
+    private void assertRepeatedWarningMessages(DiskThresholdMonitor monitor, final Map<String, DiskUsage> diskUsages, String message)
         throws IllegalAccessException {
         for (int i = between(1, 3); i >= 0; i--) {
             assertLogging(monitor, diskUsages, Level.WARN, message);
         }
     }
 
-    private void assertSingleWarningMessage(DiskThresholdMonitor monitor, ImmutableOpenMap<String, DiskUsage> diskUsages, String message)
+    private void assertSingleWarningMessage(DiskThresholdMonitor monitor, final Map<String, DiskUsage> diskUsages, String message)
         throws IllegalAccessException {
         assertLogging(monitor, diskUsages, Level.WARN, message);
         assertNoLogging(monitor, diskUsages);
     }
 
-    private void assertSingleInfoMessage(DiskThresholdMonitor monitor, ImmutableOpenMap<String, DiskUsage> diskUsages, String message)
+    private void assertSingleInfoMessage(DiskThresholdMonitor monitor, final Map<String, DiskUsage> diskUsages, String message)
         throws IllegalAccessException {
         assertLogging(monitor, diskUsages, Level.INFO, message);
         assertNoLogging(monitor, diskUsages);
     }
 
-    private void assertLogging(DiskThresholdMonitor monitor, ImmutableOpenMap<String, DiskUsage> diskUsages, Level level, String message)
+    private void assertLogging(DiskThresholdMonitor monitor, final Map<String, DiskUsage> diskUsages, Level level, String message)
         throws IllegalAccessException {
         try (MockLogAppender mockAppender = MockLogAppender.createForLoggers(LogManager.getLogger(DiskThresholdMonitor.class))) {
             mockAppender.start();
@@ -801,13 +790,13 @@ public class DiskThresholdMonitorTests extends OpenSearchAllocationTestCase {
         }
     }
 
-    private static ClusterInfo clusterInfo(ImmutableOpenMap<String, DiskUsage> diskUsages) {
-        return clusterInfo(diskUsages, ImmutableOpenMap.of());
+    private static ClusterInfo clusterInfo(final Map<String, DiskUsage> diskUsages) {
+        return clusterInfo(diskUsages, Map.of());
     }
 
     private static ClusterInfo clusterInfo(
-        ImmutableOpenMap<String, DiskUsage> diskUsages,
-        ImmutableOpenMap<ClusterInfo.NodeAndPath, ClusterInfo.ReservedSpace> reservedSpace
+        final Map<String, DiskUsage> diskUsages,
+        final Map<ClusterInfo.NodeAndPath, ClusterInfo.ReservedSpace> reservedSpace
     ) {
         return new ClusterInfo(diskUsages, null, null, null, reservedSpace);
     }

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/IndexShardConstraintDeciderOverlapTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/IndexShardConstraintDeciderOverlapTests.java
@@ -15,7 +15,6 @@ import org.opensearch.cluster.DiskUsage;
 import org.opensearch.cluster.OpenSearchAllocationWithConstraintsTestCase;
 import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.routing.ShardRouting;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.shard.ShardId;
 import org.opensearch.test.VersionUtils;
@@ -50,28 +49,22 @@ public class IndexShardConstraintDeciderOverlapTests extends OpenSearchAllocatio
             .build();
 
         // Build Shard size and disk usages
-        ImmutableOpenMap.Builder<String, DiskUsage> usagesBuilder = ImmutableOpenMap.builder();
-        usagesBuilder.put("node_0", new DiskUsage("node_0", "node_0", "/dev/null", 100, 80)); // 20% used
-        usagesBuilder.put("node_1", new DiskUsage("node_1", "node_1", "/dev/null", 100, 55)); // 45% used
-        usagesBuilder.put("node_2", new DiskUsage("node_2", "node_2", "/dev/null", 100, 35)); // 65% used
-        usagesBuilder.put("high_watermark_node_0", new DiskUsage("high_watermark_node_0", "high_watermark_node_0", "/dev/null", 100, 10)); // 90%
-                                                                                                                                           // used
-
-        ImmutableOpenMap<String, DiskUsage> usages = usagesBuilder.build();
-        ImmutableOpenMap.Builder<String, Long> shardSizesBuilder = ImmutableOpenMap.builder();
-        clusterState.getRoutingTable().allShards().forEach(shard -> shardSizesBuilder.put(shardIdentifierFromRouting(shard), 1L)); // Each
-                                                                                                                                   // shard
-                                                                                                                                   // is 1
-                                                                                                                                   // byte
-        ImmutableOpenMap<String, Long> shardSizes = shardSizesBuilder.build();
-
-        final ImmutableOpenMap<ClusterInfo.NodeAndPath, ClusterInfo.ReservedSpace> reservedSpace = new ImmutableOpenMap.Builder<
-            ClusterInfo.NodeAndPath,
-            ClusterInfo.ReservedSpace>().fPut(getNodeAndDevNullPath("node_0"), getReservedSpace())
-            .fPut(getNodeAndDevNullPath("node_1"), getReservedSpace())
-            .fPut(getNodeAndDevNullPath("node_2"), getReservedSpace())
-            .fPut(getNodeAndDevNullPath("high_watermark_node_0"), getReservedSpace())
-            .build();
+        final Map<String, DiskUsage> usages = new HashMap<>();
+        usages.put("node_0", new DiskUsage("node_0", "node_0", "/dev/null", 100, 80)); // 20% used
+        usages.put("node_1", new DiskUsage("node_1", "node_1", "/dev/null", 100, 55)); // 45% used
+        usages.put("node_2", new DiskUsage("node_2", "node_2", "/dev/null", 100, 35)); // 65% used
+        usages.put("high_watermark_node_0", new DiskUsage("high_watermark_node_0", "high_watermark_node_0", "/dev/null", 100, 10)); // 90%
+                                                                                                                                    // used
+        final Map<String, Long> shardSizes = new HashMap<>();
+        clusterState.getRoutingTable().allShards().forEach(shard -> shardSizes.put(shardIdentifierFromRouting(shard), 1L)); // Each
+                                                                                                                            // shard
+                                                                                                                            // is 1
+                                                                                                                            // byte
+        final Map<ClusterInfo.NodeAndPath, ClusterInfo.ReservedSpace> reservedSpace = new HashMap<>();
+        reservedSpace.put(getNodeAndDevNullPath("node_0"), getReservedSpace());
+        reservedSpace.put(getNodeAndDevNullPath("node_1"), getReservedSpace());
+        reservedSpace.put(getNodeAndDevNullPath("node_2"), getReservedSpace());
+        reservedSpace.put(getNodeAndDevNullPath("high_watermark_node_0"), getReservedSpace());
         final ClusterInfo clusterInfo = new DevNullClusterInfo(usages, usages, shardSizes, reservedSpace);
         ClusterInfoService cis = () -> clusterInfo;
         allocation = createAllocationService(settings, cis);
@@ -84,10 +77,9 @@ public class IndexShardConstraintDeciderOverlapTests extends OpenSearchAllocatio
         /* Shard sizes that would breach high watermark on node_2 if allocated.
          */
         addIndices("big_index_", 1, 10, 0);
-        ImmutableOpenMap.Builder<String, Long> bigIndexShardSizeBuilder = ImmutableOpenMap.builder(shardSizes);
-        clusterState.getRoutingNodes().unassigned().forEach(shard -> bigIndexShardSizeBuilder.put(shardIdentifierFromRouting(shard), 20L));
-        shardSizes = bigIndexShardSizeBuilder.build();
-        final ClusterInfo bigIndexClusterInfo = new DevNullClusterInfo(usages, usages, shardSizes, reservedSpace);
+        final Map<String, Long> bigIndexShardSizes = new HashMap<>(shardSizes);
+        clusterState.getRoutingNodes().unassigned().forEach(shard -> bigIndexShardSizes.put(shardIdentifierFromRouting(shard), 20L));
+        final ClusterInfo bigIndexClusterInfo = new DevNullClusterInfo(usages, usages, bigIndexShardSizes, reservedSpace);
         cis = () -> bigIndexClusterInfo;
         allocation = createAllocationService(settings, cis);
 
@@ -179,10 +171,10 @@ public class IndexShardConstraintDeciderOverlapTests extends OpenSearchAllocatio
      */
     public static class DevNullClusterInfo extends ClusterInfo {
         public DevNullClusterInfo(
-            ImmutableOpenMap<String, DiskUsage> leastAvailableSpaceUsage,
-            ImmutableOpenMap<String, DiskUsage> mostAvailableSpaceUsage,
-            ImmutableOpenMap<String, Long> shardSizes,
-            ImmutableOpenMap<NodeAndPath, ReservedSpace> reservedSpace
+            final Map<String, DiskUsage> leastAvailableSpaceUsage,
+            final Map<String, DiskUsage> mostAvailableSpaceUsage,
+            final Map<String, Long> shardSizes,
+            final Map<NodeAndPath, ReservedSpace> reservedSpace
         ) {
             super(leastAvailableSpaceUsage, mostAvailableSpaceUsage, shardSizes, null, reservedSpace);
         }

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/RemoteShardsBalancerBaseTestCase.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/RemoteShardsBalancerBaseTestCase.java
@@ -31,7 +31,6 @@ import org.opensearch.cluster.routing.allocation.allocator.ShardsAllocator;
 import org.opensearch.cluster.routing.allocation.decider.AllocationDecider;
 import org.opensearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.opensearch.common.SuppressForbidden;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
@@ -41,6 +40,7 @@ import org.opensearch.test.gateway.TestGatewayAllocator;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.opensearch.cluster.routing.ShardRoutingState.INITIALIZING;
@@ -248,11 +248,11 @@ public abstract class RemoteShardsBalancerBaseTestCase extends OpenSearchAllocat
      */
     public static class DevNullClusterInfo extends ClusterInfo {
         public DevNullClusterInfo(
-            ImmutableOpenMap<String, DiskUsage> leastAvailableSpaceUsage,
-            ImmutableOpenMap<String, DiskUsage> mostAvailableSpaceUsage,
-            ImmutableOpenMap<String, Long> shardSizes
+            final Map<String, DiskUsage> leastAvailableSpaceUsage,
+            final Map<String, DiskUsage> mostAvailableSpaceUsage,
+            final Map<String, Long> shardSizes
         ) {
-            super(leastAvailableSpaceUsage, mostAvailableSpaceUsage, shardSizes, null, ImmutableOpenMap.of());
+            super(leastAvailableSpaceUsage, mostAvailableSpaceUsage, shardSizes, null, Map.of());
         }
 
         @Override

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
@@ -113,17 +113,15 @@ public class DiskThresholdDeciderTests extends OpenSearchAllocationTestCase {
             .put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING.getKey(), 0.8)
             .build();
 
-        ImmutableOpenMap.Builder<String, DiskUsage> usagesBuilder = ImmutableOpenMap.builder();
-        usagesBuilder.put("node1", new DiskUsage("node1", "node1", "/dev/null", 100, 10)); // 90% used
-        usagesBuilder.put("node2", new DiskUsage("node2", "node2", "/dev/null", 100, 35)); // 65% used
-        usagesBuilder.put("node3", new DiskUsage("node3", "node3", "/dev/null", 100, 60)); // 40% used
-        usagesBuilder.put("node4", new DiskUsage("node4", "node4", "/dev/null", 100, 80)); // 20% used
-        ImmutableOpenMap<String, DiskUsage> usages = usagesBuilder.build();
+        final Map<String, DiskUsage> usages = new HashMap<>();
+        usages.put("node1", new DiskUsage("node1", "node1", "/dev/null", 100, 10)); // 90% used
+        usages.put("node2", new DiskUsage("node2", "node2", "/dev/null", 100, 35)); // 65% used
+        usages.put("node3", new DiskUsage("node3", "node3", "/dev/null", 100, 60)); // 40% used
+        usages.put("node4", new DiskUsage("node4", "node4", "/dev/null", 100, 80)); // 20% used
 
-        ImmutableOpenMap.Builder<String, Long> shardSizesBuilder = ImmutableOpenMap.builder();
-        shardSizesBuilder.put("[test][0][p]", 10L); // 10 bytes
-        shardSizesBuilder.put("[test][0][r]", 10L);
-        ImmutableOpenMap<String, Long> shardSizes = shardSizesBuilder.build();
+        final Map<String, Long> shardSizes = new HashMap<>();
+        shardSizes.put("[test][0][p]", 10L); // 10 bytes
+        shardSizes.put("[test][0][r]", 10L);
         final ClusterInfo clusterInfo = new DevNullClusterInfo(usages, usages, shardSizes);
 
         ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
@@ -294,18 +292,16 @@ public class DiskThresholdDeciderTests extends OpenSearchAllocationTestCase {
             .put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING.getKey(), "5b")
             .build();
 
-        ImmutableOpenMap.Builder<String, DiskUsage> usagesBuilder = ImmutableOpenMap.builder();
-        usagesBuilder.put("node1", new DiskUsage("node1", "n1", "/dev/null", 100, 10)); // 90% used
-        usagesBuilder.put("node2", new DiskUsage("node2", "n2", "/dev/null", 100, 10)); // 90% used
-        usagesBuilder.put("node3", new DiskUsage("node3", "n3", "/dev/null", 100, 60)); // 40% used
-        usagesBuilder.put("node4", new DiskUsage("node4", "n4", "/dev/null", 100, 80)); // 20% used
-        usagesBuilder.put("node5", new DiskUsage("node5", "n5", "/dev/null", 100, 85)); // 15% used
-        ImmutableOpenMap<String, DiskUsage> usages = usagesBuilder.build();
+        final Map<String, DiskUsage> usages = new HashMap<>();
+        usages.put("node1", new DiskUsage("node1", "n1", "/dev/null", 100, 10)); // 90% used
+        usages.put("node2", new DiskUsage("node2", "n2", "/dev/null", 100, 10)); // 90% used
+        usages.put("node3", new DiskUsage("node3", "n3", "/dev/null", 100, 60)); // 40% used
+        usages.put("node4", new DiskUsage("node4", "n4", "/dev/null", 100, 80)); // 20% used
+        usages.put("node5", new DiskUsage("node5", "n5", "/dev/null", 100, 85)); // 15% used
 
-        ImmutableOpenMap.Builder<String, Long> shardSizesBuilder = ImmutableOpenMap.builder();
-        shardSizesBuilder.put("[test][0][p]", 10L); // 10 bytes
-        shardSizesBuilder.put("[test][0][r]", 10L);
-        ImmutableOpenMap<String, Long> shardSizes = shardSizesBuilder.build();
+        final Map<String, Long> shardSizes = new HashMap<>();
+        shardSizes.put("[test][0][p]", 10L); // 10 bytes
+        shardSizes.put("[test][0][r]", 10L);
         final ClusterInfo clusterInfo = new DevNullClusterInfo(usages, usages, shardSizes);
 
         ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
@@ -360,9 +356,7 @@ public class DiskThresholdDeciderTests extends OpenSearchAllocationTestCase {
         logger.info("--> nodeWithoutPrimary: {}", nodeWithoutPrimary);
 
         // Make node without the primary now habitable to replicas
-        usagesBuilder = ImmutableOpenMap.builder(usages);
-        usagesBuilder.put(nodeWithoutPrimary, new DiskUsage(nodeWithoutPrimary, "", "/dev/null", 100, 35)); // 65% used
-        usages = usagesBuilder.build();
+        usages.put(nodeWithoutPrimary, new DiskUsage(nodeWithoutPrimary, "", "/dev/null", 100, 35)); // 65% used
         final ClusterInfo clusterInfo2 = new DevNullClusterInfo(usages, usages, shardSizes);
         cis = () -> {
             logger.info("--> calling fake getClusterInfo");
@@ -540,14 +534,15 @@ public class DiskThresholdDeciderTests extends OpenSearchAllocationTestCase {
             .put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING.getKey(), "71%")
             .build();
 
-        ImmutableOpenMap.Builder<String, DiskUsage> usagesBuilder = ImmutableOpenMap.builder();
-        usagesBuilder.put("node1", new DiskUsage("node1", "n1", "/dev/null", 100, 31)); // 69% used
-        usagesBuilder.put("node2", new DiskUsage("node2", "n2", "/dev/null", 100, 1));  // 99% used
-        ImmutableOpenMap<String, DiskUsage> usages = usagesBuilder.build();
+        final Map<String, DiskUsage> usages = Map.of(
+            "node1",
+            new DiskUsage("node1", "n1", "/dev/null", 100, 31), // 69% used
+            "node2",
+            new DiskUsage("node2", "n2", "/dev/null", 100, 1)
+        );  // 99% used
 
-        ImmutableOpenMap.Builder<String, Long> shardSizesBuilder = ImmutableOpenMap.builder();
-        shardSizesBuilder.put("[test][0][p]", 10L); // 10 bytes
-        ImmutableOpenMap<String, Long> shardSizes = shardSizesBuilder.build();
+        final Map<String, Long> shardSizes = new HashMap<>();
+        shardSizes.put("[test][0][p]", 10L); // 10 bytes
         final ClusterInfo clusterInfo = new DevNullClusterInfo(usages, usages, shardSizes);
 
         AllocationDeciders deciders = new AllocationDeciders(
@@ -612,15 +607,13 @@ public class DiskThresholdDeciderTests extends OpenSearchAllocationTestCase {
             .put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING.getKey(), 0.85)
             .build();
 
-        ImmutableOpenMap.Builder<String, DiskUsage> usagesBuilder = ImmutableOpenMap.builder();
-        usagesBuilder.put("node2", new DiskUsage("node2", "node2", "/dev/null", 100, 50)); // 50% used
-        usagesBuilder.put("node3", new DiskUsage("node3", "node3", "/dev/null", 100, 0));  // 100% used
-        ImmutableOpenMap<String, DiskUsage> usages = usagesBuilder.build();
+        final Map<String, DiskUsage> usages = new HashMap<>();
+        usages.put("node2", new DiskUsage("node2", "node2", "/dev/null", 100, 50)); // 50% used
+        usages.put("node3", new DiskUsage("node3", "node3", "/dev/null", 100, 0));  // 100% used
 
-        ImmutableOpenMap.Builder<String, Long> shardSizesBuilder = ImmutableOpenMap.builder();
-        shardSizesBuilder.put("[test][0][p]", 10L); // 10 bytes
-        shardSizesBuilder.put("[test][0][r]", 10L); // 10 bytes
-        ImmutableOpenMap<String, Long> shardSizes = shardSizesBuilder.build();
+        final Map<String, Long> shardSizes = new HashMap<>();
+        shardSizes.put("[test][0][p]", 10L); // 10 bytes
+        shardSizes.put("[test][0][r]", 10L); // 10 bytes
         final ClusterInfo clusterInfo = new DevNullClusterInfo(usages, usages, shardSizes);
 
         AllocationDeciders deciders = new AllocationDeciders(
@@ -688,11 +681,11 @@ public class DiskThresholdDeciderTests extends OpenSearchAllocationTestCase {
         RoutingNode rn = new RoutingNode("node1", newNode("node1"));
         DiskThresholdDecider decider = makeDecider(Settings.EMPTY);
 
-        ImmutableOpenMap.Builder<String, DiskUsage> usages = ImmutableOpenMap.builder();
+        final Map<String, DiskUsage> usages = new HashMap<>();
         usages.put("node2", new DiskUsage("node2", "n2", "/dev/null", 100, 50)); // 50% used
         usages.put("node3", new DiskUsage("node3", "n3", "/dev/null", 100, 0));  // 100% used
 
-        DiskUsage node1Usage = decider.averageUsage(rn, usages.build());
+        DiskUsage node1Usage = decider.averageUsage(rn, usages);
         assertThat(node1Usage.getTotalBytes(), equalTo(100L));
         assertThat(node1Usage.getFreeBytes(), equalTo(25L));
     }
@@ -718,18 +711,16 @@ public class DiskThresholdDeciderTests extends OpenSearchAllocationTestCase {
             .put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING.getKey(), 0.8)
             .build();
 
-        ImmutableOpenMap.Builder<String, DiskUsage> usagesBuilder = ImmutableOpenMap.builder();
-        usagesBuilder.put("node1", new DiskUsage("node1", "n1", "/dev/null", 100, 40)); // 60% used
-        usagesBuilder.put("node2", new DiskUsage("node2", "n2", "/dev/null", 100, 40)); // 60% used
-        usagesBuilder.put("node3", new DiskUsage("node3", "n3", "/dev/null", 100, 40)); // 60% used
-        ImmutableOpenMap<String, DiskUsage> usages = usagesBuilder.build();
+        final Map<String, DiskUsage> usages = new HashMap<>();
+        usages.put("node1", new DiskUsage("node1", "n1", "/dev/null", 100, 40)); // 60% used
+        usages.put("node2", new DiskUsage("node2", "n2", "/dev/null", 100, 40)); // 60% used
+        usages.put("node3", new DiskUsage("node3", "n3", "/dev/null", 100, 40)); // 60% used
 
-        ImmutableOpenMap.Builder<String, Long> shardSizesBuilder = ImmutableOpenMap.builder();
-        shardSizesBuilder.put("[test][0][p]", 14L); // 14 bytes
-        shardSizesBuilder.put("[test][0][r]", 14L);
-        shardSizesBuilder.put("[test2][0][p]", 1L); // 1 bytes
-        shardSizesBuilder.put("[test2][0][r]", 1L);
-        ImmutableOpenMap<String, Long> shardSizes = shardSizesBuilder.build();
+        final Map<String, Long> shardSizes = new HashMap<>();
+        shardSizes.put("[test][0][p]", 14L); // 14 bytes
+        shardSizes.put("[test][0][r]", 14L);
+        shardSizes.put("[test2][0][p]", 1L); // 1 bytes
+        shardSizes.put("[test2][0][r]", 1L);
         final ClusterInfo clusterInfo = new DevNullClusterInfo(usages, usages, shardSizes);
 
         DiskThresholdDecider decider = makeDecider(diskSettings);
@@ -801,18 +792,16 @@ public class DiskThresholdDeciderTests extends OpenSearchAllocationTestCase {
             logShardStates(clusterState);
         }
 
-        final ImmutableOpenMap.Builder<String, DiskUsage> overfullUsagesBuilder = ImmutableOpenMap.builder();
-        overfullUsagesBuilder.put("node1", new DiskUsage("node1", "n1", "/dev/null", 100, 40)); // 60% used
-        overfullUsagesBuilder.put("node2", new DiskUsage("node2", "n2", "/dev/null", 100, 40)); // 60% used
-        overfullUsagesBuilder.put("node3", new DiskUsage("node3", "n3", "/dev/null", 100, 0));  // 100% used
-        final ImmutableOpenMap<String, DiskUsage> overfullUsages = overfullUsagesBuilder.build();
+        final Map<String, DiskUsage> overfullUsages = new HashMap<>();
+        overfullUsages.put("node1", new DiskUsage("node1", "n1", "/dev/null", 100, 40)); // 60% used
+        overfullUsages.put("node2", new DiskUsage("node2", "n2", "/dev/null", 100, 40)); // 60% used
+        overfullUsages.put("node3", new DiskUsage("node3", "n3", "/dev/null", 100, 0));  // 100% used
 
-        final ImmutableOpenMap.Builder<String, Long> largerShardSizesBuilder = ImmutableOpenMap.builder();
-        largerShardSizesBuilder.put("[test][0][p]", 14L);
-        largerShardSizesBuilder.put("[test][0][r]", 14L);
-        largerShardSizesBuilder.put("[test2][0][p]", 2L);
-        largerShardSizesBuilder.put("[test2][0][r]", 2L);
-        final ImmutableOpenMap<String, Long> largerShardSizes = largerShardSizesBuilder.build();
+        final Map<String, Long> largerShardSizes = new HashMap<>();
+        largerShardSizes.put("[test][0][p]", 14L);
+        largerShardSizes.put("[test][0][r]", 14L);
+        largerShardSizes.put("[test2][0][p]", 2L);
+        largerShardSizes.put("[test2][0][r]", 2L);
 
         final ClusterInfo overfullClusterInfo = new DevNullClusterInfo(overfullUsages, overfullUsages, largerShardSizes);
 
@@ -872,10 +861,10 @@ public class DiskThresholdDeciderTests extends OpenSearchAllocationTestCase {
                     usages,
                     usages,
                     shardSizes,
-                    (new ImmutableOpenMap.Builder<ClusterInfo.NodeAndPath, ClusterInfo.ReservedSpace>()).fPut(
+                    Map.of(
                         new ClusterInfo.NodeAndPath("node1", "/dev/null"),
                         new ClusterInfo.ReservedSpace.Builder().add(new ShardId("", "", 0), between(51, 200)).build()
-                    ).build()
+                    )
                 )
             );
             clusterState = applyStartedShardsUntilNoChange(clusterState, strategy);
@@ -896,16 +885,14 @@ public class DiskThresholdDeciderTests extends OpenSearchAllocationTestCase {
             .build();
 
         // We have an index with 2 primary shards each taking 40 bytes. Each node has 100 bytes available
-        ImmutableOpenMap.Builder<String, DiskUsage> usagesBuilder = ImmutableOpenMap.builder();
-        usagesBuilder.put("node1", new DiskUsage("node1", "n1", "/dev/null", 100, 20)); // 80% used
-        usagesBuilder.put("node2", new DiskUsage("node2", "n2", "/dev/null", 100, 100)); // 0% used
-        ImmutableOpenMap<String, DiskUsage> usages = usagesBuilder.build();
+        final Map<String, DiskUsage> usages = new HashMap<>();
+        usages.put("node1", new DiskUsage("node1", "n1", "/dev/null", 100, 20)); // 80% used
+        usages.put("node2", new DiskUsage("node2", "n2", "/dev/null", 100, 100)); // 0% used
 
-        ImmutableOpenMap.Builder<String, Long> shardSizesBuilder = ImmutableOpenMap.builder();
-        shardSizesBuilder.put("[test][0][p]", 40L);
-        shardSizesBuilder.put("[test][1][p]", 40L);
-        shardSizesBuilder.put("[foo][0][p]", 10L);
-        ImmutableOpenMap<String, Long> shardSizes = shardSizesBuilder.build();
+        final Map<String, Long> shardSizes = new HashMap<>();
+        shardSizes.put("[test][0][p]", 40L);
+        shardSizes.put("[test][1][p]", 40L);
+        shardSizes.put("[foo][0][p]", 10L);
 
         final ClusterInfo clusterInfo = new DevNullClusterInfo(usages, usages, shardSizes);
 
@@ -1053,17 +1040,16 @@ public class DiskThresholdDeciderTests extends OpenSearchAllocationTestCase {
             .put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING.getKey(), "70%")
             .build();
 
-        ImmutableOpenMap.Builder<String, DiskUsage> usagesBuilder = ImmutableOpenMap.builder();
-        usagesBuilder.put("node1", new DiskUsage("node1", "n1", "/dev/null", 100, 100)); // 0% used
-        usagesBuilder.put("node2", new DiskUsage("node2", "n2", "/dev/null", 100, 20));  // 80% used
-        usagesBuilder.put("node3", new DiskUsage("node3", "n3", "/dev/null", 100, 100)); // 0% used
-        ImmutableOpenMap<String, DiskUsage> usages = usagesBuilder.build();
+        final Map<String, DiskUsage> usages = new HashMap<>();
+        usages.put("node1", new DiskUsage("node1", "n1", "/dev/null", 100, 100)); // 0% used
+        usages.put("node2", new DiskUsage("node2", "n2", "/dev/null", 100, 20));  // 80% used
+        usages.put("node3", new DiskUsage("node3", "n3", "/dev/null", 100, 100)); // 0% used
 
         // We have an index with 1 primary shards each taking 40 bytes. Each node has 100 bytes available
-        ImmutableOpenMap.Builder<String, Long> shardSizes = ImmutableOpenMap.builder();
+        final Map<String, Long> shardSizes = new HashMap<>();
         shardSizes.put("[test][0][p]", 40L);
         shardSizes.put("[test][1][p]", 40L);
-        final ClusterInfo clusterInfo = new DevNullClusterInfo(usages, usages, shardSizes.build());
+        final ClusterInfo clusterInfo = new DevNullClusterInfo(usages, usages, shardSizes);
 
         DiskThresholdDecider diskThresholdDecider = makeDecider(diskSettings);
         Metadata metadata = Metadata.builder()
@@ -1207,14 +1193,13 @@ public class DiskThresholdDeciderTests extends OpenSearchAllocationTestCase {
             .put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING.getKey(), "70%")
             .build();
 
-        ImmutableOpenMap.Builder<String, DiskUsage> usagesBuilder = ImmutableOpenMap.builder();
-        usagesBuilder.put("data", new DiskUsage("data", "data", "/dev/null", 100, 20));  // 80% used
-        ImmutableOpenMap<String, DiskUsage> usages = usagesBuilder.build();
+        final Map<String, DiskUsage> usages = new HashMap<>();
+        usages.put("data", new DiskUsage("data", "data", "/dev/null", 100, 20));  // 80% used
 
         // We have an index with 1 primary shard, taking 40 bytes. The single data node has only 20 bytes free.
-        ImmutableOpenMap.Builder<String, Long> shardSizes = ImmutableOpenMap.builder();
+        final Map<String, Long> shardSizes = new HashMap<>();
         shardSizes.put("[test][0][p]", 40L);
-        final ClusterInfo clusterInfo = new DevNullClusterInfo(usages, usages, shardSizes.build());
+        final ClusterInfo clusterInfo = new DevNullClusterInfo(usages, usages, shardSizes);
 
         DiskThresholdDecider diskThresholdDecider = makeDecider(diskSettings);
         Metadata metadata = Metadata.builder()
@@ -1319,11 +1304,10 @@ public class DiskThresholdDeciderTests extends OpenSearchAllocationTestCase {
             .put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING.getKey(), "95%")
             .build();
 
-        final ImmutableOpenMap.Builder<String, DiskUsage> usagesBuilder = ImmutableOpenMap.builder();
-        usagesBuilder.put("node1", new DiskUsage("node1", "n1", "/dev/null", 100, 21));  // 79% used
-        usagesBuilder.put("node2", new DiskUsage("node2", "n2", "/dev/null", 100, 1)); // 99% used
-        final ImmutableOpenMap<String, DiskUsage> usages = usagesBuilder.build();
-        final ClusterInfoService clusterInfoService = () -> new DevNullClusterInfo(usages, usages, ImmutableOpenMap.of());
+        final Map<String, DiskUsage> usages = new HashMap<>();
+        usages.put("node1", new DiskUsage("node1", "n1", "/dev/null", 100, 21));  // 79% used
+        usages.put("node2", new DiskUsage("node2", "n2", "/dev/null", 100, 1)); // 99% used
+        final ClusterInfoService clusterInfoService = () -> new DevNullClusterInfo(usages, usages, Map.of());
 
         final AllocationDeciders deciders = new AllocationDeciders(
             new HashSet<>(
@@ -1468,18 +1452,18 @@ public class DiskThresholdDeciderTests extends OpenSearchAllocationTestCase {
      */
     static class DevNullClusterInfo extends ClusterInfo {
         DevNullClusterInfo(
-            ImmutableOpenMap<String, DiskUsage> leastAvailableSpaceUsage,
-            ImmutableOpenMap<String, DiskUsage> mostAvailableSpaceUsage,
-            ImmutableOpenMap<String, Long> shardSizes
+            final Map<String, DiskUsage> leastAvailableSpaceUsage,
+            final Map<String, DiskUsage> mostAvailableSpaceUsage,
+            final Map<String, Long> shardSizes
         ) {
-            this(leastAvailableSpaceUsage, mostAvailableSpaceUsage, shardSizes, ImmutableOpenMap.of());
+            this(leastAvailableSpaceUsage, mostAvailableSpaceUsage, shardSizes, Map.of());
         }
 
         DevNullClusterInfo(
-            ImmutableOpenMap<String, DiskUsage> leastAvailableSpaceUsage,
-            ImmutableOpenMap<String, DiskUsage> mostAvailableSpaceUsage,
-            ImmutableOpenMap<String, Long> shardSizes,
-            ImmutableOpenMap<NodeAndPath, ReservedSpace> reservedSpace
+            final Map<String, DiskUsage> leastAvailableSpaceUsage,
+            final Map<String, DiskUsage> mostAvailableSpaceUsage,
+            final Map<String, Long> shardSizes,
+            Map<NodeAndPath, ReservedSpace> reservedSpace
         ) {
             super(leastAvailableSpaceUsage, mostAvailableSpaceUsage, shardSizes, null, reservedSpace);
         }

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
@@ -54,14 +54,15 @@ import org.opensearch.cluster.routing.ShardRoutingState;
 import org.opensearch.cluster.routing.UnassignedInfo;
 import org.opensearch.cluster.routing.allocation.AllocationService;
 import org.opensearch.cluster.routing.allocation.RoutingAllocation;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.Index;
 import org.opensearch.index.shard.ShardId;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
@@ -114,25 +115,19 @@ public class DiskThresholdDeciderUnitTests extends OpenSearchAllocationTestCase 
         clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder().add(node_0).add(node_1)).build();
 
         // actual test -- after all that bloat :)
-        ImmutableOpenMap.Builder<String, DiskUsage> leastAvailableUsages = ImmutableOpenMap.builder();
+        final Map<String, DiskUsage> leastAvailableUsages = new HashMap<>();
         leastAvailableUsages.put("node_0", new DiskUsage("node_0", "node_0", "_na_", 100, 0)); // all full
         leastAvailableUsages.put("node_1", new DiskUsage("node_1", "node_1", "_na_", 100, 0)); // all full
 
-        ImmutableOpenMap.Builder<String, DiskUsage> mostAvailableUsage = ImmutableOpenMap.builder();
+        final Map<String, DiskUsage> mostAvailableUsage = new HashMap<>();
         // 20 - 99 percent since after allocation there must be at least 10% left and shard is 10byte
         mostAvailableUsage.put("node_0", new DiskUsage("node_0", "node_0", "_na_", 100, randomIntBetween(20, 100)));
         // this is weird and smells like a bug! it should be up to 20%?
         mostAvailableUsage.put("node_1", new DiskUsage("node_1", "node_1", "_na_", 100, randomIntBetween(0, 10)));
 
-        ImmutableOpenMap.Builder<String, Long> shardSizes = ImmutableOpenMap.builder();
+        final Map<String, Long> shardSizes = new HashMap<>();
         shardSizes.put("[test][0][p]", 10L); // 10 bytes
-        final ClusterInfo clusterInfo = new ClusterInfo(
-            leastAvailableUsages.build(),
-            mostAvailableUsage.build(),
-            shardSizes.build(),
-            ImmutableOpenMap.of(),
-            ImmutableOpenMap.of()
-        );
+        final ClusterInfo clusterInfo = new ClusterInfo(leastAvailableUsages, mostAvailableUsage, shardSizes, Map.of(), Map.of());
         RoutingAllocation allocation = new RoutingAllocation(
             new AllocationDeciders(Collections.singleton(decider)),
             clusterState.getRoutingNodes(),
@@ -198,23 +193,17 @@ public class DiskThresholdDeciderUnitTests extends OpenSearchAllocationTestCase 
 
         // actual test -- after all that bloat :)
 
-        ImmutableOpenMap.Builder<String, DiskUsage> leastAvailableUsages = ImmutableOpenMap.builder();
+        final Map<String, DiskUsage> leastAvailableUsages = new HashMap<>();
         leastAvailableUsages.put("node_0", new DiskUsage("node_0", "node_0", "_na_", 100, 0)); // all full
-        ImmutableOpenMap.Builder<String, DiskUsage> mostAvailableUsage = ImmutableOpenMap.builder();
+        final Map<String, DiskUsage> mostAvailableUsage = new HashMap<>();
         final int freeBytes = randomIntBetween(20, 100);
         mostAvailableUsage.put("node_0", new DiskUsage("node_0", "node_0", "_na_", 100, freeBytes));
 
-        ImmutableOpenMap.Builder<String, Long> shardSizes = ImmutableOpenMap.builder();
+        final Map<String, Long> shardSizes = new HashMap<>();
         // way bigger than available space
         final long shardSize = randomIntBetween(110, 1000);
         shardSizes.put("[test][0][p]", shardSize);
-        ClusterInfo clusterInfo = new ClusterInfo(
-            leastAvailableUsages.build(),
-            mostAvailableUsage.build(),
-            shardSizes.build(),
-            ImmutableOpenMap.of(),
-            ImmutableOpenMap.of()
-        );
+        ClusterInfo clusterInfo = new ClusterInfo(leastAvailableUsages, mostAvailableUsage, shardSizes, Map.of(), Map.of());
         RoutingAllocation allocation = new RoutingAllocation(
             new AllocationDeciders(Collections.singleton(decider)),
             clusterState.getRoutingNodes(),
@@ -245,7 +234,7 @@ public class DiskThresholdDeciderUnitTests extends OpenSearchAllocationTestCase 
     public void testCanRemainUsesLeastAvailableSpace() {
         ClusterSettings nss = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         DiskThresholdDecider decider = new DiskThresholdDecider(Settings.EMPTY, nss);
-        ImmutableOpenMap.Builder<ShardRouting, String> shardRoutingMap = ImmutableOpenMap.builder();
+        final Map<ShardRouting, String> shardRoutingMap = new HashMap<>();
 
         DiscoveryNode node_0 = new DiscoveryNode(
             "node_0",
@@ -318,26 +307,20 @@ public class DiskThresholdDeciderUnitTests extends OpenSearchAllocationTestCase 
         clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder().add(node_0).add(node_1)).build();
 
         // actual test -- after all that bloat :)
-        ImmutableOpenMap.Builder<String, DiskUsage> leastAvailableUsages = ImmutableOpenMap.builder();
+        final Map<String, DiskUsage> leastAvailableUsages = new HashMap<>();
         leastAvailableUsages.put("node_0", new DiskUsage("node_0", "node_0", "/node0/least", 100, 10)); // 90% used
         leastAvailableUsages.put("node_1", new DiskUsage("node_1", "node_1", "/node1/least", 100, 9)); // 91% used
 
-        ImmutableOpenMap.Builder<String, DiskUsage> mostAvailableUsage = ImmutableOpenMap.builder();
+        final Map<String, DiskUsage> mostAvailableUsage = new HashMap<>();
         mostAvailableUsage.put("node_0", new DiskUsage("node_0", "node_0", "/node0/most", 100, 90)); // 10% used
         mostAvailableUsage.put("node_1", new DiskUsage("node_1", "node_1", "/node1/most", 100, 90)); // 10% used
 
-        ImmutableOpenMap.Builder<String, Long> shardSizes = ImmutableOpenMap.builder();
+        final Map<String, Long> shardSizes = new HashMap<>();
         shardSizes.put("[test][0][p]", 10L); // 10 bytes
         shardSizes.put("[test][1][p]", 10L);
         shardSizes.put("[test][2][p]", 10L);
 
-        final ClusterInfo clusterInfo = new ClusterInfo(
-            leastAvailableUsages.build(),
-            mostAvailableUsage.build(),
-            shardSizes.build(),
-            shardRoutingMap.build(),
-            ImmutableOpenMap.of()
-        );
+        final ClusterInfo clusterInfo = new ClusterInfo(leastAvailableUsages, mostAvailableUsage, shardSizes, shardRoutingMap, Map.of());
         RoutingAllocation allocation = new RoutingAllocation(
             new AllocationDeciders(Collections.singleton(decider)),
             clusterState.getRoutingNodes(),
@@ -392,16 +375,12 @@ public class DiskThresholdDeciderUnitTests extends OpenSearchAllocationTestCase 
     }
 
     public void testShardSizeAndRelocatingSize() {
-        ImmutableOpenMap.Builder<String, Long> shardSizes = ImmutableOpenMap.builder();
+        final Map<String, Long> shardSizes = new HashMap<>();
         shardSizes.put("[test][0][r]", 10L);
         shardSizes.put("[test][1][r]", 100L);
         shardSizes.put("[test][2][r]", 1000L);
         shardSizes.put("[other][0][p]", 10000L);
-        ClusterInfo info = new DiskThresholdDeciderTests.DevNullClusterInfo(
-            ImmutableOpenMap.of(),
-            ImmutableOpenMap.of(),
-            shardSizes.build()
-        );
+        ClusterInfo info = new DiskThresholdDeciderTests.DevNullClusterInfo(Map.of(), Map.of(), shardSizes);
         Metadata.Builder metaBuilder = Metadata.builder();
         metaBuilder.put(
             IndexMetadata.builder("test")
@@ -520,17 +499,13 @@ public class DiskThresholdDeciderUnitTests extends OpenSearchAllocationTestCase 
     }
 
     public void testSizeShrinkIndex() {
-        ImmutableOpenMap.Builder<String, Long> shardSizes = ImmutableOpenMap.builder();
+        final Map<String, Long> shardSizes = new HashMap<>();
         shardSizes.put("[test][0][p]", 10L);
         shardSizes.put("[test][1][p]", 100L);
         shardSizes.put("[test][2][p]", 500L);
         shardSizes.put("[test][3][p]", 500L);
 
-        ClusterInfo info = new DiskThresholdDeciderTests.DevNullClusterInfo(
-            ImmutableOpenMap.of(),
-            ImmutableOpenMap.of(),
-            shardSizes.build()
-        );
+        ClusterInfo info = new DiskThresholdDeciderTests.DevNullClusterInfo(Map.of(), Map.of(), shardSizes);
         Metadata.Builder metaBuilder = Metadata.builder();
         metaBuilder.put(
             IndexMetadata.builder("test")


### PR DESCRIPTION
With `java.util.Map` immutability and collection improvements the hppc `ImmutableOpenMap` is not needed in `ClusterInfo`. This commit refactors `ClusterInfo` to use java Maps and Immutable Collections and further trim the dependency on the aging hppc library.

reates #5910 