### PR TITLE
Download block after adding cache entry

### DIFF
--- a/benchmarks/src/main/java/org/opensearch/benchmark/store/remote/filecache/FileCacheBenchmark.java
+++ b/benchmarks/src/main/java/org/opensearch/benchmark/store/remote/filecache/FileCacheBenchmark.java
@@ -107,27 +107,10 @@ public class FileCacheBenchmark {
     /**
      * Stubbed out IndexInput that does nothing but report a fixed size
      */
-    private static class FixedSizeStubIndexInput extends CachedIndexInput {
-        private FixedSizeStubIndexInput() {
-            super(FixedSizeStubIndexInput.class.getSimpleName());
-        }
-
+    private static class FixedSizeStubIndexInput implements CachedIndexInput {
         @Override
-        public boolean isClosed() {
-            return false;
-        }
-
-        @Override
-        public void close() {}
-
-        @Override
-        public long getFilePointer() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void seek(long pos) {
-            throw new UnsupportedOperationException();
+        public IndexInput getIndexInput() {
+            return null;
         }
 
         @Override
@@ -136,18 +119,13 @@ public class FileCacheBenchmark {
         }
 
         @Override
-        public IndexInput slice(String sliceDescription, long offset, long length) {
-            throw new UnsupportedOperationException();
+        public boolean isClosed() {
+            return false;
         }
 
         @Override
-        public byte readByte() {
-            throw new UnsupportedOperationException();
-        }
+        public void close() throws Exception {
 
-        @Override
-        public void readBytes(byte[] b, int offset, int len) {
-            throw new UnsupportedOperationException();
         }
     }
 }

--- a/server/src/main/java/org/opensearch/index/store/remote/filecache/CachedIndexInput.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/filecache/CachedIndexInput.java
@@ -8,27 +8,32 @@
 
 package org.opensearch.index.store.remote.filecache;
 
+import java.io.IOException;
+
 import org.apache.lucene.store.IndexInput;
 
 /**
- * Base IndexInput whose instances will be maintained in cache.
+ * Interface for an entry in the {@link FileCache} that can return an
+ * {@link IndexInput}. Exactly how the IndexInput is created is determined by
+ * the implementations.
  *
  * @opensearch.internal
  */
-public abstract class CachedIndexInput extends IndexInput {
+public interface CachedIndexInput extends AutoCloseable {
+    /**
+     * Gets the {@link IndexInput} this cache entry represents.
+     * @return The IndexInput
+     * @throws IOException if any I/O error occurs
+     */
+    IndexInput getIndexInput() throws IOException;
 
     /**
-     * resourceDescription should be a non-null, opaque string
-     * describing this resource; it's returned from
-     * {@link #toString}.
+     * @return length in bytes
      */
-    protected CachedIndexInput(String resourceDescription) {
-        super(resourceDescription);
-    }
+    long length();
 
     /**
-     * return true this index input is closed, false if not
-     * @return true this index input is closed, false if not
+     * @return true if the entry is closed, false otherwise
      */
-    public abstract boolean isClosed();
+    boolean isClosed();
 }

--- a/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCache.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCache.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.index.store.remote.filecache;
 
+import org.apache.lucene.store.IndexInput;
 import org.opensearch.common.breaker.CircuitBreaker;
 import org.opensearch.common.breaker.CircuitBreakingException;
 import org.opensearch.index.store.remote.utils.cache.CacheUsage;
@@ -171,7 +172,7 @@ public class FileCache implements RefCountedCache<Path, CachedIndexInput> {
             .filter(Files::isRegularFile)
             .forEach(path -> {
                 try {
-                    put(path.toAbsolutePath(), new FileCachedIndexInput.ClosedIndexInput(Files.size(path)));
+                    put(path.toAbsolutePath(), new RestoredCachedIndexInput(Files.size(path)));
                     decRef(path.toAbsolutePath());
                 } catch (IOException e) {
                     throw new UncheckedIOException(
@@ -199,5 +200,40 @@ public class FileCache implements RefCountedCache<Path, CachedIndexInput> {
             stats.hitCount(),
             stats.missCount()
         );
+    }
+
+    /**
+     * Placeholder for the existing file blocks that are in the disk-based
+     * local cache at node startup time. We can't open a file handle to these
+     * blocks at this point, so we store this placeholder object in the cache.
+     * If a block is needed, then these entries will be replaced with a proper
+     * entry that will open the actual file handle to create the IndexInput.
+     * These entries are eligible for eviction so if nothing needs to reference
+     * them they will be deleted when the disk-based local cache fills up.
+     */
+    private static class RestoredCachedIndexInput implements CachedIndexInput {
+        private final long length;
+
+        private RestoredCachedIndexInput(long length) {
+            this.length = length;
+        }
+
+        @Override
+        public IndexInput getIndexInput() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long length() {
+            return length;
+        }
+
+        @Override
+        public boolean isClosed() {
+            return true;
+        }
+
+        @Override
+        public void close() throws Exception {}
     }
 }

--- a/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCacheFactory.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCacheFactory.java
@@ -8,7 +8,6 @@
 
 package org.opensearch.index.store.remote.filecache;
 
-import org.apache.lucene.store.IndexInput;
 import org.opensearch.common.breaker.CircuitBreaker;
 import org.opensearch.common.cache.RemovalReason;
 import org.opensearch.index.store.remote.utils.cache.SegmentedCache;
@@ -63,7 +62,7 @@ public class FileCacheFactory {
     private static SegmentedCache.Builder<Path, CachedIndexInput> createDefaultBuilder() {
         return SegmentedCache.<Path, CachedIndexInput>builder()
             // use length in bytes as the weight of the file item
-            .weigher(IndexInput::length)
+            .weigher(CachedIndexInput::length)
             .listener((removalNotification) -> {
                 RemovalReason removalReason = removalNotification.getRemovalReason();
                 CachedIndexInput value = removalNotification.getValue();

--- a/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCachedIndexInput.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCachedIndexInput.java
@@ -23,7 +23,7 @@ import java.nio.file.Path;
  *
  * @opensearch.internal
  */
-public class FileCachedIndexInput extends CachedIndexInput implements RandomAccessInput {
+public class FileCachedIndexInput extends IndexInput implements RandomAccessInput {
 
     protected final FileCache cache;
 
@@ -149,73 +149,6 @@ public class FileCachedIndexInput extends CachedIndexInput implements RandomAcce
                 cache.decRef(filePath);
             }
             closed = true;
-        }
-    }
-
-    /**
-     * Mainly used by File Cache to detect origin this IndexInput is closed or not
-     *
-     * @return the index input closed or not
-     */
-    @Override
-    public boolean isClosed() {
-        return closed;
-    }
-
-    /**
-     * IndexInput instance which is utilized to fetch length for the input without opening the IndexInput.
-     */
-    public static class ClosedIndexInput extends CachedIndexInput {
-        private final long length;
-
-        public ClosedIndexInput(long length) {
-            super("ClosedIndexInput");
-            this.length = length;
-        }
-
-        @Override
-        public void close() throws IOException {
-            // No-Op
-        }
-
-        @Override
-        public long getFilePointer() {
-            throw new UnsupportedOperationException("ClosedIndexInput doesn't support getFilePointer().");
-        }
-
-        @Override
-        public void seek(long pos) throws IOException {
-            throw new UnsupportedOperationException("ClosedIndexInput doesn't support seek().");
-        }
-
-        @Override
-        public long length() {
-            return length;
-        }
-
-        @Override
-        public IndexInput slice(String sliceDescription, long offset, long length) throws IOException {
-            throw new UnsupportedOperationException("ClosedIndexInput couldn't be sliced.");
-        }
-
-        @Override
-        public byte readByte() throws IOException {
-            throw new UnsupportedOperationException("ClosedIndexInput doesn't support read.");
-        }
-
-        @Override
-        public void readBytes(byte[] b, int offset, int len) throws IOException {
-            throw new UnsupportedOperationException("ClosedIndexInput doesn't support read.");
-        }
-
-        @Override
-        public IndexInput clone() {
-            throw new UnsupportedOperationException("ClosedIndexInput cannot be cloned.");
-        }
-
-        @Override
-        public boolean isClosed() {
-            return true;
         }
     }
 }

--- a/server/src/main/java/org/opensearch/index/store/remote/utils/TransferManager.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/utils/TransferManager.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.opensearch.common.blobstore.BlobContainer;
+import org.opensearch.index.store.remote.filecache.CachedIndexInput;
 import org.opensearch.index.store.remote.filecache.FileCache;
 import org.opensearch.index.store.remote.filecache.FileCachedIndexInput;
 
@@ -20,10 +21,14 @@ import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * This acts as entry point to fetch {@link BlobFetchRequest} and return actual {@link IndexInput}. Utilizes the BlobContainer interface to
@@ -50,63 +55,124 @@ public class TransferManager {
     public IndexInput fetchBlob(BlobFetchRequest blobFetchRequest) throws IOException {
         final Path key = blobFetchRequest.getFilePath();
 
-        // We need to do a privileged action here in order to fetch from remote
-        // and write to the local file cache in case this is invoked as a side
-        // effect of a plugin (such as a scripted search) that doesn't have the
-        // necessary permissions.
-        final IndexInput origin = AccessController.doPrivileged(
-            (PrivilegedAction<IndexInput>) () -> fileCache.compute(key, (path, cachedIndexInput) -> {
-                if (cachedIndexInput == null) {
-                    try {
-                        return new FileCachedIndexInput(fileCache, blobFetchRequest.getFilePath(), downloadBlockLocally(blobFetchRequest));
-                    } catch (IOException e) {
-                        logger.warn("Failed to download " + blobFetchRequest.getFilePath(), e);
-                        return null;
-                    }
-                } else {
-                    if (cachedIndexInput.isClosed()) {
-                        // if it's already in the file cache, but closed, open it and replace the original one
-                        try {
-                            final IndexInput luceneIndexInput = blobFetchRequest.getDirectory()
-                                .openInput(blobFetchRequest.getFileName(), IOContext.READ);
-                            return new FileCachedIndexInput(fileCache, blobFetchRequest.getFilePath(), luceneIndexInput);
-                        } catch (IOException e) {
-                            logger.warn("Failed to open existing file for " + blobFetchRequest.getFilePath(), e);
-                            return null;
-                        }
-                    }
-                    // already in the cache and ready to be used (open)
-                    return cachedIndexInput;
-                }
-            })
-        );
+        final CachedIndexInput cacheEntry = fileCache.compute(key, (path, cachedIndexInput) -> {
+            if (cachedIndexInput == null || cachedIndexInput.isClosed()) {
+                // Doesn't exist or is closed, either way create a new one
+                return new DelayedCreationCachedIndexInput(fileCache, blobContainer, blobFetchRequest);
+            } else {
+                // already in the cache and ready to be used (open)
+                return cachedIndexInput;
+            }
+        });
 
-        if (origin == null) {
-            throw new IOException("Failed to create IndexInput for " + blobFetchRequest.getFileName());
-        }
-
-        // Origin was either retrieved from the cache or newly added, either
+        // Cache entry was either retrieved from the cache or newly added, either
         // way the reference count has been incremented by one. We can only
         // decrement this reference _after_ creating the clone to be returned.
         try {
-            return origin.clone();
+            return cacheEntry.getIndexInput().clone();
         } finally {
             fileCache.decRef(key);
         }
     }
 
-    private IndexInput downloadBlockLocally(BlobFetchRequest blobFetchRequest) throws IOException {
-        try (
-            InputStream snapshotFileInputStream = blobContainer.readBlob(
-                blobFetchRequest.getBlobName(),
-                blobFetchRequest.getPosition(),
-                blobFetchRequest.getLength()
-            );
-            OutputStream fileOutputStream = Files.newOutputStream(blobFetchRequest.getFilePath());
-            OutputStream localFileOutputStream = new BufferedOutputStream(fileOutputStream);
-        ) {
-            snapshotFileInputStream.transferTo(localFileOutputStream);
+    private static FileCachedIndexInput createIndexInput(FileCache fileCache, BlobContainer blobContainer, BlobFetchRequest request) {
+        // We need to do a privileged action here in order to fetch from remote
+        // and write to the local file cache in case this is invoked as a side
+        // effect of a plugin (such as a scripted search) that doesn't have the
+        // necessary permissions.
+        return AccessController.doPrivileged((PrivilegedAction<FileCachedIndexInput>) () -> {
+            try {
+                if (Files.exists(request.getFilePath()) == false) {
+                    try (
+                        InputStream snapshotFileInputStream = blobContainer.readBlob(
+                            request.getBlobName(),
+                            request.getPosition(),
+                            request.getLength()
+                        );
+                        OutputStream fileOutputStream = Files.newOutputStream(request.getFilePath());
+                        OutputStream localFileOutputStream = new BufferedOutputStream(fileOutputStream)
+                    ) {
+                        snapshotFileInputStream.transferTo(localFileOutputStream);
+                    }
+                }
+                final IndexInput luceneIndexInput = request.getDirectory().openInput(request.getFileName(), IOContext.READ);
+                return new FileCachedIndexInput(fileCache, request.getFilePath(), luceneIndexInput);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        });
+    }
+
+    /**
+     * Implementation of CachedIndexInput the defers creation of the underlying
+     * IndexInput until the first invocation of {@link #getIndexInput()}. This
+     * class is thread safe, and concurrent calls to {@link #getIndexInput()} will
+     * result in blocking until the initial thread completes the creation of the
+     * IndexInput.
+     */
+    private static class DelayedCreationCachedIndexInput implements CachedIndexInput {
+        private final FileCache fileCache;
+        private final BlobContainer blobContainer;
+        private final BlobFetchRequest request;
+        private final CompletableFuture<IndexInput> result = new CompletableFuture<>();
+        private final AtomicBoolean isStarted = new AtomicBoolean(false);
+        private final AtomicBoolean isClosed = new AtomicBoolean(false);
+
+        private DelayedCreationCachedIndexInput(FileCache fileCache, BlobContainer blobContainer, BlobFetchRequest request) {
+            this.fileCache = fileCache;
+            this.blobContainer = blobContainer;
+            this.request = request;
         }
-        return blobFetchRequest.getDirectory().openInput(blobFetchRequest.getFileName(), IOContext.READ);
+
+        @Override
+        public IndexInput getIndexInput() throws IOException {
+            if (isClosed.get()) {
+                throw new IllegalStateException("Already closed");
+            }
+            if (isStarted.getAndSet(true) == false) {
+                // We're the first one here, need to download the block
+                try {
+                    result.complete(createIndexInput(fileCache, blobContainer, request));
+                } catch (Exception e) {
+                    result.completeExceptionally(e);
+                    fileCache.remove(request.getFilePath());
+                }
+            }
+            try {
+                return result.join();
+            } catch (CompletionException e) {
+                if (e.getCause() instanceof UncheckedIOException) {
+                    throw ((UncheckedIOException) e.getCause()).getCause();
+                } else if (e.getCause() instanceof RuntimeException) {
+                    throw (RuntimeException) e.getCause();
+                }
+                throw e;
+            }
+        }
+
+        @Override
+        public long length() {
+            return request.getLength();
+        }
+
+        @Override
+        public boolean isClosed() {
+            return isClosed.get();
+        }
+
+        @Override
+        public void close() throws Exception {
+            if (isClosed.getAndSet(true) == false) {
+                result.whenComplete((indexInput, error) -> {
+                    if (indexInput != null) {
+                        try {
+                            indexInput.close();
+                        } catch (IOException e) {
+                            logger.warn("Error closing IndexInput", e);
+                        }
+                    }
+                });
+            }
+        }
     }
 }

--- a/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheCleanerTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheCleanerTests.java
@@ -14,6 +14,7 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.lucene.store.IndexInput;
 import org.hamcrest.MatcherAssert;
 import org.junit.After;
 import org.junit.Before;
@@ -69,7 +70,27 @@ public class FileCacheCleanerTests extends OpenSearchTestCase {
         final Path localStorePath = shardPath.getDataPath().resolve(LOCAL_STORE_LOCATION);
         Files.createDirectories(localStorePath);
         final Path file = Files.createFile(localStorePath.resolve("file"));
-        fileCache.put(file, new FileCachedIndexInput.ClosedIndexInput(1024));
+        fileCache.put(file, new CachedIndexInput() {
+            @Override
+            public IndexInput getIndexInput() {
+                return null;
+            }
+
+            @Override
+            public long length() {
+                return 1024;
+            }
+
+            @Override
+            public boolean isClosed() {
+                return false;
+            }
+
+            @Override
+            public void close() {
+
+            }
+        });
         return file;
     }
 

--- a/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheTests.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.index.store.remote.filecache;
 
+import org.apache.lucene.store.IndexInput;
 import org.junit.Before;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.breaker.TestCircuitBreaker;
@@ -75,7 +76,7 @@ public class FileCacheTests extends OpenSearchTestCase {
     public void testGet() {
         FileCache fileCache = createFileCache(GIGA_BYTES);
         for (int i = 0; i < 4; i++) {
-            fileCache.put(createPath(Integer.toString(i)), new FileCachedIndexInput.ClosedIndexInput(8 * MEGA_BYTES));
+            fileCache.put(createPath(Integer.toString(i)), new StubCachedIndexInput(8 * MEGA_BYTES));
         }
         // verify all blocks are put into file cache
         for (int i = 0; i < 4; i++) {
@@ -100,14 +101,14 @@ public class FileCacheTests extends OpenSearchTestCase {
     public void testPutThrowCircuitBreakingException() {
         FileCache fileCache = createCircuitBreakingFileCache(GIGA_BYTES);
         Path path = createPath("0");
-        assertThrows(CircuitBreakingException.class, () -> fileCache.put(path, new FileCachedIndexInput.ClosedIndexInput(8 * MEGA_BYTES)));
+        assertThrows(CircuitBreakingException.class, () -> fileCache.put(path, new StubCachedIndexInput(8 * MEGA_BYTES)));
         assertNull(fileCache.get(path));
     }
 
     public void testCompute() {
         FileCache fileCache = createFileCache(GIGA_BYTES);
         Path path = createPath("0");
-        fileCache.put(path, new FileCachedIndexInput.ClosedIndexInput(8 * MEGA_BYTES));
+        fileCache.put(path, new StubCachedIndexInput(8 * MEGA_BYTES));
         fileCache.incRef(path);
         fileCache.compute(path, (p, i) -> null);
         // item will be removed
@@ -124,17 +125,14 @@ public class FileCacheTests extends OpenSearchTestCase {
     public void testComputeThrowCircuitBreakingException() {
         FileCache fileCache = createCircuitBreakingFileCache(GIGA_BYTES);
         Path path = createPath("0");
-        assertThrows(
-            CircuitBreakingException.class,
-            () -> fileCache.compute(path, (p, i) -> new FileCachedIndexInput.ClosedIndexInput(8 * MEGA_BYTES))
-        );
+        assertThrows(CircuitBreakingException.class, () -> fileCache.compute(path, (p, i) -> new StubCachedIndexInput(8 * MEGA_BYTES)));
         assertNull(fileCache.get(path));
     }
 
     public void testRemove() {
         FileCache fileCache = createFileCache(GIGA_BYTES);
         for (int i = 0; i < 4; i++) {
-            fileCache.put(createPath(Integer.toString(i)), new FileCachedIndexInput.ClosedIndexInput(8 * MEGA_BYTES));
+            fileCache.put(createPath(Integer.toString(i)), new StubCachedIndexInput(8 * MEGA_BYTES));
         }
 
         fileCache.remove(createPath("0"));
@@ -155,7 +153,7 @@ public class FileCacheTests extends OpenSearchTestCase {
     public void testIncDecRef() {
         FileCache fileCache = createFileCache(GIGA_BYTES);
         for (int i = 0; i < 4; i++) {
-            fileCache.put(createPath(Integer.toString(i)), new FileCachedIndexInput.ClosedIndexInput(8 * MEGA_BYTES));
+            fileCache.put(createPath(Integer.toString(i)), new StubCachedIndexInput(8 * MEGA_BYTES));
         }
 
         // try to evict previous IndexInput
@@ -208,7 +206,7 @@ public class FileCacheTests extends OpenSearchTestCase {
     public void testSize() {
         FileCache fileCache = createFileCache(GIGA_BYTES);
         for (int i = 0; i < 4; i++) {
-            fileCache.put(createPath(Integer.toString(i)), new FileCachedIndexInput.ClosedIndexInput(8 * MEGA_BYTES));
+            fileCache.put(createPath(Integer.toString(i)), new StubCachedIndexInput(8 * MEGA_BYTES));
         }
         // test file cache size
         assertEquals(fileCache.size(), 4);
@@ -244,7 +242,7 @@ public class FileCacheTests extends OpenSearchTestCase {
     public void testStats() {
         FileCache fileCache = createFileCache(GIGA_BYTES);
         for (int i = 0; i < 4; i++) {
-            fileCache.put(createPath(Integer.toString(i)), new FileCachedIndexInput.ClosedIndexInput(8 * MEGA_BYTES));
+            fileCache.put(createPath(Integer.toString(i)), new StubCachedIndexInput(8 * MEGA_BYTES));
         }
         // cache hits
         fileCache.get(createPath("0"));
@@ -278,7 +276,36 @@ public class FileCacheTests extends OpenSearchTestCase {
 
     private void putAndDecRef(FileCache cache, int path, long indexInputSize) {
         final Path key = createPath(Integer.toString(path));
-        cache.put(key, new FileCachedIndexInput.ClosedIndexInput(indexInputSize));
+        cache.put(key, new StubCachedIndexInput(indexInputSize));
         cache.decRef(key);
+    }
+
+    private static class StubCachedIndexInput implements CachedIndexInput {
+
+        private final long length;
+
+        private StubCachedIndexInput(long length) {
+            this.length = length;
+        }
+
+        @Override
+        public IndexInput getIndexInput() {
+            return null;
+        }
+
+        @Override
+        public long length() {
+            return length;
+        }
+
+        @Override
+        public boolean isClosed() {
+            return false;
+        }
+
+        @Override
+        public void close() throws Exception {
+
+        }
     }
 }


### PR DESCRIPTION
As detailed in #7031, we should not guard the download operations with the cache lock as it is too coarse-grained. This refactoring moves the long running operation outside of the cache operations.

Resolves #7031

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
