### PR TITLE
Fix flaky integ tests - CreateRemoteIndexIT,CreateRemoteIndexTranslogDisabledIT,CreateRemoteIndexClusterDefaultDocRep

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/CreateRemoteIndexClusterDefaultDocRep.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/CreateRemoteIndexClusterDefaultDocRep.java
@@ -34,10 +34,9 @@ public class CreateRemoteIndexClusterDefaultDocRep extends CreateRemoteIndexIT {
 
     @Override
     public void testRemoteStoreTranslogDisabledByUser() throws Exception {
-        final int numReplicas = internalCluster().numDataNodes();
         Settings settings = Settings.builder()
-            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 3)
-            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, numReplicas)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
             .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
             .put(SETTING_REMOTE_TRANSLOG_STORE_ENABLED, false)
             .build();
@@ -52,10 +51,9 @@ public class CreateRemoteIndexClusterDefaultDocRep extends CreateRemoteIndexIT {
 
     @Override
     public void testDefaultRemoteStoreNoUserOverride() throws Exception {
-        final int numReplicas = internalCluster().numDataNodes();
         Settings settings = Settings.builder()
-            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 3)
-            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, numReplicas)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
             .build();
         IllegalArgumentException exc = expectThrows(
             IllegalArgumentException.class,
@@ -68,10 +66,9 @@ public class CreateRemoteIndexClusterDefaultDocRep extends CreateRemoteIndexIT {
     }
 
     public void testDefaultRemoteStoreNoUserOverrideExceptReplicationTypeSegment() throws Exception {
-        final int numReplicas = internalCluster().numDataNodes();
         Settings settings = Settings.builder()
-            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 3)
-            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, numReplicas)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
             .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
             .build();
         assertAcked(client().admin().indices().prepareCreate("test-idx-1").setSettings(settings).get());

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/CreateRemoteIndexTranslogDisabledIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/CreateRemoteIndexTranslogDisabledIT.java
@@ -35,10 +35,9 @@ public class CreateRemoteIndexTranslogDisabledIT extends CreateRemoteIndexIT {
     }
 
     public void testRemoteStoreEnabledByUserWithRemoteRepo() throws Exception {
-        final int numReplicas = internalCluster().numDataNodes();
         Settings settings = Settings.builder()
-            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 3)
-            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, numReplicas)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
             .put(SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
             .put(SETTING_REMOTE_STORE_ENABLED, true)
             .put(SETTING_REMOTE_STORE_REPOSITORY, "my-custom-repo")
@@ -54,10 +53,9 @@ public class CreateRemoteIndexTranslogDisabledIT extends CreateRemoteIndexIT {
     }
 
     public void testDefaultRemoteStoreNoUserOverride() throws Exception {
-        final int numReplicas = internalCluster().numDataNodes();
         Settings settings = Settings.builder()
-            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 3)
-            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, numReplicas)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
             .build();
         assertAcked(client().admin().indices().prepareCreate("test-idx-1").setSettings(settings).get());
         GetIndexResponse getIndexResponse = client().admin()


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fixes flaky integ tests

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/7128

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
