### PR TITLE
[Backport 2.x] Make cluster manager throttling retry delay as dynamic setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add new cluster settings to ignore weighted round-robin routing and fallback to default behaviour. ([#6834](https://github.com/opensearch-project/OpenSearch/pull/6834))
 - Add experimental support for ZSTD compression. ([#3577](https://github.com/opensearch-project/OpenSearch/pull/3577))
 - [Segment Replication] Add point in time and scroll query compatibility. ([#6644](https://github.com/opensearch-project/OpenSearch/pull/6644))
+- Add retry delay as dynamic setting for cluster maanger throttling. ([#6998](https://github.com/opensearch-project/OpenSearch/pull/6998))
 
 ### Dependencies
 - Bump `org.apache.logging.log4j:log4j-core` from 2.18.0 to 2.20.0 ([#6490](https://github.com/opensearch-project/OpenSearch/pull/6490))

--- a/server/src/main/java/org/opensearch/action/bulk/BackoffPolicy.java
+++ b/server/src/main/java/org/opensearch/action/bulk/BackoffPolicy.java
@@ -115,7 +115,7 @@ public abstract class BackoffPolicy implements Iterable<TimeValue> {
      * @param maxDelayForRetry MaxDelay that can be returned from backoff policy
      * @return A backoff policy with exponential backoff with equal jitter which can't return delay more than given max delay
      */
-    public static BackoffPolicy exponentialEqualJitterBackoff(int baseDelay, int maxDelayForRetry) {
+    public static BackoffPolicy exponentialEqualJitterBackoff(long baseDelay, long maxDelayForRetry) {
         return new ExponentialEqualJitterBackoff(baseDelay, maxDelayForRetry);
     }
 
@@ -223,10 +223,10 @@ public abstract class BackoffPolicy implements Iterable<TimeValue> {
     }
 
     private static class ExponentialEqualJitterBackoff extends BackoffPolicy {
-        private final int maxDelayForRetry;
-        private final int baseDelay;
+        private final long maxDelayForRetry;
+        private final long baseDelay;
 
-        private ExponentialEqualJitterBackoff(int baseDelay, int maxDelayForRetry) {
+        private ExponentialEqualJitterBackoff(long baseDelay, long maxDelayForRetry) {
             this.maxDelayForRetry = maxDelayForRetry;
             this.baseDelay = baseDelay;
         }
@@ -252,11 +252,11 @@ public abstract class BackoffPolicy implements Iterable<TimeValue> {
          * Once delay has exceeded maxDelayForRetry, it will return maxDelayForRetry only
          * and not increase the delay.
          */
-        private final int maxDelayForRetry;
-        private final int baseDelay;
+        private final long maxDelayForRetry;
+        private final long baseDelay;
         private int retriesAttempted;
 
-        private ExponentialEqualJitterBackoffIterator(int baseDelay, int maxDelayForRetry) {
+        private ExponentialEqualJitterBackoffIterator(long baseDelay, long maxDelayForRetry) {
             this.baseDelay = baseDelay;
             this.maxDelayForRetry = maxDelayForRetry;
         }

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -602,6 +602,8 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 TaskResourceTrackingService.TASK_RESOURCE_TRACKING_ENABLED,
                 TaskManager.TASK_RESOURCE_CONSUMERS_ENABLED,
                 ClusterManagerTaskThrottler.THRESHOLD_SETTINGS,
+                ClusterManagerTaskThrottler.BASE_DELAY_SETTINGS,
+                ClusterManagerTaskThrottler.MAX_DELAY_SETTINGS,
                 // Settings related to search backpressure
                 SearchBackpressureSettings.SETTING_MODE,
 

--- a/server/src/test/java/org/opensearch/action/support/clustermanager/TransportClusterManagerNodeActionTests.java
+++ b/server/src/test/java/org/opensearch/action/support/clustermanager/TransportClusterManagerNodeActionTests.java
@@ -669,7 +669,7 @@ public class TransportClusterManagerNodeActionTests extends OpenSearchTestCase {
         assertFalse(listener.isDone());
 
         // waiting for retry to trigger
-        Thread.sleep(100);
+        Thread.sleep(10000);
 
         // Retry for above throttling exception
         capturedRequests = transport.getCapturedRequestsAndClear();


### PR DESCRIPTION
### Description

Backporting PR for making throttling retry setting as dynamic setting.

Original PR: https://github.com/opensearch-project/OpenSearch/pull/6998


### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
