### PR TITLE
Remove nebula `optional-base` package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `com.netflix.nebula.ospackage-base` from 11.0.0 to 11.2.0
 - Bump `org.apache.hadoop:hadoop-minicluster` from 3.3.4 to 3.3.5
 - Bump `org.apache.commons:commons-compress` from 1.22 to 1.23.0
+- Bump `com.netflix.nebula:gradle-extra-configurations-plugin` from 9.0.0 to 10.0.0 in /buildSrc ([#7068](https://github.com/opensearch-project/OpenSearch/pull/7068))
 
 ### Changed
 - [CCR] Add getHistoryOperationsFromTranslog method to fetch the history snapshot from translogs ([#3948](https://github.com/opensearch-project/OpenSearch/pull/3948))

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -105,7 +105,7 @@ dependencies {
   api 'commons-codec:commons-codec:1.15'
   api 'org.apache.commons:commons-compress:1.22'
   api 'org.apache.ant:ant:1.10.13'
-  api 'com.netflix.nebula:gradle-extra-configurations-plugin:9.0.0'
+  api 'com.netflix.nebula:gradle-extra-configurations-plugin:10.0.0'
   api 'com.netflix.nebula:nebula-publishing-plugin:20.2.0'
   api 'com.netflix.nebula:gradle-info-plugin:12.0.1'
   api 'org.apache.rat:apache-rat:0.15'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -105,7 +105,6 @@ dependencies {
   api 'commons-codec:commons-codec:1.15'
   api 'org.apache.commons:commons-compress:1.22'
   api 'org.apache.ant:ant:1.10.13'
-  api 'com.netflix.nebula:gradle-extra-configurations-plugin:10.0.0'
   api 'com.netflix.nebula:nebula-publishing-plugin:20.2.0'
   api 'com.netflix.nebula:gradle-info-plugin:12.0.1'
   api 'org.apache.rat:apache-rat:0.15'

--- a/libs/cli/build.gradle
+++ b/libs/cli/build.gradle
@@ -28,7 +28,6 @@
  * under the License.
  */
 apply plugin: 'opensearch.build'
-apply plugin: 'com.netflix.nebula.optional-base'
 apply plugin: 'opensearch.publish'
 
 dependencies {

--- a/libs/core/build.gradle
+++ b/libs/core/build.gradle
@@ -30,7 +30,6 @@
 
 import org.opensearch.gradle.info.BuildParams
 
-apply plugin: 'com.netflix.nebula.optional-base'
 apply plugin: 'opensearch.publish'
 
 archivesBaseName = 'opensearch-core'

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -125,13 +125,13 @@ dependencies {
   api 'org.hdrhistogram:HdrHistogram:2.1.12'
 
   // lucene spatial
-  api "org.locationtech.spatial4j:spatial4j:${versions.spatial4j}", optional
-  api "org.locationtech.jts:jts-core:${versions.jts}", optional
+  api "org.locationtech.spatial4j:spatial4j:${versions.spatial4j}"
+  api "org.locationtech.jts:jts-core:${versions.jts}"
 
   // logging
   api "org.apache.logging.log4j:log4j-api:${versions.log4j}"
   api "org.apache.logging.log4j:log4j-jul:${versions.log4j}"
-  api "org.apache.logging.log4j:log4j-core:${versions.log4j}", optional
+  api "org.apache.logging.log4j:log4j-core:${versions.log4j}"
 
   // jna
   api "net.java.dev.jna:jna:${versions.jna}"

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -31,7 +31,6 @@
 import org.opensearch.gradle.info.BuildParams
 
 apply plugin: 'opensearch.build'
-apply plugin: 'com.netflix.nebula.optional-base'
 apply plugin: 'opensearch.publish'
 apply plugin: 'opensearch.internal-cluster-test'
 
@@ -85,6 +84,20 @@ if (!isEclipse) {
   }
 }
 
+sourceSets {
+  geoSpatial {
+    java {
+      srcDirs = ['server/src/main/java/org/opensearch/common/geo', 'server/src/test/java/org/opensearch/common/geo']
+    }
+  }
+}
+
+java {
+  registerFeature('geoSpatial') {
+    usingSourceSet(sourceSets.geoSpatial)
+  }
+}
+
 dependencies {
 
   api project(':libs:opensearch-common')
@@ -125,8 +138,8 @@ dependencies {
   api 'org.hdrhistogram:HdrHistogram:2.1.12'
 
   // lucene spatial
-  api "org.locationtech.spatial4j:spatial4j:${versions.spatial4j}"
-  api "org.locationtech.jts:jts-core:${versions.jts}"
+  geoSpatialImplementation "org.locationtech.spatial4j:spatial4j:${versions.spatial4j}"
+  geoSpatialImplementation "org.locationtech.jts:jts-core:${versions.jts}"
 
   // logging
   api "org.apache.logging.log4j:log4j-api:${versions.log4j}"


### PR DESCRIPTION
### Description
Removes nebula optional-base as com.netflix.nebula:gradle-extra-configurations-plugin has removed support for `optional` flag starting 10.0.0.


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
