### PR TITLE
Adding more validation for fuzzy queries

### DIFF
--- a/server/src/main/java/org/opensearch/common/unit/Fuzziness.java
+++ b/server/src/main/java/org/opensearch/common/unit/Fuzziness.java
@@ -195,7 +195,7 @@ public final class Fuzziness implements ToXContentFragment, Writeable {
                     // Validate if the fuzziness value is formatted correctly as a numeric value.
                     try {
                         final float minimumSimilarity = Float.parseFloat(fuzziness);
-                        if (minimumSimilarity < 0.0f && !Float.isInfinite(minimumSimilarity) && !Float.isNaN(minimumSimilarity)) {
+                        if (minimumSimilarity < 0.0f || Float.isInfinite(minimumSimilarity) || Float.isNaN(minimumSimilarity)) {
                             throw new IllegalArgumentException("Invalid fuzziness value: " + fuzziness);
                         }
                         return build(fuzziness);

--- a/server/src/main/java/org/opensearch/common/unit/Fuzziness.java
+++ b/server/src/main/java/org/opensearch/common/unit/Fuzziness.java
@@ -195,7 +195,7 @@ public final class Fuzziness implements ToXContentFragment, Writeable {
                     // Validate if the fuzziness value is formatted correctly as a numeric value.
                     try {
                         final float minimumSimilarity = Float.parseFloat(fuzziness);
-                        if (minimumSimilarity < 0) {
+                        if (minimumSimilarity < 0.0f && !Float.isInfinite(minimumSimilarity) && !Float.isNaN(minimumSimilarity)) {
                             throw new IllegalArgumentException("Invalid fuzziness value: " + fuzziness);
                         }
                         return build(fuzziness);

--- a/server/src/main/java/org/opensearch/common/unit/Fuzziness.java
+++ b/server/src/main/java/org/opensearch/common/unit/Fuzziness.java
@@ -178,6 +178,9 @@ public final class Fuzziness implements ToXContentFragment, Writeable {
                 }
                 try {
                     final int minimumSimilarity = Integer.parseInt(fuzziness);
+                    if (minimumSimilarity < 0) {
+                        throw new IllegalArgumentException("Invalid fuzziness value: " + fuzziness);
+                    }
                     switch (minimumSimilarity) {
                         case 0:
                             return ZERO;
@@ -192,6 +195,9 @@ public final class Fuzziness implements ToXContentFragment, Writeable {
                     // Validate if the fuzziness value is formatted correctly as a numeric value.
                     try {
                         final float minimumSimilarity = Float.parseFloat(fuzziness);
+                        if (minimumSimilarity < 0) {
+                            throw new IllegalArgumentException("Invalid fuzziness value: " + fuzziness);
+                        }
                         return build(fuzziness);
                     } catch (NumberFormatException e) {
                         throw new IllegalArgumentException("Invalid fuzziness value: " + fuzziness);

--- a/server/src/test/java/org/opensearch/common/unit/FuzzinessTests.java
+++ b/server/src/test/java/org/opensearch/common/unit/FuzzinessTests.java
@@ -140,7 +140,7 @@ public class FuzzinessTests extends OpenSearchTestCase {
     }
 
     public void testFuzzinessValidationWithStrings() throws IOException {
-        String[] invalidStrings = new String[] { "+++", "asdfghjkl", "2k23" };
+        String[] invalidStrings = new String[] { "+++", "asdfghjkl", "2k23", "-1.0", "-100" };
         XContentBuilder json = jsonBuilder().startObject().field(Fuzziness.X_FIELD_NAME, randomFrom(invalidStrings)).endObject();
         try (XContentParser parser = createParser(json)) {
             assertThat(parser.nextToken(), equalTo(XContentParser.Token.START_OBJECT));


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Building on #5805. After checking back on my previous PR for `Fuzziness`, I noticed that negative values (both integers and floats) were not validated correctly (as per [the official documentation](https://opensearch.org/docs/latest/query-dsl/full-text/#fuzzy-query-options), only positive values are allowed. Floating point values kept in for [this test](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/test/java/org/opensearch/common/unit/FuzzinessTests.java#L49)). I've added a negative value check for both integers and floats in `Fuzziness.java` and included some values in the unit tests to reflect the changes.

Sample behavior:
```
$ curl -XGET 'http://localhost:9200/_search?pretty' -d '{"query":{"match_bool_prefix":{"date":{"query":"1972-07-04 00:00:00", "fuzziness":"-10.0"}}}}' -H 'Content-Type: application/json'
{
  "error" : {
    "root_cause" : [
      {
        "type" : "illegal_argument_exception",
        "reason" : "Invalid fuzziness value: -10.0"
      }
    ],
    "type" : "illegal_argument_exception",
    "reason" : "Invalid fuzziness value: -10.0"
  },
  "status" : 400
}
```

### Issues Resolved
#4223 #5805 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
