### PR TITLE
[Refactor] Metadata members from ImmutableOpenMap to j.u.Map

### DIFF
--- a/client/rest-high-level/src/test/java/org/opensearch/client/AbstractResponseTestCase.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/AbstractResponseTestCase.java
@@ -116,4 +116,17 @@ public abstract class AbstractResponseTestCase<S extends ToXContent, C> extends 
             assertEquals(expected.get(key), actual.get(key));
         }
     }
+
+    protected static <T> void assertMapEquals(final Map<String, T> expected, Map<String, T> actual) {
+        Set<String> expectedKeys = new HashSet<>();
+        Iterator<String> keysIt = expected.keySet().iterator();
+        while (keysIt.hasNext()) {
+            expectedKeys.add(keysIt.next());
+        }
+
+        assertEquals(expectedKeys, actual.keySet());
+        for (String key : expectedKeys) {
+            assertEquals(expected.get(key), actual.get(key));
+        }
+    }
 }

--- a/client/rest-high-level/src/test/java/org/opensearch/client/AbstractResponseTestCase.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/AbstractResponseTestCase.java
@@ -116,17 +116,4 @@ public abstract class AbstractResponseTestCase<S extends ToXContent, C> extends 
             assertEquals(expected.get(key), actual.get(key));
         }
     }
-
-    protected static <T> void assertMapEquals(final Map<String, T> expected, Map<String, T> actual) {
-        Set<String> expectedKeys = new HashSet<>();
-        Iterator<String> keysIt = expected.keySet().iterator();
-        while (keysIt.hasNext()) {
-            expectedKeys.add(keysIt.next());
-        }
-
-        assertEquals(expectedKeys, actual.keySet());
-        for (String key : expectedKeys) {
-            assertEquals(expected.get(key), actual.get(key));
-        }
-    }
 }

--- a/client/rest-high-level/src/test/java/org/opensearch/client/indices/GetIndexResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/indices/GetIndexResponseTests.java
@@ -50,13 +50,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 public class GetIndexResponseTests extends AbstractResponseTestCase<
     org.opensearch.action.admin.indices.get.GetIndexResponse,
@@ -171,18 +168,5 @@ public class GetIndexResponseTests extends AbstractResponseTestCase<
             mappings.put("type", "keyword");
         }
         return mappings;
-    }
-
-    protected static <T> void assertMapEquals(final Map<String, T> expected, Map<String, T> actual) {
-        Set<String> expectedKeys = new HashSet<>();
-        Iterator<String> keysIt = expected.keySet().iterator();
-        while (keysIt.hasNext()) {
-            expectedKeys.add(keysIt.next());
-        }
-
-        assertEquals(expectedKeys, actual.keySet());
-        for (String key : expectedKeys) {
-            assertEquals(expected.get(key), actual.get(key));
-        }
     }
 }

--- a/client/rest-high-level/src/test/java/org/opensearch/client/indices/GetIndexResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/indices/GetIndexResponseTests.java
@@ -113,7 +113,7 @@ public class GetIndexResponseTests extends AbstractResponseTestCase<
         GetIndexResponse clientInstance
     ) {
         assertArrayEquals(serverTestInstance.getIndices(), clientInstance.getIndices());
-        assertMapEquals(serverTestInstance.getMappings(), clientInstance.getMappings());
+        assertEquals(serverTestInstance.getMappings(), clientInstance.getMappings());
         assertMapEquals(serverTestInstance.getSettings(), clientInstance.getSettings());
         assertMapEquals(serverTestInstance.defaultSettings(), clientInstance.getDefaultSettings());
         assertMapEquals(serverTestInstance.getAliases(), clientInstance.getAliases());

--- a/client/rest-high-level/src/test/java/org/opensearch/client/indices/GetIndexResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/indices/GetIndexResponseTests.java
@@ -50,10 +50,13 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 public class GetIndexResponseTests extends AbstractResponseTestCase<
     org.opensearch.action.admin.indices.get.GetIndexResponse,
@@ -62,7 +65,7 @@ public class GetIndexResponseTests extends AbstractResponseTestCase<
     @Override
     protected org.opensearch.action.admin.indices.get.GetIndexResponse createServerTestInstance(XContentType xContentType) {
         String[] indices = generateRandomStringArray(5, 5, false, false);
-        ImmutableOpenMap.Builder<String, MappingMetadata> mappings = ImmutableOpenMap.builder();
+        final Map<String, MappingMetadata> mappings = new HashMap<>();
         ImmutableOpenMap.Builder<String, List<AliasMetadata>> aliases = ImmutableOpenMap.builder();
         ImmutableOpenMap.Builder<String, Settings> settings = ImmutableOpenMap.builder();
         ImmutableOpenMap.Builder<String, Settings> defaultSettings = ImmutableOpenMap.builder();
@@ -94,7 +97,7 @@ public class GetIndexResponseTests extends AbstractResponseTestCase<
         }
         return new org.opensearch.action.admin.indices.get.GetIndexResponse(
             indices,
-            mappings.build(),
+            mappings,
             aliases.build(),
             settings.build(),
             defaultSettings.build(),
@@ -168,5 +171,18 @@ public class GetIndexResponseTests extends AbstractResponseTestCase<
             mappings.put("type", "keyword");
         }
         return mappings;
+    }
+
+    protected static <T> void assertMapEquals(final Map<String, T> expected, Map<String, T> actual) {
+        Set<String> expectedKeys = new HashSet<>();
+        Iterator<String> keysIt = expected.keySet().iterator();
+        while (keysIt.hasNext()) {
+            expectedKeys.add(keysIt.next());
+        }
+
+        assertEquals(expectedKeys, actual.keySet());
+        for (String key : expectedKeys) {
+            assertEquals(expected.get(key), actual.get(key));
+        }
     }
 }

--- a/client/rest-high-level/src/test/java/org/opensearch/client/indices/GetMappingsResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/indices/GetMappingsResponseTests.java
@@ -67,7 +67,7 @@ public class GetMappingsResponseTests extends AbstractResponseTestCase<
         org.opensearch.action.admin.indices.mapping.get.GetMappingsResponse serverTestInstance,
         GetMappingsResponse clientInstance
     ) {
-        assertMapEquals(serverTestInstance.getMappings(), clientInstance.mappings());
+        assertEquals(serverTestInstance.getMappings(), clientInstance.mappings());
     }
 
     public static MappingMetadata randomMappingMetadata() {

--- a/client/rest-high-level/src/test/java/org/opensearch/client/indices/GetMappingsResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/indices/GetMappingsResponseTests.java
@@ -34,15 +34,17 @@ package org.opensearch.client.indices;
 
 import org.opensearch.client.AbstractResponseTestCase;
 import org.opensearch.cluster.metadata.MappingMetadata;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.mapper.MapperService;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
+import java.util.HashSet;
+import java.util.Set;
 
 public class GetMappingsResponseTests extends AbstractResponseTestCase<
     org.opensearch.action.admin.indices.mapping.get.GetMappingsResponse,
@@ -50,12 +52,12 @@ public class GetMappingsResponseTests extends AbstractResponseTestCase<
 
     @Override
     protected org.opensearch.action.admin.indices.mapping.get.GetMappingsResponse createServerTestInstance(XContentType xContentType) {
-        ImmutableOpenMap.Builder<String, MappingMetadata> mappings = ImmutableOpenMap.builder();
+        final Map<String, MappingMetadata> mappings = new HashMap<>();
         int numberOfIndexes = randomIntBetween(1, 5);
         for (int i = 0; i < numberOfIndexes; i++) {
             mappings.put("index-" + randomAlphaOfLength(5), randomMappingMetadata());
         }
-        return new org.opensearch.action.admin.indices.mapping.get.GetMappingsResponse(mappings.build());
+        return new org.opensearch.action.admin.indices.mapping.get.GetMappingsResponse(mappings);
     }
 
     @Override
@@ -93,5 +95,18 @@ public class GetMappingsResponseTests extends AbstractResponseTestCase<
             mappings.put("index", Objects.toString(randomBoolean()));
         }
         return mappings;
+    }
+
+    protected static <T> void assertMapEquals(Map<String, T> expected, Map<String, T> actual) {
+        final Set<String> expectedKeys = new HashSet<>();
+        final Iterator<String> keysIt = expected.keySet().iterator();
+        while (keysIt.hasNext()) {
+            expectedKeys.add(keysIt.next());
+        }
+
+        assertEquals(expectedKeys, actual.keySet());
+        for (String key : expectedKeys) {
+            assertEquals(expected.get(key), actual.get(key));
+        }
     }
 }

--- a/client/rest-high-level/src/test/java/org/opensearch/client/indices/GetMappingsResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/indices/GetMappingsResponseTests.java
@@ -40,11 +40,8 @@ import org.opensearch.index.mapper.MapperService;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
-import java.util.HashSet;
-import java.util.Set;
 
 public class GetMappingsResponseTests extends AbstractResponseTestCase<
     org.opensearch.action.admin.indices.mapping.get.GetMappingsResponse,
@@ -95,18 +92,5 @@ public class GetMappingsResponseTests extends AbstractResponseTestCase<
             mappings.put("index", Objects.toString(randomBoolean()));
         }
         return mappings;
-    }
-
-    protected static <T> void assertMapEquals(Map<String, T> expected, Map<String, T> actual) {
-        final Set<String> expectedKeys = new HashSet<>();
-        final Iterator<String> keysIt = expected.keySet().iterator();
-        while (keysIt.hasNext()) {
-            expectedKeys.add(keysIt.next());
-        }
-
-        assertEquals(expectedKeys, actual.keySet());
-        for (String key : expectedKeys) {
-            assertEquals(expected.get(key), actual.get(key));
-        }
     }
 }

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/create/CreateIndexIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/create/CreateIndexIT.java
@@ -45,7 +45,6 @@ import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.cluster.metadata.Metadata;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.settings.SettingsException;
 import org.opensearch.common.unit.TimeValue;
@@ -60,6 +59,7 @@ import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.OpenSearchIntegTestCase.ClusterScope;
 import org.opensearch.test.OpenSearchIntegTestCase.Scope;
 
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
@@ -101,7 +101,7 @@ public class CreateIndexIT extends OpenSearchIntegTestCase {
         assertThat(state, notNullValue());
         Metadata metadata = state.getMetadata();
         assertThat(metadata, notNullValue());
-        ImmutableOpenMap<String, IndexMetadata> indices = metadata.getIndices();
+        final Map<String, IndexMetadata> indices = metadata.getIndices();
         assertThat(indices, notNullValue());
         assertThat(indices.size(), equalTo(1));
         IndexMetadata index = indices.get("test");

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/get/GetIndexIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/get/GetIndexIT.java
@@ -46,6 +46,7 @@ import org.opensearch.test.OpenSearchIntegTestCase;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import static org.opensearch.cluster.metadata.IndexMetadata.INDEX_METADATA_BLOCK;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_METADATA;
@@ -271,7 +272,7 @@ public class GetIndexIT extends OpenSearchIntegTestCase {
     }
 
     private void assertMappings(GetIndexResponse response, String indexName) {
-        ImmutableOpenMap<String, MappingMetadata> mappings = response.mappings();
+        final Map<String, MappingMetadata> mappings = response.mappings();
         assertThat(mappings, notNullValue());
         assertThat(mappings.size(), equalTo(1));
         MappingMetadata indexMappings = mappings.get(indexName);
@@ -279,7 +280,7 @@ public class GetIndexIT extends OpenSearchIntegTestCase {
     }
 
     private void assertEmptyOrOnlyDefaultMappings(GetIndexResponse response, String indexName) {
-        ImmutableOpenMap<String, MappingMetadata> mappings = response.mappings();
+        final Map<String, MappingMetadata> mappings = response.mappings();
         assertThat(mappings, notNullValue());
         assertThat(mappings.size(), equalTo(1));
         MappingMetadata indexMappings = mappings.get(indexName);

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/ClusterStateDiffIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/ClusterStateDiffIT.java
@@ -75,6 +75,7 @@ import org.opensearch.test.OpenSearchIntegTestCase;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static java.util.Collections.emptyList;
@@ -526,7 +527,7 @@ public class ClusterStateDiffIT extends OpenSearchIntegTestCase {
         /**
          * Returns list of parts from metadata
          */
-        ImmutableOpenMap<String, T> parts(Metadata metadata);
+        Map<String, T> parts(Metadata metadata);
 
         /**
          * Puts the part back into metadata
@@ -556,10 +557,10 @@ public class ClusterStateDiffIT extends OpenSearchIntegTestCase {
      */
     private <T> Metadata randomParts(Metadata metadata, String prefix, RandomPart<T> randomPart) {
         Metadata.Builder builder = Metadata.builder(metadata);
-        ImmutableOpenMap<String, T> parts = randomPart.parts(metadata);
+        final Map<String, T> parts = randomPart.parts(metadata);
         int partCount = parts.size();
         if (partCount > 0) {
-            List<String> randomParts = randomSubsetOf(randomInt(partCount - 1), randomPart.parts(metadata).keys().toArray(String.class));
+            List<String> randomParts = randomSubsetOf(randomInt(partCount - 1), randomPart.parts(metadata).keySet().toArray(new String[0]));
             for (String part : randomParts) {
                 if (randomBoolean()) {
                     randomPart.remove(builder, part);
@@ -583,7 +584,7 @@ public class ClusterStateDiffIT extends OpenSearchIntegTestCase {
         return randomParts(metadata, "index", new RandomPart<IndexMetadata>() {
 
             @Override
-            public ImmutableOpenMap<String, IndexMetadata> parts(Metadata metadata) {
+            public Map<String, IndexMetadata> parts(Metadata metadata) {
                 return metadata.indices();
             }
 
@@ -645,7 +646,7 @@ public class ClusterStateDiffIT extends OpenSearchIntegTestCase {
     private Metadata randomTemplates(Metadata metadata) {
         return randomParts(metadata, "template", new RandomPart<IndexTemplateMetadata>() {
             @Override
-            public ImmutableOpenMap<String, IndexTemplateMetadata> parts(Metadata metadata) {
+            public Map<String, IndexTemplateMetadata> parts(Metadata metadata) {
                 return metadata.templates();
             }
 
@@ -702,7 +703,7 @@ public class ClusterStateDiffIT extends OpenSearchIntegTestCase {
         return randomParts(metadata, "custom", new RandomPart<Metadata.Custom>() {
 
             @Override
-            public ImmutableOpenMap<String, Metadata.Custom> parts(Metadata metadata) {
+            public Map<String, Metadata.Custom> parts(Metadata metadata) {
                 return metadata.customs();
             }
 

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/SimpleClusterStateIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/SimpleClusterStateIT.java
@@ -47,7 +47,6 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Priority;
 import org.opensearch.common.Strings;
 import org.opensearch.common.UUIDs;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -65,7 +64,6 @@ import org.opensearch.plugins.Plugin;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.script.ScriptService;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.hamcrest.CollectionAssertions;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.watcher.ResourceWatcherService;
 
@@ -76,6 +74,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
@@ -83,6 +82,7 @@ import static org.opensearch.gateway.GatewayService.STATE_NOT_RECOVERED_BLOCK;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertIndexTemplateExists;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
@@ -238,14 +238,14 @@ public class SimpleClusterStateIT extends OpenSearchIntegTestCase {
             .setIndices(indices)
             .get();
 
-        ImmutableOpenMap<String, IndexMetadata> metadata = clusterState.getState().getMetadata().indices();
+        final Map<String, IndexMetadata> metadata = clusterState.getState().getMetadata().indices();
         assertThat(metadata.size(), is(expected.length));
 
         RoutingTable routingTable = clusterState.getState().getRoutingTable();
         assertThat(routingTable.indicesRouting().size(), is(expected.length));
 
-        for (String expectedIndex : expected) {
-            assertThat(metadata, CollectionAssertions.hasKey(expectedIndex));
+        for (final String expectedIndex : expected) {
+            assertThat(metadata, hasKey(expectedIndex));
             assertThat(routingTable.hasIndex(expectedIndex), is(true));
         }
     }

--- a/server/src/internalClusterTest/java/org/opensearch/gateway/MetadataNodesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/gateway/MetadataNodesIT.java
@@ -36,7 +36,6 @@ import org.opensearch.action.admin.cluster.state.ClusterStateResponse;
 import org.opensearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.opensearch.cluster.coordination.Coordinator;
 import org.opensearch.cluster.metadata.IndexMetadata;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.discovery.Discovery;
 import org.opensearch.env.NodeEnvironment;
@@ -152,7 +151,7 @@ public class MetadataNodesIT extends OpenSearchIntegTestCase {
         );
 
         // make sure it was also written on red node although index is closed
-        ImmutableOpenMap<String, IndexMetadata> indicesMetadata = getIndicesMetadataOnNode(dataNode);
+        Map<String, IndexMetadata> indicesMetadata = getIndicesMetadataOnNode(dataNode);
         assertNotNull(((Map<String, ?>) (indicesMetadata.get(index).mapping().getSourceAsMap().get("properties"))).get("integer_field"));
         assertThat(indicesMetadata.get(index).getState(), equalTo(IndexMetadata.State.CLOSE));
 
@@ -239,7 +238,7 @@ public class MetadataNodesIT extends OpenSearchIntegTestCase {
         return false;
     }
 
-    private ImmutableOpenMap<String, IndexMetadata> getIndicesMetadataOnNode(String nodeName) {
+    private Map<String, IndexMetadata> getIndicesMetadataOnNode(String nodeName) {
         final Coordinator coordinator = (Coordinator) internalCluster().getInstance(Discovery.class, nodeName);
         return coordinator.getApplierState().getMetadata().getIndices();
     }

--- a/server/src/internalClusterTest/java/org/opensearch/gateway/RecoveryFromGatewayIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/gateway/RecoveryFromGatewayIT.java
@@ -32,8 +32,6 @@
 
 package org.opensearch.gateway;
 
-import com.carrotsearch.hppc.cursors.ObjectCursor;
-
 import org.opensearch.action.admin.cluster.configuration.AddVotingConfigExclusionsAction;
 import org.opensearch.action.admin.cluster.configuration.AddVotingConfigExclusionsRequest;
 import org.opensearch.action.admin.cluster.configuration.ClearVotingConfigExclusionsAction;
@@ -181,8 +179,7 @@ public class RecoveryFromGatewayIT extends OpenSearchIntegTestCase {
         }
         final Map<String, long[]> result = new HashMap<>();
         final ClusterState state = client().admin().cluster().prepareState().get().getState();
-        for (ObjectCursor<IndexMetadata> cursor : state.metadata().indices().values()) {
-            final IndexMetadata indexMetadata = cursor.value;
+        for (final IndexMetadata indexMetadata : state.metadata().indices().values()) {
             final String index = indexMetadata.getIndex().getName();
             final long[] previous = previousTerms.get(index);
             final long[] current = IntStream.range(0, indexMetadata.getNumberOfShards()).mapToLong(indexMetadata::primaryTerm).toArray();

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationAllocationIT.java
@@ -61,7 +61,6 @@ public class SegmentReplicationAllocationIT extends SegmentReplicationBaseIT {
     /**
      * This test verifies that the overall primary balance is attained during allocation. This test verifies primary
      * balance per index and across all indices is maintained.
-     * @throws Exception
      */
     public void testGlobalPrimaryAllocation() throws Exception {
         internalCluster().startClusterManagerOnlyNode();

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -359,7 +359,6 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
 
     /**
      * This test validates the primary node drop does not result in shard failure on replica.
-     * @throws Exception
      */
     public void testNodeDropWithOngoingReplication() throws Exception {
         internalCluster().startClusterManagerOnlyNode();
@@ -869,7 +868,6 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
 
     /**
      * Tests a scroll query on the replica
-     * @throws Exception
      */
     public void testScrollCreatedOnReplica() throws Exception {
         // create the cluster with one primary node containing primary shard and replica node containing replica shard
@@ -957,8 +955,6 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
     /**
      * Tests that when scroll query is cleared, it does not delete the temporary replication files, which are part of
      * ongoing round of segment replication
-     *
-     * @throws Exception
      */
     public void testScrollWithOngoingSegmentReplication() throws Exception {
         // create the cluster with one primary node containing primary shard and replica node containing replica shard

--- a/server/src/internalClusterTest/java/org/opensearch/operateAllIndices/DestructiveOperationsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/operateAllIndices/DestructiveOperationsIT.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.operateAllIndices;
 
-import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.opensearch.action.support.DestructiveOperations;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
@@ -109,8 +108,8 @@ public class DestructiveOperationsIT extends OpenSearchIntegTestCase {
         }
 
         ClusterState state = client().admin().cluster().prepareState().get().getState();
-        for (ObjectObjectCursor<String, IndexMetadata> indexMetadataObjectObjectCursor : state.getMetadata().indices()) {
-            assertEquals(IndexMetadata.State.CLOSE, indexMetadataObjectObjectCursor.value.getState());
+        for (final IndexMetadata indexMetadataObjectObjectCursor : state.getMetadata().indices().values()) {
+            assertEquals(IndexMetadata.State.CLOSE, indexMetadataObjectObjectCursor.getState());
         }
     }
 
@@ -141,8 +140,8 @@ public class DestructiveOperationsIT extends OpenSearchIntegTestCase {
         }
 
         ClusterState state = client().admin().cluster().prepareState().get().getState();
-        for (ObjectObjectCursor<String, IndexMetadata> indexMetadataObjectObjectCursor : state.getMetadata().indices()) {
-            assertEquals(IndexMetadata.State.OPEN, indexMetadataObjectObjectCursor.value.getState());
+        for (final IndexMetadata indexMetadataObjectObjectCursor : state.getMetadata().indices().values()) {
+            assertEquals(IndexMetadata.State.OPEN, indexMetadataObjectObjectCursor.getState());
         }
     }
 }

--- a/server/src/internalClusterTest/java/org/opensearch/recovery/RelocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/recovery/RelocationIT.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.recovery;
 
-import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.tests.util.English;
 import org.opensearch.action.ActionFuture;
@@ -770,8 +769,8 @@ public class RelocationIT extends OpenSearchIntegTestCase {
 
     private void assertActiveCopiesEstablishedPeerRecoveryRetentionLeases() throws Exception {
         assertBusy(() -> {
-            for (ObjectCursor<String> it : client().admin().cluster().prepareState().get().getState().metadata().indices().keys()) {
-                Map<ShardId, List<ShardStats>> byShardId = Stream.of(client().admin().indices().prepareStats(it.value).get().getShards())
+            for (final String it : client().admin().cluster().prepareState().get().getState().metadata().indices().keySet()) {
+                Map<ShardId, List<ShardStats>> byShardId = Stream.of(client().admin().indices().prepareStats(it).get().getShards())
                     .collect(Collectors.groupingBy(l -> l.getShardRouting().shardId()));
                 for (List<ShardStats> shardStats : byShardId.values()) {
                     Set<String> expectedLeaseIds = shardStats.stream()

--- a/server/src/internalClusterTest/java/org/opensearch/search/SearchWeightedRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/SearchWeightedRoutingIT.java
@@ -663,7 +663,6 @@ public class SearchWeightedRoutingIT extends OpenSearchIntegTestCase {
 
     /**
      * Should failopen shards even if failopen enabled with custom search preference.
-     * @throws Exception
      */
     public void testStrictWeightedRoutingWithShardPrefNetworkDisruption_FailOpenEnabled() throws Exception {
         Settings commonSettings = Settings.builder()

--- a/server/src/main/java/org/opensearch/action/admin/cluster/state/TransportClusterStateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/state/TransportClusterStateAction.java
@@ -57,6 +57,7 @@ import org.opensearch.transport.TransportService;
 
 import java.io.IOException;
 import java.util.function.Predicate;
+import java.util.Map;
 
 /**
  * Transport action for obtaining cluster state
@@ -212,9 +213,9 @@ public class TransportClusterStateAction extends TransportClusterManagerNodeRead
             }
 
             // filter out metadata that shouldn't be returned by the API
-            for (ObjectObjectCursor<String, Custom> custom : currentState.metadata().customs()) {
-                if (custom.value.context().contains(Metadata.XContentContext.API) == false) {
-                    mdBuilder.removeCustom(custom.key);
+            for (final Map.Entry<String, Custom> custom : currentState.metadata().customs().entrySet()) {
+                if (custom.getValue().context().contains(Metadata.XContentContext.API) == false) {
+                    mdBuilder.removeCustom(custom.getKey());
                 }
             }
         }

--- a/server/src/main/java/org/opensearch/action/admin/indices/dangling/delete/TransportDeleteDanglingIndexAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/dangling/delete/TransportDeleteDanglingIndexAction.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action.admin.indices.dangling.delete;
 
-import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.OpenSearchException;
@@ -186,8 +185,8 @@ public class TransportDeleteDanglingIndexAction extends TransportClusterManagerN
     private ClusterState deleteDanglingIndex(ClusterState currentState, Index indexToDelete) {
         final Metadata metaData = currentState.getMetadata();
 
-        for (ObjectObjectCursor<String, IndexMetadata> each : metaData.indices()) {
-            if (indexToDelete.getUUID().equals(each.value.getIndexUUID())) {
+        for (final IndexMetadata each : metaData.indices().values()) {
+            if (indexToDelete.getUUID().equals(each.getIndexUUID())) {
                 throw new IllegalArgumentException(
                     "Refusing to delete dangling index "
                         + indexToDelete

--- a/server/src/main/java/org/opensearch/action/admin/indices/get/GetIndexResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/get/GetIndexResponse.java
@@ -51,7 +51,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -61,7 +63,7 @@ import java.util.Objects;
  */
 public class GetIndexResponse extends ActionResponse implements ToXContentObject {
 
-    private ImmutableOpenMap<String, MappingMetadata> mappings = ImmutableOpenMap.of();
+    private Map<String, MappingMetadata> mappings = Map.of();
     private ImmutableOpenMap<String, List<AliasMetadata>> aliases = ImmutableOpenMap.of();
     private ImmutableOpenMap<String, Settings> settings = ImmutableOpenMap.of();
     private ImmutableOpenMap<String, Settings> defaultSettings = ImmutableOpenMap.of();
@@ -70,7 +72,7 @@ public class GetIndexResponse extends ActionResponse implements ToXContentObject
 
     public GetIndexResponse(
         String[] indices,
-        ImmutableOpenMap<String, MappingMetadata> mappings,
+        Map<String, MappingMetadata> mappings,
         ImmutableOpenMap<String, List<AliasMetadata>> aliases,
         ImmutableOpenMap<String, Settings> settings,
         ImmutableOpenMap<String, Settings> defaultSettings,
@@ -101,7 +103,7 @@ public class GetIndexResponse extends ActionResponse implements ToXContentObject
         this.indices = in.readStringArray();
 
         int mappingsSize = in.readVInt();
-        ImmutableOpenMap.Builder<String, MappingMetadata> mappingsMapBuilder = ImmutableOpenMap.builder();
+        Map<String, MappingMetadata> mappingsMapBuilder = new HashMap<>();
         for (int i = 0; i < mappingsSize; i++) {
             String index = in.readString();
             if (in.getVersion().before(Version.V_2_0_0)) {
@@ -122,7 +124,7 @@ public class GetIndexResponse extends ActionResponse implements ToXContentObject
                 mappingsMapBuilder.put(index, metadata != null ? metadata : MappingMetadata.EMPTY_MAPPINGS);
             }
         }
-        mappings = mappingsMapBuilder.build();
+        mappings = Collections.unmodifiableMap(mappingsMapBuilder);
 
         int aliasesSize = in.readVInt();
         ImmutableOpenMap.Builder<String, List<AliasMetadata>> aliasesMapBuilder = ImmutableOpenMap.builder();
@@ -168,11 +170,11 @@ public class GetIndexResponse extends ActionResponse implements ToXContentObject
         return indices();
     }
 
-    public ImmutableOpenMap<String, MappingMetadata> mappings() {
+    public Map<String, MappingMetadata> mappings() {
         return mappings;
     }
 
-    public ImmutableOpenMap<String, MappingMetadata> getMappings() {
+    public Map<String, MappingMetadata> getMappings() {
         return mappings();
     }
 
@@ -240,16 +242,16 @@ public class GetIndexResponse extends ActionResponse implements ToXContentObject
     public void writeTo(StreamOutput out) throws IOException {
         out.writeStringArray(indices);
         out.writeVInt(mappings.size());
-        for (ObjectObjectCursor<String, MappingMetadata> indexEntry : mappings) {
-            out.writeString(indexEntry.key);
+        for (final Map.Entry<String, MappingMetadata> indexEntry : mappings.entrySet()) {
+            out.writeString(indexEntry.getKey());
             if (out.getVersion().before(Version.V_2_0_0)) {
-                out.writeVInt(indexEntry.value == MappingMetadata.EMPTY_MAPPINGS ? 0 : 1);
-                if (indexEntry.value != MappingMetadata.EMPTY_MAPPINGS) {
+                out.writeVInt(indexEntry.getValue() == MappingMetadata.EMPTY_MAPPINGS ? 0 : 1);
+                if (indexEntry.getValue() != MappingMetadata.EMPTY_MAPPINGS) {
                     out.writeString(MapperService.SINGLE_MAPPING_NAME);
-                    indexEntry.value.writeTo(out);
+                    indexEntry.getValue().writeTo(out);
                 }
             } else {
-                out.writeOptionalWriteable(indexEntry.value);
+                out.writeOptionalWriteable(indexEntry.getValue());
             }
         }
         out.writeVInt(aliases.size());

--- a/server/src/main/java/org/opensearch/action/admin/indices/get/TransportGetIndexAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/get/TransportGetIndexAction.java
@@ -53,6 +53,7 @@ import org.opensearch.transport.TransportService;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -104,7 +105,7 @@ public class TransportGetIndexAction extends TransportClusterInfoAction<GetIndex
         final ClusterState state,
         final ActionListener<GetIndexResponse> listener
     ) {
-        ImmutableOpenMap<String, MappingMetadata> mappingsResult = ImmutableOpenMap.of();
+        Map<String, MappingMetadata> mappingsResult = Map.of();
         ImmutableOpenMap<String, List<AliasMetadata>> aliasesResult = ImmutableOpenMap.of();
         ImmutableOpenMap<String, Settings> settings = ImmutableOpenMap.of();
         ImmutableOpenMap<String, Settings> defaultSettings = ImmutableOpenMap.of();

--- a/server/src/main/java/org/opensearch/action/admin/indices/mapping/get/TransportGetMappingsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/mapping/get/TransportGetMappingsAction.java
@@ -41,7 +41,6 @@ import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.indices.IndicesService;
@@ -49,6 +48,7 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
 import java.io.IOException;
+import java.util.Map;
 
 /**
  * Transport action to get field mappings.
@@ -96,8 +96,7 @@ public class TransportGetMappingsAction extends TransportClusterInfoAction<GetMa
     ) {
         logger.trace("serving getMapping request based on version {}", state.version());
         try {
-            ImmutableOpenMap<String, MappingMetadata> result = state.metadata()
-                .findMappings(concreteIndices, indicesService.getFieldFilter());
+            final Map<String, MappingMetadata> result = state.metadata().findMappings(concreteIndices, indicesService.getFieldFilter());
             listener.onResponse(new GetMappingsResponse(result));
         } catch (IOException e) {
             listener.onFailure(e);

--- a/server/src/main/java/org/opensearch/action/admin/indices/template/get/TransportGetIndexTemplatesAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/template/get/TransportGetIndexTemplatesAction.java
@@ -31,7 +31,6 @@
 
 package org.opensearch.action.admin.indices.template.get;
 
-import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeReadAction;
@@ -51,6 +50,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Transport action to retrieve one or more Index templates
@@ -105,16 +105,16 @@ public class TransportGetIndexTemplatesAction extends TransportClusterManagerNod
 
         // If we did not ask for a specific name, then we return all templates
         if (request.names().length == 0) {
-            results = Arrays.asList(state.metadata().templates().values().toArray(IndexTemplateMetadata.class));
+            results = Arrays.asList(state.metadata().templates().values().toArray(new IndexTemplateMetadata[0]));
         } else {
             results = new ArrayList<>();
         }
 
         for (String name : request.names()) {
             if (Regex.isSimpleMatchPattern(name)) {
-                for (ObjectObjectCursor<String, IndexTemplateMetadata> entry : state.metadata().templates()) {
-                    if (Regex.simpleMatch(name, entry.key)) {
-                        results.add(entry.value);
+                for (final Map.Entry<String, IndexTemplateMetadata> entry : state.metadata().templates().entrySet()) {
+                    if (Regex.simpleMatch(name, entry.getKey())) {
+                        results.add(entry.getValue());
                     }
                 }
             } else if (state.metadata().templates().containsKey(name)) {

--- a/server/src/main/java/org/opensearch/cluster/ClusterModule.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterModule.java
@@ -230,7 +230,7 @@ public class ClusterModule extends AbstractModule {
             }
         });
         final Metadata.Builder metaBuilder = Metadata.builder(clusterState.metadata());
-        clusterState.metadata().customs().keysIt().forEachRemaining(name -> {
+        clusterState.metadata().customs().keySet().iterator().forEachRemaining(name -> {
             if (PRE_6_3_METADATA_CUSTOMS_WHITE_LIST.contains(name) == false) {
                 metaBuilder.removeCustom(name);
             }

--- a/server/src/main/java/org/opensearch/cluster/ClusterState.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterState.java
@@ -375,9 +375,9 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
         }
         if (metadata.customs().isEmpty() == false) {
             sb.append("metadata customs:\n");
-            for (final ObjectObjectCursor<String, Metadata.Custom> cursor : metadata.customs()) {
-                final String type = cursor.key;
-                final Metadata.Custom custom = cursor.value;
+            for (final Map.Entry<String, Metadata.Custom> cursor : metadata.customs().entrySet()) {
+                final String type = cursor.getKey();
+                final Metadata.Custom custom = cursor.getValue();
                 sb.append(TAB).append(type).append(": ").append(custom);
             }
             sb.append("\n");

--- a/server/src/main/java/org/opensearch/cluster/coordination/RemoveCustomsCommand.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/RemoveCustomsCommand.java
@@ -31,7 +31,6 @@
 
 package org.opensearch.cluster.coordination;
 
-import com.carrotsearch.hppc.cursors.ObjectCursor;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
 import org.opensearch.cli.ExitCodes;
@@ -84,12 +83,11 @@ public class RemoveCustomsCommand extends OpenSearchNodeCommand {
         terminal.println(Terminal.Verbosity.VERBOSE, "Loading cluster state");
         final Tuple<Long, ClusterState> termAndClusterState = loadTermAndClusterState(persistedClusterStateService, env);
         final ClusterState oldClusterState = termAndClusterState.v2();
-        terminal.println(Terminal.Verbosity.VERBOSE, "custom metadata names: " + oldClusterState.metadata().customs().keys());
+        terminal.println(Terminal.Verbosity.VERBOSE, "custom metadata names: " + oldClusterState.metadata().customs().keySet());
         final Metadata.Builder metadataBuilder = Metadata.builder(oldClusterState.metadata());
         for (String customToRemove : customsToRemove) {
             boolean matched = false;
-            for (ObjectCursor<String> customKeyCur : oldClusterState.metadata().customs().keys()) {
-                final String customKey = customKeyCur.value;
+            for (final String customKey : oldClusterState.metadata().customs().keySet()) {
                 if (Regex.simpleMatch(customToRemove, customKey)) {
                     metadataBuilder.removeCustom(customKey);
                     if (matched == false) {

--- a/server/src/main/java/org/opensearch/cluster/coordination/UnsafeBootstrapClusterManagerCommand.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/UnsafeBootstrapClusterManagerCommand.java
@@ -31,7 +31,6 @@
 
 package org.opensearch.cluster.coordination;
 
-import com.carrotsearch.hppc.cursors.ObjectCursor;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
 import org.opensearch.OpenSearchException;
@@ -151,8 +150,7 @@ public class UnsafeBootstrapClusterManagerCommand extends OpenSearchNodeCommand 
             .clusterUUIDCommitted(true)
             .persistentSettings(persistentSettings)
             .coordinationMetadata(newCoordinationMetadata);
-        for (ObjectCursor<IndexMetadata> idx : metadata.indices().values()) {
-            IndexMetadata indexMetadata = idx.value;
+        for (final IndexMetadata indexMetadata : metadata.indices().values()) {
             newMetadata.put(
                 IndexMetadata.builder(indexMetadata)
                     .settings(

--- a/server/src/main/java/org/opensearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/Metadata.java
@@ -32,10 +32,9 @@
 
 package org.opensearch.cluster.metadata;
 
-import com.carrotsearch.hppc.ObjectHashSet;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
-import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 
+import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.util.CollectionUtil;
@@ -54,7 +53,6 @@ import org.opensearch.cluster.decommission.DecommissionAttributeMetadata;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.Strings;
 import org.opensearch.common.UUIDs;
-import org.opensearch.common.collect.HppcMaps;
 import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -89,6 +87,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.Spliterators;
 import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -243,9 +242,9 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
     private final Settings persistentSettings;
     private final Settings settings;
     private final DiffableStringMap hashesOfConsistentSettings;
-    private final ImmutableOpenMap<String, IndexMetadata> indices;
-    private final ImmutableOpenMap<String, IndexTemplateMetadata> templates;
-    private final ImmutableOpenMap<String, Custom> customs;
+    private final Map<String, IndexMetadata> indices;
+    private final Map<String, IndexTemplateMetadata> templates;
+    private final Map<String, Custom> customs;
 
     private final transient int totalNumberOfShards; // Transient ? not serializable anyway?
     private final int totalOpenIndexShards;
@@ -267,9 +266,9 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         Settings transientSettings,
         Settings persistentSettings,
         DiffableStringMap hashesOfConsistentSettings,
-        ImmutableOpenMap<String, IndexMetadata> indices,
-        ImmutableOpenMap<String, IndexTemplateMetadata> templates,
-        ImmutableOpenMap<String, Custom> customs,
+        final Map<String, IndexMetadata> indices,
+        final Map<String, IndexTemplateMetadata> templates,
+        final Map<String, Custom> customs,
         String[] allIndices,
         String[] visibleIndices,
         String[] allOpenIndices,
@@ -286,15 +285,15 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         this.persistentSettings = persistentSettings;
         this.settings = Settings.builder().put(persistentSettings).put(transientSettings).build();
         this.hashesOfConsistentSettings = hashesOfConsistentSettings;
-        this.indices = indices;
-        this.customs = customs;
-        this.templates = templates;
+        this.indices = Collections.unmodifiableMap(indices);
+        this.customs = Collections.unmodifiableMap(customs);
+        this.templates = Collections.unmodifiableMap(templates);
         int totalNumberOfShards = 0;
         int totalOpenIndexShards = 0;
-        for (ObjectCursor<IndexMetadata> cursor : indices.values()) {
-            totalNumberOfShards += cursor.value.getTotalNumberOfShards();
-            if (IndexMetadata.State.OPEN.equals(cursor.value.getState())) {
-                totalOpenIndexShards += cursor.value.getTotalNumberOfShards();
+        for (IndexMetadata cursor : indices.values()) {
+            totalNumberOfShards += cursor.getTotalNumberOfShards();
+            if (IndexMetadata.State.OPEN.equals(cursor.getState())) {
+                totalOpenIndexShards += cursor.getTotalNumberOfShards();
             }
         }
         this.totalNumberOfShards = totalNumberOfShards;
@@ -358,8 +357,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
     }
 
     public boolean equalsAliases(Metadata other) {
-        for (ObjectCursor<IndexMetadata> cursor : other.indices().values()) {
-            IndexMetadata otherIndex = cursor.value;
+        for (IndexMetadata otherIndex : other.indices().values()) {
             IndexMetadata thisIndex = index(otherIndex.getIndex());
             if (thisIndex == null) {
                 return false;
@@ -468,21 +466,19 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
      * @see MapperPlugin#getFieldFilter()
      *
      */
-    public ImmutableOpenMap<String, MappingMetadata> findMappings(String[] concreteIndices, Function<String, Predicate<String>> fieldFilter)
+    public Map<String, MappingMetadata> findMappings(String[] concreteIndices, Function<String, Predicate<String>> fieldFilter)
         throws IOException {
         assert concreteIndices != null;
         if (concreteIndices.length == 0) {
-            return ImmutableOpenMap.of();
+            return Map.of();
         }
 
-        ImmutableOpenMap.Builder<String, MappingMetadata> indexMapBuilder = ImmutableOpenMap.builder();
-        Iterable<String> intersection = HppcMaps.intersection(ObjectHashSet.from(concreteIndices), indices.keys());
-        for (String index : intersection) {
-            IndexMetadata indexMetadata = indices.get(index);
-            Predicate<String> fieldPredicate = fieldFilter.apply(index);
-            indexMapBuilder.put(index, filterFields(indexMetadata.mapping(), fieldPredicate));
-        }
-        return indexMapBuilder.build();
+        final Map<String, MappingMetadata> indexMapBuilder = new HashMap<>();
+        Arrays.stream(concreteIndices)
+            .filter(indices.keySet()::contains)
+            .forEach((idx) -> indexMapBuilder.put(idx, filterFields(indices.get(idx).mapping(), fieldFilter.apply(idx))));
+
+        return Collections.unmodifiableMap(indexMapBuilder);
     }
 
     /**
@@ -785,20 +781,20 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         throw new IndexNotFoundException(index);
     }
 
-    public ImmutableOpenMap<String, IndexMetadata> indices() {
+    public Map<String, IndexMetadata> indices() {
         return this.indices;
     }
 
-    public ImmutableOpenMap<String, IndexMetadata> getIndices() {
+    public Map<String, IndexMetadata> getIndices() {
         return indices();
     }
 
-    public ImmutableOpenMap<String, IndexTemplateMetadata> templates() {
+    public Map<String, IndexTemplateMetadata> templates() {
         return this.templates;
     }
 
-    public ImmutableOpenMap<String, IndexTemplateMetadata> getTemplates() {
-        return this.templates;
+    public Map<String, IndexTemplateMetadata> getTemplates() {
+        return templates();
     }
 
     public Map<String, ComponentTemplate> componentTemplates() {
@@ -823,12 +819,12 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         return custom(DecommissionAttributeMetadata.TYPE);
     }
 
-    public ImmutableOpenMap<String, Custom> customs() {
+    public Map<String, Custom> customs() {
         return this.customs;
     }
 
-    public ImmutableOpenMap<String, Custom> getCustoms() {
-        return this.customs;
+    public Map<String, Custom> getCustoms() {
+        return this.customs();
     }
 
     /**
@@ -907,7 +903,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
 
     @Override
     public Iterator<IndexMetadata> iterator() {
-        return indices.valuesIt();
+        return indices.values().iterator();
     }
 
     public static boolean isGlobalStateEquals(Metadata metadata1, Metadata metadata2) {
@@ -931,15 +927,15 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         }
         // Check if any persistent metadata needs to be saved
         int customCount1 = 0;
-        for (ObjectObjectCursor<String, Custom> cursor : metadata1.customs) {
-            if (cursor.value.context().contains(XContentContext.GATEWAY)) {
-                if (!cursor.value.equals(metadata2.custom(cursor.key))) return false;
+        for (Map.Entry<String, Custom> cursor : metadata1.customs.entrySet()) {
+            if (cursor.getValue().context().contains(XContentContext.GATEWAY)) {
+                if (!cursor.getValue().equals(metadata2.custom(cursor.getKey()))) return false;
                 customCount1++;
             }
         }
         int customCount2 = 0;
-        for (ObjectCursor<Custom> cursor : metadata2.customs.values()) {
-            if (cursor.value.context().contains(XContentContext.GATEWAY)) {
+        for (final Custom cursor : metadata2.customs.values()) {
+            if (cursor.context().contains(XContentContext.GATEWAY)) {
                 customCount2++;
             }
         }
@@ -980,9 +976,9 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         private final Settings transientSettings;
         private final Settings persistentSettings;
         private final Diff<DiffableStringMap> hashesOfConsistentSettings;
-        private final Diff<ImmutableOpenMap<String, IndexMetadata>> indices;
-        private final Diff<ImmutableOpenMap<String, IndexTemplateMetadata>> templates;
-        private final Diff<ImmutableOpenMap<String, Custom>> customs;
+        private final Diff<Map<String, IndexMetadata>> indices;
+        private final Diff<Map<String, IndexTemplateMetadata>> templates;
+        private final Diff<Map<String, Custom>> customs;
 
         MetadataDiff(Metadata before, Metadata after) {
             clusterUUID = after.clusterUUID;
@@ -1010,9 +1006,9 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             transientSettings = Settings.readSettingsFromStream(in);
             persistentSettings = Settings.readSettingsFromStream(in);
             hashesOfConsistentSettings = DiffableStringMap.readDiffFrom(in);
-            indices = DiffableUtils.readImmutableOpenMapDiff(in, DiffableUtils.getStringKeySerializer(), INDEX_METADATA_DIFF_VALUE_READER);
-            templates = DiffableUtils.readImmutableOpenMapDiff(in, DiffableUtils.getStringKeySerializer(), TEMPLATES_DIFF_VALUE_READER);
-            customs = DiffableUtils.readImmutableOpenMapDiff(in, DiffableUtils.getStringKeySerializer(), CUSTOM_VALUE_SERIALIZER);
+            indices = DiffableUtils.readJdkMapDiff(in, DiffableUtils.getStringKeySerializer(), INDEX_METADATA_DIFF_VALUE_READER);
+            templates = DiffableUtils.readJdkMapDiff(in, DiffableUtils.getStringKeySerializer(), TEMPLATES_DIFF_VALUE_READER);
+            customs = DiffableUtils.readJdkMapDiff(in, DiffableUtils.getStringKeySerializer(), CUSTOM_VALUE_SERIALIZER);
         }
 
         @Override
@@ -1085,20 +1081,20 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             indexMetadata.writeTo(out);
         }
         out.writeVInt(templates.size());
-        for (ObjectCursor<IndexTemplateMetadata> cursor : templates.values()) {
-            cursor.value.writeTo(out);
+        for (final IndexTemplateMetadata cursor : templates.values()) {
+            cursor.writeTo(out);
         }
         // filter out custom states not supported by the other node
         int numberOfCustoms = 0;
-        for (final ObjectCursor<Custom> cursor : customs.values()) {
-            if (FeatureAware.shouldSerialize(out, cursor.value)) {
+        for (final Custom cursor : customs.values()) {
+            if (FeatureAware.shouldSerialize(out, cursor)) {
                 numberOfCustoms++;
             }
         }
         out.writeVInt(numberOfCustoms);
-        for (final ObjectCursor<Custom> cursor : customs.values()) {
-            if (FeatureAware.shouldSerialize(out, cursor.value)) {
-                out.writeNamedWriteable(cursor.value);
+        for (final Custom cursor : customs.values()) {
+            if (FeatureAware.shouldSerialize(out, cursor)) {
+                out.writeNamedWriteable(cursor);
             }
         }
     }
@@ -1127,15 +1123,15 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         private Settings persistentSettings = Settings.Builder.EMPTY_SETTINGS;
         private DiffableStringMap hashesOfConsistentSettings = new DiffableStringMap(Collections.emptyMap());
 
-        private final ImmutableOpenMap.Builder<String, IndexMetadata> indices;
-        private final ImmutableOpenMap.Builder<String, IndexTemplateMetadata> templates;
-        private final ImmutableOpenMap.Builder<String, Custom> customs;
+        private final Map<String, IndexMetadata> indices;
+        private final Map<String, IndexTemplateMetadata> templates;
+        private final Map<String, Custom> customs;
 
         public Builder() {
             clusterUUID = UNKNOWN_CLUSTER_UUID;
-            indices = ImmutableOpenMap.builder();
-            templates = ImmutableOpenMap.builder();
-            customs = ImmutableOpenMap.builder();
+            indices = new HashMap<>();
+            templates = new HashMap<>();
+            customs = new HashMap<>();
             indexGraveyard(IndexGraveyard.builder().build()); // create new empty index graveyard to initialize
         }
 
@@ -1147,9 +1143,9 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             this.persistentSettings = metadata.persistentSettings;
             this.hashesOfConsistentSettings = metadata.hashesOfConsistentSettings;
             this.version = metadata.version;
-            this.indices = ImmutableOpenMap.builder(metadata.indices);
-            this.templates = ImmutableOpenMap.builder(metadata.templates);
-            this.customs = ImmutableOpenMap.builder(metadata.customs);
+            this.indices = new HashMap<>(metadata.indices);
+            this.templates = new HashMap<>(metadata.templates);
+            this.customs = new HashMap<>(metadata.customs);
         }
 
         public Builder put(IndexMetadata.Builder indexMetadataBuilder) {
@@ -1202,7 +1198,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             return this;
         }
 
-        public Builder indices(ImmutableOpenMap<String, IndexMetadata> indices) {
+        public Builder indices(final Map<String, IndexMetadata> indices) {
             this.indices.putAll(indices);
             return this;
         }
@@ -1221,7 +1217,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             return this;
         }
 
-        public Builder templates(ImmutableOpenMap<String, IndexTemplateMetadata> templates) {
+        public Builder templates(Map<String, IndexTemplateMetadata> templates) {
             this.templates.putAll(templates);
             return this;
         }
@@ -1320,8 +1316,9 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             return this;
         }
 
-        public Builder customs(ImmutableOpenMap<String, Custom> customs) {
-            StreamSupport.stream(customs.spliterator(), false).forEach(cursor -> Objects.requireNonNull(cursor.value, cursor.key));
+        public Builder customs(Map<String, Custom> customs) {
+            StreamSupport.stream(Spliterators.spliterator(customs.entrySet(), 0), false)
+                .forEach(cursor -> Objects.requireNonNull(cursor.getValue(), cursor.getKey()));
             this.customs.putAll(customs);
             return this;
         }
@@ -1347,7 +1344,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
 
         public Builder updateSettings(Settings settings, String... indices) {
             if (indices == null || indices.length == 0) {
-                indices = this.indices.keys().toArray(String.class);
+                indices = this.indices.keySet().toArray(new String[0]);
             }
             for (String index : indices) {
                 IndexMetadata indexMetadata = this.indices.get(index);
@@ -1449,8 +1446,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             final List<String> allClosedIndices = new ArrayList<>();
             final List<String> visibleClosedIndices = new ArrayList<>();
             final Set<String> allAliases = new HashSet<>();
-            for (ObjectCursor<IndexMetadata> cursor : indices.values()) {
-                final IndexMetadata indexMetadata = cursor.value;
+            for (final IndexMetadata indexMetadata : indices.values()) {
                 final String name = indexMetadata.getIndex().getName();
                 boolean added = allIndices.add(name);
                 assert added : "double index named [" + name + "]";
@@ -1485,10 +1481,10 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             ArrayList<String> duplicates = new ArrayList<>();
             if (aliasDuplicatesWithIndices.isEmpty() == false) {
                 // iterate again and constructs a helpful message
-                for (ObjectCursor<IndexMetadata> cursor : indices.values()) {
+                for (final IndexMetadata cursor : indices.values()) {
                     for (String alias : aliasDuplicatesWithIndices) {
-                        if (cursor.value.getAliases().containsKey(alias)) {
-                            duplicates.add(alias + " (alias of " + cursor.value.getIndex() + ") conflicts with index");
+                        if (cursor.getAliases().containsKey(alias)) {
+                            duplicates.add(alias + " (alias of " + cursor.getIndex() + ") conflicts with index");
                         }
                     }
                 }
@@ -1498,10 +1494,10 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             aliasDuplicatesWithDataStreams.retainAll(allDataStreams);
             if (aliasDuplicatesWithDataStreams.isEmpty() == false) {
                 // iterate again and constructs a helpful message
-                for (ObjectCursor<IndexMetadata> cursor : indices.values()) {
+                for (final IndexMetadata cursor : indices.values()) {
                     for (String alias : aliasDuplicatesWithDataStreams) {
-                        if (cursor.value.getAliases().containsKey(alias)) {
-                            duplicates.add(alias + " (alias of " + cursor.value.getIndex() + ") conflicts with data stream");
+                        if (cursor.getAliases().containsKey(alias)) {
+                            duplicates.add(alias + " (alias of " + cursor.getIndex() + ") conflicts with data stream");
                         }
                     }
                 }
@@ -1547,9 +1543,9 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                 transientSettings,
                 persistentSettings,
                 hashesOfConsistentSettings,
-                indices.build(),
-                templates.build(),
-                customs.build(),
+                indices,
+                templates,
+                customs,
                 allIndicesArray,
                 visibleIndicesArray,
                 allOpenIndicesArray,
@@ -1586,9 +1582,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                 }
             }
 
-            for (ObjectCursor<IndexMetadata> cursor : indices.values()) {
-                IndexMetadata indexMetadata = cursor.value;
-
+            for (final IndexMetadata indexMetadata : indices.values()) {
                 IndexAbstraction.Index index;
                 DataStream parent = indexToDataStreamLookup.get(indexMetadata.getIndex().getName());
                 if (parent != null) {
@@ -1601,7 +1595,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                 IndexAbstraction existing = indicesLookup.put(indexMetadata.getIndex().getName(), index);
                 assert existing == null : "duplicate for " + indexMetadata.getIndex();
 
-                for (ObjectObjectCursor<String, AliasMetadata> aliasCursor : indexMetadata.getAliases()) {
+                for (final ObjectObjectCursor<String, AliasMetadata> aliasCursor : indexMetadata.getAliases()) {
                     AliasMetadata aliasMetadata = aliasCursor.value;
                     indicesLookup.compute(aliasMetadata.getAlias(), (aliasName, alias) -> {
                         if (alias == null) {
@@ -1685,8 +1679,8 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             }
 
             builder.startObject("templates");
-            for (ObjectCursor<IndexTemplateMetadata> cursor : metadata.templates().values()) {
-                IndexTemplateMetadata.Builder.toXContentWithTypes(cursor.value, builder, params);
+            for (final IndexTemplateMetadata cursor : metadata.templates().values()) {
+                IndexTemplateMetadata.Builder.toXContentWithTypes(cursor, builder, params);
             }
             builder.endObject();
 
@@ -1698,10 +1692,10 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                 builder.endObject();
             }
 
-            for (ObjectObjectCursor<String, Custom> cursor : metadata.customs()) {
-                if (cursor.value.context().contains(context)) {
-                    builder.startObject(cursor.key);
-                    cursor.value.toXContent(builder, params);
+            for (final Map.Entry<String, Custom> cursor : metadata.customs().entrySet()) {
+                if (cursor.getValue().context().contains(context)) {
+                    builder.startObject(cursor.getKey());
+                    cursor.getValue().toXContent(builder, params);
                     builder.endObject();
                 }
             }

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -31,7 +31,6 @@
 
 package org.opensearch.cluster.metadata;
 
-import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -170,8 +169,7 @@ public class MetadataIndexTemplateService {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 Set<String> templateNames = new HashSet<>();
-                for (ObjectCursor<String> cursor : currentState.metadata().templates().keys()) {
-                    String templateName = cursor.value;
+                for (final String templateName : currentState.metadata().templates().keySet()) {
                     if (Regex.simpleMatch(request.name, templateName)) {
                         templateNames.add(templateName);
                     }
@@ -713,9 +711,9 @@ public class MetadataIndexTemplateService {
     ) {
         Automaton v2automaton = Regex.simpleMatchToAutomaton(indexPatterns.toArray(Strings.EMPTY_ARRAY));
         Map<String, List<String>> overlappingTemplates = new HashMap<>();
-        for (ObjectObjectCursor<String, IndexTemplateMetadata> cursor : state.metadata().templates()) {
-            String name = cursor.key;
-            IndexTemplateMetadata template = cursor.value;
+        for (final Map.Entry<String, IndexTemplateMetadata> cursor : state.metadata().templates().entrySet()) {
+            String name = cursor.getKey();
+            IndexTemplateMetadata template = cursor.getValue();
             Automaton v1automaton = Regex.simpleMatchToAutomaton(template.patterns().toArray(Strings.EMPTY_ARRAY));
             if (Operations.isEmpty(Operations.intersection(v2automaton, v1automaton)) == false) {
                 logger.debug(
@@ -1014,8 +1012,7 @@ public class MetadataIndexTemplateService {
     public static List<IndexTemplateMetadata> findV1Templates(Metadata metadata, String indexName, @Nullable Boolean isHidden) {
         final Predicate<String> patternMatchPredicate = pattern -> Regex.simpleMatch(pattern, indexName);
         final List<IndexTemplateMetadata> matchedTemplates = new ArrayList<>();
-        for (ObjectCursor<IndexTemplateMetadata> cursor : metadata.templates().values()) {
-            final IndexTemplateMetadata template = cursor.value;
+        for (final IndexTemplateMetadata template : metadata.templates().values()) {
             if (isHidden == null || isHidden == Boolean.FALSE) {
                 final boolean matched = template.patterns().stream().anyMatch(patternMatchPredicate);
                 if (matched) {
@@ -1238,7 +1235,7 @@ public class MetadataIndexTemplateService {
         templates.forEach(template -> {
             if (template.aliases() != null) {
                 Map<String, AliasMetadata> aliasMeta = new HashMap<>();
-                for (ObjectObjectCursor<String, AliasMetadata> cursor : template.aliases()) {
+                for (final ObjectObjectCursor<String, AliasMetadata> cursor : template.aliases()) {
                     aliasMeta.put(cursor.key, cursor.value);
                 }
                 resolvedAliases.add(aliasMeta);

--- a/server/src/main/java/org/opensearch/cluster/metadata/TemplateUpgradeService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/TemplateUpgradeService.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.cluster.metadata;
 
-import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
@@ -48,7 +47,6 @@ import org.opensearch.cluster.ClusterStateListener;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.bytes.BytesReference;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.xcontent.ToXContent;
@@ -91,7 +89,7 @@ public class TemplateUpgradeService implements ClusterStateListener {
 
     final AtomicInteger upgradesInProgress = new AtomicInteger();
 
-    private ImmutableOpenMap<String, IndexTemplateMetadata> lastTemplateMetadata;
+    private Map<String, IndexTemplateMetadata> lastTemplateMetadata;
 
     public TemplateUpgradeService(
         Client client,
@@ -131,7 +129,7 @@ public class TemplateUpgradeService implements ClusterStateListener {
             return;
         }
 
-        ImmutableOpenMap<String, IndexTemplateMetadata> templates = state.getMetadata().getTemplates();
+        final Map<String, IndexTemplateMetadata> templates = state.getMetadata().getTemplates();
 
         if (templates == lastTemplateMetadata) {
             // we already checked these sets of templates - no reason to check it again
@@ -225,9 +223,7 @@ public class TemplateUpgradeService implements ClusterStateListener {
                 // Check upgraders are satisfied after the update completed. If they still
                 // report that changes are required, this might indicate a bug or that something
                 // else tinkering with the templates during the upgrade.
-                final ImmutableOpenMap<String, IndexTemplateMetadata> upgradedTemplates = clusterService.state()
-                    .getMetadata()
-                    .getTemplates();
+                final Map<String, IndexTemplateMetadata> upgradedTemplates = clusterService.state().getMetadata().getTemplates();
                 final boolean changesRequired = calculateTemplateChanges(upgradedTemplates).isPresent();
                 if (changesRequired) {
                     logger.warn("Templates are still reported as out of date after the upgrade. The template upgrade will be retried.");
@@ -239,13 +235,11 @@ public class TemplateUpgradeService implements ClusterStateListener {
         }
     }
 
-    Optional<Tuple<Map<String, BytesReference>, Set<String>>> calculateTemplateChanges(
-        ImmutableOpenMap<String, IndexTemplateMetadata> templates
-    ) {
+    Optional<Tuple<Map<String, BytesReference>, Set<String>>> calculateTemplateChanges(final Map<String, IndexTemplateMetadata> templates) {
         // collect current templates
         Map<String, IndexTemplateMetadata> existingMap = new HashMap<>();
-        for (ObjectObjectCursor<String, IndexTemplateMetadata> customCursor : templates) {
-            existingMap.put(customCursor.key, customCursor.value);
+        for (Map.Entry<String, IndexTemplateMetadata> customCursor : templates.entrySet()) {
+            existingMap.put(customCursor.getKey(), customCursor.getValue());
         }
         // upgrade global custom meta data
         Map<String, IndexTemplateMetadata> upgradedMap = indexTemplateMetadataUpgraders.apply(existingMap);

--- a/server/src/main/java/org/opensearch/env/NodeRepurposeCommand.java
+++ b/server/src/main/java/org/opensearch/env/NodeRepurposeCommand.java
@@ -31,7 +31,6 @@
 
 package org.opensearch.env;
 
-import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import org.opensearch.OpenSearchException;
@@ -158,7 +157,7 @@ public class NodeRepurposeCommand extends OpenSearchNodeCommand {
             Sets.union(
                 indexUUIDsFor(indexPaths),
                 StreamSupport.stream(metadata.indices().values().spliterator(), false)
-                    .map(imd -> imd.value.getIndexUUID())
+                    .map(imd -> imd.getIndexUUID())
                     .collect(Collectors.toSet())
             )
         );
@@ -302,9 +301,9 @@ public class NodeRepurposeCommand extends OpenSearchNodeCommand {
 
     private String toIndexName(String uuid, Metadata metadata) {
         if (metadata != null) {
-            for (ObjectObjectCursor<String, IndexMetadata> indexMetadata : metadata.indices()) {
-                if (indexMetadata.value.getIndexUUID().equals(uuid)) {
-                    return indexMetadata.value.getIndex().getName();
+            for (final IndexMetadata indexMetadata : metadata.indices().values()) {
+                if (indexMetadata.getIndexUUID().equals(uuid)) {
+                    return indexMetadata.getIndex().getName();
                 }
             }
         }

--- a/server/src/main/java/org/opensearch/gateway/ClusterStateUpdaters.java
+++ b/server/src/main/java/org/opensearch/gateway/ClusterStateUpdaters.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.gateway;
 
-import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
@@ -120,8 +119,8 @@ public class ClusterStateUpdaters {
     static ClusterState updateRoutingTable(final ClusterState state) {
         // initialize all index routing tables as empty
         final RoutingTable.Builder routingTableBuilder = RoutingTable.builder(state.routingTable());
-        for (final ObjectCursor<IndexMetadata> cursor : state.metadata().indices().values()) {
-            routingTableBuilder.addAsRecovery(cursor.value);
+        for (final IndexMetadata cursor : state.metadata().indices().values()) {
+            routingTableBuilder.addAsRecovery(cursor);
         }
         // start with 0 based versions for routing table
         routingTableBuilder.version(0);

--- a/server/src/main/java/org/opensearch/gateway/DanglingIndicesState.java
+++ b/server/src/main/java/org/opensearch/gateway/DanglingIndicesState.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.gateway;
 
-import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionListener;
@@ -191,8 +190,8 @@ public class DanglingIndicesState implements ClusterStateListener {
      */
     public Map<Index, IndexMetadata> findNewDanglingIndices(Map<Index, IndexMetadata> existingDanglingIndices, final Metadata metadata) {
         final Set<String> excludeIndexPathIds = new HashSet<>(metadata.indices().size() + danglingIndices.size());
-        for (ObjectCursor<IndexMetadata> cursor : metadata.indices().values()) {
-            excludeIndexPathIds.add(cursor.value.getIndex().getUUID());
+        for (final IndexMetadata indexMetadata : metadata.indices().values()) {
+            excludeIndexPathIds.add(indexMetadata.getIndex().getUUID());
         }
         for (Index index : existingDanglingIndices.keySet()) {
             excludeIndexPathIds.add(index.getUUID());

--- a/server/src/main/java/org/opensearch/gateway/Gateway.java
+++ b/server/src/main/java/org/opensearch/gateway/Gateway.java
@@ -33,7 +33,6 @@
 package org.opensearch.gateway;
 
 import com.carrotsearch.hppc.ObjectFloatHashMap;
-import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.FailedNodeException;
@@ -95,8 +94,8 @@ public class Gateway {
             } else if (nodeState.metadata().version() > electedGlobalState.version()) {
                 electedGlobalState = nodeState.metadata();
             }
-            for (final ObjectCursor<IndexMetadata> cursor : nodeState.metadata().indices().values()) {
-                indices.addTo(cursor.value.getIndex(), 1);
+            for (final IndexMetadata cursor : nodeState.metadata().indices().values()) {
+                indices.addTo(cursor.getIndex(), 1);
             }
         }
         if (found < requiredAllocation) {

--- a/server/src/main/java/org/opensearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/opensearch/gateway/GatewayMetaState.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.gateway;
 
-import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.store.AlreadyClosedException;
@@ -54,7 +53,6 @@ import org.opensearch.cluster.metadata.MetadataIndexUpgradeService;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.SetOnce;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.AbstractRunnable;
@@ -270,15 +268,15 @@ public class GatewayMetaState implements Closeable {
     }
 
     private static boolean applyPluginUpgraders(
-        ImmutableOpenMap<String, IndexTemplateMetadata> existingData,
+        final Map<String, IndexTemplateMetadata> existingData,
         UnaryOperator<Map<String, IndexTemplateMetadata>> upgrader,
         Consumer<String> removeData,
         BiConsumer<String, IndexTemplateMetadata> putData
     ) {
         // collect current data
         Map<String, IndexTemplateMetadata> existingMap = new HashMap<>();
-        for (ObjectObjectCursor<String, IndexTemplateMetadata> customCursor : existingData) {
-            existingMap.put(customCursor.key, customCursor.value);
+        for (Map.Entry<String, IndexTemplateMetadata> customCursor : existingData.entrySet()) {
+            existingMap.put(customCursor.getKey(), customCursor.getValue());
         }
         // upgrade global custom meta data
         Map<String, IndexTemplateMetadata> upgradedCustoms = upgrader.apply(existingMap);

--- a/server/src/main/java/org/opensearch/gateway/PersistedClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/PersistedClusterStateService.java
@@ -31,7 +31,6 @@
 
 package org.opensearch.gateway;
 
-import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
@@ -745,8 +744,7 @@ public class PersistedClusterStateService {
                 }
 
                 final Map<String, Long> indexMetadataVersionByUUID = new HashMap<>(previouslyWrittenMetadata.indices().size());
-                for (ObjectCursor<IndexMetadata> cursor : previouslyWrittenMetadata.indices().values()) {
-                    final IndexMetadata indexMetadata = cursor.value;
+                for (final IndexMetadata indexMetadata : previouslyWrittenMetadata.indices().values()) {
                     final Long previousValue = indexMetadataVersionByUUID.putIfAbsent(
                         indexMetadata.getIndexUUID(),
                         indexMetadata.getVersion()
@@ -756,8 +754,7 @@ public class PersistedClusterStateService {
 
                 int numIndicesUpdated = 0;
                 int numIndicesUnchanged = 0;
-                for (ObjectCursor<IndexMetadata> cursor : metadata.indices().values()) {
-                    final IndexMetadata indexMetadata = cursor.value;
+                for (final IndexMetadata indexMetadata : metadata.indices().values()) {
                     final Long previousVersion = indexMetadataVersionByUUID.get(indexMetadata.getIndexUUID());
                     if (previousVersion == null || indexMetadata.getVersion() != previousVersion) {
                         logger.trace(
@@ -817,8 +814,7 @@ public class PersistedClusterStateService {
                     metadataIndexWriter.updateGlobalMetadata(globalMetadataDocument);
                 }
 
-                for (ObjectCursor<IndexMetadata> cursor : metadata.indices().values()) {
-                    final IndexMetadata indexMetadata = cursor.value;
+                for (final IndexMetadata indexMetadata : metadata.indices().values()) {
                     final Document indexMetadataDocument = makeIndexMetadataDocument(indexMetadata, documentBuffer);
                     for (MetadataIndexWriter metadataIndexWriter : metadataIndexWriters) {
                         metadataIndexWriter.updateIndexMetadataDocument(indexMetadataDocument, indexMetadata.getIndex());

--- a/server/src/main/java/org/opensearch/index/shard/RemoveCorruptedShardDataCommand.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoveCorruptedShardDataCommand.java
@@ -144,8 +144,6 @@ public class RemoveCorruptedShardDataCommand extends OpenSearchNodeCommand {
 
         final IndexMetadata indexMetadata;
         final int shardId;
-        final int fromNodeId;
-        final int toNodeId;
 
         if (options.has(folderOption)) {
             final Path path = getPath(folderOption.value(options)).getParent();
@@ -166,10 +164,7 @@ public class RemoveCorruptedShardDataCommand extends OpenSearchNodeCommand {
                 && NodeEnvironment.NODES_FOLDER.equals(shardParentParent.getParent().getParent().getFileName().toString()) // `nodes` check
             ) {
                 shardId = Integer.parseInt(shardIdFileName);
-                fromNodeId = Integer.parseInt(nodeIdFileName);
-                toNodeId = fromNodeId + 1;
                 indexMetadata = StreamSupport.stream(clusterState.metadata().indices().values().spliterator(), false)
-                    .map(imd -> imd.value)
                     .filter(imd -> imd.getIndexUUID().equals(indexUUIDFolderName))
                     .findFirst()
                     .orElse(null);
@@ -249,11 +244,9 @@ public class RemoveCorruptedShardDataCommand extends OpenSearchNodeCommand {
             );
         }
         String[] files = directory.listAll();
-        boolean found = false;
         for (String file : files) {
             if (file.startsWith(Store.CORRUPTED_MARKER_NAME_PREFIX)) {
                 directory.deleteFile(file);
-
                 terminal.println("Deleted corrupt marker " + file + " from " + path);
             }
         }

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestTemplatesAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestTemplatesAction.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.rest.action.cat;
 
-import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.opensearch.action.admin.cluster.state.ClusterStateRequest;
 import org.opensearch.action.admin.cluster.state.ClusterStateResponse;
 import org.opensearch.client.node.NodeClient;
@@ -112,8 +111,7 @@ public class RestTemplatesAction extends AbstractCatAction {
     private Table buildTable(RestRequest request, ClusterStateResponse clusterStateResponse, String patternString) {
         Table table = getTableWithHeader(request);
         Metadata metadata = clusterStateResponse.getState().metadata();
-        for (ObjectObjectCursor<String, IndexTemplateMetadata> entry : metadata.templates()) {
-            IndexTemplateMetadata indexData = entry.value;
+        for (final IndexTemplateMetadata indexData : metadata.templates().values()) {
             if (patternString == null || Regex.simpleMatch(patternString, indexData.name())) {
                 table.startRow();
                 table.addCell(indexData.name());

--- a/server/src/main/java/org/opensearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/opensearch/snapshots/RestoreService.java
@@ -630,18 +630,18 @@ public class RestoreService implements ClusterStateApplier {
                             }
                             if (metadata.templates() != null) {
                                 // TODO: Should all existing templates be deleted first?
-                                for (ObjectCursor<IndexTemplateMetadata> cursor : metadata.templates().values()) {
-                                    mdBuilder.put(cursor.value);
+                                for (final IndexTemplateMetadata cursor : metadata.templates().values()) {
+                                    mdBuilder.put(cursor);
                                 }
                             }
                             if (metadata.customs() != null) {
-                                for (ObjectObjectCursor<String, Metadata.Custom> cursor : metadata.customs()) {
-                                    if (RepositoriesMetadata.TYPE.equals(cursor.key) == false
-                                        && DataStreamMetadata.TYPE.equals(cursor.key) == false) {
+                                for (final Map.Entry<String, Metadata.Custom> cursor : metadata.customs().entrySet()) {
+                                    if (RepositoriesMetadata.TYPE.equals(cursor.getKey()) == false
+                                        && DataStreamMetadata.TYPE.equals(cursor.getKey()) == false) {
                                         // Don't restore repositories while we are working with them
                                         // TODO: Should we restore them at the end?
                                         // Also, don't restore data streams here, we already added them to the metadata builder above
-                                        mdBuilder.putCustom(cursor.key, cursor.value);
+                                        mdBuilder.putCustom(cursor.getKey(), cursor.getValue());
                                     }
                                 }
                             }

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotUtils.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotUtils.java
@@ -31,11 +31,9 @@
 
 package org.opensearch.snapshots;
 
-import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.regex.Regex;
 import org.opensearch.index.IndexModule;
 import org.opensearch.index.IndexNotFoundException;
@@ -162,7 +160,7 @@ public class SnapshotUtils {
      * @param repoName repo name for which the verification is being done
      */
     public static void validateSnapshotsBackingAnyIndex(
-        ImmutableOpenMap<String, IndexMetadata> metadata,
+        final Map<String, IndexMetadata> metadata,
         List<SnapshotId> snapshotIds,
         String repoName
     ) {
@@ -170,8 +168,7 @@ public class SnapshotUtils {
         final Set<String> snapshotsToBeNotDeleted = new HashSet<>();
         snapshotIds.forEach(snapshotId -> uuidToSnapshotId.put(snapshotId.getUUID(), snapshotId));
 
-        for (ObjectCursor<IndexMetadata> cursor : metadata.values()) {
-            IndexMetadata indexMetadata = cursor.value;
+        for (final IndexMetadata indexMetadata : metadata.values()) {
             String storeType = indexMetadata.getSettings().get(IndexModule.INDEX_STORE_TYPE_SETTING.getKey());
             if (IndexModule.Type.REMOTE_SNAPSHOT.match(storeType)) {
                 String snapshotId = indexMetadata.getSettings().get(IndexSettings.SEARCHABLE_SNAPSHOT_ID_UUID.getKey());

--- a/server/src/test/java/org/opensearch/action/admin/cluster/reroute/ClusterRerouteResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/reroute/ClusterRerouteResponseTests.java
@@ -44,7 +44,6 @@ import org.opensearch.cluster.routing.allocation.RoutingExplanations;
 import org.opensearch.cluster.routing.allocation.command.AllocateReplicaAllocationCommand;
 import org.opensearch.cluster.routing.allocation.decider.Decision;
 import org.opensearch.common.Strings;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.transport.TransportAddress;
 import org.opensearch.core.xcontent.ToXContent;
@@ -73,9 +72,9 @@ public class ClusterRerouteResponseTests extends OpenSearchTestCase {
                     .build()
             )
             .build();
-        ImmutableOpenMap.Builder<String, IndexMetadata> openMapBuilder = ImmutableOpenMap.builder();
+        final HashMap<String, IndexMetadata> openMapBuilder = new HashMap<>();
         openMapBuilder.put("index", indexMetadata);
-        Metadata metadata = Metadata.builder().indices(openMapBuilder.build()).build();
+        Metadata metadata = Metadata.builder().indices(openMapBuilder).build();
         ClusterState clusterState = ClusterState.builder(new ClusterName("test")).nodes(nodes).metadata(metadata).build();
 
         RoutingExplanations routingExplanations = new RoutingExplanations();

--- a/server/src/test/java/org/opensearch/action/admin/indices/get/GetIndexResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/get/GetIndexResponseTests.java
@@ -47,6 +47,8 @@ import org.opensearch.test.AbstractWireSerializingTestCase;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.List;
 import java.util.Locale;
 
@@ -60,7 +62,7 @@ public class GetIndexResponseTests extends AbstractWireSerializingTestCase<GetIn
     @Override
     protected GetIndexResponse createTestInstance() {
         String[] indices = generateRandomStringArray(5, 5, false, false);
-        ImmutableOpenMap.Builder<String, MappingMetadata> mappings = ImmutableOpenMap.builder();
+        final Map<String, MappingMetadata> mappings = new HashMap<>();
         ImmutableOpenMap.Builder<String, List<AliasMetadata>> aliases = ImmutableOpenMap.builder();
         ImmutableOpenMap.Builder<String, Settings> settings = ImmutableOpenMap.builder();
         ImmutableOpenMap.Builder<String, Settings> defaultSettings = ImmutableOpenMap.builder();
@@ -90,13 +92,6 @@ public class GetIndexResponseTests extends AbstractWireSerializingTestCase<GetIn
                 dataStreams.put(index, randomAlphaOfLength(5).toLowerCase(Locale.ROOT));
             }
         }
-        return new GetIndexResponse(
-            indices,
-            mappings.build(),
-            aliases.build(),
-            settings.build(),
-            defaultSettings.build(),
-            dataStreams.build()
-        );
+        return new GetIndexResponse(indices, mappings, aliases.build(), settings.build(), defaultSettings.build(), dataStreams.build());
     }
 }

--- a/server/src/test/java/org/opensearch/action/admin/indices/mapping/get/GetMappingsResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/mapping/get/GetMappingsResponseTests.java
@@ -33,7 +33,6 @@
 package org.opensearch.action.admin.indices.mapping.get;
 
 import org.opensearch.cluster.metadata.MappingMetadata;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.test.AbstractWireSerializingTestCase;
@@ -57,11 +56,11 @@ public class GetMappingsResponseTests extends AbstractWireSerializingTestCase<Ge
     }
 
     private static GetMappingsResponse mutate(GetMappingsResponse original) {
-        ImmutableOpenMap.Builder<String, MappingMetadata> builder = ImmutableOpenMap.builder(original.mappings());
-        String indexKey = original.mappings().keys().iterator().next().value;
+        final Map<String, MappingMetadata> builder = new HashMap<>(original.mappings());
+        String indexKey = original.mappings().keySet().iterator().next();
         builder.put(indexKey + "1", createMappingsForIndex());
 
-        return new GetMappingsResponse(builder.build());
+        return new GetMappingsResponse(builder);
     }
 
     @Override
@@ -84,9 +83,9 @@ public class GetMappingsResponseTests extends AbstractWireSerializingTestCase<Ge
 
     @Override
     protected GetMappingsResponse createTestInstance() {
-        ImmutableOpenMap.Builder<String, MappingMetadata> indexBuilder = ImmutableOpenMap.builder();
+        final Map<String, MappingMetadata> indexBuilder = new HashMap<>();
         indexBuilder.put("index-" + randomAlphaOfLength(5), createMappingsForIndex());
-        GetMappingsResponse resp = new GetMappingsResponse(indexBuilder.build());
+        GetMappingsResponse resp = new GetMappingsResponse(indexBuilder);
         logger.debug("--> created: {}", resp);
         return resp;
     }

--- a/server/src/test/java/org/opensearch/action/bulk/TransportBulkActionIngestTests.java
+++ b/server/src/test/java/org/opensearch/action/bulk/TransportBulkActionIngestTests.java
@@ -82,6 +82,7 @@ import org.mockito.ArgumentCaptor;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -245,32 +246,30 @@ public class TransportBulkActionIngestTests extends OpenSearchTestCase {
         when(state.getNodes()).thenReturn(nodes);
         Metadata metadata = Metadata.builder()
             .indices(
-                ImmutableOpenMap.<String, IndexMetadata>builder()
-                    .putAll(
-                        MapBuilder.<String, IndexMetadata>newMapBuilder()
-                            .put(
-                                WITH_DEFAULT_PIPELINE,
-                                IndexMetadata.builder(WITH_DEFAULT_PIPELINE)
-                                    .settings(
-                                        settings(Version.CURRENT).put(IndexSettings.DEFAULT_PIPELINE.getKey(), "default_pipeline").build()
-                                    )
-                                    .putAlias(AliasMetadata.builder(WITH_DEFAULT_PIPELINE_ALIAS).build())
-                                    .numberOfShards(1)
-                                    .numberOfReplicas(1)
-                                    .build()
-                            )
-                            .put(
-                                ".system",
-                                IndexMetadata.builder(".system")
-                                    .settings(settings(Version.CURRENT))
-                                    .system(true)
-                                    .numberOfShards(1)
-                                    .numberOfReplicas(0)
-                                    .build()
-                            )
-                            .map()
-                    )
-                    .build()
+                new HashMap<>(
+                    MapBuilder.<String, IndexMetadata>newMapBuilder()
+                        .put(
+                            WITH_DEFAULT_PIPELINE,
+                            IndexMetadata.builder(WITH_DEFAULT_PIPELINE)
+                                .settings(
+                                    settings(Version.CURRENT).put(IndexSettings.DEFAULT_PIPELINE.getKey(), "default_pipeline").build()
+                                )
+                                .putAlias(AliasMetadata.builder(WITH_DEFAULT_PIPELINE_ALIAS).build())
+                                .numberOfShards(1)
+                                .numberOfReplicas(1)
+                                .build()
+                        )
+                        .put(
+                            ".system",
+                            IndexMetadata.builder(".system")
+                                .settings(settings(Version.CURRENT))
+                                .system(true)
+                                .numberOfShards(1)
+                                .numberOfReplicas(0)
+                                .build()
+                        )
+                        .map()
+                )
             )
             .build();
         when(state.getMetadata()).thenReturn(metadata);
@@ -659,7 +658,7 @@ public class TransportBulkActionIngestTests extends OpenSearchTestCase {
         Exception exception = new Exception("fake exception");
         ClusterState state = clusterService.state();
 
-        ImmutableOpenMap.Builder<String, IndexTemplateMetadata> templateMetadataBuilder = ImmutableOpenMap.builder();
+        final Map<String, IndexTemplateMetadata> templateMetadataBuilder = new HashMap<>();
         templateMetadataBuilder.put(
             "template1",
             IndexTemplateMetadata.builder("template1")
@@ -692,9 +691,9 @@ public class TransportBulkActionIngestTests extends OpenSearchTestCase {
         Metadata metadata = mock(Metadata.class);
         when(state.metadata()).thenReturn(metadata);
         when(state.getMetadata()).thenReturn(metadata);
-        when(metadata.templates()).thenReturn(templateMetadataBuilder.build());
-        when(metadata.getTemplates()).thenReturn(templateMetadataBuilder.build());
-        when(metadata.indices()).thenReturn(ImmutableOpenMap.of());
+        when(metadata.templates()).thenReturn(templateMetadataBuilder);
+        when(metadata.getTemplates()).thenReturn(templateMetadataBuilder);
+        when(metadata.indices()).thenReturn(Map.of());
 
         IndexRequest indexRequest = new IndexRequest("missing_index").id("id");
         indexRequest.source(emptyMap());

--- a/server/src/test/java/org/opensearch/cluster/ClusterChangedEventTests.java
+++ b/server/src/test/java/org/opensearch/cluster/ClusterChangedEventTests.java
@@ -32,8 +32,6 @@
 
 package org.opensearch.cluster;
 
-import com.carrotsearch.hppc.cursors.ObjectCursor;
-import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.opensearch.Version;
 import org.opensearch.cluster.block.ClusterBlocks;
 import org.opensearch.cluster.metadata.IndexGraveyard;
@@ -57,6 +55,7 @@ import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -411,9 +410,9 @@ public class ClusterChangedEventTests extends OpenSearchTestCase {
         final ClusterState.Builder builder = ClusterState.builder(previousState);
         builder.stateUUID(UUIDs.randomBase64UUID());
         Metadata.Builder metadataBuilder = new Metadata.Builder(previousState.metadata());
-        for (ObjectObjectCursor<String, Metadata.Custom> customMetadata : previousState.metadata().customs()) {
-            if (customMetadata.value instanceof TestCustomMetadata) {
-                metadataBuilder.removeCustom(customMetadata.key);
+        for (Map.Entry<String, Metadata.Custom> customMetadata : previousState.metadata().customs().entrySet()) {
+            if (customMetadata.getValue() instanceof TestCustomMetadata) {
+                metadataBuilder.removeCustom(customMetadata.getKey());
             }
         }
         for (TestCustomMetadata testCustomMetadata : customMetadataList) {
@@ -550,8 +549,8 @@ public class ClusterChangedEventTests extends OpenSearchTestCase {
     // Create the routing table for a cluster state.
     private static RoutingTable createRoutingTable(final long version, final Metadata metadata) {
         final RoutingTable.Builder builder = RoutingTable.builder().version(version);
-        for (ObjectCursor<IndexMetadata> cursor : metadata.indices().values()) {
-            builder.addAsNew(cursor.value);
+        for (final IndexMetadata cursor : metadata.indices().values()) {
+            builder.addAsNew(cursor);
         }
         return builder.build();
     }
@@ -582,7 +581,7 @@ public class ClusterChangedEventTests extends OpenSearchTestCase {
     ) {
         final int numAdd = randomIntBetween(0, 5); // add random # of indices to the next cluster state
         final List<Index> stateIndices = new ArrayList<>();
-        for (Iterator<IndexMetadata> iter = previousState.metadata().indices().valuesIt(); iter.hasNext();) {
+        for (Iterator<IndexMetadata> iter = previousState.metadata().indices().values().iterator(); iter.hasNext();) {
             stateIndices.add(iter.next().getIndex());
         }
         final int numDel;

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -57,7 +57,6 @@ import org.opensearch.cluster.routing.allocation.decider.AwarenessAllocationDeci
 import org.opensearch.cluster.routing.allocation.decider.MaxRetryAllocationDecider;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Strings;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.compress.CompressedXContent;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.IndexScopedSettings;
@@ -96,6 +95,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -742,9 +742,9 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
         IndexTemplateMetadata templateMetadata = addMatchingTemplate(builder -> {
             builder.settings(Settings.builder().put("template_setting", "value1"));
         });
-        ImmutableOpenMap.Builder<String, IndexTemplateMetadata> templatesBuilder = ImmutableOpenMap.builder();
+        final Map<String, IndexTemplateMetadata> templatesBuilder = new HashMap<>();
         templatesBuilder.put("template_1", templateMetadata);
-        Metadata metadata = new Metadata.Builder().templates(templatesBuilder.build()).build();
+        Metadata metadata = new Metadata.Builder().templates(templatesBuilder).build();
         ClusterState clusterState = ClusterState.builder(org.opensearch.cluster.ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
             .metadata(metadata)
             .build();

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataTests.java
@@ -659,19 +659,16 @@ public class MetadataTests extends OpenSearchTestCase {
             .build();
 
         {
-            ImmutableOpenMap<String, MappingMetadata> mappings = metadata.findMappings(Strings.EMPTY_ARRAY, MapperPlugin.NOOP_FIELD_FILTER);
+            final Map<String, MappingMetadata> mappings = metadata.findMappings(Strings.EMPTY_ARRAY, MapperPlugin.NOOP_FIELD_FILTER);
             assertEquals(0, mappings.size());
         }
         {
-            ImmutableOpenMap<String, MappingMetadata> mappings = metadata.findMappings(
-                new String[] { "index1" },
-                MapperPlugin.NOOP_FIELD_FILTER
-            );
+            final Map<String, MappingMetadata> mappings = metadata.findMappings(new String[] { "index1" }, MapperPlugin.NOOP_FIELD_FILTER);
             assertEquals(1, mappings.size());
             assertIndexMappingsNotFiltered(mappings, "index1");
         }
         {
-            ImmutableOpenMap<String, MappingMetadata> mappings = metadata.findMappings(
+            final Map<String, MappingMetadata> mappings = metadata.findMappings(
                 new String[] { "index1", "index2" },
                 MapperPlugin.NOOP_FIELD_FILTER
             );
@@ -701,15 +698,12 @@ public class MetadataTests extends OpenSearchTestCase {
             .build();
 
         {
-            ImmutableOpenMap<String, MappingMetadata> mappings = metadata.findMappings(
-                new String[] { "index1" },
-                MapperPlugin.NOOP_FIELD_FILTER
-            );
+            final Map<String, MappingMetadata> mappings = metadata.findMappings(new String[] { "index1" }, MapperPlugin.NOOP_FIELD_FILTER);
             MappingMetadata mappingMetadata = mappings.get("index1");
             assertSame(originalMappingMetadata, mappingMetadata);
         }
         {
-            ImmutableOpenMap<String, MappingMetadata> mappings = metadata.findMappings(
+            final Map<String, MappingMetadata> mappings = metadata.findMappings(
                 new String[] { "index1" },
                 index -> field -> randomBoolean()
             );
@@ -764,21 +758,18 @@ public class MetadataTests extends OpenSearchTestCase {
             .build();
 
         {
-            ImmutableOpenMap<String, MappingMetadata> mappings = metadata.findMappings(
-                new String[] { "index1", "index2", "index3" },
-                index -> {
-                    if (index.equals("index1")) {
-                        return field -> field.startsWith("name.") == false
-                            && field.startsWith("properties.key.") == false
-                            && field.equals("age") == false
-                            && field.equals("address.location") == false;
-                    }
-                    if (index.equals("index2")) {
-                        return field -> false;
-                    }
-                    return MapperPlugin.NOOP_FIELD_PREDICATE;
+            final Map<String, MappingMetadata> mappings = metadata.findMappings(new String[] { "index1", "index2", "index3" }, index -> {
+                if (index.equals("index1")) {
+                    return field -> field.startsWith("name.") == false
+                        && field.startsWith("properties.key.") == false
+                        && field.equals("age") == false
+                        && field.equals("address.location") == false;
                 }
-            );
+                if (index.equals("index2")) {
+                    return field -> false;
+                }
+                return MapperPlugin.NOOP_FIELD_PREDICATE;
+            });
 
             assertIndexMappingsNoFields(mappings, "index2");
             assertIndexMappingsNotFiltered(mappings, "index3");
@@ -825,7 +816,7 @@ public class MetadataTests extends OpenSearchTestCase {
         }
 
         {
-            ImmutableOpenMap<String, MappingMetadata> mappings = metadata.findMappings(
+            final Map<String, MappingMetadata> mappings = metadata.findMappings(
                 new String[] { "index1", "index2", "index3" },
                 index -> field -> (index.equals("index3") && field.endsWith("keyword"))
             );
@@ -860,7 +851,7 @@ public class MetadataTests extends OpenSearchTestCase {
         }
 
         {
-            ImmutableOpenMap<String, MappingMetadata> mappings = metadata.findMappings(
+            final Map<String, MappingMetadata> mappings = metadata.findMappings(
                 new String[] { "index1", "index2", "index3" },
                 index -> field -> (index.equals("index2"))
             );
@@ -881,7 +872,7 @@ public class MetadataTests extends OpenSearchTestCase {
     }
 
     @SuppressWarnings("unchecked")
-    private static void assertIndexMappingsNoFields(ImmutableOpenMap<String, MappingMetadata> mappings, String index) {
+    private static void assertIndexMappingsNoFields(final Map<String, MappingMetadata> mappings, String index) {
         MappingMetadata docMapping = mappings.get(index);
         assertNotNull(docMapping);
         Map<String, Object> sourceAsMap = docMapping.getSourceAsMap();
@@ -893,7 +884,7 @@ public class MetadataTests extends OpenSearchTestCase {
     }
 
     @SuppressWarnings("unchecked")
-    private static void assertIndexMappingsNotFiltered(ImmutableOpenMap<String, MappingMetadata> mappings, String index) {
+    private static void assertIndexMappingsNotFiltered(final Map<String, MappingMetadata> mappings, String index) {
         MappingMetadata docMapping = mappings.get(index);
         assertNotNull(docMapping);
 
@@ -1050,10 +1041,9 @@ public class MetadataTests extends OpenSearchTestCase {
     public void testBuilderRejectsNullInCustoms() {
         final Metadata.Builder builder = Metadata.builder();
         final String key = randomAlphaOfLength(10);
-        final ImmutableOpenMap.Builder<String, Metadata.Custom> mapBuilder = ImmutableOpenMap.builder();
+        final Map<String, Metadata.Custom> mapBuilder = new HashMap<>();
         mapBuilder.put(key, null);
-        final ImmutableOpenMap<String, Metadata.Custom> map = mapBuilder.build();
-        assertThat(expectThrows(NullPointerException.class, () -> builder.customs(map)).getMessage(), containsString(key));
+        assertThat(expectThrows(NullPointerException.class, () -> builder.customs(mapBuilder)).getMessage(), containsString(key));
     }
 
     public void testBuilderRejectsDataStreamThatConflictsWithIndex() {

--- a/server/src/test/java/org/opensearch/cluster/metadata/TemplateUpgradeServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/TemplateUpgradeServiceTests.java
@@ -48,7 +48,6 @@ import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.bytes.BytesArray;
 import org.opensearch.common.bytes.BytesReference;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.test.OpenSearchTestCase;
@@ -345,7 +344,7 @@ public class TemplateUpgradeServiceTests extends OpenSearchTestCase {
 
             @Override
             Optional<Tuple<Map<String, BytesReference>, Set<String>>> calculateTemplateChanges(
-                ImmutableOpenMap<String, IndexTemplateMetadata> templates
+                final Map<String, IndexTemplateMetadata> templates
             ) {
                 final Optional<Tuple<Map<String, BytesReference>, Set<String>>> ans = super.calculateTemplateChanges(templates);
                 calculateInvocation.release();

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/AddIncrementallyTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/AddIncrementallyTests.java
@@ -294,8 +294,8 @@ public class AddIncrementallyTests extends OpenSearchAllocationTestCase {
 
         Metadata metadata = metadataBuilder.build();
 
-        for (ObjectCursor<IndexMetadata> cursor : metadata.indices().values()) {
-            routingTableBuilder.addAsNew(cursor.value);
+        for (final IndexMetadata cursor : metadata.indices().values()) {
+            routingTableBuilder.addAsNew(cursor);
         }
 
         RoutingTable initialRoutingTable = routingTableBuilder.build();

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/BalanceConfigurationTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/BalanceConfigurationTests.java
@@ -654,8 +654,8 @@ public class BalanceConfigurationTests extends OpenSearchAllocationTestCase {
         }
 
         Metadata metadata = metadataBuilder.build();
-        for (ObjectCursor<IndexMetadata> cursor : metadata.indices().values()) {
-            routingTableBuilder.addAsNew(cursor.value);
+        for (final IndexMetadata cursor : metadata.indices().values()) {
+            routingTableBuilder.addAsNew(cursor);
         }
 
         RoutingTable initialRoutingTable = routingTableBuilder.build();
@@ -909,8 +909,8 @@ public class BalanceConfigurationTests extends OpenSearchAllocationTestCase {
             .numberOfReplicas(1);
         metadataBuilder = metadataBuilder.put(indexMeta);
         Metadata metadata = metadataBuilder.build();
-        for (ObjectCursor<IndexMetadata> cursor : metadata.indices().values()) {
-            routingTableBuilder.addAsNew(cursor.value);
+        for (final IndexMetadata cursor : metadata.indices().values()) {
+            routingTableBuilder.addAsNew(cursor);
         }
         RoutingTable routingTable = routingTableBuilder.build();
         DiscoveryNodes.Builder nodes = DiscoveryNodes.builder();

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/ThrottlingAllocationTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/ThrottlingAllocationTests.java
@@ -33,7 +33,6 @@
 package org.opensearch.cluster.routing.allocation;
 
 import com.carrotsearch.hppc.IntHashSet;
-import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.Version;
@@ -774,9 +773,9 @@ public class ThrottlingAllocationTests extends OpenSearchAllocationTestCase {
         Snapshot snapshot = new Snapshot("repo", new SnapshotId("snap", "randomId"));
         Set<String> snapshotIndices = new HashSet<>();
         String restoreUUID = UUIDs.randomBase64UUID();
-        for (ObjectCursor<IndexMetadata> cursor : metadata.indices().values()) {
-            Index index = cursor.value.getIndex();
-            IndexMetadata.Builder indexMetadataBuilder = IndexMetadata.builder(cursor.value);
+        for (final IndexMetadata cursor : metadata.indices().values()) {
+            Index index = cursor.getIndex();
+            IndexMetadata.Builder indexMetadataBuilder = IndexMetadata.builder(cursor);
 
             final int recoveryType = inputRecoveryType == null ? randomInt(5) : inputRecoveryType.intValue();
             if (recoveryType <= 4) {

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/decider/EnableAllocationShortCircuitTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/decider/EnableAllocationShortCircuitTests.java
@@ -135,7 +135,7 @@ public class EnableAllocationShortCircuitTests extends OpenSearchAllocationTestC
 
     public void testRebalancingSkippedIfDisabledIncludingOnSpecificIndices() {
         ClusterState clusterState = createClusterStateWithAllShardsAssigned();
-        final IndexMetadata indexMetadata = randomFrom(clusterState.metadata().indices().values().toArray(IndexMetadata.class));
+        final IndexMetadata indexMetadata = randomFrom(clusterState.metadata().indices().values().toArray(new IndexMetadata[0]));
         clusterState = ClusterState.builder(clusterState)
             .metadata(
                 Metadata.builder(clusterState.metadata())
@@ -162,7 +162,7 @@ public class EnableAllocationShortCircuitTests extends OpenSearchAllocationTestC
 
     public void testRebalancingAttemptedIfDisabledButOverridenOnSpecificIndices() {
         ClusterState clusterState = createClusterStateWithAllShardsAssigned();
-        final IndexMetadata indexMetadata = randomFrom(clusterState.metadata().indices().values().toArray(IndexMetadata.class));
+        final IndexMetadata indexMetadata = randomFrom(clusterState.metadata().indices().values().toArray(new IndexMetadata[0]));
         clusterState = ClusterState.builder(clusterState)
             .metadata(
                 Metadata.builder(clusterState.metadata())

--- a/server/src/test/java/org/opensearch/gateway/DanglingIndicesStateTests.java
+++ b/server/src/test/java/org/opensearch/gateway/DanglingIndicesStateTests.java
@@ -37,7 +37,6 @@ import org.opensearch.cluster.metadata.IndexGraveyard;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.env.NodeEnvironment;
 import org.opensearch.index.Index;
@@ -47,6 +46,7 @@ import org.hamcrest.Matchers;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -233,9 +233,8 @@ public class DanglingIndicesStateTests extends OpenSearchTestCase {
             IndexMetadata existingIndex = IndexMetadata.builder("test_index").settings(existingSettings).build();
             metaStateService.writeIndex("test_write", existingIndex);
 
-            final ImmutableOpenMap<String, IndexMetadata> indices = ImmutableOpenMap.<String, IndexMetadata>builder()
-                .fPut(dangledIndex.getIndex().getName(), existingIndex)
-                .build();
+            final Map<String, IndexMetadata> indices = new HashMap<>();
+            indices.put(dangledIndex.getIndex().getName(), existingIndex);
             final Metadata metadata = Metadata.builder().indices(indices).build();
 
             // All dangling indices should be found...

--- a/server/src/test/java/org/opensearch/index/mapper/FieldFilterMapperPluginTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/FieldFilterMapperPluginTests.java
@@ -40,7 +40,6 @@ import org.opensearch.action.fieldcaps.FieldCapabilities;
 import org.opensearch.action.fieldcaps.FieldCapabilitiesRequest;
 import org.opensearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.opensearch.cluster.metadata.MappingMetadata;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.indices.IndicesModule;
 import org.opensearch.plugins.MapperPlugin;
@@ -166,7 +165,7 @@ public class FieldFilterMapperPluginTests extends OpenSearchSingleNodeTestCase {
         assertEquals("Some unexpected fields were returned: " + fields.keySet(), 0, fields.size());
     }
 
-    private void assertExpectedMappings(ImmutableOpenMap<String, MappingMetadata> mappings) {
+    private void assertExpectedMappings(Map<String, MappingMetadata> mappings) {
         assertEquals(2, mappings.size());
         assertNotFiltered(mappings.get("index1"));
         MappingMetadata filtered = mappings.get("filtered");

--- a/server/src/test/java/org/opensearch/indices/ShardLimitValidatorTests.java
+++ b/server/src/test/java/org/opensearch/indices/ShardLimitValidatorTests.java
@@ -331,7 +331,7 @@ public class ShardLimitValidatorTests extends OpenSearchTestCase {
             counts.getFailingIndexReplicas()
         );
 
-        Index[] indices = Arrays.stream(state.metadata().indices().values().toArray(IndexMetadata.class))
+        Index[] indices = Arrays.stream(state.metadata().indices().values().toArray(new IndexMetadata[0]))
             .map(IndexMetadata::getIndex)
             .collect(Collectors.toList())
             .toArray(new Index[2]);
@@ -373,7 +373,7 @@ public class ShardLimitValidatorTests extends OpenSearchTestCase {
             counts.getFailingIndexReplicas()
         );
 
-        Index[] indices = Arrays.stream(state.metadata().indices().values().toArray(IndexMetadata.class))
+        Index[] indices = Arrays.stream(state.metadata().indices().values().toArray(new IndexMetadata[0]))
             .map(IndexMetadata::getIndex)
             .collect(Collectors.toList())
             .toArray(new Index[2]);
@@ -401,7 +401,7 @@ public class ShardLimitValidatorTests extends OpenSearchTestCase {
             counts.getFailingIndexReplicas()
         );
 
-        Index[] indices = Arrays.stream(state.metadata().indices().values().toArray(IndexMetadata.class))
+        Index[] indices = Arrays.stream(state.metadata().indices().values().toArray(new IndexMetadata[0]))
             .map(IndexMetadata::getIndex)
             .collect(Collectors.toList())
             .toArray(new Index[2]);
@@ -429,7 +429,7 @@ public class ShardLimitValidatorTests extends OpenSearchTestCase {
             counts.getFailingIndexReplicas()
         );
 
-        Index[] indices = Arrays.stream(state.metadata().indices().values().toArray(IndexMetadata.class))
+        Index[] indices = Arrays.stream(state.metadata().indices().values().toArray(new IndexMetadata[0]))
             .map(IndexMetadata::getIndex)
             .collect(Collectors.toList())
             .toArray(new Index[2]);
@@ -472,7 +472,7 @@ public class ShardLimitValidatorTests extends OpenSearchTestCase {
             counts.getFailingIndexReplicas()
         );
 
-        Index[] indices = Arrays.stream(state.metadata().indices().values().toArray(IndexMetadata.class))
+        Index[] indices = Arrays.stream(state.metadata().indices().values().toArray(new IndexMetadata[0]))
             .map(IndexMetadata::getIndex)
             .collect(Collectors.toList())
             .toArray(new Index[2]);

--- a/server/src/test/java/org/opensearch/indices/cluster/IndicesClusterStateServiceRandomUpdatesTests.java
+++ b/server/src/test/java/org/opensearch/indices/cluster/IndicesClusterStateServiceRandomUpdatesTests.java
@@ -416,7 +416,7 @@ public class IndicesClusterStateServiceRandomUpdatesTests extends AbstractIndice
         // randomly delete indices
         Set<String> indicesToDelete = new HashSet<>();
         int numberOfIndicesToDelete = randomInt(Math.min(2, state.metadata().indices().size()));
-        for (String index : randomSubsetOf(numberOfIndicesToDelete, state.metadata().indices().keys().toArray(String.class))) {
+        for (String index : randomSubsetOf(numberOfIndicesToDelete, state.metadata().indices().keySet().toArray(new String[0]))) {
             indicesToDelete.add(state.metadata().index(index).getIndex().getName());
         }
         if (indicesToDelete.isEmpty() == false) {
@@ -429,14 +429,14 @@ public class IndicesClusterStateServiceRandomUpdatesTests extends AbstractIndice
 
         // randomly close indices
         int numberOfIndicesToClose = randomInt(Math.min(1, state.metadata().indices().size()));
-        for (String index : randomSubsetOf(numberOfIndicesToClose, state.metadata().indices().keys().toArray(String.class))) {
+        for (String index : randomSubsetOf(numberOfIndicesToClose, state.metadata().indices().keySet().toArray(new String[0]))) {
             CloseIndexRequest closeIndexRequest = new CloseIndexRequest(state.metadata().index(index).getIndex().getName());
             state = cluster.closeIndices(state, closeIndexRequest);
         }
 
         // randomly open indices
         int numberOfIndicesToOpen = randomInt(Math.min(1, state.metadata().indices().size()));
-        for (String index : randomSubsetOf(numberOfIndicesToOpen, state.metadata().indices().keys().toArray(String.class))) {
+        for (String index : randomSubsetOf(numberOfIndicesToOpen, state.metadata().indices().keySet().toArray(new String[0]))) {
             OpenIndexRequest openIndexRequest = new OpenIndexRequest(state.metadata().index(index).getIndex().getName());
             state = cluster.openIndices(state, openIndexRequest);
         }
@@ -445,7 +445,7 @@ public class IndicesClusterStateServiceRandomUpdatesTests extends AbstractIndice
         Set<String> indicesToUpdate = new HashSet<>();
         boolean containsClosedIndex = false;
         int numberOfIndicesToUpdate = randomInt(Math.min(2, state.metadata().indices().size()));
-        for (String index : randomSubsetOf(numberOfIndicesToUpdate, state.metadata().indices().keys().toArray(String.class))) {
+        for (String index : randomSubsetOf(numberOfIndicesToUpdate, state.metadata().indices().keySet().toArray(new String[0]))) {
             indicesToUpdate.add(state.metadata().index(index).getIndex().getName());
             if (state.metadata().index(index).getState() == IndexMetadata.State.CLOSE) {
                 containsClosedIndex = true;

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotUtilsTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotUtilsTests.java
@@ -35,7 +35,6 @@ import org.opensearch.Version;
 import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.Metadata;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.Index;
 import org.opensearch.index.IndexModule;
@@ -44,6 +43,7 @@ import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_VERSION_CREATED;
@@ -114,7 +114,7 @@ public class SnapshotUtilsTests extends OpenSearchTestCase {
         );
     }
 
-    private static ImmutableOpenMap<String, IndexMetadata> getIndexMetadata(SnapshotId snapshotId, String repoName) {
+    private static Map<String, IndexMetadata> getIndexMetadata(SnapshotId snapshotId, String repoName) {
         final String index = "test-index";
         Snapshot snapshot = new Snapshot(repoName, snapshotId);
         final Metadata.Builder builder = Metadata.builder();


### PR DESCRIPTION
Refactors `Metadata#{indices, templates, customs}` member variables from using `ImmutableOpenMap` to using jdk Maps. Usage of these variables across the codebase is also refactored to use jdk maps.

relates #5910 