### PR TITLE
[#7101] Fixing the GeoTileIT#testMultivaluedGeoPointsAggregation testcase

### DIFF
--- a/modules/geo/src/internalClusterTest/java/org/opensearch/geo/search/aggregations/bucket/AbstractGeoBucketAggregationIntegTest.java
+++ b/modules/geo/src/internalClusterTest/java/org/opensearch/geo/search/aggregations/bucket/AbstractGeoBucketAggregationIntegTest.java
@@ -10,6 +10,7 @@ package org.opensearch.geo.search.aggregations.bucket;
 
 import com.carrotsearch.hppc.ObjectIntHashMap;
 import com.carrotsearch.hppc.ObjectIntMap;
+import org.apache.lucene.geo.GeoEncodingUtils;
 import org.opensearch.Version;
 import org.opensearch.action.index.IndexRequestBuilder;
 import org.opensearch.cluster.metadata.IndexMetadata;
@@ -252,6 +253,19 @@ public abstract class AbstractGeoBucketAggregationIntegTest extends GeoModulePlu
      */
     protected double getRadiusOfBoundingBox() {
         return 5.0;
+    }
+
+    /**
+     * Encode and Decode the {@link GeoPoint} to get a {@link GeoPoint} which has the exact precision which is being
+     * stored.
+     * @param geoPoint {@link GeoPoint}
+     * @return {@link GeoPoint}
+     */
+    protected GeoPoint toStoragePrecision(final GeoPoint geoPoint) {
+        return new GeoPoint(
+            GeoEncodingUtils.decodeLatitude(GeoEncodingUtils.encodeLatitude(geoPoint.getLat())),
+            GeoEncodingUtils.decodeLongitude(GeoEncodingUtils.encodeLongitude(geoPoint.getLon()))
+        );
     }
 
 }

--- a/modules/geo/src/internalClusterTest/java/org/opensearch/geo/search/aggregations/bucket/GeoTileGridIT.java
+++ b/modules/geo/src/internalClusterTest/java/org/opensearch/geo/search/aggregations/bucket/GeoTileGridIT.java
@@ -160,7 +160,8 @@ public class GeoTileGridIT extends AbstractGeoBucketAggregationIntegTest {
     protected Set<String> generateBucketsForGeoPoint(final GeoPoint geoPoint) {
         Set<String> buckets = new HashSet<>();
         for (int precision = GEOPOINT_MAX_PRECISION; precision > 0; precision--) {
-            final String tile = GeoTileUtils.stringEncode(geoPoint.getLon(), geoPoint.getLat(), precision);
+            final GeoPoint precisedGeoPoint = this.toStoragePrecision(geoPoint);
+            final String tile = GeoTileUtils.stringEncode(precisedGeoPoint.getLon(), precisedGeoPoint.getLat(), precision);
             buckets.add(tile);
         }
         return buckets;


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fixing the GeoTileIT#testMultivaluedGeoPointsAggregation testcase

The issue was happening because we encode the GeoPoint as long and error comes in the precision due to that encoding. The error was not taken care while generating the exepected tiles count for expected output. The error was happening for a tile: 13/1627/7465

### Solution

The idea to fix this is simple enough, while generating the expected buckets for geo-points I will encode and decode the lat-lon values. This will make sure that the precision loss comes in during the Tile creation, as showed in the below snippet. 


Code ref: https://github.com/opensearch-project/OpenSearch/blob/9386cde55a55d8b4779a0c58ba9a6240d04cbe2c/modules/geo/src/internalClusterTest/java/org/opensearch/geo/search/aggregations/bucket/GeoTileGridIT.java#L160-L166

```
protected Set<String> generateBucketsForGeoPoint(final GeoPoint geoPoint) {
        Set<String> buckets = new HashSet<>();
        for (int precision = GEOPOINT_MAX_PRECISION; precision > 0; precision--) {
            final String tile =
                    GeoTileUtils.stringEncode(GeoEncodingUtils.decodeLongitude(GeoEncodingUtils.encodeLongitude(geoPoint.getLon())), GeoEncodingUtils.decodeLatitude(GeoEncodingUtils.encodeLatitude(geoPoint.getLat())), precision);
            buckets.add(tile);
        }
        return buckets;
    }
```


### Tested by running:
```
./gradlew ':modules:geo:internalClusterTest' --tests "org.opensearch.geo.search.aggregations.bucket.GeoTileGridIT.testMultivaluedGeoPointsAggregation" -Dtests.seed=73A6EB980B2F13B4 -Dtests.security.manager=true -Dtests.jvm.argline="-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m" -Dtests.locale=is -Dtests.timezone=Africa/Addis_Ababa
```
### Issues Resolved
#7101 

### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
