### PR TITLE
Make verifier return type as ActionResponse

### DIFF
--- a/test/framework/src/main/java/org/opensearch/test/rest/RestActionTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/rest/RestActionTestCase.java
@@ -122,7 +122,7 @@ public abstract class RestActionTestCase extends OpenSearchTestCase {
          * @param verifier A function which is called in place of {@link #doExecute(ActionType, ActionRequest, ActionListener)}
          */
         public <Request extends ActionRequest, Response extends ActionResponse> void setExecuteVerifier(
-            BiFunction<ActionType<Response>, Request, Void> verifier
+            BiFunction<ActionType<Response>, Request, Response> verifier
         ) {
             executeVerifier.set(verifier);
         }
@@ -142,7 +142,7 @@ public abstract class RestActionTestCase extends OpenSearchTestCase {
          * @param verifier A function which is called in place of {@link #executeLocally(ActionType, ActionRequest, TaskListener)}
          */
         public <Request extends ActionRequest, Response extends ActionResponse> void setExecuteLocallyVerifier(
-            BiFunction<ActionType<Response>, Request, Void> verifier
+            BiFunction<ActionType<Response>, Request, Response> verifier
         ) {
             executeLocallyVerifier.set(verifier);
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
According to the comment, verifier should return either a subclass of ActionResponse or null. With previous signature, it can only return null. This commit allows the verifier to return a subclass of ActionResponse so that test case can return a desired ActionResponse.

### Issues Resolved
N/A

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
