### PR TITLE
Make file cache stats consistent with other APIs

### DIFF
--- a/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCache.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCache.java
@@ -195,8 +195,6 @@ public class FileCache implements RefCountedCache<Path, CachedIndexInput> {
             capacity(),
             usage.usage(),
             stats.evictionWeight(),
-            stats.removeWeight(),
-            stats.replaceCount(),
             stats.hitCount(),
             stats.missCount()
         );

--- a/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCacheStats.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCacheStats.java
@@ -29,10 +29,8 @@ public class FileCacheStats implements Writeable, ToXContentFragment {
     private final long total;
     private final long used;
     private final long evicted;
-    private final long removed;
-    private final long replaced;
     private final long hits;
-    private final long miss;
+    private final long misses;
 
     public FileCacheStats(
         final long timestamp,
@@ -40,20 +38,16 @@ public class FileCacheStats implements Writeable, ToXContentFragment {
         final long total,
         final long used,
         final long evicted,
-        final long removed,
-        final long replaced,
         final long hits,
-        final long miss
+        final long misses
     ) {
         this.timestamp = timestamp;
         this.active = active;
         this.total = total;
         this.used = used;
         this.evicted = evicted;
-        this.removed = removed;
-        this.replaced = replaced;
         this.hits = hits;
-        this.miss = miss;
+        this.misses = misses;
     }
 
     public FileCacheStats(final StreamInput in) throws IOException {
@@ -62,10 +56,8 @@ public class FileCacheStats implements Writeable, ToXContentFragment {
         this.total = in.readLong();
         this.used = in.readLong();
         this.evicted = in.readLong();
-        this.removed = in.readLong();
-        this.replaced = in.readLong();
         this.hits = in.readLong();
-        this.miss = in.readLong();
+        this.misses = in.readLong();
     }
 
     public static short calculatePercentage(long used, long max) {
@@ -79,10 +71,8 @@ public class FileCacheStats implements Writeable, ToXContentFragment {
         out.writeLong(total);
         out.writeLong(used);
         out.writeLong(evicted);
-        out.writeLong(removed);
-        out.writeLong(replaced);
         out.writeLong(hits);
-        out.writeLong(miss);
+        out.writeLong(misses);
     }
 
     public long getTimestamp() {
@@ -113,20 +103,12 @@ public class FileCacheStats implements Writeable, ToXContentFragment {
         return new ByteSizeValue(evicted);
     }
 
-    public ByteSizeValue getRemoved() {
-        return new ByteSizeValue(removed);
-    }
-
-    public long getReplacedCount() {
-        return replaced;
-    }
-
     public long getCacheHits() {
         return hits;
     }
 
-    public long getCacheMiss() {
-        return miss;
+    public long getCacheMisses() {
+        return misses;
     }
 
     @Override
@@ -136,13 +118,11 @@ public class FileCacheStats implements Writeable, ToXContentFragment {
         builder.humanReadableField(Fields.ACTIVE_IN_BYTES, Fields.ACTIVE, getActive());
         builder.humanReadableField(Fields.TOTAL_IN_BYTES, Fields.TOTAL, getTotal());
         builder.humanReadableField(Fields.USED_IN_BYTES, Fields.USED, getUsed());
-        builder.humanReadableField(Fields.EVICTED_IN_BYTES, Fields.EVICTED, getEvicted());
-        builder.humanReadableField(Fields.REMOVED_IN_BYTES, Fields.REMOVED, getRemoved());
-        builder.field(Fields.REPLACED_COUNT, getReplacedCount());
+        builder.humanReadableField(Fields.EVICTIONS_IN_BYTES, Fields.EVICTIONS, getEvicted());
         builder.field(Fields.ACTIVE_PERCENT, getActivePercent());
         builder.field(Fields.USED_PERCENT, getUsedPercent());
-        builder.field(Fields.CACHE_HITS, getCacheHits());
-        builder.field(Fields.CACHE_MISS, getCacheMiss());
+        builder.field(Fields.HIT_COUNT, getCacheHits());
+        builder.field(Fields.MISS_COUNT, getCacheMisses());
         builder.endObject();
         return builder;
     }
@@ -154,18 +134,15 @@ public class FileCacheStats implements Writeable, ToXContentFragment {
         static final String ACTIVE_IN_BYTES = "active_in_bytes";
         static final String USED = "used";
         static final String USED_IN_BYTES = "used_in_bytes";
-        static final String EVICTED = "evicted";
-        static final String EVICTED_IN_BYTES = "evicted_in_bytes";
-        static final String REMOVED = "removed";
-        static final String REMOVED_IN_BYTES = "removed_in_bytes";
-        static final String REPLACED_COUNT = "replaced_count";
+        static final String EVICTIONS = "evictions";
+        static final String EVICTIONS_IN_BYTES = "evictions_in_bytes";
         static final String TOTAL = "total";
         static final String TOTAL_IN_BYTES = "total_in_bytes";
 
         static final String ACTIVE_PERCENT = "active_percent";
         static final String USED_PERCENT = "used_percent";
 
-        static final String CACHE_HITS = "cache_hits";
-        static final String CACHE_MISS = "cache_miss";
+        static final String HIT_COUNT = "hit_count";
+        static final String MISS_COUNT = "miss_count";
     }
 }

--- a/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheStatsTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheStatsTests.java
@@ -45,8 +45,6 @@ public class FileCacheStatsTests extends OpenSearchTestCase {
             fileCacheCapacity,
             usage.usage(),
             stats.evictionWeight(),
-            stats.removeWeight(),
-            stats.replaceCount(),
             stats.hitCount(),
             stats.missCount()
         );
@@ -64,10 +62,8 @@ public class FileCacheStatsTests extends OpenSearchTestCase {
         assertEquals(original.getActive(), deserialized.getActive());
         assertEquals(original.getActivePercent(), deserialized.getActivePercent());
         assertEquals(original.getEvicted(), deserialized.getEvicted());
-        assertEquals(original.getRemoved(), deserialized.getRemoved());
-        assertEquals(original.getReplacedCount(), deserialized.getReplacedCount());
         assertEquals(original.getCacheHits(), deserialized.getCacheHits());
-        assertEquals(original.getCacheMiss(), deserialized.getCacheMiss());
+        assertEquals(original.getCacheMisses(), deserialized.getCacheMisses());
     }
 
     public void testFileCacheStatsSerialization() throws IOException {


### PR DESCRIPTION
Some cosmetic changes here to make the stat names consistent with [RequestCacheStats][1] and [QueryCacheStats][2] that already exist in the API.

I've also removed the 'replaced' and 'removed' stats. These are internal cache details that I don't think will be useful to a user. We can always add them back later if needed.

Note this is backward incompatible, but this is okay as this will get in ahead of the next release which removes the feature flag from searchable snapshots.

[1]: https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/index/cache/request/RequestCacheStats.java
[2]: https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/index/cache/query/QueryCacheStats.java


### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
