### PR TITLE
Make index.codec setting case-insensitive.

### DIFF
--- a/server/src/main/java/org/opensearch/index/codec/CodecService.java
+++ b/server/src/main/java/org/opensearch/index/codec/CodecService.java
@@ -41,6 +41,7 @@ import org.opensearch.common.collect.MapBuilder;
 import org.opensearch.index.mapper.MapperService;
 
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Since Lucene 4.0 low level index segments are read and written through a
@@ -76,11 +77,11 @@ public class CodecService {
     }
 
     public Codec codec(String name) {
-        Codec codec = codecs.get(name);
-        if (codec == null) {
+        Optional<String> key = codecs.keySet().stream().filter(k -> k.equalsIgnoreCase(name)).findAny();
+        if (!key.isPresent()) {
             throw new IllegalArgumentException("failed to find codec [" + name + "]");
         }
-        return codec;
+        return codecs.get(key.get());
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/codec/CodecService.java
+++ b/server/src/main/java/org/opensearch/index/codec/CodecService.java
@@ -77,7 +77,14 @@ public class CodecService {
     }
 
     public Codec codec(String name) {
-        Optional<String> key = codecs.keySet().stream().filter(k -> k.equalsIgnoreCase(name)).findAny();
+        return codecs
+            .entrySet()
+            .stream()
+            .filter(e -> e.getKey().equalsIgnoreCase(name))
+            .map(Map.Entry::getValue)
+            .findAny()
+            .orElseThrow(() -> new IllegalArgumentException("failed to find codec [" + name + "]"));
+
         if (!key.isPresent()) {
             throw new IllegalArgumentException("failed to find codec [" + name + "]");
         }

--- a/server/src/main/java/org/opensearch/index/codec/CodecService.java
+++ b/server/src/main/java/org/opensearch/index/codec/CodecService.java
@@ -41,7 +41,7 @@ import org.opensearch.common.collect.MapBuilder;
 import org.opensearch.index.mapper.MapperService;
 
 import java.util.Map;
-import java.util.Optional;
+import java.util.TreeMap;
 
 /**
  * Since Lucene 4.0 low level index segments are read and written through a
@@ -73,22 +73,16 @@ public class CodecService {
         for (String codec : Codec.availableCodecs()) {
             codecs.put(codec, Codec.forName(codec));
         }
-        this.codecs = codecs.immutableMap();
+        this.codecs = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        this.codecs.putAll(codecs.map());
     }
 
     public Codec codec(String name) {
-        return codecs
-            .entrySet()
-            .stream()
-            .filter(e -> e.getKey().equalsIgnoreCase(name))
-            .map(Map.Entry::getValue)
-            .findAny()
-            .orElseThrow(() -> new IllegalArgumentException("failed to find codec [" + name + "]"));
-
-        if (!key.isPresent()) {
+        Codec codec = codecs.get(name);
+        if (codec == null) {
             throw new IllegalArgumentException("failed to find codec [" + name + "]");
         }
-        return codecs.get(key.get());
+        return codec;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
+++ b/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
@@ -133,7 +133,7 @@ public final class EngineConfig {
                 if (!Codec.availableCodecs().stream().anyMatch(c -> c.equalsIgnoreCase(s))) { // we don't error message the not
                                                                                               // officially supported ones
                     throw new IllegalArgumentException(
-                        "unknown value for [index.codec] must be one of [default, best_compression] or "
+                        "unknown value for [index.codec] must be one of [default, best_compression, lucene_default] or "
                             + Codec.availableCodecs()
                             + " but was: "
                             + s

--- a/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
+++ b/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
@@ -123,15 +123,19 @@ public final class EngineConfig {
      * allocated on both `kind` of nodes.
      */
     public static final Setting<String> INDEX_CODEC_SETTING = new Setting<>("index.codec", "default", s -> {
-        switch (s) {
+        switch (s.toLowerCase()) {
             case "default":
             case "best_compression":
             case "lucene_default":
                 return s;
             default:
-                if (Codec.availableCodecs().contains(s) == false) { // we don't error message the not officially supported ones
+                if (!Codec.availableCodecs().stream().anyMatch(c -> c.equalsIgnoreCase(s))) { // we don't error message the not
+                                                                                              // officially supported ones
                     throw new IllegalArgumentException(
-                        "unknown value for [index.codec] must be one of [default, best_compression] but was: " + s
+                        "unknown value for [index.codec] must be one of [default, best_compression] or "
+                            + Codec.availableCodecs()
+                            + " but was: "
+                            + s
                     );
                 }
                 return s;

--- a/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
+++ b/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
@@ -130,7 +130,7 @@ public final class EngineConfig {
             case "lucene_default":
                 return s;
             default:
-                if (!Codec.availableCodecs().stream().anyMatch(c -> c.equalsIgnoreCase(s))) { // we don't error message the not
+                if (Codec.availableCodecs().stream().anyMatch(c -> c.equalsIgnoreCase(s)) == false) { // we don't error message the not
                                                                                               // officially supported ones
                     throw new IllegalArgumentException(
                         "unknown value for [index.codec] must be one of [default, best_compression, lucene_default] or "

--- a/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
+++ b/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
@@ -60,6 +60,7 @@ import org.opensearch.indices.breaker.CircuitBreakerService;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.function.BooleanSupplier;
 import java.util.function.LongSupplier;
@@ -123,7 +124,7 @@ public final class EngineConfig {
      * allocated on both `kind` of nodes.
      */
     public static final Setting<String> INDEX_CODEC_SETTING = new Setting<>("index.codec", "default", s -> {
-        switch (s.toLowerCase()) {
+        switch (s.toLowerCase(Locale.ROOT)) {
             case "default":
             case "best_compression":
             case "lucene_default":


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
OpenSearch currently supports `default`, `best_compression`, `lucene_default`, and `ZSTD` compression codecs for `index.codec`. The setting uses a case-sensitive comparison. If the user supplies `BEST_COMPRESSION`, for example, OpenSearch uses the `default` (LZ4) codec and not `best_compression` (deflate). 

This PR addresses the issue by allowing a case-insensitive match for the setting. 

### Issues Resolved
`index.codec: BEST_COMPRESSION` falls back to `default` (lz4) and not `best_compression` (deflate).

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
