### PR TITLE
[Segment Replication] Fix Assertion failure on primary mode.

### DIFF
--- a/server/src/main/java/org/opensearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/opensearch/index/seqno/ReplicationTracker.java
@@ -1209,7 +1209,6 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
      */
     public synchronized void setLatestReplicationCheckpoint(ReplicationCheckpoint checkpoint) {
         assert indexSettings.isSegRepEnabled();
-        assert primaryMode;
         assert handoffInProgress == false;
         if (checkpoint.equals(lastPublishedReplicationCheckpoint) == false) {
             this.lastPublishedReplicationCheckpoint = checkpoint;

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1763,9 +1763,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     }
 
     public void onCheckpointPublished(ReplicationCheckpoint checkpoint) {
-        if (replicationTracker.isPrimaryMode()) {
-            replicationTracker.setLatestReplicationCheckpoint(checkpoint);
-        }
+        replicationTracker.setLatestReplicationCheckpoint(checkpoint);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1763,7 +1763,9 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     }
 
     public void onCheckpointPublished(ReplicationCheckpoint checkpoint) {
-        replicationTracker.setLatestReplicationCheckpoint(checkpoint);
+        if(replicationTracker.isPrimaryMode()){
+            replicationTracker.setLatestReplicationCheckpoint(checkpoint);
+        }
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1763,7 +1763,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     }
 
     public void onCheckpointPublished(ReplicationCheckpoint checkpoint) {
-        if(replicationTracker.isPrimaryMode()){
+        if (replicationTracker.isPrimaryMode()) {
             replicationTracker.setLatestReplicationCheckpoint(checkpoint);
         }
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR adds primary mode check before calling setLatestReplicationCheckpoint() to avoid assertion failure.

### Issues Resolved
```
апр 17, 2023 1:28:46 AM com.carrotsearch.randomizedtesting.RandomizedRunner$QueueUncaughtExceptionsHandler uncaughtException
WARNING: Uncaught exception in thread: Thread[opensearch[node_t5][refresh][T#1],5,TGRP-IndexPrimaryRelocationIT]
java.lang.AssertionError
	at __randomizedtesting.SeedInfo.seed([C06CAB01F9EA9D4A]:0)
	at org.opensearch.index.seqno.ReplicationTracker.setLatestReplicationCheckpoint(ReplicationTracker.java:1214)
	at org.opensearch.index.shard.IndexShard.onCheckpointPublished(IndexShard.java:1771)
	at org.opensearch.indices.replication.checkpoint.SegmentReplicationCheckpointPublisher.publish(SegmentReplicationCheckpointPublisher.java:37)
	at org.opensearch.index.shard.CheckpointRefreshListener.afterRefresh(CheckpointRefreshListener.java:44)
	at org.apache.lucene.search.ReferenceManager.notifyRefreshListenersRefreshed(ReferenceManager.java:275)
	at org.apache.lucene.search.ReferenceManager.doMaybeRefresh(ReferenceManager.java:182)
	at org.apache.lucene.search.ReferenceManager.maybeRefreshBlocking(ReferenceManager.java:240)
	at org.opensearch.index.engine.InternalEngine$ExternalReaderManager.refreshIfNeeded(InternalEngine.java:432)
	at org.opensearch.index.engine.InternalEngine$ExternalReaderManager.refreshIfNeeded(InternalEngine.java:412)
	at org.apache.lucene.search.ReferenceManager.doMaybeRefresh(ReferenceManager.java:167)
	at org.apache.lucene.search.ReferenceManager.maybeRefresh(ReferenceManager.java:213)
	at org.opensearch.index.engine.InternalEngine.refresh(InternalEngine.java:1846)
	at org.opensearch.index.engine.InternalEngine.maybeRefresh(InternalEngine.java:1825)
	at org.opensearch.index.shard.IndexShard.scheduledRefresh(IndexShard.java:4127)
	at org.opensearch.index.IndexService.maybeRefreshEngine(IndexService.java:983)
	at org.opensearch.index.IndexService$AsyncRefreshTask.runInternal(IndexService.java:1116)
	at org.opensearch.common.util.concurrent.AbstractAsyncTask.run(AbstractAsyncTask.java:159)
	at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:747)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)

REPRODUCE WITH: ./gradlew ':server:internalClusterTest' --tests "org.opensearch.indices.recovery.IndexPrimaryRelocationIT.testPrimaryRelocationWhileIndexing" -Dtests.seed=C06CAB01F9EA9D4A -Dtests.security.manager=true -Dtests.jvm.argline="-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m" -Dtests.locale=sr-RS -Dtests.timezone=Atlantic/Madeira -Druntime.java=17
NOTE: test params are: codec=Asserting(Lucene95): {index_uuid=Lucene90, type=Lucene90}, docValues:{}, maxPointsInLeafNode=159, maxMBSortInHeap=5.093321826566994, sim=Asserting(RandomSimilarity(queryNorm=true): {}), locale=sr-RS, timezone=Atlantic/Madeira
NOTE: Linux 5.15.0-1028-aws amd64/Eclipse Adoptium 17.0.6 (64-bit)/cpus=96,threads=1,free=523168640,total=729808896
NOTE: All tests run in this JVM: [IndicesExistsIT, RareClusterStateIT, FinalPipelineIT, IndexPrimaryRelocationIT]
```

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
