### PR TITLE
Change assertion to use value match instead of array match

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/260_sort_mixed.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/260_sort_mixed.yml
@@ -50,10 +50,10 @@
   - length: { hits.hits: 3 }
   - match: { hits.hits.0._index: test_2 }
   - match: { hits.hits.0._source.counter: 1223372036854775800.23 }
-  - match: { hits.hits.0.sort: [1223372036854775800.23] }
+  - match: { hits.hits.0.sort.0: 1223372036854775800.23 }
   - match: { hits.hits.1._index: test_1 }
   - match: { hits.hits.1._source.counter: 223372036854775800 }
-  - match: { hits.hits.1.sort: [223372036854775800] }
+  - match: { hits.hits.1.sort.0: 223372036854775800  }
 
   - do:
       search:
@@ -65,7 +65,7 @@
   - length: { hits.hits: 3 }
   - match: { hits.hits.0._index: test_2 }
   - match: { hits.hits.0._source.counter: 184.4 }
-  - match: { hits.hits.0.sort: [184.4] }
+  - match: { hits.hits.0.sort.0: 184.4 }
   - match: { hits.hits.1._index: test_1 }
   - match: { hits.hits.1._source.counter: 223372036854775800 }
-  - match: { hits.hits.1.sort: [223372036854775800] }
+  - match: { hits.hits.1.sort.0: 223372036854775800 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Change assertion to use value match instead of array match to eliminate the client/language specific mismatches  (see please https://github.com/opensearch-project/opensearch-rs/pull/149). 

```
'free::search::_260_sort_mixed::search_across_indices_with_mixed_long_and_double_numeric_types' panicked at 'assertion failed: `(left == right)`
  left: `Array [Number(1.22337203685477581E18)]`,
 right: `Array [Number(1.2233720368547758e18)]`: expected value json["hits"]["hits"][0]["sort"] to match Array [Number(1.2233720368547758e18)] but was Array [Number(1.22337203685477581E18)]', yaml_test_runner/tests/free/search/_260_sort_mixed.rs:77:5
```

The array based comparisons (in Rust at least) uses string based approach but we should compare numbers instead.

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
