### PR TITLE
[Backport] [2.x] Bump com.netflix.nebula:gradle-info-plugin from 12.0.1 to 12.1.0 (#7188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 ### Dependencies
+- Bump `com.netflix.nebula:gradle-info-plugin` from 12.0.0 to 12.1.0
+- Bump `com.netflix.nebula:nebula-publishing-plugin` from 19.2.0 to 20.2.0
 
 ### Changed
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -106,8 +106,8 @@ dependencies {
   api 'org.apache.commons:commons-compress:1.22'
   api 'org.apache.ant:ant:1.10.13'
   api 'com.netflix.nebula:gradle-extra-configurations-plugin:9.0.0'
-  api 'com.netflix.nebula:nebula-publishing-plugin:19.2.0'
-  api 'com.netflix.nebula:gradle-info-plugin:12.0.0'
+  api 'com.netflix.nebula:nebula-publishing-plugin:20.2.0'
+  api 'com.netflix.nebula:gradle-info-plugin:12.1.0'
   api 'org.apache.rat:apache-rat:0.15'
   api 'commons-io:commons-io:2.7'
   api "net.java.dev.jna:jna:5.11.0"


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/7188 to 2.x