### PR TITLE
[Segment Replication] Prevent cancellation of ReplicationTracker's in-sync allocation ids

### DIFF
--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -2359,10 +2359,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
 
     // Returns true if shard routing is primary & replication tracker is in primary mode.
     public boolean isPrimaryMode() {
-        if (shardRouting.primary() && replicationTracker.isPrimaryMode()) {
-            return true;
-        }
-        return false;
+        return shardRouting.primary() && replicationTracker.isPrimaryMode();
     }
 
     private boolean assertReplicationTarget() {

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -2357,6 +2357,14 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         return true;
     }
 
+    // Returns true if shard routing is primary & replication tracker is in primary mode.
+    public boolean isPrimaryMode() {
+        if (shardRouting.primary() && replicationTracker.isPrimaryMode()) {
+            return true;
+        }
+        return false;
+    }
+
     private boolean assertReplicationTarget() {
         assert replicationTracker.isPrimaryMode() == false : "shard " + shardRouting + " in primary mode cannot be a replication target";
         return true;
@@ -2739,7 +2747,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
      */
     public void updateVisibleCheckpointForShard(final String allocationId, final ReplicationCheckpoint visibleCheckpoint) {
         // Update target replication checkpoint only when in active primary mode
-        if (shardRouting.primary() && replicationTracker.isPrimaryMode()) {
+        if (this.isPrimaryMode()) {
             verifyNotClosed();
             replicationTracker.updateVisibleCheckpointForShard(allocationId, visibleCheckpoint);
         }

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceService.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceService.java
@@ -37,6 +37,7 @@ import org.opensearch.transport.TransportRequestHandler;
 import org.opensearch.transport.TransportService;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -172,9 +173,9 @@ public class SegmentReplicationSourceService extends AbstractLifecycleComponent 
                 for (IndexShard indexShard : indexService) {
                     if (indexShard.routingEntry().primary()) {
                         final IndexMetadata indexMetadata = indexService.getIndexSettings().getIndexMetadata();
-                        Set<String> inSyncAllocationIds = indexMetadata.inSyncAllocationIds(indexShard.shardId().id());
+                        final Set<String> inSyncAllocationIds = new HashSet<>(indexMetadata.inSyncAllocationIds(indexShard.shardId().id()));
                         if (indexShard.isPrimaryMode()) {
-                            Set<String> shardTrackerInSyncIds = indexShard.getReplicationGroup().getInSyncAllocationIds();
+                            final Set<String> shardTrackerInSyncIds = indexShard.getReplicationGroup().getInSyncAllocationIds();
                             inSyncAllocationIds.addAll(shardTrackerInSyncIds);
                         }
                         ongoingSegmentReplications.clearOutOfSyncIds(indexShard.shardId(), inSyncAllocationIds);

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceService.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceService.java
@@ -172,7 +172,11 @@ public class SegmentReplicationSourceService extends AbstractLifecycleComponent 
                 for (IndexShard indexShard : indexService) {
                     if (indexShard.routingEntry().primary()) {
                         final IndexMetadata indexMetadata = indexService.getIndexSettings().getIndexMetadata();
-                        final Set<String> inSyncAllocationIds = indexMetadata.inSyncAllocationIds(indexShard.shardId().id());
+                        Set<String> inSyncAllocationIds = indexMetadata.inSyncAllocationIds(indexShard.shardId().id());
+                        if (indexShard.isPrimaryMode()) {
+                            Set<String> shardTrackerInSyncIds = indexShard.getReplicationGroup().getInSyncAllocationIds();
+                            inSyncAllocationIds.addAll(shardTrackerInSyncIds);
+                        }
                         ongoingSegmentReplications.clearOutOfSyncIds(indexShard.shardId(), inSyncAllocationIds);
                     }
                 }


### PR DESCRIPTION
### Description
Prevent cancellation of allocation ids which are marked in-sync inside replication tracker. More details in https://github.com/opensearch-project/OpenSearch/issues/7213

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/7213

### Test
RecoveryWhileUnderLoadIT.testRecoverWhileRelocating passes 500 times without failure. 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
