### PR TITLE
Use lowercase letters for zstd, zstdnodict compression codecs.

### DIFF
--- a/sandbox/plugins/custom-codecs/src/main/java/org/opensearch/index/codec/customcodecs/CustomCodecPlugin.java
+++ b/sandbox/plugins/custom-codecs/src/main/java/org/opensearch/index/codec/customcodecs/CustomCodecPlugin.java
@@ -14,8 +14,8 @@ import org.opensearch.plugins.EnginePlugin;
 /**
  * A plugin that implements custom codecs. Supports these codecs:
  * <ul>
- * <li>ZSTD
- * <li>ZSTDNODICT
+ * <li>zstd
+ * <li>zstdnodict
  * </ul>
  *
  * @opensearch.internal

--- a/sandbox/plugins/custom-codecs/src/main/java/org/opensearch/index/codec/customcodecs/Lucene95CustomCodec.java
+++ b/sandbox/plugins/custom-codecs/src/main/java/org/opensearch/index/codec/customcodecs/Lucene95CustomCodec.java
@@ -12,6 +12,8 @@ import org.apache.lucene.codecs.StoredFieldsFormat;
 import org.apache.lucene.codecs.FilterCodec;
 import org.apache.lucene.codecs.lucene95.Lucene95Codec;
 
+import java.util.Locale;
+
 abstract class Lucene95CustomCodec extends FilterCodec {
     public static final int DEFAULT_COMPRESSION_LEVEL = 6;
 
@@ -23,13 +25,25 @@ abstract class Lucene95CustomCodec extends FilterCodec {
 
     private final StoredFieldsFormat storedFieldsFormat;
 
-    /** new codec for a given compression algorithm and default compression level */
+    /**
+     * Creates a new compression codec with the default compression level.
+     *
+     * @param mode The compression codec (ZSTD or ZSTDNODICT).
+     */
     public Lucene95CustomCodec(Mode mode) {
         this(mode, DEFAULT_COMPRESSION_LEVEL);
     }
 
+    /**
+     * Creates a new compression codec with the given compression level. We use
+     * lowercase letters when registering the codec so that we remain consistent with
+     * the other compression codecs: default, lucene_default, and best_compression.
+     *
+     * @param mode The compression codec (ZSTD or ZSTDNODICT).
+     * @parama compressionLevel The compression level.
+     */
     public Lucene95CustomCodec(Mode mode, int compressionLevel) {
-        super(mode.name(), new Lucene95Codec());
+        super(mode.name().toLowerCase(Locale.ROOT), new Lucene95Codec());
         this.storedFieldsFormat = new Lucene95CustomStoredFieldsFormat(mode, compressionLevel);
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
OpenSearch supports: `default`, `lucene_default`, `best_compression`, and `ZSTD` compression codecs. This PR changes `ZSTD` to `zstd` to maintain consistency in naming compression codecs. 

### Issues Resolved
A follow up to PR: https://github.com/opensearch-project/OpenSearch/pull/7171.

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x]  Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
