### PR TITLE
[Search Pipelines] Support ad hoc pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add getter for path field in NestedQueryBuilder ([#4636](https://github.com/opensearch-project/OpenSearch/pull/4636))
 - Allow mmap to use new JDK-19 preview APIs in Apache Lucene 9.4+ ([#5151](https://github.com/opensearch-project/OpenSearch/pull/5151))
 - Add events correlation engine plugin ([#6854](https://github.com/opensearch-project/OpenSearch/issues/6854))
+- [Search Pipelines] Accept pipelines defined in search source ([#7253](https://github.com/opensearch-project/OpenSearch/pull/7253))
 - Add connectToNodeAsExtension in TransportService ([#6866](https://github.com/opensearch-project/OpenSearch/pull/6866))
-
+-
 ### Dependencies
 - Bump `log4j-core` from 2.18.0 to 2.19.0
 - Bump `forbiddenapis` from 3.3 to 3.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add getter for path field in NestedQueryBuilder ([#4636](https://github.com/opensearch-project/OpenSearch/pull/4636))
 - Allow mmap to use new JDK-19 preview APIs in Apache Lucene 9.4+ ([#5151](https://github.com/opensearch-project/OpenSearch/pull/5151))
 - Add events correlation engine plugin ([#6854](https://github.com/opensearch-project/OpenSearch/issues/6854))
-- [Search Pipelines] Accept pipelines defined in search source ([#7253](https://github.com/opensearch-project/OpenSearch/pull/7253))
 - Add connectToNodeAsExtension in TransportService ([#6866](https://github.com/opensearch-project/OpenSearch/pull/6866))
 
 ### Dependencies
@@ -83,6 +82,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Extensions] Moving Extensions APIs to support cross versions via protobuf. ([#7402](https://github.com/opensearch-project/OpenSearch/issues/7402))
 - [Extensions] Add IdentityPlugin into core to support Extension identities ([#7246](https://github.com/opensearch-project/OpenSearch/pull/7246))
 - Add connectToNodeAsExtension in TransportService ([#6866](https://github.com/opensearch-project/OpenSearch/pull/6866))
+- [Search Pipelines] Accept pipelines defined in search source ([#7253](https://github.com/opensearch-project/OpenSearch/pull/7253))
 - Add descending order search optimization through reverse segment read. ([#7244](https://github.com/opensearch-project/OpenSearch/pull/7244))
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add events correlation engine plugin ([#6854](https://github.com/opensearch-project/OpenSearch/issues/6854))
 - [Search Pipelines] Accept pipelines defined in search source ([#7253](https://github.com/opensearch-project/OpenSearch/pull/7253))
 - Add connectToNodeAsExtension in TransportService ([#6866](https://github.com/opensearch-project/OpenSearch/pull/6866))
--
+
 ### Dependencies
 - Bump `log4j-core` from 2.18.0 to 2.19.0
 - Bump `forbiddenapis` from 3.3 to 3.4

--- a/modules/search-pipeline-common/src/yamlRestTest/resources/rest-api-spec/test/search_pipeline/30_filter_query.yml
+++ b/modules/search-pipeline-common/src/yamlRestTest/resources/rest-api-spec/test/search_pipeline/30_filter_query.yml
@@ -81,3 +81,23 @@ teardown:
         }
   - match: { hits.total.value: 1 }
   - match: { hits.hits.0._id: "2" }
+
+  # Should work with inline query
+  - do:
+      search:
+        index: test
+        body: {
+          "search_pipeline" : {
+            "request_processors" : [
+              "filter_query": {
+                "query": {
+                  "term": {
+                    "field": "foo"
+                  }
+                }
+              }
+            ]
+          }
+        }
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "1" }

--- a/server/src/main/java/org/opensearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/opensearch/action/search/TransportSearchAction.java
@@ -80,7 +80,7 @@ import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.internal.AliasFilter;
 import org.opensearch.search.internal.InternalSearchResponse;
 import org.opensearch.search.internal.SearchContext;
-import org.opensearch.search.pipeline.Pipeline;
+import org.opensearch.search.pipeline.PipelinedRequest;
 import org.opensearch.search.pipeline.SearchPipelineService;
 import org.opensearch.search.profile.ProfileShardResult;
 import org.opensearch.search.profile.SearchProfileShardResults;
@@ -393,11 +393,10 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         SearchRequest searchRequest;
         ActionListener<SearchResponse> listener;
         try {
-            Pipeline searchPipeline = searchPipelineService.resolvePipeline(originalSearchRequest);
-            searchRequest = searchPipeline.transformRequest(originalSearchRequest);
+            PipelinedRequest pipelinedRequest = searchPipelineService.resolvePipeline(originalSearchRequest);
+            searchRequest = pipelinedRequest.transformedRequest();
             listener = ActionListener.wrap(
-                // TODO: Should we transform responses with the original request or the transformed request? Or both?
-                r -> originalListener.onResponse(searchPipeline.transformResponse(originalSearchRequest, r)),
+                r -> originalListener.onResponse(pipelinedRequest.transformResponse(r)),
                 originalListener::onFailure
             );
         } catch (Exception e) {

--- a/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
@@ -33,8 +33,10 @@
 package org.opensearch.search.builder;
 
 import org.opensearch.OpenSearchException;
+import org.opensearch.Version;
 import org.opensearch.common.Booleans;
 import org.opensearch.common.Nullable;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.ParseField;
 import org.opensearch.common.ParsingException;
 import org.opensearch.common.Strings;
@@ -76,6 +78,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import static org.opensearch.index.query.AbstractQueryBuilder.parseInnerQueryBuilder;
@@ -127,6 +130,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
     public static final ParseField COLLAPSE = new ParseField("collapse");
     public static final ParseField SLICE = new ParseField("slice");
     public static final ParseField POINT_IN_TIME = new ParseField("pit");
+    public static final ParseField SEARCH_PIPELINE = new ParseField("search_pipeline");
 
     public static SearchSourceBuilder fromXContent(XContentParser parser) throws IOException {
         return fromXContent(parser, true);
@@ -207,6 +211,8 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
 
     private PointInTimeBuilder pointInTimeBuilder = null;
 
+    private Map<String, Object> searchPipelineSource = null;
+
     /**
      * Constructs a new search source builder.
      */
@@ -264,6 +270,11 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
             fetchFields = in.readList(FieldAndFormat::new);
         }
         pointInTimeBuilder = in.readOptionalWriteable(PointInTimeBuilder::new);
+        if (in.getVersion().onOrAfter(Version.V_3_0_0)) { // TODO: Update if/when we backport to 2.x
+            if (in.readBoolean()) {
+                searchPipelineSource = in.readMap();
+            }
+        }
     }
 
     @Override
@@ -323,6 +334,12 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
             out.writeList(fetchFields);
         }
         out.writeOptionalWriteable(pointInTimeBuilder);
+        if (out.getVersion().onOrAfter(Version.V_3_0_0)) { // TODO: Update if/when we backport to 2.x
+            out.writeBoolean(searchPipelineSource != null);
+            if (searchPipelineSource != null) {
+                out.writeMap(searchPipelineSource);
+            }
+        }
     }
 
     /**
@@ -982,6 +999,21 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
     }
 
     /**
+     * @return a search pipeline defined within the search source (see {@link org.opensearch.search.pipeline.SearchPipelineService})
+     */
+    public Map<String, Object> searchPipelineSource() {
+        return searchPipelineSource;
+    }
+
+    /**
+     * Define a search pipeline to process this search request and/or its response. See {@link org.opensearch.search.pipeline.SearchPipelineService}.
+     */
+    public SearchSourceBuilder searchPipelineSource(Map<String, Object> searchPipelineSource) {
+        this.searchPipelineSource = searchPipelineSource;
+        return this;
+    }
+
+    /**
      * Rewrites this search source builder into its primitive form. e.g. by
      * rewriting the QueryBuilder. If the builder did not change the identity
      * reference must be returned otherwise the builder will be rewritten
@@ -1218,13 +1250,16 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
                         collapse = CollapseBuilder.fromXContent(parser);
                     } else if (POINT_IN_TIME.match(currentFieldName, parser.getDeprecationHandler())) {
                         pointInTimeBuilder = PointInTimeBuilder.fromXContent(parser);
-                    } else {
-                        throw new ParsingException(
-                            parser.getTokenLocation(),
-                            "Unknown key for a " + token + " in [" + currentFieldName + "].",
-                            parser.getTokenLocation()
-                        );
-                    }
+                    } else if (FeatureFlags.isEnabled(FeatureFlags.SEARCH_PIPELINE)
+                        && SEARCH_PIPELINE.match(currentFieldName, parser.getDeprecationHandler())) {
+                            searchPipelineSource = parser.mapOrdered();
+                        } else {
+                            throw new ParsingException(
+                                parser.getTokenLocation(),
+                                "Unknown key for a " + token + " in [" + currentFieldName + "].",
+                                parser.getTokenLocation()
+                            );
+                        }
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if (STORED_FIELDS_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     storedFieldsContext = StoredFieldsContext.fromXContent(STORED_FIELDS_FIELD.getPreferredName(), parser);
@@ -1442,6 +1477,9 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         }
         if (pointInTimeBuilder != null) {
             pointInTimeBuilder.toXContent(builder, params);
+        }
+        if (searchPipelineSource != null) {
+            builder.field(SEARCH_PIPELINE.getPreferredName(), searchPipelineSource);
         }
         return builder;
     }

--- a/server/src/main/java/org/opensearch/search/pipeline/Pipeline.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/Pipeline.java
@@ -31,7 +31,7 @@ import static org.opensearch.ingest.Pipeline.VERSION_KEY;
 /**
  * Concrete representation of a search pipeline, holding multiple processors.
  */
-public class Pipeline {
+class Pipeline {
 
     public static final String REQUEST_PROCESSORS_KEY = "request_processors";
     public static final String RESPONSE_PROCESSORS_KEY = "response_processors";

--- a/server/src/main/java/org/opensearch/search/pipeline/PipelinedRequest.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/PipelinedRequest.java
@@ -13,8 +13,10 @@ import org.opensearch.action.search.SearchResponse;
 
 /**
  * Groups a search pipeline based on a request and the request after being transformed by the pipeline.
+ *
+ * @opensearch.internal
  */
-public class PipelinedRequest {
+public final class PipelinedRequest {
     private final Pipeline pipeline;
     private final SearchRequest transformedRequest;
 
@@ -24,8 +26,6 @@ public class PipelinedRequest {
     }
 
     public SearchResponse transformResponse(SearchResponse response) {
-
-        // TODO: Should we transform responses with the original request or the transformed request? Or both?
         return pipeline.transformResponse(transformedRequest, response);
     }
 

--- a/server/src/main/java/org/opensearch/search/pipeline/PipelinedRequest.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/PipelinedRequest.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.pipeline;
+
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+
+/**
+ * Groups a search pipeline based on a request and the request after being transformed by the pipeline.
+ */
+public class PipelinedRequest {
+    private final Pipeline pipeline;
+    private final SearchRequest transformedRequest;
+
+    PipelinedRequest(Pipeline pipeline, SearchRequest transformedRequest) {
+        this.pipeline = pipeline;
+        this.transformedRequest = transformedRequest;
+    }
+
+    public SearchResponse transformResponse(SearchResponse response) {
+
+        // TODO: Should we transform responses with the original request or the transformed request? Or both?
+        return pipeline.transformResponse(transformedRequest, response);
+    }
+
+    public SearchRequest transformedRequest() {
+        return transformedRequest;
+    }
+
+    // Visible for testing
+    Pipeline getPipeline() {
+        return pipeline;
+    }
+}

--- a/server/src/main/java/org/opensearch/search/pipeline/SearchPipelineService.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/SearchPipelineService.java
@@ -331,11 +331,11 @@ public class SearchPipelineService implements ClusterStateApplier, ReportingServ
         return newState.build();
     }
 
-    public Pipeline resolvePipeline(SearchRequest searchRequest) {
+    public PipelinedRequest resolvePipeline(SearchRequest searchRequest) throws Exception {
         Pipeline pipeline = Pipeline.NO_OP_PIPELINE;
 
         if (isEnabled == false) {
-            return pipeline;
+            return new PipelinedRequest(pipeline, searchRequest);
         }
         if (searchRequest.source() != null && searchRequest.source().searchPipelineSource() != null) {
             if (searchRequest.pipeline() != null) {
@@ -361,7 +361,8 @@ public class SearchPipelineService implements ClusterStateApplier, ReportingServ
             }
             pipeline = pipelineHolder.pipeline;
         }
-        return pipeline;
+        SearchRequest transformedRequest = pipeline.transformRequest(searchRequest);
+        return new PipelinedRequest(pipeline, transformedRequest);
     }
 
     Map<String, Processor.Factory> getProcessorFactories() {

--- a/server/src/main/java/org/opensearch/search/pipeline/SearchPipelineService.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/SearchPipelineService.java
@@ -61,6 +61,7 @@ public class SearchPipelineService implements ClusterStateApplier, ReportingServ
 
     public static final String SEARCH_PIPELINE_ORIGIN = "search_pipeline";
     public static final String AD_HOC_PIPELINE_ID = "_ad_hoc_pipeline";
+    public static final String NOOP_PIPELINE_ID = "_none";
     private static final Logger logger = LogManager.getLogger(SearchPipelineService.class);
     private final ClusterService clusterService;
     private final ScriptService scriptService;
@@ -340,7 +341,7 @@ public class SearchPipelineService implements ClusterStateApplier, ReportingServ
         if (searchRequest.source() != null && searchRequest.source().searchPipelineSource() != null) {
             if (searchRequest.pipeline() != null) {
                 throw new IllegalArgumentException(
-                    "Both named and inline search pipeline were specified. Please only specify on or the other."
+                    "Both named and inline search pipeline were specified. Please only specify one or the other."
                 );
             }
             try {

--- a/test/framework/src/main/java/org/opensearch/search/RandomSearchRequestGenerator.java
+++ b/test/framework/src/main/java/org/opensearch/search/RandomSearchRequestGenerator.java
@@ -38,6 +38,7 @@ import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.text.Text;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -65,6 +66,7 @@ import org.opensearch.test.AbstractQueryTestCase;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -403,6 +405,9 @@ public class RandomSearchRequestGenerator {
                 pit.setKeepAlive(TimeValue.timeValueMinutes(randomIntBetween(1, 60)));
             }
             builder.pointInTimeBuilder(pit);
+        }
+        if (FeatureFlags.isEnabled(FeatureFlags.SEARCH_PIPELINE) && randomBoolean()) {
+            builder.searchPipelineSource(new HashMap<>());
         }
         return builder;
     }


### PR DESCRIPTION
### Description
This change allows a search pipeline to be defined within a search request body. This will take precedence over any other search pipeline, and allows ad hoc testing of pipeline configurations before persisting the pipeline definition in cluster state.

The new search source field is gated behind the search pipelines feature flag. Also, serialization of the field is gated behind a 3.0 version check. I don't think we should backport to the 2.x branch before we release 2.7. I think we'll want to update that version check to 2.8.

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/6717

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
