### PR TITLE
fix: memory leak in resource tracking

### DIFF
--- a/server/src/main/java/org/opensearch/tasks/TaskManager.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskManager.java
@@ -286,7 +286,7 @@ public class TaskManager implements ClusterStateApplier {
                 }
             }
         }
-        
+
         if (task.supportsResourceTracking() && taskResourceTrackingService.get() != null) {
             taskResourceTrackingService.get().cleanTracking(task);
         }

--- a/server/src/main/java/org/opensearch/tasks/TaskManager.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskManager.java
@@ -202,7 +202,7 @@ public class TaskManager implements ClusterStateApplier {
                 @Override
                 protected void innerOnResponse(Task task) {
                     // Stop tracking the task once the last thread has been marked inactive.
-                    if (taskResourceTrackingService.get() != null && task.supportsResourceTracking()) {
+                    if (taskResourceTrackingService.get() != null) {
                         taskResourceTrackingService.get().stopTracking(task);
                     }
                 }
@@ -285,6 +285,10 @@ public class TaskManager implements ClusterStateApplier {
                     logger.error("error encountered when updating the consumer", e);
                 }
             }
+        }
+        
+        if (task.supportsResourceTracking() && taskResourceTrackingService.get() != null) {
+            taskResourceTrackingService.get().cleanTracking(task);
         }
 
         if (task instanceof CancellableTask) {

--- a/server/src/main/java/org/opensearch/tasks/TaskResourceTrackingService.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskResourceTrackingService.java
@@ -115,8 +115,6 @@ public class TaskResourceTrackingService implements RunnableTaskExecutionListene
         } catch (Exception e) {
             logger.warn("Failed while trying to mark the task execution on current thread completed.", e);
             assert false;
-        } finally {
-            resourceAwareTasks.remove(task.getId());
         }
 
         List<Exception> exceptions = new ArrayList<>();
@@ -128,6 +126,14 @@ public class TaskResourceTrackingService implements RunnableTaskExecutionListene
             }
         }
         ExceptionsHelper.maybeThrowRuntimeAndSuppress(exceptions);
+    }
+
+    /**
+     * clean sources using by Tracking
+     * @param task task which has finished and doesn't need resource tracking.
+     */
+    public void cleanTracking(Task task) {
+        resourceAwareTasks.remove(task.getId());
     }
 
     /**


### PR DESCRIPTION
The task in map resourceAwareTasks is not be cleaned when there is a exception, I think. So I clean the resource used by tracking at task unregister function.

And I think the condition `task.supportsResourceTracking()` in if is redundant since the value can't change. 

Signed-off-by: fudongying <fudongying@bytedance.com>