### PR TITLE
[DRAFT PR]POC code to batch async shards fetch per node

### DIFF
--- a/server/src/main/java/org/opensearch/gateway/AsyncShardsFetchPerNode.java
+++ b/server/src/main/java/org/opensearch/gateway/AsyncShardsFetchPerNode.java
@@ -1,0 +1,403 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.gateway;
+
+import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.OpenSearchTimeoutException;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.action.support.nodes.BaseNodeResponse;
+import org.opensearch.action.support.nodes.BaseNodesResponse;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.common.Nullable;
+import org.opensearch.common.lease.Releasable;
+import org.opensearch.index.shard.ShardId;
+import org.opensearch.transport.ReceiveTimeoutTransportException;
+import org.opensearch.common.util.concurrent.OpenSearchRejectedExecutionException;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+
+public abstract class AsyncShardsFetchPerNode<T extends BaseNodeResponse> implements Releasable {
+
+    /**
+     * An action that lists the relevant shard data that needs to be fetched.
+     */
+    public interface Lister<NodesResponse extends BaseNodesResponse<NodeResponse>, NodeResponse extends BaseNodeResponse> {
+        void list(DiscoveryNode[] nodes, Map<ShardId,String> shardsIdMap, ActionListener<NodesResponse> listener);
+    }
+
+    protected final Logger logger;
+    protected final String type;
+    protected Map<ShardId,String> shardsToCustomDataPathMap;
+    private final AsyncShardsFetchPerNode.Lister<BaseNodesResponse<T>, T> action;
+    protected final Map<String, AsyncShardsFetchPerNode.NodeEntry<T>> cache = new HashMap<>();
+
+    private final Set<String> nodesToIgnore = new HashSet<>();
+    private final AtomicLong round = new AtomicLong();
+    private boolean closed;
+
+    @SuppressWarnings("unchecked")
+    protected AsyncShardsFetchPerNode(
+        Logger logger,
+        String type,
+        Map<ShardId, String> shardsToCustomDataPathMap,
+        AsyncShardsFetchPerNode.Lister<? extends BaseNodesResponse<T>, T> action
+    ) {
+        this.logger = logger;
+        this.type = type;
+        this.action = (AsyncShardsFetchPerNode.Lister<BaseNodesResponse<T>, T>) action;
+        this.shardsToCustomDataPathMap = shardsToCustomDataPathMap;
+    }
+
+    @Override
+    public synchronized void close() {
+        this.closed = true;
+    }
+
+    protected abstract void reroute(String reason);
+
+    /**
+     * Clear cache for node, ensuring next fetch will fetch a fresh copy.
+     */
+    synchronized void clearCacheForNode(String nodeId) {
+        cache.remove(nodeId);
+    }
+
+    /**
+     * Fills the shard fetched data with new (data) nodes and a fresh NodeEntry, and removes from
+     * it nodes that are no longer part of the state.
+     */
+    private void fillShardCacheWithDataNodes(Map<String, AsyncShardsFetchPerNode.NodeEntry<T>> shardCache, DiscoveryNodes nodes) {
+        // verify that all current data nodes are there
+        for (ObjectObjectCursor<String, DiscoveryNode> cursor : nodes.getDataNodes()) {
+            DiscoveryNode node = cursor.value;
+            if (shardCache.containsKey(node.getId()) == false) {
+                shardCache.put(node.getId(), new AsyncShardsFetchPerNode.NodeEntry<T>(node.getId()));
+            }
+        }
+        // remove nodes that are not longer part of the data nodes set
+        shardCache.keySet().removeIf(nodeId -> !nodes.nodeExists(nodeId));
+    }
+
+    /**
+     * Finds all the nodes that need to be fetched. Those are nodes that have no
+     * data, and are not in fetch mode.
+     */
+    private List<AsyncShardsFetchPerNode.NodeEntry<T>> findNodesToFetch(Map<String, AsyncShardsFetchPerNode.NodeEntry<T>> shardCache) {
+        List<AsyncShardsFetchPerNode.NodeEntry<T>> nodesToFetch = new ArrayList<>();
+        for (AsyncShardsFetchPerNode.NodeEntry<T> nodeEntry : shardCache.values()) {
+            if (nodeEntry.hasData() == false && nodeEntry.isFetching() == false) {
+                nodesToFetch.add(nodeEntry);
+            }
+        }
+        return nodesToFetch;
+    }
+
+    /**
+     * Are there any nodes that are fetching data?
+     */
+    private boolean hasAnyNodeFetching(Map<String, AsyncShardsFetchPerNode.NodeEntry<T>> shardCache) {
+        for (AsyncShardsFetchPerNode.NodeEntry<T> nodeEntry : shardCache.values()) {
+            if (nodeEntry.isFetching()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    public synchronized AsyncShardsFetchPerNode.TestFetchResult<T> testFetchData(DiscoveryNodes nodes){
+        if (closed) {
+            throw new IllegalStateException("TEST: can't fetch data from nodes on closed async fetch");
+        }
+
+        logger.info("TEST- Fetching Unassigned Shards per node");
+        fillShardCacheWithDataNodes(cache, nodes);
+        List<AsyncShardsFetchPerNode.NodeEntry<T>> nodesToFetch = findNodesToFetch(cache);
+        if (nodesToFetch.isEmpty() == false) {
+            // mark all node as fetching and go ahead and async fetch them
+            // use a unique round id to detect stale responses in processAsyncFetch
+            final long fetchingRound = round.incrementAndGet();
+            for (AsyncShardsFetchPerNode.NodeEntry<T> nodeEntry : nodesToFetch) {
+                nodeEntry.markAsFetching(fetchingRound);
+            }
+            DiscoveryNode[] discoNodesToFetch = nodesToFetch.stream()
+                .map(AsyncShardsFetchPerNode.NodeEntry::getNodeId)
+                .map(nodes::get)
+                .toArray(DiscoveryNode[]::new);
+            asyncFetchShardPerNode(discoNodesToFetch, fetchingRound);
+        }
+
+        if (hasAnyNodeFetching(cache)) {
+            return new AsyncShardsFetchPerNode.TestFetchResult<>( null);
+        } else {
+            // nothing to fetch, yay, build the return value
+            Map<DiscoveryNode, T> fetchData = new HashMap<>();
+            Set<String> failedNodes = new HashSet<>();
+            for (Iterator<Map.Entry<String, AsyncShardsFetchPerNode.NodeEntry<T>>> it = cache.entrySet().iterator(); it.hasNext();) {
+                Map.Entry<String, AsyncShardsFetchPerNode.NodeEntry<T>> entry = it.next();
+                String nodeId = entry.getKey();
+                AsyncShardsFetchPerNode.NodeEntry<T> nodeEntry = entry.getValue();
+
+                DiscoveryNode node = nodes.get(nodeId);
+                if (node != null) {
+                    if (nodeEntry.isFailed()) {
+                        // if its failed, remove it from the list of nodes, so if this run doesn't work
+                        // we try again next round to fetch it again
+                        it.remove();
+                        failedNodes.add(nodeEntry.getNodeId());
+                    } else {
+                        if (nodeEntry.getValue() != null) {
+                            fetchData.put(node, nodeEntry.getValue());
+                        }
+                    }
+                }
+            }
+
+            // if at least one node failed, make sure to have a protective reroute
+            // here, just case this round won't find anything, and we need to retry fetching data
+            if (failedNodes.isEmpty() == false ) {
+                reroute("TEST--> nodes failed [" + failedNodes.size() );
+            }
+
+            return new AsyncShardsFetchPerNode.TestFetchResult<>(fetchData);
+        }
+
+
+
+    }
+
+    void asyncFetchShardPerNode(final DiscoveryNode[] nodes, long fetchingRound) {
+        logger.info("Fetching Unassigned Shards per node");
+        action.list(nodes, shardsToCustomDataPathMap, new ActionListener<BaseNodesResponse<T>>() {
+            @Override
+            public void onResponse(BaseNodesResponse<T> tBaseNodesResponse) {
+                processTestAsyncFetch(tBaseNodesResponse.getNodes(),tBaseNodesResponse.failures(), fetchingRound);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+
+                List<FailedNodeException> failures = new ArrayList<>(nodes.length);
+                for (final DiscoveryNode node : nodes) {
+                    failures.add(new FailedNodeException(node.getId(), "Total failure in fetching", e));
+                }
+                processTestAsyncFetch(null, failures, fetchingRound);
+            }
+        });
+
+    }
+    protected synchronized void processTestAsyncFetch(List<T> responses, List<FailedNodeException> failures, long fetchingRound){
+        if (closed) {
+            // we are closed, no need to process this async fetch at all
+            logger.trace("TEST-Ignoring fetched [{}] results, already closed", type);
+            return;
+        }
+
+        logger.trace("TEST-processing fetched results");
+
+        if (responses != null) {
+            for (T response : responses) {
+                AsyncShardsFetchPerNode.NodeEntry<T> nodeEntry = cache.get(response.getNode().getId());
+                if (nodeEntry != null) {
+                    if (nodeEntry.getFetchingRound() != fetchingRound) {
+                        assert nodeEntry.getFetchingRound() > fetchingRound : "node entries only replaced by newer rounds";
+                        logger.info(
+                            "TEST--> received response for [{}] from node {} for an older fetching round (expected: {} but was: {})",
+                            nodeEntry.getNodeId(),
+                            type,
+                            nodeEntry.getFetchingRound(),
+                            fetchingRound
+                        );
+                    } else if (nodeEntry.isFailed()) {
+                        logger.info(
+                            "node {} has failed for [{}] (failure [{}])",
+                            nodeEntry.getNodeId(),
+                            type,
+                            nodeEntry.getFailure()
+                        );
+                    } else {
+                        // if the entry is there, for the right fetching round and not marked as failed already, process it
+                        logger.info("TEST--> marking {} as done for [{}], result is [{}]", nodeEntry.getNodeId(), type, response);
+                        nodeEntry.doneFetching(response);
+                    }
+                }
+            }
+        }
+        if (failures != null) {
+            for (FailedNodeException failure : failures) {
+                logger.trace("processing failure {} for [{}]", failure, type);
+                AsyncShardsFetchPerNode.NodeEntry<T> nodeEntry = cache.get(failure.nodeId());
+                if (nodeEntry != null) {
+                    if (nodeEntry.getFetchingRound() != fetchingRound) {
+                        assert nodeEntry.getFetchingRound() > fetchingRound : "node entries only replaced by newer rounds";
+                        logger.trace(
+                            "received failure for [{}] from node {} for an older fetching round (expected: {} but was: {})",
+                            nodeEntry.getNodeId(),
+                            type,
+                            nodeEntry.getFetchingRound(),
+                            fetchingRound
+                        );
+                    } else if (nodeEntry.isFailed() == false) {
+                        // if the entry is there, for the right fetching round and not marked as failed already, process it
+                        Throwable unwrappedCause = ExceptionsHelper.unwrapCause(failure.getCause());
+                        // if the request got rejected or timed out, we need to try it again next time...
+                        if (unwrappedCause instanceof OpenSearchRejectedExecutionException
+                            || unwrappedCause instanceof ReceiveTimeoutTransportException
+                            || unwrappedCause instanceof OpenSearchTimeoutException) {
+                            nodeEntry.restartFetching();
+                        } else {
+                            logger.warn(
+                                () -> new ParameterizedMessage(
+                                    "failed to list shard for {} on node [{}]",
+                                    type,
+                                    failure.nodeId()
+                                ),
+                                failure
+                            );
+                            nodeEntry.doneFetching(failure.getCause());
+                        }
+                    }
+                }
+            }
+        }
+
+        reroute("TEST_post_response");
+    }
+
+    protected synchronized void updateBatchOfShards(Map<ShardId, String> shardsToCustomDataPathMap){
+
+        // update only when current batch is completed
+        if(hasAnyNodeFetching(cache)==false && shardsToCustomDataPathMap.isEmpty()==false){
+           this.shardsToCustomDataPathMap= shardsToCustomDataPathMap;
+
+           // not intelligent enough right now to invalidate the diff.
+            // When batching the diff we can make it more intelligent
+           cache.values().forEach(NodeEntry::invalidateCurrentData);
+        }
+    }
+
+    public static class TestFetchResult<T extends BaseNodeResponse> {
+
+        private final Map<DiscoveryNode, T> nodesToShards;
+
+        public TestFetchResult(Map<DiscoveryNode, T> nodesToShards) {
+            this.nodesToShards = nodesToShards;
+        }
+
+        public Map<DiscoveryNode, T> getNodesToShards() {
+            return nodesToShards;
+        }
+
+        public boolean hasData() {
+            return nodesToShards != null;
+        }
+
+    }
+
+
+    /**
+     * A node entry, holding the state of the fetched data for a specific shard
+     * for a giving node.
+     */
+    static class NodeEntry<T> {
+        private final String nodeId;
+        private boolean fetching;
+        @Nullable
+        private T value;
+        private boolean valueSet;
+        private Throwable failure;
+        private long fetchingRound;
+
+        NodeEntry(String nodeId) {
+            this.nodeId = nodeId;
+        }
+
+        String getNodeId() {
+            return this.nodeId;
+        }
+
+        boolean isFetching() {
+            return fetching;
+        }
+
+        void markAsFetching(long fetchingRound) {
+            assert fetching == false : "double marking a node as fetching";
+            this.fetching = true;
+            this.fetchingRound = fetchingRound;
+        }
+
+        void doneFetching(T value) {
+            assert fetching : "setting value but not in fetching mode";
+            assert failure == null : "setting value when failure already set";
+            this.valueSet = true;
+            this.value = value;
+            this.fetching = false;
+        }
+
+        void doneFetching(Throwable failure) {
+            assert fetching : "setting value but not in fetching mode";
+            assert valueSet == false : "setting failure when already set value";
+            assert failure != null : "setting failure can't be null";
+            this.failure = failure;
+            this.fetching = false;
+        }
+
+        void restartFetching() {
+            assert fetching : "restarting fetching, but not in fetching mode";
+            assert valueSet == false : "value can't be set when restarting fetching";
+            assert failure == null : "failure can't be set when restarting fetching";
+            this.fetching = false;
+        }
+
+        boolean isFailed() {
+            return failure != null;
+        }
+
+        boolean hasData() {
+            return valueSet || failure != null;
+        }
+
+        Throwable getFailure() {
+            assert hasData() : "getting failure when data has not been fetched";
+            return failure;
+        }
+
+        @Nullable
+        T getValue() {
+            assert failure == null : "trying to fetch value, but its marked as failed, check isFailed";
+            assert valueSet : "value is not set, hasn't been fetched yet";
+            return value;
+        }
+
+        long getFetchingRound() {
+            return fetchingRound;
+        }
+        void invalidateCurrentData() {
+            this.value=null;
+            valueSet=false;
+            fetchingRound=0;
+            failure=null;
+        }
+    }
+
+
+}

--- a/server/src/main/java/org/opensearch/gateway/GatewayAllocator.java
+++ b/server/src/main/java/org/opensearch/gateway/GatewayAllocator.java
@@ -347,6 +347,10 @@ public class GatewayAllocator implements ExistingShardsAllocator {
         }
     }
 
+    /**
+     * Analogous to InternalAsyncFetch.
+     * @param <T>
+     */
     class TestAsyncShardFetch<T extends BaseNodeResponse> extends AsyncShardsFetchPerNode<T>
     {
         TestAsyncShardFetch(

--- a/server/src/main/java/org/opensearch/gateway/GatewayModule.java
+++ b/server/src/main/java/org/opensearch/gateway/GatewayModule.java
@@ -47,6 +47,7 @@ public class GatewayModule extends AbstractModule {
         bind(GatewayService.class).asEagerSingleton();
         bind(TransportNodesListGatewayMetaState.class).asEagerSingleton();
         bind(TransportNodesListGatewayStartedShards.class).asEagerSingleton();
+        bind(TransportNodesCollectGatewayStartedShard.class).asEagerSingleton();
         bind(LocalAllocateDangledIndices.class).asEagerSingleton();
     }
 }

--- a/server/src/main/java/org/opensearch/gateway/TransportNodesCollectGatewayStartedShard.java
+++ b/server/src/main/java/org/opensearch/gateway/TransportNodesCollectGatewayStartedShard.java
@@ -1,0 +1,481 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.gateway;
+
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.opensearch.LegacyESVersion;
+import org.opensearch.OpenSearchException;
+import org.opensearch.Version;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.ActionType;
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.nodes.BaseNodeRequest;
+import org.opensearch.action.support.nodes.BaseNodeResponse;
+import org.opensearch.action.support.nodes.BaseNodesRequest;
+import org.opensearch.action.support.nodes.BaseNodesResponse;
+import org.opensearch.action.support.nodes.TransportNodesAction;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.Nullable;
+import org.opensearch.common.collect.HppcMaps;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.env.NodeEnvironment;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.index.shard.ShardId;
+import org.opensearch.index.shard.ShardPath;
+import org.opensearch.index.shard.ShardStateMetadata;
+import org.opensearch.index.store.Store;
+import org.opensearch.indices.IndicesService;
+import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * This transport action is used to fetch the all unassigned shard version from each node during primary allocation in {@link GatewayAllocator}.
+ * We use this to find out which node holds the latest shard version and which of them used to be a primary in order to allocate
+ * shards after node or cluster restarts.
+ *
+ * @opensearch.internal
+ */
+public class TransportNodesCollectGatewayStartedShard extends TransportNodesAction<
+    TransportNodesCollectGatewayStartedShard.Request,
+    TransportNodesCollectGatewayStartedShard.NodesGatewayStartedShards,
+    TransportNodesCollectGatewayStartedShard.NodeRequest,
+    TransportNodesCollectGatewayStartedShard.ListOfNodeGatewayStartedShards>
+    implements
+    AsyncShardsFetchPerNode.Lister<
+        TransportNodesCollectGatewayStartedShard.NodesGatewayStartedShards,
+        TransportNodesCollectGatewayStartedShard.ListOfNodeGatewayStartedShards> {
+
+    public static final String ACTION_NAME = "internal:gateway/local/collect_shards";
+    public static final ActionType<NodesGatewayStartedShards> TYPE = new ActionType<>(ACTION_NAME, NodesGatewayStartedShards::new);
+
+    private final Settings settings;
+    private final NodeEnvironment nodeEnv;
+    private final IndicesService indicesService;
+    private final NamedXContentRegistry namedXContentRegistry;
+
+    @Inject
+    public TransportNodesCollectGatewayStartedShard(
+        Settings settings,
+        ThreadPool threadPool,
+        ClusterService clusterService,
+        TransportService transportService,
+        ActionFilters actionFilters,
+        NodeEnvironment env,
+        IndicesService indicesService,
+        NamedXContentRegistry namedXContentRegistry
+    ) {
+        super(
+            ACTION_NAME,
+            threadPool,
+            clusterService,
+            transportService,
+            actionFilters,
+            Request::new,
+            NodeRequest::new,
+            ThreadPool.Names.FETCH_SHARD_STARTED,
+            ListOfNodeGatewayStartedShards.class
+        );
+        this.settings = settings;
+        this.nodeEnv = env;
+        this.indicesService = indicesService;
+        this.namedXContentRegistry = namedXContentRegistry;
+    }
+
+    @Override
+    public void list(DiscoveryNode[] nodes, Map<ShardId,String>shardsIdMap,ActionListener<NodesGatewayStartedShards> listener) {
+        execute(new Request(nodes, shardsIdMap), listener);
+    }
+
+    @Override
+    protected NodeRequest newNodeRequest(Request request) {
+        return new NodeRequest(request);
+    }
+
+    @Override
+    protected ListOfNodeGatewayStartedShards newNodeResponse(StreamInput in) throws IOException {
+        return new ListOfNodeGatewayStartedShards(in);
+    }
+
+    @Override
+    protected NodesGatewayStartedShards newResponse(
+        Request request,
+        List<ListOfNodeGatewayStartedShards> responses,
+        List<FailedNodeException> failures
+    ) {
+        return new NodesGatewayStartedShards(clusterService.getClusterName(), responses, failures);
+    }
+
+    @Override
+    protected ListOfNodeGatewayStartedShards nodeOperation(NodeRequest request) {
+        logger.info("TEST->Transport call- +TC");
+        Map<ShardId, NodeGatewayStartedShards> shardsOnNode = new HashMap<>();
+        for (Map.Entry<ShardId, String> unsassignedShardsMap : request.shardIdsWithCustomDataPath.entrySet()) {
+            try {
+                final ShardId shardId = unsassignedShardsMap.getKey();
+                logger.trace("{} loading local shard state info", shardId);
+                ShardStateMetadata shardStateMetadata = ShardStateMetadata.FORMAT.loadLatestState(
+                    logger,
+                    namedXContentRegistry,
+                    nodeEnv.availableShardPaths(shardId)
+                );
+                if (shardStateMetadata != null) {
+                    if (indicesService.getShardOrNull(shardId) == null) {
+                        final String customDataPath;
+                        if (unsassignedShardsMap.getValue() != null) {
+                            customDataPath = unsassignedShardsMap.getValue();
+                        } else {
+                            // TODO: Fallback for BWC with older OpenSearch versions.
+                            // Remove once request.getCustomDataPath() always returns non-null
+                            final IndexMetadata metadata = clusterService.state().metadata().index(shardId.getIndex());
+                            if (metadata != null) {
+                                customDataPath = new IndexSettings(metadata, settings).customDataPath();
+                            } else {
+                                logger.trace("{} node doesn't have meta data for the requests index", shardId);
+                                throw new OpenSearchException("node doesn't have meta data for index " + shardId.getIndex());
+                            }
+                        }
+                        // we don't have an open shard on the store, validate the files on disk are openable
+                        ShardPath shardPath = null;
+                        try {
+                            shardPath = ShardPath.loadShardPath(logger, nodeEnv, shardId, customDataPath);
+                            if (shardPath == null) {
+                                throw new IllegalStateException(shardId + " no shard path found");
+                            }
+                            Store.tryOpenIndex(shardPath.resolveIndex(), shardId, nodeEnv::shardLock, logger);
+                        } catch (Exception exception) {
+                            final ShardPath finalShardPath = shardPath;
+                            logger.trace(
+                                () -> new ParameterizedMessage(
+                                    "{} can't open index for shard [{}] in path [{}]",
+                                    shardId,
+                                    shardStateMetadata,
+                                    (finalShardPath != null) ? finalShardPath.resolveIndex() : ""
+                                ),
+                                exception
+                            );
+                            String allocationId = shardStateMetadata.allocationId != null ? shardStateMetadata.allocationId.getId() : null;
+                            shardsOnNode.put(shardId, new NodeGatewayStartedShards(
+                                allocationId,
+                                shardStateMetadata.primary,
+                                null,
+                                exception
+                            ));
+                        }
+                    }
+
+                    logger.info("TEST---> {} shard state info found: [{}]", shardId, shardStateMetadata);
+                    String allocationId = shardStateMetadata.allocationId != null ? shardStateMetadata.allocationId.getId() : null;
+                    final IndexShard shard = indicesService.getShardOrNull(shardId);
+                    shardsOnNode.put(shardId, new NodeGatewayStartedShards(
+                        allocationId,
+                        shardStateMetadata.primary,
+                        shard != null ? shard.getLatestReplicationCheckpoint() : null
+                    ));
+                }
+                else {
+                    logger.info("TEST--> {} no local shard info found", shardId);
+                    shardsOnNode.put(shardId, new NodeGatewayStartedShards(null, false, null));
+                }
+            } catch (Exception e) {
+                throw new OpenSearchException("failed to load started shards", e);
+            }
+        }
+        return new ListOfNodeGatewayStartedShards(clusterService.localNode(), shardsOnNode);
+    }
+
+    /**
+     * The nodes request.
+     *
+     * @opensearch.internal
+     */
+    public static class Request extends BaseNodesRequest<Request> {
+
+
+        private final Map<ShardId, String> shardIdStringMap;
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            shardIdStringMap=in.readMap(ShardId::new, StreamInput::readString);
+        }
+
+        public Request(DiscoveryNode[] nodes, Map<ShardId, String> shardIdStringMap) {
+            super(nodes);
+            this.shardIdStringMap= Objects.requireNonNull(shardIdStringMap);
+        }
+
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeMap(shardIdStringMap, (o, k) -> k.writeTo(o), StreamOutput::writeString);
+        }
+
+        public Map<ShardId, String> getShardIdsMap() {
+            return shardIdStringMap;
+        }
+    }
+
+    /**
+     *  The nodes response.
+     *
+     * @opensearch.internal
+     */
+    public static class NodesGatewayStartedShards extends BaseNodesResponse<ListOfNodeGatewayStartedShards> {
+
+        public NodesGatewayStartedShards(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        public NodesGatewayStartedShards(
+            ClusterName clusterName,
+            List<ListOfNodeGatewayStartedShards> nodes,
+            List<FailedNodeException> failures
+        ) {
+            super(clusterName, nodes, failures);
+        }
+
+        @Override
+        protected List<ListOfNodeGatewayStartedShards> readNodesFrom(StreamInput in) throws IOException {
+            return in.readList(ListOfNodeGatewayStartedShards::new);
+        }
+
+        @Override
+        protected void writeNodesTo(StreamOutput out, List<ListOfNodeGatewayStartedShards> nodes) throws IOException {
+            out.writeList(nodes);
+        }
+    }
+
+    /**
+     * The request.
+     *
+     * @opensearch.internal
+     */
+    public static class NodeRequest extends BaseNodeRequest {
+
+
+        private final Map<ShardId, String> shardIdsWithCustomDataPath;
+
+        public NodeRequest(StreamInput in) throws IOException {
+            super(in);
+            shardIdsWithCustomDataPath=in.readMap(ShardId::new, StreamInput::readString);
+        }
+
+        public NodeRequest(Request request) {
+
+            this.shardIdsWithCustomDataPath=Objects.requireNonNull(request.getShardIdsMap());
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeMap(shardIdsWithCustomDataPath, (o, k) -> k.writeTo(o), StreamOutput::writeString);
+        }
+
+
+        /**
+         * Returns the custom data path that is used to look up information for this shard.
+         * Returns an empty string if no custom data path is used for this index.
+         * Returns null if custom data path information is not available (due to BWC).
+         */
+//        @Nullable
+//        public String getCustomDataPath() {
+//            return customDataPath;
+//        }
+        public Map<ShardId, String> getShardIdsWithCustomDataPath() {
+            return shardIdsWithCustomDataPath;
+        }
+
+    }
+
+    /**
+     * The response.
+     *
+     * @opensearch.internal
+     */
+    public static class NodeGatewayStartedShards  {
+        private final String allocationId;
+        private final boolean primary;
+        private final Exception storeException;
+        private final ReplicationCheckpoint replicationCheckpoint;
+
+        public NodeGatewayStartedShards(StreamInput in) throws IOException {
+            allocationId = in.readOptionalString();
+            primary = in.readBoolean();
+            if (in.readBoolean()) {
+                storeException = in.readException();
+            } else {
+                storeException = null;
+            }
+            if (in.getVersion().onOrAfter(Version.V_2_3_0) && in.readBoolean()) {
+                replicationCheckpoint = new ReplicationCheckpoint(in);
+            } else {
+                replicationCheckpoint = null;
+            }
+        }
+
+        public NodeGatewayStartedShards(
+            String allocationId,
+            boolean primary,
+            ReplicationCheckpoint replicationCheckpoint
+        ) {
+            this( allocationId, primary, replicationCheckpoint, null);
+        }
+
+        public NodeGatewayStartedShards(
+            String allocationId,
+            boolean primary,
+            ReplicationCheckpoint replicationCheckpoint,
+            Exception storeException
+        ) {
+            this.allocationId = allocationId;
+            this.primary = primary;
+            this.replicationCheckpoint = replicationCheckpoint;
+            this.storeException = storeException;
+        }
+
+        public String allocationId() {
+            return this.allocationId;
+        }
+
+        public boolean primary() {
+            return this.primary;
+        }
+
+        public ReplicationCheckpoint replicationCheckpoint() {
+            return this.replicationCheckpoint;
+        }
+
+        public Exception storeException() {
+            return this.storeException;
+        }
+
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeOptionalString(allocationId);
+            out.writeBoolean(primary);
+            if (storeException != null) {
+                out.writeBoolean(true);
+                out.writeException(storeException);
+            } else {
+                out.writeBoolean(false);
+            }
+            if (out.getVersion().onOrAfter(Version.V_2_3_0)) {
+                if (replicationCheckpoint != null) {
+                    out.writeBoolean(true);
+                    replicationCheckpoint.writeTo(out);
+                } else {
+                    out.writeBoolean(false);
+                }
+            }
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            NodeGatewayStartedShards that = (NodeGatewayStartedShards) o;
+
+            return primary == that.primary
+                && Objects.equals(allocationId, that.allocationId)
+                && Objects.equals(storeException, that.storeException)
+                && Objects.equals(replicationCheckpoint, that.replicationCheckpoint);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = (allocationId != null ? allocationId.hashCode() : 0);
+            result = 31 * result + (primary ? 1 : 0);
+            result = 31 * result + (storeException != null ? storeException.hashCode() : 0);
+            result = 31 * result + (replicationCheckpoint != null ? replicationCheckpoint.hashCode() : 0);
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder buf = new StringBuilder();
+            buf.append("NodeGatewayStartedShards[").append("allocationId=").append(allocationId).append(",primary=").append(primary);
+            if (storeException != null) {
+                buf.append(",storeException=").append(storeException);
+            }
+            if (replicationCheckpoint != null) {
+                buf.append(",ReplicationCheckpoint=").append(replicationCheckpoint.toString());
+            }
+            buf.append("]");
+            return buf.toString();
+        }
+    }
+
+    public static class ListOfNodeGatewayStartedShards extends BaseNodeResponse {
+        public Map<ShardId, NodeGatewayStartedShards> getListOfNodeGatewayStartedShards() {
+            return listOfNodeGatewayStartedShards;
+        }
+
+        private final Map<ShardId, NodeGatewayStartedShards> listOfNodeGatewayStartedShards;
+        public ListOfNodeGatewayStartedShards(StreamInput in) throws IOException {
+            super(in);
+            this.listOfNodeGatewayStartedShards = in.readMap(ShardId::new, NodeGatewayStartedShards::new);
+        }
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeMap(listOfNodeGatewayStartedShards, (o, k) -> k.writeTo(o),(o,v)->v.writeTo(o));
+        }
+
+        public ListOfNodeGatewayStartedShards(DiscoveryNode node, Map<ShardId, NodeGatewayStartedShards> listOfNodeGatewayStartedShards) {
+            super(node);
+            this.listOfNodeGatewayStartedShards=listOfNodeGatewayStartedShards;
+        }
+
+    }
+}

--- a/server/src/main/java/org/opensearch/gateway/TransportNodesCollectGatewayStartedShard.java
+++ b/server/src/main/java/org/opensearch/gateway/TransportNodesCollectGatewayStartedShard.java
@@ -156,6 +156,10 @@ public class TransportNodesCollectGatewayStartedShard extends TransportNodesActi
     protected ListOfNodeGatewayStartedShards nodeOperation(NodeRequest request) {
         logger.info("TEST->Transport call- +TC");
         Map<ShardId, NodeGatewayStartedShards> shardsOnNode = new HashMap<>();
+
+        /* This is node Operation is same as nodeOperation on TransportNodesListGatewayStartedShards, but it  does over a loop
+         for all Unassigned shards
+         */
         for (Map.Entry<ShardId, String> unsassignedShardsMap : request.shardIdsWithCustomDataPath.entrySet()) {
             try {
                 final ShardId shardId = unsassignedShardsMap.getKey();
@@ -318,24 +322,10 @@ public class TransportNodesCollectGatewayStartedShard extends TransportNodesActi
             out.writeMap(shardIdsWithCustomDataPath, (o, k) -> k.writeTo(o), StreamOutput::writeString);
         }
 
-
-        /**
-         * Returns the custom data path that is used to look up information for this shard.
-         * Returns an empty string if no custom data path is used for this index.
-         * Returns null if custom data path information is not available (due to BWC).
-         */
-//        @Nullable
-//        public String getCustomDataPath() {
-//            return customDataPath;
-//        }
-        public Map<ShardId, String> getShardIdsWithCustomDataPath() {
-            return shardIdsWithCustomDataPath;
-        }
-
     }
 
     /**
-     * The response.
+     * The response as stored by TransportNodesListGatewayStartedShards(to maintain backward compatibility).
      *
      * @opensearch.internal
      */


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This is the the draft PR to discuss on the idea of batching the `AsyncShardFetch` used in `GatewayAllocator`.

In the current flow of code ` PrimaryShardAllocator/ReplicaShardAllocator`(PSA/RSA) calls `GatewayAllocator` to do  Transport calls per shard to N data nodes for async fetching the metadata of shards from all nodes. This information is then used by PSA/RSA to make allocation Decision. Currently `GatewayAllocator` maintains two such maps ```asyncFetchStarted``` and ```asyncFetchStore``` to store async data

So we make M(number of unassigned shards)*N(number of data nodes) transport calls for assigning Unassigned Shards. 

The current POC is done to batch the async shards Transport call per node and maintain that view of shards metadata from all nodes in GatewayAllocator.

The changes tries to replace one current map `asyncFetchStarted` whose data(`TransportNodesListGatewayStartedShards.NodeGatewayStartedShards`) is used in PSA primarily, with ```shardsPerNode``` (naming can be done better here though) to maintain the same set of data  in list(`TransportNodesCollectGatewayStartedShard.ListOfNodeGatewayStartedShards`) per node.

Please note the changes are done in crude way(just to convey idea) with reusing of code from current classes and are draft changes

Flow diagrams:

* Current overview picture of how and why asyncFetchShards come into picture:

![Screenshot 2023-05-18 at 5 27 20 PM](https://github.com/opensearch-project/OpenSearch/assets/23554495/71146318-3814-4c67-a0e8-8ba847cb8c4c)

* More simpler view:
![current_flow_async](https://github.com/opensearch-project/OpenSearch/assets/23554495/f7c5ba0a-d2be-4043-8e67-87e19957e85b)

* Whats changing:
![async_2](https://github.com/opensearch-project/OpenSearch/assets/23554495/a52581f5-8202-402c-9c81-f9581c3f3de1)

* Current Transport Calls
![Transport](https://github.com/opensearch-project/OpenSearch/assets/23554495/6616ea06-e4d6-48f4-98fe-9d969653e58a)

* Optimized Transport Calls
![Transport_2](https://github.com/opensearch-project/OpenSearch/assets/23554495/3748b65b-aa0d-419f-8688-504af92f44c0)

### 


List of changes:

- GatewayAllocator

    - **Added a map `shardsPerNode` to replace `asyncFetchStarted`.**  The map will contain the current view of fetched data of unassigned shards from all nodes. This will then be used to send the data after adaptation to PSA
    - **fetchShardsFromNodes**. Is a object that maintains the current fetch status from the nodes in cache. This is analogous to `AsyncShardFetch`
    - **In `beforeAllocation()` added  `collectShardsPerNode(allocation)` as a responsibility**. beforeAllocation() is called by [AllocationService](https://github.com/Gaurav614/OpenSearch/blob/main/server/src/main/java/org/opensearch/cluster/routing/allocation/AllocationService.java#L548) before starting the allocation. This will help in populating the `shardsPerNode` and when the allocation decision needs to be taken in allocateUnassigned, the data can be used readily by PSA.
    - **`collectShardsPerNode()`**. Task to build the view of shards MD from all nodes
    - **`TestAsyncShardFetch`.** Inner class analogous `InternalAsyncFetch`
    - **`TestInternalPrimaryShardAllocator`.**  Inner class analogous `InternalPrimaryShardAllocator`. The` fetchData() `here do not actually does the heavylifting of fetching, rather adapts the current data in shardsPerNode to the `AsyncShardFetch.FetchResult` that PSA understands. This currently helps to minimize the scope of changes in POC. We can later accommodate to revamp PSA/RSA to make allocationDecision based on the batched data.
 
- Added New Transport action `TransportNodesCollectGatewayStartedShard`, analogous `TransportNodesListGatewayStartedShards`. This is added for just for simplicity of code and we can think of merging it to a single transport action
- Added a new `AsyncShardsFetchPerNode` class to keep do a track async fetch of shards(shardsToCustomDataPathMap) from all nodes. It is analogous to AsyncShardFetch class which does per the same thing per shard.We can also later remove that class or merge this class into AsyncShardFetch depending on the POC approval
 
### Testing
Did a happy test manually by spinning two data nodes and a single master with 16 shards. Restarted the data nodes, shards turned from Unassigned to Assigned . 
Also tested on number of transport calls made by adding a log line in `nodeOperation`, can verify that a single transport call per node is made(if unassigned shards set is not updated). So thats reduction of transport calls from M*N to N.

 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/5098

This might be extension of the above issue since it might not solve completely the memory issue, but solves the transport calls optimization part.


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
