### PR TITLE
[Segment Replication] Make SegmentReplicationPressureService a Singleton class and fix bug of rejected_requests reporting incorrect value

### DIFF
--- a/server/src/main/java/org/opensearch/indices/IndicesModule.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesModule.java
@@ -42,6 +42,7 @@ import org.opensearch.common.inject.AbstractModule;
 import org.opensearch.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.common.io.stream.NamedWriteableRegistry.Entry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.index.SegmentReplicationPressureService;
 import org.opensearch.index.mapper.BinaryFieldMapper;
 import org.opensearch.index.mapper.BooleanFieldMapper;
 import org.opensearch.index.mapper.CompletionFieldMapper;
@@ -284,6 +285,7 @@ public class IndicesModule extends AbstractModule {
         bind(RetentionLeaseBackgroundSyncAction.class).asEagerSingleton();
         bind(RetentionLeaseSyncer.class).asEagerSingleton();
         bind(SegmentReplicationCheckpointPublisher.class).asEagerSingleton();
+        bind(SegmentReplicationPressureService.class).asEagerSingleton();
     }
 
     /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR makes SegmentReplicationPressureService a Singleton class. This way we will only have one instance of SegmentReplicationPressureService per node.

This PR will resolve the bug of `rejected_requests` column not getting updated in  `_cat/segment_replication` API.

#### Problem:

-> Initially we were having two instances of SegmentReplicationPressureService. One intstance being used by backpressure mechanism and another instance being used by SegmentReplicationStatsAction class (used by _cat/segment_replication API).

-> As we were having two instances of SegmentReplicationStatsAction class, the changes made by backpressure mechanism are not updated to another instance, so the value of `rejected_requests` is always being 0 and never getting updated.

#### Solution:

-> The solution here would be to make SegmentReplicationStatsAction class a singleton class so that there is only one instance of SegmentReplicationStatsAction class per node and value of `rejected_requests` is always updated correctly.

### Issues Resolved
#7275 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
