### PR TITLE
Revert Enabling Segment Replication Backpressure setting by default

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/index/SegmentReplicationPressureIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/SegmentReplicationPressureIT.java
@@ -40,6 +40,7 @@ import static org.opensearch.index.SegmentReplicationPressureService.MAX_INDEXIN
 import static org.opensearch.index.SegmentReplicationPressureService.MAX_REPLICATION_TIME_SETTING;
 import static org.opensearch.index.SegmentReplicationPressureService.SEGMENT_REPLICATION_INDEXING_PRESSURE_ENABLED;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
 public class SegmentReplicationPressureIT extends SegmentReplicationBaseIT {
@@ -254,6 +255,30 @@ public class SegmentReplicationPressureIT extends SegmentReplicationBaseIT {
 
         // Verify that new replica shard after failure is different from old replica shard.
         assertNotEquals(replicaAfterFailure.routingEntry().allocationId().getId(), replicaShard.routingEntry().allocationId().getId());
+    }
+
+    public void testWithDocumentReplicationEnabledIndex() throws Exception {
+        Settings settings = Settings.builder().put(MAX_REPLICATION_TIME_SETTING.getKey(), TimeValue.timeValueMillis(500)).build();
+        // Starts a primary and replica node.
+        final String primaryNode = internalCluster().startNode(settings);
+        createIndex(
+            INDEX_NAME,
+            Settings.builder().put(indexSettings()).put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.DOCUMENT).build()
+        );
+        ensureYellowAndNoInitializingShards(INDEX_NAME);
+        final String replicaNode = internalCluster().startNode(settings);
+        ensureGreen(INDEX_NAME);
+        final AtomicInteger totalDocs = new AtomicInteger(0);
+        // Index docs until replica stale limit is reached.
+        totalDocs.getAndSet(indexUntilCheckpointCount());
+        // index again after stale limit.
+        indexDoc();
+        refresh(INDEX_NAME);
+        totalDocs.incrementAndGet();
+        // verify total doc count is same and docs are not rejected.
+        assertHitCount(client(primaryNode).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), totalDocs.get());
+        assertHitCount(client(replicaNode).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), totalDocs.get());
+
     }
 
     public void testBulkWritesRejected() throws Exception {

--- a/server/src/internalClusterTest/java/org/opensearch/index/SegmentReplicationPressureIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/SegmentReplicationPressureIT.java
@@ -38,8 +38,8 @@ import static java.util.Arrays.asList;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
 import static org.opensearch.index.SegmentReplicationPressureService.MAX_INDEXING_CHECKPOINTS;
 import static org.opensearch.index.SegmentReplicationPressureService.MAX_REPLICATION_TIME_SETTING;
+import static org.opensearch.index.SegmentReplicationPressureService.SEGMENT_REPLICATION_INDEXING_PRESSURE_ENABLED;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
-import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
 public class SegmentReplicationPressureIT extends SegmentReplicationBaseIT {
@@ -50,6 +50,7 @@ public class SegmentReplicationPressureIT extends SegmentReplicationBaseIT {
     protected Settings nodeSettings(int nodeOrdinal) {
         return Settings.builder()
             .put(super.nodeSettings(nodeOrdinal))
+            .put(SEGMENT_REPLICATION_INDEXING_PRESSURE_ENABLED.getKey(), true)
             .put(MAX_REPLICATION_TIME_SETTING.getKey(), TimeValue.timeValueSeconds(1))
             .put(MAX_INDEXING_CHECKPOINTS.getKey(), MAX_CHECKPOINTS_BEHIND)
             .build();
@@ -253,30 +254,6 @@ public class SegmentReplicationPressureIT extends SegmentReplicationBaseIT {
 
         // Verify that new replica shard after failure is different from old replica shard.
         assertNotEquals(replicaAfterFailure.routingEntry().allocationId().getId(), replicaShard.routingEntry().allocationId().getId());
-    }
-
-    public void testWithDocumentReplicationEnabledIndex() throws Exception {
-        Settings settings = Settings.builder().put(MAX_REPLICATION_TIME_SETTING.getKey(), TimeValue.timeValueMillis(500)).build();
-        // Starts a primary and replica node.
-        final String primaryNode = internalCluster().startNode(settings);
-        createIndex(
-            INDEX_NAME,
-            Settings.builder().put(indexSettings()).put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.DOCUMENT).build()
-        );
-        ensureYellowAndNoInitializingShards(INDEX_NAME);
-        final String replicaNode = internalCluster().startNode(settings);
-        ensureGreen(INDEX_NAME);
-        final AtomicInteger totalDocs = new AtomicInteger(0);
-        // Index docs until replica stale limit is reached.
-        totalDocs.getAndSet(indexUntilCheckpointCount());
-        // index again after stale limit.
-        indexDoc();
-        refresh(INDEX_NAME);
-        totalDocs.incrementAndGet();
-        // verify total doc count is same and docs are not rejected.
-        assertHitCount(client(primaryNode).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), totalDocs.get());
-        assertHitCount(client(replicaNode).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), totalDocs.get());
-
     }
 
     public void testBulkWritesRejected() throws Exception {

--- a/server/src/main/java/org/opensearch/index/SegmentReplicationPressureService.java
+++ b/server/src/main/java/org/opensearch/index/SegmentReplicationPressureService.java
@@ -128,9 +128,11 @@ public class SegmentReplicationPressureService implements Closeable {
 
     public void isSegrepLimitBreached(ShardId shardId) {
         final IndexService indexService = indicesService.indexService(shardId.getIndex());
-        final IndexShard shard = indexService.getShard(shardId.id());
-        if (isSegmentReplicationBackpressureEnabled && shard.indexSettings().isSegRepEnabled() && shard.routingEntry().primary()) {
-            validateReplicationGroup(shard);
+        if (indexService != null) {
+            final IndexShard shard = indexService.getShard(shardId.id());
+            if (isSegmentReplicationBackpressureEnabled && shard.indexSettings().isSegRepEnabled() && shard.routingEntry().primary()) {
+                validateReplicationGroup(shard);
+            }
         }
     }
 
@@ -233,6 +235,9 @@ public class SegmentReplicationPressureService implements Closeable {
                             stats.getShardStats().get(shardId).getReplicaStats()
                         );
                         final IndexService indexService = pressureService.indicesService.indexService(shardId.getIndex());
+                        if (indexService.getIndexSettings() != null && indexService.getIndexSettings().isSegRepEnabled() == false) {
+                            return;
+                        }
                         final IndexShard primaryShard = indexService.getShard(shardId.getId());
                         for (SegmentReplicationShardStats staleReplica : staleReplicas) {
                             if (staleReplica.getCurrentReplicationTimeMillis() > 2 * pressureService.maxReplicationTime.millis()) {

--- a/server/src/main/java/org/opensearch/index/SegmentReplicationPressureService.java
+++ b/server/src/main/java/org/opensearch/index/SegmentReplicationPressureService.java
@@ -52,7 +52,7 @@ public class SegmentReplicationPressureService implements Closeable {
      */
     public static final Setting<Boolean> SEGMENT_REPLICATION_INDEXING_PRESSURE_ENABLED = Setting.boolSetting(
         "segrep.pressure.enabled",
-        true,
+        false,
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
@@ -128,11 +128,9 @@ public class SegmentReplicationPressureService implements Closeable {
 
     public void isSegrepLimitBreached(ShardId shardId) {
         final IndexService indexService = indicesService.indexService(shardId.getIndex());
-        if (indexService != null) {
-            final IndexShard shard = indexService.getShard(shardId.id());
-            if (isSegmentReplicationBackpressureEnabled && shard.indexSettings().isSegRepEnabled() && shard.routingEntry().primary()) {
-                validateReplicationGroup(shard);
-            }
+        final IndexShard shard = indexService.getShard(shardId.id());
+        if (isSegmentReplicationBackpressureEnabled && shard.indexSettings().isSegRepEnabled() && shard.routingEntry().primary()) {
+            validateReplicationGroup(shard);
         }
     }
 
@@ -235,9 +233,6 @@ public class SegmentReplicationPressureService implements Closeable {
                             stats.getShardStats().get(shardId).getReplicaStats()
                         );
                         final IndexService indexService = pressureService.indicesService.indexService(shardId.getIndex());
-                        if (indexService.getIndexSettings() != null && indexService.getIndexSettings().isSegRepEnabled() == false) {
-                            return;
-                        }
                         final IndexShard primaryShard = indexService.getShard(shardId.getId());
                         for (SegmentReplicationShardStats staleReplica : staleReplicas) {
                             if (staleReplica.getCurrentReplicationTimeMillis() > 2 * pressureService.maxReplicationTime.millis()) {

--- a/server/src/test/java/org/opensearch/index/SegmentReplicationPressureServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/SegmentReplicationPressureServiceTests.java
@@ -41,12 +41,14 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
 import static org.opensearch.index.SegmentReplicationPressureService.MAX_REPLICATION_TIME_SETTING;
+import static org.opensearch.index.SegmentReplicationPressureService.SEGMENT_REPLICATION_INDEXING_PRESSURE_ENABLED;
 
 public class SegmentReplicationPressureServiceTests extends OpenSearchIndexLevelReplicationTestCase {
 
     private static ShardStateAction shardStateAction = Mockito.mock(ShardStateAction.class);
     private static final Settings settings = Settings.builder()
         .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+        .put(SEGMENT_REPLICATION_INDEXING_PRESSURE_ENABLED.getKey(), true)
         .put(MAX_REPLICATION_TIME_SETTING.getKey(), TimeValue.timeValueSeconds(5))
         .build();
 
@@ -97,7 +99,10 @@ public class SegmentReplicationPressureServiceTests extends OpenSearchIndexLevel
     }
 
     public void testIsSegrepLimitBreached_onlyCheckpointLimitBreached() throws Exception {
-        final Settings settings = Settings.builder().put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT).build();
+        final Settings settings = Settings.builder()
+            .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+            .put(SEGMENT_REPLICATION_INDEXING_PRESSURE_ENABLED.getKey(), true)
+            .build();
 
         try (ReplicationGroup shards = createGroup(1, settings, new NRTReplicationEngineFactory())) {
             shards.startAll();
@@ -121,7 +126,10 @@ public class SegmentReplicationPressureServiceTests extends OpenSearchIndexLevel
     }
 
     public void testIsSegrepLimitBreached_onlyTimeLimitBreached() throws Exception {
-        final Settings settings = Settings.builder().put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT).build();
+        final Settings settings = Settings.builder()
+            .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+            .put(SEGMENT_REPLICATION_INDEXING_PRESSURE_ENABLED.getKey(), true)
+            .build();
 
         try (ReplicationGroup shards = createGroup(1, settings, new NRTReplicationEngineFactory())) {
             shards.startAll();
@@ -186,6 +194,7 @@ public class SegmentReplicationPressureServiceTests extends OpenSearchIndexLevel
     public void testFailStaleReplicaTask() throws Exception {
         final Settings settings = Settings.builder()
             .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+            .put(SEGMENT_REPLICATION_INDEXING_PRESSURE_ENABLED.getKey(), true)
             .put(MAX_REPLICATION_TIME_SETTING.getKey(), TimeValue.timeValueMillis(10))
             .build();
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR Reverts #7183 enabling Segment Replication Backpressure as default setting. By Enabling this setting by default we are impacting the throughput of document replication.

### Issues Resolved
Resolves #7293 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
