### PR TITLE
Fix store type settings ordering for searchable snapshots

### DIFF
--- a/server/src/main/java/org/opensearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/opensearch/snapshots/RestoreService.java
@@ -1239,12 +1239,12 @@ public class RestoreService implements ClusterStateApplier {
 
     private static IndexMetadata addSnapshotToIndexSettings(IndexMetadata metadata, Snapshot snapshot, IndexId indexId) {
         final Settings newSettings = Settings.builder()
+            .put(metadata.getSettings())
             .put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), IndexModule.Type.REMOTE_SNAPSHOT.getSettingsKey())
             .put(IndexSettings.SEARCHABLE_SNAPSHOT_REPOSITORY.getKey(), snapshot.getRepository())
             .put(IndexSettings.SEARCHABLE_SNAPSHOT_ID_UUID.getKey(), snapshot.getSnapshotId().getUUID())
             .put(IndexSettings.SEARCHABLE_SNAPSHOT_ID_NAME.getKey(), snapshot.getSnapshotId().getName())
             .put(IndexSettings.SEARCHABLE_SNAPSHOT_INDEX_ID.getKey(), indexId.getId())
-            .put(metadata.getSettings())
             .build();
         return IndexMetadata.builder(metadata).settings(newSettings).build();
     }


### PR DESCRIPTION
### Description
- Restoring searchable snapshots with indices backed up with the setting `index.store.type` leads to wrong ordering for store type settings, causing the restore to be of the original configuration set on the index at backup which can be `fs` / a local restored index instead. (Sample code which does [that with benchmarks here](https://github.com/search?q=repo%3Aopensearch-project%2Fopensearch-benchmark-workloads%20%22index.store.type%22&type=code))
- This PR fixes the ordering of the settings to enable searchable snapshot index restore with the appropriate store type, irrespective of the original store type configuration for the index.

### Issues Resolved
- N/A

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
