### PR TITLE
Enable ./gradlew build on MacOS (M1) by loudly disabling bwc tests.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -207,6 +207,14 @@ updates:
     labels:
       - "dependabot"
       - "dependencies"
+  - directory: /distribution/archives/darwin-arm64-tar/
+    open-pull-requests-limit: 1
+    package-ecosystem: gradle
+    schedule:
+      interval: weekly
+    labels:
+      - "dependabot"
+      - "dependencies"
   - directory: /distribution/archives/integ-test-zip/
     open-pull-requests-limit: 1
     package-ecosystem: gradle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `jackson` from 2.14.2 to 2.15.0 ([#7286](https://github.com/opensearch-project/OpenSearch/pull/7286)
 
 ### Changed
+- Enable `./gradlew build` on MacOS by disabling bcw tests ([#7303](https://github.com/opensearch-project/OpenSearch/pull/7303))
 
 ### Deprecated
 

--- a/build.gradle
+++ b/build.gradle
@@ -225,8 +225,16 @@ tasks.register("verifyVersions") {
  */
 
 boolean bwc_tests_enabled = true
+
 /* place an issue link here when committing bwc changes */
-final String bwc_tests_disabled_issue = ""
+String bwc_tests_disabled_issue = ""
+
+/* there's no existing MacOS release, therefore disable bcw tests */
+if (Os.isFamily(Os.FAMILY_MAC)) {
+  bwc_tests_enabled = false
+  bwc_tests_disabled_issue = "https://github.com/opensearch-project/OpenSearch/issues/4173"
+}
+
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -187,6 +187,7 @@ if (project != rootProject) {
   dependencies {
     reaper project('reaper')
     distribution project(':distribution:archives:darwin-tar')
+    distribution project(':distribution:archives:darwin-arm64-tar')
     distribution project(':distribution:archives:linux-arm64-tar')
     distribution project(':distribution:archives:linux-tar')
     distribution project(':distribution:archives:windows-zip')

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -344,7 +344,7 @@ configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {
     modulesFiles = { platform ->
       copySpec {
         eachFile {
-          if (it.relativePath.segments[-2] == 'bin' || (platform == 'darwin-x64' && it.relativePath.segments[-2] == 'MacOS')) {
+          if (it.relativePath.segments[-2] == 'bin' || ((platform == 'darwin-x64' || platform == 'darwin-arm64') && it.relativePath.segments[-2] == 'MacOS')) {
             // bin files, wherever they are within modules (eg platform specific) should be executable
             // and MacOS is an alternative to bin on macOS
             it.mode = 0755
@@ -622,6 +622,7 @@ subprojects {
 }
 
 ['archives:darwin-tar',
+ 'archives:darwin-arm64-tar',
  'archives:integ-test-zip',
  'archives:linux-arm64-tar',
  'archives:linux-tar',

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -33,6 +33,7 @@ configurations {
 }
 
 dependencies {
+  arm64DockerSource project(path: ":distribution:archives:darwin-arm64-tar", configuration:"default")
   arm64DockerSource project(path: ":distribution:archives:linux-arm64-tar", configuration:"default")
   s390xDockerSource project(path: ":distribution:archives:linux-s390x-tar", configuration:"default")
   ppc64leDockerSource project(path: ":distribution:archives:linux-ppc64le-tar", configuration:"default")


### PR DESCRIPTION
### Description

Loudly disables bwc tests when running build on Mac. If we wanted to support a proper Mac distribution we would need to produce bwc artifacts for testing, which I believe means making a manual build once to get bootstrapped, then we would get rid of the `> Project :qa:full-cluster-restart declares a dependency from configuration 'opensearch_distro_extracted_testclusters-qa-full-cluster-restart-v2.1.1-1-2.1.1-' to configuration 'expanded-darwin-arm64-tar' which is not declared in the descriptor for project :distribution:bwc:bugfix.` error.

```
$ ./gradlew build
Picked up JAVA_TOOL_OPTIONS: -Dlog4j2.formatMsgNoLookups=true

> Configure project :
========================= WARNING =========================
         Backwards compatibility tests are disabled!
See https://github.com/opensearch-project/OpenSearch/issues/4173
===========================================================
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 8.1.1
  OS Info               : Mac OS X 13.3.1 (aarch64)
  JDK Version           : 17 (Eclipse Temurin JDK)
  JAVA_HOME             : /Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
  Random Testing Seed   : 8ACEB97ECBC4774
  In FIPS 140 mode      : false
=======================================
```

### Issues Resolved

Closes https://github.com/opensearch-project/OpenSearch/issues/4173.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
