### PR TITLE
[Refactor] ImmutableOpenMap to j.u.Map in IndexMetadata

### DIFF
--- a/client/rest-high-level/src/test/java/org/opensearch/client/indices/GetIndexTemplatesResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/indices/GetIndexTemplatesResponseTests.java
@@ -137,10 +137,10 @@ public class GetIndexTemplatesResponseTests extends OpenSearchTestCase {
                     assertThat(result.mappings().sourceAsMap(), equalTo(expectedMapping.get("_doc")));
 
                     assertThat(result.aliases().size(), equalTo(esIMD.aliases().size()));
-                    List<AliasMetadata> expectedAliases = Arrays.stream(esIMD.aliases().values().toArray(AliasMetadata.class))
+                    List<AliasMetadata> expectedAliases = Arrays.stream(esIMD.aliases().values().toArray(new AliasMetadata[0]))
                         .sorted(Comparator.comparing(AliasMetadata::alias))
                         .collect(Collectors.toList());
-                    List<AliasMetadata> actualAliases = Arrays.stream(result.aliases().values().toArray(AliasMetadata.class))
+                    List<AliasMetadata> actualAliases = Arrays.stream(result.aliases().values().toArray(new AliasMetadata[0]))
                         .sorted(Comparator.comparing(AliasMetadata::alias))
                         .collect(Collectors.toList());
                     for (int j = 0; j < result.aliases().size(); j++) {
@@ -216,7 +216,7 @@ public class GetIndexTemplatesResponseTests extends OpenSearchTestCase {
 
             serverTemplateBuilder.patterns(clientITMD.patterns());
 
-            Iterator<AliasMetadata> aliases = clientITMD.aliases().valuesIt();
+            Iterator<AliasMetadata> aliases = clientITMD.aliases().values().iterator();
             aliases.forEachRemaining((a) -> serverTemplateBuilder.putAlias(a));
 
             serverTemplateBuilder.settings(clientITMD.settings());

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/ClusterStateDiffIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/ClusterStateDiffIT.java
@@ -621,7 +621,7 @@ public class ClusterStateDiffIT extends OpenSearchIntegTestCase {
                         break;
                     case 1:
                         if (randomBoolean() && part.getAliases().isEmpty() == false) {
-                            builder.removeAlias(randomFrom(part.getAliases().keys().toArray(String.class)));
+                            builder.removeAlias(randomFrom(part.getAliases().keySet().toArray(new String[0])));
                         } else {
                             builder.putAlias(AliasMetadata.builder(randomAlphaOfLength(10)));
                         }

--- a/server/src/main/java/org/opensearch/action/admin/indices/get/TransportGetIndexAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/get/TransportGetIndexAction.java
@@ -54,6 +54,7 @@ import org.opensearch.transport.TransportService;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Spliterators;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -111,8 +112,8 @@ public class TransportGetIndexAction extends TransportClusterInfoAction<GetIndex
         ImmutableOpenMap<String, Settings> defaultSettings = ImmutableOpenMap.of();
         ImmutableOpenMap<String, String> dataStreams = ImmutableOpenMap.<String, String>builder()
             .putAll(
-                StreamSupport.stream(state.metadata().findDataStreams(concreteIndices).spliterator(), false)
-                    .collect(Collectors.toMap(k -> k.key, v -> v.value.getName()))
+                StreamSupport.stream(Spliterators.spliterator(state.metadata().findDataStreams(concreteIndices).entrySet(), 0), false)
+                    .collect(Collectors.toMap(k -> k.getKey(), v -> v.getValue().getName()))
             )
             .build();
         GetIndexRequest.Feature[] features = request.features();

--- a/server/src/main/java/org/opensearch/action/admin/indices/resolve/ResolveIndexAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/resolve/ResolveIndexAction.java
@@ -635,7 +635,7 @@ public class ResolveIndexAction extends ActionType<ResolveIndexAction.Response> 
                         IndexAbstraction.Index index = (IndexAbstraction.Index) ia;
 
                         String[] aliasNames = StreamSupport.stream(
-                            Spliterators.spliteratorUnknownSize(index.getWriteIndex().getAliases().keysIt(), 0),
+                            Spliterators.spliteratorUnknownSize(index.getWriteIndex().getAliases().keySet().iterator(), 0),
                             false
                         ).toArray(String[]::new);
                         Arrays.sort(aliasNames);

--- a/server/src/main/java/org/opensearch/action/admin/indices/rollover/MetadataRolloverService.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/rollover/MetadataRolloverService.java
@@ -374,7 +374,7 @@ public class MetadataRolloverService {
                         Locale.ROOT,
                         "Rollover alias [%s] can point to multiple indices, found duplicated alias [%s] in index template [%s]",
                         rolloverRequestAlias,
-                        template.aliases().keys(),
+                        template.aliases().keySet(),
                         template.name()
                     )
                 );

--- a/server/src/main/java/org/opensearch/cluster/DiffableUtils.java
+++ b/server/src/main/java/org/opensearch/cluster/DiffableUtils.java
@@ -32,13 +32,7 @@
 
 package org.opensearch.cluster;
 
-import com.carrotsearch.hppc.cursors.IntCursor;
-import com.carrotsearch.hppc.cursors.IntObjectCursor;
-import com.carrotsearch.hppc.cursors.ObjectCursor;
-import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.opensearch.Version;
-import org.opensearch.common.collect.ImmutableOpenIntMap;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable.Reader;
@@ -83,56 +77,6 @@ public final class DiffableUtils {
     }
 
     /**
-     * Calculates diff between two ImmutableOpenMaps of Diffable objects
-     */
-    public static <K, T extends Diffable<T>> MapDiff<K, T, ImmutableOpenMap<K, T>> diff(
-        ImmutableOpenMap<K, T> before,
-        ImmutableOpenMap<K, T> after,
-        KeySerializer<K> keySerializer
-    ) {
-        assert after != null && before != null;
-        return new ImmutableOpenMapDiff<>(before, after, keySerializer, DiffableValueSerializer.getWriteOnlyInstance());
-    }
-
-    /**
-     * Calculates diff between two ImmutableOpenMaps of non-diffable objects
-     */
-    public static <K, T> MapDiff<K, T, ImmutableOpenMap<K, T>> diff(
-        ImmutableOpenMap<K, T> before,
-        ImmutableOpenMap<K, T> after,
-        KeySerializer<K> keySerializer,
-        ValueSerializer<K, T> valueSerializer
-    ) {
-        assert after != null && before != null;
-        return new ImmutableOpenMapDiff<>(before, after, keySerializer, valueSerializer);
-    }
-
-    /**
-     * Calculates diff between two ImmutableOpenIntMaps of Diffable objects
-     */
-    public static <T extends Diffable<T>> MapDiff<Integer, T, ImmutableOpenIntMap<T>> diff(
-        ImmutableOpenIntMap<T> before,
-        ImmutableOpenIntMap<T> after,
-        KeySerializer<Integer> keySerializer
-    ) {
-        assert after != null && before != null;
-        return new ImmutableOpenIntMapDiff<>(before, after, keySerializer, DiffableValueSerializer.getWriteOnlyInstance());
-    }
-
-    /**
-     * Calculates diff between two ImmutableOpenIntMaps of non-diffable objects
-     */
-    public static <T> MapDiff<Integer, T, ImmutableOpenIntMap<T>> diff(
-        ImmutableOpenIntMap<T> before,
-        ImmutableOpenIntMap<T> after,
-        KeySerializer<Integer> keySerializer,
-        ValueSerializer<Integer, T> valueSerializer
-    ) {
-        assert after != null && before != null;
-        return new ImmutableOpenIntMapDiff<>(before, after, keySerializer, valueSerializer);
-    }
-
-    /**
      * Calculates diff between two Maps of Diffable objects.
      */
     public static <K, T extends Diffable<T>> MapDiff<K, T, Map<K, T>> diff(
@@ -158,28 +102,6 @@ public final class DiffableUtils {
     }
 
     /**
-     * Loads an object that represents difference between two ImmutableOpenMaps
-     */
-    public static <K, T> MapDiff<K, T, ImmutableOpenMap<K, T>> readImmutableOpenMapDiff(
-        StreamInput in,
-        KeySerializer<K> keySerializer,
-        ValueSerializer<K, T> valueSerializer
-    ) throws IOException {
-        return new ImmutableOpenMapDiff<>(in, keySerializer, valueSerializer);
-    }
-
-    /**
-     * Loads an object that represents difference between two ImmutableOpenMaps
-     */
-    public static <T> MapDiff<Integer, T, ImmutableOpenIntMap<T>> readImmutableOpenIntMapDiff(
-        StreamInput in,
-        KeySerializer<Integer> keySerializer,
-        ValueSerializer<Integer, T> valueSerializer
-    ) throws IOException {
-        return new ImmutableOpenIntMapDiff<>(in, keySerializer, valueSerializer);
-    }
-
-    /**
      * Loads an object that represents difference between two Maps of Diffable objects
      */
     public static <K, T> MapDiff<K, T, Map<K, T>> readJdkMapDiff(
@@ -188,29 +110,6 @@ public final class DiffableUtils {
         ValueSerializer<K, T> valueSerializer
     ) throws IOException {
         return new JdkMapDiff<>(in, keySerializer, valueSerializer);
-    }
-
-    /**
-     * Loads an object that represents difference between two ImmutableOpenMaps of Diffable objects using Diffable proto object
-     */
-    public static <K, T extends Diffable<T>> MapDiff<K, T, ImmutableOpenMap<K, T>> readImmutableOpenMapDiff(
-        StreamInput in,
-        KeySerializer<K> keySerializer,
-        DiffableValueReader<K, T> diffableValueReader
-    ) throws IOException {
-        return new ImmutableOpenMapDiff<>(in, keySerializer, diffableValueReader);
-    }
-
-    /**
-     * Loads an object that represents difference between two ImmutableOpenIntMaps of Diffable objects using Diffable proto object
-     */
-    public static <T extends Diffable<T>> MapDiff<Integer, T, ImmutableOpenIntMap<T>> readImmutableOpenIntMapDiff(
-        StreamInput in,
-        KeySerializer<Integer> keySerializer,
-        Reader<T> reader,
-        Reader<Diff<T>> diffReader
-    ) throws IOException {
-        return new ImmutableOpenIntMapDiff<>(in, keySerializer, new DiffableValueReader<>(reader, diffReader));
     }
 
     /**
@@ -278,157 +177,6 @@ public final class DiffableUtils {
                 builder.put(upsert.getKey(), upsert.getValue());
             }
             return builder;
-        }
-    }
-
-    /**
-     * Represents differences between two ImmutableOpenMap of (possibly diffable) objects
-     *
-     * @param <T> the object type
-     *
-     * @opensearch.internal
-     */
-    public static class ImmutableOpenMapDiff<K, T> extends MapDiff<K, T, ImmutableOpenMap<K, T>> {
-
-        protected ImmutableOpenMapDiff(StreamInput in, KeySerializer<K> keySerializer, ValueSerializer<K, T> valueSerializer)
-            throws IOException {
-            super(in, keySerializer, valueSerializer);
-        }
-
-        private ImmutableOpenMapDiff(
-            KeySerializer<K> keySerializer,
-            ValueSerializer<K, T> valueSerializer,
-            List<K> deletes,
-            Map<K, Diff<T>> diffs,
-            Map<K, T> upserts
-        ) {
-            super(keySerializer, valueSerializer, deletes, diffs, upserts);
-        }
-
-        public ImmutableOpenMapDiff(
-            ImmutableOpenMap<K, T> before,
-            ImmutableOpenMap<K, T> after,
-            KeySerializer<K> keySerializer,
-            ValueSerializer<K, T> valueSerializer
-        ) {
-            super(keySerializer, valueSerializer);
-            assert after != null && before != null;
-
-            for (ObjectCursor<K> key : before.keys()) {
-                if (!after.containsKey(key.value)) {
-                    deletes.add(key.value);
-                }
-            }
-
-            for (ObjectObjectCursor<K, T> partIter : after) {
-                T beforePart = before.get(partIter.key);
-                if (beforePart == null) {
-                    upserts.put(partIter.key, partIter.value);
-                } else if (partIter.value.equals(beforePart) == false) {
-                    if (valueSerializer.supportsDiffableValues()) {
-                        diffs.put(partIter.key, valueSerializer.diff(partIter.value, beforePart));
-                    } else {
-                        upserts.put(partIter.key, partIter.value);
-                    }
-                }
-            }
-        }
-
-        /**
-         * Returns a new diff map with the given key removed, does not modify the invoking instance.
-         * If the key does not exist in the diff map, the same instance is returned.
-         */
-        public ImmutableOpenMapDiff<K, T> withKeyRemoved(K key) {
-            if (this.diffs.containsKey(key) == false && this.upserts.containsKey(key) == false) {
-                return this;
-            }
-            Map<K, Diff<T>> newDiffs = new HashMap<>(this.diffs);
-            newDiffs.remove(key);
-            Map<K, T> newUpserts = new HashMap<>(this.upserts);
-            newUpserts.remove(key);
-            return new ImmutableOpenMapDiff<>(this.keySerializer, this.valueSerializer, this.deletes, newDiffs, newUpserts);
-        }
-
-        @Override
-        public ImmutableOpenMap<K, T> apply(ImmutableOpenMap<K, T> map) {
-            ImmutableOpenMap.Builder<K, T> builder = ImmutableOpenMap.builder();
-            builder.putAll(map);
-
-            for (K part : deletes) {
-                builder.remove(part);
-            }
-
-            for (Map.Entry<K, Diff<T>> diff : diffs.entrySet()) {
-                builder.put(diff.getKey(), diff.getValue().apply(builder.get(diff.getKey())));
-            }
-
-            for (Map.Entry<K, T> upsert : upserts.entrySet()) {
-                builder.put(upsert.getKey(), upsert.getValue());
-            }
-            return builder.build();
-        }
-    }
-
-    /**
-     * Represents differences between two ImmutableOpenIntMap of (possibly diffable) objects
-     *
-     * @param <T> the object type
-     *
-     * @opensearch.internal
-     */
-    private static class ImmutableOpenIntMapDiff<T> extends MapDiff<Integer, T, ImmutableOpenIntMap<T>> {
-
-        protected ImmutableOpenIntMapDiff(StreamInput in, KeySerializer<Integer> keySerializer, ValueSerializer<Integer, T> valueSerializer)
-            throws IOException {
-            super(in, keySerializer, valueSerializer);
-        }
-
-        ImmutableOpenIntMapDiff(
-            ImmutableOpenIntMap<T> before,
-            ImmutableOpenIntMap<T> after,
-            KeySerializer<Integer> keySerializer,
-            ValueSerializer<Integer, T> valueSerializer
-        ) {
-            super(keySerializer, valueSerializer);
-            assert after != null && before != null;
-
-            for (IntCursor key : before.keys()) {
-                if (!after.containsKey(key.value)) {
-                    deletes.add(key.value);
-                }
-            }
-
-            for (IntObjectCursor<T> partIter : after) {
-                T beforePart = before.get(partIter.key);
-                if (beforePart == null) {
-                    upserts.put(partIter.key, partIter.value);
-                } else if (partIter.value.equals(beforePart) == false) {
-                    if (valueSerializer.supportsDiffableValues()) {
-                        diffs.put(partIter.key, valueSerializer.diff(partIter.value, beforePart));
-                    } else {
-                        upserts.put(partIter.key, partIter.value);
-                    }
-                }
-            }
-        }
-
-        @Override
-        public ImmutableOpenIntMap<T> apply(ImmutableOpenIntMap<T> map) {
-            ImmutableOpenIntMap.Builder<T> builder = ImmutableOpenIntMap.builder();
-            builder.putAll(map);
-
-            for (Integer part : deletes) {
-                builder.remove(part);
-            }
-
-            for (Map.Entry<Integer, Diff<T>> diff : diffs.entrySet()) {
-                builder.put(diff.getKey(), diff.getValue().apply(builder.get(diff.getKey())));
-            }
-
-            for (Map.Entry<Integer, T> upsert : upserts.entrySet()) {
-                builder.put(upsert.getKey(), upsert.getValue());
-            }
-            return builder.build();
         }
     }
 

--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
@@ -33,9 +33,6 @@
 package org.opensearch.cluster.metadata;
 
 import com.carrotsearch.hppc.LongArrayList;
-import com.carrotsearch.hppc.cursors.IntObjectCursor;
-import com.carrotsearch.hppc.cursors.ObjectCursor;
-import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.opensearch.core.Assertions;
 import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
@@ -49,8 +46,6 @@ import org.opensearch.cluster.block.ClusterBlockLevel;
 import org.opensearch.cluster.node.DiscoveryNodeFilters;
 import org.opensearch.cluster.routing.allocation.IndexMetadataUpdater;
 import org.opensearch.common.Nullable;
-import org.opensearch.common.collect.ImmutableOpenIntMap;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.collect.MapBuilder;
 import org.opensearch.common.compress.CompressedXContent;
 import org.opensearch.common.io.stream.StreamInput;
@@ -702,15 +697,15 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
 
     private final State state;
 
-    private final ImmutableOpenMap<String, AliasMetadata> aliases;
+    private final Map<String, AliasMetadata> aliases;
 
     private final Settings settings;
 
-    private final ImmutableOpenMap<String, MappingMetadata> mappings;
+    private final Map<String, MappingMetadata> mappings;
 
-    private final ImmutableOpenMap<String, DiffableStringMap> customData;
+    private final Map<String, DiffableStringMap> customData;
 
-    private final ImmutableOpenIntMap<Set<String>> inSyncAllocationIds;
+    private final Map<Integer, Set<String>> inSyncAllocationIds;
 
     private final transient int totalNumberOfShards;
 
@@ -723,7 +718,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
     private final Version indexUpgradedVersion;
 
     private final ActiveShardCount waitForActiveShards;
-    private final ImmutableOpenMap<String, RolloverInfo> rolloverInfos;
+    private final Map<String, RolloverInfo> rolloverInfos;
     private final boolean isSystem;
 
     private IndexMetadata(
@@ -737,10 +732,10 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         final int numberOfShards,
         final int numberOfReplicas,
         final Settings settings,
-        final ImmutableOpenMap<String, MappingMetadata> mappings,
-        final ImmutableOpenMap<String, AliasMetadata> aliases,
-        final ImmutableOpenMap<String, DiffableStringMap> customData,
-        final ImmutableOpenIntMap<Set<String>> inSyncAllocationIds,
+        final Map<String, MappingMetadata> mappings,
+        final Map<String, AliasMetadata> aliases,
+        final Map<String, DiffableStringMap> customData,
+        final Map<Integer, Set<String>> inSyncAllocationIds,
         final DiscoveryNodeFilters requireFilters,
         final DiscoveryNodeFilters initialRecoveryFilters,
         final DiscoveryNodeFilters includeFilters,
@@ -750,7 +745,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         final int routingNumShards,
         final int routingPartitionSize,
         final ActiveShardCount waitForActiveShards,
-        final ImmutableOpenMap<String, RolloverInfo> rolloverInfos,
+        final Map<String, RolloverInfo> rolloverInfos,
         final boolean isSystem
     ) {
 
@@ -769,10 +764,10 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         this.numberOfReplicas = numberOfReplicas;
         this.totalNumberOfShards = numberOfShards * (numberOfReplicas + 1);
         this.settings = settings;
-        this.mappings = mappings;
-        this.customData = customData;
-        this.aliases = aliases;
-        this.inSyncAllocationIds = inSyncAllocationIds;
+        this.mappings = Collections.unmodifiableMap(mappings);
+        this.customData = Collections.unmodifiableMap(customData);
+        this.aliases = Collections.unmodifiableMap(aliases);
+        this.inSyncAllocationIds = Collections.unmodifiableMap(inSyncAllocationIds);
         this.requireFilters = requireFilters;
         this.includeFilters = includeFilters;
         this.excludeFilters = excludeFilters;
@@ -783,7 +778,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         this.routingFactor = routingNumShards / numberOfShards;
         this.routingPartitionSize = routingPartitionSize;
         this.waitForActiveShards = waitForActiveShards;
-        this.rolloverInfos = rolloverInfos;
+        this.rolloverInfos = Collections.unmodifiableMap(rolloverInfos);
         this.isSystem = isSystem;
         assert numberOfShards * routingFactor == routingNumShards : routingNumShards + " must be a multiple of " + numberOfShards;
     }
@@ -891,7 +886,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         return settings;
     }
 
-    public ImmutableOpenMap<String, AliasMetadata> getAliases() {
+    public Map<String, AliasMetadata> getAliases() {
         return this.aliases;
     }
 
@@ -900,8 +895,8 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
      */
     @Nullable
     public MappingMetadata mapping() {
-        for (ObjectObjectCursor<String, MappingMetadata> cursor : mappings) {
-            return cursor.value;
+        for (final MappingMetadata cursor : mappings.values()) {
+            return cursor;
         }
         return null;
     }
@@ -917,7 +912,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             : null;
     }
 
-    ImmutableOpenMap<String, DiffableStringMap> getCustomData() {
+    Map<String, DiffableStringMap> getCustomData() {
         return this.customData;
     }
 
@@ -925,11 +920,11 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         return this.customData.get(key);
     }
 
-    public ImmutableOpenIntMap<Set<String>> getInSyncAllocationIds() {
+    public Map<Integer, Set<String>> getInSyncAllocationIds() {
         return inSyncAllocationIds;
     }
 
-    public ImmutableOpenMap<String, RolloverInfo> getRolloverInfos() {
+    public Map<String, RolloverInfo> getRolloverInfos() {
         return rolloverInfos;
     }
 
@@ -1065,11 +1060,11 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         private final long[] primaryTerms;
         private final State state;
         private final Settings settings;
-        private final Diff<ImmutableOpenMap<String, MappingMetadata>> mappings;
-        private final Diff<ImmutableOpenMap<String, AliasMetadata>> aliases;
-        private final Diff<ImmutableOpenMap<String, DiffableStringMap>> customData;
-        private final Diff<ImmutableOpenIntMap<Set<String>>> inSyncAllocationIds;
-        private final Diff<ImmutableOpenMap<String, RolloverInfo>> rolloverInfos;
+        private final Diff<Map<String, MappingMetadata>> mappings;
+        private final Diff<Map<String, AliasMetadata>> aliases;
+        private final Diff<Map<String, DiffableStringMap>> customData;
+        private final Diff<Map<Integer, Set<String>>> inSyncAllocationIds;
+        private final Diff<Map<String, RolloverInfo>> rolloverInfos;
         private final boolean isSystem;
 
         IndexMetadataDiff(IndexMetadata before, IndexMetadata after) {
@@ -1114,19 +1109,15 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             state = State.fromId(in.readByte());
             settings = Settings.readSettingsFromStream(in);
             primaryTerms = in.readVLongArray();
-            mappings = DiffableUtils.readImmutableOpenMapDiff(in, DiffableUtils.getStringKeySerializer(), MAPPING_DIFF_VALUE_READER);
-            aliases = DiffableUtils.readImmutableOpenMapDiff(in, DiffableUtils.getStringKeySerializer(), ALIAS_METADATA_DIFF_VALUE_READER);
-            customData = DiffableUtils.readImmutableOpenMapDiff(in, DiffableUtils.getStringKeySerializer(), CUSTOM_DIFF_VALUE_READER);
-            inSyncAllocationIds = DiffableUtils.readImmutableOpenIntMapDiff(
+            mappings = DiffableUtils.readJdkMapDiff(in, DiffableUtils.getStringKeySerializer(), MAPPING_DIFF_VALUE_READER);
+            aliases = DiffableUtils.readJdkMapDiff(in, DiffableUtils.getStringKeySerializer(), ALIAS_METADATA_DIFF_VALUE_READER);
+            customData = DiffableUtils.readJdkMapDiff(in, DiffableUtils.getStringKeySerializer(), CUSTOM_DIFF_VALUE_READER);
+            inSyncAllocationIds = DiffableUtils.readJdkMapDiff(
                 in,
                 DiffableUtils.getVIntKeySerializer(),
                 DiffableUtils.StringSetValueSerializer.getInstance()
             );
-            rolloverInfos = DiffableUtils.readImmutableOpenMapDiff(
-                in,
-                DiffableUtils.getStringKeySerializer(),
-                ROLLOVER_INFO_DIFF_VALUE_READER
-            );
+            rolloverInfos = DiffableUtils.readJdkMapDiff(in, DiffableUtils.getStringKeySerializer(), ROLLOVER_INFO_DIFF_VALUE_READER);
             isSystem = in.readBoolean();
         }
 
@@ -1222,26 +1213,26 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         writeSettingsToStream(settings, out);
         out.writeVLongArray(primaryTerms);
         out.writeVInt(mappings.size());
-        for (ObjectCursor<MappingMetadata> cursor : mappings.values()) {
-            cursor.value.writeTo(out);
+        for (final MappingMetadata cursor : mappings.values()) {
+            cursor.writeTo(out);
         }
         out.writeVInt(aliases.size());
-        for (ObjectCursor<AliasMetadata> cursor : aliases.values()) {
-            cursor.value.writeTo(out);
+        for (final AliasMetadata cursor : aliases.values()) {
+            cursor.writeTo(out);
         }
         out.writeVInt(customData.size());
-        for (final ObjectObjectCursor<String, DiffableStringMap> cursor : customData) {
-            out.writeString(cursor.key);
-            cursor.value.writeTo(out);
+        for (final Map.Entry<String, DiffableStringMap> cursor : customData.entrySet()) {
+            out.writeString(cursor.getKey());
+            cursor.getValue().writeTo(out);
         }
         out.writeVInt(inSyncAllocationIds.size());
-        for (IntObjectCursor<Set<String>> cursor : inSyncAllocationIds) {
-            out.writeVInt(cursor.key);
-            DiffableUtils.StringSetValueSerializer.getInstance().write(cursor.value, out);
+        for (final Map.Entry<Integer, Set<String>> cursor : inSyncAllocationIds.entrySet()) {
+            out.writeVInt(cursor.getKey());
+            DiffableUtils.StringSetValueSerializer.getInstance().write(cursor.getValue(), out);
         }
         out.writeVInt(rolloverInfos.size());
-        for (ObjectCursor<RolloverInfo> cursor : rolloverInfos.values()) {
-            cursor.value.writeTo(out);
+        for (final RolloverInfo cursor : rolloverInfos.values()) {
+            cursor.writeTo(out);
         }
         out.writeBoolean(isSystem);
     }
@@ -1273,21 +1264,21 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         private long aliasesVersion = 1;
         private long[] primaryTerms = null;
         private Settings settings = Settings.Builder.EMPTY_SETTINGS;
-        private final ImmutableOpenMap.Builder<String, MappingMetadata> mappings;
-        private final ImmutableOpenMap.Builder<String, AliasMetadata> aliases;
-        private final ImmutableOpenMap.Builder<String, DiffableStringMap> customMetadata;
-        private final ImmutableOpenIntMap.Builder<Set<String>> inSyncAllocationIds;
-        private final ImmutableOpenMap.Builder<String, RolloverInfo> rolloverInfos;
+        private final Map<String, MappingMetadata> mappings;
+        private final Map<String, AliasMetadata> aliases;
+        private final Map<String, DiffableStringMap> customMetadata;
+        private final Map<Integer, Set<String>> inSyncAllocationIds;
+        private final Map<String, RolloverInfo> rolloverInfos;
         private Integer routingNumShards;
         private boolean isSystem;
 
         public Builder(String index) {
             this.index = index;
-            this.mappings = ImmutableOpenMap.builder();
-            this.aliases = ImmutableOpenMap.builder();
-            this.customMetadata = ImmutableOpenMap.builder();
-            this.inSyncAllocationIds = ImmutableOpenIntMap.builder();
-            this.rolloverInfos = ImmutableOpenMap.builder();
+            this.mappings = new HashMap<>();
+            this.aliases = new HashMap<>();
+            this.customMetadata = new HashMap<>();
+            this.inSyncAllocationIds = new HashMap<>();
+            this.rolloverInfos = new HashMap<>();
             this.isSystem = false;
         }
 
@@ -1300,12 +1291,12 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             this.aliasesVersion = indexMetadata.aliasesVersion;
             this.settings = indexMetadata.getSettings();
             this.primaryTerms = indexMetadata.primaryTerms.clone();
-            this.mappings = ImmutableOpenMap.builder(indexMetadata.mappings);
-            this.aliases = ImmutableOpenMap.builder(indexMetadata.aliases);
-            this.customMetadata = ImmutableOpenMap.builder(indexMetadata.customData);
+            this.mappings = new HashMap<>(indexMetadata.mappings);
+            this.aliases = new HashMap<>(indexMetadata.aliases);
+            this.customMetadata = new HashMap<>(indexMetadata.customData);
             this.routingNumShards = indexMetadata.routingNumShards;
-            this.inSyncAllocationIds = ImmutableOpenIntMap.builder(indexMetadata.inSyncAllocationIds);
-            this.rolloverInfos = ImmutableOpenMap.builder(indexMetadata.rolloverInfos);
+            this.inSyncAllocationIds = new HashMap<>(indexMetadata.inSyncAllocationIds);
+            this.rolloverInfos = new HashMap<>(indexMetadata.rolloverInfos);
             this.isSystem = indexMetadata.isSystem;
         }
 
@@ -1524,7 +1515,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         }
 
         public IndexMetadata build() {
-            ImmutableOpenMap.Builder<String, AliasMetadata> tmpAliases = aliases;
+            final Map<String, AliasMetadata> tmpAliases = aliases;
             Settings tmpSettings = settings;
 
             /*
@@ -1556,7 +1547,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             }
 
             // fill missing slots in inSyncAllocationIds with empty set if needed and make all entries immutable
-            ImmutableOpenIntMap.Builder<Set<String>> filledInSyncAllocationIds = ImmutableOpenIntMap.builder();
+            final Map<Integer, Set<String>> filledInSyncAllocationIds = new HashMap<>();
             for (int i = 0; i < numberOfShards; i++) {
                 if (inSyncAllocationIds.containsKey(i)) {
                     filledInSyncAllocationIds.put(i, Collections.unmodifiableSet(new HashSet<>(inSyncAllocationIds.get(i))));
@@ -1634,10 +1625,10 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                 numberOfShards,
                 numberOfReplicas,
                 tmpSettings,
-                mappings.build(),
-                tmpAliases.build(),
-                customMetadata.build(),
-                filledInSyncAllocationIds.build(),
+                mappings,
+                tmpAliases,
+                customMetadata,
+                filledInSyncAllocationIds,
                 requireFilters,
                 initialRecoveryFilters,
                 includeFilters,
@@ -1647,7 +1638,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                 getRoutingNumShards(),
                 routingPartitionSize,
                 waitForActiveShards,
-                rolloverInfos.build(),
+                rolloverInfos,
                 isSystem
             );
         }
@@ -1703,15 +1694,15 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                 builder.endObject();
             }
 
-            for (ObjectObjectCursor<String, DiffableStringMap> cursor : indexMetadata.customData) {
-                builder.field(cursor.key);
-                builder.map(cursor.value);
+            for (final Map.Entry<String, DiffableStringMap> cursor : indexMetadata.customData.entrySet()) {
+                builder.field(cursor.getKey());
+                builder.map(cursor.getValue());
             }
 
             if (context != Metadata.XContentContext.API) {
                 builder.startObject(KEY_ALIASES);
-                for (ObjectCursor<AliasMetadata> cursor : indexMetadata.getAliases().values()) {
-                    AliasMetadata.Builder.toXContent(cursor.value, builder, params);
+                for (final AliasMetadata cursor : indexMetadata.getAliases().values()) {
+                    AliasMetadata.Builder.toXContent(cursor, builder, params);
                 }
                 builder.endObject();
 
@@ -1722,8 +1713,8 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                 builder.endArray();
             } else {
                 builder.startArray(KEY_ALIASES);
-                for (ObjectCursor<String> cursor : indexMetadata.getAliases().keys()) {
-                    builder.value(cursor.value);
+                for (final String cursor : indexMetadata.getAliases().keySet()) {
+                    builder.value(cursor);
                 }
                 builder.endArray();
 
@@ -1735,9 +1726,9 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             }
 
             builder.startObject(KEY_IN_SYNC_ALLOCATIONS);
-            for (IntObjectCursor<Set<String>> cursor : indexMetadata.inSyncAllocationIds) {
-                builder.startArray(String.valueOf(cursor.key));
-                for (String allocationId : cursor.value) {
+            for (final Map.Entry<Integer, Set<String>> cursor : indexMetadata.inSyncAllocationIds.entrySet()) {
+                builder.startArray(String.valueOf(cursor.getKey()));
+                for (String allocationId : cursor.getValue()) {
                     builder.value(allocationId);
                 }
                 builder.endArray();
@@ -1745,8 +1736,8 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             builder.endObject();
 
             builder.startObject(KEY_ROLLOVER_INFOS);
-            for (ObjectCursor<RolloverInfo> cursor : indexMetadata.getRolloverInfos().values()) {
-                cursor.value.toXContent(builder, params);
+            for (final RolloverInfo cursor : indexMetadata.getRolloverInfos().values()) {
+                cursor.toXContent(builder, params);
             }
             builder.endObject();
             builder.field(KEY_SYSTEM, indexMetadata.isSystem);

--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -39,7 +39,6 @@ import org.opensearch.cluster.ClusterState;
 import org.opensearch.common.Booleans;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.Strings;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.regex.Regex;
@@ -566,12 +565,11 @@ public class IndexNameExpressionResolver {
             return null;
         }
 
-        final ImmutableOpenMap<String, AliasMetadata> indexAliases = indexMetadata.getAliases();
+        final Map<String, AliasMetadata> indexAliases = indexMetadata.getAliases();
         final AliasMetadata[] aliasCandidates;
         if (iterateIndexAliases(indexAliases.size(), resolvedExpressions.size())) {
             // faster to iterate indexAliases
             aliasCandidates = StreamSupport.stream(Spliterators.spliteratorUnknownSize(indexAliases.values().iterator(), 0), false)
-                .map(cursor -> cursor.value)
                 .filter(aliasMetadata -> resolvedExpressions.contains(aliasMetadata.alias()))
                 .toArray(AliasMetadata[]::new);
         } else {

--- a/server/src/main/java/org/opensearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/Metadata.java
@@ -32,9 +32,6 @@
 
 package org.opensearch.cluster.metadata;
 
-import com.carrotsearch.hppc.cursors.ObjectCursor;
-
-import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.util.CollectionUtil;
@@ -53,7 +50,6 @@ import org.opensearch.cluster.decommission.DecommissionAttributeMetadata;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.Strings;
 import org.opensearch.common.UUIDs;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.regex.Regex;
@@ -431,8 +427,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         for (String index : concreteIndices) {
             IndexMetadata indexMetadata = indices.get(index);
             List<AliasMetadata> filteredValues = new ArrayList<>();
-            for (ObjectCursor<AliasMetadata> cursor : indexMetadata.getAliases().values()) {
-                AliasMetadata value = cursor.value;
+            for (final AliasMetadata value : indexMetadata.getAliases().values()) {
                 boolean matched = matchAllAliases;
                 String alias = value.alias();
                 for (int i = 0; i < patterns.length; i++) {
@@ -484,9 +479,9 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
     /**
      * Finds the parent data streams, if any, for the specified concrete indices.
      */
-    public ImmutableOpenMap<String, IndexAbstraction.DataStream> findDataStreams(String[] concreteIndices) {
+    public Map<String, IndexAbstraction.DataStream> findDataStreams(String[] concreteIndices) {
         assert concreteIndices != null;
-        final ImmutableOpenMap.Builder<String, IndexAbstraction.DataStream> builder = ImmutableOpenMap.builder();
+        final Map<String, IndexAbstraction.DataStream> builder = new HashMap<>();
         final SortedMap<String, IndexAbstraction> lookup = getIndicesLookup();
         for (String indexName : concreteIndices) {
             IndexAbstraction index = lookup.get(indexName);
@@ -496,7 +491,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                 builder.put(indexName, index.getParentDataStream());
             }
         }
-        return builder.build();
+        return Collections.unmodifiableMap(builder);
     }
 
     @SuppressWarnings("unchecked")
@@ -1461,7 +1456,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                         visibleClosedIndices.add(name);
                     }
                 }
-                indexMetadata.getAliases().keysIt().forEachRemaining(allAliases::add);
+                indexMetadata.getAliases().keySet().iterator().forEachRemaining(allAliases::add);
             }
 
             final Set<String> allDataStreams = new HashSet<>();
@@ -1591,8 +1586,8 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                 IndexAbstraction existing = indicesLookup.put(indexMetadata.getIndex().getName(), index);
                 assert existing == null : "duplicate for " + indexMetadata.getIndex();
 
-                for (final ObjectObjectCursor<String, AliasMetadata> aliasCursor : indexMetadata.getAliases()) {
-                    AliasMetadata aliasMetadata = aliasCursor.value;
+                for (final AliasMetadata aliasCursor : indexMetadata.getAliases().values()) {
+                    AliasMetadata aliasMetadata = aliasCursor;
                     indicesLookup.compute(aliasMetadata.getAlias(), (aliasName, alias) -> {
                         if (alias == null) {
                             return new IndexAbstraction.Alias(aliasMetadata, indexMetadata);

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -31,7 +31,6 @@
 
 package org.opensearch.cluster.metadata;
 
-import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.CollectionUtil;
@@ -1235,8 +1234,8 @@ public class MetadataIndexTemplateService {
         templates.forEach(template -> {
             if (template.aliases() != null) {
                 Map<String, AliasMetadata> aliasMeta = new HashMap<>();
-                for (final ObjectObjectCursor<String, AliasMetadata> cursor : template.aliases()) {
-                    aliasMeta.put(cursor.key, cursor.value);
+                for (final Map.Entry<String, AliasMetadata> cursor : template.aliases().entrySet()) {
+                    aliasMeta.put(cursor.getKey(), cursor.getValue());
                 }
                 resolvedAliases.add(aliasMeta);
             }

--- a/server/src/main/java/org/opensearch/gateway/DanglingIndicesState.java
+++ b/server/src/main/java/org/opensearch/gateway/DanglingIndicesState.java
@@ -255,7 +255,7 @@ public class DanglingIndicesState implements ClusterStateListener {
             logger.info(
                 "[{}] stripping aliases: {} from index before importing",
                 indexMetadata.getIndex(),
-                indexMetadata.getAliases().keys()
+                indexMetadata.getAliases().keySet()
             );
             return IndexMetadata.builder(indexMetadata).removeAllAliases().build();
         }

--- a/server/src/main/java/org/opensearch/search/internal/ShardSearchRequest.java
+++ b/server/src/main/java/org/opensearch/search/internal/ShardSearchRequest.java
@@ -45,7 +45,6 @@ import org.opensearch.common.CheckedFunction;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.Strings;
 import org.opensearch.common.bytes.BytesReference;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -567,7 +566,7 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
             return null;
         }
         Index index = metadata.getIndex();
-        ImmutableOpenMap<String, AliasMetadata> aliases = metadata.getAliases();
+        final Map<String, AliasMetadata> aliases = metadata.getAliases();
         Function<AliasMetadata, QueryBuilder> parserFunction = (alias) -> {
             if (alias.filter() == null) {
                 return null;

--- a/server/src/main/java/org/opensearch/snapshots/EmptySnapshotsInfoService.java
+++ b/server/src/main/java/org/opensearch/snapshots/EmptySnapshotsInfoService.java
@@ -32,7 +32,7 @@
 
 package org.opensearch.snapshots;
 
-import org.opensearch.common.collect.ImmutableOpenMap;
+import java.util.Map;
 
 /**
  * Service for getting information about empty snapshots
@@ -44,6 +44,6 @@ public class EmptySnapshotsInfoService implements SnapshotsInfoService {
 
     @Override
     public SnapshotShardSizeInfo snapshotShardSizes() {
-        return new SnapshotShardSizeInfo(ImmutableOpenMap.of());
+        return new SnapshotShardSizeInfo(Map.of());
     }
 }

--- a/server/src/main/java/org/opensearch/snapshots/InternalSnapshotsInfoService.java
+++ b/server/src/main/java/org/opensearch/snapshots/InternalSnapshotsInfoService.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.snapshots;
 
-import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
@@ -47,7 +46,6 @@ import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.ShardRoutingState;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Priority;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
@@ -59,9 +57,11 @@ import org.opensearch.repositories.Repository;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
@@ -94,7 +94,7 @@ public class InternalSnapshotsInfoService implements ClusterStateListener, Snaps
     private final Supplier<RerouteService> rerouteService;
 
     /** contains the snapshot shards for which the size is known **/
-    private volatile ImmutableOpenMap<SnapshotShard, Long> knownSnapshotShards;
+    private volatile Map<SnapshotShard, Long> knownSnapshotShards;
 
     private volatile boolean isMaster;
 
@@ -121,7 +121,7 @@ public class InternalSnapshotsInfoService implements ClusterStateListener, Snaps
         this.threadPool = clusterService.getClusterApplierService().threadPool();
         this.repositoriesService = repositoriesServiceSupplier;
         this.rerouteService = rerouteServiceSupplier;
-        this.knownSnapshotShards = ImmutableOpenMap.of();
+        this.knownSnapshotShards = Map.of();
         this.unknownSnapshotShards = new LinkedHashSet<>();
         this.failedSnapshotShards = new LinkedHashSet<>();
         this.queue = new LinkedList<>();
@@ -142,14 +142,14 @@ public class InternalSnapshotsInfoService implements ClusterStateListener, Snaps
     @Override
     public SnapshotShardSizeInfo snapshotShardSizes() {
         synchronized (mutex) {
-            final ImmutableOpenMap.Builder<SnapshotShard, Long> snapshotShardSizes = ImmutableOpenMap.builder(knownSnapshotShards);
+            final Map<SnapshotShard, Long> snapshotShardSizes = new HashMap<>(knownSnapshotShards);
             if (failedSnapshotShards.isEmpty() == false) {
                 for (SnapshotShard snapshotShard : failedSnapshotShards) {
                     Long previous = snapshotShardSizes.put(snapshotShard, ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE);
                     assert previous == null : "snapshot shard size already known for " + snapshotShard;
                 }
             }
-            return new SnapshotShardSizeInfo(snapshotShardSizes.build());
+            return new SnapshotShardSizeInfo(snapshotShardSizes);
         }
     }
 
@@ -185,7 +185,7 @@ public class InternalSnapshotsInfoService implements ClusterStateListener, Snaps
             // have to repopulate the data over and over in an unstable cluster-manager situation?
             synchronized (mutex) {
                 // information only needed on current master
-                knownSnapshotShards = ImmutableOpenMap.of();
+                knownSnapshotShards = Map.of();
                 failedSnapshotShards.clear();
                 isMaster = false;
                 SnapshotShard snapshotShard;
@@ -250,12 +250,10 @@ public class InternalSnapshotsInfoService implements ClusterStateListener, Snaps
                 removed = unknownSnapshotShards.remove(snapshotShard);
                 assert removed : "snapshot shard to remove does not exist " + snapshotShardSize;
                 if (isMaster) {
-                    final ImmutableOpenMap.Builder<SnapshotShard, Long> newSnapshotShardSizes = ImmutableOpenMap.builder(
-                        knownSnapshotShards
-                    );
+                    final Map<SnapshotShard, Long> newSnapshotShardSizes = new HashMap<>(knownSnapshotShards);
                     updated = newSnapshotShardSizes.put(snapshotShard, snapshotShardSize) == null;
                     assert updated : "snapshot shard size already exists for " + snapshotShard;
-                    knownSnapshotShards = newSnapshotShardSizes.build();
+                    knownSnapshotShards = Collections.unmodifiableMap(newSnapshotShardSizes);
                 }
                 activeFetches -= 1;
                 assert invariant();
@@ -293,17 +291,17 @@ public class InternalSnapshotsInfoService implements ClusterStateListener, Snaps
 
     private void cleanUpSnapshotShardSizes(Set<SnapshotShard> requiredSnapshotShards) {
         assert Thread.holdsLock(mutex);
-        ImmutableOpenMap.Builder<SnapshotShard, Long> newSnapshotShardSizes = null;
-        for (ObjectCursor<SnapshotShard> shard : knownSnapshotShards.keys()) {
-            if (requiredSnapshotShards.contains(shard.value) == false) {
+        HashMap<SnapshotShard, Long> newSnapshotShardSizes = null;
+        for (final SnapshotShard shard : knownSnapshotShards.keySet()) {
+            if (requiredSnapshotShards.contains(shard) == false) {
                 if (newSnapshotShardSizes == null) {
-                    newSnapshotShardSizes = ImmutableOpenMap.builder(knownSnapshotShards);
+                    newSnapshotShardSizes = new HashMap<>(knownSnapshotShards);
                 }
-                newSnapshotShardSizes.remove(shard.value);
+                newSnapshotShardSizes.remove(shard);
             }
         }
         if (newSnapshotShardSizes != null) {
-            knownSnapshotShards = newSnapshotShardSizes.build();
+            knownSnapshotShards = Collections.unmodifiableMap(newSnapshotShardSizes);
         }
         failedSnapshotShards.retainAll(requiredSnapshotShards);
     }
@@ -312,16 +310,16 @@ public class InternalSnapshotsInfoService implements ClusterStateListener, Snaps
         assert Thread.holdsLock(mutex);
         assert activeFetches >= 0 : "active fetches should be greater than or equal to zero but got: " + activeFetches;
         assert activeFetches <= maxConcurrentFetches : activeFetches + " <= " + maxConcurrentFetches;
-        for (ObjectCursor<SnapshotShard> cursor : knownSnapshotShards.keys()) {
-            assert unknownSnapshotShards.contains(cursor.value) == false : "cannot be known and unknown at same time: " + cursor.value;
-            assert failedSnapshotShards.contains(cursor.value) == false : "cannot be known and failed at same time: " + cursor.value;
+        for (final SnapshotShard cursor : knownSnapshotShards.keySet()) {
+            assert unknownSnapshotShards.contains(cursor) == false : "cannot be known and unknown at same time: " + cursor;
+            assert failedSnapshotShards.contains(cursor) == false : "cannot be known and failed at same time: " + cursor;
         }
         for (SnapshotShard shard : unknownSnapshotShards) {
-            assert knownSnapshotShards.keys().contains(shard) == false : "cannot be unknown and known at same time: " + shard;
+            assert knownSnapshotShards.keySet().contains(shard) == false : "cannot be unknown and known at same time: " + shard;
             assert failedSnapshotShards.contains(shard) == false : "cannot be unknown and failed at same time: " + shard;
         }
         for (SnapshotShard shard : failedSnapshotShards) {
-            assert knownSnapshotShards.keys().contains(shard) == false : "cannot be failed and known at same time: " + shard;
+            assert knownSnapshotShards.keySet().contains(shard) == false : "cannot be failed and known at same time: " + shard;
             assert unknownSnapshotShards.contains(shard) == false : "cannot be failed and unknown at same time: " + shard;
         }
         return true;

--- a/server/src/main/java/org/opensearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/opensearch/snapshots/RestoreService.java
@@ -33,7 +33,6 @@ package org.opensearch.snapshots;
 
 import com.carrotsearch.hppc.IntHashSet;
 import com.carrotsearch.hppc.IntSet;
-import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
@@ -507,8 +506,8 @@ public class RestoreService implements ClusterStateApplier {
                                         // Remove all aliases - they shouldn't be restored
                                         indexMdBuilder.removeAllAliases();
                                     } else {
-                                        for (ObjectCursor<String> alias : snapshotIndexMetadata.getAliases().keys()) {
-                                            aliases.add(alias.value);
+                                        for (final String alias : snapshotIndexMetadata.getAliases().keySet()) {
+                                            aliases.add(alias);
                                         }
                                     }
                                     IndexMetadata updatedIndexMetadata = indexMdBuilder.build();
@@ -550,12 +549,12 @@ public class RestoreService implements ClusterStateApplier {
                                             indexMdBuilder.removeAllAliases();
                                         }
                                         /// Add existing aliases
-                                        for (ObjectCursor<AliasMetadata> alias : currentIndexMetadata.getAliases().values()) {
-                                            indexMdBuilder.putAlias(alias.value);
+                                        for (final AliasMetadata alias : currentIndexMetadata.getAliases().values()) {
+                                            indexMdBuilder.putAlias(alias);
                                         }
                                     } else {
-                                        for (ObjectCursor<String> alias : snapshotIndexMetadata.getAliases().keys()) {
-                                            aliases.add(alias.value);
+                                        for (final String alias : snapshotIndexMetadata.getAliases().keySet()) {
+                                            aliases.add(alias);
                                         }
                                     }
                                     final Settings.Builder indexSettingsBuilder = Settings.builder()

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotShardSizeInfo.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotShardSizeInfo.java
@@ -34,7 +34,9 @@ package org.opensearch.snapshots;
 
 import org.opensearch.cluster.routing.RecoverySource;
 import org.opensearch.cluster.routing.ShardRouting;
-import org.opensearch.common.collect.ImmutableOpenMap;
+
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * Information about a snapshot shard size
@@ -43,12 +45,12 @@ import org.opensearch.common.collect.ImmutableOpenMap;
  */
 public class SnapshotShardSizeInfo {
 
-    public static final SnapshotShardSizeInfo EMPTY = new SnapshotShardSizeInfo(ImmutableOpenMap.of());
+    public static final SnapshotShardSizeInfo EMPTY = new SnapshotShardSizeInfo(Map.of());
 
-    private final ImmutableOpenMap<InternalSnapshotsInfoService.SnapshotShard, Long> snapshotShardSizes;
+    private final Map<InternalSnapshotsInfoService.SnapshotShard, Long> snapshotShardSizes;
 
-    public SnapshotShardSizeInfo(ImmutableOpenMap<InternalSnapshotsInfoService.SnapshotShard, Long> snapshotShardSizes) {
-        this.snapshotShardSizes = snapshotShardSizes;
+    public SnapshotShardSizeInfo(final Map<InternalSnapshotsInfoService.SnapshotShard, Long> snapshotShardSizes) {
+        this.snapshotShardSizes = Collections.unmodifiableMap(snapshotShardSizes);
     }
 
     public Long getShardSize(ShardRouting shardRouting) {

--- a/server/src/test/java/org/opensearch/cluster/metadata/IndexMetadataTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/IndexMetadataTests.java
@@ -38,7 +38,6 @@ import org.opensearch.action.admin.indices.rollover.MaxSizeCondition;
 import org.opensearch.action.admin.indices.rollover.RolloverInfo;
 import org.opensearch.common.Strings;
 import org.opensearch.common.bytes.BytesReference;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.opensearch.common.io.stream.NamedWriteableRegistry;
@@ -146,9 +145,7 @@ public class IndexMetadataTests extends OpenSearchTestCase {
         assertEquals(metadata.getRoutingFactor(), fromXContentMeta.getRoutingFactor());
         assertEquals(metadata.primaryTerm(0), fromXContentMeta.primaryTerm(0));
         assertEquals(metadata.isSystem(), fromXContentMeta.isSystem());
-        ImmutableOpenMap.Builder<String, DiffableStringMap> expectedCustomBuilder = ImmutableOpenMap.builder();
-        expectedCustomBuilder.put("my_custom", new DiffableStringMap(customMap));
-        ImmutableOpenMap<String, DiffableStringMap> expectedCustom = expectedCustomBuilder.build();
+        final Map<String, DiffableStringMap> expectedCustom = Map.of("my_custom", new DiffableStringMap(customMap));
         assertEquals(metadata.getCustomData(), expectedCustom);
         assertEquals(metadata.getCustomData(), fromXContentMeta.getCustomData());
 

--- a/server/src/test/java/org/opensearch/cluster/metadata/IndexTemplateMetadataTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/IndexTemplateMetadataTests.java
@@ -33,7 +33,6 @@ package org.opensearch.cluster.metadata;
 
 import org.opensearch.common.bytes.BytesArray;
 import org.opensearch.common.bytes.BytesReference;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
@@ -48,6 +47,7 @@ import org.opensearch.test.OpenSearchTestCase;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.contains;
@@ -109,8 +109,8 @@ public class IndexTemplateMetadataTests extends OpenSearchTestCase {
                 randomInt(),
                 Collections.emptyList(),
                 Settings.EMPTY,
-                ImmutableOpenMap.of(),
-                ImmutableOpenMap.of()
+                Map.of(),
+                Map.of()
             );
         });
         assertThat(emptyPatternError.getMessage(), equalTo("Index patterns must not be null or empty; got []"));
@@ -122,8 +122,8 @@ public class IndexTemplateMetadataTests extends OpenSearchTestCase {
                 randomInt(),
                 null,
                 Settings.EMPTY,
-                ImmutableOpenMap.of(),
-                ImmutableOpenMap.of()
+                Map.of(),
+                Map.of()
             );
         });
         assertThat(nullPatternError.getMessage(), equalTo("Index patterns must not be null or empty; got null"));

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -1018,7 +1018,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
 
         // adds alias from new index to existing index
         BiConsumer<Metadata.Builder, IndexMetadata> metadataTransformer = (builder, indexMetadata) -> {
-            AliasMetadata newAlias = indexMetadata.getAliases().iterator().next().value;
+            AliasMetadata newAlias = indexMetadata.getAliases().values().iterator().next();
             IndexMetadata myIndex = builder.get("my-index");
             builder.put(IndexMetadata.builder(myIndex).putAlias(AliasMetadata.builder(newAlias.getAlias()).build()));
         };
@@ -1397,7 +1397,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
         IndexMetadata indexMetadata = buildIndexMetadata("test", aliases, () -> null, indexSettings, 4, sourceIndexMetadata, false);
 
         assertThat(indexMetadata.getAliases().size(), is(1));
-        assertThat(indexMetadata.getAliases().keys().iterator().next().value, is("alias1"));
+        assertThat(indexMetadata.getAliases().keySet().iterator().next(), is("alias1"));
         assertThat("The source index primary term must be used", indexMetadata.primaryTerm(0), is(3L));
     }
 

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataTests.java
@@ -41,7 +41,6 @@ import org.opensearch.cluster.coordination.CoordinationMetadata.VotingConfigExcl
 import org.opensearch.common.Strings;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.bytes.BytesReference;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.opensearch.common.io.stream.NamedWriteableRegistry;
@@ -173,7 +172,7 @@ public class MetadataTests extends OpenSearchTestCase {
         List<Index> allIndices = new ArrayList<>(result.indices);
         allIndices.addAll(result.backingIndices);
         String[] concreteIndices = allIndices.stream().map(Index::getName).collect(Collectors.toList()).toArray(new String[] {});
-        ImmutableOpenMap<String, IndexAbstraction.DataStream> dataStreams = result.metadata.findDataStreams(concreteIndices);
+        final Map<String, IndexAbstraction.DataStream> dataStreams = result.metadata.findDataStreams(concreteIndices);
         assertThat(dataStreams.size(), equalTo(numBackingIndices));
         for (Index backingIndex : result.backingIndices) {
             assertThat(dataStreams.containsKey(backingIndex.getName()), is(true));

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
@@ -63,7 +63,6 @@ import org.opensearch.cluster.routing.allocation.decider.NodeVersionAllocationDe
 import org.opensearch.cluster.routing.allocation.decider.ReplicaAfterPrimaryActiveAllocationDecider;
 import org.opensearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider;
 import org.opensearch.common.UUIDs;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.set.Sets;
 import org.opensearch.index.Index;
@@ -80,7 +79,9 @@ import org.opensearch.test.gateway.TestGatewayAllocator;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.shuffle;
@@ -488,9 +489,7 @@ public class NodeVersionAllocationDeciderTests extends OpenSearchAllocationTestC
         }
         Metadata metadata = Metadata.builder().put(indexMetadata).build();
 
-        final ImmutableOpenMap.Builder<InternalSnapshotsInfoService.SnapshotShard, Long> snapshotShardSizes = ImmutableOpenMap.builder(
-            numberOfShards
-        );
+        final Map<InternalSnapshotsInfoService.SnapshotShard, Long> snapshotShardSizes = new HashMap<>(numberOfShards);
         final Index index = metadata.index("test").getIndex();
         for (int i = 0; i < numberOfShards; i++) {
             final ShardId shardId = new ShardId(index, i);
@@ -517,7 +516,7 @@ public class NodeVersionAllocationDeciderTests extends OpenSearchAllocationTestC
             new TestGatewayAllocator(),
             new BalancedShardsAllocator(Settings.EMPTY),
             EmptyClusterInfoService.INSTANCE,
-            () -> new SnapshotShardSizeInfo(snapshotShardSizes.build())
+            () -> new SnapshotShardSizeInfo(snapshotShardSizes)
         );
         state = strategy.reroute(state, new AllocationCommands(), true, false).getClusterState();
 

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/ThrottlingAllocationTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/ThrottlingAllocationTests.java
@@ -55,7 +55,6 @@ import org.opensearch.cluster.routing.allocation.command.MoveAllocationCommand;
 import org.opensearch.cluster.routing.allocation.decider.Decision;
 import org.opensearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider;
 import org.opensearch.common.UUIDs;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.Index;
 import org.opensearch.index.shard.ShardId;
@@ -886,14 +885,13 @@ public class ThrottlingAllocationTests extends OpenSearchAllocationTestCase {
 
     private static class TestSnapshotsInfoService implements SnapshotsInfoService {
 
-        private volatile ImmutableOpenMap<InternalSnapshotsInfoService.SnapshotShard, Long> snapshotShardSizes = ImmutableOpenMap.of();
+        private volatile Map<InternalSnapshotsInfoService.SnapshotShard, Long> snapshotShardSizes = Map.of();
 
         synchronized void addSnapshotShardSize(Snapshot snapshot, IndexId index, ShardId shard, Long size) {
-            final ImmutableOpenMap.Builder<InternalSnapshotsInfoService.SnapshotShard, Long> newSnapshotShardSizes = ImmutableOpenMap
-                .builder(snapshotShardSizes);
+            final Map<InternalSnapshotsInfoService.SnapshotShard, Long> newSnapshotShardSizes = new HashMap<>(snapshotShardSizes);
             boolean added = newSnapshotShardSizes.put(new InternalSnapshotsInfoService.SnapshotShard(snapshot, index, shard), size) == null;
             assert added : "cannot add snapshot shard size twice";
-            this.snapshotShardSizes = newSnapshotShardSizes.build();
+            this.snapshotShardSizes = Collections.unmodifiableMap(newSnapshotShardSizes);
         }
 
         @Override

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
@@ -66,7 +66,6 @@ import org.opensearch.cluster.routing.allocation.command.AllocationCommand;
 import org.opensearch.cluster.routing.allocation.command.AllocationCommands;
 import org.opensearch.cluster.routing.allocation.command.MoveAllocationCommand;
 import org.opensearch.common.UUIDs;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.Index;
@@ -1404,7 +1403,7 @@ public class DiskThresholdDeciderTests extends OpenSearchAllocationTestCase {
         assertThat(clusterState.getRoutingNodes().shardsWithState(UNASSIGNED).size(), equalTo(1));
 
         final SnapshotShard snapshotShard = new SnapshotShard(snapshot, indexId, shardId);
-        final ImmutableOpenMap.Builder<SnapshotShard, Long> snapshotShardSizes = ImmutableOpenMap.builder();
+        final Map<SnapshotShard, Long> snapshotShardSizes = new HashMap<>();
 
         final boolean shouldAllocate;
         if (randomBoolean()) {
@@ -1418,7 +1417,7 @@ public class DiskThresholdDeciderTests extends OpenSearchAllocationTestCase {
             logger.info("--> shard is always allocated when its size could not be retrieved");
             shouldAllocate = true;
         }
-        snapshotShardSizeInfoRef.set(new SnapshotShardSizeInfo(snapshotShardSizes.build()));
+        snapshotShardSizeInfoRef.set(new SnapshotShardSizeInfo(snapshotShardSizes));
 
         // reroute uses the previous snapshot shard size
         clusterState = startInitializingShardsAndReroute(strategy, clusterState);

--- a/server/src/test/java/org/opensearch/cluster/serialization/DiffableTests.java
+++ b/server/src/test/java/org/opensearch/cluster/serialization/DiffableTests.java
@@ -36,8 +36,6 @@ import org.opensearch.cluster.AbstractDiffable;
 import org.opensearch.cluster.Diff;
 import org.opensearch.cluster.DiffableUtils;
 import org.opensearch.cluster.DiffableUtils.MapDiff;
-import org.opensearch.common.collect.ImmutableOpenIntMap;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -102,106 +100,6 @@ public class DiffableTests extends OpenSearchTestCase {
             @Override
             protected MapDiff readDiff(StreamInput in) throws IOException {
                 return DiffableUtils.readJdkMapDiff(in, keySerializer, nonDiffableValueSerializer());
-            }
-        }.execute();
-    }
-
-    public void testImmutableOpenMapDiff() throws IOException {
-        new ImmutableOpenMapDriver<TestDiffable>() {
-            @Override
-            protected boolean diffableValues() {
-                return true;
-            }
-
-            @Override
-            protected TestDiffable createValue(Integer key, boolean before) {
-                return new TestDiffable(String.valueOf(before ? key : key + 1));
-            }
-
-            @Override
-            protected MapDiff diff(ImmutableOpenMap<Integer, TestDiffable> before, ImmutableOpenMap<Integer, TestDiffable> after) {
-                return DiffableUtils.diff(before, after, keySerializer);
-            }
-
-            @Override
-            protected MapDiff readDiff(StreamInput in) throws IOException {
-                return useProtoForDiffableSerialization
-                    ? DiffableUtils.readImmutableOpenMapDiff(
-                        in,
-                        keySerializer,
-                        new DiffableUtils.DiffableValueReader<>(TestDiffable::readFrom, TestDiffable::readDiffFrom)
-                    )
-                    : DiffableUtils.readImmutableOpenMapDiff(in, keySerializer, diffableValueSerializer());
-            }
-        }.execute();
-
-        new ImmutableOpenMapDriver<String>() {
-            @Override
-            protected boolean diffableValues() {
-                return false;
-            }
-
-            @Override
-            protected String createValue(Integer key, boolean before) {
-                return String.valueOf(before ? key : key + 1);
-            }
-
-            @Override
-            protected MapDiff diff(ImmutableOpenMap<Integer, String> before, ImmutableOpenMap<Integer, String> after) {
-                return DiffableUtils.diff(before, after, keySerializer, nonDiffableValueSerializer());
-            }
-
-            @Override
-            protected MapDiff readDiff(StreamInput in) throws IOException {
-                return DiffableUtils.readImmutableOpenMapDiff(in, keySerializer, nonDiffableValueSerializer());
-            }
-        }.execute();
-    }
-
-    public void testImmutableOpenIntMapDiff() throws IOException {
-        new ImmutableOpenIntMapDriver<TestDiffable>() {
-            @Override
-            protected boolean diffableValues() {
-                return true;
-            }
-
-            @Override
-            protected TestDiffable createValue(Integer key, boolean before) {
-                return new TestDiffable(String.valueOf(before ? key : key + 1));
-            }
-
-            @Override
-            protected MapDiff diff(ImmutableOpenIntMap<TestDiffable> before, ImmutableOpenIntMap<TestDiffable> after) {
-                return DiffableUtils.diff(before, after, keySerializer);
-            }
-
-            @Override
-            protected MapDiff readDiff(StreamInput in) throws IOException {
-                return useProtoForDiffableSerialization
-                    ? DiffableUtils.readImmutableOpenIntMapDiff(in, keySerializer, TestDiffable::readFrom, TestDiffable::readDiffFrom)
-                    : DiffableUtils.readImmutableOpenIntMapDiff(in, keySerializer, diffableValueSerializer());
-            }
-        }.execute();
-
-        new ImmutableOpenIntMapDriver<String>() {
-            @Override
-            protected boolean diffableValues() {
-                return false;
-            }
-
-            @Override
-            protected String createValue(Integer key, boolean before) {
-                return String.valueOf(before ? key : key + 1);
-            }
-
-            @Override
-            protected MapDiff diff(ImmutableOpenIntMap<String> before, ImmutableOpenIntMap<String> after) {
-                return DiffableUtils.diff(before, after, keySerializer, nonDiffableValueSerializer());
-            }
-
-            @Override
-            protected MapDiff readDiff(StreamInput in) throws IOException {
-                return DiffableUtils.readImmutableOpenIntMapDiff(in, keySerializer, nonDiffableValueSerializer());
             }
         }.execute();
     }
@@ -367,42 +265,6 @@ public class DiffableTests extends OpenSearchTestCase {
 
         @Override
         protected int size(Map<Integer, V> map) {
-            return map.size();
-        }
-    }
-
-    abstract class ImmutableOpenMapDriver<V> extends MapDriver<ImmutableOpenMap<Integer, V>, V> {
-
-        @Override
-        protected ImmutableOpenMap<Integer, V> createMap(Map values) {
-            return ImmutableOpenMap.<Integer, V>builder().putAll(values).build();
-        }
-
-        @Override
-        protected V get(ImmutableOpenMap<Integer, V> map, Integer key) {
-            return map.get(key);
-        }
-
-        @Override
-        protected int size(ImmutableOpenMap<Integer, V> map) {
-            return map.size();
-        }
-    }
-
-    abstract class ImmutableOpenIntMapDriver<V> extends MapDriver<ImmutableOpenIntMap<V>, V> {
-
-        @Override
-        protected ImmutableOpenIntMap<V> createMap(Map values) {
-            return ImmutableOpenIntMap.<V>builder().putAll(values).build();
-        }
-
-        @Override
-        protected V get(ImmutableOpenIntMap<V> map, Integer key) {
-            return map.get(key);
-        }
-
-        @Override
-        protected int size(ImmutableOpenIntMap<V> map) {
             return map.size();
         }
     }

--- a/server/src/test/java/org/opensearch/gateway/PrimaryShardAllocatorTests.java
+++ b/server/src/test/java/org/opensearch/gateway/PrimaryShardAllocatorTests.java
@@ -58,7 +58,6 @@ import org.opensearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.opensearch.cluster.routing.allocation.decider.Decision;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.UUIDs;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.set.Sets;
 import org.opensearch.env.ShardLockObtainFailedException;
@@ -709,19 +708,12 @@ public class PrimaryShardAllocatorTests extends OpenSearchAllocationTestCase {
             .routingTable(routingTable)
             .nodes(DiscoveryNodes.builder().add(node1).add(node2).add(node3))
             .build();
-        return new RoutingAllocation(
-            allocationDeciders,
-            new RoutingNodes(state, false),
-            state,
-            null,
-            new SnapshotShardSizeInfo(ImmutableOpenMap.of()) {
-                @Override
-                public Long getShardSize(ShardRouting shardRouting) {
-                    return shardSize;
-                }
-            },
-            System.nanoTime()
-        );
+        return new RoutingAllocation(allocationDeciders, new RoutingNodes(state, false), state, null, new SnapshotShardSizeInfo(Map.of()) {
+            @Override
+            public Long getShardSize(ShardRouting shardRouting) {
+                return shardSize;
+            }
+        }, System.nanoTime());
     }
 
     private RoutingAllocation routingAllocationWithOnePrimaryNoReplicas(

--- a/test/framework/src/main/java/org/opensearch/cluster/OpenSearchAllocationTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/cluster/OpenSearchAllocationTestCase.java
@@ -48,7 +48,6 @@ import org.opensearch.cluster.routing.allocation.decider.AllocationDecider;
 import org.opensearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.opensearch.cluster.routing.allocation.decider.Decision;
 import org.opensearch.cluster.routing.allocation.decider.SameShardAllocationDecider;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.gateway.GatewayAllocator;
@@ -78,9 +77,7 @@ public abstract class OpenSearchAllocationTestCase extends OpenSearchTestCase {
         ClusterSettings.BUILT_IN_CLUSTER_SETTINGS
     );
 
-    public static final SnapshotsInfoService SNAPSHOT_INFO_SERVICE_WITH_NO_SHARD_SIZES = () -> new SnapshotShardSizeInfo(
-        ImmutableOpenMap.of()
-    ) {
+    public static final SnapshotsInfoService SNAPSHOT_INFO_SERVICE_WITH_NO_SHARD_SIZES = () -> new SnapshotShardSizeInfo(Map.of()) {
         @Override
         public Long getShardSize(ShardRouting shardRouting) {
             assert shardRouting.recoverySource().getType() == RecoverySource.Type.SNAPSHOT


### PR DESCRIPTION
Refactors usage of ImmutableOpenMap in IndexMetadata to java.util.Map. This continues the removal of the HPPC dependency in core.

relates #5910 