### PR TITLE
Implement buildEmptyAggregations for MultiTermsAggregator (#7089)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Enforce 512 byte document ID limit in bulk updates ([#8039](https://github.com/opensearch-project/OpenSearch/pull/8039))
 - With only GlobalAggregation in request causes unnecessary wrapping with MultiCollector ([#8125](https://github.com/opensearch-project/OpenSearch/pull/8125))
 - Fix mapping char_filter when mapping a hashtag ([#7591](https://github.com/opensearch-project/OpenSearch/pull/7591))
+- Fix NPE in multiterms aggregations involving empty buckets ([#7318](https://github.com/opensearch-project/OpenSearch/pull/7318))
 
 ### Security
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/370_multi_terms.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/370_multi_terms.yml
@@ -760,4 +760,3 @@ setup:
   - match: { aggregations.histo.buckets.2.key_as_string: "2022-03-25T00:00:00.000Z" }
   - match: { aggregations.histo.buckets.2.m_terms.buckets.0.key: [ "a", "127.0.0.1" ] }
   - match: { aggregations.histo.buckets.2.m_terms.buckets.1.key: [ "b", "127.0.0.1" ] }
-

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/370_multi_terms.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/370_multi_terms.yml
@@ -716,8 +716,8 @@ setup:
 ---
 "aggregate over multi-terms test":
   - skip:
-      version: "- 2.0.99"
-      reason:  multi_terms aggregation is introduced in 2.1.0
+      version: "- 2.9.99"
+      reason: "multi_terms aggregation was introduced in 2.1.0, NPE bug checked by this test case will manifest in any version < 3.0"
 
   - do:
       bulk:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/370_multi_terms.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/370_multi_terms.yml
@@ -712,3 +712,52 @@ setup:
   - match: { aggregations.m_terms.buckets.0.key: ["a", 1] }
   - match: { aggregations.m_terms.buckets.0.key_as_string: "a|1" }
   - match: { aggregations.m_terms.buckets.0.doc_count: 4 }
+
+---
+"aggregate over multi-terms test":
+  - skip:
+      version: "- 2.0.99"
+      reason:  multi_terms aggregation is introduced in 2.1.0
+
+  - do:
+      bulk:
+        index: test_1
+        refresh: true
+        body:
+          - '{"index": {}}'
+          - '{"str": "a", "ip": "127.0.0.1", "date": "2022-03-23"}'
+          - '{"index": {}}'
+          - '{"str": "a", "ip": "127.0.0.1", "date": "2022-03-25"}'
+          - '{"index": {}}'
+          - '{"str": "b", "ip": "127.0.0.1", "date": "2022-03-23"}'
+          - '{"index": {}}'
+          - '{"str": "b", "ip": "127.0.0.1", "date": "2022-03-25"}'
+
+  - do:
+      search:
+        index: test_1
+        size: 0
+        body:
+          aggs:
+            histo:
+              date_histogram:
+                field: date
+                calendar_interval: day
+              aggs:
+                m_terms:
+                  multi_terms:
+                    terms:
+                      - field: str
+                      - field: ip
+
+  - match: { hits.total.value: 4 }
+  - length: { aggregations.histo.buckets: 3 }
+  - match: { aggregations.histo.buckets.0.key_as_string: "2022-03-23T00:00:00.000Z" }
+  - match: { aggregations.histo.buckets.0.m_terms.buckets.0.key: ["a", "127.0.0.1"] }
+  - match: { aggregations.histo.buckets.0.m_terms.buckets.1.key: ["b", "127.0.0.1"] }
+  - match: { aggregations.histo.buckets.1.key_as_string: "2022-03-24T00:00:00.000Z" }
+  - length: { aggregations.histo.buckets.1.m_terms.buckets: 0 }
+  - match: { aggregations.histo.buckets.2.key_as_string: "2022-03-25T00:00:00.000Z" }
+  - match: { aggregations.histo.buckets.2.m_terms.buckets.0.key: [ "a", "127.0.0.1" ] }
+  - match: { aggregations.histo.buckets.2.m_terms.buckets.1.key: [ "b", "127.0.0.1" ] }
+

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregator.java
@@ -196,7 +196,20 @@ public class MultiTermsAggregator extends DeferableBucketAggregator {
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return null;
+        return new InternalMultiTerms(
+            name,
+            order,
+            order,
+            bucketCountThresholds.getRequiredSize(),
+            bucketCountThresholds.getMinDocCount(),
+            metadata(),
+            bucketCountThresholds.getShardSize(),
+            showTermDocCountError,
+            0,
+            0,
+            formats,
+            Collections.emptyList()
+        );
     }
 
     @Override


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The implementation for the 'buildEmptyAggregation' method for MultiTermsAggregator was incomplete and was simply returning null.  This change completes the implementation for this method and adds a YAML REST test case for it.

I have another PR that has a unit test for this change.  I want to get feedback on that separately from this PR.

### Issues Resolved
#7089 
#5785 

### Check List
- [ ] New functionality includes testing.
  - [x ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
