### PR TITLE
[Refactor] Version and LegacyESVersion from server module to core lib

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -105,7 +105,7 @@ jobs:
           echo Adding bwc version $NEXT_VERSION after $CURRENT_VERSION
           sed -i "s/- \"$CURRENT_VERSION\"/\0\n  - \"$NEXT_VERSION\"/g" .ci/bwcVersions
           echo Adding $NEXT_VERSION_UNDERSCORE after $CURRENT_VERSION_UNDERSCORE
-          sed -i "s/public static final Version $CURRENT_VERSION_UNDERSCORE = new Version(\([[:digit:]]\+\)\(.*\));/\0\n    public static final Version $NEXT_VERSION_UNDERSCORE = new Version($NEXT_VERSION_ID\2);/g" server/src/main/java/org/opensearch/Version.java
+          sed -i "s/public static final Version $CURRENT_VERSION_UNDERSCORE = new Version(\([[:digit:]]\+\)\(.*\));/\0\n    public static final Version $NEXT_VERSION_UNDERSCORE = new Version($NEXT_VERSION_ID\2);/g" libs/core/src/main/java/org/opensearch/Version.java
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3

--- a/buildSrc/src/main/java/org/opensearch/gradle/info/GlobalBuildInfoPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/info/GlobalBuildInfoPlugin.java
@@ -74,8 +74,8 @@ import java.util.stream.Stream;
 
 public class GlobalBuildInfoPlugin implements Plugin<Project> {
     private static final Logger LOGGER = Logging.getLogger(GlobalBuildInfoPlugin.class);
-    private static final String DEFAULT_LEGACY_VERSION_JAVA_FILE_PATH = "server/src/main/java/org/opensearch/LegacyESVersion.java";
-    private static final String DEFAULT_VERSION_JAVA_FILE_PATH = "server/src/main/java/org/opensearch/Version.java";
+    private static final String DEFAULT_LEGACY_VERSION_JAVA_FILE_PATH = "libs/core/src/main/java/org/opensearch/LegacyESVersion.java";
+    private static final String DEFAULT_VERSION_JAVA_FILE_PATH = "libs/core/src/main/java/org/opensearch/Version.java";
     private static Integer _defaultParallel = null;
 
     private final JvmMetadataDetector jvmMetadataDetector;
@@ -152,7 +152,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
             versionLines.addAll(IOUtils.readLines(fis2, "UTF-8"));
             return new BwcVersions(versionLines);
         } catch (IOException e) {
-            throw new IllegalStateException("Unable to resolve to resolve bwc versions from versionsFile.", e);
+            throw new IllegalStateException("Unable to resolve bwc versions from versionsFile.", e);
         }
     }
 

--- a/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/InstallPluginCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/InstallPluginCommandTests.java
@@ -63,7 +63,7 @@ import org.opensearch.cli.UserException;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.hash.MessageDigests;
-import org.opensearch.common.io.FileSystemUtils;
+import org.opensearch.core.util.FileSystemUtils;
 import org.opensearch.common.io.PathUtils;
 import org.opensearch.common.io.PathUtilsForTesting;
 import org.opensearch.common.settings.Settings;

--- a/libs/core/build.gradle
+++ b/libs/core/build.gradle
@@ -82,6 +82,9 @@ dependencies {
   // lucene
   api "org.apache.lucene:lucene-core:${versions.lucene}"
 
+  // logging
+  api "org.apache.logging.log4j:log4j-api:${versions.log4j}"
+
   testImplementation "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
   testImplementation "junit:junit:${versions.junit}"
   testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
@@ -95,6 +98,19 @@ tasks.named('forbiddenApisMain').configure {
   // :libs:opensearch-core does not depend on server
   // TODO: Need to decide how we want to handle for forbidden signatures with the changes to server
   replaceSignatureFiles 'jdk-signatures'
+}
+
+tasks.named("thirdPartyAudit").configure {
+  ignoreMissingClasses(
+    // from log4j
+    'org.osgi.framework.Bundle',
+    'org.osgi.framework.BundleActivator',
+    'org.osgi.framework.BundleContext',
+    'org.osgi.framework.BundleEvent',
+    'org.osgi.framework.SynchronousBundleListener',
+    'org.osgi.framework.wiring.BundleWire',
+    'org.osgi.framework.wiring.BundleWiring'
+  )
 }
 
 tasks.named("dependencyLicenses").configure {

--- a/libs/core/licenses/log4j-api-2.17.1.jar.sha1
+++ b/libs/core/licenses/log4j-api-2.17.1.jar.sha1
@@ -1,0 +1,1 @@
+d771af8e336e372fb5399c99edabe0919aeaf5b2

--- a/libs/core/licenses/log4j-api-LICENSE.txt
+++ b/libs/core/licenses/log4j-api-LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 1999-2005 The Apache Software Foundation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/libs/core/licenses/log4j-api-NOTICE.txt
+++ b/libs/core/licenses/log4j-api-NOTICE.txt
@@ -1,0 +1,5 @@
+Apache log4j
+Copyright 2007 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).

--- a/libs/core/src/main/java/org/opensearch/Build.java
+++ b/libs/core/src/main/java/org/opensearch/Build.java
@@ -33,9 +33,7 @@
 package org.opensearch;
 
 import org.opensearch.common.Booleans;
-import org.opensearch.common.io.FileSystemUtils;
-import org.opensearch.common.io.stream.StreamInput;
-import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.core.util.FileSystemUtils;
 
 import java.io.IOException;
 import java.net.URL;
@@ -204,30 +202,6 @@ public class Build {
 
     public String date() {
         return date;
-    }
-
-    public static Build readBuild(StreamInput in) throws IOException {
-        // the following is new for opensearch: we write the distribution to support any "forks"
-        final String distribution = in.readString();
-        // be lenient when reading on the wire, the enumeration values from other versions might be different than what we know
-        final Type type = Type.fromDisplayName(in.readString(), false);
-        String hash = in.readString();
-        String date = in.readString();
-        boolean snapshot = in.readBoolean();
-        final String version = in.readString();
-        return new Build(type, hash, date, snapshot, version, distribution);
-    }
-
-    public static void writeBuild(Build build, StreamOutput out) throws IOException {
-        // the following is new for opensearch: we write the distribution name to support any "forks" of the code
-        out.writeString(build.distribution);
-
-        final Type buildType = build.type();
-        out.writeString(buildType.displayName());
-        out.writeString(build.hash());
-        out.writeString(build.date());
-        out.writeBoolean(build.isSnapshot());
-        out.writeString(build.getQualifiedVersion());
     }
 
     /**

--- a/libs/core/src/main/java/org/opensearch/LegacyESVersion.java
+++ b/libs/core/src/main/java/org/opensearch/LegacyESVersion.java
@@ -32,7 +32,6 @@
 
 package org.opensearch;
 
-import org.opensearch.common.Strings;
 import org.opensearch.core.Assertions;
 
 import java.lang.reflect.Field;
@@ -150,7 +149,7 @@ public class LegacyESVersion extends Version {
      * Returns the version given its string representation, current version if the argument is null or empty
      */
     public static Version fromString(String version) {
-        if (!Strings.hasLength(version)) {
+        if (stringHasLength(version) == false) {
             return Version.CURRENT;
         }
         final Version cached = stringToVersion.get(version);

--- a/libs/core/src/main/java/org/opensearch/core/util/FileSystemUtils.java
+++ b/libs/core/src/main/java/org/opensearch/core/util/FileSystemUtils.java
@@ -30,12 +30,11 @@
  * GitHub history for details.
  */
 
-package org.opensearch.common.io;
+package org.opensearch.core.util;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.Constants;
 import org.opensearch.common.util.io.IOUtils;
-import org.opensearch.common.Strings;
 import org.opensearch.common.SuppressForbidden;
 
 import java.io.IOException;
@@ -151,7 +150,7 @@ public final class FileSystemUtils {
         if ("file".equals(protocol) == false && "jar".equals(protocol) == false) {
             throw new IllegalArgumentException("Invalid protocol [" + protocol + "], must be [file] or [jar]");
         }
-        if (Strings.isEmpty(url.getHost()) == false) {
+        if (url.getHost().isEmpty() == false) {
             throw new IllegalArgumentException("URL cannot have host. Found: [" + url.getHost() + ']');
         }
         if (url.getPort() != -1) {

--- a/libs/core/src/test/java/org/opensearch/core/util/FileSystemUtilsTests.java
+++ b/libs/core/src/test/java/org/opensearch/core/util/FileSystemUtilsTests.java
@@ -30,10 +30,11 @@
  * GitHub history for details.
  */
 
-package org.opensearch.common.io;
+package org.opensearch.core.util;
 
 import org.apache.lucene.util.Constants;
 import org.apache.lucene.tests.util.LuceneTestCase.SuppressFileSystems;
+import org.opensearch.common.io.PathUtils;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.Before;
 

--- a/modules/reindex/src/test/java/org/opensearch/index/reindex/remote/RemoteScrollableHitSourceTests.java
+++ b/modules/reindex/src/test/java/org/opensearch/index/reindex/remote/RemoteScrollableHitSourceTests.java
@@ -42,7 +42,7 @@ import org.opensearch.client.http.HttpUriRequestProducer;
 import org.opensearch.client.nio.HeapBufferedAsyncResponseConsumer;
 import org.opensearch.common.ParsingException;
 import org.opensearch.common.bytes.BytesArray;
-import org.opensearch.common.io.FileSystemUtils;
+import org.opensearch.core.util.FileSystemUtils;
 import org.opensearch.common.io.Streams;
 import org.opensearch.common.unit.ByteSizeUnit;
 import org.opensearch.common.unit.ByteSizeValue;

--- a/plugins/discovery-azure-classic/src/internalClusterTest/java/org/opensearch/discovery/azure/classic/AzureDiscoveryClusterFormationTests.java
+++ b/plugins/discovery-azure-classic/src/internalClusterTest/java/org/opensearch/discovery/azure/classic/AzureDiscoveryClusterFormationTests.java
@@ -40,7 +40,7 @@ import com.sun.net.httpserver.HttpsServer;
 import org.apache.logging.log4j.LogManager;
 import org.opensearch.cloud.azure.classic.management.AzureComputeService;
 import org.opensearch.common.SuppressForbidden;
-import org.opensearch.common.io.FileSystemUtils;
+import org.opensearch.core.util.FileSystemUtils;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.discovery.DiscoveryModule;

--- a/plugins/discovery-gce/src/test/java/org/opensearch/discovery/gce/GceMockUtils.java
+++ b/plugins/discovery-gce/src/test/java/org/opensearch/discovery/gce/GceMockUtils.java
@@ -42,7 +42,7 @@ import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.common.Strings;
-import org.opensearch.common.io.FileSystemUtils;
+import org.opensearch.core.util.FileSystemUtils;
 import org.opensearch.common.io.Streams;
 
 import java.io.IOException;

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/allocation/ClusterRerouteIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/allocation/ClusterRerouteIT.java
@@ -58,7 +58,7 @@ import org.opensearch.cluster.routing.allocation.decider.EnableAllocationDecider
 import org.opensearch.cluster.routing.allocation.decider.EnableAllocationDecider.Allocation;
 import org.opensearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider;
 import org.opensearch.common.Priority;
-import org.opensearch.common.io.FileSystemUtils;
+import org.opensearch.core.util.FileSystemUtils;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.io.IOUtils;

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/RepositoriesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/RepositoriesIT.java
@@ -42,7 +42,7 @@ import org.opensearch.client.Client;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.metadata.RepositoriesMetadata;
 import org.opensearch.cluster.metadata.RepositoryMetadata;
-import org.opensearch.common.io.FileSystemUtils;
+import org.opensearch.core.util.FileSystemUtils;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.ByteSizeUnit;
 import org.opensearch.repositories.RepositoriesService;

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/info/NodeInfo.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/info/NodeInfo.java
@@ -81,8 +81,8 @@ public class NodeInfo extends BaseNodeResponse {
 
     public NodeInfo(StreamInput in) throws IOException {
         super(in);
-        version = Version.readVersion(in);
-        build = Build.readBuild(in);
+        version = in.readVersion();
+        build = in.readBuild();
         if (in.readBoolean()) {
             totalIndexingBuffer = new ByteSizeValue(in.readLong());
         } else {
@@ -202,7 +202,7 @@ public class NodeInfo extends BaseNodeResponse {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeVInt(version.id);
-        Build.writeBuild(build, out);
+        out.writeBuild(build);
         if (totalIndexingBuffer == null) {
             out.writeBoolean(false);
         } else {

--- a/server/src/main/java/org/opensearch/action/admin/indices/upgrade/post/ShardUpgradeResult.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/upgrade/post/ShardUpgradeResult.java
@@ -66,7 +66,7 @@ class ShardUpgradeResult implements Writeable {
     ShardUpgradeResult(StreamInput in) throws IOException {
         shardId = new ShardId(in);
         primary = in.readBoolean();
-        upgradeVersion = Version.readVersion(in);
+        upgradeVersion = in.readVersion();
         try {
             oldestLuceneSegment = org.apache.lucene.util.Version.parse(in.readString());
         } catch (ParseException ex) {
@@ -94,7 +94,7 @@ class ShardUpgradeResult implements Writeable {
     public void writeTo(StreamOutput out) throws IOException {
         shardId.writeTo(out);
         out.writeBoolean(primary);
-        Version.writeVersion(upgradeVersion, out);
+        out.writeVersion(upgradeVersion);
         out.writeString(oldestLuceneSegment.toString());
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/indices/upgrade/post/UpgradeResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/upgrade/post/UpgradeResponse.java
@@ -55,7 +55,7 @@ public class UpgradeResponse extends BroadcastResponse {
 
     UpgradeResponse(StreamInput in) throws IOException {
         super(in);
-        versions = in.readMap(StreamInput::readString, i -> Tuple.tuple(Version.readVersion(i), i.readString()));
+        versions = in.readMap(StreamInput::readString, i -> Tuple.tuple(i.readVersion(), i.readString()));
     }
 
     UpgradeResponse(
@@ -73,7 +73,7 @@ public class UpgradeResponse extends BroadcastResponse {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeMap(versions, StreamOutput::writeString, (o, v) -> {
-            Version.writeVersion(v.v1(), o);
+            o.writeVersion(v.v1());
             o.writeString(v.v2());
         });
     }

--- a/server/src/main/java/org/opensearch/action/admin/indices/upgrade/post/UpgradeSettingsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/upgrade/post/UpgradeSettingsRequest.java
@@ -55,7 +55,7 @@ public class UpgradeSettingsRequest extends AcknowledgedRequest<UpgradeSettingsR
 
     public UpgradeSettingsRequest(StreamInput in) throws IOException {
         super(in);
-        versions = in.readMap(StreamInput::readString, i -> new Tuple<>(Version.readVersion(i), i.readString()));
+        versions = in.readMap(StreamInput::readString, i -> new Tuple<>(i.readVersion(), i.readString()));
     }
 
     public UpgradeSettingsRequest() {}
@@ -94,7 +94,7 @@ public class UpgradeSettingsRequest extends AcknowledgedRequest<UpgradeSettingsR
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeMap(versions, StreamOutput::writeString, (o, v) -> {
-            Version.writeVersion(v.v1(), out);
+            out.writeVersion(v.v1());
             out.writeString(v.v2());
         });
     }

--- a/server/src/main/java/org/opensearch/action/main/MainResponse.java
+++ b/server/src/main/java/org/opensearch/action/main/MainResponse.java
@@ -66,10 +66,10 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
     MainResponse(StreamInput in) throws IOException {
         super(in);
         nodeName = in.readString();
-        version = Version.readVersion(in);
+        version = in.readVersion();
         clusterName = new ClusterName(in);
         clusterUuid = in.readString();
-        build = Build.readBuild(in);
+        build = in.readBuild();
     }
 
     public MainResponse(String nodeName, Version version, ClusterName clusterName, String clusterUuid, Build build) {
@@ -103,10 +103,10 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(nodeName);
-        Version.writeVersion(version, out);
+        out.writeVersion(version);
         clusterName.writeTo(out);
         out.writeString(clusterUuid);
-        Build.writeBuild(build, out);
+        out.writeBuild(build);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/search/SearchContextId.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchContextId.java
@@ -90,7 +90,7 @@ public class SearchContextId {
         }
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             out.setVersion(version);
-            Version.writeVersion(version, out);
+            out.writeVersion(version);
             out.writeMap(shards, (o, k) -> k.writeTo(o), (o, v) -> v.writeTo(o));
             out.writeMap(aliasFilter, StreamOutput::writeString, (o, v) -> v.writeTo(o));
             return Base64.getUrlEncoder().encodeToString(BytesReference.toBytes(out.bytes()));
@@ -107,7 +107,7 @@ public class SearchContextId {
             throw new IllegalArgumentException("invalid id: [" + id + "]", e);
         }
         try (StreamInput in = new NamedWriteableAwareStreamInput(new ByteBufferStreamInput(byteBuffer), namedWriteableRegistry)) {
-            final Version version = Version.readVersion(in);
+            final Version version = in.readVersion();
             in.setVersion(version);
             final Map<ShardId, SearchContextIdForNode> shards = in.readMap(ShardId::new, SearchContextIdForNode::new);
             final Map<String, AliasFilter> aliasFilters = in.readMap(StreamInput::readString, AliasFilter::new);

--- a/server/src/main/java/org/opensearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/opensearch/cluster/SnapshotsInProgress.java
@@ -288,7 +288,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             repositoryStateId = in.readLong();
             failure = in.readOptionalString();
             userMetadata = in.readMap();
-            version = Version.readVersion(in);
+            version = in.readVersion();
             dataStreams = in.readStringList();
             source = in.readOptionalWriteable(SnapshotId::new);
             clones = in.readMap(RepositoryShardId::new, ShardSnapshotStatus::readFrom);
@@ -706,7 +706,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             out.writeLong(repositoryStateId);
             out.writeOptionalString(failure);
             out.writeMap(userMetadata);
-            Version.writeVersion(version, out);
+            out.writeVersion(version);
             out.writeStringCollection(dataStreams);
             out.writeOptionalWriteable(source);
             out.writeMap(clones, (o, v) -> v.writeTo(o), (o, v) -> v.writeTo(o));

--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
@@ -1583,7 +1583,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             } else {
                 initialRecoveryFilters = DiscoveryNodeFilters.buildOrUpdateFromKeyValue(null, OR, initialRecoveryMap);
             }
-            Version indexCreatedVersion = Version.indexCreated(settings);
+            Version indexCreatedVersion = indexCreated(settings);
             Version indexUpgradedVersion = settings.getAsVersion(IndexMetadata.SETTING_VERSION_UPGRADED, indexCreatedVersion);
 
             if (primaryTerms == null) {
@@ -1879,7 +1879,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                 }
             }
 
-            final Version indexCreatedVersion = Version.indexCreated(builder.settings);
+            final Version indexCreatedVersion = indexCreated(builder.settings);
             // Reference:
             // https://github.com/opensearch-project/OpenSearch/blob/4dde0f2a3b445b2fc61dab29c5a2178967f4a3e3/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java#L1620-L1628
             if (Assertions.ENABLED && indexCreatedVersion.onOrAfter(LegacyESVersion.V_6_5_0)) {
@@ -1926,9 +1926,28 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
     }
 
     /**
+     * Return the version the index was created from the provided index settings
+     *
+     * This looks for the presence of the {@link Version} object with key {@link IndexMetadata#SETTING_VERSION_CREATED}
+     */
+    public static Version indexCreated(final Settings indexSettings) {
+        final Version indexVersion = SETTING_INDEX_VERSION_CREATED.get(indexSettings);
+        if (indexVersion.equals(Version.V_EMPTY)) {
+            final String message = String.format(
+                Locale.ROOT,
+                "[%s] is not present in the index settings for index with UUID [%s]",
+                SETTING_INDEX_VERSION_CREATED.getKey(),
+                indexSettings.get(IndexMetadata.SETTING_INDEX_UUID)
+            );
+            throw new IllegalStateException(message);
+        }
+        return indexVersion;
+    }
+
+    /**
      * State format for {@link IndexMetadata} to write to and load from disk
      */
-    public static final MetadataStateFormat<IndexMetadata> FORMAT = new MetadataStateFormat<IndexMetadata>(INDEX_STATE_FILE_PREFIX) {
+    public static final MetadataStateFormat<IndexMetadata> FORMAT = new MetadataStateFormat<>(INDEX_STATE_FILE_PREFIX) {
 
         @Override
         public void toXContent(XContentBuilder builder, IndexMetadata state) throws IOException {

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
@@ -344,7 +344,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
             }
         }
         this.roles = Collections.unmodifiableSortedSet(new TreeSet<>(roles));
-        this.version = Version.readVersion(in);
+        this.version = in.readVersion();
     }
 
     @Override
@@ -367,7 +367,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
             out.writeString(compatibleRole.roleNameAbbreviation());
             out.writeBoolean(compatibleRole.canContainData());
         }
-        Version.writeVersion(version, out);
+        out.writeVersion(version);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/cluster/routing/RecoverySource.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RecoverySource.java
@@ -279,7 +279,7 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
         SnapshotRecoverySource(StreamInput in) throws IOException {
             restoreUUID = in.readString();
             snapshot = new Snapshot(in);
-            version = Version.readVersion(in);
+            version = in.readVersion();
             index = new IndexId(in);
             if (in.getVersion().onOrAfter(Version.V_2_7_0)) {
                 isSearchableSnapshot = in.readBoolean();
@@ -318,7 +318,7 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
         protected void writeAdditionalFields(StreamOutput out) throws IOException {
             out.writeString(restoreUUID);
             snapshot.writeTo(out);
-            Version.writeVersion(version, out);
+            out.writeVersion(version);
             index.writeTo(out);
             if (out.getVersion().onOrAfter(Version.V_2_7_0)) {
                 out.writeBoolean(isSearchableSnapshot);
@@ -388,7 +388,7 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
 
         RemoteStoreRecoverySource(StreamInput in) throws IOException {
             restoreUUID = in.readString();
-            version = Version.readVersion(in);
+            version = in.readVersion();
             index = new IndexId(in);
         }
 
@@ -413,7 +413,7 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
         @Override
         protected void writeAdditionalFields(StreamOutput out) throws IOException {
             out.writeString(restoreUUID);
-            Version.writeVersion(version, out);
+            out.writeVersion(version);
             index.writeTo(out);
         }
 

--- a/server/src/main/java/org/opensearch/common/io/stream/StreamInput.java
+++ b/server/src/main/java/org/opensearch/common/io/stream/StreamInput.java
@@ -42,6 +42,7 @@ import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.CharsRef;
 import org.joda.time.DateTimeZone;
+import org.opensearch.Build;
 import org.opensearch.OpenSearchException;
 import org.opensearch.Version;
 import org.opensearch.common.CharArrays;
@@ -1105,6 +1106,24 @@ public abstract class StreamInput extends InputStream {
             }
         }
         return null;
+    }
+
+    /** Reads the OpenSearch Version from the input stream */
+    public Version readVersion() throws IOException {
+        return Version.fromId(readVInt());
+    }
+
+    /** Reads the {@link Version} from the input stream */
+    public Build readBuild() throws IOException {
+        // the following is new for opensearch: we write the distribution to support any "forks"
+        final String distribution = readString();
+        // be lenient when reading on the wire, the enumeration values from other versions might be different than what we know
+        final Build.Type type = Build.Type.fromDisplayName(readString(), false);
+        String hash = readString();
+        String date = readString();
+        boolean snapshot = readBoolean();
+        final String version = readString();
+        return new Build(type, hash, date, snapshot, version, distribution);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/opensearch/common/io/stream/StreamOutput.java
@@ -1099,7 +1099,7 @@ public abstract class StreamOutput extends OutputStream {
         }
     }
 
-    /** Writes the OpenSearch {@Version} to the output stream */
+    /** Writes the OpenSearch {@link Version} to the output stream */
     public void writeVersion(final Version version) throws IOException {
         writeVInt(version.id);
     }

--- a/server/src/main/java/org/opensearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/opensearch/common/io/stream/StreamOutput.java
@@ -42,6 +42,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.joda.time.DateTimeZone;
 import org.joda.time.ReadableInstant;
+import org.opensearch.Build;
 import org.opensearch.OpenSearchException;
 import org.opensearch.Version;
 import org.opensearch.cluster.ClusterState;
@@ -1096,6 +1097,24 @@ public abstract class StreamOutput extends OutputStream {
             }
             OpenSearchException.writeStackTraces(throwable, this, (o, t) -> o.writeException(rootException, t, nestedLevel + 1));
         }
+    }
+
+    /** Writes the OpenSearch {@Version} to the output stream */
+    public void writeVersion(final Version version) throws IOException {
+        writeVInt(version.id);
+    }
+
+    /** Writes the OpenSearch {@link Build} informn to the output stream */
+    public void writeBuild(final Build build) throws IOException {
+        // the following is new for opensearch: we write the distribution name to support any "forks" of the code
+        writeString(build.getDistribution());
+
+        final Build.Type buildType = build.type();
+        writeString(buildType.displayName());
+        writeString(build.hash());
+        writeString(build.date());
+        writeBoolean(build.isSnapshot());
+        writeString(build.getQualifiedVersion());
     }
 
     boolean failOnTooManyNestedExceptions(Throwable throwable) {

--- a/server/src/main/java/org/opensearch/common/settings/WriteableSetting.java
+++ b/server/src/main/java/org/opensearch/common/settings/WriteableSetting.java
@@ -368,7 +368,7 @@ public class WriteableSetting implements Writeable {
                 ((ByteSizeValue) defaultValue).writeTo(out);
                 break;
             case Version:
-                Version.writeVersion((Version) defaultValue, out);
+                out.writeVersion((Version) defaultValue);
                 break;
             default:
                 // This Should Never Happen (TM)
@@ -428,7 +428,7 @@ public class WriteableSetting implements Writeable {
             case ByteSizeValue:
                 return new ByteSizeValue(in);
             case Version:
-                return Version.readVersion(in);
+                return in.readVersion();
             default:
                 // This Should Never Happen (TM)
                 throw new IllegalArgumentException("A SettingType has been added to the enum and not handled here.");

--- a/server/src/main/java/org/opensearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/opensearch/env/NodeEnvironment.java
@@ -54,7 +54,7 @@ import org.opensearch.common.Randomness;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.collect.Tuple;
-import org.opensearch.common.io.FileSystemUtils;
+import org.opensearch.core.util.FileSystemUtils;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;

--- a/server/src/main/java/org/opensearch/extensions/DiscoveryExtensionNode.java
+++ b/server/src/main/java/org/opensearch/extensions/DiscoveryExtensionNode.java
@@ -54,7 +54,7 @@ public class DiscoveryExtensionNode extends DiscoveryNode implements Writeable, 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        Version.writeVersion(minimumCompatibleVersion, out);
+        out.writeVersion(minimumCompatibleVersion);
         out.writeVInt(dependencies.size());
         for (ExtensionDependency dependency : dependencies) {
             dependency.writeTo(out);
@@ -69,7 +69,7 @@ public class DiscoveryExtensionNode extends DiscoveryNode implements Writeable, 
      */
     public DiscoveryExtensionNode(final StreamInput in) throws IOException {
         super(in);
-        minimumCompatibleVersion = Version.readVersion(in);
+        minimumCompatibleVersion = in.readVersion();
         int size = in.readVInt();
         dependencies = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {

--- a/server/src/main/java/org/opensearch/extensions/ExtensionDependency.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionDependency.java
@@ -45,13 +45,13 @@ public class ExtensionDependency implements Writeable {
     */
     public ExtensionDependency(StreamInput in) throws IOException {
         uniqueId = in.readString();
-        version = Version.readVersion(in);
+        version = in.readVersion();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(uniqueId);
-        Version.writeVersion(version, out);
+        out.writeVersion(version);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
@@ -37,7 +37,7 @@ import org.opensearch.client.node.NodeClient;
 import org.opensearch.cluster.ClusterSettingsResponse;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.common.io.FileSystemUtils;
+import org.opensearch.core.util.FileSystemUtils;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.settings.SettingsModule;

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -982,7 +982,7 @@ public final class IndexSettings {
 
     /**
      * Returns the version the index was created on.
-     * @see Version#indexCreated(Settings)
+     * @see IndexMetadata#indexCreated(Settings)
      */
     public Version getIndexVersionCreated() {
         return version;
@@ -1088,9 +1088,9 @@ public final class IndexSettings {
      */
     public synchronized boolean updateIndexMetadata(IndexMetadata indexMetadata) {
         final Settings newSettings = indexMetadata.getSettings();
-        if (version.equals(Version.indexCreated(newSettings)) == false) {
+        if (version.equals(IndexMetadata.indexCreated(newSettings)) == false) {
             throw new IllegalArgumentException(
-                "version mismatch on settings update expected: " + version + " but was: " + Version.indexCreated(newSettings)
+                "version mismatch on settings update expected: " + version + " but was: " + IndexMetadata.indexCreated(newSettings)
             );
         }
         final String newUUID = newSettings.get(IndexMetadata.SETTING_INDEX_UUID, IndexMetadata.INDEX_UUID_NA_VALUE);

--- a/server/src/main/java/org/opensearch/index/analysis/PreBuiltAnalyzerProviderFactory.java
+++ b/server/src/main/java/org/opensearch/index/analysis/PreBuiltAnalyzerProviderFactory.java
@@ -34,6 +34,7 @@ package org.opensearch.index.analysis;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.opensearch.Version;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.env.Environment;
@@ -77,7 +78,7 @@ public class PreBuiltAnalyzerProviderFactory extends PreConfiguredAnalysisCompon
     @Override
     public AnalyzerProvider<?> get(IndexSettings indexSettings, Environment environment, String name, Settings settings)
         throws IOException {
-        Version versionCreated = Version.indexCreated(settings);
+        Version versionCreated = IndexMetadata.indexCreated(settings);
         if (Version.CURRENT.equals(versionCreated) == false) {
             return super.get(indexSettings, environment, name, settings);
         } else {

--- a/server/src/main/java/org/opensearch/index/analysis/PreConfiguredAnalysisComponent.java
+++ b/server/src/main/java/org/opensearch/index/analysis/PreConfiguredAnalysisComponent.java
@@ -33,6 +33,7 @@
 package org.opensearch.index.analysis;
 
 import org.opensearch.Version;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.env.Environment;
 import org.opensearch.index.IndexSettings;
@@ -62,7 +63,7 @@ public abstract class PreConfiguredAnalysisComponent<T> implements AnalysisModul
 
     @Override
     public T get(IndexSettings indexSettings, Environment environment, String name, Settings settings) throws IOException {
-        Version versionCreated = Version.indexCreated(settings);
+        Version versionCreated = IndexMetadata.indexCreated(settings);
         synchronized (this) {
             T factory = cache.get(versionCreated);
             if (factory == null) {

--- a/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
@@ -36,6 +36,7 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexableField;
 import org.opensearch.OpenSearchParseException;
 import org.opensearch.Version;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.Strings;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.settings.Settings;
@@ -762,7 +763,7 @@ final class DocumentParser {
                             DateFieldMapper.Resolution.MILLISECONDS,
                             dateTimeFormatter,
                             ignoreMalformed,
-                            Version.indexCreated(context.indexSettings().getSettings())
+                            IndexMetadata.indexCreated(context.indexSettings().getSettings())
                         );
                     }
                     return builder;

--- a/server/src/main/java/org/opensearch/index/mapper/LegacyGeoShapeFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/LegacyGeoShapeFieldMapper.java
@@ -43,6 +43,7 @@ import org.apache.lucene.spatial.prefix.tree.QuadPrefixTree;
 import org.apache.lucene.spatial.prefix.tree.SpatialPrefixTree;
 import org.opensearch.OpenSearchParseException;
 import org.opensearch.Version;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.Explicit;
 import org.opensearch.core.ParseField;
 import org.opensearch.common.geo.GeoUtils;
@@ -519,7 +520,7 @@ public class LegacyGeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<
         CopyTo copyTo
     ) {
         super(simpleName, fieldType, mappedFieldType, ignoreMalformed, coerce, ignoreZValue, orientation, multiFields, copyTo);
-        this.indexCreatedVersion = Version.indexCreated(indexSettings);
+        this.indexCreatedVersion = IndexMetadata.indexCreated(indexSettings);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/Mapper.java
@@ -79,7 +79,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
         }
 
         public Version indexCreatedVersion() {
-            return Version.indexCreated(indexSettings);
+            return IndexMetadata.indexCreated(indexSettings);
         }
 
         public Version indexCreatedVersionOrDefault(@Nullable Version defaultValue) {

--- a/server/src/main/java/org/opensearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ObjectMapper.java
@@ -35,6 +35,7 @@ package org.opensearch.index.mapper;
 import org.apache.lucene.search.Query;
 import org.opensearch.OpenSearchParseException;
 import org.opensearch.Version;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.Explicit;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.collect.CopyOnWriteHashMap;
@@ -451,7 +452,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
         } else {
             this.mappers = CopyOnWriteHashMap.copyOf(mappers);
         }
-        Version version = Version.indexCreated(settings);
+        Version version = IndexMetadata.indexCreated(settings);
         if (version.before(Version.V_2_0_0)) {
             this.nestedTypePath = "__" + fullPath;
         } else {

--- a/server/src/main/java/org/opensearch/index/mapper/RangeFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/RangeFieldMapper.java
@@ -39,6 +39,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.OpenSearchException;
 import org.opensearch.Version;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.Explicit;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.geo.ShapeRelation;
@@ -142,7 +143,7 @@ public class RangeFieldMapper extends ParametrizedFieldMapper {
                 type,
                 COERCE_SETTING.get(settings),
                 IGNORE_MALFORMED_SETTING.get(settings),
-                hasIndexCreated(settings) ? Version.indexCreated(settings) : null
+                hasIndexCreated(settings) ? IndexMetadata.indexCreated(settings) : null
             );
         }
 

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -9,7 +9,7 @@
 package org.opensearch.index.translog;
 
 import org.opensearch.common.SetOnce;
-import org.opensearch.common.io.FileSystemUtils;
+import org.opensearch.core.util.FileSystemUtils;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.lease.Releasables;
 import org.opensearch.common.util.concurrent.ReleasableLock;

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -63,7 +63,7 @@ import org.opensearch.common.Nullable;
 import org.opensearch.common.breaker.CircuitBreaker;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.component.AbstractLifecycleComponent;
-import org.opensearch.common.io.FileSystemUtils;
+import org.opensearch.core.util.FileSystemUtils;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.opensearch.common.io.stream.NamedWriteableRegistry;

--- a/server/src/main/java/org/opensearch/indices/analysis/HunspellService.java
+++ b/server/src/main/java/org/opensearch/indices/analysis/HunspellService.java
@@ -39,7 +39,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.NIOFSDirectory;
 import org.opensearch.OpenSearchException;
 import org.opensearch.common.util.io.IOUtils;
-import org.opensearch.common.io.FileSystemUtils;
+import org.opensearch.core.util.FileSystemUtils;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.common.settings.Settings;

--- a/server/src/main/java/org/opensearch/plugins/PluginInfo.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginInfo.java
@@ -154,7 +154,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
         this.name = in.readString();
         this.description = in.readString();
         this.version = in.readString();
-        this.opensearchVersion = Version.readVersion(in);
+        this.opensearchVersion = in.readVersion();
         this.javaVersion = in.readString();
         this.classname = in.readString();
         this.customFolderName = in.readString();
@@ -167,7 +167,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
         out.writeString(name);
         out.writeString(description);
         out.writeString(version);
-        Version.writeVersion(opensearchVersion, out);
+        out.writeVersion(opensearchVersion);
         out.writeString(javaVersion);
         out.writeString(classname);
         if (customFolderName != null) {

--- a/server/src/main/java/org/opensearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginsService.java
@@ -81,7 +81,7 @@ import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.opensearch.common.io.FileSystemUtils.isAccessibleDirectory;
+import static org.opensearch.core.util.FileSystemUtils.isAccessibleDirectory;
 
 /**
  * Service responsible for loading plugins and modules (internal and external)

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotInfo.java
@@ -395,7 +395,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         totalShards = in.readVInt();
         successfulShards = in.readVInt();
         shardFailures = Collections.unmodifiableList(in.readList(SnapshotShardFailure::new));
-        version = in.readBoolean() ? Version.readVersion(in) : null;
+        version = in.readBoolean() ? in.readVersion() : null;
         includeGlobalState = in.readOptionalBoolean();
         userMetadata = in.readMap();
         dataStreams = in.readStringList();
@@ -819,7 +819,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         out.writeList(shardFailures);
         if (version != null) {
             out.writeBoolean(true);
-            Version.writeVersion(version, out);
+            out.writeVersion(version);
         } else {
             out.writeBoolean(false);
         }

--- a/server/src/main/java/org/opensearch/transport/TransportHandshaker.java
+++ b/server/src/main/java/org/opensearch/transport/TransportHandshaker.java
@@ -208,7 +208,7 @@ final class TransportHandshaker {
                 version = null;
             } else {
                 try (StreamInput messageStreamInput = remainingMessage.streamInput()) {
-                    this.version = Version.readVersion(messageStreamInput);
+                    this.version = messageStreamInput.readVersion();
                 }
             }
         }
@@ -218,7 +218,7 @@ final class TransportHandshaker {
             super.writeTo(streamOutput);
             assert version != null;
             try (BytesStreamOutput messageStreamOutput = new BytesStreamOutput(4)) {
-                Version.writeVersion(version, messageStreamOutput);
+                messageStreamOutput.writeVersion(version);
                 BytesReference reference = messageStreamOutput.bytes();
                 streamOutput.writeBytesReference(reference);
             }
@@ -235,13 +235,13 @@ final class TransportHandshaker {
 
         private HandshakeResponse(StreamInput in) throws IOException {
             super(in);
-            responseVersion = Version.readVersion(in);
+            responseVersion = in.readVersion();
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             assert responseVersion != null;
-            Version.writeVersion(responseVersion, out);
+            out.writeVersion(responseVersion);
         }
 
         Version getResponseVersion() {

--- a/server/src/main/java/org/opensearch/transport/TransportService.java
+++ b/server/src/main/java/org/opensearch/transport/TransportService.java
@@ -643,14 +643,14 @@ public class TransportService extends AbstractLifecycleComponent
             super(in);
             discoveryNode = in.readOptionalWriteable(DiscoveryNode::new);
             clusterName = new ClusterName(in);
-            version = Version.readVersion(in);
+            version = in.readVersion();
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeOptionalWriteable(discoveryNode);
             clusterName.writeTo(out);
-            Version.writeVersion(version, out);
+            out.writeVersion(version);
         }
 
         public DiscoveryNode getDiscoveryNode() {

--- a/server/src/main/java/org/opensearch/watcher/FileWatcher.java
+++ b/server/src/main/java/org/opensearch/watcher/FileWatcher.java
@@ -33,7 +33,7 @@ package org.opensearch.watcher;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.common.io.FileSystemUtils;
+import org.opensearch.core.util.FileSystemUtils;
 import org.opensearch.common.util.CollectionUtils;
 
 import java.io.IOException;

--- a/server/src/test/java/org/opensearch/BuildTests.java
+++ b/server/src/test/java/org/opensearch/BuildTests.java
@@ -32,7 +32,7 @@
 
 package org.opensearch;
 
-import org.opensearch.common.io.FileSystemUtils;
+import org.opensearch.core.util.FileSystemUtils;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
@@ -187,7 +187,7 @@ public class BuildTests extends OpenSearchTestCase {
         private final Build build;
 
         WriteableBuild(StreamInput in) throws IOException {
-            build = Build.readBuild(in);
+            build = in.readBuild();
         }
 
         WriteableBuild(Build build) {
@@ -196,7 +196,7 @@ public class BuildTests extends OpenSearchTestCase {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            Build.writeBuild(build, out);
+            out.writeBuild(build);
         }
 
         @Override

--- a/server/src/test/java/org/opensearch/VersionTests.java
+++ b/server/src/test/java/org/opensearch/VersionTests.java
@@ -173,7 +173,7 @@ public class VersionTests extends OpenSearchTestCase {
     }
 
     public void testVersionNoPresentInSettings() {
-        Exception e = expectThrows(IllegalStateException.class, () -> Version.indexCreated(Settings.builder().build()));
+        Exception e = expectThrows(IllegalStateException.class, () -> IndexMetadata.indexCreated(Settings.builder().build()));
         assertThat(e.getMessage(), containsString("[index.version.created] is not present"));
     }
 
@@ -182,7 +182,7 @@ public class VersionTests extends OpenSearchTestCase {
         final Version version = Version.CURRENT;
         assertEquals(
             version,
-            Version.indexCreated(
+            IndexMetadata.indexCreated(
                 Settings.builder().put(IndexMetadata.SETTING_INDEX_UUID, "foo").put(IndexMetadata.SETTING_VERSION_CREATED, version).build()
             )
         );

--- a/server/src/test/java/org/opensearch/common/io/stream/DelayableWriteableTests.java
+++ b/server/src/test/java/org/opensearch/common/io/stream/DelayableWriteableTests.java
@@ -118,12 +118,12 @@ public class DelayableWriteableTests extends OpenSearchTestCase {
         }
 
         SneakOtherSideVersionOnWire(StreamInput in) throws IOException {
-            version = Version.readVersion(in);
+            version = in.readVersion();
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            Version.writeVersion(out.getVersion(), out);
+            out.writeVersion(out.getVersion());
         }
     }
 

--- a/server/src/test/java/org/opensearch/index/translog/LocalTranslogTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/LocalTranslogTests.java
@@ -59,7 +59,7 @@ import org.opensearch.common.bytes.BytesArray;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.bytes.ReleasableBytesReference;
 import org.opensearch.common.collect.Tuple;
-import org.opensearch.common.io.FileSystemUtils;
+import org.opensearch.core.util.FileSystemUtils;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.settings.Settings;

--- a/server/src/test/java/org/opensearch/index/translog/RemoteFSTranslogTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/RemoteFSTranslogTests.java
@@ -28,7 +28,7 @@ import org.opensearch.common.blobstore.fs.FsBlobContainer;
 import org.opensearch.common.blobstore.fs.FsBlobStore;
 import org.opensearch.common.bytes.BytesArray;
 import org.opensearch.common.bytes.ReleasableBytesReference;
-import org.opensearch.common.io.FileSystemUtils;
+import org.opensearch.core.util.FileSystemUtils;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.ByteSizeUnit;

--- a/server/src/test/java/org/opensearch/indices/IndicesServiceTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndicesServiceTests.java
@@ -45,7 +45,7 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.UUIDs;
-import org.opensearch.common.io.FileSystemUtils;
+import org.opensearch.core.util.FileSystemUtils;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;

--- a/server/src/test/java/org/opensearch/indices/recovery/LocalStorePeerRecoverySourceHandlerTests.java
+++ b/server/src/test/java/org/opensearch/indices/recovery/LocalStorePeerRecoverySourceHandlerTests.java
@@ -62,7 +62,7 @@ import org.opensearch.common.UUIDs;
 import org.opensearch.common.bytes.BytesArray;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.concurrent.GatedCloseable;
-import org.opensearch.common.io.FileSystemUtils;
+import org.opensearch.core.util.FileSystemUtils;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.lucene.store.IndexOutputOutputStream;
 import org.opensearch.common.lucene.uid.Versions;

--- a/server/src/test/java/org/opensearch/persistent/TestPersistentTasksPlugin.java
+++ b/server/src/test/java/org/opensearch/persistent/TestPersistentTasksPlugin.java
@@ -178,7 +178,7 @@ public class TestPersistentTasksPlugin extends Plugin implements ActionPlugin, P
             executorNodeAttr = in.readOptionalString();
             responseNode = in.readOptionalString();
             testParam = in.readOptionalString();
-            minVersion = Version.readVersion(in);
+            minVersion = in.readVersion();
             feature = Optional.ofNullable(in.readOptionalString());
         }
 
@@ -208,7 +208,7 @@ public class TestPersistentTasksPlugin extends Plugin implements ActionPlugin, P
             out.writeOptionalString(executorNodeAttr);
             out.writeOptionalString(responseNode);
             out.writeOptionalString(testParam);
-            Version.writeVersion(minVersion, out);
+            out.writeVersion(minVersion);
             out.writeOptionalString(feature.orElse(null));
         }
 

--- a/server/src/test/java/org/opensearch/transport/TransportHandshakerTests.java
+++ b/server/src/test/java/org/opensearch/transport/TransportHandshakerTests.java
@@ -124,7 +124,7 @@ public class TransportHandshakerTests extends OpenSearchTestCase {
         TaskId.EMPTY_TASK_ID.writeTo(lengthCheckingHandshake);
         TaskId.EMPTY_TASK_ID.writeTo(futureHandshake);
         try (BytesStreamOutput internalMessage = new BytesStreamOutput()) {
-            Version.writeVersion(Version.CURRENT, internalMessage);
+            internalMessage.writeVersion(Version.CURRENT);
             lengthCheckingHandshake.writeBytesReference(internalMessage.bytes());
             internalMessage.write(new byte[1024]);
             futureHandshake.writeBytesReference(internalMessage.bytes());

--- a/test/framework/src/main/java/org/opensearch/bootstrap/BootstrapForTesting.java
+++ b/test/framework/src/main/java/org/opensearch/bootstrap/BootstrapForTesting.java
@@ -39,7 +39,7 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.opensearch.common.Booleans;
 import org.opensearch.common.Strings;
 import org.opensearch.common.SuppressForbidden;
-import org.opensearch.common.io.FileSystemUtils;
+import org.opensearch.core.util.FileSystemUtils;
 import org.opensearch.common.io.PathUtils;
 import org.opensearch.common.network.IfConfig;
 import org.opensearch.common.network.NetworkAddress;

--- a/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
@@ -71,7 +71,7 @@ import org.opensearch.common.Randomness;
 import org.opensearch.common.Strings;
 import org.opensearch.common.breaker.CircuitBreaker;
 import org.opensearch.common.component.LifecycleListener;
-import org.opensearch.common.io.FileSystemUtils;
+import org.opensearch.core.util.FileSystemUtils;
 import org.opensearch.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.common.lease.Releasables;
 import org.opensearch.common.settings.MockSecureSettings;


### PR DESCRIPTION
Refactors the `Version` and `LegacyESVersion` classes from the server module to the core library. All gradle build scripts and dependencies are updated. This commit serves as a foundation for refactoring all OpenSearch base classes from the server module into appropriate libraries to decouple core search logic from the cluster model so it can be reused in serverless and cloud native environments.

relates #5910 