### PR TITLE
[Backport] [2.x] Bump com.netflix.nebula:nebula-publishing-plugin from 20.2.0 to 20.3.0 (#7311)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `com.netflix.nebula:nebula-publishing-plugin` from 19.2.0 to 20.2.0
 - Bump `com.google.protobuf:protobuf-java` from 3.22.2 to 3.22.3
 - Bump `jackson` from 2.14.2 to 2.15.0 ([#7286](https://github.com/opensearch-project/OpenSearch/pull/7286)
+- Bump `com.netflix.nebula:nebula-publishing-plugin` from 20.2.0 to 20.3.0
 
 ### Changed
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -106,7 +106,7 @@ dependencies {
   api 'org.apache.commons:commons-compress:1.22'
   api 'org.apache.ant:ant:1.10.13'
   api 'com.netflix.nebula:gradle-extra-configurations-plugin:9.0.0'
-  api 'com.netflix.nebula:nebula-publishing-plugin:20.2.0'
+  api 'com.netflix.nebula:nebula-publishing-plugin:20.3.0'
   api 'com.netflix.nebula:gradle-info-plugin:12.1.0'
   api 'org.apache.rat:apache-rat:0.15'
   api 'commons-io:commons-io:2.7'


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/7311 to `2.x`