### PR TITLE
[Backport] [2.x] Bump com.netflix.nebula.ospackage-base from 11.2.0 to 11.3.0 in /distribution/packages (#7310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `com.google.protobuf:protobuf-java` from 3.22.2 to 3.22.3
 - Bump `jackson` from 2.14.2 to 2.15.0 ([#7286](https://github.com/opensearch-project/OpenSearch/pull/7286)
 - Bump `com.netflix.nebula:nebula-publishing-plugin` from 20.2.0 to 20.3.0
+- Bump `com.netflix.nebula.ospackage-base` from 11.0.0 to 11.3.0
 
 ### Changed
 

--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -63,7 +63,7 @@ import java.util.regex.Pattern
  */
 
 plugins {
-  id "com.netflix.nebula.ospackage-base" version "11.0.0"
+  id "com.netflix.nebula.ospackage-base" version "11.3.0"
 }
 
 void addProcessFilesTask(String type, boolean jdk) {


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/7310/files to `2.x`