### PR TITLE
[WIP] Faster bit-mixer to improve the performance of bucket aggregations

### DIFF
--- a/benchmarks/src/main/java/org/opensearch/common/BitMixersBenchmark.java
+++ b/benchmarks/src/main/java/org/opensearch/common/BitMixersBenchmark.java
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.opensearch.common.hash.BitMixers;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Fork(3)
+@Warmup(iterations = 5)
+@Measurement(iterations = 10)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+public class BitMixersBenchmark {
+    private final AtomicLong val = new AtomicLong();
+
+    @Benchmark
+    public void identity(Blackhole bh) {
+        bh.consume(BitMixers.IDENTITY.mix(val.incrementAndGet()));
+    }
+
+    @Benchmark
+    public void phi(Blackhole bh) {
+        bh.consume(BitMixers.PHI.mix(val.incrementAndGet()));
+    }
+
+    @Benchmark
+    public void fasthash(Blackhole bh) {
+        bh.consume(BitMixers.FASTHASH.mix(val.incrementAndGet()));
+    }
+
+    @Benchmark
+    public void xxhash(Blackhole bh) {
+        bh.consume(BitMixers.XXHASH.mix(val.incrementAndGet()));
+    }
+
+    @Benchmark
+    public void mxm(Blackhole bh) {
+        bh.consume(BitMixers.MXM.mix(val.incrementAndGet()));
+    }
+
+    @Benchmark
+    public void murmur3(Blackhole bh) {
+        bh.consume(BitMixers.MURMUR3.mix(val.incrementAndGet()));
+    }
+}

--- a/server/src/main/java/org/opensearch/common/hash/BitMixer.java
+++ b/server/src/main/java/org/opensearch/common/hash/BitMixer.java
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.hash;
+
+/**
+ * A bit-mixer (also known as a "finalizer") takes an intermediate hash value
+ * and thoroughly mixes it to increase its entropy. This improves the distribution
+ * and reduces collisions among hashes.
+ */
+public interface BitMixer {
+
+    /**
+     * Mixes and returns a 32-bit value.
+     *
+     * @param value the input value to be mixed
+     * @return value after being mixed
+     */
+    default int mix(int value) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    /**
+     * Mixes and returns a 64-bit value.
+     *
+     * @param value the input value to be mixed
+     * @return value after being mixed
+     */
+    default long mix(long value) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+}

--- a/server/src/main/java/org/opensearch/common/hash/BitMixers.java
+++ b/server/src/main/java/org/opensearch/common/hash/BitMixers.java
@@ -1,0 +1,87 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.hash;
+
+/**
+ * Contains various {@link BitMixer} implementations.
+ */
+public final class BitMixers {
+    private BitMixers() {}
+
+    /**
+     * Bit-mixer that returns the input as it is.
+     */
+    public static final BitMixer IDENTITY = new BitMixer() {
+        @Override
+        public long mix(long value) {
+            return value;
+        }
+    };
+
+    /**
+     * Bit-mixer implementation using the golden ratio (phi).
+     */
+    public static final BitMixer PHI = new BitMixer() {
+        @Override
+        public long mix(long value) {
+            value *= 0x9e3779b97f4a7c15L;
+            value ^= value >>> 32;
+            return value;
+        }
+    };
+
+    /**
+     * Bit-mixer implementation from <a href="https://code.google.com/archive/p/fast-hash/">fast-hash</a>.
+     */
+    public static final BitMixer FASTHASH = new BitMixer() {
+        @Override
+        public long mix(long value) {
+            value ^= value >>> 23;
+            value *= 0x2127599bf4325c37L;
+            value ^= value >>> 47;
+            return value;
+        }
+    };
+
+    /**
+     * Bit-mixer implementation from <a href="https://github.com/Cyan4973/xxHash">xxHash</a>.
+     */
+    public static final BitMixer XXHASH = new BitMixer() {
+        @Override
+        public long mix(long value) {
+            value ^= value >>> 37;
+            value *= 0x165667919e3779f9L;
+            value ^= value >>> 32;
+            return value;
+        }
+    };
+
+    /**
+     * Bit-mixer implementation using an MXM construction.
+     */
+    public static final BitMixer MXM = new BitMixer() {
+        @Override
+        public long mix(long value) {
+            value *= 0xbf58476d1ce4e5b9L;
+            value ^= value >>> 56;
+            value *= 0x94d049bb133111ebL;
+            return value;
+        }
+    };
+
+    /**
+     * Bit-mixer implementation from <a href="https://en.wikipedia.org/wiki/MurmurHash">MurmurHash3</a> with modified constants.
+     */
+    public static final BitMixer MURMUR3 = new BitMixer() {
+        @Override
+        public long mix(long value) {
+            return org.apache.lucene.util.hppc.BitMixer.mix64(value);
+        }
+    };
+}

--- a/server/src/main/java/org/opensearch/common/util/AbstractPagedHashMap.java
+++ b/server/src/main/java/org/opensearch/common/util/AbstractPagedHashMap.java
@@ -32,7 +32,7 @@
 
 package org.opensearch.common.util;
 
-import com.carrotsearch.hppc.BitMixer;
+import org.opensearch.common.hash.BitMixers;
 import org.opensearch.common.lease.Releasable;
 
 /**
@@ -49,7 +49,7 @@ abstract class AbstractPagedHashMap implements Releasable {
     static long hash(long value) {
         // Don't use the value directly. Under some cases eg dates, it could be that the low bits don't carry much value and we would like
         // all bits of the hash to carry as much value
-        return BitMixer.mix64(value);
+        return BitMixers.XXHASH.mix(value);
     }
 
     final BigArrays bigArrays;


### PR DESCRIPTION
## Description

Some aggregations know ahead of time about the number of buckets and owning ordinals (eg. range aggregations), thus, are able to map densely and directly. Most other aggregations cannot predict this, thus, rely on a hash lookup to identify the owning bucket ordinal.

Aggregations in the "nyc_taxis" OSB workload revealed that a major share of CPU time is spent in the custom hash table implementation (`LongHash`) to identify the bucket ordinal. As these lookups are performed for each document matched by the query, even a small improvement in the hash function can have a large overall improvement.

### Hashing vs bit-mixing
Generally, a hash function operates on a multi-byte input and returns an integer output. A bit-mixer (also known as a "finalizer") is one of the end stages of a hash function that scrambles an integer before it is returned. Though in our context, the input is a 64-bit integer, so we use a bit-mixer directly as a hash function.

### Faster bit-mixers
The speed of a bit-mixer is influenced by its construction (i.e. the instructions used) and the choice of constants (which indirectly affect the number of collisions). The following JMH benchmarks only compare the raw performance of the bit-mixer construction while using well established constants with known distribution and avalanche effect.

The current hash function borrows its implementation from the MurmurHash3's bit-mixer with modified constants.

| Name     | Construction        | OpenJDK 11.0.18 |               | OpenJDK 17.0.6 |               |
|----------|---------------------|-----------------|---------------|----------------|---------------|
|          |                     | x86_64 (ns/op)  | arm64 (ns/op) | x86_64 (ns/op) | arm64 (ns/op) |
| murmur3  | xsr-mul-xsr-mul-xsr | 9.783           | 12.116        | 8.332          | 8.362         |
| mxm      | mul-xsr-mul         | 8.715           | 10.917        | 7.747          | 8.246         |
| fasthash | xsr-mul-xsr         | 8.164           | 10.097        | 7.746          | 8.231         |
| xxhash   | xsr-mul-xsr         | 8.163           | 10.089        | 7.745          | 8.233         |
| phi      | mul-xsr             | 7.970           | 9.678         | 6.905          | 8.231         |
| identity | —                   | 7.744           | 9.407         | 5.737          | 8.277         |


### End-to-end latency
These results were obtained by running the date-histogram bucket aggregation in the "nyc_taxis" workload. They represent the real-world performance of bit-mixers accounting for hash collisions too.
* EC2: c6i.4xlarge / c6g.4xlarge
* OS: Ubuntu 22.04.2 LTS
* JVM: OpenJDK 17.0.6

| Name     |  x86_64  |          |             |   amd64  |          |             |
|----------|:--------:|:--------:|:-----------:|:--------:|:--------:|:-----------:|
|          | p50 (ms) | p90 (ms) | tps (req/s) | p50 (ms) | p90 (ms) | tps (req/s) |
| murmur3  |  308.207 |  317.316 |       3.216 |  456.810 |  458.506 |       2.188 |
| mxm      |  311.742 |  322.692 |       3.183 |  466.304 |  468.066 |       2.143 |
| fasthash |  297.803 |  307.443 |       3.329 |  433.971 |  435.019 |       2.303 |
| xxhash   |  287.049 |  298.105 |       3.453 |  429.529 |  430.760 |       2.328 |
| phi      |  325.011 |  333.765 |       3.054 |  477.562 |  479.745 |       2.092 |
| identity |  464.486 |  469.418 |       2.147 |  655.270 |  657.070 |       1.526 |

Worse performance of "noop" is due to poor distribution, frequent hash collisions, and need for open-addressing.

### OSB results
* nyc_taxis – todo
* http_logs – todo
* so – todo

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
