### PR TITLE
[Backport] [2.x] Bump gradle.plugin.com.github.johnrengelman:shadow from 7.1.2 to 8.0.0 (#7340)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `jackson` from 2.14.2 to 2.15.0 ([#7286](https://github.com/opensearch-project/OpenSearch/pull/7286)
 - Bump `com.netflix.nebula:nebula-publishing-plugin` from 20.2.0 to 20.3.0
 - Bump `com.netflix.nebula.ospackage-base` from 11.0.0 to 11.3.0
+- Bump `gradle.plugin.com.github.johnrengelman:shadow` from 7.1.2 to 8.0.0
+- Bump `jna` from 5.11.0 to 5.13.0
+- Bump `commons-io:commons-io` from 2.7 to 2.11.0
 
 ### Changed
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -109,9 +109,9 @@ dependencies {
   api 'com.netflix.nebula:nebula-publishing-plugin:20.3.0'
   api 'com.netflix.nebula:gradle-info-plugin:12.1.0'
   api 'org.apache.rat:apache-rat:0.15'
-  api 'commons-io:commons-io:2.7'
-  api "net.java.dev.jna:jna:5.11.0"
-  api 'gradle.plugin.com.github.johnrengelman:shadow:7.1.2'
+  api 'commons-io:commons-io:2.11.0'
+  api "net.java.dev.jna:jna:5.13.0"
+  api 'gradle.plugin.com.github.johnrengelman:shadow:8.0.0'
   api 'org.jdom:jdom2:2.0.6.1'
   api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${props.getProperty('kotlin')}"
   api 'de.thetaphi:forbiddenapis:3.5.1'


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/7340 to `2.x`