### PR TITLE
Fix flakiness for getNodeRoles based tests

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/stats/ClusterStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/stats/ClusterStatsIT.java
@@ -37,6 +37,7 @@ import org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.opensearch.action.admin.cluster.node.stats.NodeStats;
 import org.opensearch.action.admin.cluster.node.stats.NodesStatsRequest;
 import org.opensearch.action.admin.cluster.node.stats.NodesStatsResponse;
+import org.opensearch.client.Client;
 import org.opensearch.client.Requests;
 import org.opensearch.cluster.health.ClusterHealthStatus;
 import org.opensearch.cluster.node.DiscoveryNodeRole;
@@ -152,11 +153,12 @@ public class ClusterStatsIT extends OpenSearchIntegTestCase {
 
         Map<String, Integer> expectedCounts = getExpectedCounts(0, 1, 1, 0, 0, 0, 0);
 
-        ClusterStatsResponse response = client().admin().cluster().prepareClusterStats().get();
+        Client client = client();
+        ClusterStatsResponse response = client.admin().cluster().prepareClusterStats().get();
         assertCounts(response.getNodesStats().getCounts(), total, expectedCounts);
 
         Set<String> expectedRoles = Set.of(DiscoveryNodeRole.MASTER_ROLE.roleName());
-        assertEquals(expectedRoles, getNodeRoles(0));
+        assertEquals(expectedRoles, getNodeRoles(client, 0));
     }
 
     private static void incrementCountForRole(String role, Map<String, Integer> counts) {
@@ -327,14 +329,15 @@ public class ClusterStatsIT extends OpenSearchIntegTestCase {
 
         Map<String, Integer> expectedCounts = getExpectedCounts(0, 1, 1, 0, 1, 0, 0);
 
-        ClusterStatsResponse clusterStatsResponse = client().admin().cluster().prepareClusterStats().get();
+        Client client = client();
+        ClusterStatsResponse clusterStatsResponse = client.admin().cluster().prepareClusterStats().get();
         assertCounts(clusterStatsResponse.getNodesStats().getCounts(), total, expectedCounts);
 
         Set<String> expectedRoles = Set.of(
             DiscoveryNodeRole.MASTER_ROLE.roleName(),
             DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE.roleName()
         );
-        assertEquals(expectedRoles, getNodeRoles(0));
+        assertEquals(expectedRoles, getNodeRoles(client, 0));
     }
 
     public void testNodeRolesWithClusterManagerRole() throws ExecutionException, InterruptedException {
@@ -356,14 +359,15 @@ public class ClusterStatsIT extends OpenSearchIntegTestCase {
 
         Map<String, Integer> expectedCounts = getExpectedCounts(0, 1, 1, 0, 1, 0, 0);
 
-        ClusterStatsResponse clusterStatsResponse = client().admin().cluster().prepareClusterStats().get();
+        Client client = client();
+        ClusterStatsResponse clusterStatsResponse = client.admin().cluster().prepareClusterStats().get();
         assertCounts(clusterStatsResponse.getNodesStats().getCounts(), total, expectedCounts);
 
         Set<String> expectedRoles = Set.of(
             DiscoveryNodeRole.CLUSTER_MANAGER_ROLE.roleName(),
             DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE.roleName()
         );
-        assertEquals(expectedRoles, getNodeRoles(0));
+        assertEquals(expectedRoles, getNodeRoles(client, 0));
     }
 
     public void testNodeRolesWithSeedDataNodeLegacySettings() throws ExecutionException, InterruptedException {
@@ -379,7 +383,8 @@ public class ClusterStatsIT extends OpenSearchIntegTestCase {
 
         Map<String, Integer> expectedRoleCounts = getExpectedCounts(1, 1, 1, 0, 1, 0, 0);
 
-        ClusterStatsResponse clusterStatsResponse = client().admin().cluster().prepareClusterStats().get();
+        Client client = client();
+        ClusterStatsResponse clusterStatsResponse = client.admin().cluster().prepareClusterStats().get();
         assertCounts(clusterStatsResponse.getNodesStats().getCounts(), total, expectedRoleCounts);
 
         Set<String> expectedRoles = Set.of(
@@ -387,7 +392,7 @@ public class ClusterStatsIT extends OpenSearchIntegTestCase {
             DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE.roleName(),
             DiscoveryNodeRole.DATA_ROLE.roleName()
         );
-        assertEquals(expectedRoles, getNodeRoles(0));
+        assertEquals(expectedRoles, getNodeRoles(client, 0));
     }
 
     public void testNodeRolesWithDataNodeLegacySettings() throws ExecutionException, InterruptedException {
@@ -405,14 +410,15 @@ public class ClusterStatsIT extends OpenSearchIntegTestCase {
 
         Map<String, Integer> expectedRoleCounts = getExpectedCounts(1, 1, 1, 0, 1, 0, 0);
 
-        ClusterStatsResponse clusterStatsResponse = client().admin().cluster().prepareClusterStats().get();
+        Client client = client();
+        ClusterStatsResponse clusterStatsResponse = client.admin().cluster().prepareClusterStats().get();
         assertCounts(clusterStatsResponse.getNodesStats().getCounts(), total, expectedRoleCounts);
 
         Set<Set<String>> expectedNodesRoles = Set.of(
             Set.of(DiscoveryNodeRole.CLUSTER_MANAGER_ROLE.roleName()),
             Set.of(DiscoveryNodeRole.DATA_ROLE.roleName(), DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE.roleName())
         );
-        assertEquals(expectedNodesRoles, Set.of(getNodeRoles(0), getNodeRoles(1)));
+        assertEquals(expectedNodesRoles, Set.of(getNodeRoles(client, 0), getNodeRoles(client, 1)));
     }
 
     private Map<String, Integer> getExpectedCounts(
@@ -435,8 +441,8 @@ public class ClusterStatsIT extends OpenSearchIntegTestCase {
         return expectedCounts;
     }
 
-    private Set<String> getNodeRoles(int nodeNumber) throws ExecutionException, InterruptedException {
-        NodesStatsResponse nodesStatsResponse = client().admin().cluster().nodesStats(new NodesStatsRequest()).get();
+    private Set<String> getNodeRoles(Client client, int nodeNumber) throws ExecutionException, InterruptedException {
+        NodesStatsResponse nodesStatsResponse = client.admin().cluster().nodesStats(new NodesStatsRequest()).get();
         return nodesStatsResponse.getNodes()
             .get(nodeNumber)
             .getNode()


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
- Fixes flakiness for `getNodeRoles` based tests
- Calling `client()` randomizes the clients across nodes and can lead to a difference sequence of node outputs when checking for node roles

### Related Issues
Resolves #7327 
<!-- List any other related issues here -->
Ran the tests with offending seeds and it seems to pass now. 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
