### PR TITLE
Less temperamental bwc artifacts check when between versions

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
@@ -220,8 +220,12 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
                     @Override
                     public void execute(Task task) {
                         if (projectArtifact.exists() == false) {
+                            String foundArtifacts = stream(projectArtifact.getParentFile().listFiles())
+                                .map(f -> f.getName())
+                                .map(s -> "   - " + s)
+                                .collect(Collectors.joining("\r\n"));
                             throw new InvalidUserDataException(
-                                "Building " + bwcVersion.get() + " didn't generate expected file " + projectArtifact
+                                "Building " + bwcVersion.get() + " didn't generate expected file " + projectArtifact + "\r\nFound the following artifacts:\r\n" + foundArtifacts
                             );
                         }
                     }

--- a/buildSrc/src/main/java/org/opensearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
@@ -224,17 +224,27 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
                     @Override
                     public void execute(Task task) {
                         if (projectArtifact.exists() == false) {
-                            Optional<String> foundAlternative = alternativeProjectArtifacts.stream().filter(File::exists).map(File::getName).findFirst();
+                            Optional<String> foundAlternative = alternativeProjectArtifacts.stream()
+                                .filter(File::exists)
+                                .map(File::getName)
+                                .findFirst();
                             if (foundAlternative.isPresent()) {
-                                project.getLogger().warn("Building " + bwcVersion.get() + " found acceptable alternative artifact " + foundAlternative.get());
+                                project.getLogger()
+                                    .warn(
+                                        "Building " + bwcVersion.get() + " found acceptable alternative artifact " + foundAlternative.get()
+                                    );
                                 return;
                             }
-                            String foundArtifacts = stream(projectArtifact.getParentFile().listFiles())
-                                .map(f -> f.getName())
+                            String foundArtifacts = stream(projectArtifact.getParentFile().listFiles()).map(f -> f.getName())
                                 .map(s -> "   - " + s)
                                 .collect(Collectors.joining("\r\n"));
                             throw new InvalidUserDataException(
-                                "Building " + bwcVersion.get() + " didn't generate expected file " + projectArtifact + "\r\nFound the following artifacts:\r\n" + foundArtifacts
+                                "Building "
+                                    + bwcVersion.get()
+                                    + " didn't generate expected file "
+                                    + projectArtifact
+                                    + "\r\nFound the following artifacts:\r\n"
+                                    + foundArtifacts
                             );
                         }
                     }
@@ -260,13 +270,26 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
             this.projectPath = baseDir + "/" + name;
             final String minDesignation = version.onOrAfter("1.1.0") ? "min-" : "";
             final Function<Version, String> generateName = (Version ver) -> {
-                return baseDir + "/" + name + "/build/distributions/opensearch-" + minDesignation + ver + "-SNAPSHOT" + classifier + "." + extension;
+                return baseDir
+                    + "/"
+                    + name
+                    + "/build/distributions/opensearch-"
+                    + minDesignation
+                    + ver
+                    + "-SNAPSHOT"
+                    + classifier
+                    + "."
+                    + extension;
             };
             this.distFile = new File(checkoutDir, generateName.apply(version));
 
             final Version nextPatchVersion = new Version(version.getMajor(), version.getMinor(), version.getRevision() + 1);
             final Version nextMinorVersion = new Version(version.getMajor(), version.getMinor() + 1, 0);
-            this.alternativeDistFiles = List.of(nextPatchVersion, nextMinorVersion).stream().map(generateName).map(n -> new File(checkoutDir, n)).collect(Collectors.toList());
+            this.alternativeDistFiles = List.of(nextPatchVersion, nextMinorVersion)
+                .stream()
+                .map(generateName)
+                .map(n -> new File(checkoutDir, n))
+                .collect(Collectors.toList());
 
             // we only ported this down to the 7.x branch.
             if (version.onOrAfter("7.10.0") && (name.endsWith("zip") || name.endsWith("tar"))) {


### PR DESCRIPTION
### Description
During the release process there are times when OpenSearch has branches such as 2.x that have increamented their build version number, but that number had not be backported to main.  During this time bwc test can fail because the expected artifact version in main is lower than the version from the branch that is built.

This pull request allows for a margin of error between the expected artifacts with acceptable alternative artifacts which match either the next patch version, or the next minor version.  This should prevent unrelated changes from being caught by the misfortunate time between version update backports.

Example output if alternative artifacts are found:
```
 [2.7.0] BUILD SUCCESSFUL in 3s
 [2.7.0] 170 actionable tasks: 3 executed, 167 up-to-date
Building 2.7.0 found acceptable alternative artifact opensearch-min-2.7.1-SNAPSHOT-linux-x64.tar.gz
```

### Related Issues
- Resolves #7396

### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [ ] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
