### PR TITLE
Remove builder instance from SearchAsYouTypeFieldMapper

### DIFF
--- a/modules/mapper-extras/src/main/java/org/opensearch/index/mapper/SearchAsYouTypeFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/opensearch/index/mapper/SearchAsYouTypeFieldMapper.java
@@ -618,7 +618,7 @@ public class SearchAsYouTypeFieldMapper extends ParametrizedFieldMapper {
     private final PrefixFieldMapper prefixField;
     private final ShingleFieldMapper[] shingleFields;
 
-    private final Builder builder;
+    private final IndexAnalyzers indexAnalyzers;
 
     public SearchAsYouTypeFieldMapper(
         String simpleName,
@@ -636,7 +636,7 @@ public class SearchAsYouTypeFieldMapper extends ParametrizedFieldMapper {
         this.store = builder.store.getValue();
         this.indexOptions = builder.indexOptions.getValue();
         this.termVectors = builder.termVectors.getValue();
-        this.builder = builder;
+        this.indexAnalyzers = builder.analyzers.indexAnalyzers;
     }
 
     @Override
@@ -663,7 +663,7 @@ public class SearchAsYouTypeFieldMapper extends ParametrizedFieldMapper {
 
     @Override
     public ParametrizedFieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName(), builder.analyzers.indexAnalyzers).init(this);
+        return new Builder(simpleName(), this.indexAnalyzers).init(this);
     }
 
     public static String getShingleFieldName(String parentField, int shingleSize) {


### PR DESCRIPTION
### Description
This change removes the builder instance variable from SearchAsYouTypeFieldMapper class. This builder object was consuming a lot of memory. Now the builder will be initialized only when needed. This change is similar to the optimization done for text field mapper here : https://github.com/opensearch-project/OpenSearch/pull/7159 

### Related Issues
#7001 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
