### PR TITLE
Upgrade all jetty dependencies to 9.4.51.v20230217.

### DIFF
--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -32,6 +32,10 @@ apply plugin: 'opensearch.java'
 
 group = 'hdfs'
 
+versions << [
+  'jetty': '9.4.51.v20230217'
+]
+
 dependencies {
   api("org.apache.hadoop:hadoop-minicluster:3.3.5") {
     exclude module: 'websocket-client'
@@ -54,8 +58,8 @@ dependencies {
   api "org.mockito:mockito-core:${versions.mockito}"
   api "com.google.protobuf:protobuf-java:3.22.2"
   api "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
-  api 'org.eclipse.jetty:jetty-server:9.4.51.v20230217'
-  api 'org.eclipse.jetty.websocket:javax-websocket-server-impl:9.4.51.v20230217'
+  api "org.eclipse.jetty:jetty-server:${versions.jetty}"
+  api "org.eclipse.jetty.websocket:javax-websocket-server-impl:${versions.jetty}"
   api 'org.apache.zookeeper:zookeeper:3.8.1'
   api "org.apache.commons:commons-text:1.10.0"
   api "commons-net:commons-net:3.9.0"

--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -55,6 +55,7 @@ dependencies {
   api "com.google.protobuf:protobuf-java:3.22.2"
   api "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
   api 'org.eclipse.jetty:jetty-server:9.4.51.v20230217'
+  api 'org.eclipse.jetty.websocket:javax-websocket-server-impl:9.4.51.v20230217'
   api 'org.apache.zookeeper:zookeeper:3.8.1'
   api "org.apache.commons:commons-text:1.10.0"
   api "commons-net:commons-net:3.9.0"


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
https://github.com/opensearch-project/OpenSearch/pull/7405 bumped jetty-server to 9.4.51*, however there are additional jetty dependencies brought in by hadoop-hdfs that are still using 9.4.48* not replaced with that change.

This change explicitly defines a version of org.eclipse.jetty.websocket:javax-websocket-server-impl which transitively covers the remaining dependencies.

```
./gradlew dependencies
...
|    |    |    +--- org.apache.hadoop:hadoop-yarn-server-nodemanager:3.3.5
|    |    |    |    +--- org.eclipse.jetty.websocket:javax-websocket-server-impl:9.4.48.v20220622
|    |    |    |    |    +--- org.eclipse.jetty:jetty-annotations:9.4.48.v20220622
|    |    |    |    |    |    +--- org.eclipse.jetty:jetty-plus:9.4.48.v20220622
|    |    |    |    |    |    |    \--- org.eclipse.jetty:jetty-jndi:9.4.48.v20220622
|    |    |    |    |    +--- org.eclipse.jetty.websocket:javax-websocket-client-impl:9.4.48.v20220622
|    |    |    |    |    +--- org.eclipse.jetty.websocket:websocket-server:9.4.48.v20220622**
|    |    |    |    |    |    +--- org.eclipse.jetty.websocket:websocket-common:9.4.48.v20220622**
|    |    |    |    |    |    |    +--- org.eclipse.jetty.websocket:websocket-api:9.4.48.v20220622**
|    |    |    |    |    |    +--- org.eclipse.jetty.websocket:websocket-servlet:9.4.48.v20220622**
|    |    |    |    |    |    |    +--- org.eclipse.jetty.websocket:websocket-api:9.4.48.v20220622**
|    |    |    |    |    |    +--- org.eclipse.jetty:jetty-servlet:9.4.48.v20220622 (*)
...
```


### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
