### PR TITLE
[Backport 2.x] Add extensions to gradle plugin

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/testclusters/ExtensionsProperties.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/testclusters/ExtensionsProperties.java
@@ -1,0 +1,93 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.gradle.testclusters;
+
+public class ExtensionsProperties {
+    private String name;
+    private String uniqueId;
+    private String hostAddress;
+    private String port;
+    private String version;
+    private String opensearchVersion;
+    private String minimumCompatibleVersion;
+
+    public ExtensionsProperties(
+        String name,
+        String uniqueId,
+        String hostAddress,
+        String port,
+        String version,
+        String opensearchVersion,
+        String minimumCompatibleVersion
+    ) {
+        this.name = name;
+        this.uniqueId = uniqueId;
+        this.hostAddress = hostAddress;
+        this.port = port;
+        this.version = version;
+        this.opensearchVersion = opensearchVersion;
+        this.minimumCompatibleVersion = minimumCompatibleVersion;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getUniqueId() {
+        return uniqueId;
+    }
+
+    public void setUniqueId(String uniqueId) {
+        this.uniqueId = uniqueId;
+    }
+
+    public String getHostAddress() {
+        return hostAddress;
+    }
+
+    public void setHostAddress(String hostAddress) {
+        this.hostAddress = hostAddress;
+    }
+
+    public String getPort() {
+        return port;
+    }
+
+    public void setPort(String port) {
+        this.port = port;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getOpensearchVersion() {
+        return opensearchVersion;
+    }
+
+    public void setOpensearchVersion(String opensearchVersion) {
+        this.opensearchVersion = opensearchVersion;
+    }
+
+    public String getMinimumCompatibleVersion() {
+        return minimumCompatibleVersion;
+    }
+
+    public void setMinimumCompatibleVersion(String minimumCompatibleVersion) {
+        this.minimumCompatibleVersion = minimumCompatibleVersion;
+    }
+}

--- a/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchCluster.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchCluster.java
@@ -181,6 +181,11 @@ public class OpenSearchCluster implements TestClusterConfiguration, Named {
     }
 
     @Override
+    public void extension(ExtensionsProperties extension) {
+        nodes.all(each -> each.extension(extension));
+    }
+
+    @Override
     public void plugin(Provider<RegularFile> plugin) {
         nodes.all(each -> each.plugin(plugin));
     }

--- a/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchNode.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchNode.java
@@ -653,7 +653,7 @@ public class OpenSearchNode implements TestClusterConfiguration {
         }
 
         logToProcessStdout("Creating " + currentConfig.command + " keystore with password set to [" + keystorePassword + "]");
-        
+
         if (keystorePassword.length() > 0) {
             runOpenSearchBinScriptWithInput(keystorePassword + "\n" + keystorePassword, currentConfig.keystoreTool, "create", "-p");
         } else {

--- a/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchNode.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchNode.java
@@ -46,6 +46,8 @@ import org.opensearch.gradle.ReaperService;
 import org.opensearch.gradle.Version;
 import org.opensearch.gradle.VersionProperties;
 import org.opensearch.gradle.info.BuildParams;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
 import org.gradle.api.Action;
 import org.gradle.api.Named;
 import org.gradle.api.NamedDomainObjectContainer;
@@ -92,6 +94,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Scanner;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -142,6 +145,7 @@ public class OpenSearchNode implements TestClusterConfiguration {
     private final Map<String, Configuration> pluginAndModuleConfigurations = new HashMap<>();
     private final List<Provider<File>> plugins = new ArrayList<>();
     private final List<Provider<File>> modules = new ArrayList<>();
+    private final List<ExtensionsProperties> extensions = new ArrayList<>();
     final LazyPropertyMap<String, CharSequence> settings = new LazyPropertyMap<>("Settings", this);
     private final LazyPropertyMap<String, CharSequence> keystoreSettings = new LazyPropertyMap<>("Keystore", this);
     private final LazyPropertyMap<String, File> keystoreFiles = new LazyPropertyMap<>("Keystore files", this, FileEntry::new);
@@ -433,6 +437,42 @@ public class OpenSearchNode implements TestClusterConfiguration {
     }
 
     @Override
+    public void extension(ExtensionsProperties extensions) {
+        this.extensions.add(extensions);
+    }
+
+    public void writeExtensionFiles() {
+        try {
+            // Creates extensions.yml in the target directory
+            Path destination = getDistroDir().resolve("extensions").resolve("extensions.yml");
+            if (!Files.exists(getDistroDir().resolve("extensions"))) {
+                Files.createDirectory(getDistroDir().resolve("extensions"));
+            }
+            DumperOptions dumperOptions = new DumperOptions();
+            TestExtensionsList extensionsList = new TestExtensionsList(this.extensions);
+            dumperOptions.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+            Yaml yaml = new Yaml(dumperOptions);
+            Files.write(destination, yaml.dump(extensionsList).getBytes());
+
+            /*
+             * SnakeYaml creates a Yaml file with an unnecessary line at the top with the class name
+             * This section of code removes that line while keeping everything else the same.
+             */
+
+            Scanner scanner = new Scanner(destination);
+            scanner.nextLine();
+            StringBuilder extensionsString = new StringBuilder();
+            while (scanner.hasNextLine()) {
+                extensionsString.append("\n" + scanner.nextLine());
+            }
+            Files.write(destination, extensionsString.toString().getBytes());
+
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to write to extensions.yml", e);
+        }
+    }
+
+    @Override
     public void keystore(String key, String value) {
         keystoreSettings.put(key, value);
     }
@@ -608,7 +648,12 @@ public class OpenSearchNode implements TestClusterConfiguration {
             }
         }
 
+        if (!extensions.isEmpty()) {
+            writeExtensionFiles();
+        }
+
         logToProcessStdout("Creating " + currentConfig.command + " keystore with password set to [" + keystorePassword + "]");
+        
         if (keystorePassword.length() > 0) {
             runOpenSearchBinScriptWithInput(keystorePassword + "\n" + keystorePassword, currentConfig.keystoreTool, "create", "-p");
         } else {
@@ -891,6 +936,10 @@ public class OpenSearchNode implements TestClusterConfiguration {
         // Don't inherit anything from the environment for as that would lack reproducibility
         environment.clear();
         environment.putAll(getOpenSearchEnvironment());
+
+        if (!extensions.isEmpty()) {
+            environment.put("OPENSEARCH_JAVA_OPTS", "-Dopensearch.experimental.feature.extensions.enabled=true");
+        }
 
         // don't buffer all in memory, make sure we don't block on the default pipes
         processBuilder.redirectError(ProcessBuilder.Redirect.appendTo(currentConfig.stderrFile.toFile()));

--- a/buildSrc/src/main/java/org/opensearch/gradle/testclusters/TestClusterConfiguration.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/testclusters/TestClusterConfiguration.java
@@ -55,6 +55,8 @@ public interface TestClusterConfiguration {
 
     void setTestDistribution(TestDistribution distribution);
 
+    void extension(ExtensionsProperties extension);
+
     void plugin(Provider<RegularFile> plugin);
 
     void plugin(String pluginProjectPath);

--- a/buildSrc/src/main/java/org/opensearch/gradle/testclusters/TestExtensionsList.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/testclusters/TestExtensionsList.java
@@ -1,0 +1,27 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.gradle.testclusters;
+
+import java.util.List;
+
+public class TestExtensionsList {
+    private List<ExtensionsProperties> extensions;
+
+    public TestExtensionsList(List<ExtensionsProperties> extensionsList) {
+        extensions = extensionsList;
+    }
+
+    public List<ExtensionsProperties> getExtensions() {
+        return extensions;
+    }
+
+    public void setExtensions(List<ExtensionsProperties> extensionsList) {
+        extensions = extensionsList;
+    }
+}


### PR DESCRIPTION
### Description
In order to run integration testing for the SDK and future extensions, the OpenSearch gradle plugin needs to be able to run both extensions and plugins at the same time.  This PR adds the capability to run extensions from the gradle plugin, while leaving all existing plugin functionality untouched.

Backport of https://github.com/opensearch-project/OpenSearch/pull/7235

### Issues Resolved
https://github.com/opensearch-project/opensearch-sdk-java/issues/589

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff