### PR TITLE
[Backport] [2.x] Introduce new 'unsigned_long' numeric field type support (#6237)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Extensions] Add IdentityPlugin into core to support Extension identities ([#7246](https://github.com/opensearch-project/OpenSearch/pull/7246))
 - Add connectToNodeAsExtension in TransportService ([#6866](https://github.com/opensearch-project/OpenSearch/pull/6866))
 - Add descending order search optimization through reverse segment read. ([#7244](https://github.com/opensearch-project/OpenSearch/pull/7244))
+- Add 'unsigned_long' numeric field type ([#6237](https://github.com/opensearch-project/OpenSearch/pull/6237))
 
 ### Dependencies
 - Bump `com.netflix.nebula:gradle-info-plugin` from 12.0.0 to 12.1.0

--- a/client/rest-high-level/src/main/java/org/opensearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/RestHighLevelClient.java
@@ -153,8 +153,10 @@ import org.opensearch.search.aggregations.bucket.terms.LongTerms;
 import org.opensearch.search.aggregations.bucket.terms.ParsedDoubleTerms;
 import org.opensearch.search.aggregations.bucket.terms.ParsedLongTerms;
 import org.opensearch.search.aggregations.bucket.terms.ParsedStringTerms;
+import org.opensearch.search.aggregations.bucket.terms.ParsedUnsignedLongTerms;
 import org.opensearch.search.aggregations.bucket.terms.StringRareTerms;
 import org.opensearch.search.aggregations.bucket.terms.StringTerms;
+import org.opensearch.search.aggregations.bucket.terms.UnsignedLongTerms;
 import org.opensearch.search.aggregations.metrics.AvgAggregationBuilder;
 import org.opensearch.search.aggregations.metrics.CardinalityAggregationBuilder;
 import org.opensearch.search.aggregations.metrics.ExtendedStatsAggregationBuilder;
@@ -2274,6 +2276,7 @@ public class RestHighLevelClient implements Closeable {
         map.put(AutoDateHistogramAggregationBuilder.NAME, (p, c) -> ParsedAutoDateHistogram.fromXContent(p, (String) c));
         map.put(VariableWidthHistogramAggregationBuilder.NAME, (p, c) -> ParsedVariableWidthHistogram.fromXContent(p, (String) c));
         map.put(StringTerms.NAME, (p, c) -> ParsedStringTerms.fromXContent(p, (String) c));
+        map.put(UnsignedLongTerms.NAME, (p, c) -> ParsedUnsignedLongTerms.fromXContent(p, (String) c));
         map.put(LongTerms.NAME, (p, c) -> ParsedLongTerms.fromXContent(p, (String) c));
         map.put(DoubleTerms.NAME, (p, c) -> ParsedDoubleTerms.fromXContent(p, (String) c));
         map.put(LongRareTerms.NAME, (p, c) -> ParsedLongRareTerms.fromXContent(p, (String) c));

--- a/client/rest-high-level/src/test/java/org/opensearch/client/SearchIT.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/SearchIT.java
@@ -83,6 +83,7 @@ import org.opensearch.search.aggregations.bucket.composite.CompositeValuesSource
 import org.opensearch.search.aggregations.bucket.composite.TermsValuesSourceBuilder;
 import org.opensearch.search.aggregations.bucket.range.Range;
 import org.opensearch.search.aggregations.bucket.range.RangeAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.terms.MultiTermsAggregationBuilder;
 import org.opensearch.search.aggregations.bucket.terms.RareTerms;
 import org.opensearch.search.aggregations.bucket.terms.RareTermsAggregationBuilder;
 import org.opensearch.search.aggregations.bucket.terms.Terms;
@@ -91,6 +92,7 @@ import org.opensearch.search.aggregations.matrix.stats.MatrixStats;
 import org.opensearch.search.aggregations.matrix.stats.MatrixStatsAggregationBuilder;
 import org.opensearch.search.aggregations.metrics.WeightedAvg;
 import org.opensearch.search.aggregations.metrics.WeightedAvgAggregationBuilder;
+import org.opensearch.search.aggregations.support.MultiTermsValuesSourceConfig;
 import org.opensearch.search.aggregations.support.MultiValuesSourceFieldConfig;
 import org.opensearch.search.aggregations.support.ValueType;
 import org.opensearch.search.builder.PointInTimeBuilder;
@@ -105,6 +107,7 @@ import org.hamcrest.Matchers;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -295,6 +298,67 @@ public class SearchIT extends OpenSearchRestHighLevelClientTestCase {
         Terms.Bucket type2 = termsAgg.getBucketByKey("type2");
         assertEquals(2, type2.getDocCount());
         assertEquals(0, type2.getAggregations().asList().size());
+    }
+
+    public void testSearchWithMultiTermsAgg() throws IOException {
+        final String indexName = "multi_aggs";
+        Request createIndex = new Request(HttpPut.METHOD_NAME, "/" + indexName);
+        createIndex.setJsonEntity(
+            "{\n"
+                + "    \"mappings\": {\n"
+                + "        \"properties\" : {\n"
+                + "            \"username\" : {\n"
+                + "                \"type\" : \"keyword\"\n"
+                + "            },\n"
+                + "            \"rating\" : {\n"
+                + "                \"type\" : \"unsigned_long\"\n"
+                + "            }\n"
+                + "        }\n"
+                + "    }"
+                + "}"
+        );
+        client().performRequest(createIndex);
+
+        {
+            Request doc1 = new Request(HttpPut.METHOD_NAME, "/" + indexName + "/_doc/1");
+            doc1.setJsonEntity("{\"username\":\"bob\", \"rating\": 18446744073709551615}");
+            client().performRequest(doc1);
+            Request doc2 = new Request(HttpPut.METHOD_NAME, "/" + indexName + "/_doc/2");
+            doc2.setJsonEntity("{\"username\":\"tom\", \"rating\": 10223372036854775807}");
+            client().performRequest(doc2);
+            Request doc3 = new Request(HttpPut.METHOD_NAME, "/" + indexName + "/_doc/3");
+            doc3.setJsonEntity("{\"username\":\"john\"}");
+            client().performRequest(doc3);
+        }
+        client().performRequest(new Request(HttpPost.METHOD_NAME, "/_refresh"));
+
+        SearchRequest searchRequest = new SearchRequest().indices(indexName);
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        searchSourceBuilder.aggregation(
+            new MultiTermsAggregationBuilder("agg1").terms(
+                Arrays.asList(
+                    new MultiTermsValuesSourceConfig.Builder().setFieldName("username").build(),
+                    new MultiTermsValuesSourceConfig.Builder().setFieldName("rating").build()
+                )
+            )
+        );
+        searchSourceBuilder.size(0);
+        searchRequest.source(searchSourceBuilder);
+        SearchResponse searchResponse = execute(searchRequest, highLevelClient()::search, highLevelClient()::searchAsync);
+        assertSearchHeader(searchResponse);
+        assertNull(searchResponse.getSuggest());
+        assertEquals(Collections.emptyMap(), searchResponse.getProfileResults());
+        assertEquals(0, searchResponse.getHits().getHits().length);
+        assertEquals(Float.NaN, searchResponse.getHits().getMaxScore(), 0f);
+        Terms termsAgg = searchResponse.getAggregations().get("agg1");
+        assertEquals("agg1", termsAgg.getName());
+        assertEquals(2, termsAgg.getBuckets().size());
+        Terms.Bucket bucket1 = termsAgg.getBucketByKey("bob|18446744073709551615");
+        assertEquals(1, bucket1.getDocCount());
+        assertEquals(0, bucket1.getAggregations().asList().size());
+        Terms.Bucket bucket2 = termsAgg.getBucketByKey("tom|10223372036854775807");
+        assertEquals(1, bucket2.getDocCount());
+        assertEquals(0, bucket2.getAggregations().asList().size());
     }
 
     public void testSearchWithRareTermsAgg() throws IOException {
@@ -845,6 +909,56 @@ public class SearchIT extends OpenSearchRestHighLevelClientTestCase {
         assertThat(multiSearchResponse.getResponses()[2].getResponse().getHits().getTotalHits().value, Matchers.equalTo(2L));
         assertThat(multiSearchResponse.getResponses()[2].getResponse().getHits().getAt(0).getId(), Matchers.equalTo("5"));
         assertThat(multiSearchResponse.getResponses()[2].getResponse().getHits().getAt(1).getId(), Matchers.equalTo("6"));
+    }
+
+    public void testSearchWithSort() throws Exception {
+        final String indexName = "search_sort";
+        Request createIndex = new Request(HttpPut.METHOD_NAME, "/" + indexName);
+        createIndex.setJsonEntity(
+            "{\n"
+                + "    \"mappings\": {\n"
+                + "        \"properties\" : {\n"
+                + "            \"username\" : {\n"
+                + "                \"type\" : \"keyword\"\n"
+                + "            },\n"
+                + "            \"rating\" : {\n"
+                + "                \"type\" : \"unsigned_long\"\n"
+                + "            }\n"
+                + "        }\n"
+                + "    }"
+                + "}"
+        );
+        client().performRequest(createIndex);
+
+        {
+            Request doc1 = new Request(HttpPut.METHOD_NAME, "/" + indexName + "/_doc/1");
+            doc1.setJsonEntity("{\"username\":\"bob\", \"rating\": 18446744073709551610}");
+            client().performRequest(doc1);
+            Request doc2 = new Request(HttpPut.METHOD_NAME, "/" + indexName + "/_doc/2");
+            doc2.setJsonEntity("{\"username\":\"tom\", \"rating\": 10223372036854775807}");
+            client().performRequest(doc2);
+            Request doc3 = new Request(HttpPut.METHOD_NAME, "/" + indexName + "/_doc/3");
+            doc3.setJsonEntity("{\"username\":\"john\"}");
+            client().performRequest(doc3);
+        }
+        client().performRequest(new Request(HttpPost.METHOD_NAME, "/search_sort/_refresh"));
+
+        SearchRequest searchRequest = new SearchRequest("search_sort");
+        searchRequest.source().sort("rating", SortOrder.ASC);
+        SearchResponse searchResponse = execute(searchRequest, highLevelClient()::search, highLevelClient()::searchAsync);
+
+        assertThat(searchResponse.getTook().millis(), Matchers.greaterThanOrEqualTo(0L));
+        assertThat(searchResponse.getHits().getTotalHits().value, Matchers.equalTo(3L));
+        assertThat(searchResponse.getHits().getAt(0).getId(), Matchers.equalTo("2"));
+        assertThat(searchResponse.getHits().getAt(1).getId(), Matchers.equalTo("1"));
+        assertThat(searchResponse.getHits().getAt(2).getId(), Matchers.equalTo("3"));
+
+        assertThat(searchResponse.getHits().getAt(0).getSortValues().length, equalTo(1));
+        assertThat(searchResponse.getHits().getAt(0).getSortValues()[0], equalTo(new BigInteger("10223372036854775807")));
+        assertThat(searchResponse.getHits().getAt(1).getSortValues().length, equalTo(1));
+        assertThat(searchResponse.getHits().getAt(1).getSortValues()[0], equalTo(new BigInteger("18446744073709551610")));
+        assertThat(searchResponse.getHits().getAt(2).getSortValues().length, equalTo(1));
+        assertThat(searchResponse.getHits().getAt(2).getSortValues()[0], equalTo(new BigInteger("18446744073709551615")));
     }
 
     public void testMultiSearch_withAgg() throws Exception {

--- a/libs/common/src/main/java/org/opensearch/common/Numbers.java
+++ b/libs/common/src/main/java/org/opensearch/common/Numbers.java
@@ -32,8 +32,6 @@
 
 package org.opensearch.common;
 
-import org.apache.lucene.util.BytesRef;
-
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
@@ -43,19 +41,16 @@ import java.math.BigInteger;
  * @opensearch.internal
  */
 public final class Numbers {
+    public static final BigInteger MAX_UNSIGNED_LONG_VALUE = BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE);
+    public static final BigInteger MIN_UNSIGNED_LONG_VALUE = BigInteger.ZERO;
+
+    public static final long MIN_UNSIGNED_LONG_VALUE_AS_LONG = MIN_UNSIGNED_LONG_VALUE.longValue();
+    public static final long MAX_UNSIGNED_LONG_VALUE_AS_LONG = MAX_UNSIGNED_LONG_VALUE.longValue();
 
     private static final BigInteger MAX_LONG_VALUE = BigInteger.valueOf(Long.MAX_VALUE);
     private static final BigInteger MIN_LONG_VALUE = BigInteger.valueOf(Long.MIN_VALUE);
 
     private Numbers() {}
-
-    public static long bytesToLong(BytesRef bytes) {
-        int high = (bytes.bytes[bytes.offset + 0] << 24) | ((bytes.bytes[bytes.offset + 1] & 0xff) << 16) | ((bytes.bytes[bytes.offset + 2]
-            & 0xff) << 8) | (bytes.bytes[bytes.offset + 3] & 0xff);
-        int low = (bytes.bytes[bytes.offset + 4] << 24) | ((bytes.bytes[bytes.offset + 5] & 0xff) << 16) | ((bytes.bytes[bytes.offset + 6]
-            & 0xff) << 8) | (bytes.bytes[bytes.offset + 7] & 0xff);
-        return (((long) high) << 32) | (low & 0x0ffffffffL);
-    }
 
     public static byte[] intToBytes(int val) {
         byte[] arr = new byte[4];
@@ -139,9 +134,44 @@ public final class Numbers {
         }
     }
 
+    /** Return the {@link BigInteger} that {@code n} stores, or throws an exception if the
+     *  stored value cannot be converted to a {@link BigInteger} that stores the exact same
+     *  value. */
+    public static BigInteger toBigIntegerExact(Number n) {
+        if (n instanceof Byte || n instanceof Short || n instanceof Integer || n instanceof Long) {
+            return BigInteger.valueOf(n.longValue());
+        } else if (n instanceof Float || n instanceof Double) {
+            double d = n.doubleValue();
+            if (d != Math.round(d)) {
+                throw new IllegalArgumentException(n + " is not an integer value");
+            }
+            return BigInteger.valueOf(n.longValue());
+        } else if (n instanceof BigDecimal) {
+            return ((BigDecimal) n).toBigIntegerExact();
+        } else if (n instanceof BigInteger) {
+            return ((BigInteger) n);
+        } else {
+            throw new IllegalArgumentException("Cannot convert [" + n + "] of class [" + n.getClass().getName() + "] to a BigInteger");
+        }
+    }
+
+    /** Return the unsigned long (as {@link BigInteger}) that {@code n} stores, or throws an exception if the
+     *  stored value cannot be converted to an unsigned long that stores the exact same
+     *  value. */
+    public static BigInteger toUnsignedLongExact(Number value) {
+        final BigInteger v = Numbers.toBigIntegerExact(value);
+
+        if (v.compareTo(MAX_UNSIGNED_LONG_VALUE) > 0 || v.compareTo(MIN_UNSIGNED_LONG_VALUE) < 0) {
+            throw new IllegalArgumentException("Value [" + value + "] is out of range for an unsigned long");
+        }
+
+        return v;
+    }
+
     // weak bounds on the BigDecimal representation to allow for coercion
     private static BigDecimal BIGDECIMAL_GREATER_THAN_LONG_MAX_VALUE = BigDecimal.valueOf(Long.MAX_VALUE).add(BigDecimal.ONE);
     private static BigDecimal BIGDECIMAL_LESS_THAN_LONG_MIN_VALUE = BigDecimal.valueOf(Long.MIN_VALUE).subtract(BigDecimal.ONE);
+    private static BigDecimal BIGDECIMAL_GREATER_THAN_USIGNED_LONG_MAX_VALUE = new BigDecimal(MAX_UNSIGNED_LONG_VALUE).add(BigDecimal.ONE);
 
     /** Return the long that {@code stringValue} stores or throws an exception if the
      *  stored value cannot be converted to a long that stores the exact same
@@ -174,6 +204,31 @@ public final class Numbers {
         return bigIntegerValue.longValue();
     }
 
+    /** Return the long that {@code stringValue} stores or throws an exception if the
+     *  stored value cannot be converted to a long that stores the exact same
+     *  value and {@code coerce} is false. */
+    public static BigInteger toUnsignedLong(String stringValue, boolean coerce) {
+        final BigInteger bigIntegerValue;
+        try {
+            BigDecimal bigDecimalValue = new BigDecimal(stringValue);
+            if (bigDecimalValue.compareTo(BIGDECIMAL_GREATER_THAN_USIGNED_LONG_MAX_VALUE) >= 0
+                || bigDecimalValue.compareTo(BigDecimal.ZERO) <= 0) {
+                throw new IllegalArgumentException("Value [" + stringValue + "] is out of range for an unsigned long");
+            }
+            bigIntegerValue = coerce ? bigDecimalValue.toBigInteger() : bigDecimalValue.toBigIntegerExact();
+        } catch (ArithmeticException e) {
+            throw new IllegalArgumentException("Value [" + stringValue + "] has a decimal part");
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("For input string: \"" + stringValue + "\"");
+        }
+
+        if (bigIntegerValue.compareTo(MAX_UNSIGNED_LONG_VALUE) > 0 || bigIntegerValue.compareTo(MIN_UNSIGNED_LONG_VALUE) < 0) {
+            throw new IllegalArgumentException("Value [" + stringValue + "] is out of range for an unsigned long");
+        }
+
+        return bigIntegerValue;
+    }
+
     /** Return the int that {@code n} stores, or throws an exception if the
      *  stored value cannot be converted to an int that stores the exact same
      *  value. */
@@ -201,5 +256,37 @@ public final class Numbers {
             throw new ArithmeticException("byte overflow: " + l);
         }
         return (byte) l;
+    }
+
+    /**
+     * Return a BigInteger equal to the unsigned value of the
+     * argument.
+     */
+    public static BigInteger toUnsignedBigInteger(long i) {
+        if (i >= 0L) return BigInteger.valueOf(i);
+        else {
+            int upper = (int) (i >>> 32);
+            int lower = (int) i;
+
+            // return (upper << 32) + lower
+            return (BigInteger.valueOf(Integer.toUnsignedLong(upper))).shiftLeft(32).add(BigInteger.valueOf(Integer.toUnsignedLong(lower)));
+        }
+    }
+
+    /**
+     * Convert unsigned long to double value (see please Guava's com.google.common.primitives.UnsignedLong),
+     * this is faster then going through {@link #toUnsignedBigInteger(long)} conversion.
+     */
+    public static double unsignedLongToDouble(long value) {
+        if (value >= 0) {
+            return (double) value;
+        }
+
+        // The top bit is set, which means that the double value is going to come from the top 53 bits.
+        // So we can ignore the bottom 11, except for rounding. We can unsigned-shift right 1, aka
+        // unsigned-divide by 2, and convert that. Then we'll get exactly half of the desired double
+        // value. But in the specific case where the bottom two bits of the original number are 01, we
+        // want to replace that with 1 in the shifted value for correct rounding.
+        return (double) ((value >>> 1) | (value & 1)) * 2.0;
     }
 }

--- a/libs/common/src/test/java/org/opensearch/common/NumbersTests.java
+++ b/libs/common/src/test/java/org/opensearch/common/NumbersTests.java
@@ -164,4 +164,60 @@ public class NumbersTests extends OpenSearchTestCase {
         e = expectThrows(IllegalArgumentException.class, () -> Numbers.toByteExact(new AtomicInteger(3))); // not supported
         assertEquals("Cannot check whether [3] of class [java.util.concurrent.atomic.AtomicInteger] is actually a long", e.getMessage());
     }
+
+    public void testToUnsignedLong() {
+        assertEquals(BigInteger.valueOf(3L), Numbers.toUnsignedLong("3", false));
+        assertEquals(BigInteger.valueOf(3L), Numbers.toUnsignedLong("3.1", true));
+        assertEquals(new BigInteger("17223372036854775807"), Numbers.toUnsignedLong("17223372036854775807.00", false));
+        assertEquals(new BigInteger("17223372036854775807"), Numbers.toUnsignedLong("17223372036854775807.00", true));
+        assertEquals(new BigInteger("17223372036854775807"), Numbers.toUnsignedLong("17223372036854775807.99", true));
+        assertEquals(new BigInteger("18446744073709551000"), Numbers.toUnsignedLong("1.8446744073709551E19", true));
+
+        assertEquals(
+            "Value [19223372036854775808] is out of range for an unsigned long",
+            expectThrows(IllegalArgumentException.class, () -> Numbers.toUnsignedLong("19223372036854775808", false)).getMessage()
+        );
+        assertEquals(
+            "Value [-1] is out of range for an unsigned long",
+            expectThrows(IllegalArgumentException.class, () -> Numbers.toUnsignedLong("-1", false)).getMessage()
+        );
+
+        assertEquals(
+            "Value [1.8446744073709552E19] is out of range for an unsigned long",
+            expectThrows(IllegalArgumentException.class, () -> Numbers.toUnsignedLong("1.8446744073709552E19", false)).getMessage()
+        );
+
+        assertEquals(
+            "Value [1e99999999] is out of range for an unsigned long",
+            expectThrows(IllegalArgumentException.class, () -> Numbers.toUnsignedLong("1e99999999", false)).getMessage()
+        );
+    }
+
+    public void testToUnsignedLongExact() {
+        assertEquals(BigInteger.valueOf(3L), Numbers.toUnsignedLongExact(Long.valueOf(3L)));
+        assertEquals(BigInteger.valueOf(3L), Numbers.toUnsignedLongExact(Integer.valueOf(3)));
+        assertEquals(BigInteger.valueOf(3L), Numbers.toUnsignedLongExact(Short.valueOf((short) 3)));
+        assertEquals(BigInteger.valueOf(3L), Numbers.toUnsignedLongExact(Byte.valueOf((byte) 3)));
+        assertEquals(BigInteger.valueOf(3L), Numbers.toUnsignedLongExact(3d));
+        assertEquals(BigInteger.valueOf(3L), Numbers.toUnsignedLongExact(3f));
+        assertEquals(BigInteger.valueOf(3L), Numbers.toUnsignedLongExact(BigInteger.valueOf(3L)));
+        assertEquals(BigInteger.valueOf(3L), Numbers.toUnsignedLongExact(BigDecimal.valueOf(3L)));
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> Numbers.toUnsignedLongExact(3.1d));
+        assertEquals("3.1 is not an integer value", e.getMessage());
+        e = expectThrows(IllegalArgumentException.class, () -> Numbers.toUnsignedLongExact(Double.NaN));
+        assertEquals("NaN is not an integer value", e.getMessage());
+        e = expectThrows(IllegalArgumentException.class, () -> Numbers.toUnsignedLongExact(Double.POSITIVE_INFINITY));
+        assertEquals("Infinity is not an integer value", e.getMessage());
+        e = expectThrows(IllegalArgumentException.class, () -> Numbers.toUnsignedLongExact(3.1f));
+        assertEquals("3.1 is not an integer value", e.getMessage());
+        e = expectThrows(IllegalArgumentException.class, () -> Numbers.toUnsignedLongExact(new AtomicInteger(3))); // not supported
+        assertEquals("Cannot convert [3] of class [java.util.concurrent.atomic.AtomicInteger] to a BigInteger", e.getMessage());
+    }
+
+    public void testToUnsignedBigInteger() {
+        final BigInteger random = randomUnsignedLong();
+        assertEquals(random, Numbers.toUnsignedBigInteger(random.longValue()));
+        assertEquals(Numbers.MAX_UNSIGNED_LONG_VALUE, Numbers.toUnsignedBigInteger(Numbers.MAX_UNSIGNED_LONG_VALUE.longValue()));
+    }
 }

--- a/libs/core/build.gradle
+++ b/libs/core/build.gradle
@@ -79,6 +79,9 @@ dependencies {
 
   api "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
 
+  // lucene
+  api "org.apache.lucene:lucene-core:${versions.lucene}"
+
   testImplementation "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
   testImplementation "junit:junit:${versions.junit}"
   testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
@@ -96,4 +99,5 @@ tasks.named('forbiddenApisMain').configure {
 
 tasks.named("dependencyLicenses").configure {
   mapping from: /jackson-.*/, to: 'jackson'
+  mapping from: /lucene-.*/, to: 'lucene'
 }

--- a/libs/core/licenses/lucene-LICENSE.txt
+++ b/libs/core/licenses/lucene-LICENSE.txt
@@ -1,0 +1,475 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+
+Some code in core/src/java/org/apache/lucene/util/UnicodeUtil.java was
+derived from unicode conversion examples available at
+http://www.unicode.org/Public/PROGRAMS/CVTUTF.  Here is the copyright
+from those sources:
+
+/*
+ * Copyright 2001-2004 Unicode, Inc.
+ * 
+ * Disclaimer
+ * 
+ * This source code is provided as is by Unicode, Inc. No claims are
+ * made as to fitness for any particular purpose. No warranties of any
+ * kind are expressed or implied. The recipient agrees to determine
+ * applicability of information provided. If this file has been
+ * purchased on magnetic or optical media from Unicode, Inc., the
+ * sole remedy for any claim will be exchange of defective media
+ * within 90 days of receipt.
+ * 
+ * Limitations on Rights to Redistribute This Code
+ * 
+ * Unicode, Inc. hereby grants the right to freely use the information
+ * supplied in this file in the creation of products supporting the
+ * Unicode Standard, and to make copies of this file in any form
+ * for internal or external distribution as long as this notice
+ * remains attached.
+ */
+
+
+Some code in core/src/java/org/apache/lucene/util/ArrayUtil.java was
+derived from Python 2.4.2 sources available at
+http://www.python.org. Full license is here:
+
+  http://www.python.org/download/releases/2.4.2/license/
+
+Some code in core/src/java/org/apache/lucene/util/UnicodeUtil.java was
+derived from Python 3.1.2 sources available at
+http://www.python.org. Full license is here:
+
+  http://www.python.org/download/releases/3.1.2/license/
+
+Some code in core/src/java/org/apache/lucene/util/automaton was
+derived from Brics automaton sources available at
+www.brics.dk/automaton/. Here is the copyright from those sources:
+
+/*
+ * Copyright (c) 2001-2009 Anders Moeller
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+The levenshtein automata tables in core/src/java/org/apache/lucene/util/automaton 
+were automatically generated with the moman/finenight FSA package.
+Here is the copyright for those sources:
+
+# Copyright (c) 2010, Jean-Philippe Barrette-LaPierre, <jpb@rrette.com>
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+Some code in core/src/java/org/apache/lucene/util/UnicodeUtil.java was
+derived from ICU (http://www.icu-project.org)
+The full license is available here: 
+  http://source.icu-project.org/repos/icu/icu/trunk/license.html
+
+/*
+ * Copyright (C) 1999-2010, International Business Machines
+ * Corporation and others.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights 
+ * to use, copy, modify, merge, publish, distribute, and/or sell copies of the 
+ * Software, and to permit persons to whom the Software is furnished to do so, 
+ * provided that the above copyright notice(s) and this permission notice appear 
+ * in all copies of the Software and that both the above copyright notice(s) and
+ * this permission notice appear in supporting documentation.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF THIRD PARTY RIGHTS. 
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE BE 
+ * LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR 
+ * ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER 
+ * IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT 
+ * OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * Except as contained in this notice, the name of a copyright holder shall not 
+ * be used in advertising or otherwise to promote the sale, use or other 
+ * dealings in this Software without prior written authorization of the 
+ * copyright holder.
+ */
+ 
+The following license applies to the Snowball stemmers:
+
+Copyright (c) 2001, Dr Martin Porter
+Copyright (c) 2002, Richard Boulton
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+    * this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+    * notice, this list of conditions and the following disclaimer in the
+    * documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holders nor the names of its contributors
+    * may be used to endorse or promote products derived from this software
+    * without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The following license applies to the KStemmer:
+
+Copyright © 2003,
+Center for Intelligent Information Retrieval,
+University of Massachusetts, Amherst.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. The names "Center for Intelligent Information Retrieval" and
+"University of Massachusetts" must not be used to endorse or promote products
+derived from this software without prior written permission. To obtain
+permission, contact info@ciir.cs.umass.edu.
+
+THIS SOFTWARE IS PROVIDED BY UNIVERSITY OF MASSACHUSETTS AND OTHER CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+The following license applies to the Morfologik project:
+
+Copyright (c) 2006 Dawid Weiss
+Copyright (c) 2007-2011 Dawid Weiss, Marcin Miłkowski
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, 
+    this list of conditions and the following disclaimer.
+    
+    * Redistributions in binary form must reproduce the above copyright notice, 
+    this list of conditions and the following disclaimer in the documentation 
+    and/or other materials provided with the distribution.
+    
+    * Neither the name of Morfologik nor the names of its contributors 
+    may be used to endorse or promote products derived from this software 
+    without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR 
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON 
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+---
+
+The dictionary comes from Morfologik project. Morfologik uses data from 
+Polish ispell/myspell dictionary hosted at http://www.sjp.pl/slownik/en/ and 
+is licenced on the terms of (inter alia) LGPL and Creative Commons 
+ShareAlike. The part-of-speech tags were added in Morfologik project and
+are not found in the data from sjp.pl. The tagset is similar to IPI PAN
+tagset.
+
+---
+
+The following license applies to the Morfeusz project,
+used by org.apache.lucene.analysis.morfologik.
+
+BSD-licensed dictionary of Polish (SGJP)
+http://sgjp.pl/morfeusz/
+
+Copyright © 2011 Zygmunt Saloni, Włodzimierz Gruszczyński, 
+             Marcin Woliński, Robert Wołosz
+
+All rights reserved.
+
+Redistribution and  use in  source and binary  forms, with  or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+THIS SOFTWARE IS PROVIDED BY COPYRIGHT HOLDERS “AS IS” AND ANY EXPRESS
+OR  IMPLIED WARRANTIES,  INCLUDING, BUT  NOT LIMITED  TO,  THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT  SHALL COPYRIGHT  HOLDERS OR  CONTRIBUTORS BE
+LIABLE FOR  ANY DIRECT,  INDIRECT, INCIDENTAL, SPECIAL,  EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED  TO, PROCUREMENT OF
+SUBSTITUTE  GOODS OR  SERVICES;  LOSS  OF USE,  DATA,  OR PROFITS;  OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED  AND ON ANY THEORY OF LIABILITY,
+WHETHER IN  CONTRACT, STRICT LIABILITY, OR  TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/libs/core/licenses/lucene-NOTICE.txt
+++ b/libs/core/licenses/lucene-NOTICE.txt
@@ -1,0 +1,192 @@
+Apache Lucene
+Copyright 2014 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+Includes software from other Apache Software Foundation projects,
+including, but not limited to:
+ - Apache Ant
+ - Apache Jakarta Regexp
+ - Apache Commons
+ - Apache Xerces
+
+ICU4J, (under analysis/icu) is licensed under an MIT styles license
+and Copyright (c) 1995-2008 International Business Machines Corporation and others
+
+Some data files (under analysis/icu/src/data) are derived from Unicode data such
+as the Unicode Character Database. See http://unicode.org/copyright.html for more
+details.
+
+Brics Automaton (under core/src/java/org/apache/lucene/util/automaton) is 
+BSD-licensed, created by Anders Møller. See http://www.brics.dk/automaton/
+
+The levenshtein automata tables (under core/src/java/org/apache/lucene/util/automaton) were
+automatically generated with the moman/finenight FSA library, created by
+Jean-Philippe Barrette-LaPierre. This library is available under an MIT license,
+see http://sites.google.com/site/rrettesite/moman and 
+http://bitbucket.org/jpbarrette/moman/overview/
+
+The class org.apache.lucene.util.WeakIdentityMap was derived from
+the Apache CXF project and is Apache License 2.0.
+
+The Google Code Prettify is Apache License 2.0.
+See http://code.google.com/p/google-code-prettify/
+
+JUnit (junit-4.10) is licensed under the Common Public License v. 1.0
+See http://junit.sourceforge.net/cpl-v10.html
+
+This product includes code (JaspellTernarySearchTrie) from Java Spelling Checkin
+g Package (jaspell): http://jaspell.sourceforge.net/
+License: The BSD License (http://www.opensource.org/licenses/bsd-license.php)
+
+The snowball stemmers in
+  analysis/common/src/java/net/sf/snowball
+were developed by Martin Porter and Richard Boulton.
+The snowball stopword lists in
+  analysis/common/src/resources/org/apache/lucene/analysis/snowball
+were developed by Martin Porter and Richard Boulton.
+The full snowball package is available from
+  http://snowball.tartarus.org/
+
+The KStem stemmer in
+  analysis/common/src/org/apache/lucene/analysis/en
+was developed by Bob Krovetz and Sergio Guzman-Lara (CIIR-UMass Amherst)
+under the BSD-license.
+
+The Arabic,Persian,Romanian,Bulgarian, Hindi and Bengali analyzers (common) come with a default
+stopword list that is BSD-licensed created by Jacques Savoy.  These files reside in:
+analysis/common/src/resources/org/apache/lucene/analysis/ar/stopwords.txt,
+analysis/common/src/resources/org/apache/lucene/analysis/fa/stopwords.txt,
+analysis/common/src/resources/org/apache/lucene/analysis/ro/stopwords.txt,
+analysis/common/src/resources/org/apache/lucene/analysis/bg/stopwords.txt,
+analysis/common/src/resources/org/apache/lucene/analysis/hi/stopwords.txt,
+analysis/common/src/resources/org/apache/lucene/analysis/bn/stopwords.txt
+See http://members.unine.ch/jacques.savoy/clef/index.html.
+
+The German,Spanish,Finnish,French,Hungarian,Italian,Portuguese,Russian and Swedish light stemmers
+(common) are based on BSD-licensed reference implementations created by Jacques Savoy and
+Ljiljana Dolamic. These files reside in:
+analysis/common/src/java/org/apache/lucene/analysis/de/GermanLightStemmer.java
+analysis/common/src/java/org/apache/lucene/analysis/de/GermanMinimalStemmer.java
+analysis/common/src/java/org/apache/lucene/analysis/es/SpanishLightStemmer.java
+analysis/common/src/java/org/apache/lucene/analysis/fi/FinnishLightStemmer.java
+analysis/common/src/java/org/apache/lucene/analysis/fr/FrenchLightStemmer.java
+analysis/common/src/java/org/apache/lucene/analysis/fr/FrenchMinimalStemmer.java
+analysis/common/src/java/org/apache/lucene/analysis/hu/HungarianLightStemmer.java
+analysis/common/src/java/org/apache/lucene/analysis/it/ItalianLightStemmer.java
+analysis/common/src/java/org/apache/lucene/analysis/pt/PortugueseLightStemmer.java
+analysis/common/src/java/org/apache/lucene/analysis/ru/RussianLightStemmer.java
+analysis/common/src/java/org/apache/lucene/analysis/sv/SwedishLightStemmer.java
+
+The Stempel analyzer (stempel) includes BSD-licensed software developed 
+by the Egothor project http://egothor.sf.net/, created by Leo Galambos, Martin Kvapil,
+and Edmond Nolan.
+
+The Polish analyzer (stempel) comes with a default
+stopword list that is BSD-licensed created by the Carrot2 project. The file resides
+in stempel/src/resources/org/apache/lucene/analysis/pl/stopwords.txt.
+See http://project.carrot2.org/license.html.
+
+The SmartChineseAnalyzer source code (smartcn) was
+provided by Xiaoping Gao and copyright 2009 by www.imdict.net.
+
+WordBreakTestUnicode_*.java (under modules/analysis/common/src/test/) 
+is derived from Unicode data such as the Unicode Character Database. 
+See http://unicode.org/copyright.html for more details.
+
+The Morfologik analyzer (morfologik) includes BSD-licensed software
+developed by Dawid Weiss and Marcin Miłkowski (http://morfologik.blogspot.com/).
+
+Morfologik uses data from Polish ispell/myspell dictionary
+(http://www.sjp.pl/slownik/en/) licenced on the terms of (inter alia)
+LGPL and Creative Commons ShareAlike.
+
+Morfologic includes data from BSD-licensed dictionary of Polish (SGJP)
+(http://sgjp.pl/morfeusz/)
+
+Servlet-api.jar and javax.servlet-*.jar are under the CDDL license, the original
+source code for this can be found at http://www.eclipse.org/jetty/downloads.php
+
+===========================================================================
+Kuromoji Japanese Morphological Analyzer - Apache Lucene Integration
+===========================================================================
+
+This software includes a binary and/or source version of data from
+
+  mecab-ipadic-2.7.0-20070801
+
+which can be obtained from
+
+  http://atilika.com/releases/mecab-ipadic/mecab-ipadic-2.7.0-20070801.tar.gz
+
+or
+
+  http://jaist.dl.sourceforge.net/project/mecab/mecab-ipadic/2.7.0-20070801/mecab-ipadic-2.7.0-20070801.tar.gz
+
+===========================================================================
+mecab-ipadic-2.7.0-20070801 Notice
+===========================================================================
+
+Nara Institute of Science and Technology (NAIST),
+the copyright holders, disclaims all warranties with regard to this
+software, including all implied warranties of merchantability and
+fitness, in no event shall NAIST be liable for
+any special, indirect or consequential damages or any damages
+whatsoever resulting from loss of use, data or profits, whether in an
+action of contract, negligence or other tortuous action, arising out
+of or in connection with the use or performance of this software.
+
+A large portion of the dictionary entries
+originate from ICOT Free Software.  The following conditions for ICOT
+Free Software applies to the current dictionary as well.
+
+Each User may also freely distribute the Program, whether in its
+original form or modified, to any third party or parties, PROVIDED
+that the provisions of Section 3 ("NO WARRANTY") will ALWAYS appear
+on, or be attached to, the Program, which is distributed substantially
+in the same form as set out herein and that such intended
+distribution, if actually made, will neither violate or otherwise
+contravene any of the laws and regulations of the countries having
+jurisdiction over the User or the intended distribution itself.
+
+NO WARRANTY
+
+The program was produced on an experimental basis in the course of the
+research and development conducted during the project and is provided
+to users as so produced on an experimental basis.  Accordingly, the
+program is provided without any warranty whatsoever, whether express,
+implied, statutory or otherwise.  The term "warranty" used herein
+includes, but is not limited to, any warranty of the quality,
+performance, merchantability and fitness for a particular purpose of
+the program and the nonexistence of any infringement or violation of
+any right of any third party.
+
+Each user of the program will agree and understand, and be deemed to
+have agreed and understood, that there is no warranty whatsoever for
+the program and, accordingly, the entire risk arising from or
+otherwise connected with the program is assumed by the user.
+
+Therefore, neither ICOT, the copyright holder, or any other
+organization that participated in or was otherwise related to the
+development of the program and their respective officials, directors,
+officers and other employees shall be held liable for any and all
+damages, including, without limitation, general, special, incidental
+and consequential damages, arising out of or otherwise in connection
+with the use or inability to use the program or any product, material
+or result produced or otherwise obtained by using the program,
+regardless of whether they have been advised of, or otherwise had
+knowledge of, the possibility of such damages at any time during the
+project or thereafter.  Each user will be deemed to have agreed to the
+foregoing by his or her commencement of use of the program.  The term
+"use" as used herein includes, but is not limited to, the use,
+modification, copying and distribution of the program and the
+production of secondary products from the program.
+
+In the case where the program, whether in its original form or
+modified, was distributed or delivered to or received by a user from
+any person, organization or entity other than ICOT, unless it makes or
+grants independently of ICOT any specific warranty to the user in
+writing, such person, organization or entity, will also be exempted
+from and not be held liable to the user for any such damages as noted
+above as far as the program is concerned.

--- a/libs/core/licenses/lucene-core-9.5.0.jar.sha1
+++ b/libs/core/licenses/lucene-core-9.5.0.jar.sha1
@@ -1,0 +1,1 @@
+bba4ba5d30e71a5f0017e45e8469db8cff8ad102

--- a/libs/core/src/main/java/org/opensearch/core/util/BytesRefUtils.java
+++ b/libs/core/src/main/java/org/opensearch/core/util/BytesRefUtils.java
@@ -1,0 +1,114 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.core.util;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefArray;
+import org.apache.lucene.util.BytesRefBuilder;
+import org.apache.lucene.util.InPlaceMergeSorter;
+
+import java.util.Comparator;
+
+/**
+ * Utilities for sorting Lucene {@link BytesRefArray}
+ *
+ * @opensearch.internal
+ */
+public class BytesRefUtils {
+    public static void sort(final BytesRefArray bytes, final int[] indices) {
+        sort(new BytesRefBuilder(), new BytesRefBuilder(), bytes, indices);
+    }
+
+    private static void sort(
+        final BytesRefBuilder scratch,
+        final BytesRefBuilder scratch1,
+        final BytesRefArray bytes,
+        final int[] indices
+    ) {
+
+        final int numValues = bytes.size();
+        assert indices.length >= numValues;
+        if (numValues > 1) {
+            new InPlaceMergeSorter() {
+                final Comparator<BytesRef> comparator = Comparator.naturalOrder();
+
+                @Override
+                protected int compare(int i, int j) {
+                    return comparator.compare(bytes.get(scratch, indices[i]), bytes.get(scratch1, indices[j]));
+                }
+
+                @Override
+                protected void swap(int i, int j) {
+                    int value_i = indices[i];
+                    indices[i] = indices[j];
+                    indices[j] = value_i;
+                }
+            }.sort(0, numValues);
+        }
+
+    }
+
+    public static int sortAndDedup(final BytesRefArray bytes, final int[] indices) {
+        final BytesRefBuilder scratch = new BytesRefBuilder();
+        final BytesRefBuilder scratch1 = new BytesRefBuilder();
+        final int numValues = bytes.size();
+        assert indices.length >= numValues;
+        if (numValues <= 1) {
+            return numValues;
+        }
+        sort(scratch, scratch1, bytes, indices);
+        int uniqueCount = 1;
+        BytesRefBuilder previous = scratch;
+        BytesRefBuilder current = scratch1;
+        bytes.get(previous, indices[0]);
+        for (int i = 1; i < numValues; ++i) {
+            bytes.get(current, indices[i]);
+            if (!previous.get().equals(current.get())) {
+                indices[uniqueCount++] = indices[i];
+            }
+            BytesRefBuilder tmp = previous;
+            previous = current;
+            current = tmp;
+        }
+        return uniqueCount;
+    }
+
+    public static long bytesToLong(BytesRef bytes) {
+        int high = (bytes.bytes[bytes.offset + 0] << 24) | ((bytes.bytes[bytes.offset + 1] & 0xff) << 16) | ((bytes.bytes[bytes.offset + 2]
+            & 0xff) << 8) | (bytes.bytes[bytes.offset + 3] & 0xff);
+        int low = (bytes.bytes[bytes.offset + 4] << 24) | ((bytes.bytes[bytes.offset + 5] & 0xff) << 16) | ((bytes.bytes[bytes.offset + 6]
+            & 0xff) << 8) | (bytes.bytes[bytes.offset + 7] & 0xff);
+        return (((long) high) << 32) | (low & 0x0ffffffffL);
+    }
+
+}

--- a/libs/core/src/main/java/org/opensearch/core/util/package-info.java
+++ b/libs/core/src/main/java/org/opensearch/core/util/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/** Core utility classes that need the Lucene API */
+package org.opensearch.core.util;

--- a/libs/core/src/main/java/org/opensearch/core/xcontent/MapXContentParser.java
+++ b/libs/core/src/main/java/org/opensearch/core/xcontent/MapXContentParser.java
@@ -95,6 +95,15 @@ public class MapXContentParser extends AbstractXContentParser {
     }
 
     @Override
+    protected BigInteger doBigIntegerValue() throws IOException {
+        if (numberValue() instanceof BigInteger) {
+            return (BigInteger) numberValue();
+        } else {
+            return BigInteger.valueOf(numberValue().longValue());
+        }
+    }
+
+    @Override
     public MediaType contentType() {
         return xContentType;
     }

--- a/libs/core/src/main/java/org/opensearch/core/xcontent/XContentParser.java
+++ b/libs/core/src/main/java/org/opensearch/core/xcontent/XContentParser.java
@@ -36,6 +36,7 @@ import org.opensearch.common.CheckedFunction;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.math.BigInteger;
 import java.nio.CharBuffer;
 import java.util.List;
 import java.util.Map;
@@ -230,6 +231,8 @@ public interface XContentParser extends Closeable {
 
     double doubleValue(boolean coerce) throws IOException;
 
+    BigInteger bigIntegerValue(boolean coerce) throws IOException;
+
     short shortValue() throws IOException;
 
     int intValue() throws IOException;
@@ -239,6 +242,8 @@ public interface XContentParser extends Closeable {
     float floatValue() throws IOException;
 
     double doubleValue() throws IOException;
+
+    BigInteger bigIntegerValue() throws IOException;
 
     /**
      * @return true iff the current value is either boolean (<code>true</code> or <code>false</code>) or one of "false", "true".

--- a/libs/core/src/main/java/org/opensearch/core/xcontent/XContentSubParser.java
+++ b/libs/core/src/main/java/org/opensearch/core/xcontent/XContentSubParser.java
@@ -35,6 +35,7 @@ package org.opensearch.core.xcontent;
 import org.opensearch.common.CheckedFunction;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.nio.CharBuffer;
 import java.util.List;
 import java.util.Map;
@@ -219,7 +220,12 @@ public class XContentSubParser implements XContentParser {
 
     @Override
     public double doubleValue(boolean coerce) throws IOException {
-        return parser.doubleValue();
+        return parser.doubleValue(coerce);
+    }
+
+    @Override
+    public BigInteger bigIntegerValue(boolean coerce) throws IOException {
+        return parser.bigIntegerValue(coerce);
     }
 
     @Override
@@ -245,6 +251,11 @@ public class XContentSubParser implements XContentParser {
     @Override
     public double doubleValue() throws IOException {
         return parser.doubleValue();
+    }
+
+    @Override
+    public BigInteger bigIntegerValue() throws IOException {
+        return parser.bigIntegerValue();
     }
 
     @Override

--- a/libs/core/src/test/java/org/opensearch/core/util/BytesRefUtilsTests.java
+++ b/libs/core/src/test/java/org/opensearch/core/util/BytesRefUtilsTests.java
@@ -1,0 +1,97 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.core.util;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefArray;
+import org.apache.lucene.util.BytesRefBuilder;
+import org.apache.lucene.util.Counter;
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Tests for the {@link BytesRefUtils} class
+ */
+public class BytesRefUtilsTests extends OpenSearchTestCase {
+    public void testSortAndDedupByteRefArray() {
+        SortedSet<BytesRef> set = new TreeSet<>();
+        final int numValues = scaledRandomIntBetween(0, 10000);
+        List<BytesRef> tmpList = new ArrayList<>();
+        BytesRefArray array = new BytesRefArray(Counter.newCounter());
+        for (int i = 0; i < numValues; i++) {
+            String s = randomRealisticUnicodeOfCodepointLengthBetween(1, 100);
+            set.add(new BytesRef(s));
+            tmpList.add(new BytesRef(s));
+            array.append(new BytesRef(s));
+        }
+        if (randomBoolean()) {
+            Collections.shuffle(tmpList, random());
+            for (BytesRef ref : tmpList) {
+                array.append(ref);
+            }
+        }
+        int[] indices = new int[array.size()];
+        for (int i = 0; i < indices.length; i++) {
+            indices[i] = i;
+        }
+        int numUnique = BytesRefUtils.sortAndDedup(array, indices);
+        assertThat(numUnique, equalTo(set.size()));
+        Iterator<BytesRef> iterator = set.iterator();
+
+        BytesRefBuilder spare = new BytesRefBuilder();
+        for (int i = 0; i < numUnique; i++) {
+            assertThat(iterator.hasNext(), is(true));
+            assertThat(array.get(spare, indices[i]), equalTo(iterator.next()));
+        }
+    }
+
+    public void testSortByteRefArray() {
+        List<BytesRef> values = new ArrayList<>();
+        final int numValues = scaledRandomIntBetween(0, 10000);
+        BytesRefArray array = new BytesRefArray(Counter.newCounter());
+        for (int i = 0; i < numValues; i++) {
+            String s = randomRealisticUnicodeOfCodepointLengthBetween(1, 100);
+            values.add(new BytesRef(s));
+            array.append(new BytesRef(s));
+        }
+        if (randomBoolean()) {
+            Collections.shuffle(values, random());
+        }
+        int[] indices = new int[array.size()];
+        for (int i = 0; i < indices.length; i++) {
+            indices[i] = i;
+        }
+        BytesRefUtils.sort(array, indices);
+        Collections.sort(values);
+        Iterator<BytesRef> iterator = values.iterator();
+
+        BytesRefBuilder spare = new BytesRefBuilder();
+        for (int i = 0; i < values.size(); i++) {
+            assertThat(iterator.hasNext(), is(true));
+            assertThat(array.get(spare, indices[i]), equalTo(iterator.next()));
+        }
+    }
+
+    public void testBytesToLong() {
+        final long value = randomLong();
+        final BytesReference buffer = BytesReference.fromByteBuffer(ByteBuffer.allocate(8).putLong(value).flip());
+        assertThat(BytesRefUtils.bytesToLong(buffer.toBytesRef()), equalTo(value));
+    }
+}

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/json/JsonXContentParser.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/json/JsonXContentParser.java
@@ -43,6 +43,7 @@ import org.opensearch.core.xcontent.AbstractXContentParser;
 import org.opensearch.core.internal.io.IOUtils;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.nio.CharBuffer;
 
 public class JsonXContentParser extends AbstractXContentParser {
@@ -186,6 +187,15 @@ public class JsonXContentParser extends AbstractXContentParser {
     @Override
     public double doDoubleValue() throws IOException {
         return parser.getDoubleValue();
+    }
+
+    @Override
+    public BigInteger doBigIntegerValue() throws IOException {
+        if (parser.getCurrentToken() == JsonToken.VALUE_NUMBER_FLOAT) {
+            return parser.getDecimalValue().toBigInteger();
+        } else {
+            return parser.getBigIntegerValue();
+        }
     }
 
     @Override

--- a/modules/geo/src/main/java/org/opensearch/geo/search/aggregations/bucket/geogrid/CellIdSource.java
+++ b/modules/geo/src/main/java/org/opensearch/geo/search/aggregations/bucket/geogrid/CellIdSource.java
@@ -69,6 +69,11 @@ public class CellIdSource extends ValuesSource.Numeric {
     }
 
     @Override
+    public boolean isBigInteger() {
+        return false;
+    }
+
+    @Override
     public SortedNumericDocValues longValues(LeafReaderContext ctx) {
         if (geoBoundingBox.isUnbounded()) {
             return new UnboundedCellValues(valuesSource.geoPointValues(ctx), precision, encoder);

--- a/modules/lang-painless/src/main/resources/org/opensearch/painless/spi/org.opensearch.txt
+++ b/modules/lang-painless/src/main/resources/org/opensearch/painless/spi/org.opensearch.txt
@@ -74,6 +74,11 @@ class org.opensearch.index.fielddata.ScriptDocValues$Longs {
   long getValue()
 }
 
+class org.opensearch.index.fielddata.ScriptDocValues$UnsignedLongs {
+  BigInteger get(int)
+  BigInteger getValue()
+}
+
 class org.opensearch.script.JodaCompatibleZonedDateTime {
   ##### ZonedDateTime methods
   int getDayOfMonth()

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/90_unsigned_long.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/90_unsigned_long.yml
@@ -1,0 +1,73 @@
+setup:
+  - skip:
+      version: " - 2.99.99"
+      reason: unsigned_long is not supported before 3.0.0
+
+  - do:
+      indices.create:
+        index: test_1
+        body:
+          settings:
+            number_of_replicas: 0
+          mappings:
+            properties:
+              counter:
+                type: unsigned_long
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - index:
+              _index: test_1
+              _id: 1
+          - counter: "10223372036854775807.23"
+
+---
+"Unsigned long with decimal part test":
+
+  - do:
+      search:
+        index: test_1
+        rest_total_hits_as_int: true
+        body:
+          query:
+            term:
+              counter:
+                value: 10223372036854775807
+
+  - match: { hits.total: 1 }
+
+---
+"Stored unsigned long with decimal part test":
+  - do:
+      indices.create:
+        index: test_2
+        body:
+          settings:
+            number_of_replicas: 0
+          mappings:
+            properties:
+              counter:
+                type: unsigned_long
+                store: true
+
+      bulk:
+        refresh: true
+        body:
+          - index:
+              _index: test_2
+              _id: 2
+          - counter: "10223372036854775807"
+
+  - do:
+      search:
+        index: test_*
+        rest_total_hits_as_int: true
+        body:
+          query:
+            term:
+              counter:
+                value: 10223372036854775807
+
+  - match: { hits.total: 2 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/100_avg_metric_unsigned.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/100_avg_metric_unsigned.yml
@@ -1,0 +1,168 @@
+setup:
+  - skip:
+      version: " - 2.99.99"
+      reason: unsigned_long is not supported before 3.0.0
+
+  - do:
+      indices.create:
+          index: test_1
+          body:
+            settings:
+              number_of_replicas: 0
+            mappings:
+              properties:
+                unsigned_field:
+                   type : unsigned_long
+                double_field:
+                   type : double
+                string_field:
+                   type: keyword
+
+  - do:
+       bulk:
+         refresh: true
+         body:
+           - index:
+               _index: test_1
+               _id:    1
+           - unsigned_field: 1
+             double_field: 1.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    2
+           - unsigned_field: 51
+             double_field: 51.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    3
+           - unsigned_field: 1101
+             double_field: 1101.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    4
+           - unsigned_field: 10223372036854778000
+             double_field: 10223372036854778000.0
+             string_field: foo
+
+---
+"Basic test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_unsigned_avg:
+              avg:
+                field: unsigned_field
+            the_double_avg:
+              avg:
+                field: double_field
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.the_unsigned_avg.value: 2555843009213695000.0 }
+  - match: { aggregations.the_double_avg.value: 2555843009213695000.0 }
+
+---
+"Only aggs test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          size: 0
+          aggs:
+            the_unsigned_avg:
+              avg:
+                field: unsigned_field
+            the_double_avg:
+              avg:
+                field: double_field
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 0 }
+  - match: { aggregations.the_unsigned_avg.value: 2555843009213695000.0 }
+  - match: { aggregations.the_double_avg.value: 2555843009213695000.0 }
+
+---
+"Filtered test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query:
+            constant_score:
+              filter:
+                range:
+                  unsigned_field:
+                    gte: 50
+          aggs:
+            the_unsigned_avg:
+              avg:
+                field: unsigned_field
+            the_double_avg:
+              avg:
+                field: double_field
+
+  - match: { hits.total: 3 }
+  - length: { hits.hits: 3 }
+  - match: { aggregations.the_unsigned_avg.value: 3407790678951593500.0 }
+  - match: { aggregations.the_double_avg.value: 3407790678951593500.0 }
+
+
+---
+"Missing field with missing param":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_missing_avg:
+              avg:
+                field: foo
+                missing: 1
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.the_missing_avg.value: 1 }
+
+---
+"Missing field without missing param":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_missing_avg:
+              avg:
+                field: foo
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - is_false: aggregations.the_missing_avg.value
+
+---
+"Metadata test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_unsigned_avg:
+              meta:
+                foo: bar
+              avg:
+                field: unsigned_field
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.the_unsigned_avg.value: 2555843009213695000.0 }
+  - match: { aggregations.the_unsigned_avg.meta.foo: "bar" }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/110_max_metric_unsigned.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/110_max_metric_unsigned.yml
@@ -1,0 +1,168 @@
+setup:
+  - skip:
+      version: " - 2.99.99"
+      reason: unsigned_long is not supported before 3.0.0
+
+  - do:
+      indices.create:
+          index: test_1
+          body:
+            settings:
+              number_of_replicas: 0
+            mappings:
+              properties:
+                unsigned_field:
+                   type : unsigned_long
+                double_field:
+                   type : double
+                string_field:
+                   type: keyword
+
+  - do:
+       bulk:
+         refresh: true
+         body:
+           - index:
+               _index: test_1
+               _id:    1
+           - unsigned_field: 1
+             double_field: 1.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    2
+           - unsigned_field: 51
+             double_field: 51.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    3
+           - unsigned_field: 101
+             double_field: 101.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    4
+           - unsigned_field: 10223372036854778000
+             double_field: 10223372036854778000.0
+             string_field: foo
+
+---
+"Basic test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_unsigned_avg:
+              avg:
+                field: unsigned_field
+            the_double_avg:
+              avg:
+                field: double_field
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.the_unsigned_avg.value: 2555843009213694500.0 }
+  - match: { aggregations.the_double_avg.value: 2555843009213694500.0 }
+
+---
+"Only aggs test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          size: 0
+          aggs:
+            the_unsigned_avg:
+              avg:
+                field: unsigned_field
+            the_double_avg:
+              avg:
+                field: double_field
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 0 }
+  - match: { aggregations.the_unsigned_avg.value: 2555843009213694500.0 }
+  - match: { aggregations.the_double_avg.value: 2555843009213694500.0 }
+
+---
+"Filtered test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query:
+            constant_score:
+              filter:
+                range:
+                  unsigned_field:
+                    gte: 50
+          aggs:
+            the_unsigned_avg:
+              avg:
+                field: unsigned_field
+            the_double_avg:
+              avg:
+                field: double_field
+
+  - match: { hits.total: 3 }
+  - length: { hits.hits: 3 }
+  - match: { aggregations.the_unsigned_avg.value: 3407790678951592400.0 }
+  - match: { aggregations.the_double_avg.value: 3407790678951592400.0 }
+
+
+---
+"Missing field with missing param":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_missing_avg:
+              avg:
+                field: foo
+                missing: 1
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.the_missing_avg.value: 1 }
+
+---
+"Missing field without missing param":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_missing_avg:
+              avg:
+                field: foo
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - is_false: aggregations.the_missing_avg.value
+
+---
+"Metadata test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_unsigned_avg:
+              meta:
+                foo: bar
+              avg:
+                field: unsigned_field
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.the_unsigned_avg.value: 2555843009213694500.0 }
+  - match: { aggregations.the_unsigned_avg.meta.foo: "bar" }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/120_min_metric_unsigned.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/120_min_metric_unsigned.yml
@@ -1,0 +1,168 @@
+setup:
+  - skip:
+      version: " - 2.99.99"
+      reason: unsigned_long is not supported before 3.0.0
+
+  - do:
+      indices.create:
+          index: test_1
+          body:
+            settings:
+              number_of_replicas: 0
+            mappings:
+              properties:
+                unsigned_field:
+                   type : unsigned_long
+                double_field:
+                   type : double
+                string_field:
+                   type: keyword
+
+  - do:
+       bulk:
+         refresh: true
+         body:
+           - index:
+               _index: test_1
+               _id:    1
+           - unsigned_field: 1
+             double_field: 1.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    2
+           - unsigned_field: 51
+             double_field: 51.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    3
+           - unsigned_field: 101
+             double_field: 101.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    4
+           - unsigned_field: 10223372036854778000
+             double_field: 10223372036854778000.0
+             string_field: foo
+
+---
+"Basic test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_unsigned_min:
+              min:
+                field: unsigned_field
+            the_double_min:
+              min:
+                field: double_field
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.the_unsigned_min.value: 1.0 }
+  - match: { aggregations.the_double_min.value: 1.0 }
+
+---
+"Only aggs test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          size: 0
+          aggs:
+            the_unsigned_min:
+              min:
+                field: unsigned_field
+            the_double_min:
+              min:
+                field: double_field
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 0 }
+  - match: { aggregations.the_unsigned_min.value: 1.0 }
+  - match: { aggregations.the_double_min.value: 1.0 }
+
+---
+"Filtered test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query:
+            constant_score:
+              filter:
+                range:
+                  unsigned_field:
+                    gte: 50
+          aggs:
+            the_unsigned_min:
+              min:
+                field: unsigned_field
+            the_double_min:
+              min:
+                field: double_field
+
+  - match: { hits.total: 3 }
+  - length: { hits.hits: 3 }
+  - match: { aggregations.the_unsigned_min.value: 51.0 }
+  - match: { aggregations.the_double_min.value: 51.0 }
+
+
+---
+"Missing field with missing param":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_missing_min:
+              min:
+                field: foo
+                missing: 1
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.the_missing_min.value: 1.0 }
+
+---
+"Missing field without missing param":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_missing_min:
+              min:
+                field: foo
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - is_false: aggregations.the_missing_min.value
+
+---
+"Metadata test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_unsigned_min:
+              meta:
+                foo: bar
+              min:
+                field: unsigned_field
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.the_unsigned_min.value: 1.0 }
+  - match: { aggregations.the_unsigned_min.meta.foo: "bar" }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/130_sum_metric_unsigned.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/130_sum_metric_unsigned.yml
@@ -1,0 +1,168 @@
+setup:
+  - skip:
+      version: " - 2.99.99"
+      reason: unsigned_long is not supported before 3.0.0
+
+  - do:
+      indices.create:
+          index: test_1
+          body:
+            settings:
+              number_of_replicas: 0
+            mappings:
+              properties:
+                unsigned_field:
+                   type : unsigned_long
+                double_field:
+                   type : double
+                string_field:
+                   type: keyword
+
+  - do:
+       bulk:
+         refresh: true
+         body:
+           - index:
+               _index: test_1
+               _id:    1
+           - unsigned_field: 1
+             double_field: 1.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    2
+           - unsigned_field: 51
+             double_field: 51.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    3
+           - unsigned_field: 1101
+             double_field: 1101.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    4
+           - unsigned_field: 10223372036854778000
+             double_field: 10223372036854778000
+             string_field: foo
+
+---
+"Basic test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_unsigned_sum:
+              sum:
+                field: unsigned_field
+            the_double_sum:
+              sum:
+                field: double_field
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.the_unsigned_sum.value: 10223372036854780000.0 }
+  - match: { aggregations.the_double_sum.value: 10223372036854780000.0 }
+
+---
+"Only aggs test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          size: 0
+          aggs:
+            the_unsigned_sum:
+              sum:
+                field: unsigned_field
+            the_double_sum:
+              sum:
+                field: double_field
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 0 }
+  - match: { aggregations.the_unsigned_sum.value: 10223372036854780000.0 }
+  - match: { aggregations.the_double_sum.value: 10223372036854780000.0 }
+
+---
+"Filtered test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query:
+            constant_score:
+              filter:
+                range:
+                  unsigned_field:
+                    gte: 50
+          aggs:
+            the_unsigned_sum:
+              sum:
+                field: unsigned_field
+            the_double_sum:
+              sum:
+                field: double_field
+
+  - match: { hits.total: 3 }
+  - length: { hits.hits: 3 }
+  - match: { aggregations.the_unsigned_sum.value: 10223372036854780000.0 }
+  - match: { aggregations.the_double_sum.value: 10223372036854780000.0 }
+
+
+---
+"Missing field with missing param":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_missing_sum:
+              sum:
+                field: foo
+                missing: 1
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.the_missing_sum.value: 4.0 }
+
+---
+"Missing field without missing param":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_missing_sum:
+              sum:
+                field: foo
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.the_missing_sum.value: 0.0 }
+
+---
+"Metadata test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_unsigned_sum:
+              meta:
+                foo: bar
+              sum:
+                field: unsigned_field
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.the_unsigned_sum.value: 10223372036854780000.0 }
+  - match: { aggregations.the_unsigned_sum.meta.foo: "bar" }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/140_value_count_metric_unsigned.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/140_value_count_metric_unsigned.yml
@@ -1,0 +1,180 @@
+setup:
+  - skip:
+      version: " - 2.99.99"
+      reason: unsigned_long is not supported before 3.0.0
+
+  - do:
+      indices.create:
+          index: test_1
+          body:
+            settings:
+              number_of_replicas: 0
+            mappings:
+              properties:
+                unsigned_field:
+                   type : unsigned_long
+                double_field:
+                   type : double
+                string_field:
+                   type: keyword
+
+  - do:
+       bulk:
+         refresh: true
+         body:
+           - index:
+               _index: test_1
+               _id:    1
+           - unsigned_field: 1
+             double_field: 1.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    2
+           - unsigned_field: 51
+             double_field: 51.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    3
+           - unsigned_field: 101
+             double_field: 101.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    4
+           - unsigned_field: 10223372036854778000
+             double_field: 10223372036854778000.0
+             string_field: foo
+
+---
+"Basic test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_unsigned_value_count:
+              value_count:
+                field: unsigned_field
+            the_double_value_count:
+              value_count:
+                field: double_field
+            the_string_value_count:
+              value_count:
+                field: string_field
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.the_unsigned_value_count.value: 4 }
+  - match: { aggregations.the_double_value_count.value: 4 }
+  - match: { aggregations.the_string_value_count.value: 4 }
+
+---
+"Only aggs test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          size: 0
+          aggs:
+            the_unsigned_value_count:
+              value_count:
+                field: unsigned_field
+            the_double_value_count:
+              value_count:
+                field: double_field
+            the_string_value_count:
+              value_count:
+                field: string_field
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 0 }
+  - match: { aggregations.the_unsigned_value_count.value: 4 }
+  - match: { aggregations.the_double_value_count.value: 4 }
+  - match: { aggregations.the_string_value_count.value: 4 }
+
+---
+"Filtered test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query:
+            constant_score:
+              filter:
+                range:
+                  unsigned_field:
+                    gte: 50
+          aggs:
+            the_unsigned_value_count:
+              value_count:
+                field: unsigned_field
+            the_double_value_count:
+              value_count:
+                field: double_field
+            the_string_value_count:
+              value_count:
+                field: string_field
+
+  - match: { hits.total: 3 }
+  - length: { hits.hits: 3 }
+  - match: { aggregations.the_unsigned_value_count.value: 3 }
+  - match: { aggregations.the_double_value_count.value: 3 }
+  - match: { aggregations.the_string_value_count.value: 3 }
+
+
+---
+"Missing field with missing param":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_missing_value_count:
+              value_count:
+                field: foo
+                missing: 1
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.the_missing_value_count.value: 4 }
+
+---
+"Missing field without missing param":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_missing_value_count:
+              value_count:
+                field: foo
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - is_false: aggregations.the_missing_value_count.value
+
+---
+"Metadata test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_unsigned_value_count:
+              meta:
+                foo: bar
+              value_count:
+                field: unsigned_field
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.the_unsigned_value_count.value: 4 }
+  - match: { aggregations.the_unsigned_value_count.meta.foo: "bar" }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/150_stats_metric_unsigned.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/150_stats_metric_unsigned.yml
@@ -1,0 +1,199 @@
+setup:
+  - skip:
+      version: " - 2.99.99"
+      reason: unsigned_long is not supported before 3.0.0
+
+  - do:
+      indices.create:
+          index: test_1
+          body:
+            settings:
+              number_of_replicas: 0
+            mappings:
+              properties:
+                unsigned_field:
+                   type : unsigned_long
+                double_field:
+                   type : double
+                string_field:
+                   type: keyword
+
+  - do:
+       bulk:
+         refresh: true
+         body:
+           - index:
+               _index: test_1
+               _id:    1
+           - unsigned_field: 1
+             double_field: 1.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    2
+           - unsigned_field: 51
+             double_field: 51.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    3
+           - unsigned_field: 1101
+             double_field: 1101.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    4
+           - unsigned_field: 10223372036854778000
+             double_field: 10223372036854778000.0
+             string_field: foo
+
+---
+"Basic test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_unsigned_stats:
+              stats:
+                field: unsigned_field
+            the_double_stats:
+              stats:
+                field: double_field
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.the_unsigned_stats.count: 4 }
+  - match: { aggregations.the_unsigned_stats.min: 1.0 }
+  - match: { aggregations.the_unsigned_stats.max: 10223372036854778000.0 }
+  - match: { aggregations.the_unsigned_stats.avg: 2555843009213695000.0 }
+  - match: { aggregations.the_unsigned_stats.sum: 10223372036854780000.0 }
+  - match: { aggregations.the_double_stats.count: 4 }
+  - match: { aggregations.the_double_stats.min: 1.0 }
+  - match: { aggregations.the_double_stats.max: 10223372036854778000.0 }
+  - match: { aggregations.the_double_stats.avg: 2555843009213695000.0 }
+  - match: { aggregations.the_double_stats.sum: 10223372036854780000.0 }
+
+---
+"Only aggs test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          size: 0
+          aggs:
+            the_unsigned_stats:
+              stats:
+                field: unsigned_field
+            the_double_stats:
+              stats:
+                field: double_field
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 0 }
+  - match: { aggregations.the_unsigned_stats.count: 4 }
+  - match: { aggregations.the_unsigned_stats.min: 1.0 }
+  - match: { aggregations.the_unsigned_stats.max: 10223372036854778000.0 }
+  - match: { aggregations.the_unsigned_stats.avg: 2555843009213695000.0 }
+  - match: { aggregations.the_unsigned_stats.sum: 10223372036854780000.0 }
+  - match: { aggregations.the_double_stats.count: 4 }
+  - match: { aggregations.the_double_stats.min: 1.0 }
+  - match: { aggregations.the_double_stats.max: 10223372036854778000.0 }
+  - match: { aggregations.the_double_stats.avg: 2555843009213695000.0 }
+  - match: { aggregations.the_double_stats.sum: 10223372036854780000.0 }
+
+---
+"Filtered test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query:
+            constant_score:
+              filter:
+                range:
+                  unsigned_field:
+                    gte: 50
+          aggs:
+            the_unsigned_stats:
+              stats:
+                field: unsigned_field
+            the_double_stats:
+              stats:
+                field: double_field
+
+  - match: { hits.total: 3 }
+  - length: { hits.hits: 3 }
+  - match: { aggregations.the_unsigned_stats.count: 3 }
+  - match: { aggregations.the_unsigned_stats.min: 51.0 }
+  - match: { aggregations.the_unsigned_stats.max: 10223372036854778000.0 }
+  - match: { aggregations.the_unsigned_stats.avg: 3407790678951593500.0 }
+  - match: { aggregations.the_unsigned_stats.sum: 10223372036854780000.0 }
+  - match: { aggregations.the_double_stats.count: 3 }
+  - match: { aggregations.the_double_stats.min: 51.0 }
+  - match: { aggregations.the_double_stats.max: 10223372036854778000.0 }
+  - match: { aggregations.the_double_stats.avg: 3407790678951593500.0 }
+  - match: { aggregations.the_double_stats.sum: 10223372036854780000.0 }
+
+
+---
+"Missing field with missing param":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_missing_stats:
+              stats:
+                field: foo
+                missing: 1
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.the_missing_stats.count: 4 }
+  - match: { aggregations.the_missing_stats.min: 1.0 }
+  - match: { aggregations.the_missing_stats.max: 1.0 }
+  - match: { aggregations.the_missing_stats.avg: 1.0 }
+  - match: { aggregations.the_missing_stats.sum: 4.0 }
+
+---
+"Missing field without missing param":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_missing_stats:
+              stats:
+                field: foo
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - is_false: aggregations.the_missing_stats.value
+
+---
+"Metadata test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_unsigned_stats:
+              meta:
+                foo: bar
+              stats:
+                field: unsigned_field
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.the_unsigned_stats.count: 4 }
+  - match: { aggregations.the_unsigned_stats.min: 1.0 }
+  - match: { aggregations.the_unsigned_stats.max: 10223372036854778000.0 }
+  - match: { aggregations.the_unsigned_stats.avg: 2555843009213695000.0 }
+  - match: { aggregations.the_unsigned_stats.sum: 10223372036854780000.0 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/160_extended_stats_metric_unsigned.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/160_extended_stats_metric_unsigned.yml
@@ -1,0 +1,276 @@
+setup:
+  - skip:
+      version: " - 2.99.99"
+      reason: unsigned_long is not supported before 3.0.0
+
+  - do:
+      indices.create:
+          index: test_1
+          body:
+            settings:
+              number_of_replicas: 0
+            mappings:
+              properties:
+                unsigned_field:
+                   type : unsigned_long
+                double_field:
+                   type : double
+                string_field:
+                   type: keyword
+
+  - do:
+       bulk:
+         refresh: true
+         body:
+           - index:
+               _index: test_1
+               _id:    1
+           - unsigned_field: 1
+             double_field: 1.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    2
+           - unsigned_field: 51
+             double_field: 51.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    3
+           - unsigned_field: 10223372036854778000
+             double_field: 10223372036854778000.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    4
+           - unsigned_field: 1101
+             double_field: 1101.0
+             string_field: foo
+
+---
+"Basic test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_unsigned_extended_stats:
+              extended_stats:
+                field: unsigned_field
+            the_double_extended_stats:
+              extended_stats:
+                field: double_field
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.the_unsigned_extended_stats.count: 4 }
+  - match: { aggregations.the_unsigned_extended_stats.min: 1.0 }
+  - match: { aggregations.the_unsigned_extended_stats.max: 10223372036854778000.0 }
+  - match: { aggregations.the_unsigned_extended_stats.avg: 2555843009213695000.0 }
+  - match: { aggregations.the_unsigned_extended_stats.sum: 10223372036854780000.0 }
+  - match: { aggregations.the_unsigned_extended_stats.sum_of_squares: 104517335803944210000000000000000000000.0 }
+  - match: { aggregations.the_unsigned_extended_stats.std_deviation:  4426849948127849000.0 }
+  - match: { aggregations.the_unsigned_extended_stats.std_deviation_bounds.upper: 11409542905469393000.0 }
+  - match: { aggregations.the_unsigned_extended_stats.std_deviation_bounds.lower: -6297856887042003000.0 }
+  - match: { aggregations.the_double_extended_stats.count: 4 }
+  - match: { aggregations.the_double_extended_stats.min: 1.0 }
+  - match: { aggregations.the_double_extended_stats.max: 10223372036854778000.0 }
+  - match: { aggregations.the_double_extended_stats.avg: 2555843009213695000.0 }
+  - match: { aggregations.the_double_extended_stats.sum: 10223372036854780000.0 }
+  - match: { aggregations.the_double_extended_stats.sum_of_squares: 104517335803944210000000000000000000000.0 }
+  - match: { aggregations.the_double_extended_stats.std_deviation: 4426849948127849000.0 }
+  - match: { aggregations.the_double_extended_stats.std_deviation_bounds.upper: 11409542905469393000.0 }
+  - match: { aggregations.the_double_extended_stats.std_deviation_bounds.lower: -6297856887042003000.0 }
+
+---
+"Only aggs test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          size: 0
+          aggs:
+            the_unsigned_extended_stats:
+              extended_stats:
+                field: unsigned_field
+            the_double_extended_stats:
+              extended_stats:
+                field: double_field
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 0 }
+  - match: { aggregations.the_unsigned_extended_stats.count: 4 }
+  - match: { aggregations.the_unsigned_extended_stats.min: 1.0 }
+  - match: { aggregations.the_unsigned_extended_stats.max: 10223372036854778000.0 }
+  - match: { aggregations.the_unsigned_extended_stats.avg: 2555843009213695000.0 }
+  - match: { aggregations.the_unsigned_extended_stats.sum: 10223372036854780000.0 }
+  - match: { aggregations.the_unsigned_extended_stats.sum_of_squares: 104517335803944210000000000000000000000.0 }
+  - match: { aggregations.the_unsigned_extended_stats.std_deviation: 4426849948127849000.0 }
+  - match: { aggregations.the_unsigned_extended_stats.variance: 19597000463239538000000000000000000000.0 }
+  - match: { aggregations.the_unsigned_extended_stats.std_deviation_bounds.upper: 11409542905469393000.0 }
+  - match: { aggregations.the_unsigned_extended_stats.std_deviation_bounds.lower: -6297856887042003000.0 }
+  - match: { aggregations.the_double_extended_stats.count: 4 }
+  - match: { aggregations.the_double_extended_stats.min: 1.0 }
+  - match: { aggregations.the_double_extended_stats.max: 10223372036854778000.0 }
+  - match: { aggregations.the_double_extended_stats.avg: 2555843009213695000.0 }
+  - match: { aggregations.the_double_extended_stats.sum: 10223372036854780000.0 }
+  - match: { aggregations.the_double_extended_stats.sum_of_squares: 104517335803944210000000000000000000000.0 }
+  - match: { aggregations.the_double_extended_stats.std_deviation: 4426849948127849000.0 }
+  - match: { aggregations.the_double_extended_stats.variance: 19597000463239538000000000000000000000.0 }
+  - match: { aggregations.the_double_extended_stats.std_deviation_bounds.upper: 11409542905469393000.0 }
+  - match: { aggregations.the_double_extended_stats.std_deviation_bounds.lower: -6297856887042003000.0 }
+
+---
+"Filtered test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query:
+            constant_score:
+              filter:
+                range:
+                  unsigned_field:
+                    gte: 50
+          aggs:
+            the_unsigned_extended_stats:
+              extended_stats:
+                field: unsigned_field
+            the_double_extended_stats:
+              extended_stats:
+                field: double_field
+
+  - match: { hits.total: 3 }
+  - length: { hits.hits: 3 }
+  - match: { aggregations.the_unsigned_extended_stats.count: 3 }
+  - match: { aggregations.the_unsigned_extended_stats.min: 51.0 }
+  - match: { aggregations.the_unsigned_extended_stats.max: 10223372036854778000.0 }
+  - match: { aggregations.the_unsigned_extended_stats.avg: 3407790678951593500.0 }
+  - match: { aggregations.the_unsigned_extended_stats.sum: 10223372036854780000.0 }
+  - match: { aggregations.the_unsigned_extended_stats.sum_of_squares: 104517335803944210000000000000000000000.0 }
+  - match: { aggregations.the_unsigned_extended_stats.variance: 23226074623098710000000000000000000000.0 }
+  - match: { aggregations.the_unsigned_extended_stats.std_deviation: 4819343795901959000.0 }
+  - match: { aggregations.the_unsigned_extended_stats.std_deviation_bounds.upper: 13046478270755512000.0 }
+  - match: { aggregations.the_unsigned_extended_stats.std_deviation_bounds.lower: -6230896912852324000.0 }
+  - match: { aggregations.the_double_extended_stats.count: 3 }
+  - match: { aggregations.the_double_extended_stats.min: 51.0 }
+  - match: { aggregations.the_double_extended_stats.max: 10223372036854778000.0 }
+  - match: { aggregations.the_double_extended_stats.avg: 3407790678951593500.0 }
+  - match: { aggregations.the_double_extended_stats.sum: 10223372036854780000.0 }
+  - match: { aggregations.the_double_extended_stats.sum_of_squares: 104517335803944210000000000000000000000.0 }
+  - match: { aggregations.the_double_extended_stats.variance: 23226074623098710000000000000000000000.0 }
+  - match: { aggregations.the_double_extended_stats.std_deviation: 4819343795901959000.0 }
+  - match: { aggregations.the_double_extended_stats.std_deviation_bounds.upper: 13046478270755512000.0 }
+  - match: { aggregations.the_double_extended_stats.std_deviation_bounds.lower: -6230896912852324000.0 }
+
+
+---
+"Missing field with missing param":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_missing_extended_stats:
+              extended_stats:
+                field: foo
+                missing: 1
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.the_missing_extended_stats.count: 4 }
+  - match: { aggregations.the_missing_extended_stats.min: 1.0 }
+  - match: { aggregations.the_missing_extended_stats.max: 1.0 }
+  - match: { aggregations.the_missing_extended_stats.avg: 1.0 }
+  - match: { aggregations.the_missing_extended_stats.sum: 4.0 }
+  - match: { aggregations.the_missing_extended_stats.sum_of_squares: 4.0 }
+  - match: { aggregations.the_missing_extended_stats.variance: 0.0 }
+  - match: { aggregations.the_missing_extended_stats.std_deviation: 0.0 }
+  - match: { aggregations.the_missing_extended_stats.std_deviation_bounds.upper: 1.0 }
+  - match: { aggregations.the_missing_extended_stats.std_deviation_bounds.lower: 1.0 }
+
+---
+"Missing field without missing param":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_missing_extended_stats:
+              extended_stats:
+                field: foo
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - is_false: aggregations.the_missing_extended_stats.value
+
+---
+"Metadata test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_unsigned_extended_stats:
+              meta:
+                foo: bar
+              extended_stats:
+                field: unsigned_field
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.the_unsigned_extended_stats.count: 4 }
+  - match: { aggregations.the_unsigned_extended_stats.min: 1.0 }
+  - match: { aggregations.the_unsigned_extended_stats.max: 10223372036854778000.0 }
+  - match: { aggregations.the_unsigned_extended_stats.avg: 2555843009213695000.0 }
+  - match: { aggregations.the_unsigned_extended_stats.sum: 10223372036854780000.0 }
+  - match: { aggregations.the_unsigned_extended_stats.sum_of_squares: 104517335803944210000000000000000000000.0 }
+  - match: { aggregations.the_unsigned_extended_stats.std_deviation: 4426849948127849000.0 }
+  - match: { aggregations.the_unsigned_extended_stats.std_deviation_bounds.upper: 11409542905469393000.0 }
+  - match: { aggregations.the_unsigned_extended_stats.std_deviation_bounds.lower: -6297856887042003000.0 }
+
+---
+"Sigma test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_unsigned_extended_stats:
+              extended_stats:
+                field: unsigned_field
+                sigma: 3
+            the_double_extended_stats:
+              extended_stats:
+                field: double_field
+                sigma: 3
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.the_unsigned_extended_stats.count: 4 }
+  - match: { aggregations.the_unsigned_extended_stats.min: 1.0 }
+  - match: { aggregations.the_unsigned_extended_stats.max: 10223372036854778000.0 }
+  - match: { aggregations.the_unsigned_extended_stats.avg: 2555843009213695000.0 }
+  - match: { aggregations.the_unsigned_extended_stats.sum: 10223372036854780000.0 }
+  - match: { aggregations.the_unsigned_extended_stats.sum_of_squares: 104517335803944210000000000000000000000.0 }
+  - match: { aggregations.the_unsigned_extended_stats.variance: 19597000463239537000000000000000000000.0 }
+  - match: { aggregations.the_unsigned_extended_stats.std_deviation: 4426849948127849000.0 }
+  - match: { aggregations.the_unsigned_extended_stats.std_deviation_bounds.upper: 15836392853597241000.0 }
+  - match: { aggregations.the_unsigned_extended_stats.std_deviation_bounds.lower: -10724706835169853000.0 }
+  - match: { aggregations.the_double_extended_stats.count: 4 }
+  - match: { aggregations.the_double_extended_stats.min: 1.0 }
+  - match: { aggregations.the_double_extended_stats.max: 10223372036854778000.0 }
+  - match: { aggregations.the_double_extended_stats.avg: 2555843009213695000.0 }
+  - match: { aggregations.the_double_extended_stats.sum: 10223372036854780000.0 }
+  - match: { aggregations.the_double_extended_stats.sum_of_squares: 104517335803944210000000000000000000000.0 }
+  - match: { aggregations.the_double_extended_stats.variance: 19597000463239537000000000000000000000.0 }
+  - match: { aggregations.the_double_extended_stats.std_deviation: 4426849948127849000.0 }
+  - match: { aggregations.the_double_extended_stats.std_deviation_bounds.upper: 15836392853597241000.0 }
+  - match: { aggregations.the_double_extended_stats.std_deviation_bounds.lower: -10724706835169853000.0 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/170_cardinality_metric_unsigned.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/170_cardinality_metric_unsigned.yml
@@ -1,0 +1,287 @@
+setup:
+  - skip:
+      version: " - 2.99.99"
+      reason: unsigned_long is not supported before 3.0.0
+
+  - do:
+      indices.create:
+          index: test_1
+          body:
+            settings:
+              number_of_replicas: 0
+            mappings:
+              properties:
+                unsigned_field:
+                   type : unsigned_long
+                double_field:
+                   type : double
+                string_field:
+                   type: keyword
+
+  - do:
+       bulk:
+         refresh: true
+         body:
+           - index:
+               _index: test_1
+               _id:    1
+           - unsigned_field: 1
+             double_field: 1.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    2
+           - unsigned_field: 51
+             double_field: 51.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    3
+           - unsigned_field: 1101
+             double_field: 1101.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    4
+           - unsigned_field: 10223372036854778000
+             double_field: 10223372036854778000.0
+             string_field: foo
+
+---
+"Basic test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            distinct_unsigned:
+              cardinality:
+                field: unsigned_field
+            distinct_double:
+              cardinality:
+                field: double_field
+            distinct_string:
+              cardinality:
+                field: string_field
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.distinct_unsigned.value: 4 }
+  - match: { aggregations.distinct_double.value: 4 }
+  - match: { aggregations.distinct_string.value: 1 }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            distinct_unsigned:
+              cardinality:
+                field: unsigned_field
+                precision_threshold: 100
+            distinct_double:
+              cardinality:
+                field: double_field
+                precision_threshold: 100
+            distinct_string:
+              cardinality:
+                field: string_field
+                precision_threshold: 100
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.distinct_unsigned.value: 4 }
+  - match: { aggregations.distinct_double.value: 4 }
+  - match: { aggregations.distinct_string.value: 1 }
+
+---
+"Only aggs test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          size: 0
+          aggs:
+            distinct_unsigned:
+              cardinality:
+                field: unsigned_field
+            distinct_double:
+              cardinality:
+                field: double_field
+            distinct_string:
+              cardinality:
+                field: string_field
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 0 }
+  - match: { aggregations.distinct_unsigned.value: 4 }
+  - match: { aggregations.distinct_double.value: 4 }
+  - match: { aggregations.distinct_string.value: 1 }
+
+---
+"Filtered test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query:
+            constant_score:
+              filter:
+                range:
+                  unsigned_field:
+                    gte: 50
+          aggs:
+            distinct_unsigned:
+              cardinality:
+                field: unsigned_field
+            distinct_double:
+              cardinality:
+                field: double_field
+            distinct_string:
+              cardinality:
+                field: string_field
+
+  - match: { hits.total: 3 }
+  - length: { hits.hits: 3 }
+  - match: { aggregations.distinct_unsigned.value: 3 }
+  - match: { aggregations.distinct_double.value: 3 }
+  - match: { aggregations.distinct_string.value: 1 }
+
+
+---
+"Missing field with missing param":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            distinct_missing:
+              cardinality:
+                field: missing_field
+                missing: "foo"
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.distinct_missing.value: 1 }
+
+---
+"Missing field without missing param":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            distinct_missing:
+              cardinality:
+                field: missing_field
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - is_false: aggregations.distinct_missing.value
+
+---
+"Metadata test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            distinct_missing:
+              meta:
+                foo: bar
+              cardinality:
+                field: unsigned_field
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.distinct_missing.value: 4 }
+  - match: { aggregations.distinct_missing.meta.foo: "bar" }
+
+---
+"Invalid Precision test":
+
+  - do:
+      catch: /\[precisionThreshold\] must be greater than or equal to 0. Found \[-1\] in \[distinct_unsigned\]/
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            distinct_unsigned:
+              cardinality:
+                field: unsigned_field
+                precision_threshold: -1
+
+---
+"profiler unsigned_long":
+  - do:
+      search:
+        body:
+          profile: true
+          size: 0
+          aggs:
+            distinct_unsigned:
+              cardinality:
+                field: unsigned_field
+  - match: { aggregations.distinct_unsigned.value: 4 }
+  - gt: { profile.shards.0.aggregations.0.breakdown.initialize: 0 }
+  - gt: { profile.shards.0.aggregations.0.breakdown.build_leaf_collector: 0 }
+  - gt: { profile.shards.0.aggregations.0.breakdown.collect: 0 }
+  - gt: { profile.shards.0.aggregations.0.breakdown.build_aggregation: 0 }
+  - gt: { profile.shards.0.aggregations.0.breakdown.post_collection: 0 }
+  - match: { profile.shards.0.aggregations.0.debug.empty_collectors_used: 0 }
+  - gt: { profile.shards.0.aggregations.0.debug.numeric_collectors_used: 0 }
+  - match: { profile.shards.0.aggregations.0.debug.ordinals_collectors_used: 0 }
+  - match: { profile.shards.0.aggregations.0.debug.ordinals_collectors_overhead_too_high: 0 }
+  - match: { profile.shards.0.aggregations.0.debug.string_hashing_collectors_used: 0 }
+
+---
+"profiler double":
+  - do:
+      search:
+        body:
+          profile: true
+          size: 0
+          aggs:
+            distinct_double:
+              cardinality:
+                field: double_field
+  - match: { aggregations.distinct_double.value: 4 }
+  - gt: { profile.shards.0.aggregations.0.breakdown.initialize: 0 }
+  - gt: { profile.shards.0.aggregations.0.breakdown.build_leaf_collector: 0 }
+  - gt: { profile.shards.0.aggregations.0.breakdown.collect: 0 }
+  - gt: { profile.shards.0.aggregations.0.breakdown.build_aggregation: 0 }
+  - gt: { profile.shards.0.aggregations.0.breakdown.post_collection: 0 }
+  - match: { profile.shards.0.aggregations.0.debug.empty_collectors_used: 0 }
+  - gt: { profile.shards.0.aggregations.0.debug.numeric_collectors_used: 0 }
+  - match: { profile.shards.0.aggregations.0.debug.ordinals_collectors_used: 0 }
+  - match: { profile.shards.0.aggregations.0.debug.ordinals_collectors_overhead_too_high: 0 }
+  - match: { profile.shards.0.aggregations.0.debug.string_hashing_collectors_used: 0 }
+
+---
+"profiler string":
+  - do:
+      search:
+        body:
+          profile: true
+          size: 0
+          aggs:
+            distinct_string:
+              cardinality:
+                field: string_field
+  - match: { aggregations.distinct_string.value: 1 }
+  - gt: { profile.shards.0.aggregations.0.breakdown.initialize: 0 }
+  - gt: { profile.shards.0.aggregations.0.breakdown.build_leaf_collector: 0 }
+  - gt: { profile.shards.0.aggregations.0.breakdown.collect: 0 }
+  - gt: { profile.shards.0.aggregations.0.breakdown.build_aggregation: 0 }
+  - gt: { profile.shards.0.aggregations.0.breakdown.post_collection: 0 }
+  - match: { profile.shards.0.aggregations.0.debug.empty_collectors_used: 0 }
+  - match: { profile.shards.0.aggregations.0.debug.numeric_collectors_used: 0 }
+  - gt: { profile.shards.0.aggregations.0.debug.ordinals_collectors_used: 0 }
+  - match: { profile.shards.0.aggregations.0.debug.ordinals_collectors_overhead_too_high: 0 }
+  - match: { profile.shards.0.aggregations.0.debug.string_hashing_collectors_used: 0 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/180_percentiles_tdigest_metric_unsigned.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/180_percentiles_tdigest_metric_unsigned.yml
@@ -1,0 +1,276 @@
+setup:
+  - skip:
+      version: " - 2.99.99"
+      reason: unsigned_long is not supported before 3.0.0
+
+  - do:
+      indices.create:
+          index: test_1
+          body:
+            settings:
+              number_of_replicas: 0
+            mappings:
+              properties:
+                unsigned_field:
+                   type : unsigned_long
+                double_field:
+                   type : double
+                string_field:
+                   type: keyword
+
+  - do:
+       bulk:
+         refresh: true
+         body:
+           - index:
+               _index: test_1
+               _id:    1
+           - unsigned_field: 1
+             double_field: 1.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    2
+           - unsigned_field: 51
+             double_field: 51.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    3
+           - unsigned_field: 1101
+             double_field: 1101.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    4
+           - unsigned_field: 10223372036854778000
+             double_field: 10223372036854778000.0
+             string_field: foo
+
+---
+"Basic test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            percentiles_unsigned:
+              percentiles:
+                field: unsigned_field
+            percentiles_double:
+              percentiles:
+                field: double_field
+
+  - match:  { hits.total: 4 }
+  - length: { hits.hits: 4 }
+
+  - match:  { aggregations.percentiles_unsigned.values.1\.0: 1.0 }
+  - match:  { aggregations.percentiles_unsigned.values.5\.0: 1.0 }
+  - match:  { aggregations.percentiles_unsigned.values.25\.0: 51.0 }
+  - match:  { aggregations.percentiles_unsigned.values.50\.0: 1101.0 }
+  - match:  { aggregations.percentiles_unsigned.values.75\.0: 10223372036854778000.0 }
+  - match:  { aggregations.percentiles_unsigned.values.95\.0: 10223372036854778000.0 }
+  - match:  { aggregations.percentiles_unsigned.values.99\.0: 10223372036854778000.0 }
+
+  - match:  { aggregations.percentiles_double.values.1\.0: 1.0 }
+  - match:  { aggregations.percentiles_double.values.5\.0: 1.0 }
+  - match:  { aggregations.percentiles_double.values.25\.0: 51.0 }
+  - match:  { aggregations.percentiles_double.values.50\.0: 1101.0 }
+  - match:  { aggregations.percentiles_double.values.75\.0: 10223372036854778000.0 }
+  - match:  { aggregations.percentiles_double.values.95\.0: 10223372036854778000.0 }
+  - match:  { aggregations.percentiles_double.values.99\.0: 10223372036854778000.0 }
+
+---
+"Compression test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            percentiles_unsigned:
+              percentiles:
+                field: unsigned_field
+                tdigest:
+                  compression: 200
+            percentiles_double:
+              percentiles:
+                field: double_field
+                tdigest:
+                  compression: 200
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+
+  - match:  { aggregations.percentiles_unsigned.values.1\.0: 1.0 }
+  - match:  { aggregations.percentiles_unsigned.values.5\.0: 1.0 }
+  - match:  { aggregations.percentiles_unsigned.values.25\.0: 51.0 }
+  - match:  { aggregations.percentiles_unsigned.values.50\.0: 1101.0 }
+  - match:  { aggregations.percentiles_unsigned.values.75\.0: 10223372036854778000.0 }
+  - match:  { aggregations.percentiles_unsigned.values.95\.0: 10223372036854778000.0 }
+  - match:  { aggregations.percentiles_unsigned.values.99\.0: 10223372036854778000.0 }
+
+  - match:  { aggregations.percentiles_double.values.1\.0: 1.0 }
+  - match:  { aggregations.percentiles_double.values.5\.0: 1.0 }
+  - match:  { aggregations.percentiles_double.values.25\.0: 51.0 }
+  - match:  { aggregations.percentiles_double.values.50\.0: 1101.0 }
+  - match:  { aggregations.percentiles_double.values.75\.0: 10223372036854778000.0 }
+  - match:  { aggregations.percentiles_double.values.95\.0: 10223372036854778000.0 }
+  - match:  { aggregations.percentiles_double.values.99\.0: 10223372036854778000.0 }
+
+---
+"Only aggs test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          size: 0
+          aggs:
+            percentiles_unsigned:
+              percentiles:
+                field: unsigned_field
+            percentiles_double:
+              percentiles:
+                field: double_field
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 0 }
+
+  - match:  { aggregations.percentiles_unsigned.values.1\.0: 1.0 }
+  - match:  { aggregations.percentiles_unsigned.values.5\.0: 1.0 }
+  - match:  { aggregations.percentiles_unsigned.values.25\.0: 51.0 }
+  - match:  { aggregations.percentiles_unsigned.values.50\.0: 1101.0 }
+  - match:  { aggregations.percentiles_unsigned.values.75\.0: 10223372036854778000.0 }
+  - match:  { aggregations.percentiles_unsigned.values.95\.0: 10223372036854778000.0 }
+  - match:  { aggregations.percentiles_unsigned.values.99\.0: 10223372036854778000.0 }
+
+  - match:  { aggregations.percentiles_double.values.1\.0: 1.0 }
+  - match:  { aggregations.percentiles_double.values.5\.0: 1.0 }
+  - match:  { aggregations.percentiles_double.values.25\.0: 51.0 }
+  - match:  { aggregations.percentiles_double.values.50\.0: 1101.0 }
+  - match:  { aggregations.percentiles_double.values.75\.0: 10223372036854778000.0 }
+  - match:  { aggregations.percentiles_double.values.95\.0: 10223372036854778000.0 }
+  - match:  { aggregations.percentiles_double.values.99\.0: 10223372036854778000.0 }
+
+---
+"Filtered test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query:
+            constant_score:
+              filter:
+                range:
+                  unsigned_field:
+                    gte: 50
+          aggs:
+            percentiles_unsigned:
+              percentiles:
+                field: unsigned_field
+            percentiles_double:
+              percentiles:
+                field: double_field
+
+  - match: { hits.total: 3 }
+  - length: { hits.hits: 3 }
+
+  - match:  { aggregations.percentiles_unsigned.values.1\.0: 51.0 }
+  - match:  { aggregations.percentiles_unsigned.values.5\.0: 51.0 }
+  - match:  { aggregations.percentiles_unsigned.values.25\.0: 51.0 }
+  - match:  { aggregations.percentiles_unsigned.values.50\.0: 1101.0 }
+  - match:  { aggregations.percentiles_unsigned.values.75\.0: 10223372036854778000.0 }
+  - match:  { aggregations.percentiles_unsigned.values.95\.0: 10223372036854778000.0 }
+  - match:  { aggregations.percentiles_unsigned.values.99\.0: 10223372036854778000.0 }
+
+  - match:  { aggregations.percentiles_double.values.1\.0: 51.0 }
+  - match:  { aggregations.percentiles_double.values.5\.0: 51.0 }
+  - match:  { aggregations.percentiles_double.values.25\.0: 51.0 }
+  - match:  { aggregations.percentiles_double.values.50\.0: 1101.0 }
+  - match:  { aggregations.percentiles_double.values.75\.0: 10223372036854778000.0 }
+  - match:  { aggregations.percentiles_double.values.95\.0: 10223372036854778000.0 }
+  - match:  { aggregations.percentiles_double.values.99\.0: 10223372036854778000.0 }
+
+---
+"Metadata test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            percentiles_unsigned:
+              meta:
+                foo: bar
+              percentiles:
+                field: unsigned_field
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.percentiles_unsigned.meta.foo: "bar" }
+
+
+  - match:  { aggregations.percentiles_unsigned.values.1\.0: 1.0 }
+  - match:  { aggregations.percentiles_unsigned.values.5\.0: 1.0 }
+  - match:  { aggregations.percentiles_unsigned.values.25\.0: 51.0 }
+  - match:  { aggregations.percentiles_unsigned.values.50\.0: 1101.0 }
+  - match:  { aggregations.percentiles_unsigned.values.75\.0: 10223372036854778000.0 }
+  - match:  { aggregations.percentiles_unsigned.values.95\.0: 10223372036854778000.0 }
+  - match:  { aggregations.percentiles_unsigned.values.99\.0: 10223372036854778000.0 }
+
+---
+"Explicit Percents test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            percentiles_unsigned:
+              percentiles:
+                field: unsigned_field
+                percents: [5.0, 25.0, 50.0]
+            percentiles_double:
+              percentiles:
+                field: double_field
+                percents: [5.0, 25.0, 50.0]
+
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+
+  - match: { aggregations.percentiles_unsigned.values.5\.0: 1.0 }
+  - match: { aggregations.percentiles_unsigned.values.25\.0: 51.0 }
+  - match: { aggregations.percentiles_unsigned.values.50\.0: 1101.0 }
+
+  - match: { aggregations.percentiles_double.values.5\.0: 1.0 }
+  - match: { aggregations.percentiles_double.values.25\.0: 51.0 }
+  - match: { aggregations.percentiles_double.values.50\.0: 1101.0 }
+
+---
+"Non-keyed test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            percentiles_unsigned:
+              percentiles:
+                field: unsigned_field
+                percents: [5.0, 25.0, 50.0]
+                keyed: false
+
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+
+  - match:  { aggregations.percentiles_unsigned.values.0.key:  5.0 }
+  - match:  { aggregations.percentiles_unsigned.values.0.value:  1.0 }
+  - match:  { aggregations.percentiles_unsigned.values.1.key:  25.0 }
+  - match:  { aggregations.percentiles_unsigned.values.1.value:  51.0 }
+  - match:  { aggregations.percentiles_unsigned.values.2.key:  50.0 }
+  - match:  { aggregations.percentiles_unsigned.values.2.value:  1101.0 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/190_percentiles_hdr_metric_unsigned.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/190_percentiles_hdr_metric_unsigned.yml
@@ -1,0 +1,344 @@
+setup:
+  - skip:
+      version: " - 2.99.99"
+      reason: unsigned_long is not supported before 3.0.0
+
+  - do:
+      indices.create:
+          index: test_1
+          body:
+            settings:
+              number_of_replicas: 0
+              number_of_shards: 5
+              number_of_routing_shards: 5
+            mappings:
+              properties:
+                unsigned_field:
+                   type : unsigned_long
+                double_field:
+                   type : double
+                string_field:
+                   type: keyword
+
+  - do:
+       bulk:
+         refresh: true
+         body:
+           - index:
+               _index: test_1
+               _id:    1
+           - unsigned_field: 1
+             double_field: 1.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    2
+           - unsigned_field: 51
+             double_field: 51.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    3
+           - unsigned_field: 1101
+             double_field: 1101.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    4
+           - unsigned_field: 1425497558138880
+             double_field: 1425497558138880.0
+             string_field: foo
+
+---
+"Basic test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            percentiles_unsigned:
+              percentiles:
+                field: unsigned_field
+                hdr: {}
+            percentiles_double:
+              percentiles:
+                field: double_field
+                hdr: {}
+
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+
+  - match: { aggregations.percentiles_unsigned.values.1\.0: 1.0 }
+  - match: { aggregations.percentiles_unsigned.values.5\.0: 1.0 }
+  - match: { aggregations.percentiles_unsigned.values.25\.0: 1.0 }
+  - match: { aggregations.percentiles_unsigned.values.50\.0: 51.0302734375 }
+  - match: { aggregations.percentiles_unsigned.values.75\.0: 1101.9990234375 }
+  - match: { aggregations.percentiles_unsigned.values.95\.0: 1426066581225472 }
+  - match: { aggregations.percentiles_unsigned.values.99\.0: 1426066581225472 }
+
+  - match: { aggregations.percentiles_double.values.1\.0: 1.0 }
+  - match: { aggregations.percentiles_double.values.5\.0: 1.0 }
+  - match: { aggregations.percentiles_double.values.25\.0: 1.0 }
+  - match: { aggregations.percentiles_double.values.50\.0: 51.0302734375 }
+  - match: { aggregations.percentiles_double.values.75\.0: 1101.9990234375 }
+  - match: { aggregations.percentiles_double.values.95\.0: 1426066581225472 }
+  - match: { aggregations.percentiles_double.values.99\.0: 1426066581225472 }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            percentiles_unsigned:
+              percentiles:
+                field: unsigned_field
+                hdr:
+                  number_of_significant_value_digits: 3
+            percentiles_double:
+              percentiles:
+                field: double_field
+                hdr:
+                  number_of_significant_value_digits: 3
+
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+
+  - match: { aggregations.percentiles_unsigned.values.1\.0: 1.0 }
+  - match: { aggregations.percentiles_unsigned.values.5\.0: 1.0 }
+  - match: { aggregations.percentiles_unsigned.values.25\.0: 1.0 }
+  - match: { aggregations.percentiles_unsigned.values.50\.0: 51.0302734375 }
+  - match: { aggregations.percentiles_unsigned.values.75\.0: 1101.9990234375 }
+  - match: { aggregations.percentiles_unsigned.values.95\.0: 1426066581225472 }
+  - match: { aggregations.percentiles_unsigned.values.99\.0: 1426066581225472 }
+
+  - match: { aggregations.percentiles_double.values.1\.0: 1.0 }
+  - match: { aggregations.percentiles_double.values.5\.0: 1.0 }
+  - match: { aggregations.percentiles_double.values.25\.0: 1.0 }
+  - match: { aggregations.percentiles_double.values.50\.0: 51.0302734375 }
+  - match: { aggregations.percentiles_double.values.75\.0: 1101.9990234375 }
+  - match: { aggregations.percentiles_double.values.95\.0: 1426066581225472 }
+  - match: { aggregations.percentiles_double.values.99\.0: 1426066581225472 }
+
+
+---
+"Only aggs test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          size: 0
+          aggs:
+            percentiles_unsigned:
+              percentiles:
+                field: unsigned_field
+                hdr: {}
+            percentiles_double:
+              percentiles:
+                field: double_field
+                hdr: {}
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 0 }
+
+  - match: { aggregations.percentiles_unsigned.values.1\.0: 1.0 }
+  - match: { aggregations.percentiles_unsigned.values.5\.0: 1.0 }
+  - match: { aggregations.percentiles_unsigned.values.25\.0: 1.0 }
+  - match: { aggregations.percentiles_unsigned.values.50\.0: 51.0302734375 }
+  - match: { aggregations.percentiles_unsigned.values.75\.0: 1101.9990234375 }
+  - match: { aggregations.percentiles_unsigned.values.95\.0: 1426066581225472 }
+  - match: { aggregations.percentiles_unsigned.values.99\.0: 1426066581225472 }
+
+  - match: { aggregations.percentiles_double.values.1\.0: 1.0 }
+  - match: { aggregations.percentiles_double.values.5\.0: 1.0 }
+  - match: { aggregations.percentiles_double.values.25\.0: 1.0 }
+  - match: { aggregations.percentiles_double.values.50\.0: 51.0302734375 }
+  - match: { aggregations.percentiles_double.values.75\.0: 1101.9990234375 }
+  - match: { aggregations.percentiles_double.values.95\.0: 1426066581225472 }
+  - match: { aggregations.percentiles_double.values.99\.0: 1426066581225472 }
+
+
+---
+"Filtered test":
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - index:
+              _index: test_1
+              _id:    5
+          - unsigned_field: 126
+            double_field: 126.0
+            string_field: foo
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query:
+            constant_score:
+              filter:
+                range:
+                  unsigned_field:
+                    gte: 50
+          aggs:
+            percentiles_unsigned:
+              percentiles:
+                field: unsigned_field
+                hdr: {}
+            percentiles_double:
+              percentiles:
+                field: double_field
+                hdr: {}
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+
+  - match: { aggregations.percentiles_unsigned.values.1\.0: 51.0 }
+  - match: { aggregations.percentiles_unsigned.values.5\.0: 51.0 }
+  - match: { aggregations.percentiles_unsigned.values.25\.0: 51.0 }
+  - match: { aggregations.percentiles_unsigned.values.50\.0: 126.03125 }
+  - match: { aggregations.percentiles_unsigned.values.75\.0: 1101.96875 }
+  - match: { aggregations.percentiles_unsigned.values.95\.0: 1426066581225472 }
+  - match: { aggregations.percentiles_unsigned.values.99\.0: 1426066581225472 }
+
+  - match: { aggregations.percentiles_double.values.1\.0: 51.0 }
+  - match: { aggregations.percentiles_double.values.5\.0: 51.0 }
+  - match: { aggregations.percentiles_double.values.25\.0: 51.0 }
+  - match: { aggregations.percentiles_double.values.50\.0: 126.03125 }
+  - match: { aggregations.percentiles_double.values.75\.0: 1101.96875 }
+  - match: { aggregations.percentiles_double.values.95\.0: 1426066581225472 }
+  - match: { aggregations.percentiles_double.values.99\.0: 1426066581225472 }
+
+
+---
+"Missing field with missing param":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            percentiles_missing:
+              percentiles:
+                field: missing_field
+                missing: 1.0
+                hdr: {}
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+
+  - match: { aggregations.percentiles_missing.values.1\.0: 1.0 }
+  - match: { aggregations.percentiles_missing.values.5\.0: 1.0 }
+  - match: { aggregations.percentiles_missing.values.25\.0: 1.0 }
+  - match: { aggregations.percentiles_missing.values.50\.0: 1.0 }
+  - match: { aggregations.percentiles_missing.values.75\.0: 1.0 }
+  - match: { aggregations.percentiles_missing.values.95\.0: 1.0 }
+  - match: { aggregations.percentiles_missing.values.99\.0: 1.0 }
+
+---
+"Missing field without missing param":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            percentiles_missing:
+              percentiles:
+                field: missing_field
+                hdr: {}
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - is_false: aggregations.percentiles_missing.value
+
+---
+"Metadata test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            percentiles_unsigned:
+              meta:
+                foo: bar
+              percentiles:
+                field: unsigned_field
+                hdr: {}
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.percentiles_unsigned.meta.foo: "bar" }
+
+  - match: { aggregations.percentiles_unsigned.values.1\.0: 1.0 }
+  - match: { aggregations.percentiles_unsigned.values.5\.0: 1.0 }
+  - match: { aggregations.percentiles_unsigned.values.25\.0: 1.0 }
+  - match: { aggregations.percentiles_unsigned.values.50\.0: 51.0302734375 }
+  - match: { aggregations.percentiles_unsigned.values.75\.0: 1101.9990234375 }
+  - match: { aggregations.percentiles_unsigned.values.95\.0: 1426066581225472 }
+  - match: { aggregations.percentiles_unsigned.values.99\.0: 1426066581225472 }
+
+---
+"Explicit Percents test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            percentiles_unsigned:
+              percentiles:
+                field: unsigned_field
+                percents: [5.0, 25.0, 50.0]
+                hdr: {}
+            percentiles_double:
+              percentiles:
+                field: double_field
+                percents: [5.0, 25.0, 50.0]
+                hdr: {}
+
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+
+  - match: { aggregations.percentiles_unsigned.values.5\.0: 1.0 }
+  - match: { aggregations.percentiles_unsigned.values.25\.0: 1.0 }
+  - match: { aggregations.percentiles_unsigned.values.50\.0: 51.0302734375 }
+
+
+  - match: { aggregations.percentiles_double.values.5\.0: 1.0 }
+  - match: { aggregations.percentiles_double.values.25\.0: 1.0 }
+  - match: { aggregations.percentiles_double.values.50\.0: 51.0302734375 }
+
+
+---
+"Non-keyed test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            percentiles_unsigned:
+              percentiles:
+                field: unsigned_field
+                percents: [5.0, 25.0, 50.0]
+                keyed: false
+                hdr: {}
+
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+
+
+  - match:  { aggregations.percentiles_unsigned.values.0.key:  5.0 }
+  - match:  { aggregations.percentiles_unsigned.values.0.value:  1.0 }
+  - match:  { aggregations.percentiles_unsigned.values.1.key:  25.0 }
+  - match:  { aggregations.percentiles_unsigned.values.1.value:  1.0 }
+  - match:  { aggregations.percentiles_unsigned.values.2.key:  50.0 }
+  - match:  { aggregations.percentiles_unsigned.values.2.value:  51.0302734375 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yml
@@ -246,6 +246,106 @@ setup:
   - match: { aggregations.integer_terms.buckets.1.doc_count: 1 }
 
 ---
+"Long test":
+  - do:
+      index:
+        index: test_1
+        id: 1
+        body: { "number": 4611686018427387903 }
+
+  - do:
+      index:
+        index: test_1
+        id: 2
+        body: { "number": -4611686018427387904 }
+
+  - do:
+      index:
+        index: test_1
+        id: 3
+        body: { "number": 4611686018427387903 }
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body: { "size" : 0, "aggs" : { "long_terms" : { "terms" : { "field" : "number" } } } }
+
+  - match: { hits.total: 3 }
+
+  - length: { aggregations.long_terms.buckets: 2 }
+
+  - match: { aggregations.long_terms.buckets.0.key: 4611686018427387903 }
+
+  - is_false: aggregations.long_terms.buckets.0.key_as_string
+
+  - match: { aggregations.long_terms.buckets.0.doc_count: 2 }
+
+  - match: { aggregations.long_terms.buckets.1.key: -4611686018427387904 }
+
+  - is_false: aggregations.long_terms.buckets.1.key_as_string
+
+  - match: { aggregations.long_terms.buckets.1.doc_count: 1 }
+
+---
+"Unsigned Long test":
+  - skip:
+      version: " - 2.99.99"
+      reason: unsigned_long is not supported before 3.0.0
+
+  - do:
+      indices.put_mapping:
+        index: test_1
+        body:
+          properties:
+            unsigned:
+              type: unsigned_long
+
+  - do:
+      index:
+        index: test_1
+        id: 1
+        body: { "unsigned": 18446744073709551615 }
+
+  - do:
+      index:
+        index: test_1
+        id: 2
+        body: { "unsigned": 10223372036854775807 }
+
+  - do:
+      index:
+        index: test_1
+        id: 3
+        body: { "unsigned": 18446744073709551615 }
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body: { "size" : 0, "aggs" : { "unsigned_terms" : { "terms" : { "field" : "unsigned" } } } }
+
+  - match: { hits.total: 3 }
+
+  - length: { aggregations.unsigned_terms.buckets: 2 }
+
+  - match: { aggregations.unsigned_terms.buckets.0.key: 18446744073709551615 }
+
+  - is_false: aggregations.unsigned_terms.buckets.0.key_as_string
+
+  - match: { aggregations.unsigned_terms.buckets.0.doc_count: 2 }
+
+  - match: { aggregations.unsigned_terms.buckets.1.key: 10223372036854775807 }
+
+  - is_false: aggregations.unsigned_terms.buckets.1.key_as_string
+
+  - match: { aggregations.unsigned_terms.buckets.1.doc_count: 1 }
+
+---
 "Double test":
   - do:
       index:
@@ -568,6 +668,41 @@ setup:
   - match: { aggregations.long_terms.buckets.0.doc_count: 1 }
 
 ---
+"Unmapped unsigned longs":
+  - skip:
+      version: " - 2.99.99"
+      reason: unsigned_long is not supported before 3.0.0
+
+  - do:
+      indices.put_mapping:
+        index: test_1
+        body:
+          properties:
+            unsigned:
+              type: unsigned_long
+  - do:
+      index:
+        index: test_1
+        id: 1
+        body: {}
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body: { "size" : 0, "aggs" : { "unsigned_terms" : { "terms" : { "field" : "unmapped_unsigned", "value_type" : "unsigned_long", "missing": 3 } } } }
+
+  - match: { hits.total: 1 }
+
+  - length: { aggregations.unsigned_terms.buckets: 1 }
+
+  - match: { aggregations.unsigned_terms.buckets.0.key: 3 }
+
+  - match: { aggregations.unsigned_terms.buckets.0.doc_count: 1 }
+
+---
 "Unmapped doubles":
 
   - do:
@@ -648,6 +783,95 @@ setup:
   - match: { aggregations.number_terms.buckets.2.key: 14.6 }
 
   - match: { aggregations.number_terms.buckets.2.doc_count: 1 }
+
+---
+"Mixing longs, unsigned  long and doubles":
+  - skip:
+      version: " - 2.99.99"
+      reason: unsigned_long is not supported before 3.0.0
+
+  - do:
+      indices.put_mapping:
+        index: test_1
+        body:
+          properties:
+            unsigned:
+              type: unsigned_long
+
+  - do:
+      indices.create:
+          index: test_3
+          body:
+            settings:
+              number_of_replicas: 0
+            mappings:
+              properties:
+                number:
+                  type: unsigned_long
+
+  - do:
+      index:
+        index: test_1
+        id: 1
+        body: {"number": 100}
+
+  - do:
+      index:
+        index: test_1
+        id: 2
+        body: {"number": 10}
+
+  - do:
+      index:
+        index: test_2
+        id: 3
+        body: {"number": 100.0}
+
+  - do:
+      index:
+        index: test_2
+        id: 1
+        body: {"number": 10.0}
+
+  - do:
+      index:
+        index: test_2
+        id: 2
+        body: {"number": 14.6}
+
+  - do:
+      index:
+        index: test_3
+        id: 1
+        body: {"number": 10223372036854775807}
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body: { "size" : 0, "aggs" : { "number_terms" : { "terms" : { "field" : "number" } } } }
+
+  - match: { hits.total: 6 }
+
+  - length: { aggregations.number_terms.buckets: 4 }
+
+  - match: { aggregations.number_terms.buckets.0.key: 10.0 }
+
+  - match: { aggregations.number_terms.buckets.0.doc_count: 2 }
+
+  - match: { aggregations.number_terms.buckets.1.key: 100.0 }
+
+  - match: { aggregations.number_terms.buckets.1.doc_count: 2 }
+
+  - match: { aggregations.number_terms.buckets.2.key: 14.6 }
+
+  - match: { aggregations.number_terms.buckets.2.doc_count: 1 }
+
+  - match: { aggregations.number_terms.buckets.3.key: 10223372036854775807.0 }
+
+  - match: { aggregations.number_terms.buckets.3.doc_count: 1 }
 
 ---
 "Deprecated _term order":

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/220_filters_bucket_unsigned.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/220_filters_bucket_unsigned.yml
@@ -1,0 +1,254 @@
+setup:
+  - skip:
+      version: " - 2.99.99"
+      reason: unsigned_long is not supported before 3.0.0
+
+  - do:
+      indices.create:
+          index: test_1
+          body:
+            settings:
+              number_of_replicas: 0
+            mappings:
+              properties:
+                unsigned_field:
+                   type : unsigned_long
+                double_field:
+                   type : double
+                string_field:
+                   type: keyword
+
+  - do:
+       bulk:
+         refresh: true
+         body:
+           - index:
+               _index: test_1
+               _id:    1
+           - unsigned_field: 1
+             double_field: 1.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    2
+           - unsigned_field: 51
+             double_field: 51.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    3
+           - unsigned_field: 1101
+             double_field: 1101.0
+             string_field: foo
+           - index:
+               _index: test_1
+               _id:    4
+           - unsigned_field: 10223372036854778000
+             double_field: 10223372036854778000.0
+             string_field: foo
+
+---
+"Basic test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_filter:
+              filters:
+                filters:
+                  first_filter:
+                    match:
+                      unsigned_field: 1101
+                  second_filter:
+                    match:
+                      unsigned_field: 10223372036854778000
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.the_filter.buckets.first_filter.doc_count: 1 }
+  - match: { aggregations.the_filter.buckets.second_filter.doc_count: 1 }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_filter:
+              filters:
+                filters:
+                  first_filter:
+                    match:
+                      unsigned_field: 1101
+                  second_filter:
+                    match:
+                      unsigned_field: 10223372036854778000
+              aggs:
+                the_avg:
+                  avg:
+                    field: unsigned_field
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.the_filter.buckets.first_filter.doc_count: 1 }
+  - match: { aggregations.the_filter.buckets.first_filter.the_avg.value: 1101.0 }
+  - match: { aggregations.the_filter.buckets.second_filter.doc_count: 1 }
+  - match: { aggregations.the_filter.buckets.second_filter.the_avg.value: 10223372036854778000.0 }
+
+---
+"Anonymous filters test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_filter:
+              filters:
+                filters:
+                  - match:
+                      unsigned_field: 1101
+                  - match:
+                      unsigned_field: 10223372036854778000
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.the_filter.buckets.0.doc_count: 1 }
+  - match: { aggregations.the_filter.buckets.1.doc_count: 1 }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_filter:
+              filters:
+                filters:
+                  - match:
+                      unsigned_field: 1101
+                  - match:
+                      unsigned_field: 10223372036854778000
+              aggs:
+                the_avg:
+                  avg:
+                    field: unsigned_field
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.the_filter.buckets.0.doc_count: 1 }
+  - match: { aggregations.the_filter.buckets.0.the_avg.value: 1101.0 }
+  - match: { aggregations.the_filter.buckets.1.doc_count: 1 }
+  - match: { aggregations.the_filter.buckets.1.the_avg.value: 10223372036854778000.0 }
+
+---
+"Only aggs test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          size: 0
+          aggs:
+            the_filter:
+              filters:
+                filters:
+                  first_filter:
+                    match:
+                      unsigned_field: 1101
+                  second_filter:
+                    match:
+                      unsigned_field: 10223372036854778000
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 0 }
+  - match: { aggregations.the_filter.buckets.first_filter.doc_count: 1 }
+  - match: { aggregations.the_filter.buckets.second_filter.doc_count: 1 }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_filter:
+              filters:
+                filters:
+                  first_filter:
+                    match:
+                      unsigned_field: 1101
+                  second_filter:
+                    match:
+                      unsigned_field: 10223372036854778000
+              aggs:
+                the_avg:
+                  avg:
+                    field: unsigned_field
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.the_filter.buckets.first_filter.doc_count: 1 }
+  - match: { aggregations.the_filter.buckets.first_filter.the_avg.value: 1101.0 }
+  - match: { aggregations.the_filter.buckets.second_filter.doc_count: 1 }
+  - match: { aggregations.the_filter.buckets.second_filter.the_avg.value: 10223372036854778000.0 }
+
+---
+"Filtered test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query:
+            constant_score:
+              filter:
+                range:
+                  unsigned_field:
+                    gte: 1110
+          aggs:
+            the_filter:
+              filters:
+                filters:
+                  first_filter:
+                    match:
+                      unsigned_field: 1101
+                  second_filter:
+                    match:
+                      unsigned_field: 10223372036854778000
+              aggs:
+                the_avg:
+                  avg:
+                    field: unsigned_field
+
+  - match: { hits.total: 1 }
+  - length: { hits.hits: 1 }
+  - match: { aggregations.the_filter.buckets.first_filter.doc_count: 0 }
+  - is_false: aggregations.the_filter.buckets.first_filter.the_avg.value
+  - match: { aggregations.the_filter.buckets.second_filter.doc_count: 1 }
+  - match: { aggregations.the_filter.buckets.second_filter.the_avg.value: 10223372036854778000.0 }
+
+
+---
+"Metadata test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_filter:
+              meta:
+                foo: bar
+              filters:
+                filters:
+                  first_filter:
+                    match:
+                      unsigned_field: 1101
+                  second_filter:
+                    match:
+                      unsigned_field: 10223372036854778000
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.the_filter.buckets.first_filter.doc_count: 1 }
+  - match: { aggregations.the_filter.buckets.second_filter.doc_count: 1 }
+  - match: { aggregations.the_filter.meta.foo: "bar" }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite_unsigned.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite_unsigned.yml
@@ -1,0 +1,348 @@
+setup:
+  - skip:
+      version: " - 2.99.99"
+      reason: unsigned_long is not supported before 3.0.0
+
+  - do:
+        indices.create:
+          index: test
+          body:
+              mappings:
+                properties:
+                  date:
+                    type: date
+                  keyword:
+                    type: keyword
+                  unsigned_long:
+                    type: unsigned_long
+                  geo_point:
+                    type: geo_point
+                  nested:
+                    type: nested
+                    properties:
+                      nested_unsigned_long:
+                        type: unsigned_long
+
+  - do:
+        indices.create:
+          index: other
+          body:
+            mappings:
+              properties:
+                date:
+                  type: date
+                unsigned_long:
+                  type: unsigned_long
+                nested:
+                  type: nested
+                  properties:
+                    nested_long:
+                      type: long
+
+  - do:
+      index:
+        index: test
+        id:    1
+        body:  { "keyword": "foo", "unsigned_long": [10223372036854775807, 184], "geo_point": "37.2343,-115.8067", "nested": [{"nested_unsigned_long": 10223372036854775807}, {"nested_unsigned_long": 184}] }
+
+  - do:
+      index:
+        index: test
+        id:    2
+        body:  { "keyword": ["foo", "bar"], "geo_point": "41.12,-71.34" }
+
+  - do:
+      index:
+        index: test
+        id:    3
+        body:  { "keyword": "bar", "unsigned_long": [100, 0], "geo_point": "90.0,0.0", "nested": [{"nested_unsigned_long": 184}, {"nested_unsigned_long": 0}] }
+
+  - do:
+      index:
+        index: test
+        id:    4
+        body:  { "keyword": "bar", "unsigned_long": [1000, 0], "geo_point": "41.12,-71.34", "nested": [{"nested_unsigned_long": 1000}, {"nested_unsigned_long": 10223372036854775807}] }
+
+  - do:
+      index:
+        index: test
+        id:    5
+        body:  { "date": "2017-10-20T03:08:45" }
+
+  - do:
+      index:
+        index: test
+        id:    6
+        body:  { "date": "2017-10-21T07:00:00" }
+
+  - do:
+      index:
+        index: other
+        id:    0
+        body:  { "date": "2017-10-20T03:08:45" }
+
+  - do:
+      indices.refresh:
+        index: [test, other]
+
+
+---
+"Nested Composite aggregation":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test
+        body:
+          aggregations:
+            test:
+              composite:
+                sources: [
+                  {
+                    "unsigned_long": {
+                      "terms": {
+                        "field": "unsigned_long"
+                      }
+                    }
+                  },
+                  {
+                    "kw": {
+                      "terms": {
+                        "field": "keyword"
+                      }
+                    }
+                  }
+                ]
+
+  - match: { hits.total: 6 }
+  - length: { aggregations.test.buckets: 5 }
+  - match: { aggregations.test.buckets.0.key.unsigned_long: 0}
+  - match: { aggregations.test.buckets.0.key.kw: "bar" }
+  - match: { aggregations.test.buckets.0.doc_count: 2 }
+  - match: { aggregations.test.buckets.1.key.unsigned_long: 100 }
+  - match: { aggregations.test.buckets.1.key.kw: "bar"}
+  - match: { aggregations.test.buckets.1.doc_count: 1 }
+  - match: { aggregations.test.buckets.2.key.unsigned_long: 184 }
+  - match: { aggregations.test.buckets.2.key.kw: "foo" }
+  - match: { aggregations.test.buckets.2.doc_count: 1 }
+  - match: { aggregations.test.buckets.3.key.unsigned_long: 1000}
+  - match: { aggregations.test.buckets.3.key.kw: "bar" }
+  - match: { aggregations.test.buckets.3.doc_count: 1 }
+  - match: { aggregations.test.buckets.4.key.unsigned_long: 10223372036854775807 }
+  - match: { aggregations.test.buckets.4.key.kw: "foo" }
+  - match: { aggregations.test.buckets.4.doc_count: 1 }
+
+---
+"Aggregate After":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test
+        body:
+          aggregations:
+            test:
+              composite:
+                sources: [
+                  {
+                    "unsigned_long": {
+                      "terms": {
+                        "field": "unsigned_long"
+                      }
+                    }
+                  },
+                  {
+                    "kw": {
+                      "terms": {
+                        "field": "keyword"
+                      }
+                    }
+                  }
+                ]
+                after: { "unsigned_long": 184, "kw": "foo" }
+
+  - match: { hits.total: 6 }
+  - length: { aggregations.test.buckets: 2 }
+  - match: { aggregations.test.buckets.0.key.unsigned_long: 1000 }
+  - match: { aggregations.test.buckets.0.key.kw: "bar" }
+  - match: { aggregations.test.buckets.0.doc_count: 1 }
+  - match: { aggregations.test.buckets.1.key.unsigned_long: 10223372036854775807 }
+  - match: { aggregations.test.buckets.1.key.kw: "foo" }
+  - match: { aggregations.test.buckets.1.doc_count: 1 }
+
+---
+"Composite aggregation with nested parent":
+  - do:
+        search:
+          rest_total_hits_as_int: true
+          index: test
+          body:
+            aggregations:
+              1:
+                nested:
+                  path: nested
+                aggs:
+                  2:
+                    composite:
+                      sources: [
+                        "nested": {
+                          "terms": {
+                            "field": "nested.nested_unsigned_long"
+                        }
+                      }
+                    ]
+
+  - match: { hits.total: 6 }
+  - length: { aggregations.1.2.buckets: 4 }
+  - match: { aggregations.1.2.buckets.0.key.nested: 0 }
+  - match: { aggregations.1.2.buckets.0.doc_count:  1 }
+  - match: { aggregations.1.2.buckets.1.key.nested: 184 }
+  - match: { aggregations.1.2.buckets.1.doc_count:  2 }
+  - match: { aggregations.1.2.buckets.2.key.nested: 1000 }
+  - match: { aggregations.1.2.buckets.2.doc_count:  1 }
+  - match: { aggregations.1.2.buckets.3.key.nested: 10223372036854775807 }
+  - match: { aggregations.1.2.buckets.3.doc_count:  2 }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test
+        body:
+          aggregations:
+            1:
+              nested:
+                path: nested
+              aggs:
+                2:
+                  composite:
+                    after: { "nested": 184 }
+                    sources: [
+                      "nested": {
+                        "terms": {
+                          "field": "nested.nested_unsigned_long"
+                        }
+                      }
+                    ]
+
+  - match: {hits.total: 6}
+  - length: { aggregations.1.2.buckets: 2 }
+  - match: { aggregations.1.2.buckets.0.key.nested: 1000 }
+  - match: { aggregations.1.2.buckets.0.doc_count:  1 }
+  - match: { aggregations.1.2.buckets.1.key.nested: 10223372036854775807 }
+  - match: { aggregations.1.2.buckets.1.doc_count:  2 }
+
+---
+"Composite aggregation with unmapped field":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: [test, other]
+        body:
+          aggregations:
+            test:
+              composite:
+                sources: [
+                {
+                  "unsigned_long": {
+                    "terms": {
+                      "field": "unsigned_long"
+                    }
+                  }
+                },
+                {
+                  "kw": {
+                    "terms": {
+                      "field": "keyword"
+                    }
+                  }
+                }
+                ]
+
+  - match: {hits.total: 7}
+  - length: { aggregations.test.buckets: 5 }
+  - match: { aggregations.test.buckets.0.key.unsigned_long: 0}
+  - match: { aggregations.test.buckets.0.key.kw: "bar" }
+  - match: { aggregations.test.buckets.0.doc_count: 2 }
+  - match: { aggregations.test.buckets.1.key.unsigned_long: 100 }
+  - match: { aggregations.test.buckets.1.key.kw: "bar"}
+  - match: { aggregations.test.buckets.1.doc_count: 1 }
+  - match: { aggregations.test.buckets.2.key.unsigned_long: 184 }
+  - match: { aggregations.test.buckets.2.key.kw: "foo" }
+  - match: { aggregations.test.buckets.2.doc_count: 1 }
+  - match: { aggregations.test.buckets.3.key.unsigned_long: 1000}
+  - match: { aggregations.test.buckets.3.key.kw: "bar" }
+  - match: { aggregations.test.buckets.3.doc_count: 1 }
+  - match: { aggregations.test.buckets.4.key.unsigned_long: 10223372036854775807 }
+  - match: { aggregations.test.buckets.4.key.kw: "foo" }
+  - match: { aggregations.test.buckets.4.doc_count: 1 }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: [test, other]
+        body:
+          aggregations:
+            test:
+              composite:
+                after: { "unsigned_long": 1000, "kw": "bar" }
+                sources: [
+                {
+                  "unsigned_long": {
+                    "terms": {
+                      "field": "unsigned_long"
+                    }
+                  }
+                },
+                {
+                  "kw": {
+                    "terms": {
+                      "field": "keyword"
+                    }
+                  }
+                }
+                ]
+
+  - match: {hits.total: 7}
+  - length: { aggregations.test.buckets: 1 }
+  - match: { aggregations.test.buckets.0.key.unsigned_long: 10223372036854775807 }
+  - match: { aggregations.test.buckets.0.key.kw: "foo" }
+  - match: { aggregations.test.buckets.0.doc_count: 1 }
+
+---
+"Terms source from sorted":
+  - do:
+        indices.create:
+          index: sorted_test
+          body:
+              settings:
+                sort.field: keyword
+              mappings:
+                properties:
+                  keyword:
+                    type: keyword
+                  unsigned_long:
+                    type: unsigned_long
+
+
+  - do:
+      index:
+        index:   sorted_test
+        id:      2
+        refresh: true
+        body:  { "keyword": "foo", "unsigned_long": 1 }
+
+  - do:
+      search:
+        index: sorted_test
+        rest_total_hits_as_int: true
+        body:
+          aggregations:
+            test:
+              composite:
+                sources:
+                  - keyword:
+                      terms:
+                        field: keyword
+
+  - match: { hits.total: 1 }
+  - length: { aggregations.test.buckets: 1 }
+  - match: { aggregations.test.buckets.0.key.keyword: "foo" }
+  - match: { aggregations.test.buckets.0.doc_count: 1 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/260_weighted_avg_unsigned.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/260_weighted_avg_unsigned.yml
@@ -1,0 +1,70 @@
+setup:
+  - skip:
+      version: " - 2.99.99"
+      reason: unsigned_long is not supported before 3.0.0
+
+  - do:
+      indices.create:
+          index: test_1
+          body:
+            settings:
+              number_of_replicas: 0
+            mappings:
+              properties:
+                unsigned_field:
+                   type : unsigned_long
+                double_field:
+                   type : double
+                string_field:
+                   type: keyword
+
+  - do:
+       bulk:
+         refresh: true
+         body:
+           - index:
+               _index: test_1
+               _id:    1
+           - unsigned_field: 1
+             double_field: 1.0
+           - index:
+               _index: test_1
+               _id:    2
+           - unsigned_field: 2
+             double_field: 2.0
+           - index:
+               _index: test_1
+               _id:    3
+           - unsigned_field: 3
+             double_field: 3.0
+           - index:
+               _index: test_1
+               _id:    4
+           - unsigned_field: 4
+             double_field: 4.0
+
+---
+"Basic test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_unsigned_avg:
+              weighted_avg:
+                value:
+                  field: "unsigned_field"
+                weight:
+                  field: "unsigned_field"
+            the_double_avg:
+              weighted_avg:
+                value:
+                  field: "double_field"
+                weight:
+                  field: "double_field"
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.the_unsigned_avg.value: 3.0 }
+  - match: { aggregations.the_double_avg.value: 3.0 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/270_median_absolute_deviation_metric_unsigned.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/270_median_absolute_deviation_metric_unsigned.yml
@@ -1,0 +1,121 @@
+setup:
+  - skip:
+      version: " - 2.99.99"
+      reason: unsigned_long is not supported before 3.0.0
+
+  - do:
+        indices.create:
+            index: test
+            body:
+              settings:
+                number_of_replicas: 0
+              mappings:
+                properties:
+                  unsigned_field:
+                    type: unsigned_long
+                  double_field:
+                    type: double
+                  incomplete_field:
+                    type: integer
+  - do:
+        bulk:
+          refresh: true
+          body:
+            - index:
+                _index: test
+            - unsigned_field: 10223372036700000000
+              double_field: 10223372036700000000
+              incomplete_field: 1000
+            - index:
+                _index: test
+            - unsigned_field: 10223372036800000000
+              double_field: 10223372036800000000
+              incomplete_field: 2000
+            - index:
+                _index: test
+            - unsigned_field: 10223372036900000000
+              double_field: 10223372036900000000.0
+
+---
+"basic test":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            mad_unsigned:
+              median_absolute_deviation:
+                field: unsigned_field
+            mad_double:
+              median_absolute_deviation:
+                field: double_field
+
+  - match: { hits.total: 3 }
+  - length: { hits.hits: 3 }
+
+  - match: { aggregations.mad_unsigned.value: 99999744 }
+  - match: { aggregations.mad_double.value: 99999744.0 }
+
+---
+"with setting compression":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            mad_unsigned:
+              median_absolute_deviation:
+                field: unsigned_field
+                compression: 500
+            mad_double:
+              median_absolute_deviation:
+                field: double_field
+                compression: 500
+
+  - match: { hits.total: 3 }
+  - length: { hits.hits: 3 }
+
+  - match: { aggregations.mad_unsigned.value: 99999744 }
+  - match: { aggregations.mad_double.value: 99999744.0 }
+
+---
+"no documents":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query:
+            bool:
+              filter:
+                term:
+                  non_existent_field: non_existent_value
+          aggs:
+            mad_no_docs:
+              median_absolute_deviation:
+                field: non_existent_field
+
+  - match: { hits.total: 0 }
+  - length: { hits.hits: 0 }
+
+  - match: { aggregations.mad_no_docs.value: null }
+
+---
+"missing value":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            mad_missing:
+              median_absolute_deviation:
+                field: incomplete_field
+                missing: 30000000000000000000
+
+  - match: { hits.total: 3 }
+  - length: { hits.hits: 3 }
+
+  - match: { aggregations.mad_missing.value: 1000 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/370_multi_terms.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/370_multi_terms.yml
@@ -194,6 +194,100 @@ setup:
   - match: { aggregations.m_terms.buckets.3.doc_count: 1 }
 
 ---
+"Long test":
+  - skip:
+      version: "- 2.0.99"
+      reason:  multi_terms aggregation is introduced in 2.1.0
+
+  - do:
+      bulk:
+        index: test_1
+        refresh: true
+        body:
+          - '{"index": {}}'
+          - '{"str": "a", "number": 4611686018427387903}'
+          - '{"index": {}}'
+          - '{"str": "a", "number": -4611686018427387904}'
+          - '{"index": {}}'
+          - '{"str": "b", "number": 4611686018427387903}'
+          - '{"index": {}}'
+          - '{"str": "a", "number": 4611686018427387903}'
+
+  - do:
+      search:
+        index: test_1
+        size: 0
+        body:
+          aggs:
+            m_terms:
+              multi_terms:
+                terms:
+                  - field: str
+                  - field: number
+
+  - length: { aggregations.m_terms.buckets: 3 }
+  - match: { aggregations.m_terms.buckets.0.key: ["a", 4611686018427387903] }
+  - match: { aggregations.m_terms.buckets.0.key_as_string: "a|4611686018427387903" }
+  - match: { aggregations.m_terms.buckets.0.doc_count: 2 }
+  - match: { aggregations.m_terms.buckets.1.key: ["a", -4611686018427387904] }
+  - match: { aggregations.m_terms.buckets.1.key_as_string: "a|-4611686018427387904" }
+  - match: { aggregations.m_terms.buckets.1.doc_count: 1 }
+  - match: { aggregations.m_terms.buckets.2.key: ["b", 4611686018427387903] }
+  - match: { aggregations.m_terms.buckets.2.key_as_string: "b|4611686018427387903" }
+  - match: { aggregations.m_terms.buckets.2.doc_count: 1 }
+
+---
+"Unsigned Long test":
+  - skip:
+      version: " - 2.99.99"
+      reason: unsigned_long is not supported before 3.0.0
+
+  - do:
+      indices.put_mapping:
+        index: test_1
+        body:
+          properties:
+            unsigned:
+              type: unsigned_long
+
+  - do:
+      bulk:
+        index: test_1
+        refresh: true
+        body:
+          - '{"index": {}}'
+          - '{"str": "a", "unsigned": 18446744073709551615}'
+          - '{"index": {}}'
+          - '{"str": "a", "unsigned": 10223372036854775807}'
+          - '{"index": {}}'
+          - '{"str": "b", "unsigned": 18446744073709551615}'
+          - '{"index": {}}'
+          - '{"str": "a", "unsigned": 18446744073709551615}'
+
+  - do:
+      search:
+        index: test_1
+        size: 0
+        body:
+          aggs:
+            m_terms:
+              multi_terms:
+                terms:
+                  - field: str
+                  - field: unsigned
+
+  - length: { aggregations.m_terms.buckets: 3 }
+  - match: { aggregations.m_terms.buckets.0.key: ["a", 18446744073709551615] }
+  - match: { aggregations.m_terms.buckets.0.key_as_string: "a|18446744073709551615" }
+  - match: { aggregations.m_terms.buckets.0.doc_count: 2 }
+  - match: { aggregations.m_terms.buckets.1.key: ["a", 10223372036854775807] }
+  - match: { aggregations.m_terms.buckets.1.key_as_string: "a|10223372036854775807" }
+  - match: { aggregations.m_terms.buckets.1.doc_count: 1 }
+  - match: { aggregations.m_terms.buckets.2.key: ["b", 18446744073709551615] }
+  - match: { aggregations.m_terms.buckets.2.key_as_string: "b|18446744073709551615" }
+  - match: { aggregations.m_terms.buckets.2.doc_count: 1 }
+
+---
 "Double test":
   - skip:
       version: "- 2.0.99"

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/40_range.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/40_range.yml
@@ -427,3 +427,104 @@ setup:
   - match: { aggregations.date_range.buckets.0.key: "2020-01-01T00:00:00.000Z-*" }
   - is_false: aggregations.date_range.buckets.0.to
   - match: { aggregations.date_range.buckets.0.sounds.value: 0 }
+
+---
+"Unsigned long range":
+  - skip:
+      version: " - 2.99.99"
+      reason: unsigned_long is not supported before 3.0.0
+
+  - do:
+      indices.put_mapping:
+        index: test
+        body:
+          properties:
+            unsigned:
+              type: unsigned_long
+
+  - do:
+      index:
+        index: test
+        id: 1
+        body: { "unsigned" : 42 }
+
+  - do:
+      index:
+        index: test
+        id: 2
+        body: { "unsigned" : 100 }
+
+  - do:
+      index:
+        index: test
+        id: 3
+        body: { "unsigned" : 50 }
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body: { "size" : 0, "aggs" : { "unsigned_long_range" : { "range" : { "field" : "unsigned", "ranges": [ { "to": 50 }, { "from": 50, "to": 150 }, { "from": 150 } ] } } } }
+
+  - match: { hits.total: 3 }
+
+  - length: { aggregations.unsigned_long_range.buckets: 3 }
+
+  - match: { aggregations.unsigned_long_range.buckets.0.key: "*-50.0" }
+
+  - is_false: aggregations.unsigned_long_range.buckets.0.from
+
+  - match: { aggregations.unsigned_long_range.buckets.0.to: 50.0 }
+
+  - match: { aggregations.unsigned_long_range.buckets.0.doc_count: 1 }
+
+  - match: { aggregations.unsigned_long_range.buckets.1.key: "50.0-150.0" }
+
+  - match: { aggregations.unsigned_long_range.buckets.1.from: 50.0 }
+
+  - match: { aggregations.unsigned_long_range.buckets.1.to: 150.0 }
+
+  - match: { aggregations.unsigned_long_range.buckets.1.doc_count: 2 }
+
+  - match: { aggregations.unsigned_long_range.buckets.2.key: "150.0-*" }
+
+  - match: { aggregations.unsigned_long_range.buckets.2.from: 150.0 }
+
+  - is_false:  aggregations.unsigned_long_range.buckets.2.to
+
+  - match: { aggregations.unsigned_long_range.buckets.2.doc_count: 0 }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body: { "size" : 0, "aggs" : { "unsigned_long_range" : { "range" : { "field" : "unsigned", "ranges": [ { "from": null, "to": 50 }, { "from": 50, "to": 150 }, { "from": 150, "to": null } ] } } } }
+
+  - match: { hits.total: 3 }
+
+  - length: { aggregations.unsigned_long_range.buckets: 3 }
+
+  - match: { aggregations.unsigned_long_range.buckets.0.key: "*-50.0" }
+
+  - is_false: aggregations.unsigned_long_range.buckets.0.from
+
+  - match: { aggregations.unsigned_long_range.buckets.0.to: 50.0 }
+
+  - match: { aggregations.unsigned_long_range.buckets.0.doc_count: 1 }
+
+  - match: { aggregations.unsigned_long_range.buckets.1.key: "50.0-150.0" }
+
+  - match: { aggregations.unsigned_long_range.buckets.1.from: 50.0 }
+
+  - match: { aggregations.unsigned_long_range.buckets.1.to: 150.0 }
+
+  - match: { aggregations.unsigned_long_range.buckets.1.doc_count: 2 }
+
+  - match: { aggregations.unsigned_long_range.buckets.2.key: "150.0-*" }
+
+  - match: { aggregations.unsigned_long_range.buckets.2.from: 150.0 }
+
+  - is_false:  aggregations.unsigned_long_range.buckets.2.to
+
+  - match: { aggregations.unsigned_long_range.buckets.2.doc_count: 0 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/80_typed_keys_unsigned.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/80_typed_keys_unsigned.yml
@@ -1,0 +1,237 @@
+setup:
+  - skip:
+      version: " - 2.99.99"
+      reason: unsigned_long is not supported before 3.0.0
+
+  - do:
+      indices.create:
+          index: test
+          body:
+            settings:
+              number_of_replicas: 0
+            mappings:
+              properties:
+                name:
+                   type: keyword
+                num:
+                   type: unsigned_long
+                created:
+                  type: date
+
+  - do:
+     bulk:
+        refresh: true
+        index: test
+        body:
+          - '{"index": {}}'
+          - '{"name": "one", "num": 1, "created": "2010-03-12T01:07:45"}'
+          - '{"index": {}}'
+          - '{"name": "two", "num": 2, "created": "2010-03-12T04:11:00"}'
+          - '{"index": {}}'
+          - '{"name": "three", "num": 3, "created": "2010-04-27T03:43:34"}'
+
+---
+"Test typed keys parameter for avg aggregation":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        typed_keys: true
+        body:
+          size: 0
+          aggregations:
+            test_avg:
+              avg:
+                field: num
+  - is_true: aggregations.avg#test_avg
+
+---
+"Test typed keys parameter for cardinality aggregation":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        typed_keys: true
+        body:
+          size: 0
+          aggregations:
+            test_cardinality:
+              cardinality:
+                field: name
+  - is_true: aggregations.cardinality#test_cardinality
+
+---
+"Test typed keys parameter for extended_stats aggregation":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        typed_keys: true
+        body:
+          size: 0
+          aggregations:
+            test_extended_stats:
+              extended_stats:
+                field: num
+  - is_true: aggregations.extended_stats#test_extended_stats
+
+---
+"Test typed keys parameter for max aggregation":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        typed_keys: true
+        body:
+          size: 0
+          aggregations:
+            test_max:
+              max:
+                field: num
+  - is_true: aggregations.max#test_max
+
+---
+"Test typed keys parameter for min aggregation":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        typed_keys: true
+        body:
+          size: 0
+          aggregations:
+            test_min:
+              min:
+                field: num
+  - is_true: aggregations.min#test_min
+
+---
+"Test typed keys parameter for percentiles aggregation":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        typed_keys: true
+        body:
+          size: 0
+          aggregations:
+            test_percentiles:
+              percentiles:
+                field: num
+  - is_true: aggregations.tdigest_percentiles#test_percentiles
+
+---
+"Test typed keys parameter for percentile_ranks aggregation":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        typed_keys: true
+        body:
+          size: 0
+          aggregations:
+            test_percentile_ranks:
+              percentile_ranks:
+                field: num
+                values: [0,10]
+  - is_true: aggregations.tdigest_percentile_ranks#test_percentile_ranks
+
+---
+"Test typed keys parameter for stats aggregation":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        typed_keys: true
+        body:
+          size: 0
+          aggregations:
+            test_stats:
+              stats:
+                field: num
+  - is_true: aggregations.stats#test_stats
+
+---
+"Test typed keys parameter for sum aggregation":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        typed_keys: true
+        body:
+          size: 0
+          aggregations:
+            test_sum:
+              sum:
+                field: num
+  - is_true: aggregations.sum#test_sum
+
+---
+"Test typed keys parameter for terms and top_hits aggregation":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        typed_keys: true
+        body:
+          size: 0
+          aggregations:
+            test_terms:
+              terms:
+                field: name
+              aggs:
+                test_top_hits:
+                  top_hits:
+                    sort: num
+  - is_true: aggregations.sterms#test_terms
+  - is_true: aggregations.sterms#test_terms.buckets.0.top_hits#test_top_hits
+  - is_true: aggregations.sterms#test_terms.buckets.1.top_hits#test_top_hits
+  - is_true: aggregations.sterms#test_terms.buckets.2.top_hits#test_top_hits
+
+---
+"Test typed keys parameter for terms aggregation":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        typed_keys: true
+        body:
+          size: 0
+          aggregations:
+            test_terms:
+              terms:
+                field: num
+  - is_true: aggregations.ulterms#test_terms
+
+---
+"Test typed keys parameter for value_count aggregation":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        typed_keys: true
+        body:
+          size: 0
+          aggregations:
+            test_value_count:
+              value_count:
+                field: num
+  - is_true: aggregations.value_count#test_value_count
+
+---
+"Test typed keys parameter for date_histogram aggregation and max_bucket pipeline aggregation":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        typed_keys: true
+        body:
+          size: 0
+          aggregations:
+            test_created_histogram:
+              date_histogram:
+                field: created
+                calendar_interval: month
+              aggregations:
+                test_sum:
+                  sum:
+                    field: num
+                test_deriv:
+                  derivative:
+                    buckets_path: "test_sum"
+            test_max_bucket:
+              max_bucket:
+                buckets_path: "test_created_histogram>test_sum"
+
+  - is_true: aggregations.date_histogram#test_created_histogram
+  - is_true: aggregations.date_histogram#test_created_histogram.buckets.0.sum#test_sum
+  - is_true: aggregations.date_histogram#test_created_histogram.buckets.1.sum#test_sum
+  - is_true: aggregations.date_histogram#test_created_histogram.buckets.1.derivative#test_deriv
+  - is_true: aggregations.bucket_metric_value#test_max_bucket

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/260_sort_mixed.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/260_sort_mixed.yml
@@ -7,9 +7,6 @@
       indices.create:
         index: test_1
         body:
-          settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
           mappings:
             properties:
               counter:
@@ -19,9 +16,6 @@
       indices.create:
         index: test_2
         body:
-          settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
           mappings:
             properties:
               counter:
@@ -69,3 +63,59 @@
   - match: { hits.hits.1._index: test_1 }
   - match: { hits.hits.1._source.counter: 223372036854775800 }
   - match: { hits.hits.1.sort.0: 223372036854775800 }
+
+---
+"search across indices with mixed long, double and unsigned_long numeric types":
+  - skip:
+      version: " - 2.99.99"
+      reason: unsigned_long is not supported before 3.0.0
+
+  - do:
+      indices.create:
+        index: test_1
+        body:
+          mappings:
+            properties:
+              counter:
+                type: unsigned_long
+  - do:
+      indices.create:
+        index: test_2
+        body:
+          mappings:
+            properties:
+              counter:
+                type: long
+  - do:
+      indices.create:
+        index: test_3
+        body:
+          mappings:
+            properties:
+              counter:
+                type: double
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - index:
+              _index: test_1
+          - counter: 10223372036854775800
+          - index:
+              _index: test_2
+          - counter: 223372036854775800
+          - index:
+              _index: test_3
+          - counter: 184.0
+
+  - do:
+      catch: bad_request
+      search:
+        index: test_*
+        rest_total_hits_as_int: true
+        body:
+          sort: [{ counter: asc }]
+  # The search across fields with mixed types (where one of those is unsigned_long) is not supported
+  - match: { status: 400 }
+  - match: { error.type: search_phase_execution_exception }
+  - match: { error.caused_by.reason: "Can't do sort across indices, as a field has [unsigned_long] type in one index, and different type in another index!" }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/90_search_after.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/90_search_after.yml
@@ -224,3 +224,55 @@
   - match: {hits.hits.0._index: test }
   - match: {hits.hits.0._source.timestamp: "2019-10-21 00:30:04.828740" }
   - match: {hits.hits.0.sort: [1571617804828740000] }
+
+---
+"unsigned long":
+  - skip:
+      version: " - 2.99.99"
+      reason: unsigned_long is not supported before 3.0.0
+
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            properties:
+              population:
+                type: unsigned_long
+  - do:
+      bulk:
+        refresh: true
+        index: test
+        body: |
+          {"index":{}}
+          {"population": 10223372036854775800}
+          {"index":{}}
+          {"population": 15223372036854775800}
+
+  - do:
+      search:
+        index: test
+        rest_total_hits_as_int: true
+        body:
+          size: 1
+          sort: [{ population: asc }]
+  - match: {hits.total: 2 }
+  - length: {hits.hits: 1 }
+  - match: {hits.hits.0._index: test }
+  - match: {hits.hits.0._source.population: 10223372036854775800 }
+  - match: {hits.hits.0.sort: [10223372036854775800] }
+
+  # search_after with the sort
+  - do:
+      search:
+        index: test
+        rest_total_hits_as_int: true
+        body:
+          size: 1
+          sort: [{ population: asc }]
+          search_after: [10223372036854775800]
+  - match: {hits.total: 2 }
+  - length: {hits.hits: 1 }
+  - match: {hits.hits.0._index: test }
+  - match: {hits.hits.0._source.population: 15223372036854775800 }
+  - match: {hits.hits.0.sort: [15223372036854775800] }

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -65,10 +65,10 @@ import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.ShardRoutingState;
 import org.opensearch.cluster.routing.UnassignedInfo;
 import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.common.Numbers;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.ByteSizeUnit;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.util.BytesRefUtils;
 import org.opensearch.index.Index;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.engine.Engine;
@@ -2374,7 +2374,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         createFullSnapshot(repoName, "snapshot-1");
         repository.setFailOnIndexLatest(false);
         createFullSnapshot(repoName, "snapshot-2");
-        final long repoGenInIndexLatest = Numbers.bytesToLong(
+        final long repoGenInIndexLatest = BytesRefUtils.bytesToLong(
             new BytesRef(Files.readAllBytes(repoPath.resolve(BlobStoreRepository.INDEX_LATEST_BLOB)))
         );
         assertEquals(getRepositoryData(repoName).getGenId(), repoGenInIndexLatest);
@@ -2385,14 +2385,14 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
             Settings.builder().put("location", repoPath).put(BlobStoreRepository.SUPPORT_URL_REPO.getKey(), false)
         );
         createFullSnapshot(repoName, "snapshot-3");
-        final long repoGenInIndexLatest2 = Numbers.bytesToLong(
+        final long repoGenInIndexLatest2 = BytesRefUtils.bytesToLong(
             new BytesRef(Files.readAllBytes(repoPath.resolve(BlobStoreRepository.INDEX_LATEST_BLOB)))
         );
         assertEquals("index.latest should not have been written to", repoGenInIndexLatest, repoGenInIndexLatest2);
 
         createRepository(repoName, "fs", repoPath);
         createFullSnapshot(repoName, "snapshot-4");
-        final long repoGenInIndexLatest3 = Numbers.bytesToLong(
+        final long repoGenInIndexLatest3 = BytesRefUtils.bytesToLong(
             new BytesRef(Files.readAllBytes(repoPath.resolve(BlobStoreRepository.INDEX_LATEST_BLOB)))
         );
         assertEquals(getRepositoryData(repoName).getGenId(), repoGenInIndexLatest3);

--- a/server/src/main/java/org/opensearch/action/search/SearchPhaseController.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchPhaseController.java
@@ -584,12 +584,14 @@ public final class SearchPhaseController {
                 firstResult = false;
                 ulFormats = new boolean[formats.length];
                 for (int i = 0; i < formats.length; i++) {
-                    ulFormats[i] = formats[i] == DocValueFormat.UNSIGNED_LONG_SHIFTED ? true : false;
+                    ulFormats[i] = (formats[i] == DocValueFormat.UNSIGNED_LONG_SHIFTED || formats[i] == DocValueFormat.UNSIGNED_LONG)
+                        ? true
+                        : false;
                 }
             } else {
                 for (int i = 0; i < formats.length; i++) {
                     // if the format is unsigned_long in one shard, and something different in another shard
-                    if (ulFormats[i] ^ (formats[i] == DocValueFormat.UNSIGNED_LONG_SHIFTED)) {
+                    if (ulFormats[i] ^ (formats[i] == DocValueFormat.UNSIGNED_LONG_SHIFTED || formats[i] == DocValueFormat.UNSIGNED_LONG)) {
                         throw new IllegalArgumentException(
                             "Can't do sort across indices, as a field has [unsigned_long] type "
                                 + "in one index, and different type in another index!"

--- a/server/src/main/java/org/opensearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/opensearch/common/io/stream/StreamOutput.java
@@ -497,6 +497,10 @@ public abstract class StreamOutput extends OutputStream {
         }
     }
 
+    public final void writeBigInteger(BigInteger v) throws IOException {
+        writeString(v.toString());
+    }
+
     private static byte ZERO = 0;
     private static byte ONE = 1;
     private static byte TWO = 2;

--- a/server/src/main/java/org/opensearch/common/xcontent/JsonToStringXContentParser.java
+++ b/server/src/main/java/org/opensearch/common/xcontent/JsonToStringXContentParser.java
@@ -18,6 +18,7 @@ import org.opensearch.core.xcontent.XContentLocation;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.mapper.ParseContext;
 import java.io.IOException;
+import java.math.BigInteger;
 import java.nio.CharBuffer;
 import java.util.ArrayList;
 
@@ -243,6 +244,11 @@ public class JsonToStringXContentParser extends AbstractXContentParser {
     @Override
     protected double doDoubleValue() throws IOException {
         return this.parser.doubleValue();
+    }
+
+    @Override
+    protected BigInteger doBigIntegerValue() throws IOException {
+        return this.parser.bigIntegerValue();
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/document/SortedUnsignedLongDocValuesRangeQuery.java
+++ b/server/src/main/java/org/opensearch/index/document/SortedUnsignedLongDocValuesRangeQuery.java
@@ -1,0 +1,171 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.document;
+
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.search.ConstantScoreScorer;
+import org.apache.lucene.search.ConstantScoreWeight;
+import org.apache.lucene.search.FieldExistsQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.TwoPhaseIterator;
+import org.apache.lucene.search.Weight;
+import org.opensearch.common.Numbers;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.Objects;
+
+/**
+ * The {@link org.apache.lucene.document.SortedNumericDocValuesRangeQuery} implementation for unsigned long numeric data type.
+ *
+ * @opensearch.internal
+ */
+public abstract class SortedUnsignedLongDocValuesRangeQuery extends Query {
+    private final String field;
+    private final long lowerValue;
+    private final long upperValue;
+
+    SortedUnsignedLongDocValuesRangeQuery(String field, BigInteger lowerValue, BigInteger upperValue) {
+        this.field = Objects.requireNonNull(field);
+        this.lowerValue = lowerValue.longValue();
+        this.upperValue = upperValue.longValue();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (sameClassAs(obj) == false) {
+            return false;
+        }
+        SortedUnsignedLongDocValuesRangeQuery that = (SortedUnsignedLongDocValuesRangeQuery) obj;
+        return Objects.equals(field, that.field) && lowerValue == that.lowerValue && upperValue == that.upperValue;
+    }
+
+    @Override
+    public int hashCode() {
+        int h = classHash();
+        h = 31 * h + field.hashCode();
+        h = 31 * h + Long.hashCode(lowerValue);
+        h = 31 * h + Long.hashCode(upperValue);
+        return h;
+    }
+
+    @Override
+    public void visit(QueryVisitor visitor) {
+        if (visitor.acceptField(field)) {
+            visitor.visitLeaf(this);
+        }
+    }
+
+    @Override
+    public String toString(String field) {
+        StringBuilder b = new StringBuilder();
+        if (this.field.equals(field) == false) {
+            b.append(this.field).append(":");
+        }
+        return b.append("[")
+            .append(Long.toUnsignedString(lowerValue))
+            .append(" TO ")
+            .append(Long.toUnsignedString(upperValue))
+            .append("]")
+            .toString();
+    }
+
+    @Override
+    public Query rewrite(IndexReader reader) throws IOException {
+        if (Long.compareUnsigned(lowerValue, Numbers.MIN_UNSIGNED_LONG_VALUE_AS_LONG) == 0
+            && Long.compareUnsigned(upperValue, Numbers.MAX_UNSIGNED_LONG_VALUE_AS_LONG) == 0) {
+            return new FieldExistsQuery(field);
+        }
+        return super.rewrite(reader);
+    }
+
+    abstract SortedNumericDocValues getValues(LeafReader reader, String field) throws IOException;
+
+    @Override
+    public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+        return new ConstantScoreWeight(this, boost) {
+
+            @Override
+            public boolean isCacheable(LeafReaderContext ctx) {
+                return DocValues.isCacheable(ctx, field);
+            }
+
+            @Override
+            public Scorer scorer(LeafReaderContext context) throws IOException {
+                SortedNumericDocValues values = getValues(context.reader(), field);
+                if (values == null) {
+                    return null;
+                }
+                final NumericDocValues singleton = DocValues.unwrapSingleton(values);
+                final TwoPhaseIterator iterator;
+                if (singleton != null) {
+                    iterator = new TwoPhaseIterator(singleton) {
+                        @Override
+                        public boolean matches() throws IOException {
+                            final long value = singleton.longValue();
+                            return Long.compareUnsigned(value, lowerValue) >= 0 && Long.compareUnsigned(value, upperValue) <= 0;
+                        }
+
+                        @Override
+                        public float matchCost() {
+                            return 2; // 2 comparisons
+                        }
+                    };
+                } else {
+                    iterator = new TwoPhaseIterator(values) {
+                        @Override
+                        public boolean matches() throws IOException {
+                            for (int i = 0, count = values.docValueCount(); i < count; ++i) {
+                                final long value = values.nextValue();
+                                if (Long.compareUnsigned(value, lowerValue) < 0) {
+                                    continue;
+                                }
+                                // Values are sorted, so the first value that is >= lowerValue is our best
+                                // candidate
+                                return Long.compareUnsigned(value, upperValue) <= 0;
+                            }
+                            return false; // all values were < lowerValue
+                        }
+
+                        @Override
+                        public float matchCost() {
+                            return 2; // 2 comparisons
+                        }
+                    };
+                }
+                return new ConstantScoreScorer(this, score(), scoreMode, iterator);
+            }
+        };
+    }
+
+    public static Query newSlowRangeQuery(String field, BigInteger lowerValue, BigInteger upperValue) {
+        return new SortedUnsignedLongDocValuesRangeQuery(field, lowerValue, upperValue) {
+            @Override
+            SortedNumericDocValues getValues(LeafReader reader, String field) throws IOException {
+                FieldInfo info = reader.getFieldInfos().fieldInfo(field);
+                if (info == null) {
+                    // Queries have some optimizations when one sub scorer returns null rather
+                    // than a scorer that does not match any documents
+                    return null;
+                }
+                return DocValues.getSortedNumeric(reader, field);
+            }
+        };
+    }
+}

--- a/server/src/main/java/org/opensearch/index/document/package-info.java
+++ b/server/src/main/java/org/opensearch/index/document/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/** Package containing OpenSearch document queries */
+package org.opensearch.index.document;

--- a/server/src/main/java/org/opensearch/index/fielddata/FieldData.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/FieldData.java
@@ -38,9 +38,11 @@ import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.BytesRef;
+import org.opensearch.common.Numbers;
 import org.opensearch.common.geo.GeoPoint;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -218,6 +220,30 @@ public enum FieldData {
     }
 
     /**
+     * Given a {@link SortedNumericDocValues}, return a {@link SortedNumericDoubleValues}
+     * instance that will translate unsigned long values to doubles using
+     * {@link Numbers#toUnsignedBigInteger(long)}.
+     */
+    public static SortedNumericDoubleValues unsignedLongToDoubles(SortedNumericDocValues values) {
+        final NumericDocValues singleton = DocValues.unwrapSingleton(values);
+        if (singleton != null) {
+            final NumericDoubleValues doubles;
+            if (singleton instanceof SortableLongBitsNumericDocValues) {
+                doubles = ((SortableLongBitsNumericDocValues) singleton).getDoubleValues();
+            } else {
+                doubles = new UnsignedLongToNumericDoubleValues(singleton);
+            }
+            return singleton(doubles);
+        } else {
+            if (values instanceof SortableLongBitsSortedNumericDocValues) {
+                return ((SortableLongBitsSortedNumericDocValues) values).getDoubleValues();
+            } else {
+                return new UnsignedLongToSortedNumericDoubleValues(values);
+            }
+        }
+    }
+
+    /**
      * Wrap the provided {@link SortedNumericDocValues} instance to cast all values to doubles.
      */
     public static SortedNumericDoubleValues castToDouble(final SortedNumericDocValues values) {
@@ -322,6 +348,27 @@ public enum FieldData {
             public void get(List<CharSequence> list) throws IOException {
                 for (int i = 0, count = values.docValueCount(); i < count; ++i) {
                     list.add(Long.toString(values.nextValue()));
+                }
+            }
+        });
+    }
+
+    /**
+     * Return a {@link String} representation of the provided values treating them as unsigned. That is
+     * typically used for scripts or for the `map` execution mode of terms aggs.
+     * NOTE: this is very slow!
+     */
+    public static SortedBinaryDocValues toUnsignedString(final SortedNumericDocValues values) {
+        return toString(new ToStringValues() {
+            @Override
+            public boolean advanceExact(int doc) throws IOException {
+                return values.advanceExact(doc);
+            }
+
+            @Override
+            public void get(List<CharSequence> list) throws IOException {
+                for (int i = 0, count = values.docValueCount(); i < count; ++i) {
+                    list.add(Long.toUnsignedString(values.nextValue()));
                 }
             }
         });
@@ -590,6 +637,38 @@ public enum FieldData {
             @Override
             public long longValue() throws IOException {
                 return value;
+            }
+        };
+    }
+
+    /**
+     * Return a {@link NumericDocValues} instance that has a value for every
+     * document, returns the same value as {@code values} if there is a value
+     * for the current document and {@code missing} otherwise.
+     */
+    public static NumericDocValues replaceMissing(NumericDocValues values, BigInteger missing) {
+        return new AbstractNumericDocValues() {
+
+            private BigInteger value;
+
+            @Override
+            public int docID() {
+                return values.docID();
+            }
+
+            @Override
+            public boolean advanceExact(int target) throws IOException {
+                if (values.advanceExact(target)) {
+                    value = Numbers.toUnsignedBigInteger(values.longValue());
+                } else {
+                    value = missing;
+                }
+                return true;
+            }
+
+            @Override
+            public long longValue() throws IOException {
+                return value.longValue();
             }
         };
     }

--- a/server/src/main/java/org/opensearch/index/fielddata/IndexFieldData.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/IndexFieldData.java
@@ -192,7 +192,7 @@ public interface IndexFieldData<FD extends LeafFieldData> {
         }
 
         /** Return the missing object value according to the reduced type of the comparator. */
-        public final Object missingObject(Object missingValue, boolean reversed) {
+        public Object missingObject(Object missingValue, boolean reversed) {
             if (sortMissingFirst(missingValue) || sortMissingLast(missingValue)) {
                 final boolean min = sortMissingFirst(missingValue) ^ reversed;
                 switch (reducedType()) {

--- a/server/src/main/java/org/opensearch/index/fielddata/IndexNumericFieldData.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/IndexNumericFieldData.java
@@ -44,6 +44,7 @@ import org.opensearch.index.fielddata.fieldcomparator.DoubleValuesComparatorSour
 import org.opensearch.index.fielddata.fieldcomparator.FloatValuesComparatorSource;
 import org.opensearch.index.fielddata.fieldcomparator.IntValuesComparatorSource;
 import org.opensearch.index.fielddata.fieldcomparator.LongValuesComparatorSource;
+import org.opensearch.index.fielddata.fieldcomparator.UnsignedLongValuesComparatorSource;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.MultiValueMode;
 import org.opensearch.search.aggregations.support.CoreValuesSourceType;
@@ -75,7 +76,8 @@ public abstract class IndexNumericFieldData implements IndexFieldData<LeafNumeri
         DATE_NANOSECONDS(false, SortField.Type.LONG, CoreValuesSourceType.DATE),
         HALF_FLOAT(true, SortField.Type.LONG, CoreValuesSourceType.NUMERIC),
         FLOAT(true, SortField.Type.FLOAT, CoreValuesSourceType.NUMERIC),
-        DOUBLE(true, SortField.Type.DOUBLE, CoreValuesSourceType.NUMERIC);
+        DOUBLE(true, SortField.Type.DOUBLE, CoreValuesSourceType.NUMERIC),
+        UNSIGNED_LONG(false, SortField.Type.LONG, CoreValuesSourceType.NUMERIC);
 
         private final boolean floatingPoint;
         private final ValuesSourceType valuesSourceType;
@@ -202,6 +204,8 @@ public abstract class IndexNumericFieldData implements IndexFieldData<LeafNumeri
                 return new FloatValuesComparatorSource(this, missingValue, sortMode, nested);
             case DOUBLE:
                 return new DoubleValuesComparatorSource(this, missingValue, sortMode, nested);
+            case UNSIGNED_LONG:
+                return new UnsignedLongValuesComparatorSource(this, missingValue, sortMode, nested);
             case DATE:
                 return dateComparatorSource(missingValue, sortMode, nested);
             case DATE_NANOSECONDS:

--- a/server/src/main/java/org/opensearch/index/fielddata/UnsignedLongToNumericDoubleValues.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/UnsignedLongToNumericDoubleValues.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.fielddata;
+
+import org.apache.lucene.index.NumericDocValues;
+import org.opensearch.common.Numbers;
+
+import java.io.IOException;
+
+/**
+ * {@link NumericDoubleValues} instance that wraps a {@link NumericDocValues}
+ * and converts the unsigned long to double using {@link Numbers#unsignedLongToDouble(long)}.
+ *
+ * @opensearch.internal
+ */
+final class UnsignedLongToNumericDoubleValues extends NumericDoubleValues {
+
+    private final NumericDocValues values;
+
+    UnsignedLongToNumericDoubleValues(NumericDocValues values) {
+        this.values = values;
+    }
+
+    @Override
+    public double doubleValue() throws IOException {
+        return Numbers.unsignedLongToDouble(values.longValue());
+    }
+
+    @Override
+    public boolean advanceExact(int doc) throws IOException {
+        return values.advanceExact(doc);
+    }
+
+    /** Return the wrapped values. */
+    public NumericDocValues getLongValues() {
+        return values;
+    }
+
+}

--- a/server/src/main/java/org/opensearch/index/fielddata/UnsignedLongToSortedNumericDoubleValues.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/UnsignedLongToSortedNumericDoubleValues.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.fielddata;
+
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.opensearch.common.Numbers;
+
+import java.io.IOException;
+
+/**
+ * {@link SortedNumericDoubleValues} instance that wraps a {@link SortedNumericDocValues}
+ * and converts the unsigned long to double using {@link Numbers#unsignedLongToDouble(long)}.
+ *
+ * @opensearch.internal
+ */
+final class UnsignedLongToSortedNumericDoubleValues extends SortedNumericDoubleValues {
+
+    private final SortedNumericDocValues values;
+
+    UnsignedLongToSortedNumericDoubleValues(SortedNumericDocValues values) {
+        this.values = values;
+    }
+
+    @Override
+    public boolean advanceExact(int target) throws IOException {
+        return values.advanceExact(target);
+    }
+
+    @Override
+    public double nextValue() throws IOException {
+        return Numbers.unsignedLongToDouble(values.nextValue());
+    }
+
+    @Override
+    public int docValueCount() {
+        return values.docValueCount();
+    }
+
+    /** Return the wrapped values. */
+    public SortedNumericDocValues getLongValues() {
+        return values;
+    }
+
+}

--- a/server/src/main/java/org/opensearch/index/fielddata/fieldcomparator/UnsignedLongValuesComparatorSource.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/fieldcomparator/UnsignedLongValuesComparatorSource.java
@@ -1,0 +1,143 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.fielddata.fieldcomparator;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.FieldComparator;
+import org.apache.lucene.search.LeafFieldComparator;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.util.BitSet;
+import org.opensearch.common.Nullable;
+import org.opensearch.common.Numbers;
+import org.opensearch.common.util.BigArrays;
+import org.opensearch.index.fielddata.LeafNumericFieldData;
+import org.opensearch.index.fielddata.FieldData;
+import org.opensearch.index.fielddata.IndexFieldData;
+import org.opensearch.index.fielddata.IndexNumericFieldData;
+import org.opensearch.index.search.comparators.UnsignedLongComparator;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.MultiValueMode;
+import org.opensearch.search.sort.BucketedSort;
+import org.opensearch.search.sort.SortOrder;
+
+import java.io.IOException;
+import java.math.BigInteger;
+
+/**
+ * Comparator source for unsigned long values.
+ *
+ * @opensearch.internal
+ */
+public class UnsignedLongValuesComparatorSource extends IndexFieldData.XFieldComparatorSource {
+
+    private final IndexNumericFieldData indexFieldData;
+
+    public UnsignedLongValuesComparatorSource(
+        IndexNumericFieldData indexFieldData,
+        @Nullable Object missingValue,
+        MultiValueMode sortMode,
+        Nested nested
+    ) {
+        super(missingValue, sortMode, nested);
+        this.indexFieldData = indexFieldData;
+    }
+
+    @Override
+    public SortField.Type reducedType() {
+        return SortField.Type.LONG;
+    }
+
+    private SortedNumericDocValues loadDocValues(LeafReaderContext context) {
+        final LeafNumericFieldData data = indexFieldData.load(context);
+        SortedNumericDocValues values = data.getLongValues();
+        return values;
+    }
+
+    private NumericDocValues getNumericDocValues(LeafReaderContext context, BigInteger missingValue) throws IOException {
+        final SortedNumericDocValues values = loadDocValues(context);
+        if (nested == null) {
+            return FieldData.replaceMissing(sortMode.select(values), missingValue);
+        }
+        final BitSet rootDocs = nested.rootDocs(context);
+        final DocIdSetIterator innerDocs = nested.innerDocs(context);
+        final int maxChildren = nested.getNestedSort() != null ? nested.getNestedSort().getMaxChildren() : Integer.MAX_VALUE;
+        return sortMode.select(values, missingValue.longValue(), rootDocs, innerDocs, context.reader().maxDoc(), maxChildren);
+    }
+
+    @Override
+    public Object missingObject(Object missingValue, boolean reversed) {
+        if (sortMissingFirst(missingValue) || sortMissingLast(missingValue)) {
+            final boolean min = sortMissingFirst(missingValue) ^ reversed;
+            return min ? Numbers.MIN_UNSIGNED_LONG_VALUE : Numbers.MAX_UNSIGNED_LONG_VALUE;
+        } else {
+            if (missingValue instanceof Number) {
+                return ((Number) missingValue);
+            } else {
+                return new BigInteger(missingValue.toString());
+            }
+        }
+    }
+
+    @Override
+    public FieldComparator<?> newComparator(String fieldname, int numHits, boolean enableSkipping, boolean reversed) {
+        assert indexFieldData == null || fieldname.equals(indexFieldData.getFieldName());
+
+        final BigInteger ulMissingValue = (BigInteger) missingObject(missingValue, reversed);
+        return new UnsignedLongComparator(numHits, null, null, reversed, false) {
+            @Override
+            public LeafFieldComparator getLeafComparator(LeafReaderContext context) throws IOException {
+                return new UnsignedLongLeafComparator(context) {
+                    @Override
+                    protected NumericDocValues getNumericDocValues(LeafReaderContext context, String field) throws IOException {
+                        return UnsignedLongValuesComparatorSource.this.getNumericDocValues(context, ulMissingValue);
+                    }
+                };
+            }
+        };
+    }
+
+    @Override
+    public BucketedSort newBucketedSort(
+        BigArrays bigArrays,
+        SortOrder sortOrder,
+        DocValueFormat format,
+        int bucketSize,
+        BucketedSort.ExtraData extra
+    ) {
+        return new BucketedSort.ForUnsignedLongs(bigArrays, sortOrder, format, bucketSize, extra) {
+            private final BigInteger ulMissingValue = (BigInteger) missingObject(missingValue, sortOrder == SortOrder.DESC);
+
+            @Override
+            public Leaf forLeaf(LeafReaderContext ctx) throws IOException {
+                return new Leaf(ctx) {
+                    private final NumericDocValues docValues = getNumericDocValues(ctx, ulMissingValue);
+                    private long docValue;
+
+                    @Override
+                    protected boolean advanceExact(int doc) throws IOException {
+                        if (docValues.advanceExact(doc)) {
+                            docValue = docValues.longValue();
+                            return true;
+                        }
+                        return false;
+                    }
+
+                    @Override
+                    protected long docValue() {
+                        return docValue;
+                    }
+                };
+            }
+        };
+    }
+
+}

--- a/server/src/main/java/org/opensearch/index/search/comparators/UnsignedLongComparator.java
+++ b/server/src/main/java/org/opensearch/index/search/comparators/UnsignedLongComparator.java
@@ -1,0 +1,107 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.search.comparators;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.sandbox.document.BigIntegerPoint;
+import org.apache.lucene.search.LeafFieldComparator;
+import org.apache.lucene.search.comparators.NumericComparator;
+import org.opensearch.common.Numbers;
+
+import java.io.IOException;
+import java.math.BigInteger;
+
+/** The comparator for unsigned long numeric type */
+public class UnsignedLongComparator extends NumericComparator<BigInteger> {
+    private final BigInteger[] values;
+    protected BigInteger topValue;
+    protected BigInteger bottom;
+
+    public UnsignedLongComparator(int numHits, String field, BigInteger missingValue, boolean reverse, boolean enableSkipping) {
+        super(field, missingValue != null ? missingValue : Numbers.MIN_UNSIGNED_LONG_VALUE, reverse, enableSkipping, BigIntegerPoint.BYTES);
+        values = new BigInteger[numHits];
+    }
+
+    @Override
+    public int compare(int slot1, int slot2) {
+        return values[slot1].compareTo(values[slot2]);
+    }
+
+    @Override
+    public void setTopValue(BigInteger value) {
+        super.setTopValue(value);
+        topValue = value;
+    }
+
+    @Override
+    public BigInteger value(int slot) {
+        return values[slot];
+    }
+
+    @Override
+    public LeafFieldComparator getLeafComparator(LeafReaderContext context) throws IOException {
+        return new UnsignedLongLeafComparator(context);
+    }
+
+    /** Leaf comparator for {@link UnsignedLongComparator} that provides skipping functionality */
+    public class UnsignedLongLeafComparator extends NumericLeafComparator {
+
+        public UnsignedLongLeafComparator(LeafReaderContext context) throws IOException {
+            super(context);
+        }
+
+        private BigInteger getValueForDoc(int doc) throws IOException {
+            if (docValues.advanceExact(doc)) {
+                return Numbers.toUnsignedBigInteger(docValues.longValue());
+            } else {
+                return missingValue;
+            }
+        }
+
+        @Override
+        public void setBottom(int slot) throws IOException {
+            bottom = values[slot];
+            super.setBottom(slot);
+        }
+
+        @Override
+        public int compareBottom(int doc) throws IOException {
+            return bottom.compareTo(getValueForDoc(doc));
+        }
+
+        @Override
+        public int compareTop(int doc) throws IOException {
+            return topValue.compareTo(getValueForDoc(doc));
+        }
+
+        @Override
+        public void copy(int slot, int doc) throws IOException {
+            values[slot] = getValueForDoc(doc);
+            super.copy(slot, doc);
+        }
+
+        @Override
+        protected boolean isMissingValueCompetitive() {
+            int result = missingValue.compareTo(bottom);
+            // in reverse (desc) sort missingValue is competitive when it's greater or equal to bottom,
+            // in asc sort missingValue is competitive when it's smaller or equal to bottom
+            return reverse ? (result >= 0) : (result <= 0);
+        }
+
+        @Override
+        protected void encodeBottom(byte[] packedValue) {
+            BigIntegerPoint.encodeDimension(bottom, packedValue, 0);
+        }
+
+        @Override
+        protected void encodeTop(byte[] packedValue) {
+            BigIntegerPoint.encodeDimension(topValue, packedValue, 0);
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/index/search/comparators/package-info.java
+++ b/server/src/main/java/org/opensearch/index/search/comparators/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/** Additional comparators for numeric types */
+package org.opensearch.index.search.comparators;

--- a/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
@@ -94,6 +94,7 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.AbstractRunnable;
 import org.opensearch.common.util.concurrent.ConcurrentCollections;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.core.util.BytesRefUtils;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.XContentParser;
@@ -2303,7 +2304,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
     // package private for testing
     long readSnapshotIndexLatestBlob() throws IOException {
-        return Numbers.bytesToLong(Streams.readFully(blobContainer().readBlob(INDEX_LATEST_BLOB)).toBytesRef());
+        return BytesRefUtils.bytesToLong(Streams.readFully(blobContainer().readBlob(INDEX_LATEST_BLOB)).toBytesRef());
     }
 
     private long listBlobsToGetLatestIndexId() throws IOException {

--- a/server/src/main/java/org/opensearch/search/DocValueFormat.java
+++ b/server/src/main/java/org/opensearch/search/DocValueFormat.java
@@ -35,6 +35,7 @@ package org.opensearch.search;
 import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.LegacyESVersion;
+import org.opensearch.common.Numbers;
 import org.opensearch.common.io.stream.NamedWriteable;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -86,6 +87,13 @@ public interface DocValueFormat extends NamedWriteable {
         throw new UnsupportedOperationException();
     }
 
+    /** Format a unsigned long value. This is used by terms and histogram aggregations
+     *  to format keys for fields that use unsigned longs as a doc value representation
+     *  such as the {@code unsigned_long} field. */
+    default BigInteger format(BigInteger value) {
+        throw new UnsupportedOperationException();
+    }
+
     /** Format a binary value. This is used by terms aggregations to format
      *  keys for fields that use binary doc value representations such as the
      *  {@code keyword} and {@code ip} fields. */
@@ -96,6 +104,12 @@ public interface DocValueFormat extends NamedWriteable {
     /** Parse a value that was formatted with {@link #format(long)} back to the
      *  original long value. */
     default long parseLong(String value, boolean roundUp, LongSupplier now) {
+        throw new UnsupportedOperationException();
+    }
+
+    /** Parse a value that was formatted with {@link #format(long)} back to the
+     *  original unsigned long value. */
+    default BigInteger parseUnsignedLong(String value, boolean roundUp, LongSupplier now) {
         throw new UnsupportedOperationException();
     }
 
@@ -128,6 +142,15 @@ public interface DocValueFormat extends NamedWriteable {
 
         @Override
         public Double format(double value) {
+            return value;
+        }
+
+        /**
+         * Double docValues of the unsigned_long field type are already in the formatted representation,
+         * so we don't need to do anything here
+         */
+        @Override
+        public BigInteger format(BigInteger value) {
             return value;
         }
 
@@ -469,6 +492,15 @@ public interface DocValueFormat extends NamedWriteable {
             return format.format(value);
         }
 
+        /**
+         * Double docValues of the unsigned_long field type are already in the formatted representation,
+         * so we don't need to do anything here
+         */
+        @Override
+        public BigInteger format(BigInteger value) {
+            return value;
+        }
+
         @Override
         public String format(double value) {
             /*
@@ -571,6 +603,14 @@ public interface DocValueFormat extends NamedWriteable {
         }
 
         /**
+         * Formats the unsigned long to the shifted long format
+         */
+        @Override
+        public BigInteger parseUnsignedLong(String value, boolean roundUp, LongSupplier now) {
+            return Numbers.toUnsignedLong(value, roundUp);
+        }
+
+        /**
          * Formats a raw docValue that is stored in the shifted long format to the unsigned long representation.
          */
         @Override
@@ -583,6 +623,73 @@ public interface DocValueFormat extends NamedWriteable {
             } else {
                 return BigInteger.valueOf(formattedValue).and(BIGINTEGER_2_64_MINUS_ONE);
             }
+        }
+
+        /**
+         * Double docValues of the unsigned_long field type are already in the formatted representation,
+         * so we don't need to do anything here
+         */
+        @Override
+        public Double format(double value) {
+            return value;
+        }
+
+        @Override
+        public double parseDouble(String value, boolean roundUp, LongSupplier now) {
+            return Double.parseDouble(value);
+        }
+    };
+
+    /**
+     * DocValues format for unsigned 64 bit long values,
+     * that are stored as signed 64 bit long values.
+     */
+    DocValueFormat UNSIGNED_LONG = new DocValueFormat() {
+
+        @Override
+        public String getWriteableName() {
+            return "unsigned_long";
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) {}
+
+        @Override
+        public String toString() {
+            return "unsigned_long";
+        }
+
+        /**
+         * Formats the unsigned long to the shifted long format
+         */
+        @Override
+        public long parseLong(String value, boolean roundUp, LongSupplier now) {
+            return Long.parseUnsignedLong(value);
+        }
+
+        /**
+         * Formats the unsigned long to the shifted long format
+         */
+        @Override
+        public BigInteger parseUnsignedLong(String value, boolean roundUp, LongSupplier now) {
+            return Numbers.toUnsignedLong(value, roundUp);
+        }
+
+        /**
+         * Formats a raw docValue that is stored in the shifted long format to the unsigned long representation.
+         */
+        @Override
+        public Object format(long value) {
+            return Numbers.toUnsignedBigInteger(value);
+        }
+
+        /**
+         * Double docValues of the unsigned_long field type are already in the formatted representation,
+         * so we don't need to do anything here
+         */
+        @Override
+        public BigInteger format(BigInteger value) {
+            return value;
         }
 
         /**

--- a/server/src/main/java/org/opensearch/search/SearchModule.java
+++ b/server/src/main/java/org/opensearch/search/SearchModule.java
@@ -172,6 +172,7 @@ import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.opensearch.search.aggregations.bucket.terms.UnmappedRareTerms;
 import org.opensearch.search.aggregations.bucket.terms.UnmappedSignificantTerms;
 import org.opensearch.search.aggregations.bucket.terms.UnmappedTerms;
+import org.opensearch.search.aggregations.bucket.terms.UnsignedLongTerms;
 import org.opensearch.search.aggregations.bucket.terms.heuristic.ChiSquare;
 import org.opensearch.search.aggregations.bucket.terms.heuristic.GND;
 import org.opensearch.search.aggregations.bucket.terms.heuristic.JLHScore;
@@ -539,6 +540,7 @@ public class SearchModule {
                 .addResultReader(UnmappedTerms.NAME, UnmappedTerms::new)
                 .addResultReader(LongTerms.NAME, LongTerms::new)
                 .addResultReader(DoubleTerms.NAME, DoubleTerms::new)
+                .addResultReader(UnsignedLongTerms.NAME, UnsignedLongTerms::new)
                 .setAggregatorRegistrar(TermsAggregationBuilder::registerAggregators),
             builder
         );
@@ -1030,6 +1032,7 @@ public class SearchModule {
         registerValueFormat(DocValueFormat.RAW.getWriteableName(), in -> DocValueFormat.RAW);
         registerValueFormat(DocValueFormat.BINARY.getWriteableName(), in -> DocValueFormat.BINARY);
         registerValueFormat(DocValueFormat.UNSIGNED_LONG_SHIFTED.getWriteableName(), in -> DocValueFormat.UNSIGNED_LONG_SHIFTED);
+        registerValueFormat(DocValueFormat.UNSIGNED_LONG.getWriteableName(), in -> DocValueFormat.UNSIGNED_LONG);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/search/SearchSortValues.java
+++ b/server/src/main/java/org/opensearch/search/SearchSortValues.java
@@ -79,6 +79,8 @@ public class SearchSortValues implements ToXContentFragment, Writeable {
                 this.formattedSortValues[i] = sortValueFormats[i].format((BytesRef) sortValue);
             } else if ((sortValue instanceof Long) && (sortValueFormats[i] == DocValueFormat.UNSIGNED_LONG_SHIFTED)) {
                 this.formattedSortValues[i] = sortValueFormats[i].format((Long) sortValue);
+            } else if ((sortValue instanceof Long) && (sortValueFormats[i] == DocValueFormat.UNSIGNED_LONG)) {
+                this.formattedSortValues[i] = sortValueFormats[i].format((Long) sortValue);
             } else {
                 this.formattedSortValues[i] = sortValue;
             }

--- a/server/src/main/java/org/opensearch/search/SearchSortValuesAndFormats.java
+++ b/server/src/main/java/org/opensearch/search/SearchSortValuesAndFormats.java
@@ -39,6 +39,7 @@ import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.common.lucene.Lucene;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.Arrays;
 
 /**
@@ -62,6 +63,8 @@ public class SearchSortValuesAndFormats implements Writeable {
                 this.formattedSortValues[i] = sortValueFormats[i].format((BytesRef) sortValue);
             } else if (sortValue instanceof Long) {
                 this.formattedSortValues[i] = sortValueFormats[i].format((long) sortValue);
+            } else if (sortValue instanceof BigInteger) {
+                this.formattedSortValues[i] = sortValueFormats[i].format((BigInteger) sortValue);
             } else if (sortValue instanceof Double) {
                 this.formattedSortValues[i] = sortValueFormats[i].format((double) sortValue);
             } else if (sortValue instanceof Float || sortValue instanceof Integer) {

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/HistogramValuesSource.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/HistogramValuesSource.java
@@ -64,6 +64,11 @@ class HistogramValuesSource extends ValuesSource.Numeric {
     }
 
     @Override
+    public boolean isBigInteger() {
+        return false;
+    }
+
+    @Override
     public SortedNumericDoubleValues doubleValues(LeafReaderContext context) throws IOException {
         SortedNumericDoubleValues values = vs.doubleValues(context);
         return new SortedNumericDoubleValues() {

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/LongValuesSource.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/LongValuesSource.java
@@ -160,7 +160,7 @@ public class LongValuesSource extends SingleDimensionValuesSource<Long> {
         }
     }
 
-    private int compareValues(long v1, long v2) {
+    int compareValues(long v1, long v2) {
         return Long.compare(v1, v2) * reverseMul;
     }
 
@@ -219,7 +219,7 @@ public class LongValuesSource extends SingleDimensionValuesSource<Long> {
         };
     }
 
-    private static Query extractQuery(Query query) {
+    static Query extractQuery(Query query) {
         if (query instanceof BoostQuery) {
             return extractQuery(((BoostQuery) query).getQuery());
         } else if (query instanceof IndexOrDocValuesQuery) {
@@ -234,7 +234,7 @@ public class LongValuesSource extends SingleDimensionValuesSource<Long> {
     /**
      * Returns true if we can use <code>query</code> with a {@link SortedDocsProducer} on <code>fieldName</code>.
      */
-    private static boolean checkMatchAllOrRangeQuery(Query query, String fieldName) {
+    static boolean checkMatchAllOrRangeQuery(Query query, String fieldName) {
         if (query == null) {
             return true;
         } else if (query.getClass() == MatchAllDocsQuery.class) {

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/RoundingValuesSource.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/RoundingValuesSource.java
@@ -66,6 +66,11 @@ class RoundingValuesSource extends ValuesSource.Numeric {
         return false;
     }
 
+    @Override
+    public boolean isBigInteger() {
+        return false;
+    }
+
     public long round(long value) {
         return rounding.round(value);
     }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/TermsValuesSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/TermsValuesSourceBuilder.java
@@ -157,6 +157,17 @@ public class TermsValuesSourceBuilder extends CompositeValuesSourceBuilder<Terms
                                 compositeValuesSourceConfig.reverseMul()
                             );
 
+                        } else if (vs.isBigInteger()) {
+                            return new UnsignedLongValuesSource(
+                                bigArrays,
+                                compositeValuesSourceConfig.fieldType(),
+                                vs::longValues,
+                                compositeValuesSourceConfig.format(),
+                                compositeValuesSourceConfig.missingBucket(),
+                                compositeValuesSourceConfig.missingOrder(),
+                                size,
+                                compositeValuesSourceConfig.reverseMul()
+                            );
                         } else {
                             final LongUnaryOperator rounding;
                             rounding = LongUnaryOperator.identity();

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/UnsignedLongPointsSortedDocsProducer.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/UnsignedLongPointsSortedDocsProducer.java
@@ -1,0 +1,186 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.aggregations.bucket.composite;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.PointValues;
+import org.apache.lucene.sandbox.document.BigIntegerPoint;
+import org.apache.lucene.search.CollectionTerminatedException;
+import org.apache.lucene.search.DocIdSet;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.DocIdSetBuilder;
+import org.opensearch.common.Numbers;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.Arrays;
+
+/**
+ * A {@link SortedDocsProducer} that can sort documents based on numerics indexed for unsigned long field.
+ *
+ * @opensearch.internal
+ */
+class UnsignedLongPointsSortedDocsProducer extends SortedDocsProducer {
+    private final byte[] lowerPointQuery;
+    private final byte[] upperPointQuery;
+
+    UnsignedLongPointsSortedDocsProducer(String field, byte[] lowerPointQuery, byte[] upperPointQuery) {
+        super(field);
+        this.lowerPointQuery = lowerPointQuery;
+        this.upperPointQuery = upperPointQuery;
+    }
+
+    @Override
+    DocIdSet processLeaf(Query query, CompositeValuesCollectorQueue queue, LeafReaderContext context, boolean fillDocIdSet)
+        throws IOException {
+        final PointValues values = context.reader().getPointValues(field);
+        if (values == null) {
+            // no value for the field
+            return DocIdSet.EMPTY;
+        }
+        BigInteger lowerBucket = Numbers.MIN_UNSIGNED_LONG_VALUE;
+        Comparable<?> lowerValue = queue.getLowerValueLeadSource();
+        if (lowerValue != null) {
+            if (lowerValue.getClass() != BigInteger.class) {
+                throw new IllegalStateException("expected BigInteger, got " + lowerValue.getClass());
+            }
+            lowerBucket = (BigInteger) lowerValue;
+        }
+
+        BigInteger upperBucket = Numbers.MAX_UNSIGNED_LONG_VALUE;
+        Comparable<?> upperValue = queue.getUpperValueLeadSource();
+        if (upperValue != null) {
+            if (upperValue.getClass() != BigInteger.class) {
+                throw new IllegalStateException("expected BigInteger, got " + upperValue.getClass());
+            }
+            upperBucket = (BigInteger) upperValue;
+        }
+        DocIdSetBuilder builder = fillDocIdSet ? new DocIdSetBuilder(context.reader().maxDoc(), values, field) : null;
+        Visitor visitor = new Visitor(
+            context,
+            queue,
+            builder,
+            values.getBytesPerDimension(),
+            lowerBucket.longValue(),
+            upperBucket.longValue()
+        );
+        try {
+            values.intersect(visitor);
+            visitor.flush();
+        } catch (CollectionTerminatedException exc) {}
+        return fillDocIdSet ? builder.build() : DocIdSet.EMPTY;
+    }
+
+    private class Visitor implements PointValues.IntersectVisitor {
+        final LeafReaderContext context;
+        final CompositeValuesCollectorQueue queue;
+        final DocIdSetBuilder builder;
+        final int maxDoc;
+        final int bytesPerDim;
+        final long lowerBucket;
+        final long upperBucket;
+
+        DocIdSetBuilder bucketDocsBuilder;
+        DocIdSetBuilder.BulkAdder adder;
+        int remaining;
+        long lastBucket;
+        boolean first = true;
+
+        Visitor(
+            LeafReaderContext context,
+            CompositeValuesCollectorQueue queue,
+            DocIdSetBuilder builder,
+            int bytesPerDim,
+            long lowerBucket,
+            long upperBucket
+        ) {
+            this.context = context;
+            this.maxDoc = context.reader().maxDoc();
+            this.queue = queue;
+            this.builder = builder;
+            this.lowerBucket = lowerBucket;
+            this.upperBucket = upperBucket;
+            this.bucketDocsBuilder = new DocIdSetBuilder(maxDoc);
+            this.bytesPerDim = bytesPerDim;
+        }
+
+        @Override
+        public void grow(int count) {
+            remaining = count;
+            adder = bucketDocsBuilder.grow(count);
+        }
+
+        @Override
+        public void visit(int docID) throws IOException {
+            throw new IllegalStateException("should never be called");
+        }
+
+        @Override
+        public void visit(int docID, byte[] packedValue) throws IOException {
+            if (compare(packedValue, packedValue) != PointValues.Relation.CELL_CROSSES_QUERY) {
+                remaining--;
+                return;
+            }
+
+            long bucket = BigIntegerPoint.decodeDimension(packedValue, 0).longValue();
+            if (first == false && Long.compareUnsigned(bucket, lastBucket) != 0) {
+                final DocIdSet docIdSet = bucketDocsBuilder.build();
+                if (processBucket(queue, context, docIdSet.iterator(), lastBucket, builder) &&
+                // lower bucket is inclusive
+                    Long.compareUnsigned(lowerBucket, lastBucket) != 0) {
+                    // this bucket does not have any competitive composite buckets,
+                    // we can early terminate the collection because the remaining buckets are guaranteed
+                    // to be greater than this bucket.
+                    throw new CollectionTerminatedException();
+                }
+                bucketDocsBuilder = new DocIdSetBuilder(maxDoc);
+                assert remaining > 0;
+                adder = bucketDocsBuilder.grow(remaining);
+            }
+            lastBucket = bucket;
+            first = false;
+            adder.add(docID);
+            remaining--;
+        }
+
+        @Override
+        public PointValues.Relation compare(byte[] minPackedValue, byte[] maxPackedValue) {
+            if ((upperPointQuery != null && Arrays.compareUnsigned(minPackedValue, 0, bytesPerDim, upperPointQuery, 0, bytesPerDim) > 0)
+                || (lowerPointQuery != null
+                    && Arrays.compareUnsigned(maxPackedValue, 0, bytesPerDim, lowerPointQuery, 0, bytesPerDim) < 0)) {
+                // does not match the query
+                return PointValues.Relation.CELL_OUTSIDE_QUERY;
+            }
+
+            // check the current bounds
+            if (Long.compareUnsigned(lowerBucket, Numbers.MIN_UNSIGNED_LONG_VALUE_AS_LONG) != 0) {
+                long maxBucket = BigIntegerPoint.decodeDimension(maxPackedValue, 0).longValue();
+                if (Long.compareUnsigned(maxBucket, lowerBucket) < 0) {
+                    return PointValues.Relation.CELL_OUTSIDE_QUERY;
+                }
+            }
+
+            if (Long.compareUnsigned(upperBucket, Numbers.MAX_UNSIGNED_LONG_VALUE_AS_LONG) != 0) {
+                long minBucket = BigIntegerPoint.decodeDimension(minPackedValue, 0).longValue();
+                if (Long.compareUnsigned(minBucket, upperBucket) > 0) {
+                    return PointValues.Relation.CELL_OUTSIDE_QUERY;
+                }
+            }
+            return PointValues.Relation.CELL_CROSSES_QUERY;
+        }
+
+        public void flush() throws IOException {
+            if (first == false) {
+                final DocIdSet docIdSet = bucketDocsBuilder.build();
+                processBucket(queue, context, docIdSet.iterator(), lastBucket, builder);
+                bucketDocsBuilder = null;
+            }
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/UnsignedLongValuesSource.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/UnsignedLongValuesSource.java
@@ -1,0 +1,76 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.aggregations.bucket.composite;
+
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.search.PointRangeQuery;
+import org.apache.lucene.search.Query;
+import org.opensearch.common.CheckedFunction;
+import org.opensearch.common.util.BigArrays;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.NumberFieldMapper;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
+
+import java.io.IOException;
+import java.util.function.LongUnaryOperator;
+
+/**
+ * A {@link SingleDimensionValuesSource} for unsigned longs.
+ *
+ * @opensearch.internal
+ */
+public class UnsignedLongValuesSource extends LongValuesSource {
+    public UnsignedLongValuesSource(
+        BigArrays bigArrays,
+        MappedFieldType fieldType,
+        CheckedFunction<LeafReaderContext, SortedNumericDocValues, IOException> docValuesFunc,
+        DocValueFormat format,
+        boolean missingBucket,
+        MissingOrder missingOrder,
+        int size,
+        int reverseMul
+    ) {
+        super(bigArrays, fieldType, docValuesFunc, LongUnaryOperator.identity(), format, missingBucket, missingOrder, size, reverseMul);
+    }
+
+    @Override
+    int compareValues(long v1, long v2) {
+        return Long.compareUnsigned(v1, v2) * reverseMul;
+    }
+
+    @Override
+    SortedDocsProducer createSortedDocsProducerOrNull(IndexReader reader, Query query) {
+        query = extractQuery(query);
+        if (checkIfSortedDocsIsApplicable(reader, fieldType) == false || checkMatchAllOrRangeQuery(query, fieldType.name()) == false) {
+            return null;
+        }
+        final byte[] lowerPoint;
+        final byte[] upperPoint;
+        if (query instanceof PointRangeQuery) {
+            final PointRangeQuery rangeQuery = (PointRangeQuery) query;
+            lowerPoint = rangeQuery.getLowerPoint();
+            upperPoint = rangeQuery.getUpperPoint();
+        } else {
+            lowerPoint = null;
+            upperPoint = null;
+        }
+
+        if (fieldType instanceof NumberFieldMapper.NumberFieldType) {
+            NumberFieldMapper.NumberFieldType ft = (NumberFieldMapper.NumberFieldType) fieldType;
+            if (ft.typeName() == "unsigned_long") {
+                return new UnsignedLongPointsSortedDocsProducer(fieldType.name(), lowerPoint, upperPoint);
+            }
+        }
+
+        return null;
+    }
+}

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/range/GeoDistanceRangeAggregatorFactory.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/range/GeoDistanceRangeAggregatorFactory.java
@@ -204,6 +204,11 @@ public class GeoDistanceRangeAggregatorFactory extends ValuesSourceAggregatorFac
         }
 
         @Override
+        public boolean isBigInteger() {
+            return false;
+        }
+
+        @Override
         public SortedNumericDocValues longValues(LeafReaderContext ctx) {
             throw new UnsupportedOperationException();
         }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/DoubleTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/DoubleTerms.java
@@ -233,7 +233,17 @@ public class DoubleTerms extends InternalMappedTerms<DoubleTerms, DoubleTerms.Bu
                  */
                 promoteToDouble = true;
                 break;
-            }
+            } else if (agg instanceof UnsignedLongTerms
+                && (((UnsignedLongTerms) agg).format == DocValueFormat.RAW
+                    || ((UnsignedLongTerms) agg).format == DocValueFormat.UNSIGNED_LONG_SHIFTED
+                    || ((UnsignedLongTerms) agg).format == DocValueFormat.UNSIGNED_LONG)) {
+                        /*
+                         * this terms agg mixes unsigned longs and doubles, we must promote unsigned longs to doubles to make the internal aggs
+                         * compatible
+                         */
+                        promoteToDouble = true;
+                        break;
+                    }
         }
         if (promoteToDouble == false) {
             return super.reduce(aggregations, reduceContext);
@@ -242,6 +252,9 @@ public class DoubleTerms extends InternalMappedTerms<DoubleTerms, DoubleTerms.Bu
         for (InternalAggregation agg : aggregations) {
             if (agg instanceof LongTerms) {
                 DoubleTerms dTerms = LongTerms.convertLongTermsToDouble((LongTerms) agg, format);
+                newAggs.add(dTerms);
+            } else if (agg instanceof UnsignedLongTerms) {
+                DoubleTerms dTerms = UnsignedLongTerms.convertUnsignedLongTermsToDouble((UnsignedLongTerms) agg, format);
                 newAggs.add(dTerms);
             } else {
                 newAggs.add(agg);

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/LongTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/LongTerms.java
@@ -246,6 +246,8 @@ public class LongTerms extends InternalMappedTerms<LongTerms, LongTerms.Bucket> 
                     rawFormat = true;
                 } else if (((LongTerms) agg).format == DocValueFormat.UNSIGNED_LONG_SHIFTED) {
                     unsignedLongFormat = true;
+                } else if (((LongTerms) agg).format == DocValueFormat.UNSIGNED_LONG) {
+                    unsignedLongFormat = true;
                 }
             }
         }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregationFactory.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregationFactory.java
@@ -68,6 +68,11 @@ public class MultiTermsAggregationFactory extends AggregatorFactory {
                         longFilter = includeExclude.convertToDoubleFilter();
                     }
                     return MultiTermsAggregator.InternalValuesSourceFactory.doubleValueSource(valuesSource, longFilter);
+                } else if (valuesSource.isBigInteger()) {
+                    if (includeExclude != null) {
+                        longFilter = includeExclude.convertToDoubleFilter();
+                    }
+                    return MultiTermsAggregator.InternalValuesSourceFactory.unsignedLongValuesSource(valuesSource, longFilter);
                 } else {
                     if (includeExclude != null) {
                         longFilter = includeExclude.convertToLongFilter(valuesSourceConfig.format());

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregator.java
@@ -16,6 +16,7 @@ import org.apache.lucene.util.NumericUtils;
 import org.apache.lucene.util.PriorityQueue;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.common.CheckedSupplier;
+import org.opensearch.common.Numbers;
 import org.opensearch.common.bytes.BytesArray;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.StreamInput;
@@ -37,6 +38,7 @@ import org.opensearch.search.aggregations.support.ValuesSource;
 import org.opensearch.search.internal.SearchContext;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -387,6 +389,31 @@ public class MultiTermsAggregator extends DeferableBucketAggregator {
                         termValues.add(BytesRef.deepCopyOf(bytes));
                     }
                     return termValues;
+                };
+            };
+        }
+
+        static InternalValuesSource unsignedLongValuesSource(ValuesSource.Numeric valuesSource, IncludeExclude.LongFilter longFilter) {
+            return ctx -> {
+                SortedNumericDocValues values = valuesSource.longValues(ctx);
+                return doc -> {
+                    if (values.advanceExact(doc)) {
+                        int valuesCount = values.docValueCount();
+
+                        BigInteger previous = Numbers.MAX_UNSIGNED_LONG_VALUE;
+                        List<Object> termValues = new ArrayList<>(valuesCount);
+                        for (int i = 0; i < valuesCount; ++i) {
+                            BigInteger val = Numbers.toUnsignedBigInteger(values.nextValue());
+                            if (previous.compareTo(val) != 0 || i == 0) {
+                                if (longFilter == null || longFilter.accept(NumericUtils.doubleToSortableLong(val.doubleValue()))) {
+                                    termValues.add(val);
+                                }
+                                previous = val;
+                            }
+                        }
+                        return termValues;
+                    }
+                    return Collections.emptyList();
                 };
             };
         }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/NumericTermsAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/NumericTermsAggregator.java
@@ -37,6 +37,7 @@ import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.util.NumericUtils;
 import org.apache.lucene.util.PriorityQueue;
+import org.opensearch.common.Numbers;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.lease.Releasables;
 import org.opensearch.common.util.LongArray;
@@ -60,6 +61,7 @@ import org.opensearch.search.internal.ContextIndexSearcher;
 import org.opensearch.search.internal.SearchContext;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -490,6 +492,87 @@ public class NumericTermsAggregator extends TermsAggregator {
         @Override
         DoubleTerms buildEmptyResult() {
             return new DoubleTerms(
+                name,
+                order,
+                order,
+                bucketCountThresholds.getRequiredSize(),
+                bucketCountThresholds.getMinDocCount(),
+                metadata(),
+                format,
+                bucketCountThresholds.getShardSize(),
+                showTermDocCountError,
+                0,
+                emptyList(),
+                0
+            );
+        }
+    }
+
+    class UnsignedLongTermsResults extends StandardTermsResultStrategy<UnsignedLongTerms, UnsignedLongTerms.Bucket> {
+        UnsignedLongTermsResults(boolean showTermDocCountError) {
+            super(showTermDocCountError);
+        }
+
+        @Override
+        String describe() {
+            return "unsigned_long_terms";
+        }
+
+        @Override
+        SortedNumericDocValues getValues(LeafReaderContext ctx) throws IOException {
+            return valuesSource.longValues(ctx);
+        }
+
+        @Override
+        UnsignedLongTerms.Bucket[][] buildTopBucketsPerOrd(int size) {
+            return new UnsignedLongTerms.Bucket[size][];
+        }
+
+        @Override
+        UnsignedLongTerms.Bucket[] buildBuckets(int size) {
+            return new UnsignedLongTerms.Bucket[size];
+        }
+
+        @Override
+        UnsignedLongTerms.Bucket buildEmptyBucket() {
+            return new UnsignedLongTerms.Bucket(BigInteger.ZERO, 0, null, showTermDocCountError, 0, format);
+        }
+
+        @Override
+        void updateBucket(UnsignedLongTerms.Bucket spare, BucketOrdsEnum ordsEnum, long docCount) {
+            spare.term = Numbers.toUnsignedBigInteger(ordsEnum.value());
+            spare.docCount = docCount;
+            spare.bucketOrd = ordsEnum.ord();
+        }
+
+        @Override
+        UnsignedLongTerms buildResult(long owningBucketOrd, long otherDocCount, UnsignedLongTerms.Bucket[] topBuckets) {
+            final BucketOrder reduceOrder;
+            if (isKeyOrder(order) == false) {
+                reduceOrder = InternalOrder.key(true);
+                Arrays.sort(topBuckets, reduceOrder.comparator());
+            } else {
+                reduceOrder = order;
+            }
+            return new UnsignedLongTerms(
+                name,
+                reduceOrder,
+                order,
+                bucketCountThresholds.getRequiredSize(),
+                bucketCountThresholds.getMinDocCount(),
+                metadata(),
+                format,
+                bucketCountThresholds.getShardSize(),
+                showTermDocCountError,
+                otherDocCount,
+                List.of(topBuckets),
+                0
+            );
+        }
+
+        @Override
+        UnsignedLongTerms buildEmptyResult() {
+            return new UnsignedLongTerms(
                 name,
                 order,
                 order,

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/ParsedUnsignedLongTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/ParsedUnsignedLongTerms.java
@@ -1,0 +1,88 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.aggregations.bucket.terms;
+
+import org.opensearch.core.xcontent.ObjectParser;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.math.BigInteger;
+
+/**
+ * A long term agg result parsed between nodes
+ *
+ * @opensearch.internal
+ */
+public class ParsedUnsignedLongTerms extends ParsedTerms {
+
+    @Override
+    public String getType() {
+        return UnsignedLongTerms.NAME;
+    }
+
+    private static final ObjectParser<ParsedUnsignedLongTerms, Void> PARSER = new ObjectParser<>(
+        ParsedUnsignedLongTerms.class.getSimpleName(),
+        true,
+        ParsedUnsignedLongTerms::new
+    );
+    static {
+        declareParsedTermsFields(PARSER, ParsedBucket::fromXContent);
+    }
+
+    public static ParsedUnsignedLongTerms fromXContent(XContentParser parser, String name) throws IOException {
+        ParsedUnsignedLongTerms aggregation = PARSER.parse(parser, null);
+        aggregation.setName(name);
+        return aggregation;
+    }
+
+    /**
+     * Parsed bucket for long term values
+     *
+     * @opensearch.internal
+     */
+    public static class ParsedBucket extends ParsedTerms.ParsedBucket {
+
+        private BigInteger key;
+
+        @Override
+        public Object getKey() {
+            return key;
+        }
+
+        @Override
+        public String getKeyAsString() {
+            String keyAsString = super.getKeyAsString();
+            if (keyAsString != null) {
+                return keyAsString;
+            }
+            if (key != null) {
+                return key.toString();
+            }
+            return null;
+        }
+
+        public Number getKeyAsNumber() {
+            return key;
+        }
+
+        @Override
+        protected XContentBuilder keyToXContent(XContentBuilder builder) throws IOException {
+            builder.field(CommonFields.KEY.getPreferredName(), key);
+            if (super.getKeyAsString() != null) {
+                builder.field(CommonFields.KEY_AS_STRING.getPreferredName(), getKeyAsString());
+            }
+            return builder;
+        }
+
+        static ParsedBucket fromXContent(XContentParser parser) throws IOException {
+            return parseTermsBucketXContent(parser, ParsedBucket::new, (p, bucket) -> bucket.key = p.bigIntegerValue());
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
@@ -203,6 +203,11 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                         longFilter = includeExclude.convertToDoubleFilter();
                     }
                     resultStrategy = agg -> agg.new DoubleTermsResults(showTermDocCountError);
+                } else if (numericValuesSource.isBigInteger()) {
+                    if (includeExclude != null) {
+                        longFilter = includeExclude.convertToDoubleFilter();
+                    }
+                    resultStrategy = agg -> agg.new UnsignedLongTermsResults(showTermDocCountError);
                 } else {
                     if (includeExclude != null) {
                         longFilter = includeExclude.convertToLongFilter(format);

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/UnsignedLongTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/UnsignedLongTerms.java
@@ -1,0 +1,286 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.aggregations.bucket.terms;
+
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.BucketOrder;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.InternalAggregations;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Result of the {@link TermsAggregator} when the field is some kind of whole number like a integer,
+ * long, unsigned long or a date.
+ *
+ * @opensearch.internal
+ */
+public class UnsignedLongTerms extends InternalMappedTerms<UnsignedLongTerms, UnsignedLongTerms.Bucket> {
+    public static final String NAME = "ulterms";
+
+    /**
+     * Bucket for long terms
+     *
+     * @opensearch.internal
+     */
+    public static class Bucket extends InternalTerms.Bucket<Bucket> {
+        BigInteger term;
+
+        public Bucket(
+            BigInteger term,
+            long docCount,
+            InternalAggregations aggregations,
+            boolean showDocCountError,
+            long docCountError,
+            DocValueFormat format
+        ) {
+            super(docCount, aggregations, showDocCountError, docCountError, format);
+            this.term = term;
+        }
+
+        /**
+         * Read from a stream.
+         */
+        public Bucket(StreamInput in, DocValueFormat format, boolean showDocCountError) throws IOException {
+            super(in, format, showDocCountError);
+            term = in.readBigInteger();
+        }
+
+        @Override
+        protected void writeTermTo(StreamOutput out) throws IOException {
+            out.writeBigInteger(term);
+        }
+
+        @Override
+        public String getKeyAsString() {
+            return format.format(term).toString();
+        }
+
+        @Override
+        public Object getKey() {
+            if (format == DocValueFormat.UNSIGNED_LONG_SHIFTED) {
+                return format.format(term);
+            } else {
+                return term;
+            }
+        }
+
+        @Override
+        public Number getKeyAsNumber() {
+            if (format == DocValueFormat.UNSIGNED_LONG_SHIFTED) {
+                return (Number) format.format(term);
+            } else {
+                return term;
+            }
+        }
+
+        @Override
+        public int compareKey(Bucket other) {
+            return term.compareTo(other.term);
+        }
+
+        @Override
+        protected final XContentBuilder keyToXContent(XContentBuilder builder) throws IOException {
+            if (format == DocValueFormat.UNSIGNED_LONG_SHIFTED) {
+                builder.field(CommonFields.KEY.getPreferredName(), format.format(term));
+            } else {
+                builder.field(CommonFields.KEY.getPreferredName(), term);
+            }
+            if (format != DocValueFormat.RAW && format != DocValueFormat.UNSIGNED_LONG_SHIFTED && format != DocValueFormat.UNSIGNED_LONG) {
+                builder.field(CommonFields.KEY_AS_STRING.getPreferredName(), format.format(term).toString());
+            }
+            return builder;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return super.equals(obj) && Objects.equals(term, ((Bucket) obj).term);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), term);
+        }
+    }
+
+    public UnsignedLongTerms(
+        String name,
+        BucketOrder reduceOrder,
+        BucketOrder order,
+        int requiredSize,
+        long minDocCount,
+        Map<String, Object> metadata,
+        DocValueFormat format,
+        int shardSize,
+        boolean showTermDocCountError,
+        long otherDocCount,
+        List<Bucket> buckets,
+        long docCountError
+    ) {
+        super(
+            name,
+            reduceOrder,
+            order,
+            requiredSize,
+            minDocCount,
+            metadata,
+            format,
+            shardSize,
+            showTermDocCountError,
+            otherDocCount,
+            buckets,
+            docCountError
+        );
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public UnsignedLongTerms(StreamInput in) throws IOException {
+        super(in, Bucket::new);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    @Override
+    public UnsignedLongTerms create(List<Bucket> buckets) {
+        return new UnsignedLongTerms(
+            name,
+            reduceOrder,
+            order,
+            requiredSize,
+            minDocCount,
+            metadata,
+            format,
+            shardSize,
+            showTermDocCountError,
+            otherDocCount,
+            buckets,
+            docCountError
+        );
+    }
+
+    @Override
+    public Bucket createBucket(InternalAggregations aggregations, Bucket prototype) {
+        return new Bucket(
+            prototype.term,
+            prototype.docCount,
+            aggregations,
+            prototype.showDocCountError,
+            prototype.docCountError,
+            prototype.format
+        );
+    }
+
+    @Override
+    protected UnsignedLongTerms create(String name, List<Bucket> buckets, BucketOrder reduceOrder, long docCountError, long otherDocCount) {
+        return new UnsignedLongTerms(
+            name,
+            reduceOrder,
+            order,
+            requiredSize,
+            minDocCount,
+            getMetadata(),
+            format,
+            shardSize,
+            showTermDocCountError,
+            otherDocCount,
+            buckets,
+            docCountError
+        );
+    }
+
+    @Override
+    protected Bucket[] createBucketsArray(int size) {
+        return new Bucket[size];
+    }
+
+    @Override
+    public InternalAggregation reduce(List<InternalAggregation> aggregations, ReduceContext reduceContext) {
+        boolean unsignedLongFormat = false;
+        boolean rawFormat = false;
+        for (InternalAggregation agg : aggregations) {
+            if (agg instanceof DoubleTerms) {
+                return agg.reduce(aggregations, reduceContext);
+            }
+            if (agg instanceof UnsignedLongTerms) {
+                if (((UnsignedLongTerms) agg).format == DocValueFormat.RAW) {
+                    rawFormat = true;
+                } else if (((UnsignedLongTerms) agg).format == DocValueFormat.UNSIGNED_LONG_SHIFTED) {
+                    unsignedLongFormat = true;
+                } else if (((UnsignedLongTerms) agg).format == DocValueFormat.UNSIGNED_LONG) {
+                    unsignedLongFormat = true;
+                }
+            }
+        }
+        if (rawFormat && unsignedLongFormat) { // if we have mixed formats, convert results to double format
+            List<InternalAggregation> newAggs = new ArrayList<>(aggregations.size());
+            for (InternalAggregation agg : aggregations) {
+                if (agg instanceof UnsignedLongTerms) {
+                    DoubleTerms dTerms = UnsignedLongTerms.convertUnsignedLongTermsToDouble((UnsignedLongTerms) agg, format);
+                    newAggs.add(dTerms);
+                } else {
+                    newAggs.add(agg);
+                }
+            }
+            return newAggs.get(0).reduce(newAggs, reduceContext);
+        }
+        return super.reduce(aggregations, reduceContext);
+    }
+
+    @Override
+    Bucket createBucket(long docCount, InternalAggregations aggs, long docCountError, UnsignedLongTerms.Bucket prototype) {
+        return new Bucket(prototype.term, docCount, aggs, prototype.showDocCountError, docCountError, format);
+    }
+
+    /**
+     * Converts a {@link UnsignedLongTerms} into a {@link DoubleTerms}, returning the value of the specified long terms as doubles.
+     */
+    static DoubleTerms convertUnsignedLongTermsToDouble(UnsignedLongTerms unsignedLongTerms, DocValueFormat decimalFormat) {
+        List<UnsignedLongTerms.Bucket> buckets = unsignedLongTerms.getBuckets();
+        List<DoubleTerms.Bucket> newBuckets = new ArrayList<>();
+        for (Terms.Bucket bucket : buckets) {
+            newBuckets.add(
+                new DoubleTerms.Bucket(
+                    bucket.getKeyAsNumber().doubleValue(),
+                    bucket.getDocCount(),
+                    (InternalAggregations) bucket.getAggregations(),
+                    unsignedLongTerms.showTermDocCountError,
+                    unsignedLongTerms.showTermDocCountError ? bucket.getDocCountError() : 0,
+                    decimalFormat
+                )
+            );
+        }
+        return new DoubleTerms(
+            unsignedLongTerms.getName(),
+            unsignedLongTerms.reduceOrder,
+            unsignedLongTerms.order,
+            unsignedLongTerms.requiredSize,
+            unsignedLongTerms.minDocCount,
+            unsignedLongTerms.metadata,
+            unsignedLongTerms.format,
+            unsignedLongTerms.shardSize,
+            unsignedLongTerms.showTermDocCountError,
+            unsignedLongTerms.otherDocCount,
+            newBuckets,
+            unsignedLongTerms.docCountError
+        );
+    }
+}

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/CardinalityAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/CardinalityAggregator.java
@@ -111,7 +111,7 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
 
         if (valuesSource instanceof ValuesSource.Numeric) {
             ValuesSource.Numeric source = (ValuesSource.Numeric) valuesSource;
-            MurmurHash3Values hashValues = source.isFloatingPoint()
+            MurmurHash3Values hashValues = (source.isFloatingPoint() || source.isBigInteger())
                 ? MurmurHash3Values.hash(source.doubleValues(ctx))
                 : MurmurHash3Values.hash(source.longValues(ctx));
             numericCollectorsUsed++;

--- a/server/src/main/java/org/opensearch/search/aggregations/support/MissingValues.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/support/MissingValues.java
@@ -113,11 +113,17 @@ public enum MissingValues {
     public static ValuesSource.Numeric replaceMissing(final ValuesSource.Numeric valuesSource, final Number missing) {
         final boolean missingIsFloat = missing.doubleValue() % 1 != 0;
         final boolean isFloatingPoint = valuesSource.isFloatingPoint() || missingIsFloat;
+        final boolean isBigInteger = valuesSource.isBigInteger() && !isFloatingPoint;
         return new ValuesSource.Numeric() {
 
             @Override
             public boolean isFloatingPoint() {
                 return isFloatingPoint;
+            }
+
+            @Override
+            public boolean isBigInteger() {
+                return isBigInteger;
             }
 
             @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/support/ValueType.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/support/ValueType.java
@@ -68,7 +68,8 @@ public enum ValueType implements Writeable {
     NUMERIC((byte) 7, "numeric", "numeric", CoreValuesSourceType.NUMERIC, DocValueFormat.RAW),
     GEOPOINT((byte) 8, "geo_point", "geo_point", CoreValuesSourceType.GEOPOINT, DocValueFormat.GEOHASH),
     BOOLEAN((byte) 9, "boolean", "boolean", CoreValuesSourceType.BOOLEAN, DocValueFormat.BOOLEAN),
-    RANGE((byte) 10, "range", "range", CoreValuesSourceType.RANGE, DocValueFormat.RAW);
+    RANGE((byte) 10, "range", "range", CoreValuesSourceType.RANGE, DocValueFormat.RAW),
+    UNSIGNED_LONG((byte) 11, "unsigned_long", "unsigned_long", CoreValuesSourceType.NUMERIC, DocValueFormat.UNSIGNED_LONG),;
 
     final String description;
     final ValuesSourceType valuesSourceType;
@@ -98,6 +99,7 @@ public enum ValueType implements Writeable {
         ValueType.DOUBLE,
         ValueType.DATE,
         ValueType.LONG,
+        ValueType.UNSIGNED_LONG,
         ValueType.NUMBER,
         ValueType.NUMERIC,
         ValueType.BOOLEAN
@@ -144,6 +146,8 @@ public enum ValueType implements Writeable {
             case "short":
             case "byte":
                 return LONG;
+            case "unsigned_long":
+                return UNSIGNED_LONG;
             case "date":
                 return DATE;
             case "ip":

--- a/server/src/main/java/org/opensearch/search/searchafter/SearchAfterBuilder.java
+++ b/server/src/main/java/org/opensearch/search/searchafter/SearchAfterBuilder.java
@@ -201,9 +201,15 @@ public class SearchAfterBuilder implements ToXContentObject, Writeable {
 
                 case LONG:
                     // for unsigned_long field type we want to pass search_after value through formatting
-                    if (value instanceof Number && format != DocValueFormat.UNSIGNED_LONG_SHIFTED) {
+                    if (value instanceof Number
+                        && (format != DocValueFormat.UNSIGNED_LONG_SHIFTED && format != DocValueFormat.UNSIGNED_LONG)) {
                         return ((Number) value).longValue();
+                    } else if (format == DocValueFormat.UNSIGNED_LONG_SHIFTED || format == DocValueFormat.UNSIGNED_LONG) {
+                        return format.parseUnsignedLong(value.toString(), false, () -> {
+                            throw new IllegalStateException("now() is not allowed in [search_after] key");
+                        });
                     }
+
                     return format.parseLong(
                         value.toString(),
                         false,

--- a/server/src/main/java/org/opensearch/search/sort/BucketedSort.java
+++ b/server/src/main/java/org/opensearch/search/sort/BucketedSort.java
@@ -844,4 +844,91 @@ public abstract class BucketedSort implements Releasable {
             }
         }
     }
+
+    /**
+     * Superclass for implementations of {@linkplain BucketedSort} for {@code unsigned long} keys.
+     */
+    public abstract static class ForUnsignedLongs extends BucketedSort {
+        private LongArray values = bigArrays.newLongArray(1, false);
+
+        public ForUnsignedLongs(BigArrays bigArrays, SortOrder sortOrder, DocValueFormat format, int bucketSize, ExtraData extra) {
+            super(bigArrays, sortOrder, format, bucketSize, extra);
+            initGatherOffsets();
+        }
+
+        @Override
+        public final boolean needsScores() {
+            return false;
+        }
+
+        @Override
+        protected final BigArray values() {
+            return values;
+        }
+
+        @Override
+        protected final void growValues(long minSize) {
+            values = bigArrays.grow(values, minSize);
+        }
+
+        @Override
+        protected final int getNextGatherOffset(long rootIndex) {
+            return (int) values.get(rootIndex);
+        }
+
+        @Override
+        protected final void setNextGatherOffset(long rootIndex, int offset) {
+            values.set(rootIndex, offset);
+        }
+
+        @Override
+        protected final SortValue getValue(long index) {
+            return SortValue.fromUnsigned(values.get(index));
+        }
+
+        @Override
+        protected final boolean betterThan(long lhs, long rhs) {
+            return getOrder().reverseMul() * Long.compareUnsigned(values.get(lhs), values.get(rhs)) < 0;
+        }
+
+        @Override
+        protected final void swap(long lhs, long rhs) {
+            long tmp = values.get(lhs);
+            values.set(lhs, values.get(rhs));
+            values.set(rhs, tmp);
+        }
+
+        /**
+         * Leaf for bucketed sort
+         *
+         * @opensearch.internal
+         */
+        protected abstract class Leaf extends BucketedSort.Leaf {
+            protected Leaf(LeafReaderContext ctx) {
+                super(ctx);
+            }
+
+            /**
+             * Return the value for of this sort for the document to which
+             * we just {@link #advanceExact(int) moved}. This should be fast
+             * because it is called twice per competitive hit when in heap
+             * mode, once for {@link #docBetterThan(long)} and once
+             * for {@link #setIndexToDocValue(long)}.
+             */
+            protected abstract long docValue();
+
+            @Override
+            public final void setScorer(Scorable scorer) {}
+
+            @Override
+            protected final void setIndexToDocValue(long index) {
+                values.set(index, docValue());
+            }
+
+            @Override
+            protected final boolean docBetterThan(long index) {
+                return getOrder().reverseMul() * Long.compareUnsigned(docValue(), values.get(index)) < 0;
+            }
+        }
+    }
 }

--- a/server/src/main/java/org/opensearch/search/sort/SortValue.java
+++ b/server/src/main/java/org/opensearch/search/sort/SortValue.java
@@ -64,12 +64,20 @@ public abstract class SortValue implements NamedWriteable, Comparable<SortValue>
     }
 
     /**
+     * Get a {@linkplain SortValue} for a unsigned long.
+     */
+    public static SortValue fromUnsigned(long l) {
+        return new UnsignedLongSortValue(l);
+    }
+
+    /**
      * Get the list of {@linkplain NamedWriteable}s that this class needs.
      */
     public static List<NamedWriteableRegistry.Entry> namedWriteables() {
         return Arrays.asList(
             new NamedWriteableRegistry.Entry(SortValue.class, DoubleSortValue.NAME, DoubleSortValue::new),
-            new NamedWriteableRegistry.Entry(SortValue.class, LongSortValue.NAME, LongSortValue::new)
+            new NamedWriteableRegistry.Entry(SortValue.class, LongSortValue.NAME, LongSortValue::new),
+            new NamedWriteableRegistry.Entry(SortValue.class, UnsignedLongSortValue.NAME, UnsignedLongSortValue::new)
         );
     }
 
@@ -268,6 +276,75 @@ public abstract class SortValue implements NamedWriteable, Comparable<SortValue>
         @Override
         public String toString() {
             return Long.toString(key);
+        }
+
+        @Override
+        public Number numberValue() {
+            return key;
+        }
+    }
+
+    private static class UnsignedLongSortValue extends SortValue {
+        public static final String NAME = "unsigned_long";
+
+        private final long key;
+
+        UnsignedLongSortValue(long key) {
+            this.key = key;
+        }
+
+        UnsignedLongSortValue(StreamInput in) throws IOException {
+            key = in.readLong();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeLong(key);
+        }
+
+        @Override
+        public String getWriteableName() {
+            return NAME;
+        }
+
+        @Override
+        public Object getKey() {
+            return key;
+        }
+
+        @Override
+        public String format(DocValueFormat format) {
+            return format.format(key).toString();
+        }
+
+        @Override
+        protected XContentBuilder rawToXContent(XContentBuilder builder) throws IOException {
+            return builder.value(key);
+        }
+
+        @Override
+        protected int compareToSameType(SortValue obj) {
+            UnsignedLongSortValue other = (UnsignedLongSortValue) obj;
+            return Long.compareUnsigned(key, other.key);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == null || false == getClass().equals(obj.getClass())) {
+                return false;
+            }
+            UnsignedLongSortValue other = (UnsignedLongSortValue) obj;
+            return key == other.key;
+        }
+
+        @Override
+        public int hashCode() {
+            return Long.hashCode(key);
+        }
+
+        @Override
+        public String toString() {
+            return Long.toUnsignedString(key);
         }
 
         @Override

--- a/server/src/test/java/org/opensearch/common/xcontent/BaseXContentTestCase.java
+++ b/server/src/test/java/org/opensearch/common/xcontent/BaseXContentTestCase.java
@@ -255,6 +255,10 @@ public abstract class BaseXContentTestCase extends OpenSearchTestCase {
         assertResult("{'long':null}", () -> builder().startObject().field("long", (Long) null).endObject());
         assertResult("{'long':42}", () -> builder().startObject().field("long", Long.valueOf(42L)).endObject());
         assertResult("{'long':9223372036854775807}", () -> builder().startObject().field("long", 9_223_372_036_854_775_807L).endObject());
+        assertResult(
+            "{'unsigned_long':18446744073709551615}",
+            () -> builder().startObject().field("unsigned_long", new BigDecimal("18446744073709551615")).endObject()
+        );
         assertResult("{'long':[1,3,5,7,11]}", () -> builder().startObject().array("long", 1L, 3L, 5L, 7L, 11L).endObject());
         assertResult("{'long':null}", () -> builder().startObject().array("long", (long[]) null).endObject());
         assertResult("{'long':[]}", () -> builder().startObject().array("long", new long[] {}).endObject());

--- a/server/src/test/java/org/opensearch/index/fielddata/IndexFieldDataServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/fielddata/IndexFieldDataServiceTests.java
@@ -369,6 +369,22 @@ public class IndexFieldDataServiceTests extends OpenSearchSingleNodeTestCase {
         );
     }
 
+    public void testRequireDocValuesOnUnsignedLongs() {
+        doTestRequireDocValues(new NumberFieldMapper.NumberFieldType("field", NumberFieldMapper.NumberType.UNSIGNED_LONG));
+        doTestRequireDocValues(
+            new NumberFieldMapper.NumberFieldType(
+                "field",
+                NumberFieldMapper.NumberType.UNSIGNED_LONG,
+                true,
+                false,
+                false,
+                false,
+                null,
+                Collections.emptyMap()
+            )
+        );
+    }
+
     public void testRequireDocValuesOnBools() {
         doTestRequireDocValues(new BooleanFieldMapper.BooleanFieldType("field"));
         doTestRequireDocValues(new BooleanFieldMapper.BooleanFieldType("field", true, false, false, null, Collections.emptyMap()));

--- a/server/src/test/java/org/opensearch/index/mapper/NumberFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/NumberFieldMapperTests.java
@@ -55,12 +55,12 @@ public class NumberFieldMapperTests extends AbstractNumericFieldMapperTestCase {
 
     @Override
     protected Set<String> types() {
-        return Set.of("byte", "short", "integer", "long", "float", "double", "half_float");
+        return Set.of("byte", "short", "integer", "long", "float", "double", "half_float", "unsigned_long");
     }
 
     @Override
     protected Set<String> wholeTypes() {
-        return Set.of("byte", "short", "integer", "long");
+        return Set.of("byte", "short", "integer", "long", "unsigned_long");
     }
 
     @Override
@@ -147,7 +147,12 @@ public class NumberFieldMapperTests extends AbstractNumericFieldMapperTestCase {
         assertEquals(DocValuesType.SORTED_NUMERIC, dvField.fieldType().docValuesType());
         IndexableField storedField = fields[2];
         assertTrue(storedField.fieldType().stored());
-        assertEquals(123, storedField.numericValue().doubleValue(), 0d);
+        // The 'unsigned_long' is stored as a string
+        if (type.equalsIgnoreCase("unsigned_long")) {
+            assertEquals(123, new BigInteger(storedField.stringValue()).longValue());
+        } else {
+            assertEquals(123, storedField.numericValue().doubleValue(), 0d);
+        }
     }
 
     @Override
@@ -244,22 +249,26 @@ public class NumberFieldMapperTests extends AbstractNumericFieldMapperTestCase {
             OutOfRangeSpec.of(NumberType.INTEGER, "2147483648", "is out of range for an integer"),
             OutOfRangeSpec.of(NumberType.LONG, "9223372036854775808", "out of range for a long"),
             OutOfRangeSpec.of(NumberType.LONG, "1e999999999", "out of range for a long"),
+            OutOfRangeSpec.of(NumberType.UNSIGNED_LONG, "18446744073709551616", "out of range for an unsigned long"),
 
             OutOfRangeSpec.of(NumberType.BYTE, "-129", "is out of range for a byte"),
             OutOfRangeSpec.of(NumberType.SHORT, "-32769", "is out of range for a short"),
             OutOfRangeSpec.of(NumberType.INTEGER, "-2147483649", "is out of range for an integer"),
             OutOfRangeSpec.of(NumberType.LONG, "-9223372036854775809", "out of range for a long"),
             OutOfRangeSpec.of(NumberType.LONG, "-1e999999999", "out of range for a long"),
+            OutOfRangeSpec.of(NumberType.UNSIGNED_LONG, "-1", "out of range for an unsigned long"),
 
             OutOfRangeSpec.of(NumberType.BYTE, 128, "is out of range for a byte"),
             OutOfRangeSpec.of(NumberType.SHORT, 32768, "out of range of Java short"),
             OutOfRangeSpec.of(NumberType.INTEGER, 2147483648L, " out of range of int"),
             OutOfRangeSpec.of(NumberType.LONG, new BigInteger("9223372036854775808"), "out of range of long"),
+            OutOfRangeSpec.of(NumberType.UNSIGNED_LONG, new BigInteger("18446744073709551616"), "out of range for an unsigned long"),
 
             OutOfRangeSpec.of(NumberType.BYTE, -129, "is out of range for a byte"),
             OutOfRangeSpec.of(NumberType.SHORT, -32769, "out of range of Java short"),
             OutOfRangeSpec.of(NumberType.INTEGER, -2147483649L, " out of range of int"),
             OutOfRangeSpec.of(NumberType.LONG, new BigInteger("-9223372036854775809"), "out of range of long"),
+            OutOfRangeSpec.of(NumberType.UNSIGNED_LONG, new BigInteger("-1"), "out of range for an unsigned long"),
 
             OutOfRangeSpec.of(NumberType.HALF_FLOAT, "65520", "[half_float] supports only finite values"),
             OutOfRangeSpec.of(NumberType.FLOAT, "3.4028235E39", "[float] supports only finite values"),

--- a/server/src/test/java/org/opensearch/index/mapper/NumberFieldTypeTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/NumberFieldTypeTests.java
@@ -42,6 +42,7 @@ import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.sandbox.document.BigIntegerPoint;
 import org.apache.lucene.sandbox.document.HalfFloatPoint;
 import org.apache.lucene.search.IndexSortSortedNumericDocValuesRangeQuery;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
@@ -52,15 +53,18 @@ import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.NumericUtils;
 import org.apache.lucene.tests.util.TestUtil;
 import org.opensearch.Version;
 import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.Numbers;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.BigArrays;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.internal.io.IOUtils;
 import org.opensearch.index.IndexSettings;
+import org.opensearch.index.document.SortedUnsignedLongDocValuesRangeQuery;
 import org.opensearch.index.fielddata.IndexNumericFieldData;
 import org.opensearch.index.mapper.MappedFieldType.Relation;
 import org.opensearch.index.mapper.NumberFieldMapper.NumberFieldType;
@@ -342,11 +346,67 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
         );
     }
 
-    public void testRangeQuery() {
+    public void testUnsignedLongRangeQueryWithDecimalParts() {
+        MappedFieldType ft = new NumberFieldMapper.NumberFieldType("field", NumberType.UNSIGNED_LONG);
+        assertEquals(
+            ft.rangeQuery(2, 10, true, true, null, null, null, MOCK_QSC),
+            ft.rangeQuery(1.1, 10, true, true, null, null, null, MOCK_QSC)
+        );
+        assertEquals(
+            ft.rangeQuery(2, 10, true, true, null, null, null, MOCK_QSC),
+            ft.rangeQuery(1.1, 10, false, true, null, null, null, MOCK_QSC)
+        );
+        assertEquals(
+            ft.rangeQuery(1, 10, true, true, null, null, null, MOCK_QSC),
+            ft.rangeQuery(1, 10.1, true, true, null, null, null, MOCK_QSC)
+        );
+        assertEquals(
+            ft.rangeQuery(1, 10, true, true, null, null, null, MOCK_QSC),
+            ft.rangeQuery(1, 10.1, true, false, null, null, null, MOCK_QSC)
+        );
+    }
+
+    public void testLongRangeQuery() {
         MappedFieldType ft = new NumberFieldMapper.NumberFieldType("field", NumberFieldMapper.NumberType.LONG);
         Query expected = new IndexOrDocValuesQuery(
             LongPoint.newRangeQuery("field", 1, 3),
             SortedNumericDocValuesField.newSlowRangeQuery("field", 1, 3)
+        );
+        assertEquals(expected, ft.rangeQuery("1", "3", true, true, null, null, null, MOCK_QSC));
+
+        MappedFieldType unsearchable = unsearchable();
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> unsearchable.rangeQuery("1", "3", true, true, null, null, null, MOCK_QSC)
+        );
+        assertEquals("Cannot search on field [field] since it is not indexed.", e.getMessage());
+    }
+
+    public void testUnsignedLongRangeQuery() {
+        MappedFieldType ft = new NumberFieldMapper.NumberFieldType("field", NumberFieldMapper.NumberType.UNSIGNED_LONG);
+        Query expected = new IndexOrDocValuesQuery(
+            BigIntegerPoint.newRangeQuery("field", BigInteger.valueOf(1), BigInteger.valueOf(3)),
+            SortedUnsignedLongDocValuesRangeQuery.newSlowRangeQuery("field", BigInteger.valueOf(1), BigInteger.valueOf(3))
+        );
+        assertEquals(expected, ft.rangeQuery("1", "3", true, true, null, null, null, MOCK_QSC));
+
+        MappedFieldType unsearchable = unsearchable();
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> unsearchable.rangeQuery("1", "3", true, true, null, null, null, MOCK_QSC)
+        );
+        assertEquals("Cannot search on field [field] since it is not indexed.", e.getMessage());
+    }
+
+    public void testDoubleRangeQuery() {
+        MappedFieldType ft = new NumberFieldMapper.NumberFieldType("field", NumberFieldMapper.NumberType.DOUBLE);
+        Query expected = new IndexOrDocValuesQuery(
+            DoublePoint.newRangeQuery("field", 1d, 3d),
+            SortedNumericDocValuesField.newSlowRangeQuery(
+                "field",
+                NumericUtils.doubleToSortableLong(1),
+                NumericUtils.doubleToSortableLong(3)
+            )
         );
         assertEquals(expected, ft.rangeQuery("1", "3", true, true, null, null, null, MOCK_QSC));
 
@@ -363,6 +423,7 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
         assertEquals((short) 3, NumberType.SHORT.parse(3d, true));
         assertEquals(3, NumberType.INTEGER.parse(3d, true));
         assertEquals(3L, NumberType.LONG.parse(3d, true));
+        assertEquals(BigInteger.valueOf(3L), NumberType.UNSIGNED_LONG.parse(3d, true));
         assertEquals(3f, NumberType.HALF_FLOAT.parse(3d, true));
         assertEquals(3f, NumberType.FLOAT.parse(3d, true));
         assertEquals(3d, NumberType.DOUBLE.parse(3d, true));
@@ -371,6 +432,7 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
         assertEquals((short) 3, NumberType.SHORT.parse(3.5, true));
         assertEquals(3, NumberType.INTEGER.parse(3.5, true));
         assertEquals(3L, NumberType.LONG.parse(3.5, true));
+        assertEquals(BigInteger.valueOf(3L), NumberType.UNSIGNED_LONG.parse(3.5, true));
 
         assertEquals(3.5f, NumberType.FLOAT.parse(3.5, true));
         assertEquals(3.5d, NumberType.DOUBLE.parse(3.5, true));
@@ -383,6 +445,8 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
         assertEquals("Value [2147483648] is out of range for an integer", e.getMessage());
         e = expectThrows(IllegalArgumentException.class, () -> NumberType.LONG.parse(10000000000000000000d, true));
         assertEquals("Value [1.0E19] is out of range for a long", e.getMessage());
+        e = expectThrows(IllegalArgumentException.class, () -> NumberType.UNSIGNED_LONG.parse(100000000000000000000d, true));
+        assertEquals("Value [1.0E20] is out of range for an unsigned long", e.getMessage());
         assertEquals(1.1f, NumberType.HALF_FLOAT.parse(1.1, true));
         assertEquals(1.1f, NumberType.FLOAT.parse(1.1, true));
         assertEquals(1.1d, NumberType.DOUBLE.parse(1.1, true));
@@ -417,6 +481,13 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
         // these will lose precision if they get treated as a double
         assertEquals(-4115420654264075766L, NumberType.LONG.parse("-4115420654264075766", true));
         assertEquals(-4115420654264075766L, NumberType.LONG.parse(-4115420654264075766L, true));
+
+        assertEquals(BigInteger.valueOf(5), NumberType.UNSIGNED_LONG.parse((byte) 5, true));
+        assertEquals(BigInteger.valueOf(5), NumberType.UNSIGNED_LONG.parse("5", true));
+        assertEquals(BigInteger.valueOf(5), NumberType.UNSIGNED_LONG.parse("5.0", true));
+        assertEquals(BigInteger.valueOf(5), NumberType.UNSIGNED_LONG.parse("5.9", true));
+        assertEquals(BigInteger.valueOf(5), NumberType.UNSIGNED_LONG.parse(new BytesRef("5.3".getBytes(StandardCharsets.UTF_8)), true));
+        assertEquals(Numbers.MAX_UNSIGNED_LONG_VALUE, NumberType.UNSIGNED_LONG.parse(Numbers.MAX_UNSIGNED_LONG_VALUE, true));
     }
 
     public void testHalfFloatRange() throws IOException {
@@ -449,6 +520,37 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
             Query floatQ = NumberType.FLOAT.rangeQuery("float", l, u, includeLower, includeUpper, false, MOCK_QSC);
             Query halfFloatQ = NumberType.HALF_FLOAT.rangeQuery("half_float", l, u, includeLower, includeUpper, false, MOCK_QSC);
             assertEquals(searcher.count(floatQ), searcher.count(halfFloatQ));
+        }
+        IOUtils.close(reader, dir);
+    }
+
+    public void testUnsignedLongRange() throws IOException {
+        // make sure the accuracy loss of half floats only occurs at index time
+        // this test checks that searching half floats yields the same results as
+        // searching floats that are rounded to the closest half float
+        Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(null));
+        final int numDocs = 10000;
+        for (int i = 0; i < numDocs; ++i) {
+            Document doc = new Document();
+            BigInteger value = randomUnsignedLong();
+            doc.add(new BigIntegerPoint("unsigned_long", value));
+            doc.add(new DoublePoint("double", value.doubleValue()));
+            w.addDocument(doc);
+        }
+        final DirectoryReader reader = DirectoryReader.open(w);
+        w.close();
+
+        IndexSearcher searcher = newSearcher(reader);
+        final int numQueries = 1000;
+        for (int i = 0; i < numQueries; ++i) {
+            BigInteger l = randomUnsignedLong();
+            BigInteger u = randomUnsignedLong();
+            boolean includeLower = randomBoolean();
+            boolean includeUpper = randomBoolean();
+            Query unsignedLongQ = NumberType.UNSIGNED_LONG.rangeQuery("unsigned_long", l, u, includeLower, includeUpper, false, MOCK_QSC);
+            Query doubleQ = NumberType.DOUBLE.rangeQuery("double", l, u, includeLower, includeUpper, false, MOCK_QSC);
+            assertEquals(searcher.count(doubleQ), searcher.count(unsignedLongQ));
         }
         IOUtils.close(reader, dir);
     }
@@ -488,6 +590,10 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
 
     public void testDocValueLongRange() throws Exception {
         doTestDocValueRangeQueries(NumberType.LONG, random()::nextLong);
+    }
+
+    public void testDocValueUnsignedLongRange() throws Exception {
+        doTestDocValueRangeQueries(NumberType.UNSIGNED_LONG, FieldTypeTestCase::randomUnsignedLong);
     }
 
     public void testDocValueHalfFloatRange() throws Exception {

--- a/server/src/test/java/org/opensearch/index/mapper/StoredNumericValuesTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/StoredNumericValuesTests.java
@@ -48,6 +48,7 @@ import org.opensearch.index.fieldvisitor.CustomFieldsVisitor;
 import org.opensearch.index.mapper.MapperService.MergeReason;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
 
+import java.math.BigInteger;
 import java.util.Set;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -101,6 +102,10 @@ public class StoredNumericValuesTests extends OpenSearchSingleNodeTestCase {
                 .field("type", "boolean")
                 .field("store", true)
                 .endObject()
+                .startObject("field11")
+                .field("type", "unsigned_long")
+                .field("store", true)
+                .endObject()
                 .endObject()
                 .endObject()
                 .endObject()
@@ -129,6 +134,7 @@ public class StoredNumericValuesTests extends OpenSearchSingleNodeTestCase {
                         .field("field8", "2001:db8::2:1")
                         .field("field9", "2016-04-05")
                         .field("field10", true)
+                        .field("field11", "1")
                         .endObject()
                 ),
                 XContentType.JSON
@@ -150,13 +156,14 @@ public class StoredNumericValuesTests extends OpenSearchSingleNodeTestCase {
             "field7",
             "field8",
             "field9",
-            "field10"
+            "field10",
+            "field11"
         );
         CustomFieldsVisitor fieldsVisitor = new CustomFieldsVisitor(fieldNames, false);
         searcher.doc(0, fieldsVisitor);
 
         fieldsVisitor.postProcess(mapperService::fieldType);
-        assertThat(fieldsVisitor.fields().size(), equalTo(10));
+        assertThat(fieldsVisitor.fields().size(), equalTo(11));
         assertThat(fieldsVisitor.fields().get("field1").size(), equalTo(1));
         assertThat(fieldsVisitor.fields().get("field1").get(0), equalTo((byte) 1));
 
@@ -188,6 +195,9 @@ public class StoredNumericValuesTests extends OpenSearchSingleNodeTestCase {
 
         assertThat(fieldsVisitor.fields().get("field10").size(), equalTo(1));
         assertThat(fieldsVisitor.fields().get("field10").get(0), equalTo(true));
+
+        assertThat(fieldsVisitor.fields().get("field11").size(), equalTo(1));
+        assertThat(fieldsVisitor.fields().get("field11").get(0), equalTo(BigInteger.valueOf(1)));
 
         reader.close();
         writer.close();

--- a/server/src/test/java/org/opensearch/search/aggregations/AggregationsTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/AggregationsTests.java
@@ -69,6 +69,7 @@ import org.opensearch.search.aggregations.bucket.terms.SignificantLongTermsTests
 import org.opensearch.search.aggregations.bucket.terms.SignificantStringTermsTests;
 import org.opensearch.search.aggregations.bucket.terms.StringRareTermsTests;
 import org.opensearch.search.aggregations.bucket.terms.StringTermsTests;
+import org.opensearch.search.aggregations.bucket.terms.UnsignedLongTermsTests;
 import org.opensearch.search.aggregations.metrics.InternalExtendedStatsTests;
 import org.opensearch.search.aggregations.metrics.InternalMaxTests;
 import org.opensearch.search.aggregations.metrics.InternalMedianAbsoluteDeviationTests;
@@ -140,6 +141,7 @@ public class AggregationsTests extends OpenSearchTestCase {
         new InternalDateHistogramTests(),
         new InternalAutoDateHistogramTests(),
         new InternalVariableWidthHistogramTests(),
+        new UnsignedLongTermsTests(),
         new LongTermsTests(),
         new DoubleTermsTests(),
         new StringTermsTests(),

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/composite/SingleDimensionValuesSourceTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/composite/SingleDimensionValuesSourceTests.java
@@ -184,7 +184,8 @@ public class SingleDimensionValuesSourceTests extends OpenSearchTestCase {
             if (numberType == NumberFieldMapper.NumberType.BYTE
                 || numberType == NumberFieldMapper.NumberType.SHORT
                 || numberType == NumberFieldMapper.NumberType.INTEGER
-                || numberType == NumberFieldMapper.NumberType.LONG) {
+                || numberType == NumberFieldMapper.NumberType.LONG
+                || numberType == NumberFieldMapper.NumberType.UNSIGNED_LONG) {
 
                 source = new LongValuesSource(
                     BigArrays.NON_RECYCLING_INSTANCE,

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/UnsignedLongTermsTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/UnsignedLongTermsTests.java
@@ -1,0 +1,178 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.aggregations.bucket.terms;
+
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.BucketOrder;
+import org.opensearch.search.aggregations.InternalAggregations;
+import org.opensearch.search.aggregations.ParsedMultiBucketAggregation;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class UnsignedLongTermsTests extends InternalTermsTestCase {
+
+    @Override
+    protected InternalTerms<?, ?> createTestInstance(
+        String name,
+        Map<String, Object> metadata,
+        InternalAggregations aggregations,
+        boolean showTermDocCountError,
+        long docCountError
+    ) {
+        BucketOrder order = BucketOrder.count(false);
+        long minDocCount = 1;
+        int requiredSize = 3;
+        int shardSize = requiredSize + 2;
+        DocValueFormat format = randomNumericDocValueFormat();
+        long otherDocCount = 0;
+        List<UnsignedLongTerms.Bucket> buckets = new ArrayList<>();
+        final int numBuckets = randomNumberOfBuckets();
+        Set<BigInteger> terms = new HashSet<>();
+        for (int i = 0; i < numBuckets; ++i) {
+            BigInteger term = randomValueOtherThanMany(l -> terms.add(l) == false, InternalTermsTestCase::randomUnsignedLong);
+            int docCount = randomIntBetween(1, 100);
+            buckets.add(new UnsignedLongTerms.Bucket(term, docCount, aggregations, showTermDocCountError, docCountError, format));
+        }
+        BucketOrder reduceOrder = rarely() ? order : BucketOrder.key(true);
+        Collections.sort(buckets, reduceOrder.comparator());
+        return new UnsignedLongTerms(
+            name,
+            reduceOrder,
+            order,
+            requiredSize,
+            minDocCount,
+            metadata,
+            format,
+            shardSize,
+            showTermDocCountError,
+            otherDocCount,
+            buckets,
+            docCountError
+        );
+    }
+
+    @Override
+    protected Class<? extends ParsedMultiBucketAggregation> implementationClass() {
+        return ParsedUnsignedLongTerms.class;
+    }
+
+    @Override
+    protected InternalTerms<?, ?> mutateInstance(InternalTerms<?, ?> instance) {
+        if (instance instanceof UnsignedLongTerms) {
+            UnsignedLongTerms longTerms = (UnsignedLongTerms) instance;
+            String name = longTerms.getName();
+            BucketOrder order = longTerms.order;
+            int requiredSize = longTerms.requiredSize;
+            long minDocCount = longTerms.minDocCount;
+            DocValueFormat format = longTerms.format;
+            int shardSize = longTerms.getShardSize();
+            boolean showTermDocCountError = longTerms.showTermDocCountError;
+            long otherDocCount = longTerms.getSumOfOtherDocCounts();
+            List<UnsignedLongTerms.Bucket> buckets = longTerms.getBuckets();
+            long docCountError = longTerms.getDocCountError();
+            Map<String, Object> metadata = longTerms.getMetadata();
+            switch (between(0, 8)) {
+                case 0:
+                    name += randomAlphaOfLength(5);
+                    break;
+                case 1:
+                    requiredSize += between(1, 100);
+                    break;
+                case 2:
+                    minDocCount += between(1, 100);
+                    break;
+                case 3:
+                    shardSize += between(1, 100);
+                    break;
+                case 4:
+                    showTermDocCountError = showTermDocCountError == false;
+                    break;
+                case 5:
+                    otherDocCount += between(1, 100);
+                    break;
+                case 6:
+                    docCountError += between(1, 100);
+                    break;
+                case 7:
+                    buckets = new ArrayList<>(buckets);
+                    buckets.add(
+                        new UnsignedLongTerms.Bucket(
+                            randomUnsignedLong(),
+                            randomNonNegativeLong(),
+                            InternalAggregations.EMPTY,
+                            showTermDocCountError,
+                            docCountError,
+                            format
+                        )
+                    );
+                    break;
+                case 8:
+                    if (metadata == null) {
+                        metadata = new HashMap<>(1);
+                    } else {
+                        metadata = new HashMap<>(instance.getMetadata());
+                    }
+                    metadata.put(randomAlphaOfLength(15), randomInt());
+                    break;
+                default:
+                    throw new AssertionError("Illegal randomisation branch");
+            }
+            Collections.sort(buckets, longTerms.reduceOrder.comparator());
+            return new UnsignedLongTerms(
+                name,
+                longTerms.reduceOrder,
+                order,
+                requiredSize,
+                minDocCount,
+                metadata,
+                format,
+                shardSize,
+                showTermDocCountError,
+                otherDocCount,
+                buckets,
+                docCountError
+            );
+        } else {
+            String name = instance.getName();
+            BucketOrder order = instance.order;
+            int requiredSize = instance.requiredSize;
+            long minDocCount = instance.minDocCount;
+            Map<String, Object> metadata = instance.getMetadata();
+            switch (between(0, 3)) {
+                case 0:
+                    name += randomAlphaOfLength(5);
+                    break;
+                case 1:
+                    requiredSize += between(1, 100);
+                    break;
+                case 2:
+                    minDocCount += between(1, 100);
+                    break;
+                case 3:
+                    if (metadata == null) {
+                        metadata = new HashMap<>(1);
+                    } else {
+                        metadata = new HashMap<>(instance.getMetadata());
+                    }
+                    metadata.put(randomAlphaOfLength(15), randomInt());
+                    break;
+                default:
+                    throw new AssertionError("Illegal randomisation branch");
+            }
+            return new UnmappedTerms(name, order, requiredSize, minDocCount, metadata);
+        }
+    }
+}

--- a/server/src/test/java/org/opensearch/search/aggregations/metrics/ValueCountAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/metrics/ValueCountAggregatorTests.java
@@ -428,6 +428,8 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
             case NUMERIC:
             case LONG:
                 return new NumberFieldMapper.NumberFieldType(name, NumberFieldMapper.NumberType.LONG);
+            case UNSIGNED_LONG:
+                return new NumberFieldMapper.NumberFieldType(name, NumberFieldMapper.NumberType.UNSIGNED_LONG);
             case DATE:
                 return new DateFieldMapper.DateFieldType(name);
             case IP:

--- a/server/src/test/java/org/opensearch/search/sort/BucketedSortForUnsignedLongsTests.java
+++ b/server/src/test/java/org/opensearch/search/sort/BucketedSortForUnsignedLongsTests.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.sort;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.opensearch.search.DocValueFormat;
+
+public class BucketedSortForUnsignedLongsTests extends BucketedSortTestCase<BucketedSort.ForUnsignedLongs> {
+    @Override
+    public BucketedSort.ForUnsignedLongs build(
+        SortOrder sortOrder,
+        DocValueFormat format,
+        int bucketSize,
+        BucketedSort.ExtraData extra,
+        double[] values
+    ) {
+        return new BucketedSort.ForUnsignedLongs(bigArrays(), sortOrder, format, bucketSize, extra) {
+            @Override
+            public Leaf forLeaf(LeafReaderContext ctx) {
+                return new Leaf(ctx) {
+                    int index = -1;
+
+                    @Override
+                    protected boolean advanceExact(int doc) {
+                        index = doc;
+                        return doc < values.length;
+                    }
+
+                    @Override
+                    protected long docValue() {
+                        return (long) values[index];
+                    }
+                };
+            }
+        };
+    }
+
+    @Override
+    protected SortValue expectedSortValue(double v) {
+        return SortValue.fromUnsigned((long) v);
+    }
+
+    @Override
+    protected double randomValue() {
+        return randomUnsignedLong().doubleValue();
+    }
+
+    @Override
+    protected boolean isUnsignedNumeric() {
+        return true;
+    }
+}

--- a/server/src/test/java/org/opensearch/search/sort/BucketedSortTestCase.java
+++ b/server/src/test/java/org/opensearch/search/sort/BucketedSortTestCase.java
@@ -75,6 +75,11 @@ public abstract class BucketedSortTestCase<T extends BucketedSort> extends OpenS
      */
     protected abstract double randomValue();
 
+    /** A property to indicated the underlying bucket's numeric data type is represented as unsigned numeric */
+    protected boolean isUnsignedNumeric() {
+        return false;
+    }
+
     protected final T build(SortOrder order, int bucketSize, BucketedSort.ExtraData extra, double[] values) {
         DocValueFormat format = randomFrom(DocValueFormat.RAW, DocValueFormat.BINARY, DocValueFormat.BOOLEAN);
         return build(order, format, bucketSize, extra, values);
@@ -194,7 +199,7 @@ public abstract class BucketedSortTestCase<T extends BucketedSort> extends OpenS
 
         double[] maxes = new double[buckets.length];
 
-        try (T sort = build(SortOrder.DESC, 1, new double[] { 2, 3, -1 })) {
+        try (T sort = build(SortOrder.DESC, 1, new double[] { 2, 3, isUnsignedNumeric() ? 0 : -1 })) {
             BucketedSort.Leaf leaf = sort.forLeaf(null);
             for (int b : buckets) {
                 maxes[b] = 2;

--- a/server/src/test/java/org/opensearch/search/sort/FieldSortBuilderTests.java
+++ b/server/src/test/java/org/opensearch/search/sort/FieldSortBuilderTests.java
@@ -44,6 +44,7 @@ import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.sandbox.document.BigIntegerPoint;
 import org.apache.lucene.sandbox.document.HalfFloatPoint;
 import org.apache.lucene.tests.search.AssertingIndexSearcher;
 import org.apache.lucene.search.IndexSearcher;
@@ -78,6 +79,7 @@ import org.opensearch.search.SearchSortValuesAndFormats;
 import org.opensearch.search.builder.SearchSourceBuilder;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -538,6 +540,12 @@ public class FieldSortBuilderTests extends AbstractSortTestCase<FieldSortBuilder
                                 doc.add(new IntPoint(fieldName, v7));
                                 break;
 
+                            case UNSIGNED_LONG:
+                                BigInteger v8 = randomUnsignedLong();
+                                values[i] = v8;
+                                doc.add(new BigIntegerPoint(fieldName, v8));
+                                break;
+
                             default:
                                 throw new AssertionError("unknown type " + numberType);
                         }
@@ -546,7 +554,8 @@ public class FieldSortBuilderTests extends AbstractSortTestCase<FieldSortBuilder
                     Arrays.sort(values);
                     try (DirectoryReader reader = writer.getReader()) {
                         QueryShardContext newContext = createMockShardContext(new AssertingIndexSearcher(random(), reader));
-                        if (numberType == NumberFieldMapper.NumberType.HALF_FLOAT) {
+                        if (numberType == NumberFieldMapper.NumberType.HALF_FLOAT
+                            || numberType == NumberFieldMapper.NumberType.UNSIGNED_LONG) {
                             assertNull(getMinMaxOrNull(newContext, SortBuilders.fieldSort(fieldName + "-ni")));
                             assertNull(getMinMaxOrNull(newContext, SortBuilders.fieldSort(fieldName)));
                         } else {

--- a/test/framework/src/main/java/org/opensearch/test/InternalAggregationTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/InternalAggregationTestCase.java
@@ -106,10 +106,12 @@ import org.opensearch.search.aggregations.bucket.terms.ParsedSignificantLongTerm
 import org.opensearch.search.aggregations.bucket.terms.ParsedSignificantStringTerms;
 import org.opensearch.search.aggregations.bucket.terms.ParsedStringRareTerms;
 import org.opensearch.search.aggregations.bucket.terms.ParsedStringTerms;
+import org.opensearch.search.aggregations.bucket.terms.ParsedUnsignedLongTerms;
 import org.opensearch.search.aggregations.bucket.terms.SignificantLongTerms;
 import org.opensearch.search.aggregations.bucket.terms.SignificantStringTerms;
 import org.opensearch.search.aggregations.bucket.terms.StringRareTerms;
 import org.opensearch.search.aggregations.bucket.terms.StringTerms;
+import org.opensearch.search.aggregations.bucket.terms.UnsignedLongTerms;
 import org.opensearch.search.aggregations.metrics.AvgAggregationBuilder;
 import org.opensearch.search.aggregations.metrics.CardinalityAggregationBuilder;
 import org.opensearch.search.aggregations.metrics.ExtendedStatsAggregationBuilder;
@@ -262,6 +264,7 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
         map.put(VariableWidthHistogramAggregationBuilder.NAME, (p, c) -> ParsedVariableWidthHistogram.fromXContent(p, (String) c));
         map.put(StringTerms.NAME, (p, c) -> ParsedStringTerms.fromXContent(p, (String) c));
         map.put(LongTerms.NAME, (p, c) -> ParsedLongTerms.fromXContent(p, (String) c));
+        map.put(UnsignedLongTerms.NAME, (p, c) -> ParsedUnsignedLongTerms.fromXContent(p, (String) c));
         map.put(DoubleTerms.NAME, (p, c) -> ParsedDoubleTerms.fromXContent(p, (String) c));
         map.put(LongRareTerms.NAME, (p, c) -> ParsedLongRareTerms.fromXContent(p, (String) c));
         map.put(StringRareTerms.NAME, (p, c) -> ParsedStringRareTerms.fromXContent(p, (String) c));

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchTestCase.java
@@ -67,6 +67,7 @@ import org.opensearch.cluster.ClusterModule;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.CheckedRunnable;
+import org.opensearch.common.Numbers;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.bytes.BytesArray;
 import org.opensearch.common.bytes.BytesReference;
@@ -802,6 +803,22 @@ public abstract class OpenSearchTestCase extends LuceneTestCase {
 
     public static long randomLong() {
         return random().nextLong();
+    }
+
+    /**
+     * Returns a random BigInteger uniformly distributed over the range 0 to (2^64 - 1) inclusive
+     * Currently BigIntegers are only used for unsigned_long field type, where the max value is 2^64 - 1.
+     * Modify this random generator if a wider range for BigIntegers is necessary.
+     * @return a random bigInteger in the range [0 ; 2^64 - 1]
+     */
+    public static BigInteger randomUnsignedLong() {
+        BigInteger value = randomBigInteger().abs();
+
+        while (value.compareTo(Numbers.MAX_UNSIGNED_LONG_VALUE) == 1) {
+            value = value.subtract(Numbers.MAX_UNSIGNED_LONG_VALUE);
+        }
+
+        return value;
     }
 
     /**


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/6237 to `2.x`