### PR TITLE
[Backport] [2.7] OpenJDK Update (April 2023 Patch releases) (#7448)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 ### Dependencies
+- OpenJDK Update (April 2023 Patch releases) ([#7448](https://github.com/opensearch-project/OpenSearch/pull/7448)
 
 ### Changed
 

--- a/buildSrc/src/main/java/org/opensearch/gradle/test/DistroTestPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/test/DistroTestPlugin.java
@@ -75,9 +75,9 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 public class DistroTestPlugin implements Plugin<Project> {
-    private static final String SYSTEM_JDK_VERSION = "11.0.18+10";
+    private static final String SYSTEM_JDK_VERSION = "11.0.19+7";
     private static final String SYSTEM_JDK_VENDOR = "adoptium";
-    private static final String GRADLE_JDK_VERSION = "17.0.6+10";
+    private static final String GRADLE_JDK_VERSION = "17.0.7+7";
     private static final String GRADLE_JDK_VENDOR = "adoptium";
 
     // all distributions used by distro tests. this is temporary until tests are per distribution

--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -2,7 +2,7 @@ opensearch        = 2.7.1
 lucene            = 9.5.0
 
 bundled_jdk_vendor = adoptium
-bundled_jdk = 17.0.6+10
+bundled_jdk = 17.0.7+7
 
 # optional dependencies
 spatial4j         = 0.7


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/7448 to `2.7`