### PR TITLE
[Backport 2.x] Cleanup interfaces around ExtensionManager (#7374)

### DIFF
--- a/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
@@ -106,8 +107,7 @@ public class ExtensionsManager {
 
     private final Path extensionsPath;
     private ExtensionTransportActionsHandler extensionTransportActionsHandler;
-    // A list of initialized extensions, a subset of the values of map below which includes all extensions
-    private List<DiscoveryExtensionNode> extensions;
+    private Map<String, DiscoveryExtensionNode> initializedExtensions;
     private Map<String, DiscoveryExtensionNode> extensionIdMap;
     private RestActionsRequestHandler restActionsRequestHandler;
     private CustomSettingsRequestHandler customSettingsRequestHandler;
@@ -117,21 +117,16 @@ public class ExtensionsManager {
     private AddSettingsUpdateConsumerRequestHandler addSettingsUpdateConsumerRequestHandler;
     private NodeClient client;
 
-    public ExtensionsManager() {
-        this.extensionsPath = Path.of("");
-    }
-
     /**
      * Instantiate a new ExtensionsManager object to handle requests and responses from extensions. This is called during Node bootstrap.
      *
-     * @param settings  Settings from the node the orchestrator is running on.
      * @param extensionsPath  Path to a directory containing extensions.
      * @throws IOException  If the extensions discovery file is not properly retrieved.
      */
-    public ExtensionsManager(Settings settings, Path extensionsPath) throws IOException {
+    public ExtensionsManager(Path extensionsPath) throws IOException {
         logger.info("ExtensionsManager initialized");
         this.extensionsPath = extensionsPath;
-        this.extensions = new ArrayList<DiscoveryExtensionNode>();
+        this.initializedExtensions = new HashMap<String, DiscoveryExtensionNode>();
         this.extensionIdMap = new HashMap<String, DiscoveryExtensionNode>();
         // will be initialized in initializeServicesAndRestHandler which is called after the Node is initialized
         this.transportService = null;
@@ -184,6 +179,16 @@ public class ExtensionsManager {
             this
         );
         registerRequestHandler();
+    }
+
+    /**
+     * Lookup an initialized extension by its unique id
+     *
+     * @param extensionId The unique extension identifier
+     * @return An optional of the DiscoveryExtensionNode instance for the matching extension
+     */
+    public Optional<DiscoveryExtensionNode> lookupInitializedExtensionById(final String extensionId) {
+        return Optional.ofNullable(this.initializedExtensions.get(extensionId));
     }
 
     /**
@@ -288,7 +293,7 @@ public class ExtensionsManager {
     /*
      * Load and populate all extensions
      */
-    private void discover() throws IOException {
+    protected void discover() throws IOException {
         logger.info("Loading extensions : {}", extensionsPath);
         if (!FileSystemUtils.isAccessibleDirectory(extensionsPath, logger)) {
             return;
@@ -341,7 +346,7 @@ public class ExtensionsManager {
     }
 
     /**
-     * Iterate through all extensions and initialize them.  Initialized extensions will be added to the {@link #extensions}.
+     * Iterate through all extensions and initialize them.  Initialized extensions will be added to the {@link #initializedExtensions}.
      */
     public void initialize() {
         for (DiscoveryExtensionNode extension : extensionIdMap.values()) {
@@ -365,7 +370,7 @@ public class ExtensionsManager {
                 for (DiscoveryExtensionNode extension : extensionIdMap.values()) {
                     if (extension.getName().equals(response.getName())) {
                         extension.setImplementedInterfaces(response.getImplementedInterfaces());
-                        extensions.add(extension);
+                        initializedExtensions.put(extension.getId(), extension);
                         logger.info("Initialized extension: " + extension.getName());
                         break;
                     }
@@ -425,11 +430,17 @@ public class ExtensionsManager {
             case REQUEST_EXTENSION_DEPENDENCY_INFORMATION:
                 String uniqueId = extensionRequest.getUniqueId();
                 if (uniqueId == null) {
-                    return new ExtensionDependencyResponse(extensions);
+                    return new ExtensionDependencyResponse(
+                        initializedExtensions.entrySet().stream().map(e -> e.getValue()).collect(Collectors.toList())
+                    );
                 } else {
                     ExtensionDependency matchingId = new ExtensionDependency(uniqueId, Version.CURRENT);
                     return new ExtensionDependencyResponse(
-                        extensions.stream().filter(e -> e.dependenciesContain(matchingId)).collect(Collectors.toList())
+                        initializedExtensions.entrySet()
+                            .stream()
+                            .map(e -> e.getValue())
+                            .filter(e -> e.dependenciesContain(matchingId))
+                            .collect(Collectors.toList())
                     );
                 }
             default:
@@ -601,154 +612,83 @@ public class ExtensionsManager {
         }
     }
 
-    public static String getRequestExtensionActionName() {
+    static String getRequestExtensionActionName() {
         return REQUEST_EXTENSION_ACTION_NAME;
     }
 
-    public static String getIndicesExtensionPointActionName() {
+    static String getIndicesExtensionPointActionName() {
         return INDICES_EXTENSION_POINT_ACTION_NAME;
     }
 
-    public static String getIndicesExtensionNameActionName() {
+    static String getIndicesExtensionNameActionName() {
         return INDICES_EXTENSION_NAME_ACTION_NAME;
     }
 
-    public static String getRequestExtensionClusterState() {
+    static String getRequestExtensionClusterState() {
         return REQUEST_EXTENSION_CLUSTER_STATE;
     }
 
-    public static String getRequestExtensionClusterSettings() {
+    static String getRequestExtensionClusterSettings() {
         return REQUEST_EXTENSION_CLUSTER_SETTINGS;
     }
 
-    public static Logger getLogger() {
+    static Logger getLogger() {
         return logger;
     }
 
-    public Path getExtensionsPath() {
+    Path getExtensionsPath() {
         return extensionsPath;
     }
 
-    public List<DiscoveryExtensionNode> getExtensions() {
-        return extensions;
-    }
-
-    public TransportService getTransportService() {
+    TransportService getTransportService() {
         return transportService;
     }
 
-    public ClusterService getClusterService() {
+    ClusterService getClusterService() {
         return clusterService;
     }
 
-    public static String getRequestExtensionRegisterRestActions() {
-        return REQUEST_EXTENSION_REGISTER_REST_ACTIONS;
-    }
-
-    public static String getRequestRestExecuteOnExtensionAction() {
-        return REQUEST_REST_EXECUTE_ON_EXTENSION_ACTION;
-    }
-
-    public Map<String, DiscoveryExtensionNode> getExtensionIdMap() {
+    Map<String, DiscoveryExtensionNode> getExtensionIdMap() {
         return extensionIdMap;
     }
 
-    public RestActionsRequestHandler getRestActionsRequestHandler() {
+    RestActionsRequestHandler getRestActionsRequestHandler() {
         return restActionsRequestHandler;
     }
 
-    public void setExtensions(List<DiscoveryExtensionNode> extensions) {
-        this.extensions = extensions;
-    }
-
-    public void setExtensionIdMap(Map<String, DiscoveryExtensionNode> extensionIdMap) {
+    void setExtensionIdMap(Map<String, DiscoveryExtensionNode> extensionIdMap) {
         this.extensionIdMap = extensionIdMap;
     }
 
-    public void setRestActionsRequestHandler(RestActionsRequestHandler restActionsRequestHandler) {
+    void setRestActionsRequestHandler(RestActionsRequestHandler restActionsRequestHandler) {
         this.restActionsRequestHandler = restActionsRequestHandler;
     }
 
-    public void setTransportService(TransportService transportService) {
+    void setTransportService(TransportService transportService) {
         this.transportService = transportService;
     }
 
-    public void setClusterService(ClusterService clusterService) {
+    void setClusterService(ClusterService clusterService) {
         this.clusterService = clusterService;
     }
 
-    public static String getRequestExtensionRegisterTransportActions() {
-        return REQUEST_EXTENSION_REGISTER_TRANSPORT_ACTIONS;
-    }
-
-    public static String getRequestExtensionRegisterCustomSettings() {
-        return REQUEST_EXTENSION_REGISTER_CUSTOM_SETTINGS;
-    }
-
-    public CustomSettingsRequestHandler getCustomSettingsRequestHandler() {
+    CustomSettingsRequestHandler getCustomSettingsRequestHandler() {
         return customSettingsRequestHandler;
     }
 
-    public void setCustomSettingsRequestHandler(CustomSettingsRequestHandler customSettingsRequestHandler) {
+    void setCustomSettingsRequestHandler(CustomSettingsRequestHandler customSettingsRequestHandler) {
         this.customSettingsRequestHandler = customSettingsRequestHandler;
     }
 
-    public static String getRequestExtensionEnvironmentSettings() {
-        return REQUEST_EXTENSION_ENVIRONMENT_SETTINGS;
-    }
-
-    public static String getRequestExtensionAddSettingsUpdateConsumer() {
-        return REQUEST_EXTENSION_ADD_SETTINGS_UPDATE_CONSUMER;
-    }
-
-    public static String getRequestExtensionUpdateSettings() {
-        return REQUEST_EXTENSION_UPDATE_SETTINGS;
-    }
-
-    public AddSettingsUpdateConsumerRequestHandler getAddSettingsUpdateConsumerRequestHandler() {
+    AddSettingsUpdateConsumerRequestHandler getAddSettingsUpdateConsumerRequestHandler() {
         return addSettingsUpdateConsumerRequestHandler;
     }
 
-    public void setAddSettingsUpdateConsumerRequestHandler(
-        AddSettingsUpdateConsumerRequestHandler addSettingsUpdateConsumerRequestHandler
-    ) {
+    void setAddSettingsUpdateConsumerRequestHandler(AddSettingsUpdateConsumerRequestHandler addSettingsUpdateConsumerRequestHandler) {
         this.addSettingsUpdateConsumerRequestHandler = addSettingsUpdateConsumerRequestHandler;
     }
 
-    public Settings getEnvironmentSettings() {
+    Settings getEnvironmentSettings() {
         return environmentSettings;
     }
-
-    public void setEnvironmentSettings(Settings environmentSettings) {
-        this.environmentSettings = environmentSettings;
-    }
-
-    public static String getRequestExtensionHandleTransportAction() {
-        return REQUEST_EXTENSION_HANDLE_TRANSPORT_ACTION;
-    }
-
-    public static String getTransportActionRequestFromExtension() {
-        return TRANSPORT_ACTION_REQUEST_FROM_EXTENSION;
-    }
-
-    public static int getExtensionRequestWaitTimeout() {
-        return EXTENSION_REQUEST_WAIT_TIMEOUT;
-    }
-
-    public ExtensionTransportActionsHandler getExtensionTransportActionsHandler() {
-        return extensionTransportActionsHandler;
-    }
-
-    public void setExtensionTransportActionsHandler(ExtensionTransportActionsHandler extensionTransportActionsHandler) {
-        this.extensionTransportActionsHandler = extensionTransportActionsHandler;
-    }
-
-    public NodeClient getClient() {
-        return client;
-    }
-
-    public void setClient(NodeClient client) {
-        this.client = client;
-    }
-
 }

--- a/server/src/main/java/org/opensearch/extensions/NoopExtensionsManager.java
+++ b/server/src/main/java/org/opensearch/extensions/NoopExtensionsManager.java
@@ -8,6 +8,23 @@
 
 package org.opensearch.extensions;
 
+import java.io.IOException;
+import java.net.UnknownHostException;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import org.opensearch.action.ActionModule;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.settings.SettingsModule;
+
+import org.opensearch.extensions.action.ExtensionActionRequest;
+import org.opensearch.extensions.action.ExtensionActionResponse;
+import org.opensearch.extensions.action.RemoteExtensionActionResponse;
+import org.opensearch.index.IndexModule;
+import org.opensearch.transport.TransportService;
+
 /**
  * Noop class for ExtensionsManager
  *
@@ -15,7 +32,52 @@ package org.opensearch.extensions;
  */
 public class NoopExtensionsManager extends ExtensionsManager {
 
-    public NoopExtensionsManager() {
-        super();
+    public NoopExtensionsManager() throws IOException {
+        super(Path.of(""));
+    }
+
+    @Override
+    public void initializeServicesAndRestHandler(
+        ActionModule actionModule,
+        SettingsModule settingsModule,
+        TransportService transportService,
+        ClusterService clusterService,
+        Settings initialEnvironmentSettings,
+        NodeClient client
+    ) {
+        // no-op
+    }
+
+    @Override
+    public RemoteExtensionActionResponse handleRemoteTransportRequest(ExtensionActionRequest request) throws Exception {
+        // no-op empty response
+        return new RemoteExtensionActionResponse(true, new byte[0]);
+    }
+
+    @Override
+    public ExtensionActionResponse handleTransportRequest(ExtensionActionRequest request) throws Exception {
+        // no-op empty response
+        return new ExtensionActionResponse(new byte[0]);
+    }
+
+    @Override
+    protected void discover() throws IOException {
+        // no-op
+    }
+
+    @Override
+    public void initialize() {
+        // no-op
+    }
+
+    @Override
+    public void onIndexModule(IndexModule indexModule) throws UnknownHostException {
+        // no-op
+    }
+
+    @Override
+    public Optional<DiscoveryExtensionNode> lookupInitializedExtensionById(final String extensionId) {
+        // no-op not found
+        return Optional.empty();
     }
 }

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -84,7 +84,6 @@ import org.opensearch.common.util.concurrent.AbstractRunnable;
 import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.common.util.concurrent.OpenSearchRejectedExecutionException;
 import org.opensearch.common.util.concurrent.OpenSearchThreadPoolExecutor;
-import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.common.util.iterable.Iterables;
 import org.opensearch.common.util.set.Sets;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
@@ -339,122 +338,6 @@ public class IndicesService extends AbstractLifecycleComponent
     protected void doStart() {
         // Start thread that will manage cleaning the field data cache periodically
         threadPool.schedule(this.cacheCleaner, this.cleanInterval, ThreadPool.Names.SAME);
-    }
-
-    public IndicesService(
-        Settings settings,
-        PluginsService pluginsService,
-        NodeEnvironment nodeEnv,
-        NamedXContentRegistry xContentRegistry,
-        AnalysisRegistry analysisRegistry,
-        IndexNameExpressionResolver indexNameExpressionResolver,
-        MapperRegistry mapperRegistry,
-        NamedWriteableRegistry namedWriteableRegistry,
-        ThreadPool threadPool,
-        IndexScopedSettings indexScopedSettings,
-        CircuitBreakerService circuitBreakerService,
-        BigArrays bigArrays,
-        ScriptService scriptService,
-        ClusterService clusterService,
-        Client client,
-        MetaStateService metaStateService,
-        Collection<Function<IndexSettings, Optional<EngineFactory>>> engineFactoryProviders,
-        Map<String, IndexStorePlugin.DirectoryFactory> directoryFactories,
-        ValuesSourceRegistry valuesSourceRegistry,
-        Map<String, IndexStorePlugin.RecoveryStateFactory> recoveryStateFactories,
-        IndexStorePlugin.DirectoryFactory remoteDirectoryFactory,
-        Supplier<RepositoriesService> repositoriesServiceSupplier,
-        FileCacheCleaner fileCacheCleaner
-    ) {
-        this.settings = settings;
-        this.threadPool = threadPool;
-        this.pluginsService = pluginsService;
-        this.extensionsManager = null;
-        this.nodeEnv = nodeEnv;
-        this.xContentRegistry = xContentRegistry;
-        this.valuesSourceRegistry = valuesSourceRegistry;
-        this.shardsClosedTimeout = settings.getAsTime(INDICES_SHARDS_CLOSED_TIMEOUT, new TimeValue(1, TimeUnit.DAYS));
-        this.analysisRegistry = analysisRegistry;
-        this.indexNameExpressionResolver = indexNameExpressionResolver;
-        this.indicesRequestCache = new IndicesRequestCache(settings);
-        this.indicesQueryCache = new IndicesQueryCache(settings);
-        this.mapperRegistry = mapperRegistry;
-        this.namedWriteableRegistry = namedWriteableRegistry;
-        indexingMemoryController = new IndexingMemoryController(
-            settings,
-            threadPool,
-            // ensure we pull an iter with new shards - flatten makes a copy
-            () -> Iterables.flatten(this).iterator()
-        );
-        this.indexScopedSettings = indexScopedSettings;
-        this.circuitBreakerService = circuitBreakerService;
-        this.bigArrays = bigArrays;
-        this.scriptService = scriptService;
-        this.clusterService = clusterService;
-        this.client = client;
-        this.idFieldDataEnabled = INDICES_ID_FIELD_DATA_ENABLED_SETTING.get(clusterService.getSettings());
-        clusterService.getClusterSettings().addSettingsUpdateConsumer(INDICES_ID_FIELD_DATA_ENABLED_SETTING, this::setIdFieldDataEnabled);
-        this.indicesFieldDataCache = new IndicesFieldDataCache(settings, new IndexFieldDataCache.Listener() {
-            @Override
-            public void onRemoval(ShardId shardId, String fieldName, boolean wasEvicted, long sizeInBytes) {
-                assert sizeInBytes >= 0 : "When reducing circuit breaker, it should be adjusted with a number higher or "
-                    + "equal to 0 and not ["
-                    + sizeInBytes
-                    + "]";
-                circuitBreakerService.getBreaker(CircuitBreaker.FIELDDATA).addWithoutBreaking(-sizeInBytes);
-            }
-        });
-        this.cleanInterval = INDICES_CACHE_CLEAN_INTERVAL_SETTING.get(settings);
-        this.cacheCleaner = new CacheCleaner(indicesFieldDataCache, indicesRequestCache, logger, threadPool, this.cleanInterval);
-        this.metaStateService = metaStateService;
-        this.engineFactoryProviders = engineFactoryProviders;
-
-        this.directoryFactories = directoryFactories;
-        this.recoveryStateFactories = recoveryStateFactories;
-        this.fileCacheCleaner = fileCacheCleaner;
-        // doClose() is called when shutting down a node, yet there might still be ongoing requests
-        // that we need to wait for before closing some resources such as the caches. In order to
-        // avoid closing these resources while ongoing requests are still being processed, we use a
-        // ref count which will only close them when both this service and all index services are
-        // actually closed
-        indicesRefCount = new AbstractRefCounted("indices") {
-            @Override
-            protected void closeInternal() {
-                try {
-                    IOUtils.close(
-                        analysisRegistry,
-                        indexingMemoryController,
-                        indicesFieldDataCache,
-                        cacheCleaner,
-                        indicesRequestCache,
-                        indicesQueryCache
-                    );
-                } catch (IOException e) {
-                    throw new UncheckedIOException(e);
-                } finally {
-                    closeLatch.countDown();
-                }
-            }
-        };
-
-        final String nodeName = Objects.requireNonNull(Node.NODE_NAME_SETTING.get(settings));
-        nodeWriteDanglingIndicesInfo = WRITE_DANGLING_INDICES_INFO_SETTING.get(settings);
-        danglingIndicesThreadPoolExecutor = nodeWriteDanglingIndicesInfo
-            ? OpenSearchExecutors.newScaling(
-                nodeName + "/" + DANGLING_INDICES_UPDATE_THREAD_NAME,
-                1,
-                1,
-                0,
-                TimeUnit.MILLISECONDS,
-                daemonThreadFactory(nodeName, DANGLING_INDICES_UPDATE_THREAD_NAME),
-                threadPool.getThreadContext()
-            )
-            : null;
-
-        this.allowExpensiveQueries = ALLOW_EXPENSIVE_QUERIES.get(clusterService.getSettings());
-        clusterService.getClusterSettings().addSettingsUpdateConsumer(ALLOW_EXPENSIVE_QUERIES, this::setAllowExpensiveQueries);
-        this.remoteDirectoryFactory = remoteDirectoryFactory;
-        this.translogFactorySupplier = getTranslogFactorySupplier(repositoriesServiceSupplier, threadPool);
     }
 
     public IndicesService(
@@ -929,9 +812,7 @@ public class IndicesService extends AbstractLifecycleComponent
             indexModule.addIndexOperationListener(operationListener);
         }
         pluginsService.onIndexModule(indexModule);
-        if (FeatureFlags.isEnabled(FeatureFlags.EXTENSIONS)) {
-            extensionsManager.onIndexModule(indexModule);
-        }
+        extensionsManager.onIndexModule(indexModule);
         for (IndexEventListener listener : builtInListeners) {
             indexModule.addIndexEventListener(listener);
         }

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -468,7 +468,7 @@ public class Node implements Closeable {
             final IdentityService identityService = new IdentityService(settings, identityPlugins);
 
             if (FeatureFlags.isEnabled(FeatureFlags.EXTENSIONS)) {
-                this.extensionsManager = new ExtensionsManager(tmpSettings, initialEnvironment.extensionDir());
+                this.extensionsManager = new ExtensionsManager(initialEnvironment.extensionDir());
             } else {
                 this.extensionsManager = new NoopExtensionsManager();
             }
@@ -706,61 +706,32 @@ public class Node implements Closeable {
                 repositoriesServiceReference::get
             );
 
-            final IndicesService indicesService;
-            if (FeatureFlags.isEnabled(FeatureFlags.EXTENSIONS)) {
-                indicesService = new IndicesService(
-                    settings,
-                    pluginsService,
-                    extensionsManager,
-                    nodeEnvironment,
-                    xContentRegistry,
-                    analysisModule.getAnalysisRegistry(),
-                    clusterModule.getIndexNameExpressionResolver(),
-                    indicesModule.getMapperRegistry(),
-                    namedWriteableRegistry,
-                    threadPool,
-                    settingsModule.getIndexScopedSettings(),
-                    circuitBreakerService,
-                    bigArrays,
-                    scriptService,
-                    clusterService,
-                    client,
-                    metaStateService,
-                    engineFactoryProviders,
-                    Map.copyOf(directoryFactories),
-                    searchModule.getValuesSourceRegistry(),
-                    recoveryStateFactories,
-                    remoteDirectoryFactory,
-                    repositoriesServiceReference::get,
-                    fileCacheCleaner
-                );
-            } else {
-                indicesService = new IndicesService(
-                    settings,
-                    pluginsService,
-                    nodeEnvironment,
-                    xContentRegistry,
-                    analysisModule.getAnalysisRegistry(),
-                    clusterModule.getIndexNameExpressionResolver(),
-                    indicesModule.getMapperRegistry(),
-                    namedWriteableRegistry,
-                    threadPool,
-                    settingsModule.getIndexScopedSettings(),
-                    circuitBreakerService,
-                    bigArrays,
-                    scriptService,
-                    clusterService,
-                    client,
-                    metaStateService,
-                    engineFactoryProviders,
-                    Map.copyOf(directoryFactories),
-                    searchModule.getValuesSourceRegistry(),
-                    recoveryStateFactories,
-                    remoteDirectoryFactory,
-                    repositoriesServiceReference::get,
-                    fileCacheCleaner
-                );
-            }
+            final IndicesService indicesService = new IndicesService(
+                settings,
+                pluginsService,
+                extensionsManager,
+                nodeEnvironment,
+                xContentRegistry,
+                analysisModule.getAnalysisRegistry(),
+                clusterModule.getIndexNameExpressionResolver(),
+                indicesModule.getMapperRegistry(),
+                namedWriteableRegistry,
+                threadPool,
+                settingsModule.getIndexScopedSettings(),
+                circuitBreakerService,
+                bigArrays,
+                scriptService,
+                clusterService,
+                client,
+                metaStateService,
+                engineFactoryProviders,
+                Map.copyOf(directoryFactories),
+                searchModule.getValuesSourceRegistry(),
+                recoveryStateFactories,
+                remoteDirectoryFactory,
+                repositoriesServiceReference::get,
+                fileCacheCleaner
+            );
 
             final AliasValidator aliasValidator = new AliasValidator();
 
@@ -877,16 +848,14 @@ public class Node implements Closeable {
             );
             TopNSearchTasksLogger taskConsumer = new TopNSearchTasksLogger(settings, settingsModule.getClusterSettings());
             transportService.getTaskManager().registerTaskResourceConsumer(taskConsumer);
-            if (FeatureFlags.isEnabled(FeatureFlags.EXTENSIONS)) {
-                this.extensionsManager.initializeServicesAndRestHandler(
-                    actionModule,
-                    settingsModule,
-                    transportService,
-                    clusterService,
-                    environment.settings(),
-                    client
-                );
-            }
+            this.extensionsManager.initializeServicesAndRestHandler(
+                actionModule,
+                settingsModule,
+                transportService,
+                clusterService,
+                environment.settings(),
+                client
+            );
             final GatewayMetaState gatewayMetaState = new GatewayMetaState();
             final ResponseCollectorService responseCollectorService = new ResponseCollectorService(clusterService);
             final SearchTransportService searchTransportService = new SearchTransportService(
@@ -1319,9 +1288,7 @@ public class Node implements Closeable {
         assert clusterService.localNode().equals(localNodeFactory.getNode())
             : "clusterService has a different local node than the factory provided";
         transportService.acceptIncomingRequests();
-        if (FeatureFlags.isEnabled(FeatureFlags.EXTENSIONS)) {
-            extensionsManager.initialize();
-        }
+        extensionsManager.initialize();
         discovery.startInitialJoin();
         final TimeValue initialStateTimeout = DiscoverySettings.INITIAL_STATE_TIMEOUT_SETTING.get(settings());
         configureNodeAndClusterIdStateListener(clusterService);

--- a/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
+++ b/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
@@ -201,7 +201,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
     public void testDiscover() throws Exception {
         Files.write(extensionDir.resolve("extensions.yml"), extensionsYmlLines, StandardCharsets.UTF_8);
 
-        ExtensionsManager extensionsManager = new ExtensionsManager(settings, extensionDir);
+        ExtensionsManager extensionsManager = new ExtensionsManager(extensionDir);
 
         List<DiscoveryExtensionNode> expectedExtensions = new ArrayList<DiscoveryExtensionNode>();
 
@@ -253,7 +253,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
             .collect(Collectors.toList());
         Files.write(emptyExtensionDir.resolve("extensions.yml"), nonUniqueYmlLines, StandardCharsets.UTF_8);
 
-        ExtensionsManager extensionsManager = new ExtensionsManager(settings, emptyExtensionDir);
+        ExtensionsManager extensionsManager = new ExtensionsManager(emptyExtensionDir);
 
         List<DiscoveryExtensionNode> expectedExtensions = new ArrayList<DiscoveryExtensionNode>();
 
@@ -335,7 +335,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
         AccessControlException e = expectThrows(
 
             AccessControlException.class,
-            () -> new ExtensionsManager(settings, PathUtils.get(""))
+            () -> new ExtensionsManager(PathUtils.get(""))
         );
         assertEquals("access denied (\"java.io.FilePermission\" \"\" \"read\")", e.getMessage());
     }
@@ -354,7 +354,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
                 )
             );
 
-            new ExtensionsManager(settings, extensionDir);
+            new ExtensionsManager(extensionDir);
 
             mockLogAppender.assertAllExpectationsMatched();
         }
@@ -368,12 +368,12 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
 
         Settings settings = Settings.builder().build();
 
-        expectThrows(IOException.class, () -> new ExtensionsManager(settings, emptyExtensionDir));
+        expectThrows(IOException.class, () -> new ExtensionsManager(emptyExtensionDir));
     }
 
     public void testInitialize() throws Exception {
         Files.write(extensionDir.resolve("extensions.yml"), extensionsYmlLines, StandardCharsets.UTF_8);
-        ExtensionsManager extensionsManager = new ExtensionsManager(settings, extensionDir);
+        ExtensionsManager extensionsManager = new ExtensionsManager(extensionDir);
 
         initialize(extensionsManager);
 
@@ -416,7 +416,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
     public void testHandleRegisterRestActionsRequest() throws Exception {
         Files.write(extensionDir.resolve("extensions.yml"), extensionsYmlLines, StandardCharsets.UTF_8);
 
-        ExtensionsManager extensionsManager = new ExtensionsManager(settings, extensionDir);
+        ExtensionsManager extensionsManager = new ExtensionsManager(extensionDir);
         initialize(extensionsManager);
 
         String uniqueIdStr = "uniqueid1";
@@ -431,7 +431,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
 
     public void testHandleRegisterSettingsRequest() throws Exception {
         Files.write(extensionDir.resolve("extensions.yml"), extensionsYmlLines, StandardCharsets.UTF_8);
-        ExtensionsManager extensionsManager = new ExtensionsManager(settings, extensionDir);
+        ExtensionsManager extensionsManager = new ExtensionsManager(extensionDir);
         initialize(extensionsManager);
 
         String uniqueIdStr = "uniqueid1";
@@ -447,7 +447,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
     }
 
     public void testHandleRegisterRestActionsRequestWithInvalidMethod() throws Exception {
-        ExtensionsManager extensionsManager = new ExtensionsManager(settings, extensionDir);
+        ExtensionsManager extensionsManager = new ExtensionsManager(extensionDir);
         initialize(extensionsManager);
 
         String uniqueIdStr = "uniqueid1";
@@ -461,7 +461,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
     }
 
     public void testHandleRegisterRestActionsRequestWithInvalidDeprecatedMethod() throws Exception {
-        ExtensionsManager extensionsManager = new ExtensionsManager(settings, extensionDir);
+        ExtensionsManager extensionsManager = new ExtensionsManager(extensionDir);
         initialize(extensionsManager);
 
         String uniqueIdStr = "uniqueid1";
@@ -475,7 +475,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
     }
 
     public void testHandleRegisterRestActionsRequestWithInvalidUri() throws Exception {
-        ExtensionsManager extensionsManager = new ExtensionsManager(settings, extensionDir);
+        ExtensionsManager extensionsManager = new ExtensionsManager(extensionDir);
         initialize(extensionsManager);
         String uniqueIdStr = "uniqueid1";
         List<String> actionsList = List.of("GET", "PUT /bar", "POST /baz");
@@ -488,7 +488,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
     }
 
     public void testHandleRegisterRestActionsRequestWithInvalidDeprecatedUri() throws Exception {
-        ExtensionsManager extensionsManager = new ExtensionsManager(settings, extensionDir);
+        ExtensionsManager extensionsManager = new ExtensionsManager(extensionDir);
         initialize(extensionsManager);
         String uniqueIdStr = "uniqueid1";
         List<String> actionsList = List.of("GET /foo", "PUT /bar", "POST /baz");
@@ -501,7 +501,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
     }
 
     public void testHandleExtensionRequest() throws Exception {
-        ExtensionsManager extensionsManager = new ExtensionsManager(settings, extensionDir);
+        ExtensionsManager extensionsManager = new ExtensionsManager(extensionDir);
         initialize(extensionsManager);
 
         ExtensionRequest clusterStateRequest = new ExtensionRequest(ExtensionRequestProto.RequestType.REQUEST_EXTENSION_CLUSTER_STATE);
@@ -657,7 +657,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
     public void testAddSettingsUpdateConsumerRequest() throws Exception {
         Path extensionDir = createTempDir();
         Files.write(extensionDir.resolve("extensions.yml"), extensionsYmlLines, StandardCharsets.UTF_8);
-        ExtensionsManager extensionsManager = new ExtensionsManager(settings, extensionDir);
+        ExtensionsManager extensionsManager = new ExtensionsManager(extensionDir);
         initialize(extensionsManager);
 
         List<Setting<?>> componentSettings = List.of(
@@ -704,7 +704,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
 
         Path extensionDir = createTempDir();
         Files.write(extensionDir.resolve("extensions.yml"), extensionsYmlLines, StandardCharsets.UTF_8);
-        ExtensionsManager extensionsManager = new ExtensionsManager(settings, extensionDir);
+        ExtensionsManager extensionsManager = new ExtensionsManager(extensionDir);
         initialize(extensionsManager);
 
         List<Setting<?>> componentSettings = List.of(
@@ -726,7 +726,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
     public void testUpdateSettingsRequest() throws Exception {
         Path extensionDir = createTempDir();
         Files.write(extensionDir.resolve("extensions.yml"), extensionsYmlLines, StandardCharsets.UTF_8);
-        ExtensionsManager extensionsManager = new ExtensionsManager(settings, extensionDir);
+        ExtensionsManager extensionsManager = new ExtensionsManager(extensionDir);
         initialize(extensionsManager);
 
         Setting<?> componentSetting = Setting.boolSetting("falseSetting", false, Property.Dynamic);
@@ -755,7 +755,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
 
     public void testRegisterHandler() throws Exception {
 
-        ExtensionsManager extensionsManager = new ExtensionsManager(settings, extensionDir);
+        ExtensionsManager extensionsManager = new ExtensionsManager(extensionDir);
 
         TransportService mockTransportService = spy(
             new TransportService(
@@ -782,7 +782,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
 
     public void testOnIndexModule() throws Exception {
         Files.write(extensionDir.resolve("extensions.yml"), extensionsYmlLines, StandardCharsets.UTF_8);
-        ExtensionsManager extensionsManager = new ExtensionsManager(settings, extensionDir);
+        ExtensionsManager extensionsManager = new ExtensionsManager(extensionDir);
         initialize(extensionsManager);
 
         Environment environment = TestEnvironment.newEnvironment(settings);
@@ -839,7 +839,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
             );
 
             Files.write(extensionDir.resolve("extensions.yml"), incompatibleExtension, StandardCharsets.UTF_8);
-            ExtensionsManager extensionsManager = new ExtensionsManager(settings, extensionDir);
+            ExtensionsManager extensionsManager = new ExtensionsManager(extensionDir);
             assertEquals(0, extensionsManager.getExtensionIdMap().values().size());
             mockLogAppender.assertAllExpectationsMatched();
         }

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -157,7 +157,6 @@ import org.opensearch.common.settings.IndexScopedSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.transport.TransportAddress;
 import org.opensearch.common.util.BigArrays;
-import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.common.util.PageCacheRecycler;
 import org.opensearch.common.util.concurrent.AbstractRunnable;
 import org.opensearch.common.util.concurrent.PrioritizedOpenSearchThreadPoolExecutor;
@@ -1804,82 +1803,43 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                 final SetOnce<RepositoriesService> repositoriesServiceReference = new SetOnce<>();
                 repositoriesServiceReference.set(repositoriesService);
                 FileCacheCleaner fileCacheCleaner = new FileCacheCleaner(nodeEnv, null);
-                if (FeatureFlags.isEnabled(FeatureFlags.EXTENSIONS)) {
-                    indicesService = new IndicesService(
-                        settings,
-                        mock(PluginsService.class),
-                        mock(ExtensionsManager.class),
-                        nodeEnv,
-                        namedXContentRegistry,
-                        new AnalysisRegistry(
-                            environment,
-                            emptyMap(),
-                            emptyMap(),
-                            emptyMap(),
-                            emptyMap(),
-                            emptyMap(),
-                            emptyMap(),
-                            emptyMap(),
-                            emptyMap(),
-                            emptyMap()
-                        ),
-                        indexNameExpressionResolver,
-                        mapperRegistry,
-                        namedWriteableRegistry,
-                        threadPool,
-                        indexScopedSettings,
-                        new NoneCircuitBreakerService(),
-                        bigArrays,
-                        scriptService,
-                        clusterService,
-                        client,
-                        new MetaStateService(nodeEnv, namedXContentRegistry),
-                        Collections.emptyList(),
+                indicesService = new IndicesService(
+                    settings,
+                    mock(PluginsService.class),
+                    mock(ExtensionsManager.class),
+                    nodeEnv,
+                    namedXContentRegistry,
+                    new AnalysisRegistry(
+                        environment,
                         emptyMap(),
-                        null,
                         emptyMap(),
-                        new RemoteSegmentStoreDirectoryFactory(() -> repositoriesService),
-                        repositoriesServiceReference::get,
-                        fileCacheCleaner
-                    );
-                } else {
-                    indicesService = new IndicesService(
-                        settings,
-                        mock(PluginsService.class),
-                        nodeEnv,
-                        namedXContentRegistry,
-                        new AnalysisRegistry(
-                            environment,
-                            emptyMap(),
-                            emptyMap(),
-                            emptyMap(),
-                            emptyMap(),
-                            emptyMap(),
-                            emptyMap(),
-                            emptyMap(),
-                            emptyMap(),
-                            emptyMap()
-                        ),
-                        indexNameExpressionResolver,
-                        mapperRegistry,
-                        namedWriteableRegistry,
-                        threadPool,
-                        indexScopedSettings,
-                        new NoneCircuitBreakerService(),
-                        bigArrays,
-                        scriptService,
-                        clusterService,
-                        client,
-                        new MetaStateService(nodeEnv, namedXContentRegistry),
-                        Collections.emptyList(),
                         emptyMap(),
-                        null,
                         emptyMap(),
-                        new RemoteSegmentStoreDirectoryFactory(() -> repositoriesService),
-                        repositoriesServiceReference::get,
-                        fileCacheCleaner
-                    );
-                }
+                        emptyMap(),
+                        emptyMap(),
+                        emptyMap(),
+                        emptyMap(),
+                        emptyMap()
+                    ),
+                    indexNameExpressionResolver,
+                    mapperRegistry,
+                    namedWriteableRegistry,
+                    threadPool,
+                    indexScopedSettings,
+                    new NoneCircuitBreakerService(),
+                    bigArrays,
+                    scriptService,
+                    clusterService,
+                    client,
+                    new MetaStateService(nodeEnv, namedXContentRegistry),
+                    Collections.emptyList(),
+                    emptyMap(),
+                    null,
+                    emptyMap(),
+                    new RemoteSegmentStoreDirectoryFactory(() -> repositoriesService),
+                    repositoriesServiceReference::get,
+                    fileCacheCleaner
+                );
                 final RecoverySettings recoverySettings = new RecoverySettings(settings, clusterSettings);
                 snapshotShardsService = new SnapshotShardsService(
                     settings,


### PR DESCRIPTION
### Description
ExtensionsManager has a whole lot of functionality that shouldn't be exposed to external classes, marked much of this package protected for a cleaner interface.  Then updated the Noop version to override all public functions to remove extraneous feature flag checks.

Note; I didn't go so far to remove all getters/setters that were unused but that could be a good follow up in the future.

Signed-off-by: Peter Nied <petern@amazon.com>
(cherry picked from commit 3687d0106230186afec58dd5e7b0a58c80f6f7d1)

### Related Issues
- Related #7374

### Check List
- [ ] ~New functionality includes testing.~
  - [ ] ~All tests pass~
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [X] Commits are signed per the DCO using --signoff
- [ ] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
