### PR TITLE
[Backport] [1.3] OpenJDK Update (April 2023 Patch releases) (#7449)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump: Netty from 4.1.90.Final to 4.1.91.Final , ASM 9.4 to ASM 9.5, ByteBuddy 1.14.2 to 1.14.3 ([#6981](https://github.com/opensearch-project/OpenSearch/pull/6981))
 - Bump `org.gradle.test-retry` from 1.5.1 to 1.5.2
 - Bump `org.apache.hadoop:hadoop-minicluster` from 3.3.4 to 3.3.5
+- OpenJDK Update (April 2023 Patch releases) ([#7449](https://github.com/opensearch-project/OpenSearch/pull/7449)
 
 ### Changed
 ### Deprecated

--- a/buildSrc/src/main/java/org/opensearch/gradle/test/DistroTestPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/test/DistroTestPlugin.java
@@ -75,9 +75,9 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 public class DistroTestPlugin implements Plugin<Project> {
-    private static final String SYSTEM_JDK_VERSION = "8u362-b09";
+    private static final String SYSTEM_JDK_VERSION = "8u372-b07";
     private static final String SYSTEM_JDK_VENDOR = "adoptium";
-    private static final String GRADLE_JDK_VERSION = "11.0.18+10";
+    private static final String GRADLE_JDK_VERSION = "11.0.19+7";
     private static final String GRADLE_JDK_VENDOR = "adoptium";
 
     // all distributions used by distro tests. this is temporary until tests are per distribution

--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -2,7 +2,7 @@ opensearch        = 1.3.10
 lucene            = 8.10.1
 
 bundled_jdk_vendor = adoptium
-bundled_jdk = 11.0.18+10
+bundled_jdk = 11.0.19+7
 
 # optional dependencies
 spatial4j         = 0.7


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/7449 to `1.3`