### PR TITLE
[Backport] [2.x] Bump org.apache.commons:commons-compress from 1.22 to 1.23.0 in /test/fixtures/hdfs-fixture (#7462)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `org.apache.shiro:shiro-core` from 1.9.1 to 1.11.0 ([#7397](https://github.com/opensearch-project/OpenSearch/pull/7397))
 - Bump `jetty-server` in hdfs-fixture from 9.4.49.v20220914 to 9.4.51.v20230217 ([#7405](https://github.com/opensearch-project/OpenSearch/pull/7405))
 - OpenJDK Update (April 2023 Patch releases) ([#7448](https://github.com/opensearch-project/OpenSearch/pull/7448)
+- Bump `com.networknt:json-schema-validator` from 1.0.78 to 1.0.81 (#7460)
+- Bump `org.apache.commons:commons-compress` from 1.22 to 1.23.0 (#7462)
 
 ### Changed
 - Enable `./gradlew build` on MacOS by disabling bcw tests ([#7303](https://github.com/opensearch-project/OpenSearch/pull/7303))

--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     exclude group: 'org.codehaus.jackson'
   }
   api "org.codehaus.jettison:jettison:${versions.jettison}"
-  api "org.apache.commons:commons-compress:1.21"
+  api "org.apache.commons:commons-compress:1.23.0"
   api "commons-codec:commons-codec:${versions.commonscodec}"
   api "org.apache.logging.log4j:log4j-core:${versions.log4j}"
   api "io.netty:netty-all:${versions.netty}"


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/7462 to `2.x`