### PR TITLE
Adds ExtensionsManager.lookupExtensionSettingsById

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Allow mmap to use new JDK-19 preview APIs in Apache Lucene 9.4+ ([#5151](https://github.com/opensearch-project/OpenSearch/pull/5151))
 - Add events correlation engine plugin ([#6854](https://github.com/opensearch-project/OpenSearch/issues/6854))
 - Add connectToNodeAsExtension in TransportService ([#6866](https://github.com/opensearch-project/OpenSearch/pull/6866))
+- Adds ExtensionsManager.lookupExtensionSettingsById ([#7466](https://github.com/opensearch-project/OpenSearch/pull/7466))
 
 ### Dependencies
 - Bump `log4j-core` from 2.18.0 to 2.19.0

--- a/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
@@ -108,6 +108,8 @@ public class ExtensionsManager {
 
     private final Path extensionsPath;
     private ExtensionTransportActionsHandler extensionTransportActionsHandler;
+
+    private Map<String, Extension> extensionSettingsMap;
     private Map<String, DiscoveryExtensionNode> initializedExtensions;
     private Map<String, DiscoveryExtensionNode> extensionIdMap;
     private RestActionsRequestHandler restActionsRequestHandler;
@@ -129,6 +131,7 @@ public class ExtensionsManager {
         this.extensionsPath = extensionsPath;
         this.initializedExtensions = new HashMap<String, DiscoveryExtensionNode>();
         this.extensionIdMap = new HashMap<String, DiscoveryExtensionNode>();
+        this.extensionSettingsMap = new HashMap<String, Extension>();
         // will be initialized in initializeServicesAndRestHandler which is called after the Node is initialized
         this.transportService = null;
         this.clusterService = null;
@@ -190,6 +193,16 @@ public class ExtensionsManager {
      */
     public Optional<DiscoveryExtensionNode> lookupInitializedExtensionById(final String extensionId) {
         return Optional.ofNullable(this.initializedExtensions.get(extensionId));
+    }
+
+    /**
+     * Lookup the settings for an extension based on unique id for the settings placed in extensions.yml
+     *
+     * @param extensionId The unique extension identifier
+     * @return An optional of the Extension instance for the matching extension
+     */
+    public Optional<Extension> lookupExtensionSettings(final String extensionId) {
+        return Optional.ofNullable(this.extensionSettingsMap.get(extensionId));
     }
 
     /**
@@ -308,6 +321,7 @@ public class ExtensionsManager {
                 throw new IOException("Could not read from extensions.yml", e);
             }
             for (Extension extension : extensions) {
+                extensionSettingsMap.put(extension.getUniqueId(), extension);
                 loadExtension(extension);
             }
             if (!extensionIdMap.isEmpty()) {

--- a/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
@@ -321,7 +321,6 @@ public class ExtensionsManager {
                 throw new IOException("Could not read from extensions.yml", e);
             }
             for (Extension extension : extensions) {
-                extensionSettingsMap.put(extension.getUniqueId(), extension);
                 loadExtension(extension);
             }
             if (!extensionIdMap.isEmpty()) {
@@ -351,6 +350,7 @@ public class ExtensionsManager {
                     extension.getDependencies()
                 );
                 extensionIdMap.put(extension.getUniqueId(), discoveryExtensionNode);
+                extensionSettingsMap.put(extension.getUniqueId(), extension);
                 logger.info("Loaded extension with uniqueId " + extension.getUniqueId() + ": " + extension);
             } catch (OpenSearchException e) {
                 logger.error("Could not load extension with uniqueId " + extension.getUniqueId() + " due to " + e);

--- a/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
@@ -349,6 +349,7 @@ public class ExtensionsManager {
                     Version.fromString(extension.getMinimumCompatibleVersion()),
                     extension.getDependencies()
                 );
+
                 extensionIdMap.put(extension.getUniqueId(), discoveryExtensionNode);
                 extensionSettingsMap.put(extension.getUniqueId(), extension);
                 logger.info("Loaded extension with uniqueId " + extension.getUniqueId() + ": " + extension);

--- a/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
@@ -201,7 +201,7 @@ public class ExtensionsManager {
      * @param extensionId The unique extension identifier
      * @return An optional of the Extension instance for the matching extension
      */
-    public Optional<Extension> lookupExtensionSettings(final String extensionId) {
+    public Optional<Extension> lookupExtensionSettingsById(final String extensionId) {
         return Optional.ofNullable(this.extensionSettingsMap.get(extensionId));
     }
 

--- a/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
+++ b/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
@@ -243,7 +243,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
             assertEquals(extension.getVersion(), initializedExtension.getVersion());
             assertEquals(extension.getMinimumCompatibleVersion(), initializedExtension.getMinimumCompatibleVersion());
             assertEquals(extension.getDependencies(), initializedExtension.getDependencies());
-            assertTrue(extensionsManager.lookupExtensionSettings(extension.getId()).isPresent());
+            assertTrue(extensionsManager.lookupExtensionSettingsById(extension.getId()).isPresent());
         }
     }
 

--- a/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
+++ b/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
@@ -243,6 +243,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
             assertEquals(extension.getVersion(), initializedExtension.getVersion());
             assertEquals(extension.getMinimumCompatibleVersion(), initializedExtension.getMinimumCompatibleVersion());
             assertEquals(extension.getDependencies(), initializedExtension.getDependencies());
+            assertTrue(extensionsManager.lookupExtensionSettings(extension.getId()).isPresent());
         }
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

Companion PR in the security plugin: https://github.com/opensearch-project/security/pull/2749

Adds a public method to lookup extension settings placed in `extensions.yml` by the extension unique id. There was a recent issue with extension handshake and the security plugin where the only available method exposed looks up initialized extensions which is not populated at the time of initial handshake: https://github.com/opensearch-project/security/issues/2747

This new method is utilized in the security plugin to ensure that the unique id exists in `extensions.yml` so that it can permit the transport requests that an extension uses to bootstrap

### Related Issues
Resolves https://github.com/opensearch-project/security/issues/2747

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
