### PR TITLE
Exclude protobuf-java version included with hadoop-minicluster

### DIFF
--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     exclude module: 'jettison'
     exclude module: 'netty'
     exclude module: 'guava'
+    exclude module: 'protobuf-java'
     exclude group: 'org.codehaus.jackson'
   }
   api "org.codehaus.jettison:jettison:${versions.jettison}"
@@ -56,7 +57,7 @@ dependencies {
   api "com.fasterxml.woodstox:woodstox-core:${versions.woodstox}"
   api 'net.minidev:json-smart:2.4.10'
   api "org.mockito:mockito-core:${versions.mockito}"
-  api "com.google.protobuf:protobuf-java:3.22.2"
+  api "com.google.protobuf:protobuf-java:${versions.protobuf}"
   api "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
   api "org.eclipse.jetty:jetty-server:${versions.jetty}"
   api "org.eclipse.jetty.websocket:javax-websocket-server-impl:${versions.jetty}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This change excludes the version of protobuf-java included with hadoop-minicluster. Without this change 1.x versions of OpenSeach will include protobuf-java version 2.5.0 on the test classpath with `./gradlew :plugins:repository-hdfs:dependencies`.  This version is flagged for vulnerabilities.

This change will have no impact on main/2.x versions. other than reading version from version.properties.

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
