### PR TITLE
[Search Pipelines] Add default_search_pipeline index setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Extensions] Add IdentityPlugin into core to support Extension identities ([#7246](https://github.com/opensearch-project/OpenSearch/pull/7246))
 - Add connectToNodeAsExtension in TransportService ([#6866](https://github.com/opensearch-project/OpenSearch/pull/6866))
 - [Search Pipelines] Accept pipelines defined in search source ([#7253](https://github.com/opensearch-project/OpenSearch/pull/7253))
+- [Search Pipelines] Add `default_search_pipeline` index setting ([#7470](https://github.com/opensearch-project/OpenSearch/pull/7470))
 - Add descending order search optimization through reverse segment read. ([#7244](https://github.com/opensearch-project/OpenSearch/pull/7244))
 - Add 'unsigned_long' numeric field type ([#6237](https://github.com/opensearch-project/OpenSearch/pull/6237))
 - Add back primary shard preference for queries ([#7375](https://github.com/opensearch-project/OpenSearch/pull/7375))

--- a/modules/search-pipeline-common/src/yamlRestTest/resources/rest-api-spec/test/search_pipeline/30_filter_query.yml
+++ b/modules/search-pipeline-common/src/yamlRestTest/resources/rest-api-spec/test/search_pipeline/30_filter_query.yml
@@ -101,3 +101,24 @@ teardown:
         }
   - match: { hits.total.value: 1 }
   - match: { hits.hits.0._id: "1" }
+
+  # Make it the default for the index
+  - do:
+      indices.put_settings:
+        index: test
+        body:
+          index.default_search_pipeline: my_pipeline
+
+  - do:
+      search:
+        index: test
+        body: { }
+  - match: { hits.total.value: 1 }
+
+  # Explicitly bypass the pipeline to match both docs
+  - do:
+      search:
+        search_pipeline: _none
+        index: test
+        body: { }
+  - match: { hits.total.value: 2 }

--- a/modules/search-pipeline-common/src/yamlRestTest/resources/rest-api-spec/test/search_pipeline/30_filter_query.yml
+++ b/modules/search-pipeline-common/src/yamlRestTest/resources/rest-api-spec/test/search_pipeline/30_filter_query.yml
@@ -107,7 +107,7 @@ teardown:
       indices.put_settings:
         index: test
         body:
-          index.default_search_pipeline: my_pipeline
+          index.search.default_pipeline: my_pipeline
 
   - do:
       search:

--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -64,6 +64,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
       numberOfNodes = 4
 
       setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
+      setting 'opensearch.experimental.feature.search_pipeline.enabled', 'true'
     }
   }
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search_pipeline/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search_pipeline/10_basic.yml
@@ -1,8 +1,8 @@
 ---
 "Test basic pipeline crud":
   - skip:
-      version: " - 2.99.99"
-      reason: "to be introduced in future release / TODO: change if/when we backport to 2.x"
+      version: " - 2.7.0"
+      reason: "Added in 2.7.0"
   - do:
       search_pipeline.put:
         id: "my_pipeline"
@@ -32,8 +32,8 @@
 ---
 "Test Put Versioned Pipeline":
   - skip:
-      version: " - 2.99.99"
-      reason: "to be introduced in future release / TODO: change if/when we backport to 2.x"
+      version: " - 2.7.0"
+      reason: "Added in 2.7.0"
   - do:
       search_pipeline.put:
         id: "my_pipeline"
@@ -125,8 +125,8 @@
 ---
 "Test Get All Pipelines":
   - skip:
-      version: " - 2.99.99"
-      reason: "to be introduced in future release / TODO: change if/when we backport to 2.x"
+      version: " - 2.7.0"
+      reason: "Added in 2.7.0"
   - do:
       search_pipeline.put:
         id: "first_pipeline"
@@ -152,8 +152,8 @@
 ---
 "Test invalid config":
   - skip:
-      version: " - 2.99.99"
-      reason: "to be introduced in future release / TODO: change if/when we backport to 2.x"
+      version: " - 2.7.0"
+      reason: "Added in 2.7.0"
   - do:
       catch: /parse_exception/
       search_pipeline.put:

--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -197,6 +197,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 IndexSettings.INDEX_MERGE_ON_FLUSH_ENABLED,
                 IndexSettings.INDEX_MERGE_ON_FLUSH_MAX_FULL_FLUSH_MERGE_WAIT_TIME,
                 IndexSettings.INDEX_MERGE_ON_FLUSH_POLICY,
+                IndexSettings.DEFAULT_SEARCH_PIPELINE,
 
                 // Settings for Searchable Snapshots
                 IndexSettings.SEARCHABLE_SNAPSHOT_REPOSITORY,

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -51,6 +51,7 @@ import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.ingest.IngestService;
 import org.opensearch.node.Node;
+import org.opensearch.search.pipeline.SearchPipelineService;
 
 import java.util.Collections;
 import java.util.List;
@@ -576,6 +577,14 @@ public final class IndexSettings {
         "index.searchable_snapshot.index.id",
         Property.IndexScope,
         Property.InternalIndex
+    );
+
+    public static final Setting<String> DEFAULT_SEARCH_PIPELINE = new Setting<>(
+        "index.default_search_pipeline",
+        SearchPipelineService.NOOP_PIPELINE_ID,
+        Function.identity(),
+        Property.Dynamic,
+        Property.IndexScope
     );
 
     private final Index index;

--- a/server/src/test/java/org/opensearch/index/IndexSettingsTests.java
+++ b/server/src/test/java/org/opensearch/index/IndexSettingsTests.java
@@ -1087,23 +1087,22 @@ public class IndexSettingsTests extends OpenSearchTestCase {
 
     @SuppressForbidden(reason = "sets the SEARCH_PIPELINE feature flag")
     public void testDefaultSearchPipeline() throws Exception {
-        try (FeatureFlagSetter f = FeatureFlagSetter.set(FeatureFlags.SEARCH_PIPELINE)) {
-            IndexMetadata metadata = newIndexMeta(
-                "index",
-                Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT).build()
-            );
-            IndexSettings settings = new IndexSettings(metadata, Settings.EMPTY);
-            assertEquals(SearchPipelineService.NOOP_PIPELINE_ID, settings.getDefaultSearchPipeline());
-            metadata = newIndexMeta(
-                "index",
-                Settings.builder()
-                    .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
-                    .put(IndexSettings.DEFAULT_SEARCH_PIPELINE.getKey(), "foo")
-                    .build()
-            );
-            settings.updateIndexMetadata(metadata);
-            assertEquals("foo", settings.getDefaultSearchPipeline());
-        }
+        FeatureFlagSetter.set(FeatureFlags.SEARCH_PIPELINE);
+        IndexMetadata metadata = newIndexMeta(
+            "index",
+            Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT).build()
+        );
+        IndexSettings settings = new IndexSettings(metadata, Settings.EMPTY);
+        assertEquals(SearchPipelineService.NOOP_PIPELINE_ID, settings.getDefaultSearchPipeline());
+        metadata = newIndexMeta(
+            "index",
+            Settings.builder()
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexSettings.DEFAULT_SEARCH_PIPELINE.getKey(), "foo")
+                .build()
+        );
+        settings.updateIndexMetadata(metadata);
+        assertEquals("foo", settings.getDefaultSearchPipeline());
     }
 
     public void testDefaultSearchPipelineWithoutFeatureFlag() {

--- a/server/src/test/java/org/opensearch/index/IndexSettingsTests.java
+++ b/server/src/test/java/org/opensearch/index/IndexSettingsTests.java
@@ -46,6 +46,7 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.index.translog.Translog;
 import org.opensearch.indices.replication.common.ReplicationType;
+import org.opensearch.search.pipeline.SearchPipelineService;
 import org.opensearch.test.FeatureFlagSetter;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.VersionUtils;
@@ -1082,5 +1083,43 @@ public class IndexSettingsTests extends OpenSearchTestCase {
         IndexSettings settings = new IndexSettings(metadata, Settings.EMPTY);
         assertTrue(settings.isRemoteSnapshot());
         assertEquals(Version.CURRENT.minimumIndexCompatibilityVersion(), settings.getExtendedCompatibilitySnapshotVersion());
+    }
+
+    @SuppressForbidden(reason = "sets the SEARCH_PIPELINE feature flag")
+    public void testDefaultSearchPipeline() throws Exception {
+        try (FeatureFlagSetter f = FeatureFlagSetter.set(FeatureFlags.SEARCH_PIPELINE)) {
+            IndexMetadata metadata = newIndexMeta(
+                "index",
+                Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT).build()
+            );
+            IndexSettings settings = new IndexSettings(metadata, Settings.EMPTY);
+            assertEquals(SearchPipelineService.NOOP_PIPELINE_ID, settings.getDefaultSearchPipeline());
+            metadata = newIndexMeta(
+                "index",
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                    .put(IndexSettings.DEFAULT_SEARCH_PIPELINE.getKey(), "foo")
+                    .build()
+            );
+            settings.updateIndexMetadata(metadata);
+            assertEquals("foo", settings.getDefaultSearchPipeline());
+        }
+    }
+
+    public void testDefaultSearchPipelineWithoutFeatureFlag() {
+        IndexMetadata metadata = newIndexMeta(
+            "index",
+            Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT).build()
+        );
+        IndexSettings settings = new IndexSettings(metadata, Settings.EMPTY);
+        assertEquals(SearchPipelineService.NOOP_PIPELINE_ID, settings.getDefaultSearchPipeline());
+        IndexMetadata updatedMetadata = newIndexMeta(
+            "index",
+            Settings.builder()
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexSettings.DEFAULT_SEARCH_PIPELINE.getKey(), "foo")
+                .build()
+        );
+        assertThrows(SettingsException.class, () -> settings.updateIndexMetadata(updatedMetadata));
     }
 }


### PR DESCRIPTION
### Description
Once users have defined and tested a search pipeline, they may want to apply it by default to all queries hitting a given index.

Users should be able to bypass the default pipeline for the index by explicitly specifying `search_pipeline=_none` in the URL parameter of their search request.

### Related Issues
Resolves #6719 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
