### PR TITLE
Manual backport of guava, netty, jetty version bumps in hdfs-fixture to 1.x.

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -18,6 +18,7 @@ asm               = 9.5
 jettison          = 1.5.4
 woodstox          = 6.4.0
 kotlin            = 1.7.10
+guava             = 31.1-jre
 
 # when updating the JNA version, also update the version in buildSrc/build.gradle
 jna               = 5.5.0

--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -25,6 +25,7 @@ jna               = 5.5.0
 
 netty             = 4.1.91.Final
 joda              = 2.12.2
+jetty             = 9.4.51.v20230217
 
 # when updating this version, you need to ensure compatibility with:
 #  - plugins/ingest-attachment (transitive dependency, check the upstream POM)

--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -30,10 +30,6 @@
 
 apply plugin: 'opensearch.java'
 
-versions << [
-  'jetty': '9.4.51.v20230217'
-]
-
 dependencies {
   api("org.apache.hadoop:hadoop-minicluster:3.3.5") {
     exclude module: 'websocket-client'

--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -30,11 +30,19 @@
 
 apply plugin: 'opensearch.java'
 
+versions << [
+  'jetty': '9.4.51.v20230217'
+]
+
 dependencies {
   api("org.apache.hadoop:hadoop-minicluster:3.3.5") {
     exclude module: 'websocket-client'
     exclude module: 'jettison'
+    exclude module: 'netty'
+    exclude module: 'guava'
+    exclude group: 'org.codehaus.jackson'
   }
+
   api "org.codehaus.jettison:jettison:${versions.jettison}"
   api "org.mockito:mockito-core:${versions.mockito}"
   api "org.apache.commons:commons-compress:1.21"
@@ -51,4 +59,7 @@ dependencies {
   api 'org.eclipse.jetty:jetty-server:9.4.49.v20220914'
   api "com.google.protobuf:protobuf-java:3.21.8"
   api 'org.apache.zookeeper:zookeeper:3.8.0'
+  api "org.eclipse.jetty:jetty-server:${versions.jetty}"
+  api "org.eclipse.jetty.websocket:javax-websocket-server-impl:${versions.jetty}"
+  runtimeOnly "com.google.guava:guava:${versions.guava}"
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR manually backports various commits to bump dependencies in hdfs-fixture. This excludes guava, netty, and jackson dependencies that are included with hadoop-minicluster.

Commits backported:
https://github.com/opensearch-project/OpenSearch/pull/5666 - partial
https://github.com/opensearch-project/OpenSearch/commit/36138810ffb34213a3d6000aa5cc15eec9b972e3
