### PR TITLE
[Backport 1.3] Manual backport of guava, netty, jetty version bumps in hdfs-fixture to 1.x. (#7472)

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -19,12 +19,14 @@ jettison          = 1.5.4
 asm               = 9.5
 woodstox          = 6.4.0
 kotlin            = 1.7.10
+guava             = 31.1-jre
 
 # when updating the JNA version, also update the version in buildSrc/build.gradle
 jna               = 5.5.0
 
 netty             = 4.1.91.Final
 joda              = 2.12.2
+jetty             = 9.4.51.v20230217
 
 # when updating this version, you need to ensure compatibility with:
 #  - plugins/ingest-attachment (transitive dependency, check the upstream POM)

--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -34,7 +34,11 @@ dependencies {
   api("org.apache.hadoop:hadoop-minicluster:3.3.5") {
     exclude module: 'websocket-client'
     exclude module: 'jettison'
+    exclude module: 'netty'
+    exclude module: 'guava'
+    exclude group: 'org.codehaus.jackson'
   }
+
   api "org.codehaus.jettison:jettison:${versions.jettison}"
   api "org.mockito:mockito-core:${versions.mockito}"
   api "org.apache.commons:commons-compress:1.21"
@@ -49,5 +53,7 @@ dependencies {
   api 'net.minidev:json-smart:2.4.8'
   api 'org.apache.zookeeper:zookeeper:3.8.0'
   api "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
-  api 'org.eclipse.jetty:jetty-server:9.4.49.v20220914'
+  api "org.eclipse.jetty:jetty-server:${versions.jetty}"
+  api "org.eclipse.jetty.websocket:javax-websocket-server-impl:${versions.jetty}"
+  runtimeOnly "com.google.guava:guava:${versions.guava}"
 }


### PR DESCRIPTION
Manual backport of #7472 