### PR TITLE
[Backport] [2.x] Bump com.networknt:json-schema-validator from 1.0.78 to 1.0.81 (#7460)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `org.apache.shiro:shiro-core` from 1.9.1 to 1.11.0 ([#7397](https://github.com/opensearch-project/OpenSearch/pull/7397))
 - Bump `jetty-server` in hdfs-fixture from 9.4.49.v20220914 to 9.4.51.v20230217 ([#7405](https://github.com/opensearch-project/OpenSearch/pull/7405))
 - OpenJDK Update (April 2023 Patch releases) ([#7448](https://github.com/opensearch-project/OpenSearch/pull/7448)
-- Bump `com.networknt:json-schema-validator` from 1.0.78 to 1.0.81 (#7460)
 - Bump `org.apache.commons:commons-compress` from 1.22 to 1.23.0 (#7462)
 - Bump `com.azure:azure-core` from 1.34.0 to 1.39.0
+- Bump `com.networknt:json-schema-validator` from 1.0.78 to 1.0.81 (#7460)
 
 ### Changed
 - Enable `./gradlew build` on MacOS by disabling bcw tests ([#7303](https://github.com/opensearch-project/OpenSearch/pull/7303))

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -118,7 +118,7 @@ dependencies {
   api 'com.avast.gradle:gradle-docker-compose-plugin:0.16.11'
   api "org.yaml:snakeyaml:${props.getProperty('snakeyaml')}"
   api 'org.apache.maven:maven-model:3.9.1'
-  api 'com.networknt:json-schema-validator:1.0.73'
+  api 'com.networknt:json-schema-validator:1.0.81'
   api "com.fasterxml.jackson.core:jackson-databind:${props.getProperty('jackson_databind')}"
 
   testFixturesApi "junit:junit:${props.getProperty('junit')}"


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/7460 to `2.x`