### PR TITLE
[Backport 1.3] Exclude protobuf-java version included with hadoop-minicluster (#7480)

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -20,6 +20,7 @@ asm               = 9.5
 woodstox          = 6.4.0
 kotlin            = 1.7.10
 guava             = 31.1-jre
+protobuf          = 3.22.3
 
 # when updating the JNA version, also update the version in buildSrc/build.gradle
 jna               = 5.5.0

--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     exclude module: 'jettison'
     exclude module: 'netty'
     exclude module: 'guava'
+    exclude module: 'protobuf-java'
     exclude group: 'org.codehaus.jackson'
   }
 
@@ -53,6 +54,7 @@ dependencies {
   api 'net.minidev:json-smart:2.4.8'
   api 'org.apache.zookeeper:zookeeper:3.8.0'
   api "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
+  api "com.google.protobuf:protobuf-java:${versions.protobuf}"
   api "org.eclipse.jetty:jetty-server:${versions.jetty}"
   api "org.eclipse.jetty.websocket:javax-websocket-server-impl:${versions.jetty}"
   runtimeOnly "com.google.guava:guava:${versions.guava}"


### PR DESCRIPTION
Manual backport of #7480 to 1.3