### PR TITLE
[Backport 1.x] Bump net.minidev:json-smart from 2.4.7 to 2.4.10 in /t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump `org.apache.hadoop:hadoop-minicluster` from 3.3.4 to 3.3.5
 - Bump `snakeyaml` from 1.33 to 2.0 ([#6511](https://github.com/opensearch-project/OpenSearch/pull/6511))
 - OpenJDK Update (April 2023 Patch releases) ([#7449](https://github.com/opensearch-project/OpenSearch/pull/7449)
+- Bump `net.minidev:json-smart` from 2.4.7 to 2.4.10
 
 ### Changed
 - Changed `opensearch-env` to respect already set `OPENSEARCH_HOME` environment variable ([#6956](https://github.com/opensearch-project/OpenSearch/pull/6956/))

--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -46,7 +46,7 @@ dependencies {
   api "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:${versions.jackson}"
   api "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
   api "com.fasterxml.woodstox:woodstox-core:${versions.woodstox}"
-  api 'net.minidev:json-smart:2.4.8'
+  api 'net.minidev:json-smart:2.4.10'
   api "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
   api 'org.eclipse.jetty:jetty-server:9.4.49.v20220914'
   api "com.google.protobuf:protobuf-java:3.21.8"


### PR DESCRIPTION
### Description
[Backport 1.x] Bump net.minidev:json-smart from 2.4.7 to 2.4.10 in /test/fixtures/hdfs-fixture (#6944)

### Check List
- [ ] ~New functionality includes testing.~
  - [ ] ~All tests pass~
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
