### PR TITLE
Change INDEX_SEARCHER threadpool to resizable to support task resource tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Enable `./gradlew build` on MacOS by disabling bcw tests ([#7303](https://github.com/opensearch-project/OpenSearch/pull/7303))
 - Moved concurrent-search from sandbox plugin to server module behind feature flag ([#7203](https://github.com/opensearch-project/OpenSearch/pull/7203))
 - Allow access to indices cache clear APIs for read only indexes ([#7303](https://github.com/opensearch-project/OpenSearch/pull/7303))
+- Changed concurrent-search threadpool type to be resizable and support task resource tracking ([#7502](https://github.com/opensearch-project/OpenSearch/pull/7502))
 
 ### Deprecated
 

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/node/tasks/AbstractTasksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/node/tasks/AbstractTasksIT.java
@@ -1,0 +1,190 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.node.tasks;
+
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.ResourceNotFoundException;
+import org.opensearch.action.admin.cluster.node.tasks.get.GetTaskResponse;
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.Strings;
+import org.opensearch.common.collect.Tuple;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.tasks.TaskId;
+import org.opensearch.tasks.TaskInfo;
+import org.opensearch.tasks.ThreadResourceInfo;
+import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.test.tasks.MockTaskManager;
+import org.opensearch.test.transport.MockTransportService;
+import org.opensearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Base IT test class for Tasks ITs
+ */
+abstract class AbstractTasksIT extends OpenSearchIntegTestCase {
+
+    protected Map<Tuple<String, String>, RecordingTaskManagerListener> listeners = new HashMap<>();
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getMockPlugins() {
+        Collection<Class<? extends Plugin>> mockPlugins = new ArrayList<>(super.getMockPlugins());
+        mockPlugins.remove(MockTransportService.TestPlugin.class);
+        return mockPlugins;
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Arrays.asList(MockTransportService.TestPlugin.class, TestTaskPlugin.class);
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(MockTaskManager.USE_MOCK_TASK_MANAGER_SETTING.getKey(), true)
+            .build();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        for (Map.Entry<Tuple<String, String>, RecordingTaskManagerListener> entry : listeners.entrySet()) {
+            ((MockTaskManager) internalCluster().getInstance(TransportService.class, entry.getKey().v1()).getTaskManager()).removeListener(
+                entry.getValue()
+            );
+        }
+        listeners.clear();
+        super.tearDown();
+    }
+
+    /**
+     * Registers recording task event listeners with the given action mask on all nodes
+     */
+    protected void registerTaskManagerListeners(String actionMasks) {
+        for (String nodeName : internalCluster().getNodeNames()) {
+            DiscoveryNode node = internalCluster().getInstance(ClusterService.class, nodeName).localNode();
+            RecordingTaskManagerListener listener = new RecordingTaskManagerListener(node.getId(), actionMasks.split(","));
+            ((MockTaskManager) internalCluster().getInstance(TransportService.class, nodeName).getTaskManager()).addListener(listener);
+            RecordingTaskManagerListener oldListener = listeners.put(new Tuple<>(node.getName(), actionMasks), listener);
+            assertNull(oldListener);
+        }
+    }
+
+    /**
+     * Resets all recording task event listeners with the given action mask on all nodes
+     */
+    protected void resetTaskManagerListeners(String actionMasks) {
+        for (Map.Entry<Tuple<String, String>, RecordingTaskManagerListener> entry : listeners.entrySet()) {
+            if (actionMasks == null || entry.getKey().v2().equals(actionMasks)) {
+                entry.getValue().reset();
+            }
+        }
+    }
+
+    /**
+     * Returns the number of events that satisfy the criteria across all nodes
+     *
+     * @param actionMasks action masks to match
+     * @return number of events that satisfy the criteria
+     */
+    protected int numberOfEvents(String actionMasks, Function<Tuple<Boolean, TaskInfo>, Boolean> criteria) {
+        return findEvents(actionMasks, criteria).size();
+    }
+
+    /**
+     * Returns all events that satisfy the criteria across all nodes
+     *
+     * @param actionMasks action masks to match
+     * @return number of events that satisfy the criteria
+     */
+    protected List<TaskInfo> findEvents(String actionMasks, Function<Tuple<Boolean, TaskInfo>, Boolean> criteria) {
+        List<TaskInfo> events = new ArrayList<>();
+        for (Map.Entry<Tuple<String, String>, RecordingTaskManagerListener> entry : listeners.entrySet()) {
+            if (actionMasks == null || entry.getKey().v2().equals(actionMasks)) {
+                for (Tuple<Boolean, TaskInfo> taskEvent : entry.getValue().getEvents()) {
+                    if (criteria.apply(taskEvent)) {
+                        events.add(taskEvent.v2());
+                    }
+                }
+            }
+        }
+        return events;
+    }
+
+    protected Map<Long, List<ThreadResourceInfo>> getThreadStats(String actionMasks, TaskId taskId) {
+        for (Map.Entry<Tuple<String, String>, RecordingTaskManagerListener> entry : listeners.entrySet()) {
+            if (actionMasks == null || entry.getKey().v2().equals(actionMasks)) {
+                for (Tuple<TaskId, Map<Long, List<ThreadResourceInfo>>> threadStats : entry.getValue().getThreadStats()) {
+                    if (taskId.equals(threadStats.v1())) {
+                        return threadStats.v2();
+                    }
+                }
+            }
+        }
+        return new HashMap<>();
+    }
+
+    /**
+     * Asserts that all tasks in the tasks list have the same parentTask
+     */
+    protected void assertParentTask(List<TaskInfo> tasks, TaskInfo parentTask) {
+        for (TaskInfo task : tasks) {
+            assertParentTask(task, parentTask);
+        }
+    }
+
+    protected void assertParentTask(TaskInfo task, TaskInfo parentTask) {
+        assertTrue(task.getParentTaskId().isSet());
+        assertEquals(parentTask.getTaskId().getNodeId(), task.getParentTaskId().getNodeId());
+        assertTrue(Strings.hasLength(task.getParentTaskId().getNodeId()));
+        assertEquals(parentTask.getId(), task.getParentTaskId().getId());
+    }
+
+    protected void expectNotFound(ThrowingRunnable r) {
+        Exception e = expectThrows(Exception.class, r);
+        ResourceNotFoundException notFound = (ResourceNotFoundException) ExceptionsHelper.unwrap(e, ResourceNotFoundException.class);
+        if (notFound == null) {
+            throw new AssertionError("Expected " + ResourceNotFoundException.class.getSimpleName(), e);
+        }
+    }
+
+    /**
+     * Fetch the task status from the list tasks API using it's "fallback to get from the task index" behavior. Asserts some obvious stuff
+     * about the fetched task and returns a map of it's status.
+     */
+    protected GetTaskResponse expectFinishedTask(TaskId taskId) throws IOException {
+        GetTaskResponse response = client().admin().cluster().prepareGetTask(taskId).get();
+        assertTrue("the task should have been completed before fetching", response.getTask().isCompleted());
+        TaskInfo info = response.getTask().getTask();
+        assertEquals(taskId, info.getTaskId());
+        assertNull(info.getStatus()); // The test task doesn't have any status
+        return response;
+    }
+
+    protected void indexDocumentsWithRefresh(String indexName, int numDocs) {
+        for (int i = 0; i < numDocs; i++) {
+            client().prepareIndex(indexName)
+                .setId("test_id_" + String.valueOf(i))
+                .setSource("{\"foo_" + String.valueOf(i) + "\": \"bar_" + String.valueOf(i) + "\"}", XContentType.JSON)
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                .get();
+        }
+    }
+}

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/node/tasks/ConcurrentSearchTasksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/node/tasks/ConcurrentSearchTasksIT.java
@@ -1,0 +1,118 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.node.tasks;
+
+import org.hamcrest.MatcherAssert;
+import org.opensearch.action.admin.indices.segments.IndicesSegmentsRequest;
+import org.opensearch.action.search.SearchAction;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.collect.Tuple;
+import org.opensearch.common.settings.FeatureFlagSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.tasks.TaskInfo;
+import org.opensearch.tasks.ThreadResourceInfo;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertSearchResponse;
+
+/**
+ * Integration tests for task management API with Concurrent Segment Search
+ *
+ * The way the test framework bootstraps the test cluster makes it difficult to parameterize the feature flag.
+ * Once concurrent search is moved behind a cluster setting we can parameterize these tests behind the setting.
+ */
+public class ConcurrentSearchTasksIT extends AbstractTasksIT {
+
+    private static final int INDEX_SEARCHER_THREADS = 10;
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put("thread_pool.index_searcher.size", INDEX_SEARCHER_THREADS)
+            .put("thread_pool.index_searcher.queue_size", INDEX_SEARCHER_THREADS)
+            .build();
+    }
+
+    private int getSegmentCount(String indexName) {
+        return client().admin()
+            .indices()
+            .segments(new IndicesSegmentsRequest(indexName))
+            .actionGet()
+            .getIndices()
+            .get(indexName)
+            .getShards()
+            .get(0)
+            .getShards()[0].getSegments()
+            .size();
+    }
+
+    @Override
+    protected Settings featureFlagSettings() {
+        Settings.Builder featureSettings = Settings.builder();
+        for (Setting builtInFlag : FeatureFlagSettings.BUILT_IN_FEATURE_FLAGS) {
+            featureSettings.put(builtInFlag.getKey(), builtInFlag.getDefaultRaw(Settings.EMPTY));
+        }
+        featureSettings.put(FeatureFlags.CONCURRENT_SEGMENT_SEARCH, true);
+        return featureSettings.build();
+    }
+
+    /**
+     * Tests the number of threads that worked on a search task.
+     *
+     * Currently, we try to control concurrency by creating an index with 7 segments and rely on
+     * the way concurrent search creates leaf slices from segments. Once more concurrency controls are introduced
+     * we should improve this test to use those methods.
+     */
+    public void testConcurrentSearchTaskTracking() {
+        final String INDEX_NAME = "test";
+        final int NUM_SHARDS = 1;
+        final int NUM_DOCS = 7;
+
+        registerTaskManagerListeners(SearchAction.NAME);  // coordinator task
+        registerTaskManagerListeners(SearchAction.NAME + "[*]");  // shard task
+        createIndex(
+            INDEX_NAME,
+            Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, NUM_SHARDS)
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                .build()
+        );
+        ensureGreen(INDEX_NAME); // Make sure all shards are allocated to catch replication tasks
+        indexDocumentsWithRefresh(INDEX_NAME, NUM_DOCS); // Concurrent search requires >5 segments or >250,000 docs to have concurrency, so
+                                                         // we index 7 docs flushing between each to create new segments
+        assertSearchResponse(client().prepareSearch(INDEX_NAME).setQuery(QueryBuilders.matchAllQuery()).get());
+
+        // the search operation should produce one coordinator task
+        List<TaskInfo> mainTask = findEvents(SearchAction.NAME, Tuple::v1);
+        assertEquals(1, mainTask.size());
+        TaskInfo mainTaskInfo = mainTask.get(0);
+
+        List<TaskInfo> shardTasks = findEvents(SearchAction.NAME + "[*]", Tuple::v1);
+        assertEquals(NUM_SHARDS, shardTasks.size()); // We should only have 1 shard search task per shard
+        for (TaskInfo taskInfo : shardTasks) {
+            MatcherAssert.assertThat(taskInfo.getParentTaskId(), notNullValue());
+            assertEquals(mainTaskInfo.getTaskId(), taskInfo.getParentTaskId());
+
+            Map<Long, List<ThreadResourceInfo>> threadStats = getThreadStats(SearchAction.NAME + "[*]", taskInfo.getTaskId());
+            // Concurrent search forks each slice of 5 segments to different thread
+            assertEquals((int) Math.ceil(getSegmentCount(INDEX_NAME) / 5.0), threadStats.size());
+
+            // assert that all task descriptions have non-zero length
+            MatcherAssert.assertThat(taskInfo.getDescription().length(), greaterThan(0));
+        }
+    }
+}

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/node/tasks/TasksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/node/tasks/TasksIT.java
@@ -32,10 +32,9 @@
 
 package org.opensearch.action.admin.cluster.node.tasks;
 
+import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchTimeoutException;
-import org.opensearch.ExceptionsHelper;
-import org.opensearch.ResourceNotFoundException;
 import org.opensearch.action.ActionFuture;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.TaskOperationFailure;
@@ -57,15 +56,11 @@ import org.opensearch.action.search.SearchTransportService;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.action.support.replication.ReplicationResponse;
 import org.opensearch.action.support.replication.TransportReplicationActionTests;
-import org.opensearch.cluster.node.DiscoveryNode;
-import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.common.Strings;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.regex.Regex;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.query.QueryBuilders;
-import org.opensearch.plugins.Plugin;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskId;
@@ -75,14 +70,9 @@ import org.opensearch.tasks.TaskResultsService;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.tasks.MockTaskManager;
 import org.opensearch.test.tasks.MockTaskManagerListener;
-import org.opensearch.test.transport.MockTransportService;
 import org.opensearch.transport.ReceiveTimeoutTransportException;
 import org.opensearch.transport.TransportService;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -96,12 +86,6 @@ import java.util.function.Function;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singleton;
-import static org.opensearch.common.unit.TimeValue.timeValueMillis;
-import static org.opensearch.common.unit.TimeValue.timeValueSeconds;
-import static org.opensearch.http.HttpTransportSettings.SETTING_HTTP_MAX_HEADER_SIZE;
-import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertFutureThrows;
-import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertNoFailures;
-import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
@@ -113,6 +97,12 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
+import static org.opensearch.common.unit.TimeValue.timeValueMillis;
+import static org.opensearch.common.unit.TimeValue.timeValueSeconds;
+import static org.opensearch.http.HttpTransportSettings.SETTING_HTTP_MAX_HEADER_SIZE;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertFutureThrows;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertNoFailures;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertSearchResponse;
 
 /**
  * Integration tests for task management API
@@ -120,29 +110,7 @@ import static org.hamcrest.Matchers.startsWith;
  * We need at least 2 nodes so we have a cluster-manager node a non-cluster-manager node
  */
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, minNumDataNodes = 2)
-public class TasksIT extends OpenSearchIntegTestCase {
-
-    private Map<Tuple<String, String>, RecordingTaskManagerListener> listeners = new HashMap<>();
-
-    @Override
-    protected Collection<Class<? extends Plugin>> getMockPlugins() {
-        Collection<Class<? extends Plugin>> mockPlugins = new ArrayList<>(super.getMockPlugins());
-        mockPlugins.remove(MockTransportService.TestPlugin.class);
-        return mockPlugins;
-    }
-
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return Arrays.asList(MockTransportService.TestPlugin.class, TestTaskPlugin.class);
-    }
-
-    @Override
-    protected Settings nodeSettings(int nodeOrdinal) {
-        return Settings.builder()
-            .put(super.nodeSettings(nodeOrdinal))
-            .put(MockTaskManager.USE_MOCK_TASK_MANAGER_SETTING.getKey(), true)
-            .build();
-    }
+public class TasksIT extends AbstractTasksIT {
 
     public void testTaskCounts() {
         // Run only on data nodes
@@ -939,107 +907,5 @@ public class TasksIT extends OpenSearchIntegTestCase {
         assertEquals("test", response.getTask().getTask().getAction());
         assertNotNull(response.getTask().getError());
         assertNull(response.getTask().getResponse());
-    }
-
-    @Override
-    public void tearDown() throws Exception {
-        for (Map.Entry<Tuple<String, String>, RecordingTaskManagerListener> entry : listeners.entrySet()) {
-            ((MockTaskManager) internalCluster().getInstance(TransportService.class, entry.getKey().v1()).getTaskManager()).removeListener(
-                entry.getValue()
-            );
-        }
-        listeners.clear();
-        super.tearDown();
-    }
-
-    /**
-     * Registers recording task event listeners with the given action mask on all nodes
-     */
-    private void registerTaskManagerListeners(String actionMasks) {
-        for (String nodeName : internalCluster().getNodeNames()) {
-            DiscoveryNode node = internalCluster().getInstance(ClusterService.class, nodeName).localNode();
-            RecordingTaskManagerListener listener = new RecordingTaskManagerListener(node.getId(), actionMasks.split(","));
-            ((MockTaskManager) internalCluster().getInstance(TransportService.class, nodeName).getTaskManager()).addListener(listener);
-            RecordingTaskManagerListener oldListener = listeners.put(new Tuple<>(node.getName(), actionMasks), listener);
-            assertNull(oldListener);
-        }
-    }
-
-    /**
-     * Resets all recording task event listeners with the given action mask on all nodes
-     */
-    private void resetTaskManagerListeners(String actionMasks) {
-        for (Map.Entry<Tuple<String, String>, RecordingTaskManagerListener> entry : listeners.entrySet()) {
-            if (actionMasks == null || entry.getKey().v2().equals(actionMasks)) {
-                entry.getValue().reset();
-            }
-        }
-    }
-
-    /**
-     * Returns the number of events that satisfy the criteria across all nodes
-     *
-     * @param actionMasks action masks to match
-     * @return number of events that satisfy the criteria
-     */
-    private int numberOfEvents(String actionMasks, Function<Tuple<Boolean, TaskInfo>, Boolean> criteria) {
-        return findEvents(actionMasks, criteria).size();
-    }
-
-    /**
-     * Returns all events that satisfy the criteria across all nodes
-     *
-     * @param actionMasks action masks to match
-     * @return number of events that satisfy the criteria
-     */
-    private List<TaskInfo> findEvents(String actionMasks, Function<Tuple<Boolean, TaskInfo>, Boolean> criteria) {
-        List<TaskInfo> events = new ArrayList<>();
-        for (Map.Entry<Tuple<String, String>, RecordingTaskManagerListener> entry : listeners.entrySet()) {
-            if (actionMasks == null || entry.getKey().v2().equals(actionMasks)) {
-                for (Tuple<Boolean, TaskInfo> taskEvent : entry.getValue().getEvents()) {
-                    if (criteria.apply(taskEvent)) {
-                        events.add(taskEvent.v2());
-                    }
-                }
-            }
-        }
-        return events;
-    }
-
-    /**
-     * Asserts that all tasks in the tasks list have the same parentTask
-     */
-    private void assertParentTask(List<TaskInfo> tasks, TaskInfo parentTask) {
-        for (TaskInfo task : tasks) {
-            assertParentTask(task, parentTask);
-        }
-    }
-
-    private void assertParentTask(TaskInfo task, TaskInfo parentTask) {
-        assertTrue(task.getParentTaskId().isSet());
-        assertEquals(parentTask.getTaskId().getNodeId(), task.getParentTaskId().getNodeId());
-        assertTrue(Strings.hasLength(task.getParentTaskId().getNodeId()));
-        assertEquals(parentTask.getId(), task.getParentTaskId().getId());
-    }
-
-    private void expectNotFound(ThrowingRunnable r) {
-        Exception e = expectThrows(Exception.class, r);
-        ResourceNotFoundException notFound = (ResourceNotFoundException) ExceptionsHelper.unwrap(e, ResourceNotFoundException.class);
-        if (notFound == null) {
-            throw new AssertionError("Expected " + ResourceNotFoundException.class.getSimpleName(), e);
-        }
-    }
-
-    /**
-     * Fetch the task status from the list tasks API using it's "fallback to get from the task index" behavior. Asserts some obvious stuff
-     * about the fetched task and returns a map of it's status.
-     */
-    private GetTaskResponse expectFinishedTask(TaskId taskId) throws IOException {
-        GetTaskResponse response = client().admin().cluster().prepareGetTask(taskId).get();
-        assertTrue("the task should have been completed before fetching", response.getTask().isCompleted());
-        TaskInfo info = response.getTask().getTask();
-        assertEquals(taskId, info.getTaskId());
-        assertNull(info.getStatus()); // The test task doesn't have any status
-        return response;
     }
 }

--- a/server/src/main/java/org/opensearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/opensearch/threadpool/ThreadPool.java
@@ -183,7 +183,7 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         map.put(Names.REMOTE_PURGE, ThreadPoolType.SCALING);
         map.put(Names.REMOTE_REFRESH, ThreadPoolType.SCALING);
         if (FeatureFlags.isEnabled(FeatureFlags.CONCURRENT_SEGMENT_SEARCH)) {
-            map.put(Names.INDEX_SEARCHER, ThreadPoolType.FIXED);
+            map.put(Names.INDEX_SEARCHER, ThreadPoolType.RESIZABLE);
         }
         THREAD_POOL_TYPES = Collections.unmodifiableMap(map);
     }
@@ -268,7 +268,10 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
             new ScalingExecutorBuilder(Names.REMOTE_REFRESH, 1, halfProcMaxAt10, TimeValue.timeValueMinutes(5))
         );
         if (FeatureFlags.isEnabled(FeatureFlags.CONCURRENT_SEGMENT_SEARCH)) {
-            builders.put(Names.INDEX_SEARCHER, new FixedExecutorBuilder(settings, Names.INDEX_SEARCHER, allocatedProcessors, 1000, false));
+            builders.put(
+                Names.INDEX_SEARCHER,
+                new ResizableExecutorBuilder(settings, Names.INDEX_SEARCHER, allocatedProcessors, 1000, runnableTaskListener)
+            );
         }
 
         for (final ExecutorBuilder<?> builder : customBuilders) {

--- a/server/src/test/java/org/opensearch/tasks/TaskResourceTrackingServiceTests.java
+++ b/server/src/test/java/org/opensearch/tasks/TaskResourceTrackingServiceTests.java
@@ -20,8 +20,13 @@ import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.opensearch.tasks.ResourceStats.CPU;
 import static org.opensearch.tasks.ResourceStats.MEMORY;
 import static org.opensearch.tasks.TaskResourceTrackingService.TASK_ID;
 
@@ -86,6 +91,49 @@ public class TaskResourceTrackingServiceTests extends OpenSearchTestCase {
         // Makes sure stop tracking marks the current active thread inactive and refreshes the resource stats before returning.
         assertFalse(task.getResourceStats().get(threadId).get(0).isActive());
         assertTrue(task.getResourceStats().get(threadId).get(0).getResourceUsageInfo().getStatsInfo().get(MEMORY).getTotalValue() > 0);
+    }
+
+    /**
+     * Test if taskResourceTrackingService properly tracks resource usage when multiple threads work on the same task
+     */
+    public void testStartingTrackingHandlesMultipleThreadsPerTask() throws InterruptedException {
+        ExecutorService executor = threadPool.executor(ThreadPool.Names.GENERIC);
+        taskResourceTrackingService.setTaskResourceTrackingEnabled(true);
+        Task task = new SearchTask(1, "test", "test", () -> "Test", TaskId.EMPTY_TASK_ID, new HashMap<>());
+        taskResourceTrackingService.startTracking(task);
+        int numTasks = randomIntBetween(2, 100);
+        for (int i = 0; i < numTasks; i++) {
+            executor.execute(() -> {
+                long threadId = Thread.currentThread().getId();
+                taskResourceTrackingService.taskExecutionStartedOnThread(task.getId(), threadId);
+                // The same thread may pick up multiple runnables for the same task id
+                assertEquals(1, task.getResourceStats().get(threadId).stream().filter(ThreadResourceInfo::isActive).count());
+                taskResourceTrackingService.taskExecutionFinishedOnThread(task.getId(), threadId);
+            });
+        }
+        executor.shutdown();
+        while (true) {
+            try {
+                if (executor.awaitTermination(1, TimeUnit.MINUTES)) break;
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        Map<Long, List<ThreadResourceInfo>> stats = task.getResourceStats();
+        int numExecutions = 0;
+        for (Long threadId : stats.keySet()) {
+            for (ThreadResourceInfo info : task.getResourceStats().get(threadId)) {
+                assertTrue(info.getResourceUsageInfo().getStatsInfo().get(MEMORY).getTotalValue() > 0);
+                assertTrue(info.getResourceUsageInfo().getStatsInfo().get(CPU).getTotalValue() > 0);
+                assertFalse(info.isActive());
+                numExecutions++;
+            }
+
+        }
+        assertTrue(task.getTotalResourceStats().getCpuTimeInNanos() > 0);
+        assertTrue(task.getTotalResourceStats().getMemoryInBytes() > 0);
+        // Each execution of a runnable should record an entry in resourceStats even if it's the same thread
+        assertEquals(numTasks, numExecutions);
     }
 
     private void verifyThreadContextFixedHeaders(String key, String value) {


### PR DESCRIPTION
### Description
Change the INDEX_SEARCHER threadpool type to [`QueueResizableOpenSearchThreadPoolExecutor`](https://github.com/opensearch-project/OpenSearch/blob/5eac54d4ade73f6d0ed80b0f2408a104a98e3232/server/src/main/java/org/opensearch/common/util/concurrent/OpenSearchExecutors.java#L206) to support task resource tracking for concurrent segment search.

* Added new `ConcurrentSearchTasksIT` test to validate that multiple threads are reporting resource stats for the same task with concurrent search enabled. Note that this is separate from #7440.
* Added new UT `testStartingTrackingHandlesMultipleThreadsPerTask` to `TaskResourceTrackingServiceTests` to check that `TaskResourceTrackingService` properly handles multiple threads per task.

We already have existing tests for passing thread context between threadpools so I did not add any more tests related to `TaskAwareRunnable`.

### Related Issues
#7425 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
