### PR TITLE
[Docs] Clarify that Lucene Snapshot artifacts are releases, not snapshots

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -616,6 +616,7 @@ Pass a list of files or directories to limit your search.
 
 The Github workflow in [lucene-snapshots.yml](.github/workflows/lucene-snapshots.yml) is a Github worfklow executable by maintainers to build a top-down snapshot build of lucene.
 These snapshots are available to test compatibility with upcoming changes to Lucene by updating the version at [version.properties](buildsrc/version.properties) with the `version-snapshot-sha` version. Example: `lucene = 10.0.0-snapshot-2e941fc`.
+Note that these snapshots do not follow the typical Maven ecosystem naming convention with a (case sensitive) SNAPSHOT suffix, so these snapshots are considered "releases" by build systems such as the `mavenContent` repository filter in Gradle or `releases` artifact policies in Maven.
 
 ### Flaky Tests
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -616,7 +616,7 @@ Pass a list of files or directories to limit your search.
 
 The Github workflow in [lucene-snapshots.yml](.github/workflows/lucene-snapshots.yml) is a GitHub workflow executable by maintainers to build a top-down snapshot build of Lucene.
 These snapshots are available to test compatibility with upcoming changes to Lucene by updating the version at [version.properties](buildsrc/version.properties) with the `version-snapshot-sha` version. Example: `lucene = 10.0.0-snapshot-2e941fc`.
-Note that these snapshots do not follow the typical Maven naming convention with a (case sensitive) SNAPSHOT suffix, so these snapshots are considered "releases" by build systems such as the `mavenContent` repository filter in Gradle or `releases` artifact policies in Maven.
+Note that these snapshots do not follow the Maven [naming convention](https://maven.apache.org/guides/getting-started/index.html#what-is-a-snapshot-version) with a (case sensitive) SNAPSHOT suffix, so these artifacts are considered "releases" by build systems such as the `mavenContent` repository filter in Gradle or `releases` artifact policies in Maven.
 
 ### Flaky Tests
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -614,9 +614,9 @@ Pass a list of files or directories to limit your search.
 
 ### Lucene Snapshots
 
-The Github workflow in [lucene-snapshots.yml](.github/workflows/lucene-snapshots.yml) is a Github worfklow executable by maintainers to build a top-down snapshot build of lucene.
+The Github workflow in [lucene-snapshots.yml](.github/workflows/lucene-snapshots.yml) is a GitHub workflow executable by maintainers to build a top-down snapshot build of Lucene.
 These snapshots are available to test compatibility with upcoming changes to Lucene by updating the version at [version.properties](buildsrc/version.properties) with the `version-snapshot-sha` version. Example: `lucene = 10.0.0-snapshot-2e941fc`.
-Note that these snapshots do not follow the typical Maven ecosystem naming convention with a (case sensitive) SNAPSHOT suffix, so these snapshots are considered "releases" by build systems such as the `mavenContent` repository filter in Gradle or `releases` artifact policies in Maven.
+Note that these snapshots do not follow the typical Maven naming convention with a (case sensitive) SNAPSHOT suffix, so these snapshots are considered "releases" by build systems such as the `mavenContent` repository filter in Gradle or `releases` artifact policies in Maven.
 
 ### Flaky Tests
 
@@ -627,6 +627,6 @@ If you encounter a build/test failure in CI that is unrelated to the change in y
 1. Follow failed CI links, and locate the failing test(s).
 2. Copy-paste the failure into a comment of your PR.
 3. Search through [issues](https://github.com/opensearch-project/OpenSearch/issues?q=is%3Aopen+is%3Aissue+label%3A%22flaky-test%22) using the name of the failed test for whether this is a known flaky test.
-5. If an existing issue is found, paste a link to the known issue in a comment to your PR.
-6. If no existing issue is found, open one.
-7. Retry CI via the GitHub UX or by pushing an update to your PR.
+4. If an existing issue is found, paste a link to the known issue in a comment to your PR.
+5. If no existing issue is found, open one.
+6. Retry CI via the GitHub UX or by pushing an update to your PR.


### PR DESCRIPTION
### Description

The Maven ecosystem requires specific naming convention for snapshots, with a (case-sensitive) `-SNAPSHOT` suffix.

The "Lucene Snapshots" produced by the [lucene-snapshots.yml](.github/workflows/lucene-snapshots.yml) workflow do not conform to this convention, and are thus considered "releases" by build systems.  This produces surprising/confusing behavior.

For example, using a Gradle [repository filter](https://docs.gradle.org/current/userguide/declaring_repositories.html#maven_repository_filtering) these snapshots are excluded from `snapshotsOnly()` and included in `releasesOnly()`.  In a Maven-based build, [artifact repository policies](https://maven.apache.org/ref/3.6.3/maven-artifact/apidocs/org/apache/maven/artifact/repository/ArtifactRepositoryPolicy.html) such as update/refresh rate will apply to the "releases" element rather than "snapshots".

This PR clarifies the Developer Guide to highlight this distinction to reduce confusion.

### Related Issues

Coming from public slack conversation [here](https://opensearch.slack.com/archives/C038PDJ14JZ/p1683632217767909) in support of https://github.com/opensearch-project/opensearch-sdk-java/issues/611

### Check List
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
