### PR TITLE
Change block check type for index clear cache APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Enable `./gradlew build` on MacOS by disabling bcw tests ([#7303](https://github.com/opensearch-project/OpenSearch/pull/7303))
 - Moved concurrent-search from sandbox plugin to server module behind feature flag ([#7203](https://github.com/opensearch-project/OpenSearch/pull/7203))
+- Allow access to indices cache clear APIs for read only indexes ([#7303](https://github.com/opensearch-project/OpenSearch/pull/7303))
 
 ### Deprecated
 

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/cache/clear/ClearIndicesCacheBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/cache/clear/ClearIndicesCacheBlocksIT.java
@@ -55,7 +55,12 @@ public class ClearIndicesCacheBlocksIT extends OpenSearchIntegTestCase {
         NumShards numShards = getNumShards("test");
 
         // Request is not blocked
-        for (String blockSetting : Arrays.asList(SETTING_BLOCKS_READ, SETTING_BLOCKS_WRITE)) {
+        for (String blockSetting : Arrays.asList(
+            SETTING_BLOCKS_READ,
+            SETTING_BLOCKS_WRITE,
+            SETTING_READ_ONLY,
+            SETTING_READ_ONLY_ALLOW_DELETE
+        )) {
             try {
                 enableIndexBlock("test", blockSetting);
                 ClearIndicesCacheResponse clearIndicesCacheResponse = client().admin()
@@ -73,7 +78,7 @@ public class ClearIndicesCacheBlocksIT extends OpenSearchIntegTestCase {
             }
         }
         // Request is blocked
-        for (String blockSetting : Arrays.asList(SETTING_READ_ONLY, SETTING_BLOCKS_METADATA, SETTING_READ_ONLY_ALLOW_DELETE)) {
+        for (String blockSetting : Arrays.asList(SETTING_BLOCKS_METADATA)) {
             try {
                 enableIndexBlock("test", blockSetting);
                 assertBlocked(

--- a/server/src/main/java/org/opensearch/action/admin/indices/cache/clear/TransportClearIndicesCacheAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/cache/clear/TransportClearIndicesCacheAction.java
@@ -129,11 +129,11 @@ public class TransportClearIndicesCacheAction extends TransportBroadcastByNodeAc
 
     @Override
     protected ClusterBlockException checkGlobalBlock(ClusterState state, ClearIndicesCacheRequest request) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
     }
 
     @Override
     protected ClusterBlockException checkRequestBlock(ClusterState state, ClearIndicesCacheRequest request, String[] concreteIndices) {
-        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, concreteIndices);
+        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_READ, concreteIndices);
     }
 }

--- a/server/src/test/java/org/opensearch/action/admin/indices/cache/clear/TransportClearIndicesCacheActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/cache/clear/TransportClearIndicesCacheActionTests.java
@@ -1,0 +1,82 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.indices.cache.clear;
+
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.block.ClusterBlock;
+import org.opensearch.cluster.block.ClusterBlockLevel;
+import org.opensearch.cluster.block.ClusterBlocks;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.indices.IndicesService;
+import org.opensearch.rest.RestStatus;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.TransportService;
+
+import java.util.EnumSet;
+
+import static org.mockito.Mockito.mock;
+
+public class TransportClearIndicesCacheActionTests extends OpenSearchTestCase {
+    private final TransportClearIndicesCacheAction action = new TransportClearIndicesCacheAction(
+        mock(ClusterService.class),
+        mock(TransportService.class),
+        mock(IndicesService.class),
+        mock(ActionFilters.class),
+        mock(IndexNameExpressionResolver.class)
+    );
+
+    private final ClusterBlock writeClusterBlock = new ClusterBlock(
+        1,
+        "uuid",
+        "",
+        true,
+        true,
+        true,
+        RestStatus.OK,
+        EnumSet.of(ClusterBlockLevel.METADATA_WRITE)
+    );
+
+    private final ClusterBlock readClusterBlock = new ClusterBlock(
+        1,
+        "uuid",
+        "",
+        true,
+        true,
+        true,
+        RestStatus.OK,
+        EnumSet.of(ClusterBlockLevel.METADATA_READ)
+    );
+
+    public void testGlobalBlockCheck() {
+        ClusterBlocks.Builder builder = ClusterBlocks.builder();
+        builder.addGlobalBlock(writeClusterBlock);
+        ClusterState metadataWriteBlockedState = ClusterState.builder(ClusterState.EMPTY_STATE).blocks(builder).build();
+        assertNull(action.checkGlobalBlock(metadataWriteBlockedState, new ClearIndicesCacheRequest()));
+
+        builder = ClusterBlocks.builder();
+        builder.addGlobalBlock(readClusterBlock);
+        ClusterState metadataReadBlockedState = ClusterState.builder(ClusterState.EMPTY_STATE).blocks(builder).build();
+        assertNotNull(action.checkGlobalBlock(metadataReadBlockedState, new ClearIndicesCacheRequest()));
+    }
+
+    public void testIndexBlockCheck() {
+        String indexName = "test";
+        ClusterBlocks.Builder builder = ClusterBlocks.builder();
+        builder.addIndexBlock(indexName, writeClusterBlock);
+        ClusterState metadataWriteBlockedState = ClusterState.builder(ClusterState.EMPTY_STATE).blocks(builder).build();
+        assertNull(action.checkRequestBlock(metadataWriteBlockedState, new ClearIndicesCacheRequest(), new String[] { indexName }));
+
+        builder = ClusterBlocks.builder();
+        builder.addIndexBlock(indexName, readClusterBlock);
+        ClusterState metadataReadBlockedState = ClusterState.builder(ClusterState.EMPTY_STATE).blocks(builder).build();
+        assertNotNull(action.checkRequestBlock(metadataReadBlockedState, new ClearIndicesCacheRequest(), new String[] { indexName }));
+    }
+}


### PR DESCRIPTION

### Description
- From the findings on https://github.com/opensearch-project/OpenSearch/pull/7498/files#r1191759700, the clear fieldsdata/request/query cache paths do not seem to be affected by metadata write blocks
- Lowering the block level to `METADATA_READ` to enable cache clearing with write blocks as it will help relieve resources within the system. 

### Related Issues
- #7498

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
