### PR TITLE
Reject invalid SearchBackpressureMode (#6832)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix compression support for h2c protocol ([#4944](https://github.com/opensearch-project/OpenSearch/pull/4944))
 - Support OpenSSL Provider with default Netty allocator ([#5460](https://github.com/opensearch-project/OpenSearch/pull/5460))
 - Replaces ZipInputStream with ZipFile to fix Zip Slip vulnerability ([#7230](https://github.com/opensearch-project/OpenSearch/pull/7230))
+- Add missing validation/parsing of SearchBackpressureMode of SearchBackpressureSettings ([#7541](https://github.com/opensearch-project/OpenSearch/pull/7541))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Replaces ZipInputStream with ZipFile to fix Zip Slip vulnerability ([#7230](https://github.com/opensearch-project/OpenSearch/pull/7230))
+- Add missing validation/parsing of SearchBackpressureMode of SearchBackpressureSettings ([#7541](https://github.com/opensearch-project/OpenSearch/pull/7541))
 
 ### Security
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.put_settings/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.put_settings/10_basic.yml
@@ -84,6 +84,10 @@
 ---
 "Test set invalid search backpressure mode":
 
+  - skip:
+      version: "- 2.9.99"
+      reason: "Parsing and validation of SearchBackpressureMode does not exist in versions < 3.0"
+
   - do:
       catch: bad_request
       cluster.put_settings:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.put_settings/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.put_settings/10_basic.yml
@@ -69,3 +69,28 @@
         include_defaults: true
 
  - match: {defaults.node.attr.testattr: "test"}
+
+---
+"Test set search backpressure mode":
+
+  - do:
+      cluster.put_settings:
+        body:
+          persistent:
+            search_backpressure.mode: "monitor_only"
+
+  - match: {persistent: {search_backpressure: {mode: "monitor_only"}}}
+
+---
+"Test set invalid search backpressure mode":
+
+  - do:
+      catch: bad_request
+      cluster.put_settings:
+        body:
+          persistent:
+            search_backpressure.mode: "monitor-only"
+
+  - match: {error.root_cause.0.type: "illegal_argument_exception"}
+  - match: { error.root_cause.0.reason: "Invalid SearchBackpressureMode: monitor-only" }
+  - match: { status: 400 }

--- a/server/src/main/java/org/opensearch/search/backpressure/settings/SearchBackpressureMode.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/settings/SearchBackpressureMode.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.search.backpressure.settings;
 
+import java.util.Locale;
+
 /**
  * Defines the search backpressure mode.
  */
@@ -38,7 +40,7 @@ public enum SearchBackpressureMode {
     }
 
     public static SearchBackpressureMode fromName(String name) {
-        switch (name) {
+        switch (name.toLowerCase(Locale.ROOT)) {
             case "disabled":
                 return DISABLED;
             case "monitor_only":

--- a/server/src/main/java/org/opensearch/search/backpressure/settings/SearchBackpressureSettings.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/settings/SearchBackpressureSettings.java
@@ -43,9 +43,10 @@ public class SearchBackpressureSettings {
      * Defines the search backpressure mode. It can be either "disabled", "monitor_only" or "enforced".
      */
     private volatile SearchBackpressureMode mode;
-    public static final Setting<String> SETTING_MODE = Setting.simpleString(
+    public static final Setting<SearchBackpressureMode> SETTING_MODE = new Setting<>(
         "search_backpressure.mode",
         Defaults.MODE,
+        SearchBackpressureMode::fromName,
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
@@ -113,8 +114,8 @@ public class SearchBackpressureSettings {
 
         interval = new TimeValue(SETTING_INTERVAL_MILLIS.get(settings));
 
-        mode = SearchBackpressureMode.fromName(SETTING_MODE.get(settings));
-        clusterSettings.addSettingsUpdateConsumer(SETTING_MODE, s -> this.setMode(SearchBackpressureMode.fromName(s)));
+        mode = SETTING_MODE.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(SETTING_MODE, this::setMode);
         clusterSettings.addSettingsUpdateConsumer(SETTING_CANCELLATION_RATIO, searchShardTaskSettings::setCancellationRatio);
         clusterSettings.addSettingsUpdateConsumer(SETTING_CANCELLATION_RATE, searchShardTaskSettings::setCancellationRate);
         clusterSettings.addSettingsUpdateConsumer(SETTING_CANCELLATION_BURST, searchShardTaskSettings::setCancellationBurst);

--- a/server/src/test/java/org/opensearch/search/backpressure/settings/SearchBackpressureSettingsTests.java
+++ b/server/src/test/java/org/opensearch/search/backpressure/settings/SearchBackpressureSettingsTests.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure.settings;
+
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class SearchBackpressureSettingsTests extends OpenSearchTestCase {
+
+    /**
+     * Validate proper construction of SearchBackpressureSettings object with a valid mode.
+     */
+    public void testSearchBackpressureSettings() {
+        Settings settings = Settings.builder().put("search_backpressure.mode", "monitor_only").build();
+        ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        SearchBackpressureSettings sbs = new SearchBackpressureSettings(settings, cs);
+        assertEquals(SearchBackpressureMode.MONITOR_ONLY, sbs.getMode());
+        assertEquals(settings, sbs.getSettings());
+        assertEquals(cs, sbs.getClusterSettings());
+    }
+
+    /**
+     * Validate construction of SearchBackpressureSettings object gets rejected
+     * on invalid SearchBackpressureMode value.
+     */
+    public void testSearchBackpressureSettingValidateInvalidMode() {
+        Settings settings = Settings.builder().put("search_backpressure.mode", "foo").build();
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> new SearchBackpressureSettings(settings, new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS))
+        );
+    }
+}


### PR DESCRIPTION
ClusterState updates of SearchBackpressureMode are persisted without validation which causes the entire cluster to become unstable or corrupted when a cluster tries to load invalid mode.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This fixes #6832 that causes cluster state corruption due to a lack of validation of SearchBackpressureMode.

### Related Issues
Resolves #6832 
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [x ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
