### PR TITLE
[BUG] Flaky search.aggregation/230_composite_unsigned tests due to nested aggregations order

### DIFF
--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/LongValuesSource.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/LongValuesSource.java
@@ -160,7 +160,7 @@ public class LongValuesSource extends SingleDimensionValuesSource<Long> {
         }
     }
 
-    int compareValues(long v1, long v2) {
+    private int compareValues(long v1, long v2) {
         return Long.compare(v1, v2) * reverseMul;
     }
 

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/UnsignedLongValuesSource.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/UnsignedLongValuesSource.java
@@ -14,21 +14,35 @@ import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.search.PointRangeQuery;
 import org.apache.lucene.search.Query;
 import org.opensearch.common.CheckedFunction;
+import org.opensearch.common.Numbers;
+import org.opensearch.common.lease.Releasables;
 import org.opensearch.common.util.BigArrays;
+import org.opensearch.common.util.BitArray;
+import org.opensearch.common.util.LongArray;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.NumberFieldMapper;
 import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.LeafBucketCollector;
 import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 
 import java.io.IOException;
-import java.util.function.LongUnaryOperator;
+import java.math.BigInteger;
+import java.util.Objects;
 
 /**
  * A {@link SingleDimensionValuesSource} for unsigned longs.
  *
  * @opensearch.internal
  */
-public class UnsignedLongValuesSource extends LongValuesSource {
+public class UnsignedLongValuesSource extends SingleDimensionValuesSource<BigInteger> {
+    private final BigArrays bigArrays;
+    private final CheckedFunction<LeafReaderContext, SortedNumericDocValues, IOException> docValuesFunc;
+
+    private BitArray bits;
+    private LongArray values;
+    private long currentValue;
+    private boolean missingCurrentValue;
+
     public UnsignedLongValuesSource(
         BigArrays bigArrays,
         MappedFieldType fieldType,
@@ -39,18 +53,148 @@ public class UnsignedLongValuesSource extends LongValuesSource {
         int size,
         int reverseMul
     ) {
-        super(bigArrays, fieldType, docValuesFunc, LongUnaryOperator.identity(), format, missingBucket, missingOrder, size, reverseMul);
+        super(bigArrays, format, fieldType, missingBucket, missingOrder, size, reverseMul);
+        this.bigArrays = bigArrays;
+        this.docValuesFunc = docValuesFunc;
+        this.bits = missingBucket ? new BitArray(Math.min(size, 100), bigArrays) : null;
+        this.values = bigArrays.newLongArray(Math.min(size, 100), false);
     }
 
     @Override
-    int compareValues(long v1, long v2) {
+    void copyCurrent(int slot) {
+        values = bigArrays.grow(values, slot + 1);
+        if (missingBucket && missingCurrentValue) {
+            bits.clear(slot);
+        } else {
+            assert missingCurrentValue == false;
+            if (missingBucket) {
+                bits.set(slot);
+            }
+            values.set(slot, currentValue);
+        }
+    }
+
+    @Override
+    int compare(int from, int to) {
+        if (missingBucket) {
+            int result = missingOrder.compare(() -> bits.get(from) == false, () -> bits.get(to) == false, reverseMul);
+            if (MissingOrder.unknownOrder(result) == false) {
+                return result;
+            }
+        }
+        return compareValues(values.get(from), values.get(to));
+    }
+
+    @Override
+    int compareCurrent(int slot) {
+        if (missingBucket) {
+            int result = missingOrder.compare(() -> missingCurrentValue, () -> bits.get(slot) == false, reverseMul);
+            if (MissingOrder.unknownOrder(result) == false) {
+                return result;
+            }
+        }
+        return compareValues(currentValue, values.get(slot));
+    }
+
+    @Override
+    int compareCurrentWithAfter() {
+        if (missingBucket) {
+            int result = missingOrder.compare(() -> missingCurrentValue, () -> Objects.isNull(afterValue), reverseMul);
+            if (MissingOrder.unknownOrder(result) == false) {
+                return result;
+            }
+        }
+        return compareValues(currentValue, afterValue.longValue());
+    }
+
+    @Override
+    int hashCode(int slot) {
+        if (missingBucket && bits.get(slot) == false) {
+            return 0;
+        } else {
+            return Long.hashCode(values.get(slot));
+        }
+    }
+
+    @Override
+    int hashCodeCurrent() {
+        if (missingCurrentValue) {
+            return 0;
+        } else {
+            return Long.hashCode(currentValue);
+        }
+    }
+
+    @Override
+    protected void setAfter(Comparable value) {
+        if (missingBucket && value == null) {
+            afterValue = null;
+        } else {
+            // parse the value from a string in case it is a date or a formatted unsigned long.
+            afterValue = format.parseUnsignedLong(value.toString(), false, () -> {
+                throw new IllegalArgumentException("now() is not supported in [after] key");
+            });
+        }
+    }
+
+    @Override
+    BigInteger toComparable(int slot) {
+        if (missingBucket && bits.get(slot) == false) {
+            return null;
+        }
+        return Numbers.toUnsignedBigInteger(values.get(slot));
+    }
+
+    @Override
+    LeafBucketCollector getLeafCollector(LeafReaderContext context, LeafBucketCollector next) throws IOException {
+        final SortedNumericDocValues dvs = docValuesFunc.apply(context);
+        return new LeafBucketCollector() {
+            @Override
+            public void collect(int doc, long bucket) throws IOException {
+                if (dvs.advanceExact(doc)) {
+                    int num = dvs.docValueCount();
+                    for (int i = 0; i < num; i++) {
+                        currentValue = dvs.nextValue();
+                        missingCurrentValue = false;
+                        next.collect(doc, bucket);
+                    }
+                } else if (missingBucket) {
+                    missingCurrentValue = true;
+                    next.collect(doc, bucket);
+                }
+            }
+        };
+    }
+
+    @Override
+    LeafBucketCollector getLeafCollector(Comparable value, LeafReaderContext context, LeafBucketCollector next) {
+        // We still accept long here (not BigInteger)
+        if (value.getClass() != Long.class) {
+            throw new IllegalArgumentException("Expected Long, got " + value.getClass());
+        }
+        currentValue = (Long) value;
+        return new LeafBucketCollector() {
+            @Override
+            public void collect(int doc, long bucket) throws IOException {
+                next.collect(doc, bucket);
+            }
+        };
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(values, bits);
+    }
+
+    private int compareValues(long v1, long v2) {
         return Long.compareUnsigned(v1, v2) * reverseMul;
     }
 
     @Override
     SortedDocsProducer createSortedDocsProducerOrNull(IndexReader reader, Query query) {
-        query = extractQuery(query);
-        if (checkIfSortedDocsIsApplicable(reader, fieldType) == false || checkMatchAllOrRangeQuery(query, fieldType.name()) == false) {
+        query = LongValuesSource.extractQuery(query);
+        if (checkIfSortedDocsIsApplicable(reader, fieldType) == false
+            || LongValuesSource.checkMatchAllOrRangeQuery(query, fieldType.name()) == false) {
             return null;
         }
         final byte[] lowerPoint;


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Flaky search.aggregation/230_composite_unsigned tests due to nested aggregations order. The issue was related to the fact that `toComparable` returned `Long` which messed up the sorting order sometimes.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
