### PR TITLE
Provide mechanism to configure XContent parsing constraints (after update to Jackson 2.15.0 and above)

### DIFF
--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/cbor/CborXContent.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/cbor/CborXContent.java
@@ -35,6 +35,7 @@ package org.opensearch.common.xcontent.cbor;
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
 import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.MediaType;
@@ -56,6 +57,9 @@ import java.util.Set;
  * A CBOR based content implementation using Jackson.
  */
 public class CborXContent implements XContent {
+    public static final int DEFAULT_MAX_STRING_LEN = Integer.parseInt(
+        System.getProperty("opensearch.xcontent.string.length.max", "50000000" /* ~50 Mb */)
+    );
 
     public static XContentBuilder contentBuilder() throws IOException {
         return XContentBuilder.builder(cborXContent);
@@ -70,6 +74,7 @@ public class CborXContent implements XContent {
         // Do not automatically close unclosed objects/arrays in com.fasterxml.jackson.dataformat.cbor.CBORGenerator#close() method
         cborFactory.configure(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT, false);
         cborFactory.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true);
+        cborFactory.setStreamReadConstraints(StreamReadConstraints.builder().maxStringLength(DEFAULT_MAX_STRING_LEN).build());
         cborXContent = new CborXContent();
     }
 

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/json/JsonXContent.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/json/JsonXContent.java
@@ -36,6 +36,8 @@ import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.StreamReadConstraints;
+
 import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.MediaType;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
@@ -55,6 +57,9 @@ import java.util.Set;
  * A JSON based content implementation using Jackson.
  */
 public class JsonXContent implements XContent {
+    public static final int DEFAULT_MAX_STRING_LEN = Integer.parseInt(
+        System.getProperty("opensearch.xcontent.string.length.max", "50000000" /* ~50 Mb */)
+    );
 
     public static XContentBuilder contentBuilder() throws IOException {
         return XContentBuilder.builder(jsonXContent);
@@ -72,6 +77,7 @@ public class JsonXContent implements XContent {
         // Do not automatically close unclosed objects/arrays in com.fasterxml.jackson.core.json.UTF8JsonGenerator#close() method
         jsonFactory.configure(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT, false);
         jsonFactory.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true);
+        jsonFactory.setStreamReadConstraints(StreamReadConstraints.builder().maxStringLength(DEFAULT_MAX_STRING_LEN).build());
         jsonXContent = new JsonXContent();
     }
 

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/smile/SmileXContent.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/smile/SmileXContent.java
@@ -35,6 +35,7 @@ package org.opensearch.common.xcontent.smile;
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.dataformat.smile.SmileFactory;
 import com.fasterxml.jackson.dataformat.smile.SmileGenerator;
 import org.opensearch.core.xcontent.DeprecationHandler;
@@ -56,6 +57,9 @@ import java.util.Set;
  * A Smile based content implementation using Jackson.
  */
 public class SmileXContent implements XContent {
+    public static final int DEFAULT_MAX_STRING_LEN = Integer.parseInt(
+        System.getProperty("opensearch.xcontent.string.length.max", "50000000" /* ~50 Mb */)
+    );
 
     public static XContentBuilder contentBuilder() throws IOException {
         return XContentBuilder.builder(smileXContent);
@@ -72,6 +76,7 @@ public class SmileXContent implements XContent {
         // Do not automatically close unclosed objects/arrays in com.fasterxml.jackson.dataformat.smile.SmileGenerator#close() method
         smileFactory.configure(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT, false);
         smileFactory.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true);
+        smileFactory.setStreamReadConstraints(StreamReadConstraints.builder().maxStringLength(DEFAULT_MAX_STRING_LEN).build());
         smileXContent = new SmileXContent();
     }
 

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/yaml/YamlXContent.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/yaml/YamlXContent.java
@@ -34,6 +34,7 @@ package org.opensearch.common.xcontent.yaml;
 
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
@@ -54,6 +55,9 @@ import java.util.Set;
  * A YAML based content implementation using Jackson.
  */
 public class YamlXContent implements XContent {
+    public static final int DEFAULT_MAX_STRING_LEN = Integer.parseInt(
+        System.getProperty("opensearch.xcontent.string.length.max", "50000000" /* ~50 Mb */)
+    );
 
     public static XContentBuilder contentBuilder() throws IOException {
         return XContentBuilder.builder(yamlXContent);
@@ -65,6 +69,7 @@ public class YamlXContent implements XContent {
     static {
         yamlFactory = new YAMLFactory();
         yamlFactory.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true);
+        yamlFactory.setStreamReadConstraints(StreamReadConstraints.builder().maxStringLength(DEFAULT_MAX_STRING_LEN).build());
         yamlXContent = new YamlXContent();
     }
 

--- a/libs/x-content/src/test/java/org/opensearch/common/xcontent/XContentParserTests.java
+++ b/libs/x-content/src/test/java/org/opensearch/common/xcontent/XContentParserTests.java
@@ -33,10 +33,15 @@
 package org.opensearch.common.xcontent;
 
 import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.exc.StreamConstraintsException;
+import com.fasterxml.jackson.dataformat.yaml.JacksonYAMLParseException;
+
 import org.opensearch.common.CheckedSupplier;
 import org.opensearch.common.Strings;
 import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.xcontent.cbor.CborXContent;
 import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.common.xcontent.smile.SmileXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParseException;
 import org.opensearch.core.xcontent.XContentParser;
@@ -50,6 +55,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
@@ -57,6 +63,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasLength;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.instanceOf;
@@ -64,6 +71,103 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 
 public class XContentParserTests extends OpenSearchTestCase {
+    private static final Map<XContentType, Supplier<String>> GENERATORS = Map.of(
+        XContentType.JSON,
+        () -> randomAlphaOfLengthBetween(1, JsonXContent.DEFAULT_MAX_STRING_LEN),
+        XContentType.CBOR,
+        () -> randomAlphaOfLengthBetween(1, CborXContent.DEFAULT_MAX_STRING_LEN),
+        XContentType.SMILE,
+        () -> randomAlphaOfLengthBetween(1, SmileXContent.DEFAULT_MAX_STRING_LEN),
+        /* YAML parser limitation */
+        XContentType.YAML,
+        () -> randomRealisticUnicodeOfCodepointLengthBetween(1, 3140000)
+    );
+
+    private static final Map<XContentType, Supplier<String>> OFF_LIMIT_GENERATORS = Map.of(
+        XContentType.JSON,
+        () -> randomAlphaOfLength(JsonXContent.DEFAULT_MAX_STRING_LEN + 1),
+        XContentType.CBOR,
+        () -> randomAlphaOfLength(CborXContent.DEFAULT_MAX_STRING_LEN + 1),
+        XContentType.SMILE,
+        () -> randomAlphaOfLength(SmileXContent.DEFAULT_MAX_STRING_LEN + 1),
+        /* YAML parser limitation */
+        XContentType.YAML,
+        () -> randomRealisticUnicodeOfCodepointLength(3145730)
+    );
+
+    public void testStringOffLimit() throws IOException {
+        final XContentType xContentType = randomFrom(XContentType.values());
+
+        final String field = randomAlphaOfLengthBetween(1, 5);
+        final String value = OFF_LIMIT_GENERATORS.get(xContentType).get();
+
+        try (XContentBuilder builder = XContentBuilder.builder(xContentType.xContent())) {
+            builder.startObject();
+            if (randomBoolean()) {
+                builder.field(field, value);
+            } else {
+                builder.field(field).value(value);
+            }
+            builder.endObject();
+
+            try (XContentParser parser = createParser(xContentType.xContent(), BytesReference.bytes(builder))) {
+                assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
+                assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
+                assertEquals(field, parser.currentName());
+                assertEquals(XContentParser.Token.VALUE_STRING, parser.nextToken());
+                if (xContentType != XContentType.YAML) {
+                    assertThrows(StreamConstraintsException.class, () -> parser.text());
+                } else {
+                    assertThrows(JacksonYAMLParseException.class, () -> parser.nextToken());
+                }
+            }
+        }
+    }
+
+    public void testString() throws IOException {
+        final XContentType xContentType = randomFrom(XContentType.values());
+
+        final String field = randomAlphaOfLengthBetween(1, 5);
+        final String value = GENERATORS.get(xContentType).get();
+
+        try (XContentBuilder builder = XContentBuilder.builder(xContentType.xContent())) {
+            builder.startObject();
+            if (randomBoolean()) {
+                builder.field(field, value);
+            } else {
+                builder.field(field).value(value);
+            }
+            builder.endObject();
+
+            final String text;
+            try (XContentParser parser = createParser(xContentType.xContent(), BytesReference.bytes(builder))) {
+                assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
+                assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
+                assertEquals(field, parser.currentName());
+                assertEquals(XContentParser.Token.VALUE_STRING, parser.nextToken());
+
+                text = parser.text();
+
+                assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());
+                assertNull(parser.nextToken());
+            }
+
+            assertThat(text, hasLength(value.length()));
+
+            switch (xContentType) {
+                case CBOR:
+                case SMILE:
+                    assertThat(text, instanceOf(String.class));
+                    break;
+                case JSON:
+                case YAML:
+                    assertThat(text, instanceOf(String.class));
+                    break;
+                default:
+                    throw new AssertionError("unexpected x-content type [" + xContentType + "]");
+            }
+        }
+    }
 
     public void testFloat() throws IOException {
         final XContentType xContentType = randomFrom(XContentType.values());

--- a/libs/x-content/src/test/java/org/opensearch/common/xcontent/XContentParserTests.java
+++ b/libs/x-content/src/test/java/org/opensearch/common/xcontent/XContentParserTests.java
@@ -153,19 +153,6 @@ public class XContentParserTests extends OpenSearchTestCase {
             }
 
             assertThat(text, hasLength(value.length()));
-
-            switch (xContentType) {
-                case CBOR:
-                case SMILE:
-                    assertThat(text, instanceOf(String.class));
-                    break;
-                case JSON:
-                case YAML:
-                    assertThat(text, instanceOf(String.class));
-                    break;
-                default:
-                    throw new AssertionError("unexpected x-content type [" + xContentType + "]");
-            }
         }
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Provide mechanism to configure XContent parsing constraints (after update to Jackson 2.15.0 and above)

### Related Issues
Resolves #[7549](https://github.com/opensearch-project/OpenSearch/issues/7549)
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
