### PR TITLE
Fix flaky test SegmentReplicationIT.testScrollWithOngoingSegmentReplication

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -1045,19 +1045,24 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
         // wait for segrep to start and copy temporary files
         waitForFileCopy.await();
 
-        // verify replica contains temporary files
-        IndexShard replicaShard = getIndexShard(replica, INDEX_NAME);
-        List<String> temporaryFiles = Arrays.stream(replicaShard.store().directory().listAll())
-            .filter(fileName -> fileName.startsWith(REPLICATION_PREFIX))
-            .collect(Collectors.toList());
-        logger.info("--> temporaryFiles {}", temporaryFiles);
-        assertTrue(temporaryFiles.size() > 0);
+        final IndexShard replicaShard = getIndexShard(replica, INDEX_NAME);
+        // Wait until replica has written a tmp file to disk.
+        List<String> temporaryFiles = new ArrayList<>();
+        assertBusy(() -> {
+            // verify replica contains temporary files
+            temporaryFiles.addAll(
+                Arrays.stream(replicaShard.store().directory().listAll())
+                    .filter(fileName -> fileName.startsWith(REPLICATION_PREFIX))
+                    .collect(Collectors.toList())
+            );
+            logger.info("--> temporaryFiles {}", temporaryFiles);
+            assertTrue(temporaryFiles.size() > 0);
+        });
 
         // Clear scroll query, this should clean up files on replica
         client(replica).prepareClearScroll().addScrollId(searchResponse.getScrollId()).get();
 
         // verify temporary files still exist
-        replicaShard = getIndexShard(replica, INDEX_NAME);
         List<String> temporaryFilesPostClear = Arrays.stream(replicaShard.store().directory().listAll())
             .filter(fileName -> fileName.startsWith(REPLICATION_PREFIX))
             .collect(Collectors.toList());
@@ -1066,7 +1071,6 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
         // Unblock segment replication
         blockFileCopy.countDown();
 
-        assertEquals(temporaryFiles.size(), temporaryFilesPostClear.size());
         assertTrue(temporaryFilesPostClear.containsAll(temporaryFiles));
 
         // wait for replica to catch up and verify doc count


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fix flaky test SegmentReplicationIT.testScrollWithOngoingSegmentReplication

This test has flaky failures for two reasons:
1. Fetches list of temporary files on disk starting with ".replication" before the replica has time to 
flush received chunks to disk. Fixed by wrapping the assertion that a tmp file exists with assertBusy.
2. Asserts that the count of tmp files is exactly the same before/after a scroll request is cleared. However,
it is possible that additional tmp files have been written to disk concurrently, causing a count mismatch. Fixed
by removing the size assertion.  For the sake of this test we don't care if this is the case, as long as the tmp files 
originally fetched remain after a scroll query is cleared.

### Related Issues
resolves #7569 

<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
