### PR TITLE
Extend SegRep allocation and relocation ITs with remote store

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationAllocationIT.java
@@ -36,7 +36,7 @@ import org.opensearch.cluster.OpenSearchAllocationTestCase.ShardAllocations;
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
 public class SegmentReplicationAllocationIT extends SegmentReplicationBaseIT {
 
-    private void createIndex(String idxName, int shardCount, int replicaCount, boolean isSegRep) {
+    public void createIndex(String idxName, int shardCount, int replicaCount, boolean isSegRep) {
         Settings.Builder builder = Settings.builder()
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, shardCount)
             .put(IndexModule.INDEX_QUERY_CACHE_ENABLED_SETTING.getKey(), false)

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationRelocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationRelocationIT.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.indices.replication;
 
+import org.junit.Before;
 import org.opensearch.OpenSearchCorruptionException;
 import org.opensearch.action.ActionFuture;
 import org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
@@ -43,6 +44,11 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
 public class SegmentReplicationRelocationIT extends SegmentReplicationBaseIT {
     private final TimeValue ACCEPTABLE_RELOCATION_TIME = new TimeValue(5, TimeUnit.MINUTES);
 
+    @Before
+    public void setup() {
+        internalCluster().startClusterManagerOnlyNode();
+    }
+
     private void createIndex(int replicaCount) {
         prepareCreate(INDEX_NAME, Settings.builder().put(SETTING_NUMBER_OF_REPLICAS, replicaCount)).get();
     }
@@ -75,7 +81,7 @@ public class SegmentReplicationRelocationIT extends SegmentReplicationBaseIT {
             .cluster()
             .prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
-            .setWaitForNodes("3")
+            .setWaitForNodes("4")
             .execute()
             .actionGet();
         assertEquals(clusterHealthResponse.isTimedOut(), false);
@@ -152,7 +158,7 @@ public class SegmentReplicationRelocationIT extends SegmentReplicationBaseIT {
             .cluster()
             .prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
-            .setWaitForNodes("3")
+            .setWaitForNodes("4")
             .execute()
             .actionGet();
         assertEquals(clusterHealthResponse.isTimedOut(), false);
@@ -242,7 +248,7 @@ public class SegmentReplicationRelocationIT extends SegmentReplicationBaseIT {
             .cluster()
             .prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
-            .setWaitForNodes("3")
+            .setWaitForNodes("4")
             .execute()
             .actionGet();
         assertEquals(clusterHealthResponse.isTimedOut(), false);
@@ -319,7 +325,7 @@ public class SegmentReplicationRelocationIT extends SegmentReplicationBaseIT {
             .cluster()
             .prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
-            .setWaitForNodes("3")
+            .setWaitForNodes("4")
             .execute()
             .actionGet();
         assertEquals(clusterHealthResponse.isTimedOut(), false);
@@ -488,7 +494,7 @@ public class SegmentReplicationRelocationIT extends SegmentReplicationBaseIT {
             .cluster()
             .prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
-            .setWaitForNodes("2")
+            .setWaitForNodes("3")
             .setWaitForGreenStatus()
             .setTimeout(TimeValue.timeValueSeconds(2))
             .execute()
@@ -516,7 +522,7 @@ public class SegmentReplicationRelocationIT extends SegmentReplicationBaseIT {
             .cluster()
             .prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
-            .setWaitForNodes("3")
+            .setWaitForNodes("4")
             .execute()
             .actionGet();
         assertEquals(clusterHealthResponse.isTimedOut(), false);

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreSegmentReplicationAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreSegmentReplicationAllocationIT.java
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.remotestore;
+
+import org.junit.After;
+import org.junit.Before;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.index.IndexModule;
+import org.opensearch.indices.replication.SegmentReplicationAllocationIT;
+import org.opensearch.indices.replication.common.ReplicationType;
+
+import java.nio.file.Path;
+
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+
+public class RemoteStoreSegmentReplicationAllocationIT extends SegmentReplicationAllocationIT {
+    private static final String REPOSITORY_NAME = "test-remore-store-repo";
+
+    @Override
+    public void createIndex(String idxName, int shardCount, int replicaCount, boolean isSegRep) {
+        Settings.Builder builder = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, shardCount)
+            .put(IndexModule.INDEX_QUERY_CACHE_ENABLED_SETTING.getKey(), false)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, replicaCount);
+        if (isSegRep) {
+            builder = builder.put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+                .put(IndexMetadata.SETTING_REMOTE_STORE_ENABLED, true)
+                .put(IndexMetadata.SETTING_REMOTE_STORE_REPOSITORY, REPOSITORY_NAME)
+                .put(IndexMetadata.SETTING_REMOTE_TRANSLOG_STORE_ENABLED, true)
+                .put(IndexMetadata.SETTING_REMOTE_TRANSLOG_STORE_REPOSITORY, REPOSITORY_NAME);
+
+        } else {
+            builder = builder.put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.DOCUMENT);
+        }
+        prepareCreate(idxName, builder).get();
+    }
+
+    @Override
+    protected Settings featureFlagSettings() {
+        return Settings.builder().put(super.featureFlagSettings()).put(FeatureFlags.REMOTE_STORE, "true").build();
+    }
+
+    @Before
+    public void setup() {
+        internalCluster().startClusterManagerOnlyNode();
+        Path absolutePath = randomRepoPath().toAbsolutePath();
+        assertAcked(
+            clusterAdmin().preparePutRepository(REPOSITORY_NAME).setType("fs").setSettings(Settings.builder().put("location", absolutePath))
+        );
+    }
+
+    @After
+    public void teardown() {
+        assertAcked(clusterAdmin().prepareDeleteRepository(REPOSITORY_NAME));
+    }
+}

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreSegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreSegmentReplicationIT.java
@@ -28,7 +28,7 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
  */
 @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/7643")
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
-public class SegmentReplicationRemoteStoreIT extends SegmentReplicationIT {
+public class RemoteStoreSegmentReplicationIT extends SegmentReplicationIT {
 
     private static final String REPOSITORY_NAME = "test-remore-store-repo";
 

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreSegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreSegmentReplicationIT.java
@@ -26,7 +26,6 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
  * This makes sure that the constructs/flows that are being tested with Segment Replication, holds true after enabling
  * remote store.
  */
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/7643")
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
 public class RemoteStoreSegmentReplicationIT extends SegmentReplicationIT {
 

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreSegmentReplicationRelocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreSegmentReplicationRelocationIT.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.remotestore;
+
+import org.junit.After;
+import org.junit.Before;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.indices.replication.SegmentReplicationRelocationIT;
+
+import java.nio.file.Path;
+
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+
+public class RemoteStoreSegmentReplicationRelocationIT extends SegmentReplicationRelocationIT {
+    private static final String REPOSITORY_NAME = "test-remore-store-repo";
+
+    @Override
+    public Settings indexSettings() {
+        return Settings.builder()
+            .put(super.indexSettings())
+            .put(IndexMetadata.SETTING_REMOTE_STORE_ENABLED, true)
+            .put(IndexMetadata.SETTING_REMOTE_STORE_REPOSITORY, REPOSITORY_NAME)
+            .put(IndexMetadata.SETTING_REMOTE_TRANSLOG_STORE_ENABLED, true)
+            .put(IndexMetadata.SETTING_REMOTE_TRANSLOG_STORE_REPOSITORY, REPOSITORY_NAME)
+            .build();
+    }
+
+    @Override
+    protected Settings featureFlagSettings() {
+        return Settings.builder().put(super.featureFlagSettings()).put(FeatureFlags.REMOTE_STORE, "true").build();
+    }
+
+    @Before
+    public void setupRepository() {
+        Path absolutePath = randomRepoPath().toAbsolutePath();
+        assertAcked(
+            clusterAdmin().preparePutRepository(REPOSITORY_NAME).setType("fs").setSettings(Settings.builder().put("location", absolutePath))
+        );
+    }
+
+    @After
+    public void teardown() {
+        assertAcked(clusterAdmin().prepareDeleteRepository(REPOSITORY_NAME));
+    }
+}

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -4522,7 +4522,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             if (refreshLevelSegmentSync && remoteSegmentMetadata != null) {
                 try (
                     ChecksumIndexInput indexInput = new BufferedChecksumIndexInput(
-                        new ByteArrayIndexInput("", remoteSegmentMetadata.getSegmentInfosBytes())
+                        new ByteArrayIndexInput("Snapshot of SegmentInfos", remoteSegmentMetadata.getSegmentInfosBytes())
                     );
                 ) {
                     SegmentInfos infosSnapshot = SegmentInfos.readCommit(

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -4533,6 +4533,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                         indexInput,
                         remoteSegmentMetadata.getGeneration()
                     );
+                    long processedLocalCheckpoint = Long.parseLong(infosSnapshot.getUserData().get(LOCAL_CHECKPOINT_KEY));
                     // Following code block makes sure to commit SegmentInfosSnapshot with the highest generation.
                     // If local filesystem already has segments_N+2 and infosSnapshot has generation N, after commit,
                     // there would be 2 files that would be created segments_N+1 and segments_N+2. With the policy of preserving
@@ -4547,7 +4548,6 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                             infosSnapshot = localSegmentInfos.clone();
                         }
                     }
-                    long processedLocalCheckpoint = Long.parseLong(infosSnapshot.getUserData().get(LOCAL_CHECKPOINT_KEY));
                     store.commitSegmentInfos(infosSnapshot, processedLocalCheckpoint, processedLocalCheckpoint);
                 }
             }

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -19,7 +19,6 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FilterDirectory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
-import org.apache.lucene.store.IndexOutput;
 import org.opensearch.action.bulk.BackoffPolicy;
 import org.opensearch.common.CheckedFunction;
 import org.opensearch.common.concurrent.GatedCloseable;
@@ -37,7 +36,6 @@ import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -201,7 +199,6 @@ public final class RemoteStoreRefreshListener implements ReferenceManager.Refres
                     deleteStaleCommits();
                 }
 
-                String segmentInfoSnapshotFilename = null;
                 try (GatedCloseable<SegmentInfos> segmentInfosGatedCloseable = indexShard.getSegmentInfosSnapshot()) {
                     SegmentInfos segmentInfos = segmentInfosGatedCloseable.get();
                     // Capture replication checkpoint before uploading the segments as upload can take some time and checkpoint can
@@ -233,16 +230,8 @@ public final class RemoteStoreRefreshListener implements ReferenceManager.Refres
                         // Start the segments files upload
                         boolean newSegmentsUploadStatus = uploadNewSegments(localSegmentsPostRefresh);
                         if (newSegmentsUploadStatus) {
-                            segmentInfoSnapshotFilename = uploadSegmentInfosSnapshot(latestSegmentInfos.get(), segmentInfos);
-                            localSegmentsPostRefresh.add(segmentInfoSnapshotFilename);
-
                             // Start metadata file upload
-                            remoteDirectory.uploadMetadata(
-                                localSegmentsPostRefresh,
-                                storeDirectory,
-                                indexShard.getOperationPrimaryTerm(),
-                                segmentInfos.getGeneration()
-                            );
+                            uploadMetadata(localSegmentsPostRefresh, segmentInfos);
                             clearStaleFilesFromLocalSegmentChecksumMap(localSegmentsPostRefresh);
                             onSuccessfulSegmentsSync(refreshTimeMs, refreshSeqNo);
                             indexShard.getEngine().translogManager().setMinSeqNoToKeep(lastRefreshedCheckpoint + 1);
@@ -254,14 +243,6 @@ public final class RemoteStoreRefreshListener implements ReferenceManager.Refres
                     }
                 } catch (EngineException e) {
                     logger.warn("Exception while reading SegmentInfosSnapshot", e);
-                } finally {
-                    try {
-                        if (segmentInfoSnapshotFilename != null) {
-                            storeDirectory.deleteFile(segmentInfoSnapshotFilename);
-                        }
-                    } catch (IOException e) {
-                        logger.warn("Exception while deleting: " + segmentInfoSnapshotFilename, e);
-                    }
                 }
             } catch (IOException e) {
                 // We don't want to fail refresh if upload of new segments fails. The missed segments will be re-tried
@@ -347,22 +328,21 @@ public final class RemoteStoreRefreshListener implements ReferenceManager.Refres
             && !remoteDirectory.containsFile(lastCommittedLocalSegmentFileName, getChecksumOfLocalFile(lastCommittedLocalSegmentFileName)));
     }
 
-    String uploadSegmentInfosSnapshot(String latestSegmentsNFilename, SegmentInfos segmentInfosSnapshot) throws IOException {
-        final long maxSeqNoFromSegmentInfos = indexShard.getEngine().getMaxSeqNoFromSegmentInfos(segmentInfosSnapshot);
+    void uploadMetadata(Collection<String> localSegmentsPostRefresh, SegmentInfos segmentInfos) throws IOException {
+        final long maxSeqNoFromSegmentInfos = indexShard.getEngine().getMaxSeqNoFromSegmentInfos(segmentInfos);
 
+        SegmentInfos segmentInfosSnapshot = segmentInfos.clone();
         Map<String, String> userData = segmentInfosSnapshot.getUserData();
         userData.put(LOCAL_CHECKPOINT_KEY, String.valueOf(maxSeqNoFromSegmentInfos));
         userData.put(SequenceNumbers.MAX_SEQ_NO, Long.toString(maxSeqNoFromSegmentInfos));
         segmentInfosSnapshot.setUserData(userData, false);
 
-        long commitGeneration = SegmentInfos.generationFromSegmentsFileName(latestSegmentsNFilename);
-        String segmentInfoSnapshotFilename = SEGMENT_INFO_SNAPSHOT_FILENAME_PREFIX + "__" + commitGeneration;
-        try (IndexOutput indexOutput = storeDirectory.createOutput(segmentInfoSnapshotFilename, IOContext.DEFAULT)) {
-            segmentInfosSnapshot.write(indexOutput);
-        }
-        storeDirectory.sync(Collections.singleton(segmentInfoSnapshotFilename));
-        remoteDirectory.copyFrom(storeDirectory, segmentInfoSnapshotFilename, segmentInfoSnapshotFilename, IOContext.DEFAULT, true);
-        return segmentInfoSnapshotFilename;
+        remoteDirectory.uploadMetadata(
+            localSegmentsPostRefresh,
+            segmentInfosSnapshot,
+            storeDirectory,
+            indexShard.getOperationPrimaryTerm()
+        );
     }
 
     private boolean uploadNewSegments(Collection<String> localSegmentsPostRefresh) throws IOException {

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -472,7 +472,7 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
             }
 
             ByteBuffersDataOutput byteBuffersIndexOutput = new ByteBuffersDataOutput();
-            segmentInfosSnapshot.write(new ByteBuffersIndexOutput(byteBuffersIndexOutput, "", ""));
+            segmentInfosSnapshot.write(new ByteBuffersIndexOutput(byteBuffersIndexOutput, "Snapshot of SegmentInfos", "SegmentInfos"));
             byte[] byteArray = byteBuffersIndexOutput.toArrayCopy();
 
             metadataStreamWrapper.writeStream(

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -473,13 +473,13 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
 
             ByteBuffersDataOutput byteBuffersIndexOutput = new ByteBuffersDataOutput();
             segmentInfosSnapshot.write(new ByteBuffersIndexOutput(byteBuffersIndexOutput, "Snapshot of SegmentInfos", "SegmentInfos"));
-            byte[] byteArray = byteBuffersIndexOutput.toArrayCopy();
+            byte[] segmentInfoSnapshotByteArray = byteBuffersIndexOutput.toArrayCopy();
 
             metadataStreamWrapper.writeStream(
                 indexOutput,
                 new RemoteSegmentMetadata(
                     RemoteSegmentMetadata.fromMapOfStrings(uploadedSegments),
-                    byteArray,
+                    segmentInfoSnapshotByteArray,
                     segmentInfosSnapshot.getGeneration()
                 )
             );

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -11,6 +11,9 @@ package org.opensearch.index.store;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.store.ByteBuffersDataOutput;
+import org.apache.lucene.store.ByteBuffersIndexOutput;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FilterDirectory;
 import org.apache.lucene.store.IOContext;
@@ -111,9 +114,15 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
      * It is caller's responsibility to call init() again to ensure that cache is properly updated.
      * @throws IOException if there were any failures in reading the metadata file
      */
-    public void init() throws IOException {
+    public RemoteSegmentMetadata init() throws IOException {
         this.commonFilenameSuffix = UUIDs.base64UUID();
-        this.segmentsUploadedToRemoteStore = new ConcurrentHashMap<>(readLatestMetadataFile());
+        RemoteSegmentMetadata remoteSegmentMetadata = readLatestMetadataFile();
+        if (remoteSegmentMetadata != null) {
+            this.segmentsUploadedToRemoteStore = new ConcurrentHashMap<>(remoteSegmentMetadata.getMetadata());
+        } else {
+            this.segmentsUploadedToRemoteStore = new ConcurrentHashMap<>();
+        }
+        return remoteSegmentMetadata;
     }
 
     /**
@@ -128,28 +137,29 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
      * @return Map of segment filename to uploaded filename with checksum
      * @throws IOException if there were any failures in reading the metadata file
      */
-    private Map<String, UploadedSegmentMetadata> readLatestMetadataFile() throws IOException {
+    private RemoteSegmentMetadata readLatestMetadataFile() throws IOException {
         Map<String, UploadedSegmentMetadata> segmentMetadataMap = new HashMap<>();
+        RemoteSegmentMetadata remoteSegmentMetadata = null;
 
         Collection<String> metadataFiles = remoteMetadataDirectory.listFilesByPrefix(MetadataFilenameUtils.METADATA_PREFIX);
         Optional<String> latestMetadataFile = metadataFiles.stream().max(METADATA_FILENAME_COMPARATOR);
 
         if (latestMetadataFile.isPresent()) {
             logger.info("Reading latest Metadata file {}", latestMetadataFile.get());
-            segmentMetadataMap = readMetadataFile(latestMetadataFile.get());
+            remoteSegmentMetadata = readMetadataFile(latestMetadataFile.get());
         } else {
             logger.info("No metadata file found, this can happen for new index with no data uploaded to remote segment store");
         }
 
-        return segmentMetadataMap;
+        return remoteSegmentMetadata;
     }
 
-    private Map<String, UploadedSegmentMetadata> readMetadataFile(String metadataFilename) throws IOException {
+    private RemoteSegmentMetadata readMetadataFile(String metadataFilename) throws IOException {
         try (IndexInput indexInput = remoteMetadataDirectory.openInput(metadataFilename, IOContext.DEFAULT)) {
             byte[] metadataBytes = new byte[(int) indexInput.length()];
             indexInput.readBytes(metadataBytes, 0, (int) indexInput.length());
             RemoteSegmentMetadata metadata = metadataStreamWrapper.readStream(new ByteArrayIndexInput(metadataFilename, metadataBytes));
-            return metadata.getMetadata();
+            return metadata;
         }
     }
 
@@ -262,7 +272,7 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
      */
     @Override
     public String[] listAll() throws IOException {
-        return readLatestMetadataFile().keySet().toArray(new String[0]);
+        return readLatestMetadataFile().getMetadata().keySet().toArray(new String[0]);
     }
 
     /**
@@ -434,15 +444,23 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
     /**
      * Upload metadata file
      * @param segmentFiles segment files that are part of the shard at the time of the latest refresh
+     * @param segmentInfosSnapshot SegmentInfos bytes to store as part of metadata file
      * @param storeDirectory instance of local directory to temporarily create metadata file before upload
      * @param primaryTerm primary term to be used in the name of metadata file
-     * @param generation commit generation
      * @throws IOException in case of I/O error while uploading the metadata file
      */
-    public void uploadMetadata(Collection<String> segmentFiles, Directory storeDirectory, long primaryTerm, long generation)
-        throws IOException {
+    public void uploadMetadata(
+        Collection<String> segmentFiles,
+        SegmentInfos segmentInfosSnapshot,
+        Directory storeDirectory,
+        long primaryTerm
+    ) throws IOException {
         synchronized (this) {
-            String metadataFilename = MetadataFilenameUtils.getMetadataFilename(primaryTerm, generation, this.commonFilenameSuffix);
+            String metadataFilename = MetadataFilenameUtils.getMetadataFilename(
+                primaryTerm,
+                segmentInfosSnapshot.getGeneration(),
+                this.commonFilenameSuffix
+            );
             IndexOutput indexOutput = storeDirectory.createOutput(metadataFilename, IOContext.DEFAULT);
             Map<String, String> uploadedSegments = new HashMap<>();
             for (String file : segmentFiles) {
@@ -452,7 +470,15 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
                     throw new NoSuchFileException(file);
                 }
             }
-            metadataStreamWrapper.writeStream(indexOutput, RemoteSegmentMetadata.fromMapOfStrings(uploadedSegments));
+
+            ByteBuffersDataOutput byteBuffersIndexOutput = new ByteBuffersDataOutput();
+            segmentInfosSnapshot.write(new ByteBuffersIndexOutput(byteBuffersIndexOutput, "", ""));
+            byte[] byteArray = byteBuffersIndexOutput.toArrayCopy();
+
+            metadataStreamWrapper.writeStream(
+                indexOutput,
+                new RemoteSegmentMetadata(RemoteSegmentMetadata.fromMapOfStrings(uploadedSegments), byteArray, segmentInfosSnapshot.getGeneration())
+            );
             indexOutput.close();
             storeDirectory.sync(Collections.singleton(metadataFilename));
             remoteMetadataDirectory.copyFrom(storeDirectory, metadataFilename, metadataFilename, IOContext.DEFAULT);
@@ -490,7 +516,9 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
     public Map<String, UploadedSegmentMetadata> getSegmentsUploadedToRemoteStore(long primaryTerm, long generation) throws IOException {
         String metadataFile = getMetadataFileForCommit(primaryTerm, generation);
 
-        Map<String, UploadedSegmentMetadata> segmentsUploadedToRemoteStore = new ConcurrentHashMap<>(readMetadataFile(metadataFile));
+        Map<String, UploadedSegmentMetadata> segmentsUploadedToRemoteStore = new ConcurrentHashMap<>(
+            readMetadataFile(metadataFile).getMetadata()
+        );
         return Collections.unmodifiableMap(segmentsUploadedToRemoteStore);
     }
 
@@ -546,14 +574,14 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
         Map<String, UploadedSegmentMetadata> activeSegmentFilesMetadataMap = new HashMap<>();
         Set<String> activeSegmentRemoteFilenames = new HashSet<>();
         for (String metadataFile : sortedMetadataFileList) {
-            Map<String, UploadedSegmentMetadata> segmentMetadataMap = readMetadataFile(metadataFile);
+            Map<String, UploadedSegmentMetadata> segmentMetadataMap = readMetadataFile(metadataFile).getMetadata();
             activeSegmentFilesMetadataMap.putAll(segmentMetadataMap);
             activeSegmentRemoteFilenames.addAll(
                 segmentMetadataMap.values().stream().map(metadata -> metadata.uploadedFilename).collect(Collectors.toSet())
             );
         }
         for (String metadataFile : metadataFilesToBeDeleted) {
-            Map<String, UploadedSegmentMetadata> staleSegmentFilesMetadataMap = readMetadataFile(metadataFile);
+            Map<String, UploadedSegmentMetadata> staleSegmentFilesMetadataMap = readMetadataFile(metadataFile).getMetadata();
             Set<String> staleSegmentRemoteFilenames = staleSegmentFilesMetadataMap.values()
                 .stream()
                 .map(metadata -> metadata.uploadedFilename)

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -477,7 +477,11 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
 
             metadataStreamWrapper.writeStream(
                 indexOutput,
-                new RemoteSegmentMetadata(RemoteSegmentMetadata.fromMapOfStrings(uploadedSegments), byteArray, segmentInfosSnapshot.getGeneration())
+                new RemoteSegmentMetadata(
+                    RemoteSegmentMetadata.fromMapOfStrings(uploadedSegments),
+                    byteArray,
+                    segmentInfosSnapshot.getGeneration()
+                )
             );
             indexOutput.close();
             storeDirectory.sync(Collections.singleton(metadataFilename));

--- a/server/src/main/java/org/opensearch/index/store/remote/metadata/RemoteSegmentMetadata.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/metadata/RemoteSegmentMetadata.java
@@ -8,9 +8,11 @@
 
 package org.opensearch.index.store.remote.metadata;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.apache.lucene.store.IndexOutput;
 import org.opensearch.index.store.RemoteSegmentStoreDirectory;
 
 /**
@@ -33,8 +35,18 @@ public class RemoteSegmentMetadata {
      */
     private final Map<String, RemoteSegmentStoreDirectory.UploadedSegmentMetadata> metadata;
 
-    public RemoteSegmentMetadata(Map<String, RemoteSegmentStoreDirectory.UploadedSegmentMetadata> metadata) {
+    private final byte[] segmentInfosBytes;
+
+    private final long generation;
+
+    public RemoteSegmentMetadata(
+        Map<String, RemoteSegmentStoreDirectory.UploadedSegmentMetadata> metadata,
+        byte[] segmentInfosBytes,
+        long generation
+    ) {
         this.metadata = metadata;
+        this.segmentInfosBytes = segmentInfosBytes;
+        this.generation = generation;
     }
 
     /**
@@ -43,6 +55,14 @@ public class RemoteSegmentMetadata {
      */
     public Map<String, RemoteSegmentStoreDirectory.UploadedSegmentMetadata> getMetadata() {
         return this.metadata;
+    }
+
+    public byte[] getSegmentInfosBytes() {
+        return segmentInfosBytes;
+    }
+
+    public long getGeneration() {
+        return generation;
     }
 
     /**
@@ -58,16 +78,21 @@ public class RemoteSegmentMetadata {
      * @param segmentMetadata metadata content in the form of {@code Map<String, String>}
      * @return {@link RemoteSegmentMetadata}
      */
-    public static RemoteSegmentMetadata fromMapOfStrings(Map<String, String> segmentMetadata) {
-        return new RemoteSegmentMetadata(
-            segmentMetadata.entrySet()
-                .stream()
-                .collect(
-                    Collectors.toMap(
-                        Map.Entry::getKey,
-                        entry -> RemoteSegmentStoreDirectory.UploadedSegmentMetadata.fromString(entry.getValue())
-                    )
+    public static Map<String, RemoteSegmentStoreDirectory.UploadedSegmentMetadata> fromMapOfStrings(Map<String, String> segmentMetadata) {
+        return segmentMetadata.entrySet()
+            .stream()
+            .collect(
+                Collectors.toMap(
+                    Map.Entry::getKey,
+                    entry -> RemoteSegmentStoreDirectory.UploadedSegmentMetadata.fromString(entry.getValue())
                 )
-        );
+            );
+    }
+
+    public void write(IndexOutput out) throws IOException {
+        out.writeMapOfStrings(toMapOfStrings());
+        out.writeLong(generation);
+        out.writeLong(segmentInfosBytes.length);
+        out.writeBytes(segmentInfosBytes, segmentInfosBytes.length);
     }
 }

--- a/server/src/main/java/org/opensearch/index/store/remote/metadata/RemoteSegmentMetadata.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/metadata/RemoteSegmentMetadata.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.opensearch.index.store.RemoteSegmentStoreDirectory;
 
@@ -94,5 +95,14 @@ public class RemoteSegmentMetadata {
         out.writeLong(generation);
         out.writeLong(segmentInfosBytes.length);
         out.writeBytes(segmentInfosBytes, segmentInfosBytes.length);
+    }
+
+    public static RemoteSegmentMetadata read(IndexInput indexInput) throws IOException {
+        Map<String, String> metadata = indexInput.readMapOfStrings();
+        long generation = indexInput.readLong();
+        int byteArraySize = (int) indexInput.readLong();
+        byte[] segmentInfosBytes = new byte[byteArraySize];
+        indexInput.readBytes(segmentInfosBytes, 0, byteArraySize);
+        return new RemoteSegmentMetadata(RemoteSegmentMetadata.fromMapOfStrings(metadata), segmentInfosBytes, generation);
     }
 }

--- a/server/src/main/java/org/opensearch/index/store/remote/metadata/RemoteSegmentMetadataHandler.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/metadata/RemoteSegmentMetadataHandler.java
@@ -9,6 +9,7 @@
 package org.opensearch.index.store.remote.metadata;
 
 import java.io.IOException;
+import java.util.Map;
 
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
@@ -27,7 +28,12 @@ public class RemoteSegmentMetadataHandler implements IndexIOStreamHandler<Remote
      */
     @Override
     public RemoteSegmentMetadata readContent(IndexInput indexInput) throws IOException {
-        return RemoteSegmentMetadata.fromMapOfStrings(indexInput.readMapOfStrings());
+        Map<String, String> metadata = indexInput.readMapOfStrings();
+        long generation = indexInput.readLong();
+        int byteArraySize = (int) indexInput.readLong();
+        byte[] segmentInfosBytes = new byte[byteArraySize];
+        indexInput.readBytes(segmentInfosBytes, 0, byteArraySize);
+        return new RemoteSegmentMetadata(RemoteSegmentMetadata.fromMapOfStrings(metadata), segmentInfosBytes, generation);
     }
 
     /**
@@ -37,6 +43,6 @@ public class RemoteSegmentMetadataHandler implements IndexIOStreamHandler<Remote
      */
     @Override
     public void writeContent(IndexOutput indexOutput, RemoteSegmentMetadata content) throws IOException {
-        indexOutput.writeMapOfStrings(content.toMapOfStrings());
+        content.write(indexOutput);
     }
 }

--- a/server/src/main/java/org/opensearch/index/store/remote/metadata/RemoteSegmentMetadataHandler.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/metadata/RemoteSegmentMetadataHandler.java
@@ -9,7 +9,6 @@
 package org.opensearch.index.store.remote.metadata;
 
 import java.io.IOException;
-import java.util.Map;
 
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
@@ -28,12 +27,7 @@ public class RemoteSegmentMetadataHandler implements IndexIOStreamHandler<Remote
      */
     @Override
     public RemoteSegmentMetadata readContent(IndexInput indexInput) throws IOException {
-        Map<String, String> metadata = indexInput.readMapOfStrings();
-        long generation = indexInput.readLong();
-        int byteArraySize = (int) indexInput.readLong();
-        byte[] segmentInfosBytes = new byte[byteArraySize];
-        indexInput.readBytes(segmentInfosBytes, 0, byteArraySize);
-        return new RemoteSegmentMetadata(RemoteSegmentMetadata.fromMapOfStrings(metadata), segmentInfosBytes, generation);
+        return RemoteSegmentMetadata.read(indexInput);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -413,8 +413,10 @@ public class RemoteFsTranslog extends Translog {
         // are older files that are no longer needed and should be cleaned up. In here, we delete all files that are part
         // of older primary term.
         if (olderPrimaryCleaned.trySet(Boolean.TRUE)) {
+            if (readers.isEmpty()) {
+                return;
+            }
             // First we delete all stale primary terms folders from remote store
-            assert readers.isEmpty() == false : "Expected non-empty readers";
             long minimumReferencedPrimaryTerm = readers.stream().map(BaseTranslogReader::getPrimaryTerm).min(Long::compare).get();
             translogTransferManager.deletePrimaryTermsAsync(minimumReferencedPrimaryTerm);
             // Second we delete all stale metadata files from remote store

--- a/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
@@ -449,17 +449,5 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
                 }
             }
         }
-        if (segmentsNFilename != null) {
-            String commitGeneration = segmentsNFilename.substring((IndexFileNames.SEGMENTS + "_").length());
-            assertTrue(
-                uploadedSegments.keySet()
-                    .stream()
-                    .anyMatch(
-                        s -> s.startsWith(
-                            SEGMENT_INFO_SNAPSHOT_FILENAME_PREFIX + "__" + Long.parseLong(commitGeneration, Character.MAX_RADIX)
-                        )
-                    )
-            );
-        }
     }
 }

--- a/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
@@ -44,7 +44,6 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REPLICATION_TYPE;
-import static org.opensearch.index.shard.RemoteStoreRefreshListener.SEGMENT_INFO_SNAPSHOT_FILENAME_PREFIX;
 
 public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
     private IndexShard indexShard;

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -12,29 +12,39 @@ import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.IndexFormatTooNewException;
 import org.apache.lucene.index.IndexFormatTooOldException;
+import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.store.ByteBuffersDataOutput;
+import org.apache.lucene.store.ByteBuffersIndexOutput;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.OutputStreamIndexOutput;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.junit.After;
 import org.junit.Before;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.io.VersionedCodecStreamWrapper;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.lucene.store.ByteArrayIndexInput;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.engine.NRTReplicationEngineFactory;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.index.shard.IndexShardTestCase;
 import org.opensearch.index.store.lockmanager.RemoteStoreMetadataLockManager;
 import org.opensearch.index.store.remote.metadata.RemoteSegmentMetadata;
-import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.index.store.remote.metadata.RemoteSegmentMetadataHandler;
 
 import java.io.IOException;
 import java.nio.file.NoSuchFileException;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.HashMap;
-import java.util.Collection;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -47,12 +57,14 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.doReturn;
 
-public class RemoteSegmentStoreDirectoryTests extends OpenSearchTestCase {
+public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
     private RemoteDirectory remoteDataDirectory;
     private RemoteDirectory remoteMetadataDirectory;
     private RemoteStoreMetadataLockManager mdLockManager;
 
     private RemoteSegmentStoreDirectory remoteSegmentStoreDirectory;
+    private IndexShard indexShard;
+    private SegmentInfos segmentInfos;
 
     @Before
     public void setup() throws IOException {
@@ -61,6 +73,21 @@ public class RemoteSegmentStoreDirectoryTests extends OpenSearchTestCase {
         mdLockManager = mock(RemoteStoreMetadataLockManager.class);
 
         remoteSegmentStoreDirectory = new RemoteSegmentStoreDirectory(remoteDataDirectory, remoteMetadataDirectory, mdLockManager);
+
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, org.opensearch.Version.CURRENT)
+            .build();
+
+        indexShard = newStartedShard(false, indexSettings, new NRTReplicationEngineFactory());
+        try (Store store = indexShard.store()) {
+            segmentInfos = store.readLastCommittedSegmentsInfo();
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        indexShard.close("test tearDown", true);
+        super.tearDown();
     }
 
     public void testUploadedSegmentMetadataToString() {
@@ -203,11 +230,18 @@ public class RemoteSegmentStoreDirectoryTests extends OpenSearchTestCase {
      * @return ByteArrayIndexInput: metadata file bytes with header and footer
      * @throws IOException IOException
      */
-    private ByteArrayIndexInput createMetadataFileBytes(Map<String, String> segmentFilesMap) throws IOException {
+    private ByteArrayIndexInput createMetadataFileBytes(Map<String, String> segmentFilesMap, long generation) throws IOException {
+        ByteBuffersDataOutput byteBuffersIndexOutput = new ByteBuffersDataOutput();
+        segmentInfos.write(new ByteBuffersIndexOutput(byteBuffersIndexOutput, "", ""));
+        byte[] byteArray = byteBuffersIndexOutput.toArrayCopy();
+
         BytesStreamOutput output = new BytesStreamOutput();
         OutputStreamIndexOutput indexOutput = new OutputStreamIndexOutput("segment metadata", "metadata output stream", output, 4096);
         CodecUtil.writeHeader(indexOutput, RemoteSegmentMetadata.METADATA_CODEC, RemoteSegmentMetadata.CURRENT_VERSION);
         indexOutput.writeMapOfStrings(segmentFilesMap);
+        indexOutput.writeLong(generation);
+        indexOutput.writeLong(byteArray.length);
+        indexOutput.writeBytes(byteArray, byteArray.length);
         CodecUtil.writeFooter(indexOutput);
         indexOutput.close();
         return new ByteArrayIndexInput("segment metadata", BytesReference.toBytes(output.bytes()));
@@ -229,14 +263,14 @@ public class RemoteSegmentStoreDirectoryTests extends OpenSearchTestCase {
         );
 
         when(remoteMetadataDirectory.openInput("metadata__1__5__abc", IOContext.DEFAULT)).thenReturn(
-            createMetadataFileBytes(metadataFilenameContentMapping.get("metadata__1__5__abc"))
+            createMetadataFileBytes(metadataFilenameContentMapping.get("metadata__1__5__abc"), 1)
         );
         when(remoteMetadataDirectory.openInput("metadata__1__6__pqr", IOContext.DEFAULT)).thenReturn(
-            createMetadataFileBytes(metadataFilenameContentMapping.get("metadata__1__6__pqr"))
+            createMetadataFileBytes(metadataFilenameContentMapping.get("metadata__1__6__pqr"), 1)
         );
         when(remoteMetadataDirectory.openInput("metadata__2__1__zxv", IOContext.DEFAULT)).thenReturn(
-            createMetadataFileBytes(metadataFilenameContentMapping.get("metadata__2__1__zxv")),
-            createMetadataFileBytes(metadataFilenameContentMapping.get("metadata__2__1__zxv"))
+            createMetadataFileBytes(metadataFilenameContentMapping.get("metadata__2__1__zxv"), 1),
+            createMetadataFileBytes(metadataFilenameContentMapping.get("metadata__2__1__zxv"), 1)
         );
 
         return metadataFilenameContentMapping;
@@ -471,7 +505,7 @@ public class RemoteSegmentStoreDirectoryTests extends OpenSearchTestCase {
         );
 
         when(remoteMetadataDirectory.openInput("metadata__1__5__abc", IOContext.DEFAULT)).thenReturn(
-            createMetadataFileBytes(metadataFilenameContentMapping.get("metadata__1__5__abc"))
+            createMetadataFileBytes(metadataFilenameContentMapping.get("metadata__1__5__abc"), 1)
         );
 
         assert (remoteSegmentStoreDirectory.getSegmentsUploadedToRemoteStore(testPrimaryTerm, testGeneration).containsKey("segments_5"));
@@ -545,7 +579,7 @@ public class RemoteSegmentStoreDirectoryTests extends OpenSearchTestCase {
         metadata.put("_0.cfe", "_0.cfe::_0.cfe__" + UUIDs.base64UUID() + "::1234::512");
         metadata.put("_0.cfs", "_0.cfs::_0.cfs__" + UUIDs.base64UUID() + "::2345::1024");
 
-        when(remoteMetadataDirectory.openInput("metadata__1__5__abc", IOContext.DEFAULT)).thenReturn(createMetadataFileBytes(metadata));
+        when(remoteMetadataDirectory.openInput("metadata__1__5__abc", IOContext.DEFAULT)).thenReturn(createMetadataFileBytes(metadata, 1));
 
         remoteSegmentStoreDirectory.init();
 
@@ -573,7 +607,7 @@ public class RemoteSegmentStoreDirectoryTests extends OpenSearchTestCase {
         when(storeDirectory.createOutput(startsWith("metadata__12__o"), eq(IOContext.DEFAULT))).thenReturn(indexOutput);
 
         Collection<String> segmentFiles = List.of("s1", "s2", "s3");
-        assertThrows(NoSuchFileException.class, () -> remoteSegmentStoreDirectory.uploadMetadata(segmentFiles, storeDirectory, 12L, 24L));
+        assertThrows(NoSuchFileException.class, () -> remoteSegmentStoreDirectory.uploadMetadata(segmentFiles, segmentInfos, storeDirectory, 12L));
     }
 
     public void testUploadMetadataNonEmpty() throws IOException {
@@ -583,25 +617,33 @@ public class RemoteSegmentStoreDirectoryTests extends OpenSearchTestCase {
         Directory storeDirectory = mock(Directory.class);
         BytesStreamOutput output = new BytesStreamOutput();
         IndexOutput indexOutput = new OutputStreamIndexOutput("segment metadata", "metadata output stream", output, 4096);
-        when(storeDirectory.createOutput(startsWith("metadata__12__o"), eq(IOContext.DEFAULT))).thenReturn(indexOutput);
 
-        Collection<String> segmentFiles = List.of("_0.si");
-        remoteSegmentStoreDirectory.uploadMetadata(segmentFiles, storeDirectory, 12L, 24L);
+        long generation = segmentInfos.getGeneration();
+        when(storeDirectory.createOutput(startsWith("metadata__12__" + generation), eq(IOContext.DEFAULT))).thenReturn(indexOutput);
+
+        Collection<String> segmentFiles = List.of("_0.si", "_0.cfe", "_0.cfs", "segments_1");
+        remoteSegmentStoreDirectory.uploadMetadata(segmentFiles, segmentInfos, storeDirectory, 12L);
 
         verify(remoteMetadataDirectory).copyFrom(
             eq(storeDirectory),
-            startsWith("metadata__12__o"),
-            startsWith("metadata__12__o"),
+            startsWith("metadata__12__" + generation),
+            startsWith("metadata__12__" + generation),
             eq(IOContext.DEFAULT)
         );
-        String metadataString = remoteSegmentStoreDirectory.getSegmentsUploadedToRemoteStore().get("_0.si").toString();
 
-        ByteArrayIndexInput expectedMetadataFileContent = createMetadataFileBytes(Map.of("_0.si", metadataString));
-        int expectedBytesLength = (int) expectedMetadataFileContent.length();
-        byte[] expectedBytes = new byte[expectedBytesLength];
-        expectedMetadataFileContent.readBytes(expectedBytes, 0, expectedBytesLength);
+        VersionedCodecStreamWrapper<RemoteSegmentMetadata> streamWrapper = new VersionedCodecStreamWrapper<>(
+            new RemoteSegmentMetadataHandler(),
+            RemoteSegmentMetadata.CURRENT_VERSION,
+            RemoteSegmentMetadata.METADATA_CODEC
+        );
+        RemoteSegmentMetadata remoteSegmentMetadata = streamWrapper.readStream(new ByteArrayIndexInput("expected", BytesReference.toBytes(output.bytes())));
 
-        assertArrayEquals(expectedBytes, BytesReference.toBytes(output.bytes()));
+        Map<String, RemoteSegmentStoreDirectory.UploadedSegmentMetadata> actual = remoteSegmentStoreDirectory.getSegmentsUploadedToRemoteStore();
+        Map<String, RemoteSegmentStoreDirectory.UploadedSegmentMetadata> expected = remoteSegmentMetadata.getMetadata();
+
+        for(String filename: expected.keySet()) {
+            assertEquals(expected.get(filename).toString(), actual.get(filename).toString());
+        }
     }
 
     public void testNoMetadataHeaderCorruptIndexException() throws IOException {

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -74,9 +74,7 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
 
         remoteSegmentStoreDirectory = new RemoteSegmentStoreDirectory(remoteDataDirectory, remoteMetadataDirectory, mdLockManager);
 
-        Settings indexSettings = Settings.builder()
-            .put(IndexMetadata.SETTING_VERSION_CREATED, org.opensearch.Version.CURRENT)
-            .build();
+        Settings indexSettings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, org.opensearch.Version.CURRENT).build();
 
         indexShard = newStartedShard(false, indexSettings, new NRTReplicationEngineFactory());
         try (Store store = indexShard.store()) {
@@ -607,7 +605,10 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         when(storeDirectory.createOutput(startsWith("metadata__12__o"), eq(IOContext.DEFAULT))).thenReturn(indexOutput);
 
         Collection<String> segmentFiles = List.of("s1", "s2", "s3");
-        assertThrows(NoSuchFileException.class, () -> remoteSegmentStoreDirectory.uploadMetadata(segmentFiles, segmentInfos, storeDirectory, 12L));
+        assertThrows(
+            NoSuchFileException.class,
+            () -> remoteSegmentStoreDirectory.uploadMetadata(segmentFiles, segmentInfos, storeDirectory, 12L)
+        );
     }
 
     public void testUploadMetadataNonEmpty() throws IOException {
@@ -636,12 +637,15 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
             RemoteSegmentMetadata.CURRENT_VERSION,
             RemoteSegmentMetadata.METADATA_CODEC
         );
-        RemoteSegmentMetadata remoteSegmentMetadata = streamWrapper.readStream(new ByteArrayIndexInput("expected", BytesReference.toBytes(output.bytes())));
+        RemoteSegmentMetadata remoteSegmentMetadata = streamWrapper.readStream(
+            new ByteArrayIndexInput("expected", BytesReference.toBytes(output.bytes()))
+        );
 
-        Map<String, RemoteSegmentStoreDirectory.UploadedSegmentMetadata> actual = remoteSegmentStoreDirectory.getSegmentsUploadedToRemoteStore();
+        Map<String, RemoteSegmentStoreDirectory.UploadedSegmentMetadata> actual = remoteSegmentStoreDirectory
+            .getSegmentsUploadedToRemoteStore();
         Map<String, RemoteSegmentStoreDirectory.UploadedSegmentMetadata> expected = remoteSegmentMetadata.getMetadata();
 
-        for(String filename: expected.keySet()) {
+        for (String filename : expected.keySet()) {
             assertEquals(expected.get(filename).toString(), actual.get(filename).toString());
         }
     }

--- a/server/src/test/java/org/opensearch/index/store/remote/metadata/RemoteSegmentMetadataHandlerTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/metadata/RemoteSegmentMetadataHandlerTests.java
@@ -11,7 +11,6 @@ package org.opensearch.index.store.remote.metadata;
 import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.store.ByteBuffersDataOutput;
 import org.apache.lucene.store.ByteBuffersIndexOutput;
-import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.OutputStreamIndexOutput;
 import org.junit.After;
 import org.junit.Before;
@@ -25,7 +24,6 @@ import org.opensearch.index.engine.NRTReplicationEngineFactory;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.shard.IndexShardTestCase;
 import org.opensearch.index.store.Store;
-import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -43,9 +41,7 @@ public class RemoteSegmentMetadataHandlerTests extends IndexShardTestCase {
     public void setup() throws IOException {
         remoteSegmentMetadataHandler = new RemoteSegmentMetadataHandler();
 
-        Settings indexSettings = Settings.builder()
-            .put(IndexMetadata.SETTING_VERSION_CREATED, org.opensearch.Version.CURRENT)
-            .build();
+        Settings indexSettings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, org.opensearch.Version.CURRENT).build();
 
         indexShard = newStartedShard(false, indexSettings, new NRTReplicationEngineFactory());
         try (Store store = indexShard.store()) {
@@ -104,7 +100,11 @@ public class RemoteSegmentMetadataHandlerTests extends IndexShardTestCase {
         segmentInfos.write(segmentInfosOutput);
         byte[] segmentInfosBytes = segmentInfosOutput.toArrayCopy();
 
-        RemoteSegmentMetadata remoteSegmentMetadata = new RemoteSegmentMetadata(RemoteSegmentMetadata.fromMapOfStrings(expectedOutput), segmentInfosBytes, 1234);
+        RemoteSegmentMetadata remoteSegmentMetadata = new RemoteSegmentMetadata(
+            RemoteSegmentMetadata.fromMapOfStrings(expectedOutput),
+            segmentInfosBytes,
+            1234
+        );
         remoteSegmentMetadataHandler.writeContent(indexOutput, remoteSegmentMetadata);
         indexOutput.close();
 

--- a/server/src/test/java/org/opensearch/index/store/remote/metadata/RemoteSegmentMetadataHandlerTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/metadata/RemoteSegmentMetadataHandlerTests.java
@@ -8,12 +8,23 @@
 
 package org.opensearch.index.store.remote.metadata;
 
+import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.store.ByteBuffersDataOutput;
+import org.apache.lucene.store.ByteBuffersIndexOutput;
+import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.OutputStreamIndexOutput;
+import org.junit.After;
 import org.junit.Before;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.lucene.store.ByteArrayIndexInput;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.engine.NRTReplicationEngineFactory;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.index.shard.IndexShardTestCase;
+import org.opensearch.index.store.Store;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
@@ -23,35 +34,86 @@ import java.util.Map;
 /**
  * Unit Tests for {@link RemoteSegmentMetadataHandler}
  */
-public class RemoteSegmentMetadataHandlerTests extends OpenSearchTestCase {
+public class RemoteSegmentMetadataHandlerTests extends IndexShardTestCase {
     private RemoteSegmentMetadataHandler remoteSegmentMetadataHandler;
+    private IndexShard indexShard;
+    private SegmentInfos segmentInfos;
 
     @Before
     public void setup() throws IOException {
         remoteSegmentMetadataHandler = new RemoteSegmentMetadataHandler();
+
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, org.opensearch.Version.CURRENT)
+            .build();
+
+        indexShard = newStartedShard(false, indexSettings, new NRTReplicationEngineFactory());
+        try (Store store = indexShard.store()) {
+            segmentInfos = store.readLastCommittedSegmentsInfo();
+        }
     }
 
-    public void testReadContent() throws IOException {
+    @After
+    public void tearDown() throws Exception {
+        indexShard.close("test tearDown", true);
+        super.tearDown();
+    }
+
+    public void testReadContentNoSegmentInfos() throws IOException {
         BytesStreamOutput output = new BytesStreamOutput();
         OutputStreamIndexOutput indexOutput = new OutputStreamIndexOutput("dummy bytes", "dummy stream", output, 4096);
         Map<String, String> expectedOutput = getDummyData();
         indexOutput.writeMapOfStrings(expectedOutput);
+        indexOutput.writeLong(1234);
+        indexOutput.writeLong(0);
+        indexOutput.writeBytes(new byte[0], 0);
         indexOutput.close();
         RemoteSegmentMetadata metadata = remoteSegmentMetadataHandler.readContent(
             new ByteArrayIndexInput("dummy bytes", BytesReference.toBytes(output.bytes()))
         );
         assertEquals(expectedOutput, metadata.toMapOfStrings());
+        assertEquals(1234, metadata.getGeneration());
+    }
+
+    public void testReadContentWithSegmentInfos() throws IOException {
+        BytesStreamOutput output = new BytesStreamOutput();
+        OutputStreamIndexOutput indexOutput = new OutputStreamIndexOutput("dummy bytes", "dummy stream", output, 4096);
+        Map<String, String> expectedOutput = getDummyData();
+        indexOutput.writeMapOfStrings(expectedOutput);
+        indexOutput.writeLong(1234);
+        ByteBuffersIndexOutput segmentInfosOutput = new ByteBuffersIndexOutput(new ByteBuffersDataOutput(), "test", "resource");
+        segmentInfos.write(segmentInfosOutput);
+        byte[] segmentInfosBytes = segmentInfosOutput.toArrayCopy();
+        indexOutput.writeLong(segmentInfosBytes.length);
+        indexOutput.writeBytes(segmentInfosBytes, 0, segmentInfosBytes.length);
+        indexOutput.close();
+        RemoteSegmentMetadata metadata = remoteSegmentMetadataHandler.readContent(
+            new ByteArrayIndexInput("dummy bytes", BytesReference.toBytes(output.bytes()))
+        );
+        assertEquals(expectedOutput, metadata.toMapOfStrings());
+        assertEquals(1234, metadata.getGeneration());
+        assertArrayEquals(segmentInfosBytes, metadata.getSegmentInfosBytes());
     }
 
     public void testWriteContent() throws IOException {
         BytesStreamOutput output = new BytesStreamOutput();
         OutputStreamIndexOutput indexOutput = new OutputStreamIndexOutput("dummy bytes", "dummy stream", output, 4096);
+
         Map<String, String> expectedOutput = getDummyData();
-        remoteSegmentMetadataHandler.writeContent(indexOutput, RemoteSegmentMetadata.fromMapOfStrings(expectedOutput));
+        ByteBuffersIndexOutput segmentInfosOutput = new ByteBuffersIndexOutput(new ByteBuffersDataOutput(), "test", "resource");
+        segmentInfos.write(segmentInfosOutput);
+        byte[] segmentInfosBytes = segmentInfosOutput.toArrayCopy();
+
+        RemoteSegmentMetadata remoteSegmentMetadata = new RemoteSegmentMetadata(RemoteSegmentMetadata.fromMapOfStrings(expectedOutput), segmentInfosBytes, 1234);
+        remoteSegmentMetadataHandler.writeContent(indexOutput, remoteSegmentMetadata);
         indexOutput.close();
-        Map<String, String> actualOutput = new ByteArrayIndexInput("dummy bytes", BytesReference.toBytes(output.bytes()))
-            .readMapOfStrings();
-        assertEquals(expectedOutput, actualOutput);
+
+        RemoteSegmentMetadata metadata = remoteSegmentMetadataHandler.readContent(
+            new ByteArrayIndexInput("dummy bytes", BytesReference.toBytes(output.bytes()))
+        );
+        assertEquals(expectedOutput, metadata.toMapOfStrings());
+        assertEquals(1234, metadata.getGeneration());
+        assertArrayEquals(segmentInfosBytes, metadata.getSegmentInfosBytes());
     }
 
     private Map<String, String> getDummyData() {


### PR DESCRIPTION
### Description
- Extend existing SegRep integ tests related to allocation and relocation with remote store settings.

### Related Issues
<TBD>

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
