### PR TITLE
[Backport 2.x][Search Pipelines] Add default_search_pipeline index setting (#7470)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Extensions] Add IdentityPlugin into core to support Extension identities ([#7246](https://github.com/opensearch-project/OpenSearch/pull/7246))
 - Add connectToNodeAsExtension in TransportService ([#6866](https://github.com/opensearch-project/OpenSearch/pull/6866))
 - [Search Pipelines] Accept pipelines defined in search source ([#7253](https://github.com/opensearch-project/OpenSearch/pull/7253))
+- [Search Pipelines] Add `default_search_pipeline` index setting ([#7470](https://github.com/opensearch-project/OpenSearch/pull/7470))
 - Add descending order search optimization through reverse segment read. ([#7244](https://github.com/opensearch-project/OpenSearch/pull/7244))
 - Add 'unsigned_long' numeric field type ([#6237](https://github.com/opensearch-project/OpenSearch/pull/6237))
 - Add back primary shard preference for queries ([#7375](https://github.com/opensearch-project/OpenSearch/pull/7375))

--- a/modules/search-pipeline-common/src/yamlRestTest/resources/rest-api-spec/test/search_pipeline/30_filter_query.yml
+++ b/modules/search-pipeline-common/src/yamlRestTest/resources/rest-api-spec/test/search_pipeline/30_filter_query.yml
@@ -101,3 +101,24 @@ teardown:
         }
   - match: { hits.total.value: 1 }
   - match: { hits.hits.0._id: "1" }
+
+  # Make it the default for the index
+  - do:
+      indices.put_settings:
+        index: test
+        body:
+          index.search.default_pipeline: my_pipeline
+
+  - do:
+      search:
+        index: test
+        body: { }
+  - match: { hits.total.value: 1 }
+
+  # Explicitly bypass the pipeline to match both docs
+  - do:
+      search:
+        search_pipeline: _none
+        index: test
+        body: { }
+  - match: { hits.total.value: 2 }

--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -64,6 +64,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
       numberOfNodes = 4
 
       setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
+      setting 'opensearch.experimental.feature.search_pipeline.enabled', 'true'
     }
   }
 

--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -64,7 +64,9 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
       numberOfNodes = 4
 
       setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
-      setting 'opensearch.experimental.feature.search_pipeline.enabled', 'true'
+      if (bwcVersion.onOrAfter("2.7.0")) {
+        setting 'opensearch.experimental.feature.search_pipeline.enabled', 'true'
+      }
     }
   }
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search_pipeline/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search_pipeline/10_basic.yml
@@ -1,8 +1,8 @@
 ---
 "Test basic pipeline crud":
   - skip:
-      version: " - 2.99.99"
-      reason: "to be introduced in future release / TODO: change if/when we backport to 2.x"
+      version: " - 2.7.0"
+      reason: "Added in 2.7.0"
   - do:
       search_pipeline.put:
         id: "my_pipeline"
@@ -32,8 +32,8 @@
 ---
 "Test Put Versioned Pipeline":
   - skip:
-      version: " - 2.99.99"
-      reason: "to be introduced in future release / TODO: change if/when we backport to 2.x"
+      version: " - 2.7.0"
+      reason: "Added in 2.7.0"
   - do:
       search_pipeline.put:
         id: "my_pipeline"
@@ -125,8 +125,8 @@
 ---
 "Test Get All Pipelines":
   - skip:
-      version: " - 2.99.99"
-      reason: "to be introduced in future release / TODO: change if/when we backport to 2.x"
+      version: " - 2.7.0"
+      reason: "Added in 2.7.0"
   - do:
       search_pipeline.put:
         id: "first_pipeline"
@@ -152,8 +152,8 @@
 ---
 "Test invalid config":
   - skip:
-      version: " - 2.99.99"
-      reason: "to be introduced in future release / TODO: change if/when we backport to 2.x"
+      version: " - 2.7.0"
+      reason: "Added in 2.7.0"
   - do:
       catch: /parse_exception/
       search_pipeline.put:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search_pipeline/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search_pipeline/10_basic.yml
@@ -1,7 +1,7 @@
 ---
 "Test basic pipeline crud":
   - skip:
-      version: " - 2.7.0"
+      version: " - 2.6.99"
       reason: "Added in 2.7.0"
   - do:
       search_pipeline.put:
@@ -32,7 +32,7 @@
 ---
 "Test Put Versioned Pipeline":
   - skip:
-      version: " - 2.7.0"
+      version: " - 2.6.99"
       reason: "Added in 2.7.0"
   - do:
       search_pipeline.put:
@@ -125,7 +125,7 @@
 ---
 "Test Get All Pipelines":
   - skip:
-      version: " - 2.7.0"
+      version: " - 2.6.99"
       reason: "Added in 2.7.0"
   - do:
       search_pipeline.put:
@@ -152,7 +152,7 @@
 ---
 "Test invalid config":
   - skip:
-      version: " - 2.7.0"
+      version: " - 2.6.99"
       reason: "Added in 2.7.0"
   - do:
       catch: /parse_exception/

--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -197,6 +197,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 IndexSettings.INDEX_MERGE_ON_FLUSH_ENABLED,
                 IndexSettings.INDEX_MERGE_ON_FLUSH_MAX_FULL_FLUSH_MERGE_WAIT_TIME,
                 IndexSettings.INDEX_MERGE_ON_FLUSH_POLICY,
+                IndexSettings.DEFAULT_SEARCH_PIPELINE,
 
                 // Settings for Searchable Snapshots
                 IndexSettings.SEARCHABLE_SNAPSHOT_REPOSITORY,

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -43,6 +43,7 @@ import org.opensearch.common.settings.IndexScopedSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.settings.SettingsException;
 import org.opensearch.common.unit.ByteSizeUnit;
 import org.opensearch.common.unit.ByteSizeValue;
 import org.opensearch.common.unit.TimeValue;
@@ -52,6 +53,7 @@ import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.ingest.IngestService;
 import org.opensearch.node.Node;
+import org.opensearch.search.pipeline.SearchPipelineService;
 
 import java.util.Collections;
 import java.util.List;
@@ -63,6 +65,7 @@ import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
 import static org.opensearch.common.util.FeatureFlags.SEARCHABLE_SNAPSHOT_EXTENDED_COMPATIBILITY;
+import static org.opensearch.common.util.FeatureFlags.SEARCH_PIPELINE;
 import static org.opensearch.index.mapper.MapperService.INDEX_MAPPING_DEPTH_LIMIT_SETTING;
 import static org.opensearch.index.mapper.MapperService.INDEX_MAPPING_FIELD_NAME_LENGTH_LIMIT_SETTING;
 import static org.opensearch.index.mapper.MapperService.INDEX_MAPPING_NESTED_DOCS_LIMIT_SETTING;
@@ -579,6 +582,14 @@ public final class IndexSettings {
         Property.InternalIndex
     );
 
+    public static final Setting<String> DEFAULT_SEARCH_PIPELINE = new Setting<>(
+        "index.search.default_pipeline",
+        SearchPipelineService.NOOP_PIPELINE_ID,
+        Function.identity(),
+        Property.Dynamic,
+        Property.IndexScope
+    );
+
     private final Index index;
     private final Version version;
     private final Logger logger;
@@ -618,6 +629,8 @@ public final class IndexSettings {
     private volatile long softDeleteRetentionOperations;
 
     private volatile long retentionLeaseMillis;
+
+    private volatile String defaultSearchPipeline;
 
     /**
      * The maximum age of a retention lease before it is considered expired.
@@ -822,6 +835,7 @@ public final class IndexSettings {
         maxFullFlushMergeWaitTime = scopedSettings.get(INDEX_MERGE_ON_FLUSH_MAX_FULL_FLUSH_MERGE_WAIT_TIME);
         mergeOnFlushEnabled = scopedSettings.get(INDEX_MERGE_ON_FLUSH_ENABLED);
         setMergeOnFlushPolicy(scopedSettings.get(INDEX_MERGE_ON_FLUSH_POLICY));
+        defaultSearchPipeline = scopedSettings.get(DEFAULT_SEARCH_PIPELINE);
 
         scopedSettings.addSettingsUpdateConsumer(MergePolicyConfig.INDEX_COMPOUND_FORMAT_SETTING, mergePolicyConfig::setNoCFSRatio);
         scopedSettings.addSettingsUpdateConsumer(
@@ -895,6 +909,7 @@ public final class IndexSettings {
         scopedSettings.addSettingsUpdateConsumer(INDEX_MERGE_ON_FLUSH_MAX_FULL_FLUSH_MERGE_WAIT_TIME, this::setMaxFullFlushMergeWaitTime);
         scopedSettings.addSettingsUpdateConsumer(INDEX_MERGE_ON_FLUSH_ENABLED, this::setMergeOnFlushEnabled);
         scopedSettings.addSettingsUpdateConsumer(INDEX_MERGE_ON_FLUSH_POLICY, this::setMergeOnFlushPolicy);
+        scopedSettings.addSettingsUpdateConsumer(DEFAULT_SEARCH_PIPELINE, this::setDefaultSearchPipeline);
     }
 
     private void setSearchSegmentOrderReversed(boolean reversed) {
@@ -1576,5 +1591,17 @@ public final class IndexSettings {
 
     public Optional<UnaryOperator<MergePolicy>> getMergeOnFlushPolicy() {
         return Optional.ofNullable(mergeOnFlushPolicy);
+    }
+
+    public String getDefaultSearchPipeline() {
+        return defaultSearchPipeline;
+    }
+
+    public void setDefaultSearchPipeline(String defaultSearchPipeline) {
+        if (FeatureFlags.isEnabled(SEARCH_PIPELINE)) {
+            this.defaultSearchPipeline = defaultSearchPipeline;
+        } else {
+            throw new SettingsException("Unsupported setting: " + DEFAULT_SEARCH_PIPELINE.getKey());
+        }
     }
 }


### PR DESCRIPTION
* [Search Pipelines] Add default_search_pipeline index setting

Once users have defined and tested a search pipeline, they may want to apply it by default to all queries hitting a given index.

Users should be able to bypass the default pipeline for the index by explicitly specifying `search_pipeline=_none` in the URL parameter of their search request.

Signed-off-by: Michael Froh <froh@amazon.com>

* Rename default search pipeline setting and add getter/setter

Also change version check for ad hoc pipeline to 2.8

Signed-off-by: Michael Froh <froh@amazon.com>

* Add tests for new IndexSettings methods

Signed-off-by: Michael Froh <froh@amazon.com>

* Update test to reflect change to FeatureFlagSetter

Signed-off-by: Michael Froh <froh@amazon.com>

---------

Signed-off-by: Michael Froh <froh@amazon.com>
(cherry picked from commit 59847356b1c82562498f38896adef66ea1702cd6)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
