### PR TITLE
Fix mapping char_filter when mapping a hashtag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Support OpenSSL Provider with default Netty allocator ([#5460](https://github.com/opensearch-project/OpenSearch/pull/5460))
 - Replaces ZipInputStream with ZipFile to fix Zip Slip vulnerability ([#7230](https://github.com/opensearch-project/OpenSearch/pull/7230))
 - Add missing validation/parsing of SearchBackpressureMode of SearchBackpressureSettings ([#7541](https://github.com/opensearch-project/OpenSearch/pull/7541))
+- Fix mapping char_filter when mapping a hashtag ([#7591](https://github.com/opensearch-project/OpenSearch/pull/7591))
 
 ### Security
 

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/MappingCharFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/MappingCharFilterFactory.java
@@ -54,7 +54,7 @@ public class MappingCharFilterFactory extends AbstractCharFilterFactory implemen
     MappingCharFilterFactory(IndexSettings indexSettings, Environment env, String name, Settings settings) {
         super(indexSettings, name);
 
-        List<MappingRule<String, String>> rules = Analysis.parseWordList(env, settings, "mappings", this::parse);
+        List<MappingRule<String, String>> rules = Analysis.parseWordList(env, settings, "mappings", this::parse, false);
         if (rules == null) {
             throw new IllegalArgumentException("mapping requires either `mappings` or `mappings_path` to be configured");
         }

--- a/modules/analysis-common/src/test/java/org/opensearch/analysis/common/MappingCharFilterFactoryTests.java
+++ b/modules/analysis-common/src/test/java/org/opensearch/analysis/common/MappingCharFilterFactoryTests.java
@@ -37,11 +37,11 @@ public class MappingCharFilterFactoryTests extends OpenSearchTestCase {
 
     public void testRulesOk() throws IOException {
         MappingCharFilterFactory mappingCharFilterFactory = (MappingCharFilterFactory) create(
-            "# This is a comment",
+            "# => _hashtag_",
             ":) => _happy_",
             ":( => _sad_"
         );
-        CharFilter inputReader = (CharFilter) mappingCharFilterFactory.create(new StringReader("I'm so :)"));
+        CharFilter inputReader = (CharFilter) mappingCharFilterFactory.create(new StringReader("I'm so :), I'm so :( #confused"));
         char[] tempBuff = new char[14];
         StringBuilder output = new StringBuilder();
         while (true) {
@@ -49,7 +49,7 @@ public class MappingCharFilterFactoryTests extends OpenSearchTestCase {
             if (length == -1) break;
             output.append(tempBuff, 0, length);
         }
-        assertEquals("I'm so _happy_", output.toString());
+        assertEquals("I'm so _happy_, I'm so _sad_ _hashtag_confused", output.toString());
     }
 
     public void testRuleError() {
@@ -64,7 +64,7 @@ public class MappingCharFilterFactoryTests extends OpenSearchTestCase {
     }
 
     public void testRulePartError() {
-        RuntimeException ex = expectThrows(RuntimeException.class, () -> create("# This is a comment", ":) => _happy_", "a:b"));
+        RuntimeException ex = expectThrows(RuntimeException.class, () -> create("# => _hashtag_", ":) => _happy_", "a:b"));
         assertEquals("Line [3]: Invalid mapping rule : [a:b]", ex.getMessage());
     }
 }

--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/analysis-common/50_char_filters.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/analysis-common/50_char_filters.yml
@@ -57,3 +57,21 @@
     - match:  { detail.tokenizer.tokens.0.start_offset: 0 }
     - match:  { detail.tokenizer.tokens.0.end_offset: 15 }
     - match:  { detail.tokenizer.tokens.0.position: 0 }
+---
+"mapping_with_hashtag":
+  - do:
+      indices.analyze:
+        body:
+          text: 'test #test @test'
+          tokenizer: standard
+          filter:
+            - lowercase
+          char_filter:
+            - type: mapping
+              mappings:
+                - "# => _hashsign_"
+                - "@ => _atsign_"
+  - length: { tokens: 3 }
+  - match: { tokens.0.token: test }
+  - match: { tokens.1.token: _hashsign_test }
+  - match: { tokens.2.token: _atsign_test }

--- a/server/src/main/java/org/opensearch/index/analysis/Analysis.java
+++ b/server/src/main/java/org/opensearch/index/analysis/Analysis.java
@@ -222,6 +222,16 @@ public class Analysis {
         return parseWordList(env, settings, settingPrefix + "_path", settingPrefix, parser);
     }
 
+    public static <T> List<T> parseWordList(
+        Environment env,
+        Settings settings,
+        String settingPrefix,
+        CustomMappingRuleParser<T> parser,
+        boolean removeComments
+    ) {
+        return parseWordList(env, settings, settingPrefix + "_path", settingPrefix, parser, removeComments);
+    }
+
     /**
      * Parses a list of words from the specified settings or from a file, with the given parser.
      *
@@ -237,6 +247,17 @@ public class Analysis {
         String settingList,
         CustomMappingRuleParser<T> parser
     ) {
+        return parseWordList(env, settings, settingPath, settingList, parser, true);
+    }
+
+    public static <T> List<T> parseWordList(
+        Environment env,
+        Settings settings,
+        String settingPath,
+        String settingList,
+        CustomMappingRuleParser<T> parser,
+        boolean removeComments
+    ) {
         List<String> words = getWordList(env, settings, settingPath, settingList);
         if (words == null) {
             return null;
@@ -245,7 +266,7 @@ public class Analysis {
         int lineNum = 0;
         for (String word : words) {
             lineNum++;
-            if (word.startsWith("#") == false) {
+            if (removeComments == false || word.startsWith("#") == false) {
                 try {
                     rules.add(parser.apply(word));
                 } catch (RuntimeException ex) {


### PR DESCRIPTION
### Description
Fix the mapping `char_filter` to allow mapping hashtags, example:

```python
from elasticsearch_dsl import analyzer, char_filter


STD_WITH_SPECIAL_CHARS: Final = analyzer(
    'std_with_hashtag_chars',
    type='custom',
    tokenizer='standard',
    filter=['lowercase'],
    char_filter=char_filter(
        'hashtag_char_filter',
        type='mapping',
        mappings=[
            '# => _hashsign_',
        ],
    ),
)
```

More details in the issue below.

### Related Issues
Resolves: https://github.com/opensearch-project/OpenSearch/issues/7308

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
