### PR TITLE
Add support for ignoring missing Javadoc on generated code using annotation (# 7264)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add getter for path field in NestedQueryBuilder ([#4636](https://github.com/opensearch-project/OpenSearch/pull/4636))
 - Allow mmap to use new JDK-19 preview APIs in Apache Lucene 9.4+ ([#5151](https://github.com/opensearch-project/OpenSearch/pull/5151))
 - Add events correlation engine plugin ([#6854](https://github.com/opensearch-project/OpenSearch/issues/6854))
+- Add support for ignoring missing Javadoc on generated code using annotation and "*" ([#7604](https://github.com/opensearch-project/OpenSearch/pull/7604))
 
 ### Dependencies
 - Bump `log4j-core` from 2.18.0 to 2.19.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add getter for path field in NestedQueryBuilder ([#4636](https://github.com/opensearch-project/OpenSearch/pull/4636))
 - Allow mmap to use new JDK-19 preview APIs in Apache Lucene 9.4+ ([#5151](https://github.com/opensearch-project/OpenSearch/pull/5151))
 - Add events correlation engine plugin ([#6854](https://github.com/opensearch-project/OpenSearch/issues/6854))
-- Add support for ignoring missing Javadoc on generated code using annotation and "*" ([#7604](https://github.com/opensearch-project/OpenSearch/pull/7604))
+- Add support for ignoring missing Javadoc on generated code using annotation ([#7604](https://github.com/opensearch-project/OpenSearch/pull/7604))
 
 ### Dependencies
 - Bump `log4j-core` from 2.18.0 to 2.19.0

--- a/buildSrc/reaper/build.gradle
+++ b/buildSrc/reaper/build.gradle
@@ -20,11 +20,3 @@ jar {
     attributes 'Main-Class': 'org.opensearch.gradle.reaper.Reaper'
   }
 }
-
-repositories {
-  mavenCentral()
-}
-
-dependencies {
-  implementation "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:1.0.2.Final"
-}

--- a/buildSrc/reaper/build.gradle
+++ b/buildSrc/reaper/build.gradle
@@ -20,3 +20,11 @@ jar {
     attributes 'Main-Class': 'org.opensearch.gradle.reaper.Reaper'
   }
 }
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  implementation "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:1.0.2.Final"
+}

--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -23,6 +23,7 @@ kotlin            = 1.7.10
 antlr4            = 4.11.1
 guava             = 31.1-jre
 protobuf          = 3.22.3
+jboss_annotation  = 1.0.2.Final
 
 # when updating the JNA version, also update the version in buildSrc/build.gradle
 jna               = 5.5.0

--- a/doc-tools/missing-doclet/build.gradle
+++ b/doc-tools/missing-doclet/build.gradle
@@ -9,6 +9,10 @@ repositories {
     mavenCentral()
 }
 
+dependencies {
+  implementation "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:1.0.2.Final"
+}
+
 tasks.withType(JavaCompile) {
   options.compilerArgs += ["--release", targetCompatibility.toString()]
   options.encoding = "UTF-8"

--- a/doc-tools/missing-doclet/build.gradle
+++ b/doc-tools/missing-doclet/build.gradle
@@ -5,14 +5,6 @@ plugins {
 group 'org.opensearch'
 version '1.0.0-SNAPSHOT'
 
-repositories {
-    mavenCentral()
-}
-
-dependencies {
-  implementation "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:1.0.2.Final"
-}
-
 tasks.withType(JavaCompile) {
   options.compilerArgs += ["--release", targetCompatibility.toString()]
   options.encoding = "UTF-8"

--- a/doc-tools/missing-doclet/src/main/java/org/opensearch/missingdoclet/MissingDoclet.java
+++ b/doc-tools/missing-doclet/src/main/java/org/opensearch/missingdoclet/MissingDoclet.java
@@ -309,6 +309,11 @@ public class MissingDoclet extends StandardDoclet {
         if (ignored.contains(elementStr)) {
             return;
         }
+
+        if (element.getAnnotation(javax.annotation.Generated.class) != null) {
+            return;
+        }
+
         var tree = docTrees.getDocCommentTree(element);
         if (tree == null || tree.getFirstSentence().isEmpty()) {
             // Check for methods that override other stuff and perhaps inherit their Javadocs.

--- a/doc-tools/missing-doclet/src/main/java/org/opensearch/missingdoclet/MissingDoclet.java
+++ b/doc-tools/missing-doclet/src/main/java/org/opensearch/missingdoclet/MissingDoclet.java
@@ -60,11 +60,9 @@ public class MissingDoclet extends StandardDoclet {
     private static final int METHOD = 2;
     // checks that @param tags are present for any method/constructor parameters
     private static final int PARAMETER = 3;
-    private static final Set<String> ALLOWED_TO_BE_IGNORED = new HashSet<>();
-    static {
-        // TODO Should we stick this list in missing-javadoc.gradle instead?
-        ALLOWED_TO_BE_IGNORED.add("org.opensearch.extensions.proto");
-    }
+    // TODO Should we stick this list in missing-javadoc.gradle instead?
+    private static final Set<String> ALLOWED_TO_BE_IGNORED = new HashSet<>(List.of(
+        "org.opensearch.extensions.proto"));
     int level = PARAMETER;
     Reporter reporter;
     DocletEnvironment docEnv;

--- a/doc-tools/missing-doclet/src/main/java/org/opensearch/missingdoclet/MissingDoclet.java
+++ b/doc-tools/missing-doclet/src/main/java/org/opensearch/missingdoclet/MissingDoclet.java
@@ -70,8 +70,8 @@ public class MissingDoclet extends StandardDoclet {
     DocletEnvironment docEnv;
     DocTrees docTrees;
     Elements elementUtils;
-    Set<String> ignored = Collections.emptySet();
-    Set<String> ignoredGroups = Collections.emptySet();
+    Set<String> ignored = new HashSet<>();
+    Set<String> ignoredGroups = new HashSet<>();
     Set<String> methodPackages = Collections.emptySet();
 
     @Override

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -148,6 +148,7 @@ dependencies {
 
   // protobuf
   api "com.google.protobuf:protobuf-java:${versions.protobuf}"
+  implementation "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:${versions.jboss_annotation}"
 
   testImplementation(project(":test:framework")) {
     // tests use the locally compiled version of server
@@ -176,6 +177,7 @@ tasks.named("forbiddenPatterns").configure {
     exclude '**/*.dic'
     exclude '**/*.binary'
     exclude '**/*.st'
+    exclude '**/*.meta'
 }
 
 tasks.named("testingConventions").configure {
@@ -220,6 +222,16 @@ def generatePluginsList = tasks.register("generatePluginsList") {
 protobuf {
   protoc {
     artifact = "com.google.protobuf:protoc:${versions.protobuf}"
+  }
+
+  generateProtoTasks {
+    all().each { task ->
+      task.builtins {
+        java {
+          option "annotate_code"
+        }
+      }
+    }
   }
 }
 
@@ -353,17 +365,8 @@ tasks.named("missingJavadoc").configure {
    */
   dependsOn("generateProto")
   javadocMissingIgnore = [
-    "org.opensearch.extensions.proto.ExtensionIdentityProto",
-    "org.opensearch.extensions.proto.ExtensionIdentityProto.ExtensionIdentityOrBuilder",
-    "org.opensearch.extensions.proto.RegisterRestActionsProto",
-    "org.opensearch.extensions.proto.RegisterRestActionsProto.RegisterRestActionsOrBuilder",
-    "org.opensearch.extensions.proto.ExtensionRequestProto",
-    "org.opensearch.extensions.proto.ExtensionRequestProto.ExtensionRequestOrBuilder",
-    "org.opensearch.extensions.proto.RegisterTransportActionsProto",
-    "org.opensearch.extensions.proto.RegisterTransportActionsProto.RegisterTransportActionsOrBuilder",
-    "org.opensearch.extensions.proto.ExtensionTransportMessageProto",
-    "org.opensearch.extensions.proto.ExtensionTransportMessageProto.ExtensionTransportMessageOrBuilder",
-    "org.opensearch.extensions.proto"
+    "org.opensearch.extensions.proto",
+    "org.opensearch.extensions.proto.*"
   ]
 }
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -356,20 +356,6 @@ tasks.named("dependencyLicenses").configure {
     }
 }
 
-tasks.named("missingJavadoc").configure {
-  /*
-   * Generated code doesn't follow javadocs formats.
-   * Unfortunately the missingJavadoc task doesnt take *.
-   * TODO: Add support to missingJavadoc task to ignore all generated source code
-   *  https://github.com/opensearch-project/OpenSearch/issues/7264
-   */
-  dependsOn("generateProto")
-  javadocMissingIgnore = [
-    // Packages containing only generated classes annotated with @javax.annotation.Generated
-    // do not need to be listed here as they are ignored in code.
-  ]
-}
-
 tasks.named("filepermissions").configure {
   mustRunAfter("generateProto")
 }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -365,8 +365,8 @@ tasks.named("missingJavadoc").configure {
    */
   dependsOn("generateProto")
   javadocMissingIgnore = [
-    "org.opensearch.extensions.proto",
-    "org.opensearch.extensions.proto.*"
+    // Packages containing only generated classes annotated with @javax.annotation.Generated
+    // do not need to be listed here as they are ignored in code.
   ]
 }
 

--- a/server/licenses/jboss-annotations-api_1.2_spec-1.0.2.Final.jar.sha1
+++ b/server/licenses/jboss-annotations-api_1.2_spec-1.0.2.Final.jar.sha1
@@ -1,0 +1,1 @@
+0d6b20c0e95c5b38f313cc2ab1a55560cedabe1f

--- a/server/licenses/jboss-annotations-api_1.2_spec-LICENSE.txt
+++ b/server/licenses/jboss-annotations-api_1.2_spec-LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/server/licenses/jboss-annotations-api_1.2_spec-NOTICE.txt
+++ b/server/licenses/jboss-annotations-api_1.2_spec-NOTICE.txt
@@ -1,0 +1,12 @@
+OpenSearch (https://opensearch.org/)
+Copyright OpenSearch Contributors
+
+This product includes software developed by
+Elasticsearch (http://www.elastic.co).
+Copyright 2009-2018 Elasticsearch
+
+This product includes software developed by The Apache Software
+Foundation (http://www.apache.org/).
+
+This product includes software developed by
+Joda.org (http://www.joda.org/).


### PR DESCRIPTION
It can be tedious and error prone to have to specify individual source files of generated code that does not follow OpenSearch standards.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Allow wildcard expressions in missingJavadoc.

### Related Issues
Resolves #7264 
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x ] Commits are signed per the DCO using --signoff
- [ x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
