### PR TITLE
[Backport] [2.x] Bump org.apache.commons:commons-compress from 1.22 to 1.23.0 (#7563)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `com.google.cloud:google-cloud-core-http` from 1.93.3 to 2.17.0 (#7488)
 - Bump `com.google.guava:guava` from 30.1.1-jre to 31.1-jre (#7565)
 - Bump `com.azure:azure-storage-common` from 12.20.0 to 12.21.0 (#7566)
+- Bump `org.apache.commons:commons-compress` from 1.22 to 1.23.0 (#7563)
 
 ### Changed
 - Enable `./gradlew build` on MacOS by disabling bcw tests ([#7303](https://github.com/opensearch-project/OpenSearch/pull/7303))

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -103,7 +103,7 @@ dependencies {
   api localGroovy()
 
   api 'commons-codec:commons-codec:1.15'
-  api 'org.apache.commons:commons-compress:1.22'
+  api 'org.apache.commons:commons-compress:1.23.0'
   api 'org.apache.ant:ant:1.10.13'
   api 'com.netflix.nebula:gradle-extra-configurations-plugin:9.0.0'
   api 'com.netflix.nebula:nebula-publishing-plugin:20.3.0'


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/7563 to `2.x`