### PR TITLE
Fix version check for search pipelines REST test

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search_pipeline/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search_pipeline/10_basic.yml
@@ -1,7 +1,7 @@
 ---
 "Test basic pipeline crud":
   - skip:
-      version: " - 2.7.0"
+      version: " - 2.6.99"
       reason: "Added in 2.7.0"
   - do:
       search_pipeline.put:
@@ -32,7 +32,7 @@
 ---
 "Test Put Versioned Pipeline":
   - skip:
-      version: " - 2.7.0"
+      version: " - 2.6.99"
       reason: "Added in 2.7.0"
   - do:
       search_pipeline.put:
@@ -125,7 +125,7 @@
 ---
 "Test Get All Pipelines":
   - skip:
-      version: " - 2.7.0"
+      version: " - 2.6.99"
       reason: "Added in 2.7.0"
   - do:
       search_pipeline.put:
@@ -152,7 +152,7 @@
 ---
 "Test invalid config":
   - skip:
-      version: " - 2.7.0"
+      version: " - 2.6.99"
       reason: "Added in 2.7.0"
   - do:
       catch: /parse_exception/


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
As @reta pointed out, these tests should be skipped for versions less than 2.7.0, but the skip version ranges are inclusive. So, the upper bound of the range should be 2.6.99.

This brings a change made for
https://github.com/opensearch-project/OpenSearch/pull/7589 onto the main branch.

### Related Issues
Related to https://github.com/opensearch-project/OpenSearch/pull/7589

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
