### PR TITLE
Fix flaky org.opensearch.common.xcontent.XContentParserTests.testString test case

### DIFF
--- a/libs/x-content/src/test/java/org/opensearch/common/xcontent/XContentParserTests.java
+++ b/libs/x-content/src/test/java/org/opensearch/common/xcontent/XContentParserTests.java
@@ -80,7 +80,7 @@ public class XContentParserTests extends OpenSearchTestCase {
         () -> randomAlphaOfLengthBetween(1, SmileXContent.DEFAULT_MAX_STRING_LEN),
         /* YAML parser limitation */
         XContentType.YAML,
-        () -> randomRealisticUnicodeOfCodepointLengthBetween(1, 3140000)
+        () -> randomAlphaOfLengthBetween(1, 3140000)
     );
 
     private static final Map<XContentType, Supplier<String>> OFF_LIMIT_GENERATORS = Map.of(


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fix flaky org.opensearch.common.xcontent.XContentParserTests.testString test case

```
com.fasterxml.jackson.dataformat.yaml.JacksonYAMLParseException: The incoming YAML document exceeds the limit: 3145728 code points.
 at [Source: (byte[])"---
yaMBb: "㾘䲙䞆䮪㵺㽮㣭䟋㚾㨻㼃㓷㭛䎭䲤䍉䖻䇸䡁㟯䢂䄺㩰䏠㝯䟫㤩䦗䛎䥽㫼㔲䨞䦀䀇㮩䌒㢇䝩㣝㦹䩇㠛㷡㠐䮈㟪㜵䰈䕉㦕㦣㒷㭻㞾㲁䦔㿪㜗䚇㷧㥃䶢䁅䛸䤕䦘䏣䵚㮶㷔㙶䕼䬜\
  䊹䞠䰧䧨䏉㒤㞆䊶㰿䪵䡆䪗䗳䖴㓗㒄䗌䙫㴇䑞䌃䂩㐄䀓䐤䰸䂫㧼㘗䈜䔦㡬㚋㓒䟄䫨㮷䩐㡎䵾䏈㟜㦺䙪㦹㨔㩨䄚䒂䫷䍺䴈㻥䊵䑅㯚㚏䂲㿽㟵䎃䗃㜥㕿䓤䔈㫋㼟䮳䒓㦗䚉䟾䤼䩻㙟㬣䕔䵞㟦\
  㑉䐫㪢䟦㸏䄷"[truncated 9568407 bytes]; line: 39218, column: 73]

```

### Related Issues
Resolves #[7615]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
