### PR TITLE
Update SearchPipelineInfo backcompat check

### DIFF
--- a/server/src/main/java/org/opensearch/search/pipeline/SearchPipelineInfo.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/SearchPipelineInfo.java
@@ -43,8 +43,7 @@ public class SearchPipelineInfo implements ReportingService.Info {
      * Read from a stream.
      */
     public SearchPipelineInfo(StreamInput in) throws IOException {
-        // TODO: When we backport this to 2.8, we must change this condition to out.getVersion().before(V_2_8_0)
-        if (in.getVersion().onOrBefore(Version.V_2_8_0)) {
+        if (in.getVersion().before(Version.V_2_8_0)) {
             // Prior to version 2.8, we had a flat list of processors. For best compatibility, assume they're valid
             // request and response processor, since we couldn't tell the difference back then.
             final int size = in.readVInt();
@@ -84,8 +83,7 @@ public class SearchPipelineInfo implements ReportingService.Info {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        // TODO: When we backport this to 2.8, we must change this condition to out.getVersion().before(V_2_8_0)
-        if (out.getVersion().onOrBefore(Version.V_2_8_0)) {
+        if (out.getVersion().before(Version.V_2_8_0)) {
             // Prior to version 2.8, we grouped all processors into a single list.
             Set<ProcessorInfo> processorInfos = new TreeSet<>();
             processorInfos.addAll(processors.getOrDefault(Pipeline.REQUEST_PROCESSORS_KEY, Collections.emptySet()));


### PR DESCRIPTION
### Description
Now that we've backported the SearchPipelineInfo serialization change to 2.x ahead of the 2.8 release, we need to update the compatibility check from <=2.8 to <2.8, as mentioned in the previous TODO (see https://github.com/opensearch-project/OpenSearch/pull/7597).

This change should be merged (immediately) after
https://github.com/opensearch-project/OpenSearch/pull/7669.

### Related Issues
Follows from https://github.com/opensearch-project/OpenSearch/pull/7597 and https://github.com/opensearch-project/OpenSearch/pull/7669.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
