### PR TITLE
[Remote Store] Deletion of Remote Segments and Translog upon Index Deletion

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/index/shard/GlobalCheckpointListenersIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/shard/GlobalCheckpointListenersIT.java
@@ -126,7 +126,7 @@ public class GlobalCheckpointListenersIT extends OpenSearchSingleNodeTestCase {
             }
 
         }, null);
-        shard.close("closed", randomBoolean());
+        shard.close("closed", randomBoolean(), false);
         assertBusy(() -> assertTrue(invoked.get()));
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/index/shard/IndexShardIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/shard/IndexShardIT.java
@@ -620,7 +620,7 @@ public class IndexShardIT extends OpenSearchSingleNodeTestCase {
         client().prepareIndex("test").setId("1").setSource("{\"foo\" : \"bar\"}", XContentType.JSON).setRefreshPolicy(IMMEDIATE).get();
 
         CheckedFunction<DirectoryReader, DirectoryReader, IOException> wrapper = directoryReader -> directoryReader;
-        shard.close("simon says", false);
+        shard.close("simon says", false, false);
         AtomicReference<IndexShard> shardRef = new AtomicReference<>();
         List<Exception> failures = new ArrayList<>();
         IndexingOperationListener listener = new IndexingOperationListener() {
@@ -658,7 +658,7 @@ public class IndexShardIT extends OpenSearchSingleNodeTestCase {
         try {
             ExceptionsHelper.rethrowAndSuppress(failures);
         } finally {
-            newShard.close("just do it", randomBoolean());
+            newShard.close("just do it", randomBoolean(), false);
         }
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
@@ -263,7 +263,11 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
         assertTrue(getFileCount(indexPath) > 0);
         assertAcked(client().admin().indices().delete(new DeleteIndexRequest(INDEX_NAME)).get());
         // Delete is async. Give time for it
-        assertBusy(() -> { assertThat(getFileCount(indexPath), comparesEqualTo(0)); }, 30, TimeUnit.SECONDS);
+        assertBusy(() -> {
+            try {
+                assertThat(getFileCount(indexPath), comparesEqualTo(0));
+            } catch (Exception e) {}
+        }, 30, TimeUnit.SECONDS);
     }
 
     public void testRemoteSegmentCleanup() throws Exception {

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
@@ -9,6 +9,7 @@
 package org.opensearch.remotestore;
 
 import org.opensearch.action.admin.cluster.remotestore.restore.RestoreRemoteStoreRequest;
+import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.opensearch.action.admin.indices.recovery.RecoveryResponse;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.PlainActionFuture;
@@ -23,6 +24,7 @@ import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.transport.MockTransportService;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -30,6 +32,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+import static org.hamcrest.Matchers.comparesEqualTo;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
 
@@ -240,5 +243,34 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
 
     public void testPeerRecoveryWithRemoteStoreAndRemoteTranslogRefresh() throws Exception {
         testPeerRecovery(true, randomIntBetween(2, 5), false);
+    }
+
+    private void verifyRemoteStoreCleanup(boolean remoteTranslog) throws Exception {
+        internalCluster().startDataOnlyNodes(3);
+        if (remoteTranslog) {
+            createIndex(INDEX_NAME, remoteTranslogIndexSettings(1));
+        } else {
+            createIndex(INDEX_NAME, remoteStoreIndexSettings(1));
+        }
+
+        indexData(5, randomBoolean());
+        String indexUUID = client().admin()
+            .indices()
+            .prepareGetSettings(INDEX_NAME)
+            .get()
+            .getSetting(INDEX_NAME, IndexMetadata.SETTING_INDEX_UUID);
+        Path indexPath = Path.of(String.valueOf(absolutePath), indexUUID);
+        assertTrue(getFileCount(indexPath) > 0);
+        assertAcked(client().admin().indices().delete(new DeleteIndexRequest(INDEX_NAME)).get());
+        // Delete is async. Give time for it
+        assertBusy(() -> { assertThat(getFileCount(indexPath), comparesEqualTo(0)); }, 30, TimeUnit.SECONDS);
+    }
+
+    public void testRemoteSegmentCleanup() throws Exception {
+        verifyRemoteStoreCleanup(false);
+    }
+
+    public void testRemoteTranslogCleanup() throws Exception {
+        verifyRemoteStoreCleanup(true);
     }
 }

--- a/server/src/main/java/org/opensearch/index/IndexService.java
+++ b/server/src/main/java/org/opensearch/index/IndexService.java
@@ -616,7 +616,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                     try {
                         // only flush if we are closed (closed index or shutdown) and if we are not deleted
                         final boolean flushEngine = deleted.get() == false && closed.get();
-                        indexShard.close(reason, flushEngine);
+                        indexShard.close(reason, flushEngine, deleted.get());
                     } catch (Exception e) {
                         logger.debug(() -> new ParameterizedMessage("[{}] failed to close index shard", shardId), e);
                         // ignore

--- a/server/src/main/java/org/opensearch/index/IndexService.java
+++ b/server/src/main/java/org/opensearch/index/IndexService.java
@@ -603,6 +603,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
     private void closeShard(String reason, ShardId sId, IndexShard indexShard, Store store, IndexEventListener listener) {
         final int shardId = sId.id();
         final Settings indexSettings = this.getIndexSettings().getSettings();
+        Store remoteStore = indexShard.remoteStore();
         if (store != null) {
             store.beforeClose();
         }
@@ -632,6 +633,11 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                 } else {
                     logger.trace("[{}] store not initialized prior to closing shard, nothing to close", shardId);
                 }
+
+                if (remoteStore != null && indexShard.isPrimaryMode() && deleted.get()) {
+                    remoteStore.close();
+                }
+
             } catch (Exception e) {
                 logger.warn(
                     () -> new ParameterizedMessage("[{}] failed to close store on shard removal (reason: [{}])", shardId, reason),

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1918,7 +1918,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     }
 
     private RemoteSegmentStoreDirectory getRemoteDirectory() {
-        assert isRemoteStoreEnabled();
+        assert indexSettings.isRemoteStoreEnabled();
         assert remoteStore.directory() instanceof FilterDirectory : "Store.directory is not an instance of FilterDirectory";
         FilterDirectory remoteStoreDirectory = (FilterDirectory) remoteStore.directory();
         FilterDirectory byteSizeCachingStoreDirectory = (FilterDirectory) remoteStoreDirectory.getDelegate();

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1906,7 +1906,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                         remoteDirectory.deleteIfEmpty();
                     }
 
-                    if (engine != null) {
+                    if (deleted && engine != null) {
                         // Translog Clean up
                         engine.translogManager().onDelete();
                     }

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1905,8 +1905,12 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                         remoteDirectory.deleteStaleSegments(0);
                         remoteDirectory.deleteIfEmpty();
                     }
-                    // Translog Clean up
-                    engine.translogManager().onDelete();
+
+                    if (engine != null) {
+                        // Translog Clean up
+                        engine.translogManager().onDelete();
+                    }
+
                     indexShardOperationPermits.close();
                 }
             }

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1899,7 +1899,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                     // Also closing refreshListeners to prevent us from accumulating any more listeners
                     IOUtils.close(engine, globalCheckpointListeners, refreshListeners, pendingReplicationActions);
 
-                    if (deleted && engine != null) {
+                    if (deleted && engine != null && isPrimaryMode()) {
                         // Translog Clean up
                         engine.translogManager().onDelete();
                     }

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1899,13 +1899,6 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                     // Also closing refreshListeners to prevent us from accumulating any more listeners
                     IOUtils.close(engine, globalCheckpointListeners, refreshListeners, pendingReplicationActions);
 
-                    // Remote Segment Store Cleanup
-                    if (deleted && isPrimaryMode() && isRemoteStoreEnabled()) {
-                        RemoteSegmentStoreDirectory remoteDirectory = getRemoteDirectory();
-                        remoteDirectory.deleteStaleSegments(0);
-                        remoteDirectory.deleteIfEmpty();
-                    }
-
                     if (deleted && engine != null) {
                         // Translog Clean up
                         engine.translogManager().onDelete();
@@ -1917,6 +1910,9 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         }
     }
 
+    /*
+    ToDo : Fix this https://github.com/opensearch-project/OpenSearch/issues/8003
+     */
     private RemoteSegmentStoreDirectory getRemoteDirectory() {
         assert indexSettings.isRemoteStoreEnabled();
         assert remoteStore.directory() instanceof FilterDirectory : "Store.directory is not an instance of FilterDirectory";

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1882,7 +1882,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
 
     }
 
-    public void close(String reason, boolean flushEngine) throws IOException {
+    public void close(String reason, boolean flushEngine, boolean deleted) throws IOException {
         synchronized (engineMutex) {
             try {
                 synchronized (mutex) {
@@ -1890,16 +1890,6 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                 }
             } finally {
                 final Engine engine = this.currentEngineReference.getAndSet(null);
-                engine.translogManager().onDelete();
-                if (isRemoteStoreEnabled()) {
-                    assert remoteStore.directory() instanceof FilterDirectory : "Store.directory is not an instance of FilterDirectory";
-                    FilterDirectory remoteStoreDirectory = (FilterDirectory) remoteStore.directory();
-                    FilterDirectory byteSizeCachingStoreDirectory = (FilterDirectory) remoteStoreDirectory.getDelegate();
-                    final Directory remoteDirectory = byteSizeCachingStoreDirectory.getDelegate();
-                    ((RemoteSegmentStoreDirectory) remoteDirectory).deleteStaleSegments(0);
-                    //who deletes the directory ?
-                }
-
                 try {
                     if (engine != null && flushEngine) {
                         engine.flushAndClose();
@@ -1908,11 +1898,28 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                     // playing safe here and close the engine even if the above succeeds - close can be called multiple times
                     // Also closing refreshListeners to prevent us from accumulating any more listeners
                     IOUtils.close(engine, globalCheckpointListeners, refreshListeners, pendingReplicationActions);
-                    indexShardOperationPermits.close();
 
+                    // Remote Segment Store and Remote Translog Cleanup
+                    if (deleted && isPrimaryMode() && isRemoteStoreEnabled()) {
+                        RemoteSegmentStoreDirectory remoteDirectory = getRemoteDirectory();
+                        remoteDirectory.deleteStaleSegments(0);
+                        remoteDirectory.deleteIfEmpty();
+                        // Translog Clean up
+                        engine.translogManager().onDelete();
+                    }
+                    indexShardOperationPermits.close();
                 }
             }
         }
+    }
+
+    private RemoteSegmentStoreDirectory getRemoteDirectory() {
+        assert isRemoteStoreEnabled();
+        assert remoteStore.directory() instanceof FilterDirectory : "Store.directory is not an instance of FilterDirectory";
+        FilterDirectory remoteStoreDirectory = (FilterDirectory) remoteStore.directory();
+        FilterDirectory byteSizeCachingStoreDirectory = (FilterDirectory) remoteStoreDirectory.getDelegate();
+        final Directory remoteDirectory = byteSizeCachingStoreDirectory.getDelegate();
+        return ((RemoteSegmentStoreDirectory) remoteDirectory);
     }
 
     public void preRecovery() {
@@ -4531,16 +4538,10 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         throws IOException {
         assert indexSettings.isRemoteStoreEnabled();
         logger.info("Downloading segments from remote segment store");
-        assert remoteStore.directory() instanceof FilterDirectory : "Store.directory is not an instance of FilterDirectory";
-        FilterDirectory remoteStoreDirectory = (FilterDirectory) remoteStore.directory();
-        assert remoteStoreDirectory.getDelegate() instanceof FilterDirectory
-            : "Store.directory is not enclosing an instance of FilterDirectory";
-        FilterDirectory byteSizeCachingStoreDirectory = (FilterDirectory) remoteStoreDirectory.getDelegate();
-        final Directory remoteDirectory = byteSizeCachingStoreDirectory.getDelegate();
+        RemoteSegmentStoreDirectory remoteDirectory = getRemoteDirectory();
         // We need to call RemoteSegmentStoreDirectory.init() in order to get latest metadata of the files that
         // are uploaded to the remote segment store.
-        assert remoteDirectory instanceof RemoteSegmentStoreDirectory : "remoteDirectory is not an instance of RemoteSegmentStoreDirectory";
-        RemoteSegmentMetadata remoteSegmentMetadata = ((RemoteSegmentStoreDirectory) remoteDirectory).init();
+        RemoteSegmentMetadata remoteSegmentMetadata =  remoteDirectory.init();
         Map<String, RemoteSegmentStoreDirectory.UploadedSegmentMetadata> uploadedSegments = ((RemoteSegmentStoreDirectory) remoteDirectory)
             .getSegmentsUploadedToRemoteStore();
         store.incRef();

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1899,14 +1899,14 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                     // Also closing refreshListeners to prevent us from accumulating any more listeners
                     IOUtils.close(engine, globalCheckpointListeners, refreshListeners, pendingReplicationActions);
 
-                    // Remote Segment Store and Remote Translog Cleanup
+                    // Remote Segment Store Cleanup
                     if (deleted && isPrimaryMode() && isRemoteStoreEnabled()) {
                         RemoteSegmentStoreDirectory remoteDirectory = getRemoteDirectory();
                         remoteDirectory.deleteStaleSegments(0);
                         remoteDirectory.deleteIfEmpty();
-                        // Translog Clean up
-                        engine.translogManager().onDelete();
                     }
+                    // Translog Clean up
+                    engine.translogManager().onDelete();
                     indexShardOperationPermits.close();
                 }
             }

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -4545,7 +4545,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         RemoteSegmentStoreDirectory remoteDirectory = getRemoteDirectory();
         // We need to call RemoteSegmentStoreDirectory.init() in order to get latest metadata of the files that
         // are uploaded to the remote segment store.
-        RemoteSegmentMetadata remoteSegmentMetadata =  remoteDirectory.init();
+        RemoteSegmentMetadata remoteSegmentMetadata = remoteDirectory.init();
         Map<String, RemoteSegmentStoreDirectory.UploadedSegmentMetadata> uploadedSegments = ((RemoteSegmentStoreDirectory) remoteDirectory)
             .getSegmentsUploadedToRemoteStore();
         store.incRef();

--- a/server/src/main/java/org/opensearch/index/store/RemoteDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteDirectory.java
@@ -210,4 +210,8 @@ public class RemoteDirectory extends Directory {
     public Lock obtainLock(String name) throws IOException {
         throw new UnsupportedOperationException();
     }
+
+    public void delete() throws IOException {
+        blobContainer.delete();
+    }
 }

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -618,18 +618,26 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
         }
     }
 
-    public void delete() throws IOException {
+    /*
+    Tries to delete shard level directory if it is empty
+    Return true if it deleted it successfully
+     */
+    public boolean deleteIfEmpty() throws IOException {
         Collection<String> metadataFiles = remoteMetadataDirectory.listFilesByPrefix(MetadataFilenameUtils.METADATA_PREFIX);
         if (metadataFiles.size() != 0) {
             logger.info("Remote directory still has files , not deleting the path");
-            return;
+            return false;
         }
+
         try {
             remoteDataDirectory.delete();
             remoteMetadataDirectory.delete();
-            // ToDo : clean up the lock directory as well
+            mdLockManager.delete();
         } catch (Exception e) {
-            logger.error("Exception occurred while deleting directory {}", e);
+            logger.error("Exception occurred while deleting directory", e);
+            return false;
         }
+
+        return true;
     }
 }

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -622,7 +622,7 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
     Tries to delete shard level directory if it is empty
     Return true if it deleted it successfully
      */
-    public boolean deleteIfEmpty() throws IOException {
+    private boolean deleteIfEmpty() throws IOException {
         Collection<String> metadataFiles = remoteMetadataDirectory.listFilesByPrefix(MetadataFilenameUtils.METADATA_PREFIX);
         if (metadataFiles.size() != 0) {
             logger.info("Remote directory still has files , not deleting the path");
@@ -639,5 +639,10 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
         }
 
         return true;
+    }
+
+    public void close() throws IOException {
+        deleteStaleSegments(0);
+        deleteIfEmpty();
     }
 }

--- a/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreLockManager.java
+++ b/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreLockManager.java
@@ -22,7 +22,7 @@ public interface RemoteStoreLockManager {
      * @param lockInfo lock info instance for which we need to acquire lock.
      * @throws IOException throws exception in case there is a problem with acquiring lock.
      */
-    public void acquire(LockInfo lockInfo) throws IOException;
+    void acquire(LockInfo lockInfo) throws IOException;
 
     /**
      *
@@ -38,4 +38,9 @@ public interface RemoteStoreLockManager {
      * @throws IOException throws exception in case there is a problem in checking if a given file is locked or not.
      */
     Boolean isAcquired(LockInfo lockInfo) throws IOException;
+
+    /*
+    Deletes all lock related files and directories
+     */
+    void delete() throws IOException;
 }

--- a/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreMetadataLockManager.java
+++ b/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreMetadataLockManager.java
@@ -83,4 +83,8 @@ public class RemoteStoreMetadataLockManager implements RemoteStoreLockManager {
         Collection<String> lockFiles = lockDirectory.listFilesByPrefix(((FileLockInfo) lockInfo).getLockPrefix());
         return !lockFiles.isEmpty();
     }
+
+    public void delete() throws IOException {
+        lockDirectory.delete();
+    }
 }

--- a/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
@@ -296,7 +296,9 @@ public class InternalTranslogManager implements TranslogManager, Closeable {
         translog.setMinSeqNoToKeep(seqNo);
     }
 
-    public void onDelete() { translog.onDelete(); }
+    public void onDelete() {
+        translog.onDelete();
+    }
 
     /**
      * Reads operations from the translog

--- a/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
@@ -296,6 +296,8 @@ public class InternalTranslogManager implements TranslogManager, Closeable {
         translog.setMinSeqNoToKeep(seqNo);
     }
 
+    public void onDelete() { translog.onDelete(); }
+
     /**
      * Reads operations from the translog
      * @param location location of translog

--- a/server/src/main/java/org/opensearch/index/translog/NoOpTranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/NoOpTranslogManager.java
@@ -121,5 +121,5 @@ public class NoOpTranslogManager implements TranslogManager {
         throw new UnsupportedOperationException("Translog snapshot unsupported with no-op translogs");
     }
 
-    public void onDelete() { }
+    public void onDelete() {}
 }

--- a/server/src/main/java/org/opensearch/index/translog/NoOpTranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/NoOpTranslogManager.java
@@ -120,4 +120,6 @@ public class NoOpTranslogManager implements TranslogManager {
     public Translog.Snapshot newChangesSnapshot(long fromSeqNo, long toSeqNo, boolean requiredFullRange) throws IOException {
         throw new UnsupportedOperationException("Translog snapshot unsupported with no-op translogs");
     }
+
+    public void onDelete() { }
 }

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -423,7 +423,7 @@ public class RemoteFsTranslog extends Translog {
         }
     }
 
-    protected void onDelete()  {
+    protected void onDelete() {
         // clean up all remote translog files
         translogTransferManager.delete();
     }

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -422,4 +422,9 @@ public class RemoteFsTranslog extends Translog {
             translogTransferManager.deleteStaleTranslogMetadataFilesAsync();
         }
     }
+
+    protected void onDelete()  {
+        // clean up all remote translog files
+        translogTransferManager.delete();
+    }
 }

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -424,6 +424,11 @@ public class RemoteFsTranslog extends Translog {
     }
 
     protected void onDelete() {
+        if (primaryModeSupplier.getAsBoolean() == false) {
+            logger.trace("skipped delete translog");
+            // NO-OP
+            return ;
+        }
         // clean up all remote translog files
         translogTransferManager.delete();
     }

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -427,7 +427,7 @@ public class RemoteFsTranslog extends Translog {
         if (primaryModeSupplier.getAsBoolean() == false) {
             logger.trace("skipped delete translog");
             // NO-OP
-            return ;
+            return;
         }
         // clean up all remote translog files
         translogTransferManager.delete();

--- a/server/src/main/java/org/opensearch/index/translog/Translog.java
+++ b/server/src/main/java/org/opensearch/index/translog/Translog.java
@@ -1807,6 +1807,8 @@ public abstract class Translog extends AbstractIndexShardComponent implements In
      */
     protected void setMinSeqNoToKeep(long seqNo) {}
 
+    protected void onDelete() {}
+
     /**
      * deletes all files associated with a reader. package-private to be able to simulate node failures at this point
      */

--- a/server/src/main/java/org/opensearch/index/translog/TranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/TranslogManager.java
@@ -126,4 +126,9 @@ public interface TranslogManager {
      * This might be required when segments are persisted via other mechanism than flush.
      */
     void setMinSeqNoToKeep(long seqNo);
+
+    /*
+    Clean up if any needed on deletion of index
+     */
+    void onDelete();
 }

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
@@ -325,22 +325,18 @@ public class TranslogTransferManager {
     }
 
     public void delete() {
-        // cleans up all the translog contents
-        transferService.deleteAsync(
-            ThreadPool.Names.REMOTE_PURGE,
-            remoteBaseTransferPath,
-            new ActionListener<>() {
-                @Override
-                public void onResponse(Void unused) {
-                    logger.info("Deleted all remote translog data  for {}",  shardId);
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    logger.error(new ParameterizedMessage("Exception occurred while cleaning translog {}"), e);
-                }
+        // cleans up all the translog contents in async fashion
+        transferService.deleteAsync(ThreadPool.Names.REMOTE_PURGE, remoteBaseTransferPath, new ActionListener<>() {
+            @Override
+            public void onResponse(Void unused) {
+                logger.info("Deleted all remote translog data  for {}", shardId);
             }
-        );
+
+            @Override
+            public void onFailure(Exception e) {
+                logger.error("Exception occurred while cleaning translog ", e);
+            }
+        });
     }
 
     public void deleteStaleTranslogMetadataFilesAsync() {

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
@@ -56,6 +56,7 @@ public class TranslogTransferManager {
     private final TransferService transferService;
     private final BlobPath remoteDataTransferPath;
     private final BlobPath remoteMetadataTransferPath;
+    private final BlobPath remoteBaseTransferPath;
     private final FileTransferTracker fileTransferTracker;
 
     private static final long TRANSFER_TIMEOUT_IN_MILLIS = 30000;
@@ -74,13 +75,14 @@ public class TranslogTransferManager {
     public TranslogTransferManager(
         ShardId shardId,
         TransferService transferService,
-        BlobPath remoteDataTransferPath,
+        BlobPath remoteBaseTransferPath,
         FileTransferTracker fileTransferTracker
     ) {
         this.shardId = shardId;
         this.transferService = transferService;
-        this.remoteDataTransferPath = remoteDataTransferPath.add(DATA_DIR);
-        this.remoteMetadataTransferPath = remoteDataTransferPath.add(METADATA_DIR);
+        this.remoteBaseTransferPath = remoteBaseTransferPath;
+        this.remoteDataTransferPath = remoteBaseTransferPath.add(DATA_DIR);
+        this.remoteMetadataTransferPath = remoteBaseTransferPath.add(METADATA_DIR);
         this.fileTransferTracker = fileTransferTracker;
     }
 

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
@@ -324,6 +324,25 @@ public class TranslogTransferManager {
         );
     }
 
+    public void delete() {
+        // cleans up all the translog contents
+        transferService.deleteAsync(
+            ThreadPool.Names.REMOTE_PURGE,
+            remoteBaseTransferPath,
+            new ActionListener<>() {
+                @Override
+                public void onResponse(Void unused) {
+                    logger.info("Deleted all remote translog data  for {}",  shardId);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    logger.error(new ParameterizedMessage("Exception occurred while cleaning translog {}"), e);
+                }
+            }
+        );
+    }
+
     public void deleteStaleTranslogMetadataFilesAsync() {
         transferService.listAllAsync(ThreadPool.Names.REMOTE_PURGE, remoteMetadataTransferPath, new ActionListener<>() {
             @Override

--- a/server/src/test/java/org/opensearch/index/engine/NoOpEngineRecoveryTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/NoOpEngineRecoveryTests.java
@@ -50,7 +50,7 @@ public class NoOpEngineRecoveryTests extends IndexShardTestCase {
         for (int i = 0; i < nbDocs; i++) {
             indexDoc(indexShard, "_doc", String.valueOf(i));
         }
-        indexShard.close("test", true);
+        indexShard.close("test", true, false);
 
         final ShardRouting shardRouting = indexShard.routingEntry();
         IndexShard primary = reinitShard(

--- a/server/src/test/java/org/opensearch/index/replication/RecoveryDuringReplicationTests.java
+++ b/server/src/test/java/org/opensearch/index/replication/RecoveryDuringReplicationTests.java
@@ -161,10 +161,10 @@ public class RecoveryDuringReplicationTests extends OpenSearchIndexLevelReplicat
                 new SourceToParse("index", "replica", new BytesArray("{}"), XContentType.JSON)
             );
             shards.promoteReplicaToPrimary(promotedReplica).get();
-            oldPrimary.close("demoted", randomBoolean());
+            oldPrimary.close("demoted", randomBoolean(), false);
             oldPrimary.store().close();
             shards.removeReplica(remainingReplica);
-            remainingReplica.close("disconnected", false);
+            remainingReplica.close("disconnected", false, false);
             remainingReplica.store().close();
             // randomly introduce a conflicting document
             final boolean extra = randomBoolean();
@@ -289,7 +289,7 @@ public class RecoveryDuringReplicationTests extends OpenSearchIndexLevelReplicat
                 newPrimary.flush(new FlushRequest());
             }
 
-            oldPrimary.close("demoted", false);
+            oldPrimary.close("demoted", false, false);
             oldPrimary.store().close();
 
             IndexShard newReplica = shards.addReplicaWithExistingPath(oldPrimary.shardPath(), oldPrimary.routingEntry().currentNodeId());
@@ -335,7 +335,7 @@ public class RecoveryDuringReplicationTests extends OpenSearchIndexLevelReplicat
             shards.promoteReplicaToPrimary(newPrimary).get();
             // Recover a replica should rollback the stale documents
             shards.removeReplica(replica);
-            replica.close("recover replica - first time", false);
+            replica.close("recover replica - first time", false, false);
             replica.store().close();
             replica = shards.addReplicaWithExistingPath(replica.shardPath(), replica.routingEntry().currentNodeId());
             shards.recoverReplica(replica);
@@ -346,7 +346,7 @@ public class RecoveryDuringReplicationTests extends OpenSearchIndexLevelReplicat
             assertThat(replica.getLastSyncedGlobalCheckpoint(), equalTo(replica.seqNoStats().getMaxSeqNo()));
             // Recover a replica again should also rollback the stale documents.
             shards.removeReplica(replica);
-            replica.close("recover replica - second time", false);
+            replica.close("recover replica - second time", false, false);
             replica.store().close();
             IndexShard anotherReplica = shards.addReplicaWithExistingPath(replica.shardPath(), replica.routingEntry().currentNodeId());
             shards.recoverReplica(anotherReplica);

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -291,7 +291,7 @@ public class IndexShardTests extends IndexShardTestCase {
         assertNotNull(shardPath);
         // fail shard
         shard.failShard("test shard fail", new CorruptIndexException("", ""));
-        shard.close("do not assert history", false);
+        shard.close("do not assert history", false, false);
         shard.store().close();
         // check state file still exists
         ShardStateMetadata shardStateMetadata = load(logger, shardPath.getShardStatePath());
@@ -1614,7 +1614,7 @@ public class IndexShardTests extends IndexShardTestCase {
         snapshot = newShard.snapshotStoreMetadata();
         assertThat(snapshot.getSegmentsFile().name(), equalTo("segments_3"));
 
-        newShard.close("test", false);
+        newShard.close("test", false, false);
 
         snapshot = newShard.snapshotStoreMetadata();
         assertThat(snapshot.getSegmentsFile().name(), equalTo("segments_3"));
@@ -1874,7 +1874,7 @@ public class IndexShardTests extends IndexShardTestCase {
         AtomicInteger preDelete = new AtomicInteger();
         AtomicInteger postDelete = new AtomicInteger();
         AtomicInteger postDeleteException = new AtomicInteger();
-        shard.close("simon says", true);
+        shard.close("simon says", true, false);
         shard = reinitShard(shard, new IndexingOperationListener() {
             @Override
             public Engine.Index preIndex(ShardId shardId, Engine.Index operation) {
@@ -1961,7 +1961,7 @@ public class IndexShardTests extends IndexShardTestCase {
         assertEquals(1, postDelete.get());
         assertEquals(0, postDeleteException.get());
 
-        shard.close("Unexpected close", true);
+        shard.close("Unexpected close", true, false);
         shard.state = IndexShardState.STARTED; // It will generate exception
 
         try {
@@ -4362,7 +4362,7 @@ public class IndexShardTests extends IndexShardTestCase {
         Thread closeShardThread = new Thread(() -> {
             try {
                 readyToCloseLatch.await();
-                shard.close("testing", false);
+                shard.close("testing", false, false);
                 // in integration tests, this is done as a listener on IndexService.
                 MockFSDirectoryFactory.checkIndex(logger, shard.store(), shard.shardId);
             } catch (InterruptedException | IOException e) {
@@ -4811,7 +4811,7 @@ public class IndexShardTests extends IndexShardTestCase {
         recoveryThread.start();
         try {
             warmerStarted.await();
-            shard.close("testing", false);
+            shard.close("testing", false, false);
             assertThat(shard.state, equalTo(IndexShardState.CLOSED));
         } finally {
             warmerBlocking.countDown();

--- a/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
@@ -579,7 +579,7 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
             assertEqualCommittedSegments(primary, replica_1);
 
             shards.promoteReplicaToPrimary(replica_2).get();
-            primary.close("demoted", false);
+            primary.close("demoted", false, false);
             primary.store().close();
             IndexShard oldPrimary = shards.addReplicaWithExistingPath(primary.shardPath(), primary.routingEntry().currentNodeId());
             shards.recoverReplica(oldPrimary);
@@ -618,7 +618,7 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
 
                 // randomly resetart a replica
                 final IndexShard replicaToRestart = getRandomReplica(shards);
-                replicaToRestart.close("restart", false);
+                replicaToRestart.close("restart", false, false);
                 replicaToRestart.store().close();
                 shards.removeReplica(replicaToRestart);
                 final IndexShard newReplica = shards.addReplicaWithExistingPath(
@@ -716,7 +716,7 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
             shards.promoteReplicaToPrimary(nextPrimary).get();
 
             // close oldPrimary.
-            oldPrimary.close("demoted", false);
+            oldPrimary.close("demoted", false, false);
             oldPrimary.store().close();
 
             assertEquals(InternalEngine.class, nextPrimary.getEngine().getClass());
@@ -783,7 +783,7 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
             shards.promoteReplicaToPrimary(nextPrimary);
 
             // close and start the oldPrimary as a replica.
-            oldPrimary.close("demoted", false);
+            oldPrimary.close("demoted", false, false);
             oldPrimary.store().close();
             oldPrimary = shards.addReplicaWithExistingPath(oldPrimary.shardPath(), oldPrimary.routingEntry().currentNodeId());
             shards.recoverReplica(oldPrimary);
@@ -866,7 +866,7 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
             assertEquals(nextPrimary.getEngine().getClass(), InternalEngine.class);
             nextPrimary.refresh("test");
 
-            oldPrimary.close("demoted", false);
+            oldPrimary.close("demoted", false, false);
             oldPrimary.store().close();
             IndexShard newReplica = shards.addReplicaWithExistingPath(oldPrimary.shardPath(), oldPrimary.routingEntry().currentNodeId());
             shards.recoverReplica(newReplica);
@@ -1074,7 +1074,7 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
         IndexShard primary = shards.getPrimary();
         final IndexShard newPrimary = getRandomReplica(shards);
         shards.promoteReplicaToPrimary(newPrimary);
-        primary.close("demoted", true);
+        primary.close("demoted", true, false);
         primary.store().close();
         primary = shards.addReplicaWithExistingPath(primary.shardPath(), primary.routingEntry().currentNodeId());
         shards.recoverReplica(primary);

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -84,7 +84,7 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
 
     @After
     public void tearDown() throws Exception {
-        indexShard.close("test tearDown", true);
+        indexShard.close("test tearDown", true, false);
         super.tearDown();
     }
 

--- a/server/src/test/java/org/opensearch/index/store/remote/metadata/RemoteSegmentMetadataHandlerTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/metadata/RemoteSegmentMetadataHandlerTests.java
@@ -51,7 +51,7 @@ public class RemoteSegmentMetadataHandlerTests extends IndexShardTestCase {
 
     @After
     public void tearDown() throws Exception {
-        indexShard.close("test tearDown", true);
+        indexShard.close("test tearDown", true, false);
         super.tearDown();
     }
 

--- a/server/src/test/java/org/opensearch/indices/IndexingMemoryControllerTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndexingMemoryControllerTests.java
@@ -369,7 +369,7 @@ public class IndexingMemoryControllerTests extends IndexShardTestCase {
         for (int i = 0; i < 100; i++) {
             indexDoc(shard, Integer.toString(i), "{\"foo\" : \"bar\"}", XContentType.JSON, null);
         }
-        shard.close("simon says", false);
+        shard.close("simon says", false, false);
         AtomicReference<IndexShard> shardRef = new AtomicReference<>();
         Settings settings = Settings.builder().put("indices.memory.index_buffer_size", "50kb").build();
         Iterable<IndexShard> iterable = () -> (shardRef.get() == null)

--- a/server/src/test/java/org/opensearch/indices/recovery/PeerRecoveryTargetServiceTests.java
+++ b/server/src/test/java/org/opensearch/indices/recovery/PeerRecoveryTargetServiceTests.java
@@ -380,7 +380,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
         );
         IndexShard shard = newStartedShard(false);
         final SeqNoStats seqNoStats = populateRandomData(shard);
-        shard.close("test", false);
+        shard.close("test", false, false);
         if (randomBoolean()) {
             shard.store().associateIndexWithNewTranslog(UUIDs.randomBase64UUID());
         } else if (randomBoolean()) {

--- a/server/src/test/java/org/opensearch/indices/recovery/RecoveryStatusTests.java
+++ b/server/src/test/java/org/opensearch/indices/recovery/RecoveryStatusTests.java
@@ -94,7 +94,7 @@ public class RecoveryStatusTests extends OpenSearchSingleNodeTestCase {
             }
         }
         assertNotNull(expectedFile);
-        indexShard.close("foo", false);// we have to close it here otherwise rename fails since the write.lock is held by the engine
+        indexShard.close("foo", false, false);// we have to close it here otherwise rename fails since the write.lock is held by the engine
         multiFileWriter.renameAllTempFiles();
         strings = Sets.newHashSet(indexShard.store().directory().listAll());
         assertTrue(strings.toString(), strings.contains("foo.bar"));

--- a/server/src/test/java/org/opensearch/indices/recovery/RecoveryTests.java
+++ b/server/src/test/java/org/opensearch/indices/recovery/RecoveryTests.java
@@ -267,7 +267,7 @@ public class RecoveryTests extends OpenSearchIndexLevelReplicationTestCase {
             final String historyUUID = replica.getHistoryUUID();
             Translog.TranslogGeneration translogGeneration = getTranslog(replica).getGeneration();
             shards.removeReplica(replica);
-            replica.close("test", false);
+            replica.close("test", false, false);
             IndexWriterConfig iwc = new IndexWriterConfig(null).setCommitOnClose(false)
                 // we don't want merges to happen here - we call maybe merge on the engine
                 // later once we stared it up otherwise we would need to wait for it here
@@ -391,7 +391,7 @@ public class RecoveryTests extends OpenSearchIndexLevelReplicationTestCase {
             if (randomBoolean()) {
                 shards.flush();
             }
-            replica.close("test", randomBoolean());
+            replica.close("test", randomBoolean(), false);
             replica.store().close();
             final IndexShard newReplica = shards.addReplicaWithExistingPath(replica.shardPath(), replica.routingEntry().currentNodeId());
             shards.recoverReplica(newReplica);
@@ -509,7 +509,7 @@ public class RecoveryTests extends OpenSearchIndexLevelReplicationTestCase {
             }
             shards.syncGlobalCheckpoint();
             shards.promoteReplicaToPrimary(randomFrom(shards.getReplicas())).get();
-            oldPrimary.close("demoted", false);
+            oldPrimary.close("demoted", false, false);
             oldPrimary.store().close();
             oldPrimary = shards.addReplicaWithExistingPath(oldPrimary.shardPath(), oldPrimary.routingEntry().currentNodeId());
             shards.recoverReplica(oldPrimary);

--- a/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryRestoreTests.java
+++ b/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryRestoreTests.java
@@ -162,7 +162,7 @@ public class BlobStoreRepositoryRestoreTests extends IndexShardTestCase {
         } finally {
             if (shard != null && shard.state() != IndexShardState.CLOSED) {
                 try {
-                    shard.close("test", false);
+                    shard.close("test", false, false);
                 } finally {
                     IOUtils.close(shard.store());
                 }
@@ -228,7 +228,7 @@ public class BlobStoreRepositoryRestoreTests extends IndexShardTestCase {
         } finally {
             if (shard != null && shard.state() != IndexShardState.CLOSED) {
                 try {
-                    shard.close("test", false);
+                    shard.close("test", false, false);
                 } finally {
                     IOUtils.close(shard.store());
                 }

--- a/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
@@ -806,7 +806,7 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
                 EngineTestCase.assertAtMostOneLuceneDocumentPerSequenceNumber(engine);
             }
         } finally {
-            IOUtils.close(() -> shard.close("test", false), shard.store());
+            IOUtils.close(() -> shard.close("test", false, false), shard.store());
         }
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Upon Index deletion, we delete Remote Translog and delete files in Remote Segments which are not referenced by any snapshots. 

### ToDo

Index level folders are still not deleted . We are only cleaning shard level folders in this change . Will be creating an issue for same. 

Make Remote Segment Deletion Async - Current implementation will increase index deletion time . But we already plan to make it async .  

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/3511 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
