### PR TITLE
Add remote refresh lag in millis from local refresh

### DIFF
--- a/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/stats/RemoteStoreStats.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/stats/RemoteStoreStats.java
@@ -43,8 +43,7 @@ public class RemoteStoreStats implements Writeable, ToXContentFragment {
         builder.startObject()
             .field(Fields.SHARD_ID, remoteSegmentUploadShardStats.shardId)
 
-            .field(Fields.LOCAL_REFRESH_TIMESTAMP, remoteSegmentUploadShardStats.localRefreshTimeMs)
-            .field(Fields.REMOTE_REFRESH_TIMESTAMP, remoteSegmentUploadShardStats.remoteRefreshTimeMs)
+            .field(Fields.REFRESH_TIME_LAG_IN_MILLIS, remoteSegmentUploadShardStats.refreshTimeLagMs)
             .field(Fields.REFRESH_LAG, remoteSegmentUploadShardStats.localRefreshNumber - remoteSegmentUploadShardStats.remoteRefreshNumber)
             .field(Fields.BYTES_LAG, remoteSegmentUploadShardStats.bytesLag)
 
@@ -91,16 +90,6 @@ public class RemoteStoreStats implements Writeable, ToXContentFragment {
         static final String SHARD_ID = "shard_id";
 
         /**
-         * Last successful local refresh timestamp in milliseconds
-         */
-        static final String LOCAL_REFRESH_TIMESTAMP = "local_refresh_timestamp_in_millis";
-
-        /**
-         * Last successful remote refresh timestamp in milliseconds
-         */
-        static final String REMOTE_REFRESH_TIMESTAMP = "remote_refresh_timestamp_in_millis";
-
-        /**
          * Lag in terms of bytes b/w local and remote store
          */
         static final String BYTES_LAG = "bytes_lag";
@@ -109,6 +98,11 @@ public class RemoteStoreStats implements Writeable, ToXContentFragment {
          * No of refresh remote store is lagging behind local
          */
         static final String REFRESH_LAG = "refresh_lag";
+
+        /**
+         * Time in millis remote refresh is behind local refresh
+         */
+        static final String REFRESH_TIME_LAG_IN_MILLIS = "refresh_time_lag_in_millis";
 
         /**
          * Total write rejections due to remote store backpressure kick in

--- a/server/src/main/java/org/opensearch/index/remote/RemoteRefreshSegmentTracker.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteRefreshSegmentTracker.java
@@ -445,10 +445,9 @@ public class RemoteRefreshSegmentTracker {
     public RemoteRefreshSegmentTracker.Stats stats() {
         return new RemoteRefreshSegmentTracker.Stats(
             shardId,
+            timeMsLag,
             localRefreshSeqNo,
-            localRefreshTimeMs,
             remoteRefreshSeqNo,
-            remoteRefreshTimeMs,
             uploadBytesStarted,
             uploadBytesSucceeded,
             uploadBytesFailed,
@@ -473,10 +472,9 @@ public class RemoteRefreshSegmentTracker {
     public static class Stats implements Writeable {
 
         public final ShardId shardId;
+        public final long refreshTimeLagMs;
         public final long localRefreshNumber;
-        public final long localRefreshTimeMs;
         public final long remoteRefreshNumber;
-        public final long remoteRefreshTimeMs;
         public final long uploadBytesStarted;
         public final long uploadBytesFailed;
         public final long uploadBytesSucceeded;
@@ -493,10 +491,9 @@ public class RemoteRefreshSegmentTracker {
 
         public Stats(
             ShardId shardId,
+            long refreshTimeLagMs,
             long localRefreshNumber,
-            long localRefreshTimeMs,
             long remoteRefreshNumber,
-            long remoteRefreshTimeMs,
             long uploadBytesStarted,
             long uploadBytesSucceeded,
             long uploadBytesFailed,
@@ -512,10 +509,9 @@ public class RemoteRefreshSegmentTracker {
             long bytesLag
         ) {
             this.shardId = shardId;
+            this.refreshTimeLagMs = refreshTimeLagMs;
             this.localRefreshNumber = localRefreshNumber;
-            this.localRefreshTimeMs = localRefreshTimeMs;
             this.remoteRefreshNumber = remoteRefreshNumber;
-            this.remoteRefreshTimeMs = remoteRefreshTimeMs;
             this.uploadBytesStarted = uploadBytesStarted;
             this.uploadBytesFailed = uploadBytesFailed;
             this.uploadBytesSucceeded = uploadBytesSucceeded;
@@ -534,10 +530,9 @@ public class RemoteRefreshSegmentTracker {
         public Stats(StreamInput in) throws IOException {
             try {
                 this.shardId = new ShardId(in);
+                this.refreshTimeLagMs = in.readLong();
                 this.localRefreshNumber = in.readLong();
-                this.localRefreshTimeMs = in.readLong();
                 this.remoteRefreshNumber = in.readLong();
-                this.remoteRefreshTimeMs = in.readLong();
                 this.uploadBytesStarted = in.readLong();
                 this.uploadBytesFailed = in.readLong();
                 this.uploadBytesSucceeded = in.readLong();
@@ -559,10 +554,9 @@ public class RemoteRefreshSegmentTracker {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             shardId.writeTo(out);
+            out.writeLong(refreshTimeLagMs);
             out.writeLong(localRefreshNumber);
-            out.writeLong(localRefreshTimeMs);
             out.writeLong(remoteRefreshNumber);
-            out.writeLong(remoteRefreshTimeMs);
             out.writeLong(uploadBytesStarted);
             out.writeLong(uploadBytesFailed);
             out.writeLong(uploadBytesSucceeded);

--- a/server/src/test/java/org/opensearch/action/admin/cluster/remotestore/stats/RemoteStoreStatsTestHelper.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/remotestore/stats/RemoteStoreStatsTestHelper.java
@@ -14,43 +14,22 @@ import org.opensearch.index.shard.ShardId;
 import java.util.Map;
 
 import static org.opensearch.test.OpenSearchTestCase.assertEquals;
-import static org.opensearch.test.OpenSearchTestCase.randomIntBetween;
 
 /**
  * Helper utilities for Remote Store stats tests
  */
 public class RemoteStoreStatsTestHelper {
     static RemoteRefreshSegmentTracker.Stats createPressureTrackerStats(ShardId shardId) {
-        return new RemoteRefreshSegmentTracker.Stats(
-            shardId,
-            3,
-            System.nanoTime() / 1_000_000L + randomIntBetween(10, 100),
-            2,
-            System.nanoTime() / 1_000_000L + randomIntBetween(10, 100),
-            10,
-            5,
-            5,
-            10,
-            5,
-            5,
-            3,
-            2,
-            5,
-            2,
-            3,
-            4,
-            9
-        );
+        return new RemoteRefreshSegmentTracker.Stats(shardId, 100, 3, 2, 10, 5, 5, 10, 5, 5, 3, 2, 5, 2, 3, 4, 9);
     }
 
     static void compareStatsResponse(Map<String, Object> statsObject, RemoteRefreshSegmentTracker.Stats pressureTrackerStats) {
         assertEquals(statsObject.get(RemoteStoreStats.Fields.SHARD_ID), pressureTrackerStats.shardId.toString());
-        assertEquals(statsObject.get(RemoteStoreStats.Fields.LOCAL_REFRESH_TIMESTAMP), (int) pressureTrackerStats.localRefreshTimeMs);
+        assertEquals(statsObject.get(RemoteStoreStats.Fields.REFRESH_TIME_LAG_IN_MILLIS), (int) pressureTrackerStats.refreshTimeLagMs);
         assertEquals(
             statsObject.get(RemoteStoreStats.Fields.REFRESH_LAG),
             (int) (pressureTrackerStats.localRefreshNumber - pressureTrackerStats.remoteRefreshNumber)
         );
-        assertEquals(statsObject.get(RemoteStoreStats.Fields.REMOTE_REFRESH_TIMESTAMP), (int) pressureTrackerStats.remoteRefreshTimeMs);
         assertEquals(statsObject.get(RemoteStoreStats.Fields.BYTES_LAG), (int) pressureTrackerStats.bytesLag);
 
         assertEquals(statsObject.get(RemoteStoreStats.Fields.BACKPRESSURE_REJECTION_COUNT), (int) pressureTrackerStats.rejectionCount);

--- a/server/src/test/java/org/opensearch/action/admin/cluster/remotestore/stats/RemoteStoreStatsTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/remotestore/stats/RemoteStoreStatsTests.java
@@ -62,10 +62,9 @@ public class RemoteStoreStatsTests extends OpenSearchTestCase {
             try (StreamInput in = out.bytes().streamInput()) {
                 RemoteStoreStats deserializedStats = new RemoteStoreStats(in);
                 assertEquals(deserializedStats.getStats().shardId.toString(), stats.getStats().shardId.toString());
+                assertEquals(deserializedStats.getStats().refreshTimeLagMs, stats.getStats().refreshTimeLagMs);
                 assertEquals(deserializedStats.getStats().localRefreshNumber, stats.getStats().localRefreshNumber);
-                assertEquals(deserializedStats.getStats().localRefreshTimeMs, stats.getStats().localRefreshTimeMs);
                 assertEquals(deserializedStats.getStats().remoteRefreshNumber, stats.getStats().remoteRefreshNumber);
-                assertEquals(deserializedStats.getStats().remoteRefreshTimeMs, stats.getStats().remoteRefreshTimeMs);
                 assertEquals(deserializedStats.getStats().uploadBytesStarted, stats.getStats().uploadBytesStarted);
                 assertEquals(deserializedStats.getStats().uploadBytesSucceeded, stats.getStats().uploadBytesSucceeded);
                 assertEquals(deserializedStats.getStats().uploadBytesFailed, stats.getStats().uploadBytesFailed);

--- a/server/src/test/java/org/opensearch/index/remote/RemoteRefreshSegmentTrackerTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteRefreshSegmentTrackerTests.java
@@ -411,9 +411,8 @@ public class RemoteRefreshSegmentTrackerTests extends OpenSearchTestCase {
         pressureTracker = constructTracker();
         RemoteRefreshSegmentTracker.Stats pressureTrackerStats = pressureTracker.stats();
         assertEquals(pressureTracker.getShardId(), pressureTrackerStats.shardId);
-        assertEquals(pressureTracker.getLocalRefreshTimeMs(), (int) pressureTrackerStats.localRefreshTimeMs);
+        assertEquals(pressureTracker.getTimeMsLag(), (int) pressureTrackerStats.refreshTimeLagMs);
         assertEquals(pressureTracker.getLocalRefreshSeqNo(), (int) pressureTrackerStats.localRefreshNumber);
-        assertEquals(pressureTracker.getRemoteRefreshTimeMs(), (int) pressureTrackerStats.remoteRefreshTimeMs);
         assertEquals(pressureTracker.getRemoteRefreshSeqNo(), (int) pressureTrackerStats.remoteRefreshNumber);
         assertEquals(pressureTracker.getBytesLag(), (int) pressureTrackerStats.bytesLag);
         assertEquals(pressureTracker.getRejectionCount(), (int) pressureTrackerStats.rejectionCount);
@@ -441,9 +440,8 @@ public class RemoteRefreshSegmentTrackerTests extends OpenSearchTestCase {
             try (StreamInput in = out.bytes().streamInput()) {
                 RemoteRefreshSegmentTracker.Stats deserializedStats = new RemoteRefreshSegmentTracker.Stats(in);
                 assertEquals(deserializedStats.shardId, pressureTrackerStats.shardId);
-                assertEquals((int) deserializedStats.localRefreshTimeMs, (int) pressureTrackerStats.localRefreshTimeMs);
+                assertEquals((int) deserializedStats.refreshTimeLagMs, (int) pressureTrackerStats.refreshTimeLagMs);
                 assertEquals((int) deserializedStats.localRefreshNumber, (int) pressureTrackerStats.localRefreshNumber);
-                assertEquals((int) deserializedStats.remoteRefreshTimeMs, (int) pressureTrackerStats.remoteRefreshTimeMs);
                 assertEquals((int) deserializedStats.remoteRefreshNumber, (int) pressureTrackerStats.remoteRefreshNumber);
                 assertEquals((int) deserializedStats.bytesLag, (int) pressureTrackerStats.bytesLag);
                 assertEquals((int) deserializedStats.rejectionCount, (int) pressureTrackerStats.rejectionCount);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Since the actual timestamps populated are not the actual system epoch, changing the stats api to return the lag. In future we'll work on adding the actual timestamps as well

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
