### PR TITLE
[Backport 2.x] Change default search preference to _primary for searchable snapshot …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Enable `./gradlew build` on MacOS by disabling bcw tests ([#7303](https://github.com/opensearch-project/OpenSearch/pull/7303))
 - Moved concurrent-search from sandbox plugin to server module behind feature flag ([#7203](https://github.com/opensearch-project/OpenSearch/pull/7203))
 - Allow access to indices cache clear APIs for read only indexes ([#7303](https://github.com/opensearch-project/OpenSearch/pull/7303))
+- Default search preference to _primary for searchable snapshot indices ([#7628](https://github.com/opensearch-project/OpenSearch/pull/7628))
 
 ### Deprecated
 

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/SearchableSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/SearchableSnapshotIT.java
@@ -10,6 +10,8 @@ import org.hamcrest.MatcherAssert;
 import org.opensearch.action.admin.cluster.node.stats.NodeStats;
 import org.opensearch.action.admin.cluster.node.stats.NodesStatsRequest;
 import org.opensearch.action.admin.cluster.node.stats.NodesStatsResponse;
+import org.opensearch.action.admin.cluster.shards.ClusterSearchShardsGroup;
+import org.opensearch.action.admin.cluster.shards.ClusterSearchShardsRequest;
 import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
 import org.opensearch.action.admin.cluster.snapshots.delete.DeleteSnapshotRequest;
 import org.opensearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
@@ -41,6 +43,7 @@ import org.opensearch.repositories.fs.FsRepository;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -662,6 +665,58 @@ public final class SearchableSnapshotIT extends AbstractSnapshotIntegTestCase {
         // The index count will be 0 since the only restored index "test-idx-copy" was deleted
         assertCacheDirectoryReplicaAndIndexCount(numShards, 0);
         logger.info("--> validated that the cache file path doesn't exist");
+    }
+
+    /**
+     * Test scenario that validates that the default search preference for searchable snapshot
+     * is primary shards
+     */
+    public void testDefaultShardPreference() throws Exception {
+        final int numReplicas = 1;
+        final String indexName = "test-idx";
+        final String restoredIndexName = indexName + "-copy";
+        final String repoName = "test-repo";
+        final String snapshotName = "test-snap";
+        final Client client = client();
+
+        // Create an index, snapshot and restore as a searchable snapshot index
+        internalCluster().ensureAtLeastNumSearchAndDataNodes(numReplicas + 1);
+        createIndexWithDocsAndEnsureGreen(numReplicas, 100, indexName);
+        createRepositoryWithSettings(null, repoName);
+        takeSnapshot(client, snapshotName, repoName, indexName);
+        restoreSnapshotAndEnsureGreen(client, snapshotName, repoName);
+        assertDocCount(restoredIndexName, 100L);
+        assertRemoteSnapshotIndexSettings(client, restoredIndexName);
+
+        // ClusterSearchShards API returns a list of shards that will be used
+        // when querying a particular index
+        ClusterSearchShardsGroup[] shardGroups = client.admin()
+            .cluster()
+            .searchShards(new ClusterSearchShardsRequest(restoredIndexName))
+            .actionGet()
+            .getGroups();
+
+        // Ensure when no preferences are set (default preference), the only compatible shards are primary
+        for (ClusterSearchShardsGroup shardsGroup : shardGroups) {
+            assertEquals(1, shardsGroup.getShards().length);
+            assertTrue(shardsGroup.getShards()[0].primary());
+        }
+
+        // Ensure when preferences are set, all the compatible shards are returned
+        shardGroups = client.admin()
+            .cluster()
+            .searchShards(new ClusterSearchShardsRequest(restoredIndexName).preference("foo"))
+            .actionGet()
+            .getGroups();
+
+        // Ensures that the compatible shards are not just primaries
+        for (ClusterSearchShardsGroup shardsGroup : shardGroups) {
+            assertTrue(shardsGroup.getShards().length > 1);
+            boolean containsReplica = Arrays.stream(shardsGroup.getShards())
+                .map(shardRouting -> !shardRouting.primary())
+                .reduce(false, (s1, s2) -> s1 || s2);
+            assertTrue(containsReplica);
+        }
     }
 
     /**

--- a/server/src/main/java/org/opensearch/cluster/routing/OperationRouting.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/OperationRouting.java
@@ -42,6 +42,7 @@ import org.opensearch.common.Strings;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.index.IndexModule;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.shard.ShardId;
 import org.opensearch.node.ResponseCollectorService;
@@ -238,6 +239,13 @@ public class OperationRouting {
         final Set<IndexShardRoutingTable> shards = computeTargetedShards(clusterState, concreteIndices, routing);
         final Set<ShardIterator> set = new HashSet<>(shards.size());
         for (IndexShardRoutingTable shard : shards) {
+            IndexMetadata indexMetadataForShard = indexMetadata(clusterState, shard.shardId.getIndex().getName());
+            if (IndexModule.Type.REMOTE_SNAPSHOT.match(
+                indexMetadataForShard.getSettings().get(IndexModule.INDEX_STORE_TYPE_SETTING.getKey())
+            ) && (preference == null || preference.isEmpty())) {
+                preference = Preference.PRIMARY.type();
+            }
+
             ShardIterator iterator = preferenceActiveShardIterator(
                 shard,
                 clusterState.nodes().getLocalNodeId(),


### PR DESCRIPTION
…indices (#7628)

Signed-off-by: Kunal Kotwani <kkotwani@amazon.com>
(cherry picked from commit fa878ae05ea2016bee99a8fc305ae506050f65d4)

- Backports #7628 to `2.x`

### Related Issues
- Backports #7628 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
