### PR TITLE
[Backport] [2.x] Bump net.minidev:json-smart from 2.4.10 to 2.4.11 in /test/fixtures/hdfs-fixture (#7660)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `com.azure:azure-storage-common` from 12.20.0 to 12.21.0 (#7566)
 - Bump `org.apache.commons:commons-compress` from 1.22 to 1.23.0 (#7563)
 - Bump `jackson` from 2.15.0 to 2.15.1 ([#7603](https://github.com/opensearch-project/OpenSearch/pull/7603))
+- Bump `net.minidev:json-smart` from 2.4.10 to 2.4.11 (#7660)
 
 ### Changed
 - Enable `./gradlew build` on MacOS by disabling bcw tests ([#7303](https://github.com/opensearch-project/OpenSearch/pull/7303))

--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -54,7 +54,7 @@ dependencies {
   api "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:${versions.jackson}"
   api "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
   api "com.fasterxml.woodstox:woodstox-core:${versions.woodstox}"
-  api 'net.minidev:json-smart:2.4.9'
+  api 'net.minidev:json-smart:2.4.11'
   api "org.mockito:mockito-core:${versions.mockito}"
   api "com.google.protobuf:protobuf-java:3.22.2"
   api "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/7660 to `2.x`