### PR TITLE
Run publish maven snapshots on all branches matching pattern

### DIFF
--- a/.github/workflows/publish-maven-snapshots.yml
+++ b/.github/workflows/publish-maven-snapshots.yml
@@ -5,8 +5,8 @@ on:
   push:
       branches:
         - main
-        - '1.3'
-        - 2.x
+        - '[0-9]+.[0-9]+'
+        - '[0-9]+.x'
 
 jobs:
   build-and-publish-snapshots:

--- a/.github/workflows/publish-maven-snapshots.yml
+++ b/.github/workflows/publish-maven-snapshots.yml
@@ -5,9 +5,8 @@ on:
   push:
       branches:
         - main
-        - '1.3'
-        - '2.x'
-        - '2.8'
+        - '[0-9]+.[0-9]+'
+        - '[0-9]+.x'
 
 jobs:
   build-and-publish-snapshots:

--- a/.github/workflows/publish-maven-snapshots.yml
+++ b/.github/workflows/publish-maven-snapshots.yml
@@ -5,9 +5,9 @@ on:
   push:
       branches:
         - main
-        - 1.3
-        - 2.x
-        - 2.8
+        - '1.3'
+        - '2.x'
+        - '2.8'
 
 jobs:
   build-and-publish-snapshots:

--- a/.github/workflows/publish-maven-snapshots.yml
+++ b/.github/workflows/publish-maven-snapshots.yml
@@ -5,8 +5,9 @@ on:
   push:
       branches:
         - main
-        - '[0-9]+.[0-9]+'
-        - '[0-9]+.x'
+        - 1.3
+        - 2.x
+        - 2.8
 
 jobs:
   build-and-publish-snapshots:


### PR DESCRIPTION
### Description

Updates the branches that `publish-maven-snapshots` github workflow is run with. It now uses a regex to match any released of unreleased branches. I noticed that the .NET client was using the same patterns: https://github.com/opensearch-project/opensearch-net/blob/main/.github/workflows/test-jobs.yml#L16-L17

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/7705
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
