### PR TITLE
[Backport 2.x] Adding task cancellation timestamp in task API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add descending order search optimization through reverse segment read. ([#7244](https://github.com/opensearch-project/OpenSearch/pull/7244))
 - Add 'unsigned_long' numeric field type ([#6237](https://github.com/opensearch-project/OpenSearch/pull/6237))
 - Add back primary shard preference for queries ([#7375](https://github.com/opensearch-project/OpenSearch/pull/7375))
+- Add task cancellation timestamp in task API ([#7455](https://github.com/opensearch-project/OpenSearch/pull/7455))
 - Adds ExtensionsManager.lookupExtensionSettingsById ([#7466](https://github.com/opensearch-project/OpenSearch/pull/7466))
 - Provide mechanism to configure XContent parsing constraints (after update to Jackson 2.15.0 and above) ([#7550](https://github.com/opensearch-project/OpenSearch/pull/7550))
 - Support to clear filecache using clear indices cache API ([#7498](https://github.com/opensearch-project/OpenSearch/pull/7498))

--- a/client/rest-high-level/src/test/java/org/opensearch/client/core/tasks/GetTaskResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/core/tasks/GetTaskResponseTests.java
@@ -95,6 +95,10 @@ public class GetTaskResponseTests extends OpenSearchTestCase {
         boolean cancellable = randomBoolean();
         boolean cancelled = cancellable == true ? randomBoolean() : false;
         TaskId parentTaskId = randomBoolean() ? TaskId.EMPTY_TASK_ID : randomTaskId();
+        Long cancellationStartTime = null;
+        if (cancelled) {
+            cancellationStartTime = randomNonNegativeLong();
+        }
         Map<String, String> headers = randomBoolean()
             ? Collections.emptyMap()
             : Collections.singletonMap(randomAlphaOfLength(5), randomAlphaOfLength(5));
@@ -110,7 +114,8 @@ public class GetTaskResponseTests extends OpenSearchTestCase {
             cancelled,
             parentTaskId,
             headers,
-            randomResourceStats()
+            randomResourceStats(),
+            cancellationStartTime
         );
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/node/tasks/TasksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/node/tasks/TasksIT.java
@@ -543,6 +543,17 @@ public class TasksIT extends OpenSearchIntegTestCase {
             .get();
         assertEquals(1, cancelTasksResponse.getTasks().size());
 
+        // Tasks are marked as cancelled at this point but not yet completed.
+        List<TaskInfo> taskInfoList = client().admin()
+            .cluster()
+            .prepareListTasks()
+            .setActions(TestTaskPlugin.TestTaskAction.NAME + "*")
+            .get()
+            .getTasks();
+        for (TaskInfo taskInfo : taskInfoList) {
+            assertTrue(taskInfo.isCancelled());
+            assertNotNull(taskInfo.getCancellationStartTime());
+        }
         future.get();
 
         logger.info("--> checking that test tasks are not running");

--- a/server/src/main/java/org/opensearch/tasks/CancellableTask.java
+++ b/server/src/main/java/org/opensearch/tasks/CancellableTask.java
@@ -50,6 +50,14 @@ public abstract class CancellableTask extends Task {
     private volatile String reason;
     private final AtomicBoolean cancelled = new AtomicBoolean(false);
     private final TimeValue cancelAfterTimeInterval;
+    /**
+     * The time this task was cancelled as a wall clock time since epoch ({@link System#currentTimeMillis()} style).
+     */
+    private Long cancellationStartTime = null;
+    /**
+     * The time this task was cancelled as a relative time ({@link System#nanoTime()} style).
+     */
+    private Long cancellationStartTimeNanos = null;
 
     public CancellableTask(long id, String type, String action, String description, TaskId parentTaskId, Map<String, String> headers) {
         this(id, type, action, description, parentTaskId, headers, NO_TIMEOUT);
@@ -74,6 +82,8 @@ public abstract class CancellableTask extends Task {
     public void cancel(String reason) {
         assert reason != null;
         if (cancelled.compareAndSet(false, true)) {
+            this.cancellationStartTime = System.currentTimeMillis();
+            this.cancellationStartTimeNanos = System.nanoTime();
             this.reason = reason;
             onCancelled();
         }
@@ -85,6 +95,14 @@ public abstract class CancellableTask extends Task {
      */
     public boolean cancelOnParentLeaving() {
         return true;
+    }
+
+    public Long getCancellationStartTime() {
+        return cancellationStartTime;
+    }
+
+    public Long getCancellationStartTimeNanos() {
+        return cancellationStartTimeNanos;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/tasks/Task.java
+++ b/server/src/main/java/org/opensearch/tasks/Task.java
@@ -192,6 +192,11 @@ public class Task {
      * Build a proper {@link TaskInfo} for this task.
      */
     protected final TaskInfo taskInfo(String localNodeId, String description, Status status, TaskResourceStats resourceStats) {
+        boolean cancelled = this instanceof CancellableTask && ((CancellableTask) this).isCancelled();
+        Long cancellationStartTime = null;
+        if (cancelled) {
+            cancellationStartTime = ((CancellableTask) this).getCancellationStartTime();
+        }
         return new TaskInfo(
             new TaskId(localNodeId, getId()),
             getType(),
@@ -201,10 +206,11 @@ public class Task {
             startTime,
             System.nanoTime() - startTimeNanos,
             this instanceof CancellableTask,
-            this instanceof CancellableTask && ((CancellableTask) this).isCancelled(),
+            cancelled,
             parentTask,
             headers,
-            resourceStats
+            resourceStats,
+            cancellationStartTime
         );
     }
 

--- a/server/src/main/java/org/opensearch/tasks/TaskInfo.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskInfo.java
@@ -185,7 +185,7 @@ public final class TaskInfo implements Writeable, ToXContentFragment {
         } else {
             resourceStats = null;
         }
-        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_2_8_0)) {
             cancellationStartTime = in.readOptionalLong();
         } else {
             cancellationStartTime = null;
@@ -210,7 +210,7 @@ public final class TaskInfo implements Writeable, ToXContentFragment {
         if (out.getVersion().onOrAfter(Version.V_2_1_0)) {
             out.writeOptionalWriteable(resourceStats);
         }
-        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_2_8_0)) {
             out.writeOptionalLong(cancellationStartTime);
         }
     }

--- a/server/src/main/java/org/opensearch/tasks/TaskInfo.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskInfo.java
@@ -85,6 +85,8 @@ public final class TaskInfo implements Writeable, ToXContentFragment {
 
     private final boolean cancelled;
 
+    private final Long cancellationStartTime;
+
     private final TaskId parentTaskId;
 
     private final Map<String, String> headers;
@@ -105,6 +107,38 @@ public final class TaskInfo implements Writeable, ToXContentFragment {
         Map<String, String> headers,
         TaskResourceStats resourceStats
     ) {
+        this(
+            taskId,
+            type,
+            action,
+            description,
+            status,
+            startTime,
+            runningTimeNanos,
+            cancellable,
+            cancelled,
+            parentTaskId,
+            headers,
+            resourceStats,
+            null
+        );
+    }
+
+    public TaskInfo(
+        TaskId taskId,
+        String type,
+        String action,
+        String description,
+        Task.Status status,
+        long startTime,
+        long runningTimeNanos,
+        boolean cancellable,
+        boolean cancelled,
+        TaskId parentTaskId,
+        Map<String, String> headers,
+        TaskResourceStats resourceStats,
+        Long cancellationStartTime
+    ) {
         if (cancellable == false && cancelled == true) {
             throw new IllegalArgumentException("task cannot be cancelled");
         }
@@ -120,6 +154,7 @@ public final class TaskInfo implements Writeable, ToXContentFragment {
         this.parentTaskId = parentTaskId;
         this.headers = headers;
         this.resourceStats = resourceStats;
+        this.cancellationStartTime = cancellationStartTime;
     }
 
     /**
@@ -150,6 +185,11 @@ public final class TaskInfo implements Writeable, ToXContentFragment {
         } else {
             resourceStats = null;
         }
+        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+            cancellationStartTime = in.readOptionalLong();
+        } else {
+            cancellationStartTime = null;
+        }
     }
 
     @Override
@@ -169,6 +209,9 @@ public final class TaskInfo implements Writeable, ToXContentFragment {
         out.writeMap(headers, StreamOutput::writeString, StreamOutput::writeString);
         if (out.getVersion().onOrAfter(Version.V_2_1_0)) {
             out.writeOptionalWriteable(resourceStats);
+        }
+        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+            out.writeOptionalLong(cancellationStartTime);
         }
     }
 
@@ -228,6 +271,10 @@ public final class TaskInfo implements Writeable, ToXContentFragment {
         return cancelled;
     }
 
+    public Long getCancellationStartTime() {
+        return cancellationStartTime;
+    }
+
     /**
      * Returns the parent task id
      */
@@ -281,6 +328,9 @@ public final class TaskInfo implements Writeable, ToXContentFragment {
             resourceStats.toXContent(builder, params);
             builder.endObject();
         }
+        if (cancellationStartTime != null) {
+            builder.humanReadableField("cancellation_time_millis", "cancellation_time", new TimeValue(cancellationStartTime));
+        }
         return builder;
     }
 
@@ -308,6 +358,7 @@ public final class TaskInfo implements Writeable, ToXContentFragment {
         }
         @SuppressWarnings("unchecked")
         TaskResourceStats resourceStats = (TaskResourceStats) a[i++];
+        Long cancellationStartTime = (Long) a[i++];
         RawTaskStatus status = statusBytes == null ? null : new RawTaskStatus(statusBytes);
         TaskId parentTaskId = parentTaskIdString == null ? TaskId.EMPTY_TASK_ID : new TaskId(parentTaskIdString);
         return new TaskInfo(
@@ -322,7 +373,8 @@ public final class TaskInfo implements Writeable, ToXContentFragment {
             cancelled,
             parentTaskId,
             headers,
-            resourceStats
+            resourceStats,
+            cancellationStartTime
         );
     });
     static {
@@ -341,6 +393,7 @@ public final class TaskInfo implements Writeable, ToXContentFragment {
         PARSER.declareString(optionalConstructorArg(), new ParseField("parent_task_id"));
         PARSER.declareObject(optionalConstructorArg(), (p, c) -> p.mapStrings(), new ParseField("headers"));
         PARSER.declareObject(optionalConstructorArg(), (p, c) -> TaskResourceStats.fromXContent(p), new ParseField("resource_stats"));
+        PARSER.declareLong(optionalConstructorArg(), new ParseField("cancellation_time_millis"));
     }
 
     @Override
@@ -366,7 +419,8 @@ public final class TaskInfo implements Writeable, ToXContentFragment {
             && Objects.equals(cancelled, other.cancelled)
             && Objects.equals(status, other.status)
             && Objects.equals(headers, other.headers)
-            && Objects.equals(resourceStats, other.resourceStats);
+            && Objects.equals(resourceStats, other.resourceStats)
+            && Objects.equals(cancellationStartTime, other.cancellationStartTime);
     }
 
     @Override
@@ -383,7 +437,8 @@ public final class TaskInfo implements Writeable, ToXContentFragment {
             cancelled,
             status,
             headers,
-            resourceStats
+            resourceStats,
+            cancellationStartTime
         );
     }
 }

--- a/server/src/test/java/org/opensearch/action/admin/cluster/node/tasks/TaskTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/node/tasks/TaskTests.java
@@ -89,6 +89,7 @@ public class TaskTests extends OpenSearchTestCase {
         long taskId = randomIntBetween(0, 100000);
         long startTime = randomNonNegativeLong();
         long runningTime = randomNonNegativeLong();
+        long cancellationStartTime = randomNonNegativeLong();
         boolean cancellable = true;
         boolean cancelled = true;
         TaskInfo taskInfo = new TaskInfo(
@@ -103,12 +104,14 @@ public class TaskTests extends OpenSearchTestCase {
             cancelled,
             TaskId.EMPTY_TASK_ID,
             Collections.singletonMap("foo", "bar"),
-            randomResourceStats(randomBoolean())
+            randomResourceStats(randomBoolean()),
+            cancellationStartTime
         );
         String taskInfoString = taskInfo.toString();
         Map<String, Object> map = XContentHelper.convertToMap(new BytesArray(taskInfoString.getBytes(StandardCharsets.UTF_8)), true).v2();
         assertEquals(map.get("cancellable"), cancellable);
         assertEquals(map.get("cancelled"), cancelled);
+        assertEquals(map.get("cancellation_time_millis"), cancellationStartTime);
     }
 
     public void testCancellableOptionWhenCancelledFalse() {

--- a/server/src/test/java/org/opensearch/tasks/ListTasksResponseTests.java
+++ b/server/src/test/java/org/opensearch/tasks/ListTasksResponseTests.java
@@ -78,7 +78,8 @@ public class ListTasksResponseTests extends AbstractXContentTestCase<ListTasksRe
                 {
                     put("dummy-type1", new TaskResourceUsage(100, 100));
                 }
-            })
+            }),
+            0L
         );
         ListTasksResponse tasksResponse = new ListTasksResponse(singletonList(info), emptyList(), emptyList());
         assertEquals(
@@ -105,7 +106,9 @@ public class ListTasksResponseTests extends AbstractXContentTestCase<ListTasksRe
                 + "          \"cpu_time_in_nanos\" : 100,\n"
                 + "          \"memory_in_bytes\" : 100\n"
                 + "        }\n"
-                + "      }\n"
+                + "      },\n"
+                + "      \"cancellation_time\" : \"0s\",\n"
+                + "      \"cancellation_time_millis\" : 0\n"
                 + "    }\n"
                 + "  ]\n"
                 + "}",

--- a/server/src/test/java/org/opensearch/tasks/TaskInfoTests.java
+++ b/server/src/test/java/org/opensearch/tasks/TaskInfoTests.java
@@ -83,7 +83,7 @@ public class TaskInfoTests extends AbstractSerializingTestCase<TaskInfo> {
 
     @Override
     protected TaskInfo mutateInstance(TaskInfo info) {
-        switch (between(0, 10)) {
+        switch (between(0, 11)) {
             case 0:
                 TaskId taskId = new TaskId(info.getTaskId().getNodeId() + randomAlphaOfLength(5), info.getTaskId().getId());
                 return new TaskInfo(
@@ -98,7 +98,8 @@ public class TaskInfoTests extends AbstractSerializingTestCase<TaskInfo> {
                     info.isCancelled(),
                     info.getParentTaskId(),
                     info.getHeaders(),
-                    info.getResourceStats()
+                    info.getResourceStats(),
+                    info.getCancellationStartTime()
                 );
             case 1:
                 return new TaskInfo(
@@ -113,7 +114,8 @@ public class TaskInfoTests extends AbstractSerializingTestCase<TaskInfo> {
                     info.isCancelled(),
                     info.getParentTaskId(),
                     info.getHeaders(),
-                    info.getResourceStats()
+                    info.getResourceStats(),
+                    info.getCancellationStartTime()
                 );
             case 2:
                 return new TaskInfo(
@@ -128,7 +130,8 @@ public class TaskInfoTests extends AbstractSerializingTestCase<TaskInfo> {
                     info.isCancelled(),
                     info.getParentTaskId(),
                     info.getHeaders(),
-                    info.getResourceStats()
+                    info.getResourceStats(),
+                    info.getCancellationStartTime()
                 );
             case 3:
                 return new TaskInfo(
@@ -143,7 +146,8 @@ public class TaskInfoTests extends AbstractSerializingTestCase<TaskInfo> {
                     info.isCancelled(),
                     info.getParentTaskId(),
                     info.getHeaders(),
-                    info.getResourceStats()
+                    info.getResourceStats(),
+                    info.getCancellationStartTime()
                 );
             case 4:
                 Task.Status newStatus = randomValueOtherThan(info.getStatus(), TaskInfoTests::randomRawTaskStatus);
@@ -159,7 +163,8 @@ public class TaskInfoTests extends AbstractSerializingTestCase<TaskInfo> {
                     info.isCancelled(),
                     info.getParentTaskId(),
                     info.getHeaders(),
-                    info.getResourceStats()
+                    info.getResourceStats(),
+                    info.getCancellationStartTime()
                 );
             case 5:
                 return new TaskInfo(
@@ -174,7 +179,8 @@ public class TaskInfoTests extends AbstractSerializingTestCase<TaskInfo> {
                     info.isCancelled(),
                     info.getParentTaskId(),
                     info.getHeaders(),
-                    info.getResourceStats()
+                    info.getResourceStats(),
+                    info.getCancellationStartTime()
                 );
             case 6:
                 return new TaskInfo(
@@ -189,7 +195,8 @@ public class TaskInfoTests extends AbstractSerializingTestCase<TaskInfo> {
                     info.isCancelled(),
                     info.getParentTaskId(),
                     info.getHeaders(),
-                    info.getResourceStats()
+                    info.getResourceStats(),
+                    info.getCancellationStartTime()
                 );
             case 7:
                 return new TaskInfo(
@@ -204,7 +211,8 @@ public class TaskInfoTests extends AbstractSerializingTestCase<TaskInfo> {
                     false,
                     info.getParentTaskId(),
                     info.getHeaders(),
-                    info.getResourceStats()
+                    info.getResourceStats(),
+                    info.getCancellationStartTime()
                 );
             case 8:
                 TaskId parentId = new TaskId(info.getParentTaskId().getNodeId() + randomAlphaOfLength(5), info.getParentTaskId().getId());
@@ -220,7 +228,8 @@ public class TaskInfoTests extends AbstractSerializingTestCase<TaskInfo> {
                     info.isCancelled(),
                     parentId,
                     info.getHeaders(),
-                    info.getResourceStats()
+                    info.getResourceStats(),
+                    info.getCancellationStartTime()
                 );
             case 9:
                 Map<String, String> headers = info.getHeaders();
@@ -242,7 +251,8 @@ public class TaskInfoTests extends AbstractSerializingTestCase<TaskInfo> {
                     info.isCancelled(),
                     info.getParentTaskId(),
                     headers,
-                    info.getResourceStats()
+                    info.getResourceStats(),
+                    info.getCancellationStartTime()
                 );
             case 10:
                 Map<String, TaskResourceUsage> resourceUsageMap;
@@ -266,6 +276,22 @@ public class TaskInfoTests extends AbstractSerializingTestCase<TaskInfo> {
                     info.getHeaders(),
                     new TaskResourceStats(resourceUsageMap)
                 );
+            case 11:
+                return new TaskInfo(
+                    info.getTaskId(),
+                    info.getType(),
+                    info.getAction(),
+                    info.getDescription(),
+                    info.getStatus(),
+                    info.getStartTime(),
+                    info.getRunningTimeNanos(),
+                    true,
+                    true,
+                    info.getParentTaskId(),
+                    info.getHeaders(),
+                    info.getResourceStats(),
+                    randomNonNegativeLong()
+                );
             default:
                 throw new IllegalStateException();
         }
@@ -285,6 +311,10 @@ public class TaskInfoTests extends AbstractSerializingTestCase<TaskInfo> {
         long runningTimeNanos = randomLong();
         boolean cancellable = randomBoolean();
         boolean cancelled = cancellable == true ? randomBoolean() : false;
+        Long cancellationStartTime = null;
+        if (cancelled) {
+            cancellationStartTime = randomNonNegativeLong();
+        }
         TaskId parentTaskId = randomBoolean() ? TaskId.EMPTY_TASK_ID : randomTaskId();
         Map<String, String> headers = randomBoolean()
             ? Collections.emptyMap()
@@ -301,7 +331,8 @@ public class TaskInfoTests extends AbstractSerializingTestCase<TaskInfo> {
             cancelled,
             parentTaskId,
             headers,
-            randomResourceStats(detailed)
+            randomResourceStats(detailed),
+            cancellationStartTime
         );
     }
 
@@ -312,7 +343,7 @@ public class TaskInfoTests extends AbstractSerializingTestCase<TaskInfo> {
     private static RawTaskStatus randomRawTaskStatus() {
         try (XContentBuilder builder = XContentBuilder.builder(Requests.INDEX_CONTENT_TYPE.xContent())) {
             builder.startObject();
-            int fields = between(0, 10);
+            int fields = between(0, 11);
             for (int f = 0; f < fields; f++) {
                 builder.field(randomAlphaOfLength(5), randomAlphaOfLength(5));
             }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Backports - https://github.com/opensearch-project/OpenSearch/pull/7445

### Related Issues
https://github.com/opensearch-project/OpenSearch/pull/7445

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
