### PR TITLE
[Backport] [2.x] Bump org.apache.maven:maven-model from 3.9.1 to 3.9.2 (#7655)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `io.projectreactor.netty:reactor-netty-core` from 1.0.24 to 1.1.7 ([#7724](https://github.com/opensearch-project/OpenSearch/pull/7724))
 - Bump `io.projectreactor.netty:reactor-netty` from 1.1.4 to 1.1.7 ([#7724](https://github.com/opensearch-project/OpenSearch/pull/7724))
 - Bump `io.projectreactor.netty:reactor-netty-http` from 1.1.4 to 1.1.7 ([#7724](https://github.com/opensearch-project/OpenSearch/pull/7724))
+- Bump `org.apache.maven:maven-model` from 3.9.1 to 3.9.2 (#7655)
 
 ### Changed
 - Enable `./gradlew build` on MacOS by disabling bcw tests ([#7303](https://github.com/opensearch-project/OpenSearch/pull/7303))

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -117,7 +117,7 @@ dependencies {
   api 'de.thetaphi:forbiddenapis:3.5.1'
   api 'com.avast.gradle:gradle-docker-compose-plugin:0.16.11'
   api "org.yaml:snakeyaml:${props.getProperty('snakeyaml')}"
-  api 'org.apache.maven:maven-model:3.9.1'
+  api 'org.apache.maven:maven-model:3.9.2'
   api 'com.networknt:json-schema-validator:1.0.81'
   api "com.fasterxml.jackson.core:jackson-databind:${props.getProperty('jackson_databind')}"
 


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/7655 to `2.x`