### PR TITLE
[Segment Replication] Mute testIndexingWithSegRep flaky test failure

### DIFF
--- a/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/IndexingIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/IndexingIT.java
@@ -245,6 +245,7 @@ public class IndexingIT extends AbstractRollingTestCase {
      *
      * @throws Exception
      */
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/7679")
     public void testIndexingWithSegRep() throws Exception {
         final String indexName = "test-index-segrep";
         final int shardCount = 3;


### PR DESCRIPTION
### Description
This change mutes the recently introduces backward compatible tests for segment replication indices. The test currently fails for two different reasons:
1. Targeted shard search request failures. This is posibly due to stale {index}/_stats results, where shard allocation is not correct. 
```
org.opensearch.client.ResponseException: method [POST], host [http://127.0.0.1:35875], URI [/test-index-segrep/_search?rest_total_hits_as_int=true&filter_path=hits.total&preference=_shards%3A1%7C_only_nodes%3A8kJEQo6ASOaPpQE9rnJFRQ], status line [HTTP/1.1 400 Bad Request]
{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"no data nodes with criteria [8kJEQo6ASOaPpQE9rnJFRQ] found for shard: [test-index-segrep][1]"}],"type":"illegal_argument_exception","reason":"no data nodes with criteria [8kJEQo6ASOaPpQE9rnJFRQ] found for shard: [test-index-segrep][1]"},"status":400}
```
2. Index already exists exception. This is happens on retry of the test. Sample failure https://build.ci.opensearch.org/job/gradle-check/16262/testReport/
```
org.opensearch.client.ResponseException: method [PUT], host [http://127.0.0.1:44593/], URI [/test-index-segrep], status line [HTTP/1.1 400 Bad Request]
    {"error":{"root_cause":[{"type":"resource_already_exists_exception","reason":"index [test-index-segrep/-b5P3IJMS2mZGT60HKdIcQ] already exists","index":"test-index-segrep","index_uuid":"-b5P3IJMS2mZGT60HKdIcQ"}],"type":"resource_already_exists_exception","reason":"index [test-index-segrep/-b5P3IJMS2mZGT60HKdIcQ] already exists","index":"test-index-segrep","index_uuid":"-b5P3IJMS2mZGT60HKdIcQ"},"status":400}
```

### Related Issues
Related: https://github.com/opensearch-project/OpenSearch/issues/7679

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
