### PR TITLE
[Extensions ] Adds HttpPort setting to ExtensionInitializationRequest

### DIFF
--- a/server/src/main/java/org/opensearch/discovery/InitializeExtensionRequest.java
+++ b/server/src/main/java/org/opensearch/discovery/InitializeExtensionRequest.java
@@ -25,16 +25,19 @@ import java.util.Objects;
 public class InitializeExtensionRequest extends TransportRequest {
     private final DiscoveryNode sourceNode;
     private final DiscoveryExtensionNode extension;
+    private final String httpPort;
 
-    public InitializeExtensionRequest(DiscoveryNode sourceNode, DiscoveryExtensionNode extension) {
+    public InitializeExtensionRequest(DiscoveryNode sourceNode, DiscoveryExtensionNode extension, String httpPort) {
         this.sourceNode = sourceNode;
         this.extension = extension;
+        this.httpPort = httpPort;
     }
 
     public InitializeExtensionRequest(StreamInput in) throws IOException {
         super(in);
         sourceNode = new DiscoveryNode(in);
         extension = new DiscoveryExtensionNode(in);
+        httpPort = in.readString();
     }
 
     @Override
@@ -42,6 +45,7 @@ public class InitializeExtensionRequest extends TransportRequest {
         super.writeTo(out);
         sourceNode.writeTo(out);
         extension.writeTo(out);
+        out.writeString(httpPort);
     }
 
     public DiscoveryNode getSourceNode() {
@@ -52,9 +56,13 @@ public class InitializeExtensionRequest extends TransportRequest {
         return extension;
     }
 
+    public String getHttpPort() {
+        return httpPort;
+    }
+
     @Override
     public String toString() {
-        return "InitializeExtensionsRequest{" + "sourceNode=" + sourceNode + ", extension=" + extension + '}';
+        return "InitializeExtensionsRequest{" + "sourceNode=" + sourceNode + ", extension=" + extension + ", httpPort=" + httpPort + '}';
     }
 
     @Override
@@ -62,11 +70,13 @@ public class InitializeExtensionRequest extends TransportRequest {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         InitializeExtensionRequest that = (InitializeExtensionRequest) o;
-        return Objects.equals(sourceNode, that.sourceNode) && Objects.equals(extension, that.extension);
+        return Objects.equals(sourceNode, that.sourceNode)
+            && Objects.equals(extension, that.extension)
+            && Objects.equals(httpPort, that.httpPort);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(sourceNode, extension);
+        return Objects.hash(sourceNode, extension, httpPort);
     }
 }

--- a/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
@@ -409,11 +409,13 @@ public class ExtensionsManager {
         };
         try {
             logger.info("Sending extension request type: " + REQUEST_EXTENSION_ACTION_NAME);
+            // Defaults httpPort to 9200 if not set via opensearch.yml configuration
+            String httpPort = environmentSettings.get("http.port") != null ? environmentSettings.get("http.port") : "9200";
             transportService.connectToExtensionNode(extension);
             transportService.sendRequest(
                 extension,
                 REQUEST_EXTENSION_ACTION_NAME,
-                new InitializeExtensionRequest(transportService.getLocalNode(), extension),
+                new InitializeExtensionRequest(transportService.getLocalNode(), extension, httpPort),
                 initializeExtensionResponseHandler
             );
             inProgressFuture.orTimeout(EXTENSION_REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS).join();

--- a/server/src/test/java/org/opensearch/discovery/InitializeExtensionRequestTests.java
+++ b/server/src/test/java/org/opensearch/discovery/InitializeExtensionRequestTests.java
@@ -26,6 +26,7 @@ public class InitializeExtensionRequestTests extends OpenSearchTestCase {
 
     public void testInitializeExtensionRequest() throws Exception {
         String expectedUniqueId = "test uniqueid";
+        String expectedHttpPort = "test httpPort";
         Version expectedVersion = Version.fromString("2.0.0");
         ExtensionDependency expectedDependency = new ExtensionDependency(expectedUniqueId, expectedVersion);
         DiscoveryExtensionNode expectedExtensionNode = new DiscoveryExtensionNode(
@@ -46,9 +47,14 @@ public class InitializeExtensionRequestTests extends OpenSearchTestCase {
             Version.CURRENT
         );
 
-        InitializeExtensionRequest initializeExtensionRequest = new InitializeExtensionRequest(expectedSourceNode, expectedExtensionNode);
+        InitializeExtensionRequest initializeExtensionRequest = new InitializeExtensionRequest(
+            expectedSourceNode,
+            expectedExtensionNode,
+            expectedHttpPort
+        );
         assertEquals(expectedExtensionNode, initializeExtensionRequest.getExtension());
         assertEquals(expectedSourceNode, initializeExtensionRequest.getSourceNode());
+        assertEquals(expectedHttpPort, initializeExtensionRequest.getHttpPort());
 
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             initializeExtensionRequest.writeTo(out);
@@ -58,6 +64,7 @@ public class InitializeExtensionRequestTests extends OpenSearchTestCase {
 
                 assertEquals(expectedExtensionNode, initializeExtensionRequest.getExtension());
                 assertEquals(expectedSourceNode, initializeExtensionRequest.getSourceNode());
+                assertEquals(expectedHttpPort, initializeExtensionRequest.getHttpPort());
             }
         }
     }


### PR DESCRIPTION
### Description
Companion SDK PR : https://github.com/opensearch-project/opensearch-sdk-java/pull/788

Retrieves the `http.host` setting from `Node.java` and sends this value (present or default) to the extension during initialization for use in updating the extension settings, rest/java clients.

See related comment [here](https://github.com/opensearch-project/opensearch-sdk-java/issues/782#issuecomment-1563683155)

### Related Issues
https://github.com/opensearch-project/opensearch-sdk-java/issues/782

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
