### PR TITLE
[Remote Store] Fix stats api rejection count response

### DIFF
--- a/server/src/main/java/org/opensearch/index/remote/RemoteRefreshSegmentTracker.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteRefreshSegmentTracker.java
@@ -325,6 +325,7 @@ public class RemoteRefreshSegmentTracker {
 
     void incrementRejectionCount(String rejectionReason) {
         rejectionCountMap.computeIfAbsent(rejectionReason, k -> new AtomicLong()).incrementAndGet();
+        incrementRejectionCount();
     }
 
     long getRejectionCount(String rejectionReason) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The `backpressure_rejection_count` field in the `_remotestore/stats/{index}` api response was coming to be zero always. The issue is narrowed to the missing code of incrementing the global rejection counter when the remote segment backpressure framework rejects a write request. In the PR, we have fixed the issue.

### Related Issues
Resolves #7774

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
