### PR TITLE
[Remote Segment Store] Combine metadata and snapshot files

### DIFF
--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -4527,6 +4527,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                         indexInput,
                         remoteSegmentMetadata.getGeneration()
                     );
+                    long processedLocalCheckpoint = Long.parseLong(infosSnapshot.getUserData().get(LOCAL_CHECKPOINT_KEY));
                     // Following code block makes sure to commit SegmentInfosSnapshot with the highest generation.
                     // If local filesystem already has segments_N+2 and infosSnapshot has generation N, after commit,
                     // there would be 2 files that would be created segments_N+1 and segments_N+2. With the policy of preserving
@@ -4541,7 +4542,6 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                             infosSnapshot = localSegmentInfos.clone();
                         }
                     }
-                    long processedLocalCheckpoint = Long.parseLong(infosSnapshot.getUserData().get(LOCAL_CHECKPOINT_KEY));
                     store.commitSegmentInfos(infosSnapshot, processedLocalCheckpoint, processedLocalCheckpoint);
                 }
             }

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -4516,7 +4516,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             if (refreshLevelSegmentSync && remoteSegmentMetadata != null) {
                 try (
                     ChecksumIndexInput indexInput = new BufferedChecksumIndexInput(
-                        new ByteArrayIndexInput("", remoteSegmentMetadata.getSegmentInfosBytes())
+                        new ByteArrayIndexInput("Snapshot of SegmentInfos", remoteSegmentMetadata.getSegmentInfosBytes())
                     );
                 ) {
                     SegmentInfos infosSnapshot = SegmentInfos.readCommit(

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -40,6 +40,7 @@ import org.apache.lucene.index.CheckIndex;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.FilterDirectoryReader;
 import org.apache.lucene.index.IndexCommit;
+import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.index.Term;
@@ -197,6 +198,7 @@ import java.nio.file.NoSuchFileException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
@@ -4513,6 +4515,10 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                     skippedSegments.add(file);
                 }
             }
+            Optional<String> localMaxSegmentInfos = localSegmentFiles.stream()
+                .filter(file -> file.startsWith(IndexFileNames.SEGMENTS))
+                .max(Comparator.comparingLong(SegmentInfos::generationFromSegmentsFileName));
+
             if (refreshLevelSegmentSync && remoteSegmentMetadata != null) {
                 try (
                     ChecksumIndexInput indexInput = new BufferedChecksumIndexInput(
@@ -4525,6 +4531,18 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                         remoteSegmentMetadata.getGeneration()
                     );
                     long processedLocalCheckpoint = Long.parseLong(infosSnapshot.getUserData().get(LOCAL_CHECKPOINT_KEY));
+                    // Following code block makes sure to commit SegmentInfosSnapshot with the highest generation.
+                    // If local filesystem already has segments_N+1 and infosSnapshot has generation N, after commit,
+                    // there would be 2 files that would be created segments_N and segments_N+1. With the policy of preserving
+                    // only the latest commit, we will delete segments_N which in fact is the part of the latest commit.
+                    if (localMaxSegmentInfos.isPresent()) {
+                        infosSnapshot.setNextWriteGeneration(
+                            Math.max(
+                                infosSnapshot.getGeneration(),
+                                SegmentInfos.generationFromSegmentsFileName(localMaxSegmentInfos.get()) + 1
+                            )
+                        );
+                    }
                     store.commitSegmentInfos(infosSnapshot, processedLocalCheckpoint, processedLocalCheckpoint);
                 }
             }

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -56,6 +56,7 @@ import org.apache.lucene.store.FilterDirectory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.ThreadInterruptedException;
+import org.opensearch.common.lucene.store.ByteArrayIndexInput;
 import org.opensearch.core.Assertions;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchException;
@@ -159,6 +160,7 @@ import org.opensearch.index.store.Store;
 import org.opensearch.index.store.Store.MetadataSnapshot;
 import org.opensearch.index.store.StoreFileMetadata;
 import org.opensearch.index.store.StoreStats;
+import org.opensearch.index.store.remote.metadata.RemoteSegmentMetadata;
 import org.opensearch.index.translog.RemoteBlobStoreInternalTranslogFactory;
 import org.opensearch.index.translog.RemoteFsTranslog;
 import org.opensearch.index.translog.Translog;
@@ -223,7 +225,6 @@ import static org.opensearch.index.seqno.RetentionLeaseActions.RETAIN_ALL;
 import static org.opensearch.index.seqno.SequenceNumbers.LOCAL_CHECKPOINT_KEY;
 import static org.opensearch.index.seqno.SequenceNumbers.MAX_SEQ_NO;
 import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
-import static org.opensearch.index.shard.RemoteStoreRefreshListener.SEGMENT_INFO_SNAPSHOT_FILENAME_PREFIX;
 import static org.opensearch.index.translog.Translog.Durability;
 
 /**
@@ -4477,7 +4478,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         // We need to call RemoteSegmentStoreDirectory.init() in order to get latest metadata of the files that
         // are uploaded to the remote segment store.
         assert remoteDirectory instanceof RemoteSegmentStoreDirectory : "remoteDirectory is not an instance of RemoteSegmentStoreDirectory";
-        ((RemoteSegmentStoreDirectory) remoteDirectory).init();
+        RemoteSegmentMetadata remoteSegmentMetadata = ((RemoteSegmentStoreDirectory) remoteDirectory).init();
         Map<String, RemoteSegmentStoreDirectory.UploadedSegmentMetadata> uploadedSegments = ((RemoteSegmentStoreDirectory) remoteDirectory)
             .getSegmentsUploadedToRemoteStore();
         store.incRef();
@@ -4499,7 +4500,6 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             } else {
                 storeDirectory = store.directory();
             }
-            String segmentInfosSnapshotFilename = null;
             Set<String> localSegmentFiles = Sets.newHashSet(storeDirectory.listAll());
             for (String file : uploadedSegments.keySet()) {
                 long checksum = Long.parseLong(uploadedSegments.get(file).getChecksum());
@@ -4509,24 +4509,20 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                     }
                     storeDirectory.copyFrom(remoteDirectory, file, file, IOContext.DEFAULT);
                     downloadedSegments.add(file);
-                    if (file.startsWith(SEGMENT_INFO_SNAPSHOT_FILENAME_PREFIX)) {
-                        assert segmentInfosSnapshotFilename == null : "There should be only one SegmentInfosSnapshot file";
-                        segmentInfosSnapshotFilename = file;
-                    }
                 } else {
                     skippedSegments.add(file);
                 }
             }
-            if (refreshLevelSegmentSync && segmentInfosSnapshotFilename != null) {
+            if (refreshLevelSegmentSync && remoteSegmentMetadata != null) {
                 try (
                     ChecksumIndexInput indexInput = new BufferedChecksumIndexInput(
-                        storeDirectory.openInput(segmentInfosSnapshotFilename, IOContext.DEFAULT)
-                    )
+                        new ByteArrayIndexInput("", remoteSegmentMetadata.getSegmentInfosBytes())
+                    );
                 ) {
                     SegmentInfos infosSnapshot = SegmentInfos.readCommit(
                         store.directory(),
                         indexInput,
-                        Long.parseLong(segmentInfosSnapshotFilename.split("__")[1])
+                        remoteSegmentMetadata.getGeneration()
                     );
                     long processedLocalCheckpoint = Long.parseLong(infosSnapshot.getUserData().get(LOCAL_CHECKPOINT_KEY));
                     store.commitSegmentInfos(infosSnapshot, processedLocalCheckpoint, processedLocalCheckpoint);

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -4515,9 +4515,6 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                     skippedSegments.add(file);
                 }
             }
-            Optional<String> localMaxSegmentInfos = localSegmentFiles.stream()
-                .filter(file -> file.startsWith(IndexFileNames.SEGMENTS))
-                .max(Comparator.comparingLong(SegmentInfos::generationFromSegmentsFileName));
 
             if (refreshLevelSegmentSync && remoteSegmentMetadata != null) {
                 try (
@@ -4530,19 +4527,21 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                         indexInput,
                         remoteSegmentMetadata.getGeneration()
                     );
-                    long processedLocalCheckpoint = Long.parseLong(infosSnapshot.getUserData().get(LOCAL_CHECKPOINT_KEY));
                     // Following code block makes sure to commit SegmentInfosSnapshot with the highest generation.
-                    // If local filesystem already has segments_N+1 and infosSnapshot has generation N, after commit,
-                    // there would be 2 files that would be created segments_N and segments_N+1. With the policy of preserving
-                    // only the latest commit, we will delete segments_N which in fact is the part of the latest commit.
-                    if (localMaxSegmentInfos.isPresent()) {
-                        infosSnapshot.setNextWriteGeneration(
-                            Math.max(
-                                infosSnapshot.getGeneration(),
-                                SegmentInfos.generationFromSegmentsFileName(localMaxSegmentInfos.get()) + 1
-                            )
-                        );
+                    // If local filesystem already has segments_N+2 and infosSnapshot has generation N, after commit,
+                    // there would be 2 files that would be created segments_N+1 and segments_N+2. With the policy of preserving
+                    // only the latest commit, we will delete segments_N+1 which in fact is the part of the latest commit.
+                    Optional<String> localMaxSegmentInfos = localSegmentFiles.stream()
+                        .filter(file -> file.startsWith(IndexFileNames.SEGMENTS))
+                        .max(Comparator.comparingLong(SegmentInfos::generationFromSegmentsFileName));
+                    if (localMaxSegmentInfos.isPresent()
+                        && infosSnapshot.getGeneration() < SegmentInfos.generationFromSegmentsFileName(localMaxSegmentInfos.get()) - 1) {
+                        SegmentInfos localSegmentInfos = store.readLastCommittedSegmentsInfo();
+                        if (localSegmentInfos.files(false).equals(infosSnapshot.files(false))) {
+                            infosSnapshot = localSegmentInfos.clone();
+                        }
                     }
+                    long processedLocalCheckpoint = Long.parseLong(infosSnapshot.getUserData().get(LOCAL_CHECKPOINT_KEY));
                     store.commitSegmentInfos(infosSnapshot, processedLocalCheckpoint, processedLocalCheckpoint);
                 }
             }

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -19,7 +19,6 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FilterDirectory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
-import org.apache.lucene.store.IndexOutput;
 import org.opensearch.action.bulk.BackoffPolicy;
 import org.opensearch.common.CheckedFunction;
 import org.opensearch.common.concurrent.GatedCloseable;
@@ -37,7 +36,6 @@ import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -201,7 +199,6 @@ public final class RemoteStoreRefreshListener implements ReferenceManager.Refres
                     deleteStaleCommits();
                 }
 
-                String segmentInfoSnapshotFilename = null;
                 try (GatedCloseable<SegmentInfos> segmentInfosGatedCloseable = indexShard.getSegmentInfosSnapshot()) {
                     SegmentInfos segmentInfos = segmentInfosGatedCloseable.get();
                     // Capture replication checkpoint before uploading the segments as upload can take some time and checkpoint can
@@ -233,16 +230,8 @@ public final class RemoteStoreRefreshListener implements ReferenceManager.Refres
                         // Start the segments files upload
                         boolean newSegmentsUploadStatus = uploadNewSegments(localSegmentsPostRefresh);
                         if (newSegmentsUploadStatus) {
-                            segmentInfoSnapshotFilename = uploadSegmentInfosSnapshot(latestSegmentInfos.get(), segmentInfos);
-                            localSegmentsPostRefresh.add(segmentInfoSnapshotFilename);
-
                             // Start metadata file upload
-                            remoteDirectory.uploadMetadata(
-                                localSegmentsPostRefresh,
-                                storeDirectory,
-                                indexShard.getOperationPrimaryTerm(),
-                                segmentInfos.getGeneration()
-                            );
+                            uploadMetadata(localSegmentsPostRefresh, segmentInfos);
                             clearStaleFilesFromLocalSegmentChecksumMap(localSegmentsPostRefresh);
                             onSuccessfulSegmentsSync(refreshTimeMs, refreshSeqNo);
                             indexShard.getEngine().translogManager().setMinSeqNoToKeep(lastRefreshedCheckpoint + 1);
@@ -254,14 +243,6 @@ public final class RemoteStoreRefreshListener implements ReferenceManager.Refres
                     }
                 } catch (EngineException e) {
                     logger.warn("Exception while reading SegmentInfosSnapshot", e);
-                } finally {
-                    try {
-                        if (segmentInfoSnapshotFilename != null) {
-                            storeDirectory.deleteFile(segmentInfoSnapshotFilename);
-                        }
-                    } catch (IOException e) {
-                        logger.warn("Exception while deleting: " + segmentInfoSnapshotFilename, e);
-                    }
                 }
             } catch (IOException e) {
                 // We don't want to fail refresh if upload of new segments fails. The missed segments will be re-tried
@@ -347,22 +328,21 @@ public final class RemoteStoreRefreshListener implements ReferenceManager.Refres
             && !remoteDirectory.containsFile(lastCommittedLocalSegmentFileName, getChecksumOfLocalFile(lastCommittedLocalSegmentFileName)));
     }
 
-    String uploadSegmentInfosSnapshot(String latestSegmentsNFilename, SegmentInfos segmentInfosSnapshot) throws IOException {
-        final long maxSeqNoFromSegmentInfos = indexShard.getEngine().getMaxSeqNoFromSegmentInfos(segmentInfosSnapshot);
+    void uploadMetadata(Collection<String> localSegmentsPostRefresh, SegmentInfos segmentInfos) throws IOException {
+        final long maxSeqNoFromSegmentInfos = indexShard.getEngine().getMaxSeqNoFromSegmentInfos(segmentInfos);
 
+        SegmentInfos segmentInfosSnapshot = segmentInfos.clone();
         Map<String, String> userData = segmentInfosSnapshot.getUserData();
         userData.put(LOCAL_CHECKPOINT_KEY, String.valueOf(maxSeqNoFromSegmentInfos));
         userData.put(SequenceNumbers.MAX_SEQ_NO, Long.toString(maxSeqNoFromSegmentInfos));
         segmentInfosSnapshot.setUserData(userData, false);
 
-        long commitGeneration = SegmentInfos.generationFromSegmentsFileName(latestSegmentsNFilename);
-        String segmentInfoSnapshotFilename = SEGMENT_INFO_SNAPSHOT_FILENAME_PREFIX + "__" + commitGeneration;
-        try (IndexOutput indexOutput = storeDirectory.createOutput(segmentInfoSnapshotFilename, IOContext.DEFAULT)) {
-            segmentInfosSnapshot.write(indexOutput);
-        }
-        storeDirectory.sync(Collections.singleton(segmentInfoSnapshotFilename));
-        remoteDirectory.copyFrom(storeDirectory, segmentInfoSnapshotFilename, segmentInfoSnapshotFilename, IOContext.DEFAULT, true);
-        return segmentInfoSnapshotFilename;
+        remoteDirectory.uploadMetadata(
+            localSegmentsPostRefresh,
+            segmentInfosSnapshot,
+            storeDirectory,
+            indexShard.getOperationPrimaryTerm()
+        );
     }
 
     private boolean uploadNewSegments(Collection<String> localSegmentsPostRefresh) throws IOException {

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -83,7 +83,6 @@ public final class RemoteStoreRefreshListener implements ReferenceManager.Refres
     static final Set<String> EXCLUDE_FILES = Set.of("write.lock");
     // Visible for testing
     static final int LAST_N_METADATA_FILES_TO_KEEP = 10;
-    static final String SEGMENT_INFO_SNAPSHOT_FILENAME_PREFIX = "segment_infos_snapshot_filename";
 
     private final IndexShard indexShard;
     private final Directory storeDirectory;

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -472,7 +472,7 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
             }
 
             ByteBuffersDataOutput byteBuffersIndexOutput = new ByteBuffersDataOutput();
-            segmentInfosSnapshot.write(new ByteBuffersIndexOutput(byteBuffersIndexOutput, "", ""));
+            segmentInfosSnapshot.write(new ByteBuffersIndexOutput(byteBuffersIndexOutput, "Snapshot of SegmentInfos", "SegmentInfos"));
             byte[] byteArray = byteBuffersIndexOutput.toArrayCopy();
 
             metadataStreamWrapper.writeStream(

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -473,13 +473,13 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
 
             ByteBuffersDataOutput byteBuffersIndexOutput = new ByteBuffersDataOutput();
             segmentInfosSnapshot.write(new ByteBuffersIndexOutput(byteBuffersIndexOutput, "Snapshot of SegmentInfos", "SegmentInfos"));
-            byte[] byteArray = byteBuffersIndexOutput.toArrayCopy();
+            byte[] segmentInfoSnapshotByteArray = byteBuffersIndexOutput.toArrayCopy();
 
             metadataStreamWrapper.writeStream(
                 indexOutput,
                 new RemoteSegmentMetadata(
                     RemoteSegmentMetadata.fromMapOfStrings(uploadedSegments),
-                    byteArray,
+                    segmentInfoSnapshotByteArray,
                     segmentInfosSnapshot.getGeneration()
                 )
             );

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -11,6 +11,9 @@ package org.opensearch.index.store;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.store.ByteBuffersDataOutput;
+import org.apache.lucene.store.ByteBuffersIndexOutput;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FilterDirectory;
 import org.apache.lucene.store.IOContext;
@@ -111,9 +114,15 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
      * It is caller's responsibility to call init() again to ensure that cache is properly updated.
      * @throws IOException if there were any failures in reading the metadata file
      */
-    public void init() throws IOException {
+    public RemoteSegmentMetadata init() throws IOException {
         this.commonFilenameSuffix = UUIDs.base64UUID();
-        this.segmentsUploadedToRemoteStore = new ConcurrentHashMap<>(readLatestMetadataFile());
+        RemoteSegmentMetadata remoteSegmentMetadata = readLatestMetadataFile();
+        if (remoteSegmentMetadata != null) {
+            this.segmentsUploadedToRemoteStore = new ConcurrentHashMap<>(remoteSegmentMetadata.getMetadata());
+        } else {
+            this.segmentsUploadedToRemoteStore = new ConcurrentHashMap<>();
+        }
+        return remoteSegmentMetadata;
     }
 
     /**
@@ -128,28 +137,29 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
      * @return Map of segment filename to uploaded filename with checksum
      * @throws IOException if there were any failures in reading the metadata file
      */
-    private Map<String, UploadedSegmentMetadata> readLatestMetadataFile() throws IOException {
+    private RemoteSegmentMetadata readLatestMetadataFile() throws IOException {
         Map<String, UploadedSegmentMetadata> segmentMetadataMap = new HashMap<>();
+        RemoteSegmentMetadata remoteSegmentMetadata = null;
 
         Collection<String> metadataFiles = remoteMetadataDirectory.listFilesByPrefix(MetadataFilenameUtils.METADATA_PREFIX);
         Optional<String> latestMetadataFile = metadataFiles.stream().max(METADATA_FILENAME_COMPARATOR);
 
         if (latestMetadataFile.isPresent()) {
             logger.info("Reading latest Metadata file {}", latestMetadataFile.get());
-            segmentMetadataMap = readMetadataFile(latestMetadataFile.get());
+            remoteSegmentMetadata = readMetadataFile(latestMetadataFile.get());
         } else {
             logger.info("No metadata file found, this can happen for new index with no data uploaded to remote segment store");
         }
 
-        return segmentMetadataMap;
+        return remoteSegmentMetadata;
     }
 
-    private Map<String, UploadedSegmentMetadata> readMetadataFile(String metadataFilename) throws IOException {
+    private RemoteSegmentMetadata readMetadataFile(String metadataFilename) throws IOException {
         try (IndexInput indexInput = remoteMetadataDirectory.openInput(metadataFilename, IOContext.DEFAULT)) {
             byte[] metadataBytes = new byte[(int) indexInput.length()];
             indexInput.readBytes(metadataBytes, 0, (int) indexInput.length());
             RemoteSegmentMetadata metadata = metadataStreamWrapper.readStream(new ByteArrayIndexInput(metadataFilename, metadataBytes));
-            return metadata.getMetadata();
+            return metadata;
         }
     }
 
@@ -262,7 +272,7 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
      */
     @Override
     public String[] listAll() throws IOException {
-        return readLatestMetadataFile().keySet().toArray(new String[0]);
+        return readLatestMetadataFile().getMetadata().keySet().toArray(new String[0]);
     }
 
     /**
@@ -434,15 +444,23 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
     /**
      * Upload metadata file
      * @param segmentFiles segment files that are part of the shard at the time of the latest refresh
+     * @param segmentInfosSnapshot SegmentInfos bytes to store as part of metadata file
      * @param storeDirectory instance of local directory to temporarily create metadata file before upload
      * @param primaryTerm primary term to be used in the name of metadata file
-     * @param generation commit generation
      * @throws IOException in case of I/O error while uploading the metadata file
      */
-    public void uploadMetadata(Collection<String> segmentFiles, Directory storeDirectory, long primaryTerm, long generation)
-        throws IOException {
+    public void uploadMetadata(
+        Collection<String> segmentFiles,
+        SegmentInfos segmentInfosSnapshot,
+        Directory storeDirectory,
+        long primaryTerm
+    ) throws IOException {
         synchronized (this) {
-            String metadataFilename = MetadataFilenameUtils.getMetadataFilename(primaryTerm, generation, this.commonFilenameSuffix);
+            String metadataFilename = MetadataFilenameUtils.getMetadataFilename(
+                primaryTerm,
+                segmentInfosSnapshot.getGeneration(),
+                this.commonFilenameSuffix
+            );
             IndexOutput indexOutput = storeDirectory.createOutput(metadataFilename, IOContext.DEFAULT);
             Map<String, String> uploadedSegments = new HashMap<>();
             for (String file : segmentFiles) {
@@ -452,7 +470,19 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
                     throw new NoSuchFileException(file);
                 }
             }
-            metadataStreamWrapper.writeStream(indexOutput, RemoteSegmentMetadata.fromMapOfStrings(uploadedSegments));
+
+            ByteBuffersDataOutput byteBuffersIndexOutput = new ByteBuffersDataOutput();
+            segmentInfosSnapshot.write(new ByteBuffersIndexOutput(byteBuffersIndexOutput, "", ""));
+            byte[] byteArray = byteBuffersIndexOutput.toArrayCopy();
+
+            metadataStreamWrapper.writeStream(
+                indexOutput,
+                new RemoteSegmentMetadata(
+                    RemoteSegmentMetadata.fromMapOfStrings(uploadedSegments),
+                    byteArray,
+                    segmentInfosSnapshot.getGeneration()
+                )
+            );
             indexOutput.close();
             storeDirectory.sync(Collections.singleton(metadataFilename));
             remoteMetadataDirectory.copyFrom(storeDirectory, metadataFilename, metadataFilename, IOContext.DEFAULT);
@@ -490,7 +520,9 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
     public Map<String, UploadedSegmentMetadata> getSegmentsUploadedToRemoteStore(long primaryTerm, long generation) throws IOException {
         String metadataFile = getMetadataFileForCommit(primaryTerm, generation);
 
-        Map<String, UploadedSegmentMetadata> segmentsUploadedToRemoteStore = new ConcurrentHashMap<>(readMetadataFile(metadataFile));
+        Map<String, UploadedSegmentMetadata> segmentsUploadedToRemoteStore = new ConcurrentHashMap<>(
+            readMetadataFile(metadataFile).getMetadata()
+        );
         return Collections.unmodifiableMap(segmentsUploadedToRemoteStore);
     }
 
@@ -546,14 +578,14 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
         Map<String, UploadedSegmentMetadata> activeSegmentFilesMetadataMap = new HashMap<>();
         Set<String> activeSegmentRemoteFilenames = new HashSet<>();
         for (String metadataFile : sortedMetadataFileList) {
-            Map<String, UploadedSegmentMetadata> segmentMetadataMap = readMetadataFile(metadataFile);
+            Map<String, UploadedSegmentMetadata> segmentMetadataMap = readMetadataFile(metadataFile).getMetadata();
             activeSegmentFilesMetadataMap.putAll(segmentMetadataMap);
             activeSegmentRemoteFilenames.addAll(
                 segmentMetadataMap.values().stream().map(metadata -> metadata.uploadedFilename).collect(Collectors.toSet())
             );
         }
         for (String metadataFile : metadataFilesToBeDeleted) {
-            Map<String, UploadedSegmentMetadata> staleSegmentFilesMetadataMap = readMetadataFile(metadataFile);
+            Map<String, UploadedSegmentMetadata> staleSegmentFilesMetadataMap = readMetadataFile(metadataFile).getMetadata();
             Set<String> staleSegmentRemoteFilenames = staleSegmentFilesMetadataMap.values()
                 .stream()
                 .map(metadata -> metadata.uploadedFilename)

--- a/server/src/main/java/org/opensearch/index/store/remote/metadata/RemoteSegmentMetadata.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/metadata/RemoteSegmentMetadata.java
@@ -8,9 +8,11 @@
 
 package org.opensearch.index.store.remote.metadata;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.apache.lucene.store.IndexOutput;
 import org.opensearch.index.store.RemoteSegmentStoreDirectory;
 
 /**
@@ -33,8 +35,18 @@ public class RemoteSegmentMetadata {
      */
     private final Map<String, RemoteSegmentStoreDirectory.UploadedSegmentMetadata> metadata;
 
-    public RemoteSegmentMetadata(Map<String, RemoteSegmentStoreDirectory.UploadedSegmentMetadata> metadata) {
+    private final byte[] segmentInfosBytes;
+
+    private final long generation;
+
+    public RemoteSegmentMetadata(
+        Map<String, RemoteSegmentStoreDirectory.UploadedSegmentMetadata> metadata,
+        byte[] segmentInfosBytes,
+        long generation
+    ) {
         this.metadata = metadata;
+        this.segmentInfosBytes = segmentInfosBytes;
+        this.generation = generation;
     }
 
     /**
@@ -43,6 +55,14 @@ public class RemoteSegmentMetadata {
      */
     public Map<String, RemoteSegmentStoreDirectory.UploadedSegmentMetadata> getMetadata() {
         return this.metadata;
+    }
+
+    public byte[] getSegmentInfosBytes() {
+        return segmentInfosBytes;
+    }
+
+    public long getGeneration() {
+        return generation;
     }
 
     /**
@@ -58,16 +78,21 @@ public class RemoteSegmentMetadata {
      * @param segmentMetadata metadata content in the form of {@code Map<String, String>}
      * @return {@link RemoteSegmentMetadata}
      */
-    public static RemoteSegmentMetadata fromMapOfStrings(Map<String, String> segmentMetadata) {
-        return new RemoteSegmentMetadata(
-            segmentMetadata.entrySet()
-                .stream()
-                .collect(
-                    Collectors.toMap(
-                        Map.Entry::getKey,
-                        entry -> RemoteSegmentStoreDirectory.UploadedSegmentMetadata.fromString(entry.getValue())
-                    )
+    public static Map<String, RemoteSegmentStoreDirectory.UploadedSegmentMetadata> fromMapOfStrings(Map<String, String> segmentMetadata) {
+        return segmentMetadata.entrySet()
+            .stream()
+            .collect(
+                Collectors.toMap(
+                    Map.Entry::getKey,
+                    entry -> RemoteSegmentStoreDirectory.UploadedSegmentMetadata.fromString(entry.getValue())
                 )
-        );
+            );
+    }
+
+    public void write(IndexOutput out) throws IOException {
+        out.writeMapOfStrings(toMapOfStrings());
+        out.writeLong(generation);
+        out.writeLong(segmentInfosBytes.length);
+        out.writeBytes(segmentInfosBytes, segmentInfosBytes.length);
     }
 }

--- a/server/src/main/java/org/opensearch/index/store/remote/metadata/RemoteSegmentMetadata.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/metadata/RemoteSegmentMetadata.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.opensearch.index.store.RemoteSegmentStoreDirectory;
 
@@ -94,5 +95,14 @@ public class RemoteSegmentMetadata {
         out.writeLong(generation);
         out.writeLong(segmentInfosBytes.length);
         out.writeBytes(segmentInfosBytes, segmentInfosBytes.length);
+    }
+
+    public static RemoteSegmentMetadata read(IndexInput indexInput) throws IOException {
+        Map<String, String> metadata = indexInput.readMapOfStrings();
+        long generation = indexInput.readLong();
+        int byteArraySize = (int) indexInput.readLong();
+        byte[] segmentInfosBytes = new byte[byteArraySize];
+        indexInput.readBytes(segmentInfosBytes, 0, byteArraySize);
+        return new RemoteSegmentMetadata(RemoteSegmentMetadata.fromMapOfStrings(metadata), segmentInfosBytes, generation);
     }
 }

--- a/server/src/main/java/org/opensearch/index/store/remote/metadata/RemoteSegmentMetadataHandler.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/metadata/RemoteSegmentMetadataHandler.java
@@ -9,6 +9,7 @@
 package org.opensearch.index.store.remote.metadata;
 
 import java.io.IOException;
+import java.util.Map;
 
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
@@ -27,7 +28,12 @@ public class RemoteSegmentMetadataHandler implements IndexIOStreamHandler<Remote
      */
     @Override
     public RemoteSegmentMetadata readContent(IndexInput indexInput) throws IOException {
-        return RemoteSegmentMetadata.fromMapOfStrings(indexInput.readMapOfStrings());
+        Map<String, String> metadata = indexInput.readMapOfStrings();
+        long generation = indexInput.readLong();
+        int byteArraySize = (int) indexInput.readLong();
+        byte[] segmentInfosBytes = new byte[byteArraySize];
+        indexInput.readBytes(segmentInfosBytes, 0, byteArraySize);
+        return new RemoteSegmentMetadata(RemoteSegmentMetadata.fromMapOfStrings(metadata), segmentInfosBytes, generation);
     }
 
     /**
@@ -37,6 +43,6 @@ public class RemoteSegmentMetadataHandler implements IndexIOStreamHandler<Remote
      */
     @Override
     public void writeContent(IndexOutput indexOutput, RemoteSegmentMetadata content) throws IOException {
-        indexOutput.writeMapOfStrings(content.toMapOfStrings());
+        content.write(indexOutput);
     }
 }

--- a/server/src/main/java/org/opensearch/index/store/remote/metadata/RemoteSegmentMetadataHandler.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/metadata/RemoteSegmentMetadataHandler.java
@@ -9,7 +9,6 @@
 package org.opensearch.index.store.remote.metadata;
 
 import java.io.IOException;
-import java.util.Map;
 
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
@@ -28,12 +27,7 @@ public class RemoteSegmentMetadataHandler implements IndexIOStreamHandler<Remote
      */
     @Override
     public RemoteSegmentMetadata readContent(IndexInput indexInput) throws IOException {
-        Map<String, String> metadata = indexInput.readMapOfStrings();
-        long generation = indexInput.readLong();
-        int byteArraySize = (int) indexInput.readLong();
-        byte[] segmentInfosBytes = new byte[byteArraySize];
-        indexInput.readBytes(segmentInfosBytes, 0, byteArraySize);
-        return new RemoteSegmentMetadata(RemoteSegmentMetadata.fromMapOfStrings(metadata), segmentInfosBytes, generation);
+        return RemoteSegmentMetadata.read(indexInput);
     }
 
     /**

--- a/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
@@ -449,17 +449,5 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
                 }
             }
         }
-        if (segmentsNFilename != null) {
-            String commitGeneration = segmentsNFilename.substring((IndexFileNames.SEGMENTS + "_").length());
-            assertTrue(
-                uploadedSegments.keySet()
-                    .stream()
-                    .anyMatch(
-                        s -> s.startsWith(
-                            SEGMENT_INFO_SNAPSHOT_FILENAME_PREFIX + "__" + Long.parseLong(commitGeneration, Character.MAX_RADIX)
-                        )
-                    )
-            );
-        }
     }
 }

--- a/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
@@ -44,7 +44,6 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REPLICATION_TYPE;
-import static org.opensearch.index.shard.RemoteStoreRefreshListener.SEGMENT_INFO_SNAPSHOT_FILENAME_PREFIX;
 
 public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
     private IndexShard indexShard;

--- a/server/src/test/java/org/opensearch/index/store/remote/metadata/RemoteSegmentMetadataHandlerTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/metadata/RemoteSegmentMetadataHandlerTests.java
@@ -8,13 +8,22 @@
 
 package org.opensearch.index.store.remote.metadata;
 
+import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.store.ByteBuffersDataOutput;
+import org.apache.lucene.store.ByteBuffersIndexOutput;
 import org.apache.lucene.store.OutputStreamIndexOutput;
+import org.junit.After;
 import org.junit.Before;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.lucene.store.ByteArrayIndexInput;
-import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.engine.NRTReplicationEngineFactory;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.index.shard.IndexShardTestCase;
+import org.opensearch.index.store.Store;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -23,35 +32,88 @@ import java.util.Map;
 /**
  * Unit Tests for {@link RemoteSegmentMetadataHandler}
  */
-public class RemoteSegmentMetadataHandlerTests extends OpenSearchTestCase {
+public class RemoteSegmentMetadataHandlerTests extends IndexShardTestCase {
     private RemoteSegmentMetadataHandler remoteSegmentMetadataHandler;
+    private IndexShard indexShard;
+    private SegmentInfos segmentInfos;
 
     @Before
     public void setup() throws IOException {
         remoteSegmentMetadataHandler = new RemoteSegmentMetadataHandler();
+
+        Settings indexSettings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, org.opensearch.Version.CURRENT).build();
+
+        indexShard = newStartedShard(false, indexSettings, new NRTReplicationEngineFactory());
+        try (Store store = indexShard.store()) {
+            segmentInfos = store.readLastCommittedSegmentsInfo();
+        }
     }
 
-    public void testReadContent() throws IOException {
+    @After
+    public void tearDown() throws Exception {
+        indexShard.close("test tearDown", true);
+        super.tearDown();
+    }
+
+    public void testReadContentNoSegmentInfos() throws IOException {
         BytesStreamOutput output = new BytesStreamOutput();
         OutputStreamIndexOutput indexOutput = new OutputStreamIndexOutput("dummy bytes", "dummy stream", output, 4096);
         Map<String, String> expectedOutput = getDummyData();
         indexOutput.writeMapOfStrings(expectedOutput);
+        indexOutput.writeLong(1234);
+        indexOutput.writeLong(0);
+        indexOutput.writeBytes(new byte[0], 0);
         indexOutput.close();
         RemoteSegmentMetadata metadata = remoteSegmentMetadataHandler.readContent(
             new ByteArrayIndexInput("dummy bytes", BytesReference.toBytes(output.bytes()))
         );
         assertEquals(expectedOutput, metadata.toMapOfStrings());
+        assertEquals(1234, metadata.getGeneration());
+    }
+
+    public void testReadContentWithSegmentInfos() throws IOException {
+        BytesStreamOutput output = new BytesStreamOutput();
+        OutputStreamIndexOutput indexOutput = new OutputStreamIndexOutput("dummy bytes", "dummy stream", output, 4096);
+        Map<String, String> expectedOutput = getDummyData();
+        indexOutput.writeMapOfStrings(expectedOutput);
+        indexOutput.writeLong(1234);
+        ByteBuffersIndexOutput segmentInfosOutput = new ByteBuffersIndexOutput(new ByteBuffersDataOutput(), "test", "resource");
+        segmentInfos.write(segmentInfosOutput);
+        byte[] segmentInfosBytes = segmentInfosOutput.toArrayCopy();
+        indexOutput.writeLong(segmentInfosBytes.length);
+        indexOutput.writeBytes(segmentInfosBytes, 0, segmentInfosBytes.length);
+        indexOutput.close();
+        RemoteSegmentMetadata metadata = remoteSegmentMetadataHandler.readContent(
+            new ByteArrayIndexInput("dummy bytes", BytesReference.toBytes(output.bytes()))
+        );
+        assertEquals(expectedOutput, metadata.toMapOfStrings());
+        assertEquals(1234, metadata.getGeneration());
+        assertArrayEquals(segmentInfosBytes, metadata.getSegmentInfosBytes());
     }
 
     public void testWriteContent() throws IOException {
         BytesStreamOutput output = new BytesStreamOutput();
         OutputStreamIndexOutput indexOutput = new OutputStreamIndexOutput("dummy bytes", "dummy stream", output, 4096);
+
         Map<String, String> expectedOutput = getDummyData();
-        remoteSegmentMetadataHandler.writeContent(indexOutput, RemoteSegmentMetadata.fromMapOfStrings(expectedOutput));
+        ByteBuffersIndexOutput segmentInfosOutput = new ByteBuffersIndexOutput(new ByteBuffersDataOutput(), "test", "resource");
+        segmentInfos.write(segmentInfosOutput);
+        byte[] segmentInfosBytes = segmentInfosOutput.toArrayCopy();
+
+        RemoteSegmentMetadata remoteSegmentMetadata = new RemoteSegmentMetadata(
+            RemoteSegmentMetadata.fromMapOfStrings(expectedOutput),
+            segmentInfosBytes,
+            1234
+        );
+        remoteSegmentMetadataHandler.writeContent(indexOutput, remoteSegmentMetadata);
         indexOutput.close();
-        Map<String, String> actualOutput = new ByteArrayIndexInput("dummy bytes", BytesReference.toBytes(output.bytes()))
-            .readMapOfStrings();
-        assertEquals(expectedOutput, actualOutput);
+
+        RemoteSegmentMetadata metadata = remoteSegmentMetadataHandler.readContent(
+            new ByteArrayIndexInput("dummy bytes", BytesReference.toBytes(output.bytes()))
+        );
+        assertEquals(expectedOutput, metadata.toMapOfStrings());
+        assertEquals(1234, metadata.getGeneration());
+        assertArrayEquals(segmentInfosBytes, metadata.getSegmentInfosBytes());
     }
 
     private Map<String, String> getDummyData() {


### PR DESCRIPTION
### Description
- Currently, we upload 2 files in addition to segment files per refresh (we upload these files even if there are no segments to upload - that will be fixed by https://github.com/opensearch-project/OpenSearch/issues/7443)
- These 2 files are metadata file and `SegmentInfosSnapshot` file. In order to avoid explosion of number of files in the remote store, we use the same name of metadata and snapshot file per commit.
- But the assumed invariant is: there is 1:1 mapping between metadata and SegmentInfosSnapshot file. 
- This does not work if while reading we read metadata file and by the time we read snapshot file, remote store has new snapshot file with the same name.
- To avoid this race condition, this change combines these 2 files. metadata file will have one more field: `segmentInfosBytes` and in the restore flow, instance of `SegmentInfos` will be created by this field in the metadata.


### Related Issues
- https://github.com/opensearch-project/OpenSearch/issues/7772

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
