### PR TITLE
[Bug] Fix Build Metadata 

### DIFF
--- a/libs/core/src/main/java/org/opensearch/Build.java
+++ b/libs/core/src/main/java/org/opensearch/Build.java
@@ -114,12 +114,14 @@ public class Build {
         // these are parsed at startup, and we require that we are able to recognize the values passed in by the startup scripts
         type = Type.fromDisplayName(System.getProperty("opensearch.distribution.type", "unknown"), true);
 
-        final String opensearchPrefix = distribution + "-" + Version.CURRENT;
+        final String opensearchPrefix = distribution;
         final URL url = getOpenSearchCodeSourceLocation();
         final String urlStr = url == null ? "" : url.toString();
         if (urlStr.startsWith("file:/")
-            && (urlStr.endsWith(opensearchPrefix + ".jar")
-                || urlStr.matches("(.*)" + opensearchPrefix + "(-)?((alpha|beta|rc)[0-9]+)?(-SNAPSHOT)?.jar"))) {
+            && (urlStr.endsWith(opensearchPrefix + "-" + Version.CURRENT + ".jar")
+                || urlStr.matches(
+                    "(.*)" + opensearchPrefix + "(-)?(.*?)" + Version.CURRENT + "(-)?((alpha|beta|rc)[0-9]+)?(-SNAPSHOT)?.jar"
+                ))) {
             try (JarInputStream jar = new JarInputStream(FileSystemUtils.openFileURLStream(url))) {
                 Manifest manifest = jar.getManifest();
                 hash = manifest.getMainAttributes().getValue("Change");

--- a/server/src/test/java/org/opensearch/BuildTests.java
+++ b/server/src/test/java/org/opensearch/BuildTests.java
@@ -60,9 +60,11 @@ public class BuildTests extends OpenSearchTestCase {
         URL url = Build.getOpenSearchCodeSourceLocation();
         // throws exception if does not exist, or we cannot access it
         try (InputStream ignored = FileSystemUtils.openFileURLStream(url)) {}
-        // these should never be null
+        // these should never be null or "unknown"
         assertNotNull(Build.CURRENT.date());
+        assertNotEquals(Build.CURRENT.date(), "unknown");
         assertNotNull(Build.CURRENT.hash());
+        assertNotEquals(Build.CURRENT.hash(), "unknown");
     }
 
     public void testIsProduction() {


### PR DESCRIPTION
### Description
Expect Build class to be in `opensearch-core-{version}.jar` not `opensearch-{version}.jar`.

Fixes breakage introduced in #7328, causing `GET /` to return "unknown" for build hash and date.

### Related Issues

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
