### PR TITLE
adding serialization support for InetSocketAddress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Allow mmap to use new JDK-19 preview APIs in Apache Lucene 9.4+ ([#5151](https://github.com/opensearch-project/OpenSearch/pull/5151))
 - Add events correlation engine plugin ([#6854](https://github.com/opensearch-project/OpenSearch/issues/6854))
 - Add support for ignoring missing Javadoc on generated code using annotation ([#7604](https://github.com/opensearch-project/OpenSearch/pull/7604))
+- Add support for serializing `InetSocketAddress` in StreamOutput/StreamInput
 
 ### Dependencies
 - Bump `log4j-core` from 2.18.0 to 2.19.0

--- a/server/src/main/java/org/opensearch/common/io/stream/StreamInput.java
+++ b/server/src/main/java/org/opensearch/common/io/stream/StreamInput.java
@@ -63,6 +63,8 @@ import java.io.FileNotFoundException;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.DirectoryNotEmptyException;
@@ -344,6 +346,14 @@ public abstract class StreamInput extends BaseStreamInput {
 
     public BigInteger readBigInteger() throws IOException {
         return new BigInteger(readString());
+    }
+
+    public InetSocketAddress readInetSocketAddress() throws IOException {
+        String host = this.readString();
+        byte[] addressBytes = this.readByteArray();
+        InetAddress addr = InetAddress.getByAddress(host, addressBytes);
+        int port = this.readInt();
+        return new InetSocketAddress(addr, port);
     }
 
     @Nullable
@@ -742,6 +752,8 @@ public abstract class StreamInput extends BaseStreamInput {
                 return readCollection(StreamInput::readGenericValue, HashSet::new, Collections.emptySet());
             case 26:
                 return readBigInteger();
+            case 27:
+                return readInetSocketAddress();
             default:
                 throw new IOException("Can't read unknown type [" + type + "]");
         }

--- a/server/src/main/java/org/opensearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/opensearch/common/io/stream/StreamOutput.java
@@ -795,7 +795,7 @@ public abstract class StreamOutput extends BaseStreamOutput {
         writers.put(InetSocketAddress.class, (o, v) -> {
             final InetSocketAddress inetSocketAddress = (InetSocketAddress) v;
             o.writeByte((byte) 27);
-            o.writeString(inetSocketAddress.getHostName());
+            o.writeString(inetSocketAddress.getHostString());
             o.writeByteArray(inetSocketAddress.getAddress().getAddress());
             o.writeInt(inetSocketAddress.getPort());
         });

--- a/server/src/main/java/org/opensearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/opensearch/common/io/stream/StreamOutput.java
@@ -63,6 +63,7 @@ import java.io.EOFException;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.net.InetSocketAddress;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.DirectoryNotEmptyException;
@@ -790,6 +791,13 @@ public abstract class StreamOutput extends BaseStreamOutput {
         writers.put(BigInteger.class, (o, v) -> {
             o.writeByte((byte) 26);
             o.writeString(v.toString());
+        });
+        writers.put(InetSocketAddress.class, (o, v) -> {
+            final InetSocketAddress inetSocketAddress = (InetSocketAddress) v;
+            o.writeByte((byte) 27);
+            o.writeString(inetSocketAddress.getHostName());
+            o.writeByteArray(inetSocketAddress.getAddress().getAddress());
+            o.writeInt(inetSocketAddress.getPort());
         });
         WRITERS = Collections.unmodifiableMap(writers);
     }

--- a/server/src/test/java/org/opensearch/common/io/stream/BaseStreamTests.java
+++ b/server/src/test/java/org/opensearch/common/io/stream/BaseStreamTests.java
@@ -516,7 +516,7 @@ public abstract class BaseStreamTests extends OpenSearchTestCase {
     }
 
     public void testInetSocketAddress() throws IOException {
-        InetSocketAddress toWrite = new InetSocketAddress(InetAddress.getLocalHost(), 80);
+        InetSocketAddress toWrite = new InetSocketAddress(InetAddress.getLoopbackAddress(), 80);
         BytesStreamOutput out = new BytesStreamOutput();
         out.writeGenericValue(toWrite);
         assertEquals(toWrite, getStreamInput(out.bytes()).readGenericValue());

--- a/server/src/test/java/org/opensearch/common/io/stream/BaseStreamTests.java
+++ b/server/src/test/java/org/opensearch/common/io/stream/BaseStreamTests.java
@@ -46,6 +46,8 @@ import org.opensearch.test.OpenSearchTestCase;
 import java.io.ByteArrayInputStream;
 import java.io.EOFException;
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
@@ -511,6 +513,14 @@ public abstract class BaseStreamTests extends OpenSearchTestCase {
         goodMap.put("c", "d");
         StreamOutput.checkWriteable(goodMap);
         assertNotWriteable(Collections.singletonMap("a", new Unwriteable()), Unwriteable.class);
+    }
+
+    public void testInetSocketAddress() throws IOException {
+        InetSocketAddress toWrite = new InetSocketAddress(InetAddress.getLocalHost(), 80);
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.writeGenericValue(toWrite);
+        assertEquals(toWrite, getStreamInput(out.bytes()).readGenericValue());
+        out.close();
     }
 
     public void testObjectArrayIsWriteable() throws IOException {

--- a/server/src/test/java/org/opensearch/common/io/stream/BytesStreamsTests.java
+++ b/server/src/test/java/org/opensearch/common/io/stream/BytesStreamsTests.java
@@ -313,7 +313,7 @@ public class BytesStreamsTests extends OpenSearchTestCase {
         float[] floatArray = { 1.1f, 2.2f, 3.3f };
         out.writeGenericValue(floatArray);
         double[] doubleArray = { 1.1, 2.2, 3.3 };
-        InetSocketAddress inetSocketAddress = new InetSocketAddress(InetAddress.getLocalHost(), 80);
+        InetSocketAddress inetSocketAddress = new InetSocketAddress(InetAddress.getLoopbackAddress(), 80);
         out.writeGenericValue(doubleArray);
         out.writeString("hello");
         out.writeString("goodbye");

--- a/server/src/test/java/org/opensearch/common/io/stream/BytesStreamsTests.java
+++ b/server/src/test/java/org/opensearch/common/io/stream/BytesStreamsTests.java
@@ -48,6 +48,8 @@ import org.joda.time.DateTimeZone;
 
 import java.io.EOFException;
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -311,6 +313,7 @@ public class BytesStreamsTests extends OpenSearchTestCase {
         float[] floatArray = { 1.1f, 2.2f, 3.3f };
         out.writeGenericValue(floatArray);
         double[] doubleArray = { 1.1, 2.2, 3.3 };
+        InetSocketAddress inetSocketAddress = new InetSocketAddress(InetAddress.getLocalHost(), 80);
         out.writeGenericValue(doubleArray);
         out.writeString("hello");
         out.writeString("goodbye");
@@ -324,6 +327,7 @@ public class BytesStreamsTests extends OpenSearchTestCase {
         out.writeOptionalTimeZone(DateTimeZone.getDefault());
         out.writeOptionalTimeZone(null);
         out.writeGenericValue(new DateTime(123456, DateTimeZone.forID("America/Los_Angeles")));
+        out.writeGenericValue(inetSocketAddress);
         final byte[] bytes = BytesReference.toBytes(out.bytes());
         StreamInput in = StreamInput.wrap(BytesReference.toBytes(out.bytes()));
         assertEquals(in.available(), bytes.length);
@@ -361,6 +365,7 @@ public class BytesStreamsTests extends OpenSearchTestCase {
         JodaCompatibleZonedDateTime jdt = (JodaCompatibleZonedDateTime) dt;
         assertThat(jdt.getZonedDateTime().toInstant().toEpochMilli(), equalTo(123456L));
         assertThat(jdt.getZonedDateTime().getZone(), equalTo(ZoneId.of("America/Los_Angeles")));
+        assertEquals(inetSocketAddress, in.readGenericValue());
         assertEquals(0, in.available());
         IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> out.writeGenericValue(new Object() {
             @Override


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Adds support for serialization of `InetSocketAddress` in OpenSearch's custom serialization framework (StreamInput / StreamOutput ).

This is needed to support custom serialization in security plugin. 

### Related Issues
https://github.com/opensearch-project/security/issues/2780


### Check List
- [ x ] New functionality includes testing.
  - [ x ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ x ] Commits are signed per the DCO using --signoff
- [ x ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
