### PR TITLE
[Backport] [2.x] Bump com.google.guava:guava from 31.1-jre to 32.0.0-jre in /distribution/tools/keystore-cli (#7811)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Dependencies
 - Bump `com.azure:azure-storage-common` from 12.21.0 to 12.21.1 (#7566, #7814)
+- Bump `com.google.guava:guava` from 30.1.1-jre to 32.0.0-jre (#7565, #7811)
 
 ### Changed
 

--- a/distribution/tools/keystore-cli/build.gradle
+++ b/distribution/tools/keystore-cli/build.gradle
@@ -35,5 +35,5 @@ dependencies {
   compileOnly project(":libs:opensearch-cli")
   testImplementation project(":test:framework")
   testImplementation 'com.google.jimfs:jimfs:1.2'
-  testRuntimeOnly 'com.google.guava:guava:31.1-jre'
+  testRuntimeOnly 'com.google.guava:guava:32.0.0-jre'
 }


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/7811 to `2.x`