### PR TITLE
[Backport] [2.x] Reduce memory copy in zstd compression (#7681)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - Replace jboss-annotations-api_1.2_spec with jakarta.annotation-api ([#7836](https://github.com/opensearch-project/OpenSearch/pull/7836))
+- Reduce memory copy in zstd compression ([#7681](https://github.com/opensearch-project/OpenSearch/pull/7681))
 
 ### Deprecated
 

--- a/sandbox/plugins/custom-codecs/src/main/java/org/opensearch/index/codec/customcodecs/ZstdCompressionMode.java
+++ b/sandbox/plugins/custom-codecs/src/main/java/org/opensearch/index/codec/customcodecs/ZstdCompressionMode.java
@@ -77,7 +77,7 @@ public class ZstdCompressionMode extends CompressionMode {
                 return;
             }
             final int maxCompressedLength = (int) Zstd.compressBound(length);
-            compressedBuffer = ArrayUtil.grow(compressedBuffer, maxCompressedLength);
+            compressedBuffer = ArrayUtil.growNoCopy(compressedBuffer, maxCompressedLength);
 
             int compressedSize = cctx.compressByteArray(compressedBuffer, 0, compressedBuffer.length, bytes, offset, length);
 
@@ -139,7 +139,7 @@ public class ZstdCompressionMode extends CompressionMode {
                 return;
             }
 
-            compressedBuffer = ArrayUtil.grow(compressedBuffer, compressedLength);
+            compressedBuffer = ArrayUtil.growNoCopy(compressedBuffer, compressedLength);
             in.readBytes(compressedBuffer, 0, compressedLength);
 
             bytes.bytes = ArrayUtil.grow(bytes.bytes, bytes.length + decompressedLen);
@@ -161,7 +161,7 @@ public class ZstdCompressionMode extends CompressionMode {
             }
             final int dictLength = in.readVInt();
             final int blockLength = in.readVInt();
-            bytes.bytes = ArrayUtil.grow(bytes.bytes, dictLength);
+            bytes.bytes = ArrayUtil.growNoCopy(bytes.bytes, dictLength);
             bytes.offset = bytes.length = 0;
 
             try (ZstdDecompressCtx dctx = new ZstdDecompressCtx()) {

--- a/sandbox/plugins/custom-codecs/src/main/java/org/opensearch/index/codec/customcodecs/ZstdNoDictCompressionMode.java
+++ b/sandbox/plugins/custom-codecs/src/main/java/org/opensearch/index/codec/customcodecs/ZstdNoDictCompressionMode.java
@@ -83,7 +83,7 @@ public class ZstdNoDictCompressionMode extends CompressionMode {
                 }
 
                 final int maxCompressedLength = (int) Zstd.compressBound(l);
-                compressedBuffer = ArrayUtil.grow(compressedBuffer, maxCompressedLength);
+                compressedBuffer = ArrayUtil.growNoCopy(compressedBuffer, maxCompressedLength);
 
                 int compressedSize = (int) Zstd.compressByteArray(
                     compressedBuffer,
@@ -151,7 +151,7 @@ public class ZstdNoDictCompressionMode extends CompressionMode {
                 if (compressedLength == 0) {
                     return;
                 }
-                compressed = ArrayUtil.grow(compressed, compressedLength);
+                compressed = ArrayUtil.growNoCopy(compressed, compressedLength);
                 in.readBytes(compressed, 0, compressedLength);
 
                 int l = Math.min(blockLength, originalLength - offsetInBlock);


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/7681 to `2.x`