### PR TITLE
Revert changes to tasks_list test rest api spec test

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/tasks.list/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/tasks.list/10_basic.yml
@@ -17,13 +17,8 @@
   - do:
       tasks.list:
         group_by: parents
-        detailed: true
-  - set:
-      tasks._arbitrary_key_: task_id
 
   - is_true: tasks
-  - is_true: tasks.$task_id.resource_stats
-  - is_true: tasks.$task_id.resource_stats.total
 
 ---
 "tasks_list headers":
@@ -39,7 +34,24 @@
   - match: { tasks.0.headers.X-Opaque-Id: "That is me" }
 
 ---
-"tasks_list detailed":
+"tasks_list resource stats":
+  - skip:
+      version: " - 2.0.99"
+      reason: resource_stats was introduced in 2.1.0
+
+  - do:
+      tasks.list:
+        group_by: parents
+        detailed: true
+  - set:
+      tasks._arbitrary_key_: task_id
+
+  - is_true: tasks
+  - is_true: tasks.$task_id.resource_stats
+  - is_true: tasks.$task_id.resource_stats.total
+
+---
+"tasks_list thread info":
   - skip:
       version: " - 2.99.99"
       reason: thread_info was introduced in 3.0.0


### PR DESCRIPTION
### Description
DIscovered a problem with one of the test updates in #7673 as a part of the backport #7856.
`resource_stats` does not exist in OS < 2.X so I am reverting the update to the test.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
