### PR TITLE
[Segment Replication] Wait for shard relocation before building node to shard allocation map

### DIFF
--- a/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/IndexingIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/IndexingIT.java
@@ -43,7 +43,9 @@ import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.Booleans;
+import org.opensearch.common.Strings;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.seqno.SeqNoStats;
 import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.rest.action.document.RestBulkAction;
@@ -95,7 +97,8 @@ public class IndexingIT extends AbstractRollingTestCase {
     private void waitForSearchableDocs(String index, int shardCount) throws Exception {
         Map<Integer,String> primaryShardToNodeIDMap = new HashMap<>();
         Map<Integer,String> replicaShardToNodeIDMap = new HashMap<>();
-        logger.info("--> _cat/shards \n{}", EntityUtils.toString(client().performRequest(new Request("GET", "/_cat/shards?v")).getEntity()));
+        waitForClusterHealthWithNoShardMigration(index, "green");
+        logger.info("--> _cat/shards before search \n{}", EntityUtils.toString(client().performRequest(new Request("GET", "/_cat/shards?v")).getEntity()));
 
         Request request = new Request("GET", index + "/_stats");
         request.addParameter("level", "shards");

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/IndexingIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/IndexingIT.java
@@ -31,30 +31,20 @@
 
 package org.opensearch.upgrades;
 
-import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.ParseException;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
-import org.apache.lucene.tests.util.LuceneTestCase;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
-import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
-import org.opensearch.client.ResponseException;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.Booleans;
-import org.opensearch.common.Strings;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.xcontent.XContentType;
-import org.opensearch.index.seqno.SeqNoStats;
 import org.opensearch.indices.replication.common.ReplicationType;
-import org.opensearch.rest.action.document.RestBulkAction;
 import org.opensearch.test.rest.yaml.ObjectPath;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -248,7 +238,6 @@ public class IndexingIT extends AbstractRollingTestCase {
      *
      * @throws Exception
      */
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/7679")
     public void testIndexingWithSegRep() throws Exception {
         final String indexName = "test-index-segrep";
         final int shardCount = 3;


### PR DESCRIPTION
### Description
This change fixes the flakyness of recently introduced segment replication bwc test. For doc count assertion, this test first makes API call to `index/_stats` to build map of shardId to nodeID (`[index][1] -> abcdXXX`) (separate maps for primary and replica). Once map is built, a targeted search request is made which asserts same doc count for both primary and replica shards. The existing flakyness exists due to shard relocations which completes by the time search query hits the speicfic shard (now moved away to a different node). The fix here is to wait for relocations to complete before verifying doc count.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/7679

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
