### PR TITLE
[Remote Store] Fix flaky test - closes #7703

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/AbstractRemoteStoreMockRepositoryIntegTestCase.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/AbstractRemoteStoreMockRepositoryIntegTestCase.java
@@ -70,7 +70,7 @@ public abstract class AbstractRemoteStoreMockRepositoryIntegTestCase extends Abs
         assertAcked(clusterAdmin().prepareDeleteRepository(REPOSITORY_NAME));
     }
 
-    protected void setup(Path repoLocation, double ioFailureRate, String skipExceptionBlobList) {
+    protected void setup(Path repoLocation, double ioFailureRate, String skipExceptionBlobList, long maxFailure) {
         logger.info("--> Creating repository={} at the path={}", REPOSITORY_NAME, repoLocation);
         // The random_control_io_exception_rate setting ensures that 10-25% of all operations to remote store results in
         /// IOException. skip_exception_on_verification_file & skip_exception_on_list_blobs settings ensures that the
@@ -85,7 +85,7 @@ public abstract class AbstractRemoteStoreMockRepositoryIntegTestCase extends Abs
                 .put("skip_exception_on_list_blobs", true)
                 // Skipping is required for metadata as it is part of recovery
                 .put("skip_exception_on_blobs", skipExceptionBlobList)
-                .put("max_failure_number", Long.MAX_VALUE)
+                .put("max_failure_number", maxFailure)
         );
 
         internalCluster().startDataOnlyNodes(1);

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreBackpressureIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreBackpressureIT.java
@@ -29,7 +29,7 @@ public class RemoteStoreBackpressureIT extends AbstractRemoteStoreMockRepository
 
     public void testWritesRejected() {
         Path location = randomRepoPath().toAbsolutePath();
-        setup(location, 1d, "metadata");
+        setup(location, 1d, "metadata", Long.MAX_VALUE);
 
         Settings request = Settings.builder().put(REMOTE_REFRESH_SEGMENT_PRESSURE_ENABLED.getKey(), true).build();
         ClusterUpdateSettingsResponse clusterUpdateResponse = client().admin()

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreRefreshListenerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreRefreshListenerIT.java
@@ -30,7 +30,7 @@ public class RemoteStoreRefreshListenerIT extends AbstractRemoteStoreMockReposit
     public void testRemoteRefreshRetryOnFailure() throws Exception {
 
         Path location = randomRepoPath().toAbsolutePath();
-        setup(location, randomDoubleBetween(0.1, 0.25, true), "metadata");
+        setup(location, randomDoubleBetween(0.1, 0.15, true), "metadata", 10L);
 
         // Here we are having flush/refresh after each iteration of indexing. However, the refresh will not always succeed
         // due to IOExceptions that are thrown while doing uploadBlobs.

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreRefreshListenerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreRefreshListenerIT.java
@@ -15,6 +15,9 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -47,8 +50,12 @@ public class RemoteStoreRefreshListenerIT extends AbstractRemoteStoreMockReposit
         assertBusy(() -> {
             Set<String> filesInLocal = getSegmentFiles(location.getRoot().resolve(segmentDataLocalPath));
             Set<String> filesInRepo = getSegmentFiles(segmentDataRepoPath);
+            List<String> sortedFilesInLocal = new ArrayList<>(filesInLocal), sortedFilesInRepo = new ArrayList<>(filesInRepo);
+            Collections.sort(sortedFilesInLocal);
+            Collections.sort(sortedFilesInRepo);
+            logger.info("Local files = {}, Repo files = {}", sortedFilesInLocal, sortedFilesInRepo);
             assertTrue(filesInRepo.containsAll(filesInLocal));
-        }, 60, TimeUnit.SECONDS);
+        }, 90, TimeUnit.SECONDS);
         deleteRepo();
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fixes flaky test org.opensearch.remotestore.RemoteStoreRefreshListenerIT.testRemoteRefreshRetryOnFailure. For the fix, we have increased the timeout to 90s. 

### Related Issues
Resolves #7703

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
