### PR TITLE
[Backport] [2.x] Bump com.google.guava:guava from 31.1-jre to 32.0.0-jre in /distribution/tools/plugin-cli (#7808)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Dependencies
 - Bump `com.azure:azure-storage-common` from 12.21.0 to 12.21.1 (#7566, #7814)
-- Bump `com.google.guava:guava` from 30.1.1-jre to 32.0.0-jre (#7565, #7811, #7807)
+- Bump `com.google.guava:guava` from 30.1.1-jre to 32.0.0-jre (#7565, #7811, #7807, #7808)
 - Bump `net.minidev:json-smart` from 2.4.10 to 2.4.11 (#7660, #7812)
 
 ### Changed

--- a/distribution/tools/plugin-cli/build.gradle
+++ b/distribution/tools/plugin-cli/build.gradle
@@ -39,7 +39,7 @@ dependencies {
   api "org.bouncycastle:bc-fips:1.0.2.3"
   testImplementation project(":test:framework")
   testImplementation 'com.google.jimfs:jimfs:1.2'
-  testRuntimeOnly 'com.google.guava:guava:31.1-jre'
+  testRuntimeOnly 'com.google.guava:guava:32.0.0-jre'
 
   implementation 'org.apache.commons:commons-compress:1.23.0'
 }


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/7808 to `2.x`