### PR TITLE
[Backport] [2.x] Bump org.gradle.test-retry from 1.5.2 to 1.5.3 (#7810)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `com.azure:azure-storage-common` from 12.21.0 to 12.21.1 (#7566, #7814)
 - Bump `com.google.guava:guava` from 30.1.1-jre to 32.0.0-jre (#7565, #7811, #7807, #7808)
 - Bump `net.minidev:json-smart` from 2.4.10 to 2.4.11 (#7660, #7812)
+- Bump `org.gradle.test-retry` from 1.5.2 to 1.5.3 (#7810)
+- Bump `com.diffplug.spotless` from 6.17.0 to 6.18.0 (#7896)
 
 ### Changed
 - Replace jboss-annotations-api_1.2_spec with jakarta.annotation-api ([#7836](https://github.com/opensearch-project/OpenSearch/pull/7836))

--- a/build.gradle
+++ b/build.gradle
@@ -53,8 +53,8 @@ plugins {
   id 'lifecycle-base'
   id 'opensearch.docker-support'
   id 'opensearch.global-build-info'
-  id "com.diffplug.spotless" version "6.17.0" apply false
-  id "org.gradle.test-retry" version "1.5.2" apply false
+  id "com.diffplug.spotless" version "6.18.0" apply false
+  id "org.gradle.test-retry" version "1.5.3" apply false
   id "test-report-aggregation"
   id 'jacoco-report-aggregation'
 }


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/7810 to `2.x`