### PR TITLE
[Remote Store] Optimize segments metadata upload

### DIFF
--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -167,7 +167,7 @@ public final class RemoteStoreRefreshListener implements ReferenceManager.Refres
     @Override
     public void afterRefresh(boolean didRefresh) {
 
-        if (didRefresh) {
+        if (didRefresh || remoteDirectory.getSegmentsUploadedToRemoteStore().isEmpty()) {
             updateLocalRefreshTimeAndSeqNo();
             try {
                 indexShard.getThreadPool().executor(ThreadPool.Names.REMOTE_REFRESH).submit(() -> syncSegments(false)).get();

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -169,12 +169,11 @@ public final class RemoteStoreRefreshListener implements ReferenceManager.Refres
 
         if (didRefresh) {
             updateLocalRefreshTimeAndSeqNo();
-        }
-
-        try {
-            indexShard.getThreadPool().executor(ThreadPool.Names.REMOTE_REFRESH).submit(() -> syncSegments(false)).get();
-        } catch (InterruptedException | ExecutionException e) {
-            logger.info("Exception occurred while scheduling syncSegments", e);
+            try {
+                indexShard.getThreadPool().executor(ThreadPool.Names.REMOTE_REFRESH).submit(() -> syncSegments(false)).get();
+            } catch (InterruptedException | ExecutionException e) {
+                logger.info("Exception occurred while scheduling syncSegments", e);
+            }
         }
     }
 
@@ -244,9 +243,7 @@ public final class RemoteStoreRefreshListener implements ReferenceManager.Refres
                                 segmentInfos.getGeneration()
                             );
                             clearStaleFilesFromLocalSegmentChecksumMap(localSegmentsPostRefresh);
-                            onSuccessfulSegmentsSync(refreshTimeMs, refreshSeqNo);
-                            indexShard.getEngine().translogManager().setMinSeqNoToKeep(lastRefreshedCheckpoint + 1);
-                            checkpointPublisher.publish(indexShard, checkpoint);
+                            onSuccessfulSegmentsSync(refreshTimeMs, refreshSeqNo, lastRefreshedCheckpoint, checkpoint);
                             // At this point since we have uploaded new segments, segment infos and segment metadata file,
                             // along with marking minSeqNoToKeep, upload has succeeded completely.
                             shouldRetry = false;
@@ -298,7 +295,12 @@ public final class RemoteStoreRefreshListener implements ReferenceManager.Refres
         segmentTracker.incrementTotalUploadsStarted();
     }
 
-    private void onSuccessfulSegmentsSync(long refreshTimeMs, long refreshSeqNo) {
+    private void onSuccessfulSegmentsSync(
+        long refreshTimeMs,
+        long refreshSeqNo,
+        long lastRefreshedCheckpoint,
+        ReplicationCheckpoint checkpoint
+    ) {
         // Update latest uploaded segment files name in segment tracker
         segmentTracker.setLatestUploadedFiles(latestFileNameSizeOnLocalMap.keySet());
         // Update the remote refresh time and refresh seq no
@@ -307,6 +309,10 @@ public final class RemoteStoreRefreshListener implements ReferenceManager.Refres
         resetBackOffDelayIterator();
         // Cancel the scheduled cancellable retry if possible and set it to null
         cancelAndResetScheduledCancellableRetry();
+        // Set the minimum sequence number for keeping translog
+        indexShard.getEngine().translogManager().setMinSeqNoToKeep(lastRefreshedCheckpoint + 1);
+        // Publishing the new checkpoint which is used for remote store + segrep indexes
+        checkpointPublisher.publish(indexShard, checkpoint);
     }
 
     /**

--- a/server/src/test/java/org/opensearch/index/shard/ReplicaRecoveryWithRemoteTranslogOnPrimaryTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/ReplicaRecoveryWithRemoteTranslogOnPrimaryTests.java
@@ -120,7 +120,7 @@ public class ReplicaRecoveryWithRemoteTranslogOnPrimaryTests extends OpenSearchI
             shards.flush();
             List<DocIdSeqNoAndSource> docIdAndSeqNosAfterFlush = getDocIdAndSeqNos(primary);
             int moreDocs = shards.indexDocs(randomIntBetween(20, 100));
-            assertEquals(moreDocs, getTranslog(primary).totalOperations());
+            assertEquals(numDocs + moreDocs, getTranslog(primary).totalOperations());
 
             // Step 2 - Start replica, recovery happens, check docs recovered till last flush
             final IndexShard replica = shards.addReplica();


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Currently in afterRefresh method of RemoteStoreRefreshListener, we upload metadata file even if the local and remote store has not difference in segment files. We need to skip the upload if there are no differences in segment files on local and remote store. With this PR, we are not creating / uploading the metadata file if there are no differences in the segments files in local primary store and remote store.  

### Related Issues
Resolves #7443

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
