### PR TITLE
Remove COMPRESSOR variable from CompressorFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Remove LegacyESVersion.V_7_10_ Constants ([#5018](https://github.com/opensearch-project/OpenSearch/pull/5018))
 - Remove Version.V_1_ Constants ([#5021](https://github.com/opensearch-project/OpenSearch/pull/5021))
 - Remove custom Map, List and Set collection classes ([#6871](https://github.com/opensearch-project/OpenSearch/pull/6871))
+- Remove COMPRESSOR variable from CompressorFactory and use DEFLATE_COMPRESSOR instead ([7907](https://github.com/opensearch-project/OpenSearch/pull/7907))
 
 ### Fixed
 - Fix 'org.apache.hc.core5.http.ParseException: Invalid protocol version' under JDK 16+ ([#4827](https://github.com/opensearch-project/OpenSearch/pull/4827))

--- a/server/src/main/java/org/opensearch/cluster/coordination/CompressedStreamUtils.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/CompressedStreamUtils.java
@@ -37,7 +37,7 @@ public final class CompressedStreamUtils {
     public static BytesReference createCompressedStream(Version version, CheckedConsumer<StreamOutput, IOException> outputConsumer)
         throws IOException {
         final BytesStreamOutput bStream = new BytesStreamOutput();
-        try (StreamOutput stream = new OutputStreamStreamOutput(CompressorFactory.COMPRESSOR.threadLocalOutputStream(bStream))) {
+        try (StreamOutput stream = new OutputStreamStreamOutput(CompressorFactory.defaultCompressor().threadLocalOutputStream(bStream))) {
             stream.setVersion(version);
             outputConsumer.accept(stream);
         }

--- a/server/src/main/java/org/opensearch/common/compress/CompressedXContent.java
+++ b/server/src/main/java/org/opensearch/common/compress/CompressedXContent.java
@@ -85,7 +85,7 @@ public final class CompressedXContent {
      */
     public CompressedXContent(ToXContent xcontent, ToXContent.Params params) throws IOException {
         BytesStreamOutput bStream = new BytesStreamOutput();
-        OutputStream compressedStream = CompressorFactory.COMPRESSOR.threadLocalOutputStream(bStream);
+        OutputStream compressedStream = CompressorFactory.defaultCompressor().threadLocalOutputStream(bStream);
         CRC32 crc32 = new CRC32();
         OutputStream checkedStream = new CheckedOutputStream(compressedStream, crc32);
         try (XContentBuilder builder = XContentFactory.jsonBuilder(checkedStream)) {
@@ -113,7 +113,7 @@ public final class CompressedXContent {
             this.bytes = BytesReference.toBytes(data);
             this.crc32 = crc32(uncompressed());
         } else {
-            this.bytes = BytesReference.toBytes(CompressorFactory.COMPRESSOR.compress(data));
+            this.bytes = BytesReference.toBytes(CompressorFactory.defaultCompressor().compress(data));
             this.crc32 = crc32(data);
         }
         assertConsistent();

--- a/server/src/main/java/org/opensearch/common/compress/CompressorFactory.java
+++ b/server/src/main/java/org/opensearch/common/compress/CompressorFactory.java
@@ -48,9 +48,6 @@ public class CompressorFactory {
 
     public static final Compressor DEFLATE_COMPRESSOR = new DeflateCompressor();
 
-    @Deprecated
-    public static final Compressor COMPRESSOR = DEFLATE_COMPRESSOR;
-
     public static final Compressor ZSTD_COMPRESSOR = new ZstdCompressor();
 
     public static final Compressor NONE_COMPRESSOR = new NoneCompressor();
@@ -59,14 +56,18 @@ public class CompressorFactory {
         return compressor(bytes) != null;
     }
 
+    public static Compressor defaultCompressor() {
+        return DEFLATE_COMPRESSOR;
+    }
+
     @Nullable
     public static Compressor compressor(BytesReference bytes) {
-        if (COMPRESSOR.isCompressed(bytes)) {
+        if (DEFLATE_COMPRESSOR.isCompressed(bytes)) {
             // bytes should be either detected as compressed or as xcontent,
             // if we have bytes that can be either detected as compressed or
             // as a xcontent, we have a problem
             assert XContentHelper.xContentType(bytes) == null;
-            return COMPRESSOR;
+            return DEFLATE_COMPRESSOR;
         } else if (ZSTD_COMPRESSOR.isCompressed(bytes)) {
             assert XContentHelper.xContentType(bytes) == null;
             return ZSTD_COMPRESSOR;

--- a/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
@@ -1720,7 +1720,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         if (cacheRepositoryData && bestEffortConsistency == false) {
             final BytesReference serialized;
             try {
-                serialized = CompressorFactory.COMPRESSOR.compress(updated);
+                serialized = CompressorFactory.defaultCompressor().compress(updated);
                 final int len = serialized.length();
                 if (len > ByteSizeUnit.KB.toBytes(500)) {
                     logger.debug(
@@ -1756,7 +1756,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     }
 
     private RepositoryData repositoryDataFromCachedEntry(Tuple<Long, BytesReference> cacheEntry) throws IOException {
-        try (InputStream input = CompressorFactory.COMPRESSOR.threadLocalInputStream(cacheEntry.v2().streamInput())) {
+        try (InputStream input = CompressorFactory.defaultCompressor().threadLocalInputStream(cacheEntry.v2().streamInput())) {
             return RepositoryData.snapshotsFromXContent(
                 XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, input),
                 cacheEntry.v1()

--- a/server/src/main/java/org/opensearch/transport/CompressibleBytesOutputStream.java
+++ b/server/src/main/java/org/opensearch/transport/CompressibleBytesOutputStream.java
@@ -68,7 +68,7 @@ final class CompressibleBytesOutputStream extends StreamOutput {
         this.bytesStreamOutput = bytesStreamOutput;
         this.shouldCompress = shouldCompress;
         if (shouldCompress) {
-            this.stream = CompressorFactory.COMPRESSOR.threadLocalOutputStream(Streams.flushOnCloseStream(bytesStreamOutput));
+            this.stream = CompressorFactory.defaultCompressor().threadLocalOutputStream(Streams.flushOnCloseStream(bytesStreamOutput));
         } else {
             this.stream = bytesStreamOutput;
         }

--- a/server/src/main/java/org/opensearch/transport/TransportDecompressor.java
+++ b/server/src/main/java/org/opensearch/transport/TransportDecompressor.java
@@ -37,6 +37,7 @@ import org.apache.lucene.util.BytesRefIterator;
 import org.opensearch.common.bytes.BytesArray;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.bytes.ReleasableBytesReference;
+import org.opensearch.common.compress.Compressor;
 import org.opensearch.common.compress.CompressorFactory;
 import org.opensearch.common.recycler.Recycler;
 import org.opensearch.common.util.PageCacheRecycler;
@@ -69,7 +70,8 @@ public class TransportDecompressor implements Closeable {
     public int decompress(BytesReference bytesReference) throws IOException {
         int bytesConsumed = 0;
         if (hasReadHeader == false) {
-            if (CompressorFactory.COMPRESSOR.isCompressed(bytesReference) == false) {
+            final Compressor compressor = CompressorFactory.defaultCompressor();
+            if (compressor.isCompressed(bytesReference) == false) {
                 int maxToRead = Math.min(bytesReference.length(), 10);
                 StringBuilder sb = new StringBuilder("stream marked as compressed, but no compressor found, first [").append(maxToRead)
                     .append("] content bytes out of [")
@@ -85,7 +87,7 @@ public class TransportDecompressor implements Closeable {
                 throw new IllegalStateException(sb.toString());
             }
             hasReadHeader = true;
-            int headerLength = CompressorFactory.COMPRESSOR.headerLength();
+            int headerLength = compressor.headerLength();
             bytesReference = bytesReference.slice(headerLength, bytesReference.length() - headerLength);
             bytesConsumed += headerLength;
         }
@@ -135,7 +137,7 @@ public class TransportDecompressor implements Closeable {
     }
 
     public boolean canDecompress(int bytesAvailable) {
-        return hasReadHeader || bytesAvailable >= CompressorFactory.COMPRESSOR.headerLength();
+        return hasReadHeader || bytesAvailable >= CompressorFactory.defaultCompressor().headerLength();
     }
 
     public boolean isEOS() {

--- a/server/src/main/java/org/opensearch/transport/TransportLogger.java
+++ b/server/src/main/java/org/opensearch/transport/TransportLogger.java
@@ -179,7 +179,7 @@ public final class TransportLogger {
     private static StreamInput decompressingStream(byte status, StreamInput streamInput) throws IOException {
         if (TransportStatus.isCompress(status) && streamInput.available() > 0) {
             try {
-                return new InputStreamStreamInput(CompressorFactory.COMPRESSOR.threadLocalInputStream(streamInput));
+                return new InputStreamStreamInput(CompressorFactory.defaultCompressor().threadLocalInputStream(streamInput));
             } catch (IllegalArgumentException e) {
                 throw new IllegalStateException("stream marked as compressed, but is missing deflate header");
             }

--- a/server/src/test/java/org/opensearch/index/mapper/BinaryFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/BinaryFieldMapperTests.java
@@ -119,7 +119,7 @@ public class BinaryFieldMapperTests extends MapperTestCase {
 
         // case 2: a value that looks compressed: this used to fail in 1.x
         BytesStreamOutput out = new BytesStreamOutput();
-        try (OutputStream compressed = CompressorFactory.COMPRESSOR.threadLocalOutputStream(out)) {
+        try (OutputStream compressed = CompressorFactory.defaultCompressor().threadLocalOutputStream(out)) {
             new BytesArray(binaryValue1).writeTo(compressed);
         }
         final byte[] binaryValue2 = BytesReference.toBytes(out.bytes());

--- a/server/src/test/java/org/opensearch/transport/CompressibleBytesOutputStreamTests.java
+++ b/server/src/test/java/org/opensearch/transport/CompressibleBytesOutputStreamTests.java
@@ -56,7 +56,7 @@ public class CompressibleBytesOutputStreamTests extends OpenSearchTestCase {
         // Closing compression stream does not close underlying stream
         stream.close();
 
-        assertFalse(CompressorFactory.COMPRESSOR.isCompressed(bytesRef));
+        assertFalse(CompressorFactory.defaultCompressor().isCompressed(bytesRef));
 
         StreamInput streamInput = bytesRef.streamInput();
         byte[] actualBytes = new byte[expectedBytes.length];
@@ -83,9 +83,11 @@ public class CompressibleBytesOutputStreamTests extends OpenSearchTestCase {
         BytesReference bytesRef = stream.materializeBytes();
         stream.close();
 
-        assertTrue(CompressorFactory.COMPRESSOR.isCompressed(bytesRef));
+        assertTrue(CompressorFactory.defaultCompressor().isCompressed(bytesRef));
 
-        StreamInput streamInput = new InputStreamStreamInput(CompressorFactory.COMPRESSOR.threadLocalInputStream(bytesRef.streamInput()));
+        StreamInput streamInput = new InputStreamStreamInput(
+            CompressorFactory.defaultCompressor().threadLocalInputStream(bytesRef.streamInput())
+        );
         byte[] actualBytes = new byte[expectedBytes.length];
         streamInput.readBytes(actualBytes, 0, expectedBytes.length);
 
@@ -108,7 +110,7 @@ public class CompressibleBytesOutputStreamTests extends OpenSearchTestCase {
         stream.write(expectedBytes);
 
         StreamInput streamInput = new InputStreamStreamInput(
-            CompressorFactory.COMPRESSOR.threadLocalInputStream(bStream.bytes().streamInput())
+            CompressorFactory.defaultCompressor().threadLocalInputStream(bStream.bytes().streamInput())
         );
         byte[] actualBytes = new byte[expectedBytes.length];
         EOFException e = expectThrows(EOFException.class, () -> streamInput.readBytes(actualBytes, 0, expectedBytes.length));

--- a/server/src/test/java/org/opensearch/transport/TransportDecompressorTests.java
+++ b/server/src/test/java/org/opensearch/transport/TransportDecompressorTests.java
@@ -53,7 +53,10 @@ public class TransportDecompressorTests extends OpenSearchTestCase {
     public void testSimpleCompression() throws IOException {
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             byte randomByte = randomByte();
-            try (OutputStream deflateStream = CompressorFactory.COMPRESSOR.threadLocalOutputStream(Streams.flushOnCloseStream(output))) {
+            try (
+                OutputStream deflateStream = CompressorFactory.defaultCompressor()
+                    .threadLocalOutputStream(Streams.flushOnCloseStream(output))
+            ) {
                 deflateStream.write(randomByte);
             }
 
@@ -74,7 +77,7 @@ public class TransportDecompressorTests extends OpenSearchTestCase {
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             try (
                 StreamOutput deflateStream = new OutputStreamStreamOutput(
-                    CompressorFactory.COMPRESSOR.threadLocalOutputStream(Streams.flushOnCloseStream(output))
+                    CompressorFactory.defaultCompressor().threadLocalOutputStream(Streams.flushOnCloseStream(output))
                 )
             ) {
                 for (int i = 0; i < 10000; ++i) {
@@ -106,7 +109,7 @@ public class TransportDecompressorTests extends OpenSearchTestCase {
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             try (
                 StreamOutput deflateStream = new OutputStreamStreamOutput(
-                    CompressorFactory.COMPRESSOR.threadLocalOutputStream(Streams.flushOnCloseStream(output))
+                    CompressorFactory.defaultCompressor().threadLocalOutputStream(Streams.flushOnCloseStream(output))
                 )
             ) {
                 for (int i = 0; i < 10000; ++i) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The aim of this PR is to remove a deprecated `COMPRESSOR` variable from
`CompressorFactory` and use `DEFLATE_COMPRESSOR` instead.

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
