### PR TITLE
Fixing error: adding a new/forgotten parameter to the configuration for checking the config on startup in plugins/repository-s3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 ### Fixed
+-  Fixing error: adding a new/forgotten parameter to the configuration for checking the config on startup in plugins/repository-s3 #7924 
 
 ### Security
 

--- a/plugins/repository-s3/src/internalClusterTest/java/org/opensearch/repositories/s3/S3BlobStoreRepositoryTests.java
+++ b/plugins/repository-s3/src/internalClusterTest/java/org/opensearch/repositories/s3/S3BlobStoreRepositoryTests.java
@@ -140,6 +140,7 @@ public class S3BlobStoreRepositoryTests extends OpenSearchMockAPIBasedRepository
             .put(S3ClientSettings.DISABLE_CHUNKED_ENCODING.getConcreteSettingForNamespace("test").getKey(), true)
             // Disable request throttling because some random values in tests might generate too many failures for the S3 client
             .put(S3ClientSettings.USE_THROTTLE_RETRIES_SETTING.getConcreteSettingForNamespace("test").getKey(), false)
+            .put(S3ClientSettings.PROXY_TYPE_SETTING.getConcreteSettingForNamespace("test").getKey(), ProxySettings.ProxyType.DIRECT)
             .put(super.nodeSettings(nodeOrdinal))
             .setSecureSettings(secureSettings);
 

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3RepositoryPlugin.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3RepositoryPlugin.java
@@ -104,6 +104,7 @@ public class S3RepositoryPlugin extends Plugin implements RepositoryPlugin, Relo
             S3ClientSettings.SESSION_TOKEN_SETTING,
             S3ClientSettings.ENDPOINT_SETTING,
             S3ClientSettings.PROTOCOL_SETTING,
+            S3ClientSettings.PROXY_TYPE_SETTING,
             S3ClientSettings.PROXY_HOST_SETTING,
             S3ClientSettings.PROXY_PORT_SETTING,
             S3ClientSettings.PROXY_USERNAME_SETTING,


### PR DESCRIPTION
### Description
Fixing error: adding a new/forgotten parameter to the configuration for checking the config on startup.

The error fixes the situation that arises when configuring a proxy for accessing the S3 service. When setting up the proxy, the proxy.type is required, but this parameter causes an error upon node startup. This change rectifies the current situation and ensures behavior as described in the documentation.

This modification has already been tested on our systems.

### Related Issues
#2160  

s3.client.default.proxy.type
repository-s3

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [x] New functionality has been documented.
  - [X] New functionality has javadoc added
- [?] Commits are signed per the DCO using --signoff
- [ x ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
