### PR TITLE
Remove error path for ancient compression detection

### DIFF
--- a/server/src/main/java/org/opensearch/common/compress/CompressorFactory.java
+++ b/server/src/main/java/org/opensearch/common/compress/CompressorFactory.java
@@ -35,7 +35,6 @@ package org.opensearch.common.compress;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.xcontent.XContentHelper;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -73,20 +72,11 @@ public class CompressorFactory {
             return ZSTD_COMPRESSOR;
         }
 
-        XContentType contentType = XContentHelper.xContentType(bytes);
-        if (contentType == null) {
-            if (isAncient(bytes)) {
-                throw new IllegalStateException("unsupported compression: index was created before v2.0.0.beta1 and wasn't upgraded?");
-            }
+        if (XContentHelper.xContentType(bytes) == null) {
             throw new NotXContentException("Compressor detection can only be called on some xcontent bytes or compressed xcontent bytes");
         }
 
         return null;
-    }
-
-    /** true if the bytes were compressed with LZF*/
-    private static boolean isAncient(BytesReference bytes) {
-        return bytes.length() >= 3 && bytes.get(0) == 'Z' && bytes.get(1) == 'V' && (bytes.get(2) == 0 || bytes.get(2) == 1);
     }
 
     /**


### PR DESCRIPTION
The error message generated by this code path refers to Elasticsearch version 2.0.0.beta1, which is likely to cause confusion with the OpenSearch 2.x line if it were ever to be encountered. The ES2 version is so old that I don't think we need any special handling here and can just fall back to the default "not xcontent" error message.

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
