### PR TITLE
Add dynamic index and cluster setting for concurrent segment search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add events correlation engine plugin ([#6854](https://github.com/opensearch-project/OpenSearch/issues/6854))
 - Add support for ignoring missing Javadoc on generated code using annotation ([#7604](https://github.com/opensearch-project/OpenSearch/pull/7604))
 - Implement concurrent aggregations support without profile option ([#7514](https://github.com/opensearch-project/OpenSearch/pull/7514))
+- Add dynamic index and cluster setting for concurrent segment search ([#7944](https://github.com/opensearch-project/OpenSearch/pull/7944))
 
 ### Dependencies
 - Bump `log4j-core` from 2.18.0 to 2.19.0
@@ -105,7 +106,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 ### Fixed
--  Fixing error: adding a new/forgotten parameter to the configuration for checking the config on startup in plugins/repository-s3 #7924 
+-  Fixing error: adding a new/forgotten parameter to the configuration for checking the config on startup in plugins/repository-s3 #7924
 
 ### Security
 

--- a/distribution/src/config/opensearch.yml
+++ b/distribution/src/config/opensearch.yml
@@ -130,4 +130,11 @@ ${path.logs}
 #
 # Gates the search pipeline feature. This feature enables configurable processors
 # for search requests and search responses, similar to ingest pipelines.
+#
 #opensearch.experimental.feature.search_pipeline.enabled: false
+#
+#
+# Gates the concurrent segment search feature. This feature enables concurrent segment search in a separate
+# index searcher threadpool.
+#
+#opensearch.experimental.feature.concurrent_segment_search.enabled: true

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/node/tasks/ConcurrentSearchTasksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/node/tasks/ConcurrentSearchTasksIT.java
@@ -44,6 +44,7 @@ public class ConcurrentSearchTasksIT extends AbstractTasksIT {
             .put(super.nodeSettings(nodeOrdinal))
             .put("thread_pool.index_searcher.size", INDEX_SEARCHER_THREADS)
             .put("thread_pool.index_searcher.queue_size", INDEX_SEARCHER_THREADS)
+            .put("search.concurrent_segment_search.enabled", true)
             .build();
     }
 

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -360,6 +360,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 ClusterManagerService.CLUSTER_MANAGER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING,
                 SearchService.DEFAULT_SEARCH_TIMEOUT_SETTING,
                 SearchService.DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS,
+                SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING,
                 TransportSearchAction.SHARD_COUNT_LIMIT_SETTING,
                 TransportSearchAction.SEARCH_CANCEL_AFTER_TIME_INTERVAL_SETTING,
                 RemoteClusterService.REMOTE_CLUSTER_SKIP_UNAVAILABLE,

--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -198,6 +198,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 IndexSettings.INDEX_MERGE_ON_FLUSH_MAX_FULL_FLUSH_MERGE_WAIT_TIME,
                 IndexSettings.INDEX_MERGE_ON_FLUSH_POLICY,
                 IndexSettings.DEFAULT_SEARCH_PIPELINE,
+                IndexSettings.INDEX_CONCURRENT_SEGMENT_SEARCH_SETTING,
 
                 // Settings for Searchable Snapshots
                 IndexSettings.SEARCHABLE_SNAPSHOT_REPOSITORY,

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -62,6 +62,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
+import static org.opensearch.common.util.FeatureFlags.CONCURRENT_SEGMENT_SEARCH;
 import static org.opensearch.common.util.FeatureFlags.SEARCHABLE_SNAPSHOT_EXTENDED_COMPATIBILITY;
 import static org.opensearch.common.util.FeatureFlags.SEARCH_PIPELINE;
 import static org.opensearch.index.mapper.MapperService.INDEX_MAPPING_DEPTH_LIMIT_SETTING;
@@ -588,6 +589,13 @@ public final class IndexSettings {
         Property.IndexScope
     );
 
+    public static final Setting<Boolean> INDEX_CONCURRENT_SEGMENT_SEARCH_SETTING = Setting.boolSetting(
+        "index.search.concurrent_segment_search.enabled",
+        false,
+        Property.IndexScope,
+        Property.Dynamic
+    );
+
     private final Index index;
     private final Version version;
     private final Logger logger;
@@ -665,6 +673,7 @@ public final class IndexSettings {
     private volatile long mappingTotalFieldsLimit;
     private volatile long mappingDepthLimit;
     private volatile long mappingFieldNameLengthLimit;
+    private volatile boolean indexConcurrentSegmentSearchEnabled;
 
     /**
      * The maximum number of refresh listeners allows on this shard.
@@ -829,6 +838,7 @@ public final class IndexSettings {
         mergeOnFlushEnabled = scopedSettings.get(INDEX_MERGE_ON_FLUSH_ENABLED);
         setMergeOnFlushPolicy(scopedSettings.get(INDEX_MERGE_ON_FLUSH_POLICY));
         defaultSearchPipeline = scopedSettings.get(DEFAULT_SEARCH_PIPELINE);
+        indexConcurrentSegmentSearchEnabled = scopedSettings.get(INDEX_CONCURRENT_SEGMENT_SEARCH_SETTING);
 
         scopedSettings.addSettingsUpdateConsumer(MergePolicyConfig.INDEX_COMPOUND_FORMAT_SETTING, mergePolicyConfig::setNoCFSRatio);
         scopedSettings.addSettingsUpdateConsumer(
@@ -903,6 +913,7 @@ public final class IndexSettings {
         scopedSettings.addSettingsUpdateConsumer(INDEX_MERGE_ON_FLUSH_ENABLED, this::setMergeOnFlushEnabled);
         scopedSettings.addSettingsUpdateConsumer(INDEX_MERGE_ON_FLUSH_POLICY, this::setMergeOnFlushPolicy);
         scopedSettings.addSettingsUpdateConsumer(DEFAULT_SEARCH_PIPELINE, this::setDefaultSearchPipeline);
+        scopedSettings.addSettingsUpdateConsumer(INDEX_CONCURRENT_SEGMENT_SEARCH_SETTING, this::setIndexConcurrentSegmentSearchEnabled);
     }
 
     private void setSearchIdleAfter(TimeValue searchIdleAfter) {
@@ -1592,5 +1603,17 @@ public final class IndexSettings {
         } else {
             throw new SettingsException("Unsupported setting: " + DEFAULT_SEARCH_PIPELINE.getKey());
         }
+    }
+
+    public void setIndexConcurrentSegmentSearchEnabled(boolean indexConcurrentSegmentSearchEnabled) {
+        if (FeatureFlags.isEnabled(CONCURRENT_SEGMENT_SEARCH)) {
+            this.indexConcurrentSegmentSearchEnabled = indexConcurrentSegmentSearchEnabled;
+        } else {
+            throw new SettingsException("Unsupported setting: " + INDEX_CONCURRENT_SEGMENT_SEARCH_SETTING.getKey());
+        }
+    }
+
+    public boolean isIndexConcurrentSegmentSearchEnabled() {
+        return indexConcurrentSegmentSearchEnabled;
     }
 }

--- a/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
@@ -193,7 +193,8 @@ final class DefaultSearchContext extends SearchContext {
         Version minNodeVersion,
         boolean validate,
         Executor executor,
-        Function<SearchSourceBuilder, InternalAggregation.ReduceContextBuilder> requestToAggReduceContextBuilder
+        Function<SearchSourceBuilder, InternalAggregation.ReduceContextBuilder> requestToAggReduceContextBuilder,
+        boolean concurrentSegmentSearchEnabled
     ) throws IOException {
         this.readerContext = readerContext;
         this.request = request;
@@ -231,6 +232,7 @@ final class DefaultSearchContext extends SearchContext {
         queryBoost = request.indexBoost();
         this.lowLevelCancellation = lowLevelCancellation;
         this.requestToAggReduceContextBuilder = requestToAggReduceContextBuilder;
+        this.concurrentSegmentSearchEnabled = concurrentSegmentSearchEnabled;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/ConcurrentAggregationProcessor.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/ConcurrentAggregationProcessor.java
@@ -32,53 +32,61 @@ public class ConcurrentAggregationProcessor extends DefaultAggregationProcessor 
 
     @Override
     public void preProcess(SearchContext context) {
-        try {
-            if (context.aggregations() != null) {
-                if (context.aggregations().factories().hasNonGlobalAggregator()) {
-                    context.queryCollectorManagers().put(NonGlobalAggCollectorManager.class, new NonGlobalAggCollectorManager(context));
+        if (context.concurrentSegmentSearchEnabled()) {
+            try {
+                if (context.aggregations() != null) {
+                    if (context.aggregations().factories().hasNonGlobalAggregator()) {
+                        context.queryCollectorManagers().put(NonGlobalAggCollectorManager.class, new NonGlobalAggCollectorManager(context));
+                    }
+                    // initialize global aggregators as well, such that any failure to initialize can be caught before executing the request
+                    if (context.aggregations().factories().hasGlobalAggregator()) {
+                        context.queryCollectorManagers().put(GlobalAggCollectorManager.class, new GlobalAggCollectorManager(context));
+                    }
                 }
-                // initialize global aggregators as well, such that any failure to initialize can be caught before executing the request
-                if (context.aggregations().factories().hasGlobalAggregator()) {
-                    context.queryCollectorManagers().put(GlobalAggCollectorManager.class, new GlobalAggCollectorManager(context));
-                }
+            } catch (IOException ex) {
+                throw new AggregationInitializationException("Could not initialize aggregators", ex);
             }
-        } catch (IOException ex) {
-            throw new AggregationInitializationException("Could not initialize aggregators", ex);
+        } else {
+            super.preProcess(context);
         }
     }
 
     @Override
     public void postProcess(SearchContext context) {
-        if (context.aggregations() == null) {
-            context.queryResult().aggregations(null);
-            return;
-        }
-
-        // for concurrent case we will perform only global aggregation in post process as QueryResult is already populated with results of
-        // processing the non-global aggregation
-        CollectorManager<? extends Collector, ReduceableSearchResult> globalCollectorManager = context.queryCollectorManagers()
-            .get(GlobalAggCollectorManager.class);
-        try {
-            if (globalCollectorManager != null) {
-                Query query = context.buildFilteredQuery(Queries.newMatchAllQuery());
-                globalCollectorManager = new InternalProfileCollectorManager(
-                    globalCollectorManager,
-                    CollectorResult.REASON_AGGREGATION_GLOBAL,
-                    Collections.emptyList()
-                );
-                if (context.getProfilers() != null) {
-                    context.getProfilers().addQueryProfiler().setCollector((InternalProfileComponent) globalCollectorManager);
-                }
-                final ReduceableSearchResult result = context.searcher().search(query, globalCollectorManager);
-                result.reduce(context.queryResult());
+        if (context.concurrentSegmentSearchEnabled()) {
+            if (context.aggregations() == null) {
+                context.queryResult().aggregations(null);
+                return;
             }
-        } catch (Exception e) {
-            throw new QueryPhaseExecutionException(context.shardTarget(), "Failed to execute global aggregators", e);
-        }
 
-        // disable aggregations so that they don't run on next pages in case of scrolling
-        context.aggregations(null);
-        context.queryCollectorManagers().remove(NonGlobalAggCollectorManager.class);
-        context.queryCollectorManagers().remove(GlobalAggCollectorManager.class);
+            // for concurrent case we will perform only global aggregation in post process as QueryResult is already populated with results
+            // of processing the non-global aggregation
+            CollectorManager<? extends Collector, ReduceableSearchResult> globalCollectorManager = context.queryCollectorManagers()
+                .get(GlobalAggCollectorManager.class);
+            try {
+                if (globalCollectorManager != null) {
+                    Query query = context.buildFilteredQuery(Queries.newMatchAllQuery());
+                    globalCollectorManager = new InternalProfileCollectorManager(
+                        globalCollectorManager,
+                        CollectorResult.REASON_AGGREGATION_GLOBAL,
+                        Collections.emptyList()
+                    );
+                    if (context.getProfilers() != null) {
+                        context.getProfilers().addQueryProfiler().setCollector((InternalProfileComponent) globalCollectorManager);
+                    }
+                    final ReduceableSearchResult result = context.searcher().search(query, globalCollectorManager);
+                    result.reduce(context.queryResult());
+                }
+            } catch (Exception e) {
+                throw new QueryPhaseExecutionException(context.shardTarget(), "Failed to execute global aggregators", e);
+            }
+
+            // disable aggregations so that they don't run on next pages in case of scrolling
+            context.aggregations(null);
+            context.queryCollectorManagers().remove(NonGlobalAggCollectorManager.class);
+            context.queryCollectorManagers().remove(GlobalAggCollectorManager.class);
+        } else {
+            super.postProcess(context);
+        }
     }
 }

--- a/server/src/main/java/org/opensearch/search/internal/SearchContext.java
+++ b/server/src/main/java/org/opensearch/search/internal/SearchContext.java
@@ -97,6 +97,7 @@ public abstract class SearchContext implements Releasable {
     private final List<Releasable> releasables = new CopyOnWriteArrayList<>();
     private final AtomicBoolean closed = new AtomicBoolean(false);
     private InnerHitsContext innerHitsContext;
+    protected boolean concurrentSegmentSearchEnabled;
 
     protected SearchContext() {}
 
@@ -365,6 +366,17 @@ public abstract class SearchContext implements Releasable {
      * Return a handle over the profilers for the current search request, or {@code null} if profiling is not enabled.
      */
     public abstract Profilers getProfilers();
+
+    /**
+     * Returns concurrent segment search status for the search context
+     */
+    public boolean concurrentSegmentSearchEnabled() {
+        return concurrentSegmentSearchEnabled;
+    }
+
+    public void setConcurrentSegmentSearchEnabled(boolean concurrentSegmentSearchEnabled) {
+        this.concurrentSegmentSearchEnabled = concurrentSegmentSearchEnabled;
+    }
 
     /**
      * Adds a releasable that will be freed when this context is closed.

--- a/server/src/main/java/org/opensearch/search/query/ConcurrentQueryPhaseSearcher.java
+++ b/server/src/main/java/org/opensearch/search/query/ConcurrentQueryPhaseSearcher.java
@@ -47,7 +47,7 @@ public class ConcurrentQueryPhaseSearcher extends DefaultQueryPhaseSearcher {
         boolean hasFilterCollector,
         boolean hasTimeout
     ) throws IOException {
-        boolean couldUseConcurrentSegmentSearch = allowConcurrentSegmentSearch(searcher);
+        boolean couldUseConcurrentSegmentSearch = allowConcurrentSegmentSearch(searcher, searchContext);
 
         if (couldUseConcurrentSegmentSearch) {
             LOGGER.debug("Using concurrent search over index segments (experimental)");
@@ -108,8 +108,8 @@ public class ConcurrentQueryPhaseSearcher extends DefaultQueryPhaseSearcher {
         return new ConcurrentAggregationProcessor();
     }
 
-    private static boolean allowConcurrentSegmentSearch(final ContextIndexSearcher searcher) {
-        return (searcher.getExecutor() != null);
+    private static boolean allowConcurrentSegmentSearch(final ContextIndexSearcher searcher, final SearchContext searchContext) {
+        return (searcher.getExecutor() != null) && searchContext.concurrentSegmentSearchEnabled();
     }
 
 }

--- a/server/src/test/java/org/opensearch/search/DefaultSearchContextTests.java
+++ b/server/src/test/java/org/opensearch/search/DefaultSearchContextTests.java
@@ -214,7 +214,8 @@ public class DefaultSearchContextTests extends OpenSearchTestCase {
                 Version.CURRENT,
                 false,
                 executor,
-                null
+                null,
+                randomBoolean()
             );
             contextWithoutScroll.from(300);
             contextWithoutScroll.close();
@@ -257,7 +258,8 @@ public class DefaultSearchContextTests extends OpenSearchTestCase {
                 Version.CURRENT,
                 false,
                 executor,
-                null
+                null,
+                randomBoolean()
             );
             context1.from(300);
             exception = expectThrows(IllegalArgumentException.class, () -> context1.preProcess(false));
@@ -328,7 +330,8 @@ public class DefaultSearchContextTests extends OpenSearchTestCase {
                 Version.CURRENT,
                 false,
                 executor,
-                null
+                null,
+                randomBoolean()
             );
 
             SliceBuilder sliceBuilder = mock(SliceBuilder.class);
@@ -368,7 +371,8 @@ public class DefaultSearchContextTests extends OpenSearchTestCase {
                 Version.CURRENT,
                 false,
                 executor,
-                null
+                null,
+                randomBoolean()
             );
             ParsedQuery parsedQuery = ParsedQuery.parsedMatchAllQuery();
             context3.sliceBuilder(null).parsedQuery(parsedQuery).preProcess(false);
@@ -404,7 +408,8 @@ public class DefaultSearchContextTests extends OpenSearchTestCase {
                 Version.CURRENT,
                 false,
                 executor,
-                null
+                null,
+                randomBoolean()
             );
             context4.sliceBuilder(new SliceBuilder(1, 2)).parsedQuery(parsedQuery).preProcess(false);
             Query query1 = context4.query();
@@ -435,7 +440,8 @@ public class DefaultSearchContextTests extends OpenSearchTestCase {
                 Version.CURRENT,
                 false,
                 executor,
-                null
+                null,
+                randomBoolean()
             );
             int numSlicesForPit = maxSlicesPerPit + randomIntBetween(1, 100);
             when(sliceBuilder.getMax()).thenReturn(numSlicesForPit);
@@ -533,7 +539,8 @@ public class DefaultSearchContextTests extends OpenSearchTestCase {
                 Version.CURRENT,
                 false,
                 executor,
-                null
+                null,
+                randomBoolean()
             );
             assertThat(context.searcher().hasCancellations(), is(false));
             context.searcher().addQueryCancellation(() -> {});

--- a/server/src/test/java/org/opensearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/opensearch/search/SearchServiceTests.java
@@ -38,6 +38,7 @@ import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.store.AlreadyClosedException;
+import org.junit.Before;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.OriginalIndices;
 import org.opensearch.action.index.IndexResponse;
@@ -61,6 +62,7 @@ import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.settings.SettingsException;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -111,7 +113,6 @@ import org.opensearch.search.sort.SortOrder;
 import org.opensearch.search.suggest.SuggestBuilder;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
 import org.opensearch.threadpool.ThreadPool;
-import org.junit.Before;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -129,16 +130,16 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import static java.util.Collections.singletonList;
-import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
-import static org.opensearch.indices.cluster.IndicesClusterStateService.AllocatedIndices.IndexRemovalReason.DELETED;
-import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
-import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
-import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertSearchHits;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.startsWith;
+import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
+import static org.opensearch.indices.cluster.IndicesClusterStateService.AllocatedIndices.IndexRemovalReason.DELETED;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertSearchHits;
 
 public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
 
@@ -227,7 +228,7 @@ public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
 
     @Override
     protected Settings nodeSettings() {
-        return Settings.builder().put("search.default_search_timeout", "5s").build();
+        return Settings.builder().put("search.default_search_timeout", "5s").put(FeatureFlags.CONCURRENT_SEGMENT_SEARCH, true).build();
     }
 
     public void testClearOnClose() {
@@ -1175,6 +1176,109 @@ public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
             assertSame(searchShardTarget, searchContext.queryResult().getSearchShardTarget());
             assertSame(searchShardTarget, searchContext.fetchResult().getSearchShardTarget());
         }
+    }
+
+    /**
+     * Test that the Search Context for concurrent segment search enabled is set correctly based on both
+     * index and cluster settings.
+     */
+    public void testConcurrentSegmentSearchSearchContext() throws IOException {
+        Boolean[][] scenarios = {
+            // cluster setting, index setting, concurrent search enabled?
+            { null, null, false },
+            { null, false, false },
+            { null, true, true },
+            { true, null, true },
+            { true, false, false },
+            { true, true, true },
+            { false, null, false },
+            { false, false, false },
+            { false, true, true } };
+
+        String index = randomAlphaOfLengthBetween(5, 10).toLowerCase(Locale.ROOT);
+        IndexService indexService = createIndex(index);
+        final SearchService service = getInstanceFromNode(SearchService.class);
+        ShardId shardId = new ShardId(indexService.index(), 0);
+        long nowInMillis = System.currentTimeMillis();
+        String clusterAlias = randomBoolean() ? null : randomAlphaOfLengthBetween(3, 10);
+        SearchRequest searchRequest = new SearchRequest();
+        searchRequest.allowPartialSearchResults(randomBoolean());
+        ShardSearchRequest request = new ShardSearchRequest(
+            OriginalIndices.NONE,
+            searchRequest,
+            shardId,
+            indexService.numberOfShards(),
+            AliasFilter.EMPTY,
+            1f,
+            nowInMillis,
+            clusterAlias,
+            Strings.EMPTY_ARRAY
+        );
+
+        for (Boolean[] scenario : scenarios) {
+            Boolean clusterSetting = scenario[0];
+            Boolean indexSetting = scenario[1];
+            Boolean concurrentSearchEnabled = scenario[2];
+
+            if (clusterSetting == null) {
+                client().admin()
+                    .cluster()
+                    .prepareUpdateSettings()
+                    .setTransientSettings(Settings.builder().putNull(SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING.getKey()))
+                    .get();
+            } else {
+                client().admin()
+                    .cluster()
+                    .prepareUpdateSettings()
+                    .setTransientSettings(
+                        Settings.builder().put(SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING.getKey(), clusterSetting)
+                    )
+                    .get();
+            }
+
+            if (indexSetting == null) {
+                client().admin()
+                    .indices()
+                    .prepareUpdateSettings(index)
+                    .setSettings(Settings.builder().putNull(IndexSettings.INDEX_CONCURRENT_SEGMENT_SEARCH_SETTING.getKey()))
+                    .get();
+            } else {
+                client().admin()
+                    .indices()
+                    .prepareUpdateSettings(index)
+                    .setSettings(Settings.builder().put(IndexSettings.INDEX_CONCURRENT_SEGMENT_SEARCH_SETTING.getKey(), indexSetting))
+                    .get();
+            }
+
+            try (DefaultSearchContext searchContext = service.createSearchContext(request, new TimeValue(System.currentTimeMillis()))) {
+                assertEquals(
+                    clusterSetting,
+                    client().admin()
+                        .cluster()
+                        .prepareState()
+                        .get()
+                        .getState()
+                        .getMetadata()
+                        .transientSettings()
+                        .getAsBoolean(SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING.getKey(), null)
+                );
+                assertEquals(
+                    indexSetting == null ? null : indexSetting.toString(),
+                    client().admin()
+                        .indices()
+                        .prepareGetSettings(index)
+                        .get()
+                        .getSetting(index, IndexSettings.INDEX_CONCURRENT_SEGMENT_SEARCH_SETTING.getKey())
+                );
+                assertEquals(concurrentSearchEnabled, searchContext.concurrentSegmentSearchEnabled());
+            }
+        }
+        // Cleanup
+        client().admin()
+            .cluster()
+            .prepareUpdateSettings()
+            .setTransientSettings(Settings.builder().putNull(SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING.getKey()))
+            .get();
     }
 
     /**

--- a/server/src/test/java/org/opensearch/search/aggregations/AggregationSetupTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/AggregationSetupTests.java
@@ -36,6 +36,7 @@ public class AggregationSetupTests extends OpenSearchSingleNodeTestCase {
         client().prepareIndex("idx").setId("1").setSource("f", 5).execute().get();
         client().admin().indices().prepareRefresh("idx").get();
         context = createSearchContext(index);
+        context.setConcurrentSegmentSearchEnabled(true);
     }
 
     protected AggregatorFactories getAggregationFactories(String agg) throws IOException {

--- a/server/src/test/java/org/opensearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/opensearch/search/query/QueryPhaseTests.java
@@ -411,6 +411,9 @@ public class QueryPhaseTests extends IndexShardTestCase {
         TestSearchContext context = new TestSearchContext(null, indexShard, newContextSearcher(reader, executor));
         context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
         context.parsedQuery(new ParsedQuery(new MatchAllDocsQuery()));
+        if (this.executor != null) {
+            context.setConcurrentSegmentSearchEnabled(true);
+        }
 
         context.terminateAfter(numDocs);
         {


### PR DESCRIPTION
### Description
Add dynamic cluster and index setting to control concurrent segment search. Index level setting overrides cluster level setting.

### Related Issues
Resolves #7356

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
