### PR TITLE
Make remote translog store path consistent to remote segment store

### DIFF
--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -65,6 +65,7 @@ public class RemoteFsTranslog extends Translog {
     private final SetOnce<Boolean> olderPrimaryCleaned = new SetOnce<>();
 
     private static final int REMOTE_DELETION_PERMITS = 2;
+    private static final String TRANSLOG = "translog";
 
     // Semaphore used to allow only single remote generation to happen at a time
     private final Semaphore remoteGenerationDeletionPermits = new Semaphore(REMOTE_DELETION_PERMITS);
@@ -167,7 +168,7 @@ public class RemoteFsTranslog extends Translog {
         return new TranslogTransferManager(
             shardId,
             new BlobStoreTransferService(blobStoreRepository.blobStore(), threadPool),
-            blobStoreRepository.basePath().add(shardId.getIndex().getUUID()).add(String.valueOf(shardId.id())),
+            blobStoreRepository.basePath().add(shardId.getIndex().getUUID()).add(String.valueOf(shardId.id())).add(TRANSLOG),
             fileTransferTracker
         );
     }

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -65,7 +65,7 @@ public class RemoteFsTranslog extends Translog {
     private final SetOnce<Boolean> olderPrimaryCleaned = new SetOnce<>();
 
     private static final int REMOTE_DELETION_PERMITS = 2;
-    private static final String TRANSLOG = "translog";
+    public static final String TRANSLOG = "translog";
 
     // Semaphore used to allow only single remote generation to happen at a time
     private final Semaphore remoteGenerationDeletionPermits = new Semaphore(REMOTE_DELETION_PERMITS);

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
@@ -59,6 +59,7 @@ public class TranslogTransferManager {
     private static final Logger logger = LogManager.getLogger(TranslogTransferManager.class);
 
     private final static String METADATA_DIR = "metadata";
+    private final static String DATA_DIR = "data";
 
     public TranslogTransferManager(
         ShardId shardId,
@@ -68,7 +69,7 @@ public class TranslogTransferManager {
     ) {
         this.shardId = shardId;
         this.transferService = transferService;
-        this.remoteBaseTransferPath = remoteBaseTransferPath.add("data");
+        this.remoteBaseTransferPath = remoteBaseTransferPath.add(DATA_DIR);
         this.remoteMetadataTransferPath = remoteBaseTransferPath.add(METADATA_DIR);
         this.fileTransferTracker = fileTransferTracker;
     }

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
@@ -110,7 +110,7 @@ public class TranslogTransferManager {
                 fileSnapshot -> transferService.uploadBlobAsync(
                     ThreadPool.Names.TRANSLOG_TRANSFER,
                     fileSnapshot,
-                    remoteBaseTransferPath.add(String.valueOf(fileSnapshot.getPrimaryTerm())),
+                    remoteBaseTransferPath.add("data").add(String.valueOf(fileSnapshot.getPrimaryTerm())),
                     latchedActionListener
                 )
             );

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
@@ -68,7 +68,7 @@ public class TranslogTransferManager {
     ) {
         this.shardId = shardId;
         this.transferService = transferService;
-        this.remoteBaseTransferPath = remoteBaseTransferPath;
+        this.remoteBaseTransferPath = remoteBaseTransferPath.add("data");
         this.remoteMetadataTransferPath = remoteBaseTransferPath.add(METADATA_DIR);
         this.fileTransferTracker = fileTransferTracker;
     }
@@ -110,7 +110,7 @@ public class TranslogTransferManager {
                 fileSnapshot -> transferService.uploadBlobAsync(
                     ThreadPool.Names.TRANSLOG_TRANSFER,
                     fileSnapshot,
-                    remoteBaseTransferPath.add("data").add(String.valueOf(fileSnapshot.getPrimaryTerm())),
+                    remoteBaseTransferPath.add(String.valueOf(fileSnapshot.getPrimaryTerm())),
                     latchedActionListener
                 )
             );

--- a/server/src/test/java/org/opensearch/index/translog/RemoteFSTranslogTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/RemoteFSTranslogTests.java
@@ -489,7 +489,9 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
         assertEquals(2, mdFiles.size());
         logger.info("All md files {}", mdFiles);
 
-        Set<String> tlogFiles = blobStoreTransferService.listAll(getTranslogDirectory().add(DATA_DIR).add(String.valueOf(primaryTerm.get())));
+        Set<String> tlogFiles = blobStoreTransferService.listAll(
+            getTranslogDirectory().add(DATA_DIR).add(String.valueOf(primaryTerm.get()))
+        );
         logger.info("All data files {}", tlogFiles);
 
         // assert content of ckp and tlog files

--- a/server/src/test/java/org/opensearch/index/translog/RemoteFSTranslogTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/RemoteFSTranslogTests.java
@@ -93,6 +93,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.opensearch.common.util.BigArrays.NON_RECYCLING_INSTANCE;
+import static org.opensearch.index.translog.RemoteFsTranslog.TRANSLOG;
 import static org.opensearch.index.translog.SnapshotMatchers.containsOperationsInAnyOrder;
 import static org.opensearch.index.translog.TranslogDeletionPolicies.createTranslogDeletionPolicy;
 
@@ -483,21 +484,19 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
         translog.rollGeneration();
         assertEquals(6, translog.allUploaded().size());
 
-        Set<String> mdFiles = blobStoreTransferService.listAll(
-            repository.basePath().add(shardId.getIndex().getUUID()).add(String.valueOf(shardId.id())).add("metadata")
-        );
+        Set<String> mdFiles = blobStoreTransferService.listAll(getTranslogDirectory().add("metadata"));
         assertEquals(2, mdFiles.size());
         logger.info("All md files {}", mdFiles);
 
-        Set<String> tlogFiles = blobStoreTransferService.listAll(
-            repository.basePath().add(shardId.getIndex().getUUID()).add(String.valueOf(shardId.id())).add(String.valueOf(primaryTerm.get()))
-        );
+        Set<String> tlogFiles = blobStoreTransferService.listAll(getTranslogDirectory().add("data").add(String.valueOf(primaryTerm.get())));
         logger.info("All data files {}", tlogFiles);
 
         // assert content of ckp and tlog files
         BlobPath path = repository.basePath()
             .add(shardId.getIndex().getUUID())
             .add(String.valueOf(shardId.id()))
+            .add(TRANSLOG)
+            .add("data")
             .add(String.valueOf(primaryTerm.get()));
         for (TranslogReader reader : translog.readers) {
             final long readerGeneration = reader.getGeneration();
@@ -537,6 +536,8 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
                     repository.basePath()
                         .add(shardId.getIndex().getUUID())
                         .add(String.valueOf(shardId.id()))
+                        .add(TRANSLOG)
+                        .add("data")
                         .add(String.valueOf(primaryTerm.get()))
                 ).size()
             );
@@ -555,6 +556,8 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
                     repository.basePath()
                         .add(shardId.getIndex().getUUID())
                         .add(String.valueOf(shardId.id()))
+                        .add(TRANSLOG)
+                        .add("data")
                         .add(String.valueOf(primaryTerm.get()))
                 ).size()
             );
@@ -583,14 +586,7 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
             assertEquals(1, translog.readers.size());
         }
         assertBusy(() -> assertEquals(4, translog.allUploaded().size()));
-        assertBusy(
-            () -> assertEquals(
-                2,
-                blobStoreTransferService.listAll(
-                    repository.basePath().add(shardId.getIndex().getUUID()).add(String.valueOf(shardId.id())).add(METADATA_DIR)
-                ).size()
-            )
-        );
+        assertBusy(() -> assertEquals(2, blobStoreTransferService.listAll(getTranslogDirectory().add(METADATA_DIR)).size()));
         int moreDocs = randomIntBetween(3, 10);
         logger.info("numDocs={} moreDocs={}", numDocs, moreDocs);
         for (int i = numDocs; i < numDocs + moreDocs; i++) {
@@ -599,14 +595,7 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
         translog.trimUnreferencedReaders();
         assertEquals(1 + moreDocs, translog.readers.size());
         assertBusy(() -> assertEquals(2 + 2L * moreDocs, translog.allUploaded().size()));
-        assertBusy(
-            () -> assertEquals(
-                1 + moreDocs,
-                blobStoreTransferService.listAll(
-                    repository.basePath().add(shardId.getIndex().getUUID()).add(String.valueOf(shardId.id())).add(METADATA_DIR)
-                ).size()
-            )
-        );
+        assertBusy(() -> assertEquals(1 + moreDocs, blobStoreTransferService.listAll(getTranslogDirectory().add(METADATA_DIR)).size()));
 
         int totalDocs = numDocs + moreDocs;
         translog.setMinSeqNoToKeep(totalDocs - 1);
@@ -619,14 +608,7 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
         );
         translog.setMinSeqNoToKeep(totalDocs);
         translog.trimUnreferencedReaders();
-        assertBusy(
-            () -> assertEquals(
-                2,
-                blobStoreTransferService.listAll(
-                    repository.basePath().add(shardId.getIndex().getUUID()).add(String.valueOf(shardId.id())).add(METADATA_DIR)
-                ).size()
-            )
-        );
+        assertBusy(() -> assertEquals(2, blobStoreTransferService.listAll(getTranslogDirectory().add(METADATA_DIR)).size()));
 
         // Change primary term and test the deletion of older primaries
         String translogUUID = translog.translogUUID;
@@ -642,9 +624,7 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
         long newPrimaryTerm = primaryTerm.incrementAndGet();
 
         // Check all metadata files corresponds to old primary term
-        Set<String> mdFileNames = blobStoreTransferService.listAll(
-            repository.basePath().add(shardId.getIndex().getUUID()).add(String.valueOf(shardId.id())).add(METADATA_DIR)
-        );
+        Set<String> mdFileNames = blobStoreTransferService.listAll(getTranslogDirectory().add(METADATA_DIR));
         assertTrue(mdFileNames.stream().allMatch(name -> name.startsWith(String.valueOf(oldPrimaryTerm).concat("__"))));
 
         // Creating RemoteFsTranslog with the same location
@@ -658,9 +638,7 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
         }
 
         // Check that all metadata files are belonging now to the new primary
-        mdFileNames = blobStoreTransferService.listAll(
-            repository.basePath().add(shardId.getIndex().getUUID()).add(String.valueOf(shardId.id())).add(METADATA_DIR)
-        );
+        mdFileNames = blobStoreTransferService.listAll(getTranslogDirectory().add(METADATA_DIR));
         assertTrue(mdFileNames.stream().allMatch(name -> name.startsWith(String.valueOf(newPrimaryTerm).concat("__"))));
 
         try {
@@ -669,6 +647,10 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
             // Ignoring this exception for now. Once the download flow populates FileTracker,
             // we can remove this try-catch block
         }
+    }
+
+    private BlobPath getTranslogDirectory() {
+        return repository.basePath().add(shardId.getIndex().getUUID()).add(String.valueOf(shardId.id())).add(TRANSLOG);
     }
 
     private Long populateTranslogOps(boolean withMissingOps) throws IOException {

--- a/server/src/test/java/org/opensearch/index/translog/RemoteFSTranslogTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/RemoteFSTranslogTests.java
@@ -112,6 +112,7 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
     private final AtomicReference<LongConsumer> persistedSeqNoConsumer = new AtomicReference<>();
     private ThreadPool threadPool;
     private final static String METADATA_DIR = "metadata";
+    private final static String DATA_DIR = "data";
     BlobStoreRepository repository;
 
     BlobStoreTransferService blobStoreTransferService;
@@ -484,20 +485,15 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
         translog.rollGeneration();
         assertEquals(6, translog.allUploaded().size());
 
-        Set<String> mdFiles = blobStoreTransferService.listAll(getTranslogDirectory().add("metadata"));
+        Set<String> mdFiles = blobStoreTransferService.listAll(getTranslogDirectory().add(METADATA_DIR));
         assertEquals(2, mdFiles.size());
         logger.info("All md files {}", mdFiles);
 
-        Set<String> tlogFiles = blobStoreTransferService.listAll(getTranslogDirectory().add("data").add(String.valueOf(primaryTerm.get())));
+        Set<String> tlogFiles = blobStoreTransferService.listAll(getTranslogDirectory().add(DATA_DIR).add(String.valueOf(primaryTerm.get())));
         logger.info("All data files {}", tlogFiles);
 
         // assert content of ckp and tlog files
-        BlobPath path = repository.basePath()
-            .add(shardId.getIndex().getUUID())
-            .add(String.valueOf(shardId.id()))
-            .add(TRANSLOG)
-            .add("data")
-            .add(String.valueOf(primaryTerm.get()));
+        BlobPath path = getTranslogDirectory().add(DATA_DIR).add(String.valueOf(primaryTerm.get()));
         for (TranslogReader reader : translog.readers) {
             final long readerGeneration = reader.getGeneration();
             logger.error("Asserting content of {}", readerGeneration);
@@ -532,14 +528,7 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
             assertEquals(4, translog.allUploaded().size());
             assertEquals(
                 4,
-                blobStoreTransferService.listAll(
-                    repository.basePath()
-                        .add(shardId.getIndex().getUUID())
-                        .add(String.valueOf(shardId.id()))
-                        .add(TRANSLOG)
-                        .add("data")
-                        .add(String.valueOf(primaryTerm.get()))
-                ).size()
+                blobStoreTransferService.listAll(getTranslogDirectory().add(DATA_DIR).add(String.valueOf(primaryTerm.get()))).size()
             );
         });
 
@@ -552,14 +541,7 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
             assertEquals(4, translog.allUploaded().size());
             assertEquals(
                 4,
-                blobStoreTransferService.listAll(
-                    repository.basePath()
-                        .add(shardId.getIndex().getUUID())
-                        .add(String.valueOf(shardId.id()))
-                        .add(TRANSLOG)
-                        .add("data")
-                        .add(String.valueOf(primaryTerm.get()))
-                ).size()
+                blobStoreTransferService.listAll(getTranslogDirectory().add(DATA_DIR).add(String.valueOf(primaryTerm.get()))).size()
             );
         });
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR updates remote translog store path to be consistent with segment.

#### Remote Segment Store Path 
- `s3://remote-store-perf-test/cluster-1/zqQpla0QS_mFK3Q42FbQ0A/<shardid>/segments/data/`
- `s3://remote-store-perf-test/cluster-1/zqQpla0QS_mFK3Q42FbQ0A/<shardid>/segments/metadata/`

#### Previous Translog paths
- `s3://remote-store-perf-test/cluster-1/zqQpla0QS_mFK3Q42FbQ0A/<shardid>/<primaryterm>/(*.tlog|*.ckp)`
- `s3://remote-store-perf-test/cluster-1/zqQpla0QS_mFK3Q42FbQ0A/<shardid>/metadata`

#### New Translog paths
- `s3://remote-store-perf-test/cluster-1/zqQpla0QS_mFK3Q42FbQ0A/<shardid>/translog/data/<primaryterm>/(*.tlog|*.ckp)`
- `s3://remote-store-perf-test/cluster-1/zqQpla0QS_mFK3Q42FbQ0A/<shardid>/translog/metadata`


### Related Issues
Addresses #1 in https://github.com/opensearch-project/OpenSearch/issues/3589#issuecomment-1534329922

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
