### PR TITLE
Default discovery-ec2 region to none.

### DIFF
--- a/plugins/discovery-ec2/src/main/java/org/opensearch/discovery/ec2/AwsEc2ServiceImpl.java
+++ b/plugins/discovery-ec2/src/main/java/org/opensearch/discovery/ec2/AwsEc2ServiceImpl.java
@@ -84,7 +84,7 @@ class AwsEc2ServiceImpl implements AwsEc2Service {
         ProxyConfiguration proxyConfiguration,
         ClientOverrideConfiguration overrideConfiguration,
         String endpoint,
-        Region region,
+        String region,
         long readTimeoutMillis
     ) {
         ApacheHttpClient.Builder clientBuilder = ApacheHttpClient.builder()
@@ -94,12 +94,16 @@ class AwsEc2ServiceImpl implements AwsEc2Service {
         Ec2ClientBuilder builder = Ec2Client.builder()
             .overrideConfiguration(overrideConfiguration)
             .httpClientBuilder(clientBuilder)
-            .credentialsProvider(awsCredentialsProvider)
-            .region(region);
+            .credentialsProvider(awsCredentialsProvider);
 
         if (Strings.hasText(endpoint)) {
             logger.debug("using explicit ec2 endpoint [{}]", endpoint);
             builder.endpointOverride(URI.create(endpoint));
+        }
+
+        if (Strings.hasText(region)) {
+            logger.debug("using explicit ec2 region [{}]", region);
+            builder.region(Region.of(region));
         }
 
         return SocketAccess.doPrivileged(builder::build);

--- a/plugins/discovery-ec2/src/main/java/org/opensearch/discovery/ec2/Ec2ClientSettings.java
+++ b/plugins/discovery-ec2/src/main/java/org/opensearch/discovery/ec2/Ec2ClientSettings.java
@@ -46,7 +46,6 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.core.Protocol;
-import software.amazon.awssdk.regions.Region;
 
 import java.util.Locale;
 
@@ -79,10 +78,10 @@ final class Ec2ClientSettings {
     );
 
     /** An override for the scoping region for authentication. */
-    static final Setting<Region> REGION_SETTING = new Setting<>(
+    static final Setting<String> REGION_SETTING = new Setting<>(
         "discovery.ec2.region",
-        "us-west-2",
-        s -> Region.of(s.toLowerCase(Locale.ROOT)),
+        "",
+        s -> s.toLowerCase(Locale.ROOT),
         Property.NodeScope
     );
 
@@ -124,7 +123,7 @@ final class Ec2ClientSettings {
     /**
      * The ec2 signing region.
      */
-    final Region region;
+    final String region;
 
     /** The protocol to use to talk to ec2. Defaults to https. */
     final Protocol protocol;
@@ -150,7 +149,7 @@ final class Ec2ClientSettings {
     protected Ec2ClientSettings(
         AwsCredentials credentials,
         String endpoint,
-        Region region,
+        String region,
         Protocol protocol,
         String proxyHost,
         int proxyPort,

--- a/plugins/discovery-ec2/src/test/java/org/opensearch/discovery/ec2/Ec2DiscoveryPluginTests.java
+++ b/plugins/discovery-ec2/src/test/java/org/opensearch/discovery/ec2/Ec2DiscoveryPluginTests.java
@@ -109,16 +109,16 @@ public class Ec2DiscoveryPluginTests extends AbstractEc2DiscoveryTestCase {
     public void testDefaultRegion() throws IOException {
         final Settings settings = Settings.builder().build();
         try (Ec2DiscoveryPluginMock plugin = new Ec2DiscoveryPluginMock(settings)) {
-            final Region region = ((MockEc2Client) plugin.ec2Service.client().get()).region;
-            assertEquals(region, Region.US_WEST_2);
+            final String region = ((MockEc2Client) plugin.ec2Service.client().get()).region;
+            assertEquals(region, "");
         }
     }
 
     public void testSpecificRegion() throws IOException {
         final Settings settings = Settings.builder().put(Ec2ClientSettings.REGION_SETTING.getKey(), "us-west-2").build();
         try (Ec2DiscoveryPluginMock plugin = new Ec2DiscoveryPluginMock(settings)) {
-            final Region region = ((MockEc2Client) plugin.ec2Service.client().get()).region;
-            assertEquals(region, Region.US_WEST_2);
+            final String region = ((MockEc2Client) plugin.ec2Service.client().get()).region;
+            assertEquals(region, Region.US_WEST_2.toString());
         }
     }
 
@@ -249,7 +249,7 @@ public class Ec2DiscoveryPluginTests extends AbstractEc2DiscoveryTestCase {
                     ProxyConfiguration proxyConfiguration,
                     ClientOverrideConfiguration overrideConfiguration,
                     String endpoint,
-                    Region region,
+                    String region,
                     long readTimeoutMillis
                 ) {
                     return new MockEc2Client(credentials, proxyConfiguration, overrideConfiguration, endpoint, region, readTimeoutMillis);
@@ -261,7 +261,7 @@ public class Ec2DiscoveryPluginTests extends AbstractEc2DiscoveryTestCase {
     private static class MockEc2Client implements Ec2Client {
 
         String endpoint;
-        final Region region;
+        final String region;
         final AwsCredentialsProvider credentials;
         final ClientOverrideConfiguration clientOverrideConfiguration;
         final ProxyConfiguration proxyConfiguration;
@@ -272,7 +272,7 @@ public class Ec2DiscoveryPluginTests extends AbstractEc2DiscoveryTestCase {
             ProxyConfiguration proxyConfiguration,
             ClientOverrideConfiguration clientOverrideConfiguration,
             String endpoint,
-            Region region,
+            String region,
             long readTimeoutMillis
         ) {
             this.credentials = credentials;


### PR DESCRIPTION
### Description

Defaults discovery-ec2 plugin default region to none. According to https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html this _should_ automatically determine the Region from the environment. 

### Related Issues

Resolves https://github.com/opensearch-project/OpenSearch/issues/7959.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
