### PR TITLE
Refactor QueryPhaseSearcher to support contextual aggregation processors at query phase

### DIFF
--- a/server/src/main/java/org/opensearch/search/query/ConcurrentQueryPhaseSearcher.java
+++ b/server/src/main/java/org/opensearch/search/query/ConcurrentQueryPhaseSearcher.java
@@ -32,6 +32,7 @@ import static org.opensearch.search.query.TopDocsCollectorContext.createTopDocsC
  */
 public class ConcurrentQueryPhaseSearcher extends DefaultQueryPhaseSearcher {
     private static final Logger LOGGER = LogManager.getLogger(ConcurrentQueryPhaseSearcher.class);
+    private final AggregationProcessor aggregationProcessor = new ConcurrentAggregationProcessor();
 
     /**
      * Default constructor
@@ -104,8 +105,8 @@ public class ConcurrentQueryPhaseSearcher extends DefaultQueryPhaseSearcher {
     }
 
     @Override
-    public AggregationProcessor newAggregationProcessor() {
-        return new ConcurrentAggregationProcessor();
+    public AggregationProcessor aggregationProcessor(SearchContext searchContext) {
+        return aggregationProcessor;
     }
 
     private static boolean allowConcurrentSegmentSearch(final ContextIndexSearcher searcher) {

--- a/server/src/main/java/org/opensearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/opensearch/search/query/QueryPhase.java
@@ -55,6 +55,7 @@ import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.SearchContextSourcePrinter;
 import org.opensearch.search.SearchService;
 import org.opensearch.search.aggregations.AggregationProcessor;
+import org.opensearch.search.aggregations.DefaultAggregationProcessor;
 import org.opensearch.search.aggregations.GlobalAggCollectorManager;
 import org.opensearch.search.internal.ContextIndexSearcher;
 import org.opensearch.search.internal.ScrollContext;
@@ -93,7 +94,6 @@ public class QueryPhase {
     public static final boolean SYS_PROP_REWRITE_SORT = Booleans.parseBoolean(System.getProperty("opensearch.search.rewrite_sort", "true"));
     public static final QueryPhaseSearcher DEFAULT_QUERY_PHASE_SEARCHER = new DefaultQueryPhaseSearcher();
     private final QueryPhaseSearcher queryPhaseSearcher;
-    private final AggregationProcessor aggregationProcessor;
     private final SuggestPhase suggestPhase;
     private final RescorePhase rescorePhase;
 
@@ -103,10 +103,6 @@ public class QueryPhase {
 
     public QueryPhase(QueryPhaseSearcher queryPhaseSearcher) {
         this.queryPhaseSearcher = Objects.requireNonNull(queryPhaseSearcher, "QueryPhaseSearcher is required");
-        this.aggregationProcessor = Objects.requireNonNull(
-            queryPhaseSearcher.newAggregationProcessor(),
-            "AggregationProcessor is required"
-        );
         this.suggestPhase = new SuggestPhase();
         this.rescorePhase = new RescorePhase();
     }
@@ -147,6 +143,7 @@ public class QueryPhase {
             LOGGER.trace("{}", new SearchContextSourcePrinter(searchContext));
         }
 
+        final AggregationProcessor aggregationProcessor = queryPhaseSearcher.aggregationProcessor(searchContext);
         // Pre-process aggregations as late as possible. In the case of a DFS_Q_T_F
         // request, preProcess is called on the DFS phase phase, this is why we pre-process them
         // here to make sure it happens during the QUERY phase
@@ -171,11 +168,6 @@ public class QueryPhase {
     // making public for testing
     public QueryPhaseSearcher getQueryPhaseSearcher() {
         return queryPhaseSearcher;
-    }
-
-    // making public for testing
-    public AggregationProcessor getAggregationProcessor() {
-        return aggregationProcessor;
     }
 
     /**
@@ -410,10 +402,14 @@ public class QueryPhase {
      * @opensearch.internal
      */
     public static class DefaultQueryPhaseSearcher implements QueryPhaseSearcher {
+        private final AggregationProcessor aggregationProcessor;
+
         /**
          * Please use {@link QueryPhase#DEFAULT_QUERY_PHASE_SEARCHER}
          */
-        protected DefaultQueryPhaseSearcher() {}
+        protected DefaultQueryPhaseSearcher() {
+            aggregationProcessor = new DefaultAggregationProcessor();
+        }
 
         @Override
         public boolean searchWith(
@@ -425,6 +421,11 @@ public class QueryPhase {
             boolean hasTimeout
         ) throws IOException {
             return searchWithCollector(searchContext, searcher, query, collectors, hasFilterCollector, hasTimeout);
+        }
+
+        @Override
+        public AggregationProcessor aggregationProcessor(SearchContext searchContext) {
+            return aggregationProcessor;
         }
 
         protected boolean searchWithCollector(

--- a/server/src/main/java/org/opensearch/search/query/QueryPhaseSearcher.java
+++ b/server/src/main/java/org/opensearch/search/query/QueryPhaseSearcher.java
@@ -45,9 +45,10 @@ public interface QueryPhaseSearcher {
 
     /**
      * {@link AggregationProcessor} to use to setup and post process aggregation related collectors during search request
+     * @param searchContext search context
      * @return {@link AggregationProcessor} to use
      */
-    default AggregationProcessor newAggregationProcessor() {
+    default AggregationProcessor aggregationProcessor(SearchContext searchContext) {
         return new DefaultAggregationProcessor();
     }
 }

--- a/server/src/test/java/org/opensearch/search/SearchModuleTests.java
+++ b/server/src/test/java/org/opensearch/search/SearchModuleTests.java
@@ -92,6 +92,7 @@ import org.opensearch.search.suggest.SuggestionSearchContext.SuggestionContext;
 import org.opensearch.search.suggest.term.TermSuggestion;
 import org.opensearch.search.suggest.term.TermSuggestionBuilder;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.TestSearchContext;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
@@ -422,18 +423,20 @@ public class SearchModuleTests extends OpenSearchTestCase {
 
     public void testDefaultQueryPhaseSearcher() {
         SearchModule searchModule = new SearchModule(Settings.EMPTY, Collections.emptyList());
+        TestSearchContext searchContext = new TestSearchContext(null);
         QueryPhase queryPhase = searchModule.getQueryPhase();
         assertTrue(queryPhase.getQueryPhaseSearcher() instanceof QueryPhase.DefaultQueryPhaseSearcher);
-        assertTrue(queryPhase.getAggregationProcessor() instanceof DefaultAggregationProcessor);
+        assertTrue(queryPhase.getQueryPhaseSearcher().aggregationProcessor(searchContext) instanceof DefaultAggregationProcessor);
     }
 
     public void testConcurrentQueryPhaseSearcher() {
         Settings settings = Settings.builder().put(FeatureFlags.CONCURRENT_SEGMENT_SEARCH, true).build();
         FeatureFlags.initializeFeatureFlags(settings);
         SearchModule searchModule = new SearchModule(settings, Collections.emptyList());
+        TestSearchContext searchContext = new TestSearchContext(null);
         QueryPhase queryPhase = searchModule.getQueryPhase();
         assertTrue(queryPhase.getQueryPhaseSearcher() instanceof ConcurrentQueryPhaseSearcher);
-        assertTrue(queryPhase.getAggregationProcessor() instanceof ConcurrentAggregationProcessor);
+        assertTrue(queryPhase.getQueryPhaseSearcher().aggregationProcessor(searchContext) instanceof ConcurrentAggregationProcessor);
         FeatureFlags.initializeFeatureFlags(Settings.EMPTY);
     }
 
@@ -449,8 +452,9 @@ public class SearchModuleTests extends OpenSearchTestCase {
         };
         SearchModule searchModule = new SearchModule(settings, Collections.singletonList(plugin1));
         QueryPhase queryPhase = searchModule.getQueryPhase();
+        TestSearchContext searchContext = new TestSearchContext(null);
         assertEquals(queryPhaseSearcher, queryPhase.getQueryPhaseSearcher());
-        assertTrue(queryPhase.getAggregationProcessor() instanceof DefaultAggregationProcessor);
+        assertTrue(queryPhaseSearcher.aggregationProcessor(searchContext) instanceof DefaultAggregationProcessor);
         FeatureFlags.initializeFeatureFlags(Settings.EMPTY);
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
As part of https://github.com/opensearch-project/OpenSearch/pull/7956, we would new to move off from static to contextual aggregation processor instantiation, refactoring QueryPhaseSearcher to allow such possibility.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
