### PR TITLE
Fix flaky test `**/SearchBackpressureIT.testSearchTaskCancellationWithHighCpu`

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/backpressure/SearchBackpressureIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/backpressure/SearchBackpressureIT.java
@@ -151,7 +151,7 @@ public class SearchBackpressureIT extends OpenSearchIntegTestCase {
     public void testSearchTaskCancellationWithHighCpu() throws InterruptedException {
         Settings request = Settings.builder()
             .put(SearchBackpressureSettings.SETTING_MODE.getKey(), "enforced")
-            .put(SearchTaskSettings.SETTING_CPU_TIME_MILLIS_THRESHOLD.getKey(), 1000)
+            .put(SearchTaskSettings.SETTING_CPU_TIME_MILLIS_THRESHOLD.getKey(), 500)
             .build();
         assertAcked(client().admin().cluster().prepareUpdateSettings().setPersistentSettings(request).get());
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This change resolves the issue of the SearchBackpressureIT.testSearchTaskCancellationWithHighCPU encountered here https://github.com/opensearch-project/OpenSearch/issues/7972. 

The issue was happening because the selected timelimit threshold for the test was too high leading the test to pass on occasion. To check this, I ran the test with additional logging at line 51 of the `CpuUsageTracker.java` class which is what processes the reason for failure. I then ran the test to verify the issue and found that the Optional.empty() was being returned in cases where the completion time of the request was around .9 seconds (just under the 1 second threshold). 

I dropped the threshold to be .5 seconds so that it should always trigger. Since this value is just for testing that the correct exception messages are logged, it should not matter what the value is. The default value remains 3 seconds and is unaffected by this change. 

### Related Issues
#7972 

### Check List
- [ ] ~New functionality includes testing.~
  - [ ] A~ll tests pass~
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [x] Commits are signed per the DCO using --signoff
- [ ] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
