### PR TITLE
Fix flaky test `SearchRestCancellationIT.testAutomaticCancellationMultiSearchDuringFetchPhase`

### DIFF
--- a/qa/smoke-test-http/src/test/java/org/opensearch/http/SearchRestCancellationIT.java
+++ b/qa/smoke-test-http/src/test/java/org/opensearch/http/SearchRestCancellationIT.java
@@ -163,7 +163,7 @@ public class SearchRestCancellationIT extends HttpSmokeTestCase {
         verifyCancellationDuringFetchPhase(MultiSearchAction.NAME, restRequest);
     }
 
-    void    verifyCancellationDuringFetchPhase(String searchAction, Request searchRequest) throws Exception {
+    void verifyCancellationDuringFetchPhase(String searchAction, Request searchRequest) throws Exception {
         Map<String, String> nodeIdToName = readNodesInfo();
 
         List<ScriptedBlockPlugin> plugins = initBlockFactory();

--- a/qa/smoke-test-http/src/test/java/org/opensearch/http/SearchRestCancellationIT.java
+++ b/qa/smoke-test-http/src/test/java/org/opensearch/http/SearchRestCancellationIT.java
@@ -183,8 +183,7 @@ public class SearchRestCancellationIT extends HttpSmokeTestCase {
                 latch.countDown();
             }
         });
-
-        latch.await();
+        latch.await(5, TimeUnit.SECONDS);
         awaitForBlock(plugins);
         cancellable.cancel();
         ensureSearchTaskIsCancelled(searchAction, nodeIdToName::get);

--- a/qa/smoke-test-http/src/test/java/org/opensearch/http/SearchRestCancellationIT.java
+++ b/qa/smoke-test-http/src/test/java/org/opensearch/http/SearchRestCancellationIT.java
@@ -183,6 +183,7 @@ public class SearchRestCancellationIT extends HttpSmokeTestCase {
                 latch.countDown();
             }
         });
+
         latch.await(5, TimeUnit.SECONDS);
         awaitForBlock(plugins);
         cancellable.cancel();

--- a/qa/smoke-test-http/src/test/java/org/opensearch/http/SearchRestCancellationIT.java
+++ b/qa/smoke-test-http/src/test/java/org/opensearch/http/SearchRestCancellationIT.java
@@ -83,6 +83,7 @@ import static org.opensearch.index.query.QueryBuilders.scriptQuery;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.awaitLatch;
 
 public class SearchRestCancellationIT extends HttpSmokeTestCase {
 
@@ -162,7 +163,7 @@ public class SearchRestCancellationIT extends HttpSmokeTestCase {
         verifyCancellationDuringFetchPhase(MultiSearchAction.NAME, restRequest);
     }
 
-    void verifyCancellationDuringFetchPhase(String searchAction, Request searchRequest) throws Exception {
+    void    verifyCancellationDuringFetchPhase(String searchAction, Request searchRequest) throws Exception {
         Map<String, String> nodeIdToName = readNodesInfo();
 
         List<ScriptedBlockPlugin> plugins = initBlockFactory();
@@ -183,6 +184,7 @@ public class SearchRestCancellationIT extends HttpSmokeTestCase {
             }
         });
 
+        latch.await();
         awaitForBlock(plugins);
         cancellable.cancel();
         ensureSearchTaskIsCancelled(searchAction, nodeIdToName::get);

--- a/qa/smoke-test-http/src/test/java/org/opensearch/http/SearchRestCancellationIT.java
+++ b/qa/smoke-test-http/src/test/java/org/opensearch/http/SearchRestCancellationIT.java
@@ -184,7 +184,7 @@ public class SearchRestCancellationIT extends HttpSmokeTestCase {
             }
         });
 
-        latch.await(5, TimeUnit.SECONDS);
+        latch.await(2, TimeUnit.SECONDS);
         awaitForBlock(plugins);
         cancellable.cancel();
         ensureSearchTaskIsCancelled(searchAction, nodeIdToName::get);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR seeks to correct a flaky test `SearchRestCancellationIT.testAutomaticCancellationMultiSearchDuringFetchPhase`.
In the test, a multisearch REST request is created and then cancelled. The test sometimes fails on a runner because the latch had not been set to await for its countdown. By adding the `latch.await(2, Seconds)` statement the latch should force the following block 

```
CountDownLatch latch = new CountDownLatch(1);
        AtomicReference<Exception> error = new AtomicReference<>();
        Cancellable cancellable = getRestClient().performRequestAsync(searchRequest, new ResponseListener() {
            @Override
            public void onSuccess(Response response) {
                latch.countDown();
            }

            @Override
            public void onFailure(Exception exception) {
                error.set(exception);
                latch.countDown();
            }
        });

        latch.await(2, SECONDS);
```
to perform the asynchronous request before continuing. This should mean that even on a faster runner, the request will have had to execute before the later assertion can be checked. 

### Related Issues
Resolves #7980

### Check List
- [ ] ~New functionality includes testing.~
  - [ ] ~All tests pass~
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [x] Commits are signed per the DCO using --signoff
- [ ] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
