### PR TITLE
[BUG] Fix org.opensearch.backwards.MixedClusterClientYamlTestSuiteIT.test {p0=search/110_field_collapsing/field collapsing and search_after} flaky test

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/110_field_collapsing.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/110_field_collapsing.yml
@@ -254,6 +254,7 @@ setup:
   - do:
       catch:      /cannot use \`collapse\` in conjunction with \`search_after\`/
       search:
+        allow_partial_search_results: false
         rest_total_hits_as_int: true
         index: test
         body:
@@ -267,6 +268,7 @@ setup:
   - do:
       catch:      /cannot use \`collapse\` in conjunction with \`rescore\`/
       search:
+        allow_partial_search_results: false
         rest_total_hits_as_int: true
         index: test
         body:


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Flipping `allow_partial_search_results` default was causing the search request to not report an error but return just partial results instead.

### Related Issues
Resolves #7873 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
