### PR TITLE
Enable Partial Flat Object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Adds mock implementation for TelemetryPlugin ([#7545](https://github.com/opensearch-project/OpenSearch/issues/7545))
 - Support transport action names when registering NamedRoutes ([#7957](https://github.com/opensearch-project/OpenSearch/pull/7957))
 - Create concept of persistent ThreadContext headers that are unstashable ([#8291]()https://github.com/opensearch-project/OpenSearch/pull/8291)
+- Enable Partial Flat Object ([#7997](https://github.com/opensearch-project/OpenSearch/pull/7997))
 
 ### Dependencies
 - Bump `com.azure:azure-storage-common` from 12.21.0 to 12.21.1 (#7566, #7814)

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/100_partial_flat_object.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/100_partial_flat_object.yml
@@ -1,0 +1,539 @@
+---
+# The test setup includes:
+# - Create flat_object mapping for test_partial_flat_object index
+# - Index two example documents
+# - Refresh the index so it is ready for search tests
+
+setup:
+  - do:
+      indices.create:
+        index: test_partial_flat_object
+        body:
+          mappings:
+            properties:
+              issue:
+                properties:
+                  number:
+                    type : "integer"
+                  labels:
+                    type : "flat_object"
+  - do:
+      index:
+        index: test_partial_flat_object
+        id: 1
+        body: {
+          "issue": {
+            "number": 123,
+            "labels": {
+              "version": "2.2",
+              "backport": [
+                "2.0",
+                "1.9"
+              ],
+              "category": {
+                "type": "API",
+                "level": "bug"
+              },
+              "createdDate": "2023-01-01",
+              "comment" : [["Doe","Shipped"],["John","Approved"]],
+              "views": 288,
+              "priority": 5.00
+            }
+          }
+        }
+
+  - do:
+      index:
+        index: test_partial_flat_object
+        id: 2
+        body: {
+          "issue": {
+            "number": 456,
+            "labels": {
+              "version": "2.1",
+              "backport": [
+                "2.0",
+                "1.3"
+              ],
+              "category": {
+                "type": "API",
+                "level": "enhancement"
+              },
+              "createdDate": "2023-02-01",
+              "comment" : [["Mike","LGTM"],["John","Approved"]],
+              "views": 3333,
+              "priority": 1.50
+            }
+          }
+        }
+  - do:
+      indices.refresh:
+        index: test_partial_flat_object
+---
+# Delete Index when connection is teardown
+teardown:
+  - do:
+      indices.delete:
+        index: test_partial_flat_object
+
+
+---
+# Verify that mappings under the catalog field did not expand
+# and no dynamic fields were created.
+"Mappings":
+  - skip:
+      version: " - 2.99.99"
+      reason: "flat_object is introduced in 3.0.0 in main branch"
+
+  - do:
+      indices.get_mapping:
+        index: test_partial_flat_object
+  - is_true: test_partial_flat_object.mappings
+  - match: { test_partial_flat_object.mappings.properties.issue.properties.number.type:  integer     }
+  - match: { test_partial_flat_object.mappings.properties.issue.properties.labels.type: flat_object }
+  # https://github.com/opensearch-project/OpenSearch/tree/main/rest-api-spec/src/main/resources/rest-api-spec/test#length
+  - length: { test_partial_flat_object.mappings.properties.issue.properties: 2 }
+  - length: { test_partial_flat_object.mappings.properties.issue.properties.labels: 1 }
+
+
+---
+"Supported queries":
+  - skip:
+      version: " - 2.99.99"
+      reason: "flat_object is introduced in 3.0.0 in main branch"
+
+
+  # Verify Document Count
+  - do:
+      search:
+        body: {
+          query: {
+            match_all: {}
+          }
+        }
+
+  - length:   { hits.hits: 2  }
+
+  # Match Query with exact dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            match: { "issue.labels.version": "2.1" }
+          }
+        }
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._source.issue.labels.version: "2.1" }
+
+  # Match Query without exact dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            match: { issue.labels: "2.1" }
+          }
+        }
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._source.issue.labels.version: "2.1" }
+
+  # Multi Match Query with exact dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            multi_match: {
+              "query": "2.0",
+              "fields": [ "issue.labels.version", "issue.labels.backport" ]
+            }
+          }
+        }
+
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._source.issue.labels.backport: [ "2.0", "1.9"] }
+
+  # Term Query1 with exact dot path for date
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            term: { issue.labels.createdDate: "2023-01-01" }
+          }
+        }
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._source.issue.labels.createdDate: "2023-01-01" }
+
+  # Term Query1 without exact dot path for date
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            term: { issue.labels: "2023-01-01" }
+          }
+        }
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._source.issue.labels.createdDate: "2023-01-01" }
+
+
+  # Term Query2 with dot path for string
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            term: { "issue.labels.category.type": "API" }
+          }
+        }
+
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._source.issue.labels.category.type: "API" }
+
+  # Term Query2 without exact dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            term: { issue.labels: "API" }
+          }
+        }
+
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._source.issue.labels.category.type: "API" }
+
+  # Term Query3 with dot path for array
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            term: { issue.labels.backport: "1.9" }
+          }
+        }
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._source.issue.labels.backport: [ "2.0", "1.9"]}
+
+  # Term Query3 without dot path for array
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            term: { issue.labels: "1.9" }
+          }
+        }
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._source.issue.labels.backport: [ "2.0", "1.9"]}
+
+  # Term Query4 with  dot path for nested-array
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            term: { issue.labels.comment: "LGTM" }
+          }
+        }
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._source.issue.labels.comment: [["Mike","LGTM"],["John","Approved"]]}
+
+  # Term Query4 without dot path for nested-array
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            term: { issue.labels: "LGTM"  }
+          }
+        }
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._source.issue.labels.comment: [["Mike","LGTM"],["John","Approved"]] }
+
+  # Terms Query without dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            terms: { issue.labels: [ "John","Mike" ] }
+          }
+        }
+
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._source.issue.labels.comment: [["Doe","Shipped"],["John","Approved"]] }
+
+  # Terms Query with dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            terms: { issue.labels.comment: ["John","Mike"] }
+          }
+        }
+
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._source.issue.labels.comment: [["Doe","Shipped"],["John","Approved"]] }
+
+  # Prefix Query with dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            "prefix": {
+              "issue.labels.comment": {
+                "value": "Mi"
+              }
+            }
+          }
+        }
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._source.issue.labels.comment:  [["Mike","LGTM"],["John","Approved"]] }
+
+  # Prefix Query without dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            "prefix": {
+              "issue.labels": {
+                "value": "Mi"
+              }
+            }
+          }
+        }
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._source.issue.labels.comment:  [["Mike","LGTM"],["John","Approved"]] }
+
+  # Range Query with dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            "range": {
+              "issue.labels.version": {
+                "gte": "2.1",
+                "lte": "3.0"
+              }
+            }
+          }
+        }
+
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._source.issue.labels.version: "2.2" }
+
+  # Range Query without dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            "range": {
+              "issue.labels": {
+                "gte": "2.1",
+                "lte": "3.0"
+              }
+            }
+          }
+        }
+
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._source.issue.labels.version: "2.2" }
+
+  # Range Query with integer input with dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            "range": {
+              "issue.labels.views": {
+                "gte": 3000,
+                "lte": 4000
+              }
+            }
+          }
+        }
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._source.issue.labels.views: 3333 }
+
+  # Range Query with integer input without dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            "range": {
+              "issue.labels": {
+                "gte": 3000,
+                "lte": 4000
+              }
+            }
+          }
+        }
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._source.issue.labels.views: 3333  }
+
+
+  # Range Query with double input with dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            "range": {
+              "issue.labels.priority": {
+                "gte": 4.1234,
+                "lte": 5.1234
+              }
+            }
+          }
+        }
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._source.issue.labels.priority: 5.00 }
+
+  # Range Query with double input without dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            "range": {
+              "issue.labels": {
+                "gte": 4.1234,
+                "lte": 5.1234
+              }
+            }
+          }
+        }
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._source.issue.labels.priority: 5.00 }
+
+
+  # Exists Query with dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            "exists": {
+              "field": issue.labels.priority
+            }
+          }
+        }
+
+  - length: { hits.hits: 2 }
+
+  # Exists Query with nested dot path, use the flat_object_field_name.last_key
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            "exists": {
+              "field": issue.labels.type
+            }
+          }
+        }
+
+  - length: { hits.hits: 2 }
+
+  # Exists Query without dot path for the flat_object_field_name
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            "exists": {
+              "field": issue.labels
+            }
+          }
+        }
+
+  - length: { hits.hits: 2 }
+
+  # Query_string Query without dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            "query_string": {
+              "fields": [ "issue.labels"],
+              "query": "Doe OR Mike"
+            }
+          }
+        }
+
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._source.issue.labels.comment: [["Doe","Shipped"],["John","Approved"]]}
+  - match: { hits.hits.1._source.issue.labels.comment: [["Mike","LGTM"],["John","Approved"]]}
+
+  # Query_string Query with dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            "query_string": {
+              "fields": [ "issue.labels.comment" ],
+              "query": "Doe OR Mike"
+            }
+          }
+        }
+
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._source.issue.labels.comment: [["Doe","Shipped"],["John","Approved"]]}
+  - match: { hits.hits.1._source.issue.labels.comment: [["Mike","LGTM"],["John","Approved"]]}
+
+  # Simple_query_string Query without full dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            "simple_query_string": {
+              "query": "Doe",
+              "fields": [ "issue.labels" ]
+            }
+          }
+        }
+
+  - length: { hits.hits: 1 }
+  - match: {  hits.hits.0._source.issue.labels.comment: [["Doe","Shipped"],["John","Approved"]] }
+
+  # Simple_query_string Query with dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            "simple_query_string": {
+              "query": "Doe",
+              "fields": [ "issue.labels.comment" ]
+            }
+          }
+        }
+
+  - length: { hits.hits: 1 }
+  - match: {  hits.hits.0._source.issue.labels.comment: [["Doe","Shipped"],["John","Approved"]] }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/100_partial_flat_object.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/100_partial_flat_object.yml
@@ -14,9 +14,9 @@ setup:
               issue:
                 properties:
                   number:
-                    type : "integer"
+                    type: "integer"
                   labels:
-                    type : "flat_object"
+                    type: "flat_object"
   - do:
       index:
         index: test_partial_flat_object
@@ -35,7 +35,7 @@ setup:
                 "level": "bug"
               },
               "createdDate": "2023-01-01",
-              "comment" : [["Doe","Shipped"],["John","Approved"]],
+              "comment": [ [ "Doe","Shipped" ],[ "John","Approved" ] ],
               "views": 288,
               "priority": 5.00
             }
@@ -50,6 +50,7 @@ setup:
           "issue": {
             "number": 456,
             "labels": {
+              "author": "Liu",
               "version": "2.1",
               "backport": [
                 "2.0",
@@ -60,12 +61,34 @@ setup:
                 "level": "enhancement"
               },
               "createdDate": "2023-02-01",
-              "comment" : [["Mike","LGTM"],["John","Approved"]],
+              "comment": [ [ "Mike","LGTM" ],[ "John","Approved" ] ],
               "views": 3333,
               "priority": 1.50
             }
           }
         }
+
+  - do:
+      index:
+        index: test_partial_flat_object
+        id: 3
+        body: {
+          "issue": {
+            "number": 999,
+            "labels": [ {
+              "version": "1.1",
+              "backport": [
+                "1.0",
+                "0.9"
+              ],
+              "category": {
+                "type": "Module",
+                "level": "feature"
+              }
+            } ]
+          }
+        }
+
   - do:
       indices.refresh:
         index: test_partial_flat_object
@@ -89,7 +112,7 @@ teardown:
       indices.get_mapping:
         index: test_partial_flat_object
   - is_true: test_partial_flat_object.mappings
-  - match: { test_partial_flat_object.mappings.properties.issue.properties.number.type:  integer     }
+  - match: { test_partial_flat_object.mappings.properties.issue.properties.number.type: integer }
   - match: { test_partial_flat_object.mappings.properties.issue.properties.labels.type: flat_object }
   # https://github.com/opensearch-project/OpenSearch/tree/main/rest-api-spec/src/main/resources/rest-api-spec/test#length
   - length: { test_partial_flat_object.mappings.properties.issue.properties: 2 }
@@ -108,11 +131,11 @@ teardown:
       search:
         body: {
           query: {
-            match_all: {}
+            match_all: { }
           }
         }
 
-  - length:   { hits.hits: 2  }
+  - length: { hits.hits: 3 }
 
   # Match Query with exact dot path.
   - do:
@@ -154,7 +177,8 @@ teardown:
         }
 
   - length: { hits.hits: 2 }
-  - match: { hits.hits.0._source.issue.labels.backport: [ "2.0", "1.9"] }
+  - match: { hits.hits.0._source.issue.labels.backport: [ "2.0", "1.9" ] }
+  - match: { hits.hits.1._source.issue.labels.backport: [ "2.0", "1.3" ] }
 
   # Term Query1 with exact dot path for date
   - do:
@@ -195,6 +219,7 @@ teardown:
 
   - length: { hits.hits: 2 }
   - match: { hits.hits.0._source.issue.labels.category.type: "API" }
+  - match: { hits.hits.1._source.issue.labels.category.type: "API" }
 
   # Term Query2 without exact dot path.
   - do:
@@ -208,6 +233,7 @@ teardown:
 
   - length: { hits.hits: 2 }
   - match: { hits.hits.0._source.issue.labels.category.type: "API" }
+  - match: { hits.hits.1._source.issue.labels.category.type: "API" }
 
   # Term Query3 with dot path for array
   - do:
@@ -220,7 +246,7 @@ teardown:
         }
 
   - length: { hits.hits: 1 }
-  - match: { hits.hits.0._source.issue.labels.backport: [ "2.0", "1.9"]}
+  - match: { hits.hits.0._source.issue.labels.backport: [ "2.0", "1.9" ] }
 
   # Term Query3 without dot path for array
   - do:
@@ -233,7 +259,7 @@ teardown:
         }
 
   - length: { hits.hits: 1 }
-  - match: { hits.hits.0._source.issue.labels.backport: [ "2.0", "1.9"]}
+  - match: { hits.hits.0._source.issue.labels.backport: [ "2.0", "1.9" ] }
 
   # Term Query4 with  dot path for nested-array
   - do:
@@ -246,7 +272,7 @@ teardown:
         }
 
   - length: { hits.hits: 1 }
-  - match: { hits.hits.0._source.issue.labels.comment: [["Mike","LGTM"],["John","Approved"]]}
+  - match: { hits.hits.0._source.issue.labels.comment: [ [ "Mike","LGTM" ],[ "John","Approved" ] ] }
 
   # Term Query4 without dot path for nested-array
   - do:
@@ -254,12 +280,35 @@ teardown:
         body: {
           _source: true,
           query: {
-            term: { issue.labels: "LGTM"  }
+            term: { issue.labels: "LGTM" }
+          }
+        }
+
+  # Term Query5 with  dot path for array
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            term: { issue.labels.category.type: "Module" }
           }
         }
 
   - length: { hits.hits: 1 }
-  - match: { hits.hits.0._source.issue.labels.comment: [["Mike","LGTM"],["John","Approved"]] }
+  - match: { hits.hits.0._source.issue.labels.0.category.type: "Module" }
+
+  # Term Query5 without dot path for array
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            term: { issue.labels: "Module" }
+          }
+        }
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._source.issue.labels.0.category.type: "Module" }
 
   # Terms Query without dot path.
   - do:
@@ -272,7 +321,8 @@ teardown:
         }
 
   - length: { hits.hits: 2 }
-  - match: { hits.hits.0._source.issue.labels.comment: [["Doe","Shipped"],["John","Approved"]] }
+  - match: { hits.hits.0._source.issue.labels.comment: [ [ "Doe","Shipped" ],[ "John","Approved" ] ] }
+  - match: { hits.hits.1._source.issue.labels.comment: [ [ "Mike","LGTM" ],[ "John","Approved" ] ] }
 
   # Terms Query with dot path.
   - do:
@@ -280,12 +330,13 @@ teardown:
         body: {
           _source: true,
           query: {
-            terms: { issue.labels.comment: ["John","Mike"] }
+            terms: { issue.labels.comment: [ "John","Mike" ] }
           }
         }
 
   - length: { hits.hits: 2 }
-  - match: { hits.hits.0._source.issue.labels.comment: [["Doe","Shipped"],["John","Approved"]] }
+  - match: { hits.hits.0._source.issue.labels.comment: [ [ "Doe","Shipped" ],[ "John","Approved" ] ] }
+  - match: { hits.hits.1._source.issue.labels.comment: [ [ "Mike","LGTM" ],[ "John","Approved" ] ] }
 
   # Prefix Query with dot path.
   - do:
@@ -302,7 +353,7 @@ teardown:
         }
 
   - length: { hits.hits: 1 }
-  - match: { hits.hits.0._source.issue.labels.comment:  [["Mike","LGTM"],["John","Approved"]] }
+  - match: { hits.hits.0._source.issue.labels.comment: [ [ "Mike","LGTM" ],[ "John","Approved" ] ] }
 
   # Prefix Query without dot path.
   - do:
@@ -319,7 +370,7 @@ teardown:
         }
 
   - length: { hits.hits: 1 }
-  - match: { hits.hits.0._source.issue.labels.comment:  [["Mike","LGTM"],["John","Approved"]] }
+  - match: { hits.hits.0._source.issue.labels.comment: [ [ "Mike","LGTM" ],[ "John","Approved" ] ] }
 
   # Range Query with dot path.
   - do:
@@ -338,6 +389,7 @@ teardown:
 
   - length: { hits.hits: 2 }
   - match: { hits.hits.0._source.issue.labels.version: "2.2" }
+  - match: { hits.hits.1._source.issue.labels.version: "2.1" }
 
   # Range Query without dot path.
   - do:
@@ -356,6 +408,7 @@ teardown:
 
   - length: { hits.hits: 2 }
   - match: { hits.hits.0._source.issue.labels.version: "2.2" }
+  - match: { hits.hits.1._source.issue.labels.version: "2.1" }
 
   # Range Query with integer input with dot path.
   - do:
@@ -391,7 +444,7 @@ teardown:
         }
 
   - length: { hits.hits: 1 }
-  - match: { hits.hits.0._source.issue.labels.views: 3333  }
+  - match: { hits.hits.0._source.issue.labels.views: 3333 }
 
 
   # Range Query with double input with dot path.
@@ -456,7 +509,7 @@ teardown:
           }
         }
 
-  - length: { hits.hits: 2 }
+  - length: { hits.hits: 3 }
 
   # Exists Query without dot path for the flat_object_field_name
   - do:
@@ -470,7 +523,21 @@ teardown:
           }
         }
 
-  - length: { hits.hits: 2 }
+  - length: { hits.hits: 3 }
+
+  # Exists Query2 with dot path for one hit
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            "exists": {
+              "field": issue.labels.author
+            }
+          }
+        }
+
+  - length: { hits.hits: 1 }
 
   # Query_string Query without dot path.
   - do:
@@ -479,15 +546,15 @@ teardown:
           _source: true,
           query: {
             "query_string": {
-              "fields": [ "issue.labels"],
+              "fields": [ "issue.labels" ],
               "query": "Doe OR Mike"
             }
           }
         }
 
   - length: { hits.hits: 2 }
-  - match: { hits.hits.0._source.issue.labels.comment: [["Doe","Shipped"],["John","Approved"]]}
-  - match: { hits.hits.1._source.issue.labels.comment: [["Mike","LGTM"],["John","Approved"]]}
+  - match: { hits.hits.0._source.issue.labels.comment: [ [ "Doe","Shipped" ],[ "John","Approved" ] ] }
+  - match: { hits.hits.1._source.issue.labels.comment: [ [ "Mike","LGTM" ],[ "John","Approved" ] ] }
 
   # Query_string Query with dot path.
   - do:
@@ -503,8 +570,8 @@ teardown:
         }
 
   - length: { hits.hits: 2 }
-  - match: { hits.hits.0._source.issue.labels.comment: [["Doe","Shipped"],["John","Approved"]]}
-  - match: { hits.hits.1._source.issue.labels.comment: [["Mike","LGTM"],["John","Approved"]]}
+  - match: { hits.hits.0._source.issue.labels.comment: [ [ "Doe","Shipped" ],[ "John","Approved" ] ] }
+  - match: { hits.hits.1._source.issue.labels.comment: [ [ "Mike","LGTM" ],[ "John","Approved" ] ] }
 
   # Simple_query_string Query without full dot path.
   - do:
@@ -520,7 +587,7 @@ teardown:
         }
 
   - length: { hits.hits: 1 }
-  - match: {  hits.hits.0._source.issue.labels.comment: [["Doe","Shipped"],["John","Approved"]] }
+  - match: { hits.hits.0._source.issue.labels.comment: [ [ "Doe","Shipped" ],[ "John","Approved" ] ] }
 
   # Simple_query_string Query with dot path.
   - do:
@@ -536,4 +603,4 @@ teardown:
         }
 
   - length: { hits.hits: 1 }
-  - match: {  hits.hits.0._source.issue.labels.comment: [["Doe","Shipped"],["John","Approved"]] }
+  - match: { hits.hits.0._source.issue.labels.comment: [ [ "Doe","Shipped" ],[ "John","Approved" ] ] }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/105_partial_flat_object_nested.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/105_partial_flat_object_nested.yml
@@ -1,0 +1,636 @@
+---
+# The test setup includes:
+# - Create flat_object mapping for test_partial_flat_object_nested index
+# - Index two example documents
+# - Refresh the index so it is ready for search tests
+
+setup:
+  - do:
+      indices.create:
+        index: test_partial_flat_object_nested
+        body:
+          mappings:
+            properties:
+              issue:
+                type: "nested"
+                properties:
+                  number:
+                    type: "integer"
+                  labels:
+                    type: "flat_object"
+  - do:
+      index:
+        index: test_partial_flat_object_nested
+        id: 1
+        body: {
+          "issue": [
+            {
+              "number": 123,
+              "labels": {
+                "version": "2.2",
+                "backport": [
+                  "2.0",
+                  "1.9"
+                ],
+                "category": {
+                  "type": "API",
+                  "level": "bug"
+                },
+                "createdDate": "2023-01-01",
+                "comment": [ [ "Doe","Shipped" ],[ "John","Approved" ] ],
+                "views": 288,
+                "priority": 5.00
+              }
+            }
+          ]
+        }
+
+  - do:
+      index:
+        index: test_partial_flat_object_nested
+        id: 2
+        body: {
+          "issue": [
+            {
+              "number": 456,
+              "labels": {
+                "author": "Liu",
+                "version": "2.1",
+                "backport": [
+                  "2.0",
+                  "1.3"
+                ],
+                "category": {
+                  "type": "API",
+                  "level": "enhancement"
+                },
+                "createdDate": "2023-02-01",
+                "comment": [ [ "Mike","LGTM" ],[ "John","Approved" ] ],
+                "views": 3333,
+                "priority": 1.50
+              }
+            }
+          ]
+        }
+
+  - do:
+      indices.refresh:
+        index: test_partial_flat_object_nested
+---
+# Delete Index when connection is teardown
+teardown:
+  - do:
+      indices.delete:
+        index: test_partial_flat_object_nested
+
+
+---
+# Verify that mappings under the catalog field did not expand
+# and no dynamic fields were created.
+"Mappings":
+  - skip:
+      version: " - 2.99.99"
+      reason: "flat_object is introduced in 3.0.0 in main branch"
+
+  - do:
+      indices.get_mapping:
+        index: test_partial_flat_object_nested
+  - is_true: test_partial_flat_object_nested.mappings
+  - match: { test_partial_flat_object_nested.mappings.properties.issue.properties.number.type: integer }
+  - match: { test_partial_flat_object_nested.mappings.properties.issue.properties.labels.type: flat_object }
+  # https://github.com/opensearch-project/OpenSearch/tree/main/rest-api-spec/src/main/resources/rest-api-spec/test#length
+  - length: { test_partial_flat_object_nested.mappings.properties.issue.properties: 2 }
+  - length: { test_partial_flat_object_nested.mappings.properties.issue.properties.labels: 1 }
+
+
+---
+"Supported queries":
+  - skip:
+      version: " - 2.99.99"
+      reason: "flat_object is introduced in 3.0.0 in main branch"
+
+
+  # Verify Document Count
+  - do:
+      search:
+        body: {
+          query: {
+            match_all: { }
+          }
+        }
+
+  - length: { hits.hits: 2 }
+
+  # Match Query with exact dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            nested: {
+              path: "issue",
+              query: {
+                match: { "issue.labels.version": "2.1" }
+              }
+            }
+          }
+        }
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._source.issue.0.labels.version: "2.1" }
+
+  # Match Query without exact dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            nested: {
+              path: "issue",
+              query: {
+                match: { "issue.labels": "2.1" }
+              }
+            }
+          }
+        }
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._source.issue.0.labels.version: "2.1" }
+
+  # Term Query1 with exact dot path for date
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            nested: {
+              path: "issue",
+              query: {
+                term: { issue.labels.createdDate: "2023-01-01" }
+              }
+            } } }
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._source.issue.0.labels.createdDate: "2023-01-01" }
+
+  # Term Query1 without exact dot path for date
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            nested: {
+              path: "issue",
+              query: {
+                term: { issue.labels: "2023-01-01" }
+              } } }
+        }
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._source.issue.0.labels.createdDate: "2023-01-01" }
+
+  # Term Query2 with dot path for string
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            nested: {
+              path: "issue",
+              query: {
+                term: { "issue.labels.category.type": "API" }
+              } } }
+        }
+
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._source.issue.0.labels.category.type: "API" }
+  - match: { hits.hits.1._source.issue.0.labels.category.type: "API" }
+
+  # Term Query2 without exact dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            nested: {
+              path: "issue",
+              query: {
+                term: { issue.labels: "API" }
+              } } }
+        }
+
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._source.issue.0.labels.category.type: "API" }
+  - match: { hits.hits.1._source.issue.0.labels.category.type: "API" }
+
+  # Term Query3 with dot path for array
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            nested: {
+              path: "issue",
+              query: {
+                term: { issue.labels.backport: "1.9" }
+              } } }
+        }
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._source.issue.0.labels.backport: [ "2.0", "1.9" ] }
+
+  # Term Query3 without dot path for array
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            nested: {
+              path: "issue",
+              query: {
+                term: { issue.labels: "1.9" }
+              } } }
+        }
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._source.issue.0.labels.backport: [ "2.0", "1.9" ] }
+
+  # Term Query4 with  dot path for nested-array
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            nested: {
+              path: "issue",
+              query: {
+                term: { issue.labels.comment: "LGTM" }
+              } } }
+        }
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._source.issue.0.labels.comment: [ [ "Mike","LGTM" ],[ "John","Approved" ] ] }
+
+  # Term Query4 without dot path for nested-array
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            nested: {
+              path: "issue",
+              query: {
+                term: { issue.labels: "LGTM" } } }
+          }
+        }
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._source.issue.0.labels.comment: [ [ "Mike","LGTM" ],[ "John","Approved" ] ] }
+
+  # Terms Query without dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            nested: {
+              path: "issue",
+              query: {
+                terms: { issue.labels: [ "John","Mike" ] } } }
+          }
+        }
+
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._source.issue.0.labels.comment: [ [ "Doe","Shipped" ],[ "John","Approved" ] ] }
+  - match: { hits.hits.1._source.issue.0.labels.comment: [ [ "Mike","LGTM" ],[ "John","Approved" ] ] }
+
+  # Terms Query with dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            nested: {
+              path: "issue",
+              query: {
+                terms: { issue.labels.comment: [ "John","Mike" ] } } }
+          }
+        }
+
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._source.issue.0.labels.comment: [ [ "Doe","Shipped" ],[ "John","Approved" ] ] }
+  - match: { hits.hits.1._source.issue.0.labels.comment: [ [ "Mike","LGTM" ],[ "John","Approved" ] ] }
+
+  # Prefix Query with dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            nested: {
+              path: "issue",
+              query: {
+                "prefix": {
+                  "issue.labels.comment": {
+                    "value": "Mi"
+                  } } }
+            }
+          }
+        }
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._source.issue.0.labels.comment: [ [ "Mike","LGTM" ],[ "John","Approved" ] ] }
+
+  # Prefix Query without dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            nested: {
+              path: "issue",
+              query: {
+                "prefix": {
+                  "issue.labels": {
+                    "value": "Mi"
+                  }
+                }
+              } } }
+        }
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._source.issue.0.labels.comment: [ [ "Mike","LGTM" ],[ "John","Approved" ] ] }
+
+  # Range Query with dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            nested: {
+              path: "issue",
+              query: {
+                "range": {
+                  "issue.labels.version": {
+                    "gte": "2.1",
+                    "lte": "3.0"
+                  } } }
+            }
+          }
+        }
+
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._source.issue.0.labels.version: "2.2" }
+  - match: { hits.hits.1._source.issue.0.labels.version: "2.1" }
+
+  # Range Query without dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            nested: {
+              path: "issue",
+              query: {
+                "range": {
+                  "issue.labels": {
+                    "gte": "2.1",
+                    "lte": "3.0"
+                  } } }
+            }
+          }
+        }
+
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._source.issue.0.labels.version: "2.2" }
+  - match: { hits.hits.1._source.issue.0.labels.version: "2.1" }
+
+  # Range Query with integer input with dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            nested: {
+              path: "issue",
+              query: {
+                "range": {
+                  "issue.labels.views": {
+                    "gte": 3000,
+                    "lte": 4000
+                  } } }
+            }
+          }
+        }
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._source.issue.0.labels.views: 3333 }
+
+  # Range Query with integer input without dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            nested: {
+              path: "issue",
+              query: {
+                "range": {
+                  "issue.labels": {
+                    "gte": 3000,
+                    "lte": 4000
+                  } } }
+            }
+          }
+        }
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._source.issue.0.labels.views: 3333 }
+
+
+  # Range Query with double input with dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            nested: {
+              path: "issue",
+              query: {
+                "range": {
+                  "issue.labels.priority": {
+                    "gte": 4.1234,
+                    "lte": 5.1234
+                  } } }
+            }
+          }
+        }
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._source.issue.0.labels.priority: 5.00 }
+
+  # Range Query with double input without dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            nested: {
+              path: "issue",
+              query: {
+                "range": {
+                  "issue.labels": {
+                    "gte": 4.1234,
+                    "lte": 5.1234
+                  } } }
+            }
+          }
+        }
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._source.issue.0.labels.priority: 5.00 }
+
+
+  # Exists Query with dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            nested: {
+              path: "issue",
+              query: {
+                "exists": {
+                  "field": issue.labels.priority
+                } } }
+          }
+        }
+
+  - length: { hits.hits: 2 }
+
+  # Exists Query with nested dot path, use the flat_object_field_name.last_key
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            nested: {
+              path: "issue",
+              query: {
+                "exists": {
+                  "field": issue.labels.type
+                } } }
+          }
+        }
+
+  - length: { hits.hits: 2 }
+
+  # Exists Query without dot path for the flat_object_field_name
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            nested: {
+              path: "issue",
+              query: {
+                "exists": {
+                  "field": issue.labels
+                } } }
+          }
+        }
+
+  - length: { hits.hits: 2 }
+
+  # Exists Query2 with dot path for one hit
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            nested: {
+              path: "issue",
+              query: {
+                "exists": {
+                  "field": issue.labels.author
+                } } }
+          }
+        }
+
+  - length: { hits.hits: 1 }
+
+  # Query_string Query without dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            nested: {
+              path: "issue",
+              query: {
+                "query_string": {
+                  "fields": [ "issue.labels" ],
+                  "query": "Doe OR Mike"
+                } } }
+          }
+        }
+
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._source.issue.0.labels.comment: [ [ "Doe","Shipped" ],[ "John","Approved" ] ] }
+  - match: { hits.hits.1._source.issue.0.labels.comment: [ [ "Mike","LGTM" ],[ "John","Approved" ] ] }
+
+  # Query_string Query with dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            nested: {
+              path: "issue",
+              query: {
+                "query_string": {
+                  "fields": [ "issue.labels.comment" ],
+                  "query": "Doe OR Mike"
+                } } }
+          }
+        }
+
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._source.issue.0.labels.comment: [ [ "Doe","Shipped" ],[ "John","Approved" ] ] }
+  - match: { hits.hits.1._source.issue.0.labels.comment: [ [ "Mike","LGTM" ],[ "John","Approved" ] ] }
+
+  # Simple_query_string Query without full dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            nested: {
+              path: "issue",
+              query: {
+                "simple_query_string": {
+                  "query": "Doe",
+                  "fields": [ "issue.labels" ]
+                } } }
+          }
+        }
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._source.issue.0.labels.comment: [ [ "Doe","Shipped" ],[ "John","Approved" ] ] }
+
+  # Simple_query_string Query with dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            nested: {
+              path: "issue",
+              query: {
+                "simple_query_string": {
+                  "query": "Doe",
+                  "fields": [ "issue.labels.comment" ]
+                } } }
+          }
+        }
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._source.issue.0.labels.comment: [ [ "Doe","Shipped" ],[ "John","Approved" ] ] }

--- a/server/src/main/java/org/opensearch/index/mapper/FlatObjectFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FlatObjectFieldMapper.java
@@ -85,7 +85,7 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
 
     @Override
     public MappedFieldType keyedFieldType(String key) {
-        return new FlatObjectFieldType(this.name() + DOT_SYMBOL + key);
+        return new FlatObjectFieldType(this.name() + DOT_SYMBOL + key, this.name());
     }
 
     /**
@@ -186,6 +186,8 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
         private final int ignoreAbove;
         private final String nullValue;
 
+        private final String mappedFieldTypeName;
+
         private KeywordFieldMapper.KeywordFieldType valueFieldType;
 
         private KeywordFieldMapper.KeywordFieldType valueAndPathFieldType;
@@ -195,10 +197,7 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
             setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
             this.ignoreAbove = Integer.MAX_VALUE;
             this.nullValue = null;
-        }
-
-        public FlatObjectFieldType(String name) {
-            this(name, true, true, Collections.emptyMap());
+            this.mappedFieldTypeName = null;
         }
 
         public FlatObjectFieldType(String name, FieldType fieldType) {
@@ -212,12 +211,28 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
             );
             this.ignoreAbove = Integer.MAX_VALUE;
             this.nullValue = null;
+            this.mappedFieldTypeName = null;
         }
 
         public FlatObjectFieldType(String name, NamedAnalyzer analyzer) {
             super(name, true, false, true, new TextSearchInfo(Defaults.FIELD_TYPE, null, analyzer, analyzer), Collections.emptyMap());
             this.ignoreAbove = Integer.MAX_VALUE;
             this.nullValue = null;
+            this.mappedFieldTypeName = null;
+        }
+
+        public FlatObjectFieldType(String name, String mappedFieldTypeName) {
+            super(
+                name,
+                true,
+                false,
+                true,
+                new TextSearchInfo(Defaults.FIELD_TYPE, null, Lucene.KEYWORD_ANALYZER, Lucene.KEYWORD_ANALYZER),
+                Collections.emptyMap()
+            );
+            this.ignoreAbove = Integer.MAX_VALUE;
+            this.nullValue = null;
+            this.mappedFieldTypeName = mappedFieldTypeName;
         }
 
         void setValueFieldType(KeywordFieldMapper.KeywordFieldType valueFieldType) {
@@ -356,11 +371,10 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
          * @return directedSubFieldName
          */
         public String directSubfield() {
-            if (name().contains(DOT_SYMBOL)) {
-                String[] dotPathList = name().split("\\.");
-                return dotPathList[0] + VALUE_AND_PATH_SUFFIX;
+            if (mappedFieldTypeName == null) {
+                return new StringBuilder().append(this.name()).append(VALUE_SUFFIX).toString();
             } else {
-                return this.valueFieldType.name();
+                return new StringBuilder().append(this.mappedFieldTypeName).append(VALUE_AND_PATH_SUFFIX).toString();
             }
         }
 
@@ -371,13 +385,30 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
          * @return rewriteSearchValue
          */
         public String rewriteValue(String searchValueString) {
-            if (!name().contains(DOT_SYMBOL)) {
+            if (!hasDotPath(name())) {
                 return searchValueString;
             } else {
                 String rewriteSearchValue = new StringBuilder().append(name()).append(EQUAL_SYMBOL).append(searchValueString).toString();
                 return rewriteSearchValue;
             }
 
+        }
+
+        private boolean hasDotPath(String input) {
+            String prefix = this.mappedFieldTypeName;
+            if (prefix == null) {
+                return false;
+            }
+            if (!input.startsWith(prefix)) {
+                return false;
+            }
+            String rest = input.substring(prefix.length());
+
+            if (rest.isEmpty()) {
+                return false;
+            } else {
+                return true;
+            }
         }
 
         private String inputToString(Object inputValue) {
@@ -460,15 +491,15 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
         }
 
         /**
-         * if there is dot path. query the field name in flatObject parent field.
+         * if there is dot path. query the field name in flatObject parent field (mappedFieldTypeName).
          * else query in _field_names system field
          */
         @Override
         public Query existsQuery(QueryShardContext context) {
             String searchKey;
             String searchField;
-            if (name().contains(DOT_SYMBOL)) {
-                searchKey = name().split("\\.")[0];
+            if (hasDotPath(name())) {
+                searchKey = this.mappedFieldTypeName;
                 searchField = name();
             } else {
                 searchKey = FieldNamesFieldMapper.NAME;

--- a/server/src/main/java/org/opensearch/index/mapper/FlatObjectFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FlatObjectFieldMapper.java
@@ -385,7 +385,7 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
          * @return rewriteSearchValue
          */
         public String rewriteValue(String searchValueString) {
-            if (!hasDotPath(name())) {
+            if (!hasMappedFieldTyeNameInQueryFieldName(name())) {
                 return searchValueString;
             } else {
                 String rewriteSearchValue = new StringBuilder().append(name()).append(EQUAL_SYMBOL).append(searchValueString).toString();
@@ -394,7 +394,7 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
 
         }
 
-        private boolean hasDotPath(String input) {
+        private boolean hasMappedFieldTyeNameInQueryFieldName(String input) {
             String prefix = this.mappedFieldTypeName;
             if (prefix == null) {
                 return false;
@@ -498,7 +498,7 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
         public Query existsQuery(QueryShardContext context) {
             String searchKey;
             String searchField;
-            if (hasDotPath(name())) {
+            if (hasMappedFieldTyeNameInQueryFieldName(name())) {
                 searchKey = this.mappedFieldTypeName;
                 searchField = name();
             } else {

--- a/server/src/main/java/org/opensearch/index/mapper/FlatObjectFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FlatObjectFieldMapper.java
@@ -379,9 +379,9 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
         }
 
         /**
-         * If the search key is assigned with value,
-         * the dot path was used in search query, then
-         * rewrite the searchValueString as the format "dotpath=value",
+         * If the search key has mappedFieldTypeName as prefix,
+         * then the dot path was used in search query,
+         * then rewrite the searchValueString as the format "dotpath=value",
          * @return rewriteSearchValue
          */
         public String rewriteValue(String searchValueString) {

--- a/server/src/test/java/org/opensearch/index/mapper/FlatObjectFieldTypeTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/FlatObjectFieldTypeTests.java
@@ -120,7 +120,6 @@ public class FlatObjectFieldTypeTests extends FieldTypeTestCase {
             MappedFieldType dynamicMappedFieldType = new FlatObjectFieldMapper.FlatObjectFieldType("field.bar", ft.name());
             assertEquals(new TermQuery(new Term("field", "field.bar")), dynamicMappedFieldType.existsQuery(null));
 
-
         }
         {
             FlatObjectFieldMapper.FlatObjectFieldType ft = new FlatObjectFieldMapper.FlatObjectFieldType(

--- a/server/src/test/java/org/opensearch/index/mapper/FlatObjectFieldTypeTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/FlatObjectFieldTypeTests.java
@@ -1,0 +1,97 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.mapper;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.TermQuery;
+import org.opensearch.Version;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class FlatObjectFieldTypeTests extends FieldTypeTestCase {
+
+    public void testFetchSourceValue() throws IOException {
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
+
+        MappedFieldType mapper = new FlatObjectFieldMapper.Builder("field").build(context).fieldType();
+
+        Map<String, Object> jsonPoint = new HashMap<>();
+        jsonPoint.put("type", "flat_object");
+        jsonPoint.put("coordinates", Arrays.asList(42.0, 27.1));
+        Map<String, Object> otherJsonPoint = new HashMap<>();
+        otherJsonPoint.put("type", "Point");
+        otherJsonPoint.put("coordinates", Arrays.asList(30.0, 50.0));
+
+        ArrayList<String> jsonPointList = new ArrayList<>();
+        jsonPointList.add(jsonPoint.toString());
+
+        ArrayList<String> otherJsonPointList = new ArrayList<>();
+        otherJsonPointList.add(otherJsonPoint.toString());
+
+        assertEquals(jsonPointList, fetchSourceValue(mapper, jsonPoint, null));
+        assertEquals(otherJsonPointList, fetchSourceValue(mapper, otherJsonPoint, null));
+
+    }
+
+    public void testTermQuery() {
+
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
+        MappedFieldType flatParentFieldType = new FlatObjectFieldMapper.Builder("field").build(context).fieldType();
+
+        // when searching for "foo", the term query is directed to search in field._value field
+        String searchFieldName = ((FlatObjectFieldMapper.FlatObjectFieldType) flatParentFieldType).directSubfield();
+        String searchValues = ((FlatObjectFieldMapper.FlatObjectFieldType) flatParentFieldType).rewriteValue("foo");
+        assertEquals("field._value", searchFieldName);
+        assertEquals("foo", searchValues);
+        assertEquals(new TermQuery(new Term(searchFieldName, searchValues)), flatParentFieldType.termQuery(searchValues, null));
+
+        MappedFieldType dynamicMappedFieldType = new FlatObjectFieldMapper.FlatObjectFieldType("bar", flatParentFieldType.name());
+
+        // when searching for "field.bar", the term query is directed to search in field._valueAndPath field
+        String searchFieldNameDocPath = ((FlatObjectFieldMapper.FlatObjectFieldType) dynamicMappedFieldType).directSubfield();
+        String searchValuesDocPath = ((FlatObjectFieldMapper.FlatObjectFieldType) dynamicMappedFieldType).rewriteValue("field.bar");
+        assertEquals("field._valueAndPath", searchFieldNameDocPath);
+        assertEquals("field.bar", searchValuesDocPath);
+        assertEquals(
+            new TermQuery(new Term(searchFieldNameDocPath, searchValuesDocPath)),
+            dynamicMappedFieldType.termQuery(searchValuesDocPath, null)
+        );
+
+        MappedFieldType unsearchable = new FlatObjectFieldMapper.FlatObjectFieldType("field", false, true, Collections.emptyMap());
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> unsearchable.termQuery("bar", null));
+        assertEquals("Cannot search on field [field] since it is not indexed.", e.getMessage());
+    }
+
+    public void testExistsQuery() {
+        {
+            Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+            Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
+            MappedFieldType ft = new FlatObjectFieldMapper.Builder("field").build(context).fieldType();
+            assertEquals(new TermQuery(new Term(null, "field")), ft.existsQuery(null));
+        }
+        {
+            FlatObjectFieldMapper.FlatObjectFieldType ft = new FlatObjectFieldMapper.FlatObjectFieldType(
+                "field",
+                true,
+                false,
+                Collections.emptyMap()
+            );
+            assertEquals(new TermQuery(new Term(FieldNamesFieldMapper.NAME, "field")), ft.existsQuery(null));
+        }
+    }
+}


### PR DESCRIPTION

### Description
Before this PR, flat_object can only be defined at the root field of JSON object in 2.7 and 2.8, because the json object is flatten so it lost the structure of a tree. Now,  this PR enables json object to be partially mapped as flat_object field type while other fields in the JSON can be other field type. 

The main idea is to remember the flat object field name as `mappedFieldTypeName` in the dynamic created field (only in query time and it will vanish after returning result), which helps the logic to identify the starting point of a flat object, to decide if a query contains a dot path after flat object field name. 

In the example given in the issue, 

`issue.label` is defined as a flat_object, so `issue.labels` is the flat object field name, and`issue.label.comment` contains a dot path after the flat_object field name . 

### Related Issues
 #7136 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
