### PR TITLE
Add a gradle task to check compability with child components

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ import org.gradle.plugins.ide.eclipse.model.EclipseJdt
 import org.gradle.plugins.ide.eclipse.model.SourceFolder
 import org.gradle.api.Project;
 import org.gradle.process.ExecResult;
+import org.opensearch.gradle.CheckCompatibilityTask
 
 import static org.opensearch.gradle.util.GradleUtils.maybeConfigure
 
@@ -642,4 +643,16 @@ tasks.withType(TestTaskReports).configureEach {
 
 tasks.named(JavaBasePlugin.CHECK_TASK_NAME) {
   dependsOn tasks.named('testAggregateTestReport', TestReport)
+}
+
+tasks.register('checkCompatibility', CheckCompatibilityTask) {
+  description('Checks the compatibility with child components')
+}
+
+allprojects { project ->
+  project.afterEvaluate {
+    if (project.tasks.findByName('publishToMavenLocal')) {
+      checkCompatibility.dependsOn(project.tasks.publishToMavenLocal)
+    }
+  }
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -124,7 +124,6 @@ dependencies {
   api "com.fasterxml.jackson.core:jackson-databind:${props.getProperty('jackson_databind')}"
   api "org.ajoberstar.grgit:grgit-core:5.2.0"
 
-
   testFixturesApi "junit:junit:${props.getProperty('junit')}"
   testFixturesApi "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${props.getProperty('randomizedrunner')}"
   testFixturesApi gradleApi()

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -122,6 +122,8 @@ dependencies {
   api 'org.jruby.jcodings:jcodings:1.0.58'
   api 'org.jruby.joni:joni:2.1.48'
   api "com.fasterxml.jackson.core:jackson-databind:${props.getProperty('jackson_databind')}"
+  api "org.ajoberstar.grgit:grgit-core:5.2.0"
+
 
   testFixturesApi "junit:junit:${props.getProperty('junit')}"
   testFixturesApi "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${props.getProperty('randomizedrunner')}"

--- a/buildSrc/src/main/groovy/org/opensearch/gradle/CheckCompatibilityTask.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/gradle/CheckCompatibilityTask.groovy
@@ -1,0 +1,108 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.gradle
+
+import groovy.json.JsonSlurper
+import org.ajoberstar.grgit.Grgit
+import org.ajoberstar.grgit.operation.BranchListOp
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.internal.os.OperatingSystem
+
+import java.nio.file.Paths
+
+class CheckCompatibilityTask extends DefaultTask {
+
+    static final String REPO_URL = 'https://raw.githubusercontent.com/opensearch-project/opensearch-plugins/main/plugins/.meta'
+
+    @Input
+    List repositoryUrls = project.hasProperty('repositoryUrls') ? project.property('repositoryUrls').split(',') : getRepoUrls()
+
+    @Input
+    String ref = project.hasProperty('ref') ? project.property('ref') : 'main'
+
+    @Internal
+    List failedComponents = []
+
+    @Internal
+    List gitFailedComponents = []
+
+    @Internal
+    List compatibleComponents = []
+
+    @TaskAction
+    void checkCompatibility() {
+        logger.info("Checking compatibility for: $repositoryUrls for $ref")
+        repositoryUrls.parallelStream().forEach { repositoryUrl ->
+            def tempDir = File.createTempDir()
+            try {
+                if (cloneAndCheckout(repositoryUrl, tempDir)) {
+                    if (repositoryUrl.toString().endsWithAny('notifications', 'notifications.git')) {
+                        tempDir = Paths.get(tempDir.getAbsolutePath(), 'notifications')
+                    }
+                    project.exec {
+                        workingDir = tempDir
+                        def stdout = new ByteArrayOutputStream()
+                        executable = (OperatingSystem.current().isWindows()) ? 'gradlew.bat' : './gradlew'
+                        args 'assemble'
+                        standardOutput stdout
+                    }
+                    compatibleComponents.add(repositoryUrl)
+                } else {
+                    logger.lifecycle("Skipping compatibility check for $repositoryUrl")
+                }
+            } catch (ex) {
+                failedComponents.add(repositoryUrl)
+                logger.info("Gradle assemble failed for $repositoryUrl", ex)
+            } finally {
+                tempDir.deleteDir()
+            }
+        }
+        if (!failedComponents.isEmpty()) {
+            logger.lifecycle("Incompatible components: $failedComponents")
+            logger.info("Compatible components: $compatibleComponents")
+        }
+        if (!gitFailedComponents.isEmpty()) {
+            logger.lifecycle("Components skipped due to git failures: $gitFailedComponents")
+            logger.info("Compatible components: $compatibleComponents")
+        }
+        if (!compatibleComponents.isEmpty()) {
+            logger.lifecycle("Compatible components: $compatibleComponents")
+        }
+    }
+
+    protected static List getRepoUrls() {
+        def json = new JsonSlurper().parse(REPO_URL.toURL())
+        def labels = json.projects.values()
+        return labels as List
+    }
+
+    protected boolean cloneAndCheckout(repoUrl, directory) {
+        try {
+            def grgit = Grgit.clone(dir: directory, uri: repoUrl)
+            def remoteBranches = grgit.branch.list(mode: BranchListOp.Mode.REMOTE)
+            String targetBranch = 'origin/' + ref
+            if (remoteBranches.find { it.name == targetBranch } == null) {
+                gitFailedComponents.add(repoUrl)
+                logger.info("$ref does not exist for $repoUrl. Skipping the compatibility check!!")
+                return false
+            } else {
+                logger.info("Checking out $targetBranch")
+                grgit.checkout(branch: targetBranch)
+                return true
+            }
+        } catch (ex) {
+            logger.error('Exception occurred during GitHub operations', ex)
+            gitFailedComponents.add(repoUrl)
+            return false
+        }
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This change adds a gradle task to check the compatibility with any child projects/components. The task is dependent on `publishToMavenLocal` as it publishes the core engine to maven local and then clones the remote project in temporary directory and runs `./gradlew assemble`.
The task takes 2 inputs:
1. repositoryUrls: a comma separated git url of the components. Defaults to https://raw.githubusercontent.com/opensearch-project/opensearch-plugins/main/plugins/.meta
2. ref: branch or reference to checkout. Defaults to `main`

Run with specific components:
```
./gradlew checkCompatibility
> Task :checkCompatibility
Incompatible components: [git@github.com:opensearch-project/k-nn.git, git@github.com:opensearch-project/asynchronous-search.git, git@github.com:opensearch-project/anomaly-detection.git, git@github.com:opensearch-project/observability.git, git@github.com:opensearch-project/performance-analyzer-rca.git, git@github.com:opensearch-project/performance-analyzer.git, git@github.com:opensearch-project/reporting.git, git@github.com:opensearch-project/geospatial.git, git@github.com:opensearch-project/sql.git, git@github.com:opensearch-project/cross-cluster-replication.git, git@github.com:opensearch-project/opensearch-oci-object-storage.git, git@github.com:opensearch-project/neural-search.git]
Compatible components: [git@github.com:opensearch-project/job-scheduler.git, git@github.com:opensearch-project/common-utils.git, git@github.com:opensearch-project/notifications.git, git@github.com:opensearch-project/security.git, git@github.com:opensearch-project/alerting.git, git@github.com:opensearch-project/security-analytics.git, git@github.com:opensearch-project/index-management.git, git@github.com:opensearch-project/ml-commons.git]

BUILD SUCCESSFUL in 11m 49s
983 actionable tasks: 821 executed, 90 from cache, 72 up-to-date
```

Run with all components:

```
./gradlew checkCompatibility -PrepositoryUrls=https://github.com/opensearch-project/job-scheduler.git,https://github.com/opensearch-project/common-utils.git,https://github.com/opensearch-project/asynchronous-search.git
> Task :checkCompatibility
Incompatible components: [https://github.com/opensearch-project/asynchronous-search.git]
Compatible components: [https://github.com/opensearch-project/common-utils.git, https://github.com/opensearch-project/job-scheduler.git]

BUILD SUCCESSFUL in 1m 57s
837 actionable tasks: 259 executed, 578 up-to-date

BUILD SUCCESSFUL in 2m 23s
837 actionable tasks: 259 executed, 578 up-to-date
```
Run with specific branch
```
./gradlew checkCompatibility -PrepositoryUrls=https://github.com/opensearch-project/common-utils -Pref=lol

> Task :checkCompatibility
Skipping compatibility check for https://github.com/opensearch-project/common-utils
Components skipped due to git failures: [https://github.com/opensearch-project/common-utils]

BUILD SUCCESSFUL in 14s
837 actionable tasks: 255 executed, 582 up-to-date
```
### Related Issues
https://github.com/opensearch-project/opensearch-devops/issues/114#issuecomment-1548868449
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
