### PR TITLE
SegRep with Remote: Update components of segrep backpressure to suppo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add TokenManager Interface ([#7452](https://github.com/opensearch-project/OpenSearch/pull/7452))
 - Add Remote store as a segment replication source ([#7653](https://github.com/opensearch-project/OpenSearch/pull/7653))
 - Add descending order search optimization through reverse segment read. ([#7967](https://github.com/opensearch-project/OpenSearch/pull/7967))
-
+- Update components of segrep backpressure to support remote store. ([#8020](https://github.com/opensearch-project/OpenSearch/pull/8020))
 
 ### Dependencies
 - Bump `jackson` from 2.15.1 to 2.15.2 ([#7897](https://github.com/opensearch-project/OpenSearch/pull/7897))

--- a/server/src/internalClusterTest/java/org/opensearch/index/SegmentReplicationPressureIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/SegmentReplicationPressureIT.java
@@ -30,7 +30,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -324,15 +323,6 @@ public class SegmentReplicationPressureIT extends SegmentReplicationBaseIT {
         executeBulkRequest(nodes, totalDocs);
         waitForSearchableDocs(totalDocs * 2L, replicaNodes.toArray(new String[] {}));
         verifyStoreContent();
-    }
-
-    private void assertReplicaCheckpointUpdated(IndexShard primaryShard) throws Exception {
-        assertBusy(() -> {
-            Set<SegmentReplicationShardStats> groupStats = primaryShard.getReplicationStats();
-            for (SegmentReplicationShardStats shardStat : groupStats) {
-                assertEquals(0, shardStat.getCheckpointsBehindCount());
-            }
-        }, 30, TimeUnit.SECONDS);
     }
 
     private BulkResponse executeBulkRequest(List<String> nodes, int docsPerBatch) {

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationBaseIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationBaseIT.java
@@ -23,6 +23,7 @@ import org.opensearch.index.Index;
 import org.opensearch.index.IndexModule;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.SegmentReplicationPerGroupStats;
+import org.opensearch.index.SegmentReplicationShardStats;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.store.Store;
 import org.opensearch.index.store.StoreFileMetadata;
@@ -38,6 +39,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -222,4 +224,13 @@ public class SegmentReplicationBaseIT extends OpenSearchIntegTestCase {
         };
     }
 
+    protected void assertReplicaCheckpointUpdated(IndexShard primaryShard) throws Exception {
+        assertBusy(() -> {
+            Set<SegmentReplicationShardStats> groupStats = primaryShard.getReplicationStats();
+            assertEquals(primaryShard.indexSettings().getNumberOfReplicas(), groupStats.size());
+            for (SegmentReplicationShardStats shardStat : groupStats) {
+                assertEquals(0, shardStat.getCheckpointsBehindCount());
+            }
+        }, 30, TimeUnit.SECONDS);
+    }
 }

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationBaseIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationBaseIT.java
@@ -204,7 +204,7 @@ public class SegmentReplicationBaseIT extends OpenSearchIntegTestCase {
                 node
             ));
             mockTargetTransportService.addSendBehavior((connection, requestId, action, request, options) -> {
-                if (action.equals(SegmentReplicationSourceService.Actions.GET_SEGMENT_FILES)) {
+                if (action.equals(SegmentReplicationSourceService.Actions.UPDATE_VISIBLE_CHECKPOINT)) {
                     try {
                         latch.countDown();
                         pauseReplicationLatch.await();

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -78,7 +78,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
@@ -877,7 +876,7 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
                 assertEquals(1, shardStatsSet.size());
                 final SegmentReplicationShardStats stats = shardStatsSet.stream().findFirst().get();
                 assertEquals(0, stats.getCheckpointsBehindCount());
-            }, 30, TimeUnit.SECONDS);
+            });
         }
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -78,6 +78,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
@@ -796,10 +797,6 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
     }
 
     public void testPressureServiceStats() throws Exception {
-        assumeFalse(
-            "Skipping the test as pressure service is not compatible with SegRep and Remote store yet.",
-            segmentReplicationWithRemoteEnabled()
-        );
         final String primaryNode = internalCluster().startNode();
         createIndex(INDEX_NAME);
         final String replicaNode = internalCluster().startNode();
@@ -880,7 +877,7 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
                 assertEquals(1, shardStatsSet.size());
                 final SegmentReplicationShardStats stats = shardStatsSet.stream().findFirst().get();
                 assertEquals(0, stats.getCheckpointsBehindCount());
-            });
+            }, 30, TimeUnit.SECONDS);
         }
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/SegmentReplicationWithRemoteStorePressureIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/SegmentReplicationWithRemoteStorePressureIT.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.remotestore;
+
+import org.junit.After;
+import org.junit.Before;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.index.SegmentReplicationPressureIT;
+import org.opensearch.indices.replication.common.ReplicationType;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.nio.file.Path;
+
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+
+/**
+ * This class executes the SegmentReplicationPressureIT suite with remote store integration enabled.
+ * Setup is similar to SegmentReplicationPressureIT but this also enables the segment replication using remote store which
+ * is behind SEGMENT_REPLICATION_EXPERIMENTAL flag.
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class SegmentReplicationWithRemoteStorePressureIT extends SegmentReplicationPressureIT {
+
+    private static final String REPOSITORY_NAME = "test-remote-store-repo";
+
+    @Override
+    public Settings indexSettings() {
+        return Settings.builder()
+            .put(super.indexSettings())
+            .put(IndexMetadata.SETTING_REMOTE_STORE_ENABLED, true)
+            .put(IndexMetadata.SETTING_REMOTE_STORE_REPOSITORY, REPOSITORY_NAME)
+            .put(IndexMetadata.SETTING_REMOTE_TRANSLOG_STORE_ENABLED, false)
+            .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+            .build();
+    }
+
+    @Override
+    protected Settings featureFlagSettings() {
+        return Settings.builder()
+            .put(super.featureFlagSettings())
+            .put(FeatureFlags.REMOTE_STORE, "true")
+            .put(FeatureFlags.SEGMENT_REPLICATION_EXPERIMENTAL, "true")
+            .build();
+    }
+
+    @Before
+    public void setup() {
+        internalCluster().startClusterManagerOnlyNode();
+        Path absolutePath = randomRepoPath().toAbsolutePath();
+        assertAcked(
+            clusterAdmin().preparePutRepository(REPOSITORY_NAME).setType("fs").setSettings(Settings.builder().put("location", absolutePath))
+        );
+    }
+
+    @After
+    public void teardown() {
+        assertAcked(clusterAdmin().prepareDeleteRepository(REPOSITORY_NAME));
+    }
+}

--- a/server/src/main/java/org/opensearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/opensearch/index/seqno/ReplicationTracker.java
@@ -1185,7 +1185,7 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
             // Compute the max lag from the set of completed timers.
             final AtomicLong lastFinished = new AtomicLong(0L);
             cps.checkpointTimers.entrySet().removeIf((entry) -> {
-                boolean result = !entry.getKey().isAheadOf(visibleCheckpoint);
+                boolean result = entry.getKey().isAheadOf(visibleCheckpoint) == false;
                 if (result) {
                     final ReplicationTimer timer = entry.getValue();
                     timer.stop();

--- a/server/src/main/java/org/opensearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/opensearch/index/seqno/ReplicationTracker.java
@@ -1174,13 +1174,18 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
         assert handoffInProgress == false;
         assert invariant();
         final CheckpointState cps = checkpoints.get(allocationId);
-        assert !this.shardAllocationId.equals(allocationId) && cps != null;
+        assert !this.shardAllocationId.equals(allocationId);
+        // Ignore if the cps is null (i.e. replica shard not in active state).
+        if (cps == null) {
+            logger.warn("Ignoring the checkpoint update for allocation ID {} as its not being tracked by primary", allocationId);
+            return;
+        }
         if (cps.checkpointTimers.isEmpty() == false) {
             // stop any timers for checkpoints up to the received cp and remove from cps.checkpointTimers.
             // Compute the max lag from the set of completed timers.
             final AtomicLong lastFinished = new AtomicLong(0L);
             cps.checkpointTimers.entrySet().removeIf((entry) -> {
-                boolean result = visibleCheckpoint.equals(entry.getKey()) || visibleCheckpoint.isAheadOf(entry.getKey());
+                boolean result = !entry.getKey().isAheadOf(visibleCheckpoint);
                 if (result) {
                     final ReplicationTimer timer = entry.getValue();
                     timer.stop();

--- a/server/src/main/java/org/opensearch/indices/replication/OngoingSegmentReplications.java
+++ b/server/src/main/java/org/opensearch/indices/replication/OngoingSegmentReplications.java
@@ -121,10 +121,6 @@ class OngoingSegmentReplications {
                 }
             });
             if (request.getFilesToFetch().isEmpty()) {
-                // before completion, alert the primary of the replica's state.
-                handler.getCopyState()
-                    .getShard()
-                    .updateVisibleCheckpointForShard(request.getTargetAllocationId(), handler.getCopyState().getCheckpoint());
                 wrappedListener.onResponse(new GetSegmentFilesResponse(Collections.emptyList()));
             } else {
                 handler.sendFiles(request, wrappedListener);

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceHandler.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceHandler.java
@@ -159,7 +159,6 @@ class SegmentReplicationSourceHandler {
 
             sendFileStep.whenComplete(r -> {
                 try {
-                    shard.updateVisibleCheckpointForShard(allocationId, copyState.getCheckpoint());
                     future.onResponse(new GetSegmentFilesResponse(List.of(storeFileMetadata)));
                 } finally {
                     IOUtils.close(resources);

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceService.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceService.java
@@ -64,7 +64,6 @@ public class SegmentReplicationSourceService extends AbstractLifecycleComponent 
 
         public static final String GET_CHECKPOINT_INFO = "internal:index/shard/replication/get_checkpoint_info";
         public static final String GET_SEGMENT_FILES = "internal:index/shard/replication/get_segment_files";
-
         public static final String UPDATE_VISIBLE_CHECKPOINT = "internal:index/shard/replication/update_visible_checkpoint";
     }
 

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceService.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceService.java
@@ -34,6 +34,7 @@ import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportChannel;
 import org.opensearch.transport.TransportRequestHandler;
+import org.opensearch.transport.TransportResponse;
 import org.opensearch.transport.TransportService;
 
 import java.io.IOException;
@@ -63,6 +64,8 @@ public class SegmentReplicationSourceService extends AbstractLifecycleComponent 
 
         public static final String GET_CHECKPOINT_INFO = "internal:index/shard/replication/get_checkpoint_info";
         public static final String GET_SEGMENT_FILES = "internal:index/shard/replication/get_segment_files";
+
+        public static final String UPDATE_VISIBLE_CHECKPOINT = "internal:index/shard/replication/update_visible_checkpoint";
     }
 
     private final OngoingSegmentReplications ongoingSegmentReplications;
@@ -88,6 +91,12 @@ public class SegmentReplicationSourceService extends AbstractLifecycleComponent 
             ThreadPool.Names.GENERIC,
             GetSegmentFilesRequest::new,
             new GetSegmentFilesRequestHandler()
+        );
+        transportService.registerRequestHandler(
+            Actions.UPDATE_VISIBLE_CHECKPOINT,
+            ThreadPool.Names.GENERIC,
+            UpdateVisibleCheckpointRequest::new,
+            new UpdateVisibleCheckpointRequestHandler()
         );
     }
 
@@ -139,6 +148,20 @@ public class SegmentReplicationSourceService extends AbstractLifecycleComponent 
         @Override
         public void messageReceived(GetSegmentFilesRequest request, TransportChannel channel, Task task) throws Exception {
             ongoingSegmentReplications.startSegmentCopy(request, new ChannelActionListener<>(channel, Actions.GET_SEGMENT_FILES, request));
+        }
+    }
+
+    private class UpdateVisibleCheckpointRequestHandler implements TransportRequestHandler<UpdateVisibleCheckpointRequest> {
+        @Override
+        public void messageReceived(UpdateVisibleCheckpointRequest request, TransportChannel channel, Task task) throws Exception {
+            try {
+                IndexService indexService = indicesService.indexServiceSafe(request.getPrimaryShardId().getIndex());
+                IndexShard indexShard = indexService.getShard(request.getPrimaryShardId().id());
+                indexShard.updateVisibleCheckpointForShard(request.getTargetAllocationId(), request.getCheckpoint());
+                channel.sendResponse(TransportResponse.Empty.INSTANCE);
+            } catch (Exception e) {
+                channel.sendResponse(e);
+            }
         }
     }
 

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
@@ -13,7 +13,9 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.BaseExceptionsHelper;
 import org.opensearch.action.ActionListener;
+import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.routing.ShardRouting;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.CancellableThreads;
@@ -26,6 +28,7 @@ import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.recovery.FileChunkRequest;
 import org.opensearch.indices.recovery.ForceSyncRequest;
 import org.opensearch.indices.recovery.RecoverySettings;
+import org.opensearch.indices.recovery.RetryableTransportClient;
 import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
 import org.opensearch.indices.replication.common.ReplicationCollection;
 import org.opensearch.indices.replication.common.ReplicationCollection.ReplicationRef;
@@ -36,6 +39,7 @@ import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportChannel;
 import org.opensearch.transport.TransportRequestHandler;
+import org.opensearch.transport.TransportRequestOptions;
 import org.opensearch.transport.TransportResponse;
 import org.opensearch.transport.TransportService;
 
@@ -44,6 +48,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
+
+import static org.opensearch.indices.replication.SegmentReplicationSourceService.Actions.UPDATE_VISIBLE_CHECKPOINT;
 
 /**
  * Service class that orchestrates replication events on replicas.
@@ -66,6 +72,8 @@ public class SegmentReplicationTargetService implements IndexEventListener {
     protected final Map<ShardId, ReplicationCheckpoint> latestReceivedCheckpoint = ConcurrentCollections.newConcurrentMap();
 
     private final IndicesService indicesService;
+    private final ClusterService clusterService;
+    private final TransportService transportService;
 
     public ReplicationRef<SegmentReplicationTarget> get(long replicationId) {
         return onGoingReplications.get(replicationId);
@@ -86,7 +94,8 @@ public class SegmentReplicationTargetService implements IndexEventListener {
         final RecoverySettings recoverySettings,
         final TransportService transportService,
         final SegmentReplicationSourceFactory sourceFactory,
-        final IndicesService indicesService
+        final IndicesService indicesService,
+        final ClusterService clusterService
     ) {
         this(
             threadPool,
@@ -94,6 +103,7 @@ public class SegmentReplicationTargetService implements IndexEventListener {
             transportService,
             sourceFactory,
             indicesService,
+            clusterService,
             new ReplicationCollection<>(logger, threadPool)
         );
     }
@@ -104,6 +114,7 @@ public class SegmentReplicationTargetService implements IndexEventListener {
         final TransportService transportService,
         final SegmentReplicationSourceFactory sourceFactory,
         final IndicesService indicesService,
+        final ClusterService clusterService,
         final ReplicationCollection<SegmentReplicationTarget> ongoingSegmentReplications
     ) {
         this.threadPool = threadPool;
@@ -111,6 +122,8 @@ public class SegmentReplicationTargetService implements IndexEventListener {
         this.onGoingReplications = ongoingSegmentReplications;
         this.sourceFactory = sourceFactory;
         this.indicesService = indicesService;
+        this.clusterService = clusterService;
+        this.transportService = transportService;
 
         transportService.registerRequestHandler(
             Actions.FILE_CHUNK,
@@ -240,6 +253,10 @@ public class SegmentReplicationTargetService implements IndexEventListener {
                                 state.getTimingData()
                             )
                         );
+
+                        // update visible checkpoint to primary
+                        updateVisibleCheckpoint(state.getReplicationId(), replicaShard);
+
                         // if we received a checkpoint during the copy event that is ahead of this
                         // try and process it.
                         processLatestReceivedCheckpoint(replicaShard, thread);
@@ -272,6 +289,62 @@ public class SegmentReplicationTargetService implements IndexEventListener {
                 () -> new ParameterizedMessage("Ignoring checkpoint, shard not started {} {}", receivedCheckpoint, replicaShard.state())
             );
         }
+    }
+
+    protected void updateVisibleCheckpoint(long replicationId, IndexShard replicaShard) {
+        ShardRouting primaryShard = clusterService.state().routingTable().shardRoutingTable(replicaShard.shardId()).primaryShard();
+
+        final UpdateVisibleCheckpointRequest request = new UpdateVisibleCheckpointRequest(
+            replicationId,
+            replicaShard.routingEntry().allocationId().getId(),
+            primaryShard.shardId(),
+            getPrimaryNode(primaryShard),
+            replicaShard.getLatestReplicationCheckpoint()
+        );
+
+        final TransportRequestOptions options = TransportRequestOptions.builder()
+            .withTimeout(recoverySettings.internalActionTimeout())
+            .build();
+        logger.debug("Updating replication checkpoint to {}", request.getCheckpoint());
+        RetryableTransportClient transportClient = new RetryableTransportClient(
+            transportService,
+            getPrimaryNode(primaryShard),
+            recoverySettings.internalActionRetryTimeout(),
+            logger
+        );
+        final ActionListener<Void> listener = new ActionListener<>() {
+            @Override
+            public void onResponse(Void unused) {
+                logger.debug(
+                    "Successfully updated replication checkpoint {} for replica {}",
+                    replicaShard.shardId(),
+                    request.getCheckpoint()
+                );
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                logger.error(
+                    "Failed to update visible checkpoint for replica {}, {}: {}",
+                    replicaShard.shardId(),
+                    request.getCheckpoint(),
+                    e
+                );
+                transportClient.cancel();
+            }
+        };
+
+        transportClient.executeRetryableAction(
+            UPDATE_VISIBLE_CHECKPOINT,
+            request,
+            options,
+            ActionListener.map(listener, r -> null),
+            in -> TransportResponse.Empty.INSTANCE
+        );
+    }
+
+    private DiscoveryNode getPrimaryNode(ShardRouting primaryShard) {
+        return clusterService.state().nodes().get(primaryShard.currentNodeId());
     }
 
     // visible to tests
@@ -436,6 +509,9 @@ public class SegmentReplicationTargetService implements IndexEventListener {
                         // Promote engine type for primary target
                         if (indexShard.recoveryState().getPrimary() == true) {
                             indexShard.resetToWriteableEngine();
+                        } else {
+                            // Update the replica's checkpoint on primary's replication tracker.
+                            updateVisibleCheckpoint(state.getReplicationId(), indexShard);
                         }
                         channel.sendResponse(TransportResponse.Empty.INSTANCE);
                     } catch (InterruptedException | TimeoutException | IOException e) {

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
@@ -330,7 +330,6 @@ public class SegmentReplicationTargetService implements IndexEventListener {
                     request.getCheckpoint(),
                     e
                 );
-                transportClient.cancel();
             }
         };
 

--- a/server/src/main/java/org/opensearch/indices/replication/UpdateVisibleCheckpointRequest.java
+++ b/server/src/main/java/org/opensearch/indices/replication/UpdateVisibleCheckpointRequest.java
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.indices.replication;
+
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.index.shard.ShardId;
+import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
+import org.opensearch.indices.replication.common.SegmentReplicationTransportRequest;
+
+import java.io.IOException;
+
+/**
+ * Request object for updating the replica's checkpoint on primary for tracking.
+ *
+ * @opensearch.internal
+ */
+public class UpdateVisibleCheckpointRequest extends SegmentReplicationTransportRequest {
+
+    private final ReplicationCheckpoint checkpoint;
+    private final ShardId primaryShardId;
+
+    public UpdateVisibleCheckpointRequest(StreamInput in) throws IOException {
+        super(in);
+        checkpoint = new ReplicationCheckpoint(in);
+        primaryShardId = new ShardId(in);
+    }
+
+    public UpdateVisibleCheckpointRequest(
+        long replicationId,
+        String targetAllocationId,
+        ShardId primaryShardId,
+        DiscoveryNode targetNode,
+        ReplicationCheckpoint checkpoint
+    ) {
+        super(replicationId, targetAllocationId, targetNode);
+        this.checkpoint = checkpoint;
+        this.primaryShardId = primaryShardId;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        checkpoint.writeTo(out);
+        primaryShardId.writeTo(out);
+    }
+
+    public ReplicationCheckpoint getCheckpoint() {
+        return checkpoint;
+    }
+
+    public ShardId getPrimaryShardId() {
+        return primaryShardId;
+    }
+}

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -1103,7 +1103,8 @@ public class Node implements Closeable {
                                 recoverySettings,
                                 transportService,
                                 new SegmentReplicationSourceFactory(transportService, recoverySettings, clusterService),
-                                indicesService
+                                indicesService,
+                                clusterService
                             )
                         );
                     b.bind(SegmentReplicationSourceService.class)

--- a/server/src/test/java/org/opensearch/index/seqno/ReplicationTrackerTests.java
+++ b/server/src/test/java/org/opensearch/index/seqno/ReplicationTrackerTests.java
@@ -1868,6 +1868,64 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
         }
     }
 
+    public void testSegmentReplicationCheckpointTrackingInvalidAllocationIDs() {
+        Settings settings = Settings.builder().put(SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT).build();
+        final long initialClusterStateVersion = randomNonNegativeLong();
+        final int numberOfActiveAllocationsIds = randomIntBetween(2, 16);
+        final int numberOfInitializingIds = randomIntBetween(2, 16);
+        final Tuple<Set<AllocationId>, Set<AllocationId>> activeAndInitializingAllocationIds = randomActiveAndInitializingAllocationIds(
+            numberOfActiveAllocationsIds,
+            numberOfInitializingIds
+        );
+        final Set<AllocationId> activeAllocationIds = activeAndInitializingAllocationIds.v1();
+        final Set<AllocationId> initializingIds = activeAndInitializingAllocationIds.v2();
+        AllocationId primaryId = activeAllocationIds.iterator().next();
+        IndexShardRoutingTable routingTable = routingTable(initializingIds, primaryId);
+        final ReplicationTracker tracker = newTracker(primaryId, settings);
+
+        tracker.updateFromClusterManager(initialClusterStateVersion, ids(activeAllocationIds), routingTable);
+        tracker.activatePrimaryMode(NO_OPS_PERFORMED);
+        assertThat(tracker.getReplicationGroup().getInSyncAllocationIds(), equalTo(ids(activeAllocationIds)));
+        assertThat(tracker.getReplicationGroup().getRoutingTable(), equalTo(routingTable));
+        assertTrue(activeAllocationIds.stream().allMatch(a -> tracker.getTrackedLocalCheckpointForShard(a.getId()).inSync));
+
+        // get insync ids, filter out the primary.
+        final Set<String> inSyncAllocationIds = tracker.getReplicationGroup()
+            .getInSyncAllocationIds()
+            .stream()
+            .filter(id -> tracker.shardAllocationId.equals(id) == false)
+            .collect(Collectors.toSet());
+
+        final ReplicationCheckpoint initialCheckpoint = new ReplicationCheckpoint(
+            tracker.shardId(),
+            0L,
+            1,
+            1,
+            1L,
+            Codec.getDefault().getName()
+        );
+        tracker.setLatestReplicationCheckpoint(initialCheckpoint);
+
+        Set<SegmentReplicationShardStats> groupStats = tracker.getSegmentReplicationStats();
+        assertEquals(inSyncAllocationIds.size(), groupStats.size());
+        for (SegmentReplicationShardStats shardStat : groupStats) {
+            assertEquals(1, shardStat.getCheckpointsBehindCount());
+        }
+
+        // simulate replicas moved up to date.
+        final Map<String, ReplicationTracker.CheckpointState> checkpoints = tracker.checkpoints;
+        for (String id : inSyncAllocationIds) {
+            final ReplicationTracker.CheckpointState checkpointState = checkpoints.get(id);
+            assertEquals(1, checkpointState.checkpointTimers.size());
+            tracker.updateVisibleCheckpointForShard(id, initialCheckpoint);
+            assertEquals(0, checkpointState.checkpointTimers.size());
+        }
+
+        // Unknown allocation ID will be ignored.
+        tracker.updateVisibleCheckpointForShard("randomAllocationID", initialCheckpoint);
+        assertThrows(AssertionError.class, () -> tracker.updateVisibleCheckpointForShard(tracker.shardAllocationId, initialCheckpoint));
+    }
+
     public void testPrimaryContextHandoffWithRemoteTranslogEnabled() throws IOException {
         Settings settings = Settings.builder().put("index.remote_store.translog.enabled", "true").build();
         final IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", settings);

--- a/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
@@ -19,6 +19,7 @@ import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.ShardRoutingHelper;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.concurrent.GatedCloseable;
 import org.opensearch.common.settings.ClusterSettings;
@@ -295,7 +296,13 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
     public void testRejectCheckpointOnShardRoutingPrimary() throws IOException {
         IndexShard primaryShard = newStartedShard(true);
         SegmentReplicationTargetService sut;
-        sut = prepareForReplication(primaryShard, null, mock(TransportService.class), mock(IndicesService.class));
+        sut = prepareForReplication(
+            primaryShard,
+            null,
+            mock(TransportService.class),
+            mock(IndicesService.class),
+            mock(ClusterService.class)
+        );
         SegmentReplicationTargetService spy = spy(sut);
 
         // Starting a new shard in PrimaryMode and shard routing primary.
@@ -1011,6 +1018,7 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
             new RecoverySettings(Settings.EMPTY, new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)),
             mock(TransportService.class),
             sourceFactory,
+            null,
             null
         );
     }

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -1867,7 +1867,8 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                         recoverySettings,
                         transportService,
                         new SegmentReplicationSourceFactory(transportService, recoverySettings, clusterService),
-                        indicesService
+                        indicesService,
+                        clusterService
                     ),
                     mock(SegmentReplicationSourceService.class),
                     shardStateAction,

--- a/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
@@ -1302,7 +1302,6 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
         IndexShard primaryShard,
         IndexShard target,
         TransportService transportService,
-
         IndicesService indicesService,
         ClusterService clusterService
     ) {

--- a/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
@@ -1302,7 +1302,9 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
         IndexShard primaryShard,
         IndexShard target,
         TransportService transportService,
-        IndicesService indicesService
+
+        IndicesService indicesService,
+        ClusterService clusterService
     ) {
         final SegmentReplicationSourceFactory sourceFactory = mock(SegmentReplicationSourceFactory.class);
         final SegmentReplicationTargetService targetService = new SegmentReplicationTargetService(
@@ -1310,7 +1312,8 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
             new RecoverySettings(Settings.EMPTY, new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)),
             transportService,
             sourceFactory,
-            indicesService
+            indicesService,
+            clusterService
         );
         final SegmentReplicationSource replicationSource = new TestReplicationSource() {
             @Override
@@ -1379,7 +1382,8 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
                 primaryShard,
                 replica,
                 mock(TransportService.class),
-                mock(IndicesService.class)
+                mock(IndicesService.class),
+                mock(ClusterService.class)
             );
             final SegmentReplicationTarget target = targetService.startReplication(
                 replica,


### PR DESCRIPTION
…rt remote store.

### Description
Update components of segrep backpressure to support remote store.

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/7410

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
