### PR TITLE
Fix bug with delete shard routing weights on node restart

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/WeightedRouting.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/WeightedRouting.java
@@ -47,8 +47,7 @@ public class WeightedRouting implements Writeable {
     }
 
     public boolean isSet() {
-        if (this.attributeName == null || this.weights == null) return false;
-        return (!this.attributeName.isEmpty() && !this.weights.isEmpty());
+        return this.attributeName != null && !this.attributeName.isEmpty() && this.weights != null && !this.weights.isEmpty();
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/cluster/routing/WeightedRouting.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/WeightedRouting.java
@@ -47,6 +47,7 @@ public class WeightedRouting implements Writeable {
     }
 
     public boolean isSet() {
+        if (this.attributeName == null || this.weights == null) return false;
         return (!this.attributeName.isEmpty() && !this.weights.isEmpty());
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
When a node is restarted after deleting the shard routing weights, the node fails to come up due to NPE encountered while reading WRR metadata. This PR fixes the bug

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
