### PR TITLE
[Backport] [2.x] Rename QueryPhase actors like Suggest, Rescore to be processors rather than phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Change `com.amazonaws.sdk.stsEndpointOverride` to `aws.stsEndpointOverride` ([7372](https://github.com/opensearch-project/OpenSearch/pull/7372/))
 - Add new query profile collector fields with concurrent search execution ([#7898](https://github.com/opensearch-project/OpenSearch/pull/7898))
 - Align range and default value for deletes_pct_allowed in merge policy ([#7730](https://github.com/opensearch-project/OpenSearch/pull/7730))
+- Rename QueryPhase actors like Suggest, Rescore to be processors rather than phase ([#8025](https://github.com/opensearch-project/OpenSearch/pull/8025))
 
 ### Deprecated
 

--- a/server/src/main/java/org/opensearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/opensearch/search/query/QueryPhase.java
@@ -63,9 +63,9 @@ import org.opensearch.search.internal.SearchContext;
 import org.opensearch.search.profile.ProfileShardResult;
 import org.opensearch.search.profile.SearchProfileShardResults;
 import org.opensearch.search.profile.query.InternalProfileCollector;
-import org.opensearch.search.rescore.RescorePhase;
+import org.opensearch.search.rescore.RescoreProcessor;
 import org.opensearch.search.sort.SortAndFormats;
-import org.opensearch.search.suggest.SuggestPhase;
+import org.opensearch.search.suggest.SuggestProcessor;
 import org.opensearch.tasks.TaskCancelledException;
 import org.opensearch.threadpool.ThreadPool;
 
@@ -94,8 +94,8 @@ public class QueryPhase {
     public static final boolean SYS_PROP_REWRITE_SORT = Booleans.parseBoolean(System.getProperty("opensearch.search.rewrite_sort", "true"));
     public static final QueryPhaseSearcher DEFAULT_QUERY_PHASE_SEARCHER = new DefaultQueryPhaseSearcher();
     private final QueryPhaseSearcher queryPhaseSearcher;
-    private final SuggestPhase suggestPhase;
-    private final RescorePhase rescorePhase;
+    private final SuggestProcessor suggestProcessor;
+    private final RescoreProcessor rescoreProcessor;
 
     public QueryPhase() {
         this(DEFAULT_QUERY_PHASE_SEARCHER);
@@ -103,8 +103,8 @@ public class QueryPhase {
 
     public QueryPhase(QueryPhaseSearcher queryPhaseSearcher) {
         this.queryPhaseSearcher = Objects.requireNonNull(queryPhaseSearcher, "QueryPhaseSearcher is required");
-        this.suggestPhase = new SuggestPhase();
-        this.rescorePhase = new RescorePhase();
+        this.suggestProcessor = new SuggestProcessor();
+        this.rescoreProcessor = new RescoreProcessor();
     }
 
     public void preProcess(SearchContext context) {
@@ -130,7 +130,7 @@ public class QueryPhase {
 
     public void execute(SearchContext searchContext) throws QueryPhaseExecutionException {
         if (searchContext.hasOnlySuggest()) {
-            suggestPhase.execute(searchContext);
+            suggestProcessor.process(searchContext);
             searchContext.queryResult()
                 .topDocs(
                     new TopDocsAndMaxScore(new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), Lucene.EMPTY_SCORE_DOCS), Float.NaN),
@@ -151,9 +151,9 @@ public class QueryPhase {
         boolean rescore = executeInternal(searchContext, queryPhaseSearcher);
 
         if (rescore) { // only if we do a regular search
-            rescorePhase.execute(searchContext);
+            rescoreProcessor.process(searchContext);
         }
-        suggestPhase.execute(searchContext);
+        suggestProcessor.process(searchContext);
         aggregationProcessor.postProcess(searchContext);
 
         if (searchContext.getProfilers() != null) {

--- a/server/src/main/java/org/opensearch/search/rescore/RescoreProcessor.java
+++ b/server/src/main/java/org/opensearch/search/rescore/RescoreProcessor.java
@@ -41,13 +41,13 @@ import org.opensearch.search.internal.SearchContext;
 import java.io.IOException;
 
 /**
- * Rescore phase of a search request, used to run potentially expensive scoring models against the top matching documents.
+ * RescoreProcessor of a search request, used to run potentially expensive scoring models against the top matching documents.
  *
  * @opensearch.internal
  */
-public class RescorePhase {
+public class RescoreProcessor {
 
-    public void execute(SearchContext context) {
+    public void process(SearchContext context) {
         TopDocs topDocs = context.queryResult().topDocs().topDocs;
         if (topDocs.scoreDocs.length == 0) {
             return;

--- a/server/src/main/java/org/opensearch/search/suggest/SuggestProcessor.java
+++ b/server/src/main/java/org/opensearch/search/suggest/SuggestProcessor.java
@@ -45,13 +45,13 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Suggest phase of a search request, used to collect suggestions
+ * SuggestProcessor of a search request, used to collect suggestions
  *
  * @opensearch.internal
  */
-public class SuggestPhase {
+public class SuggestProcessor {
 
-    public void execute(SearchContext context) {
+    public void process(SearchContext context) {
         final SuggestionSearchContext suggest = context.suggest();
         if (suggest == null) {
             return;


### PR DESCRIPTION
### Description
Backport of #8025 to 2.x

### Related Issues
Resolves #8025 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [] New functionality has been documented.
  - [] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
