### PR TITLE
[Backport 2.x] [Snapshot Interop] Add Changes in Create Snapshot Flow…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add new query profile collector fields with concurrent search execution ([#7898](https://github.com/opensearch-project/OpenSearch/pull/7898))
 - Align range and default value for deletes_pct_allowed in merge policy ([#7730](https://github.com/opensearch-project/OpenSearch/pull/7730))
 - Rename QueryPhase actors like Suggest, Rescore to be processors rather than phase ([#8025](https://github.com/opensearch-project/OpenSearch/pull/8025))
+- [Snapshot Interop] Add Changes in Create Snapshot Flow for remote store interoperability. ([#8071](https://github.com/opensearch-project/OpenSearch/pull/8071))
 
 ### Deprecated
 

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/ClusterStateDiffIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/ClusterStateDiffIT.java
@@ -776,7 +776,8 @@ public class ClusterStateDiffIT extends OpenSearchIntegTestCase {
                                     ImmutableOpenMap.of(),
                                     null,
                                     SnapshotInfoTests.randomUserMetadata(),
-                                    randomVersion(random())
+                                    randomVersion(random()),
+                                    false
                                 )
                             )
                         );

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1486,6 +1486,46 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         }
     }
 
+    public GatedCloseable<IndexCommit> acquireLastIndexCommitAndRefresh(boolean flushFirst) throws EngineException {
+        GatedCloseable<IndexCommit> indexCommit = acquireLastIndexCommit(flushFirst);
+        getEngine().refresh("Snapshot for Remote Store based Shard");
+        return indexCommit;
+    }
+
+    /**
+     *
+     * @param snapshotId Snapshot UUID.
+     * @param primaryTerm current primary term.
+     * @param generation Snapshot Commit Generation.
+     * @throws IOException if there is some failure in acquiring lock in remote store.
+     */
+    public void acquireLockOnCommitData(String snapshotId, long primaryTerm, long generation) throws IOException {
+        RemoteSegmentStoreDirectory remoteSegmentStoreDirectory = getRemoteSegmentDirectoryForShard();
+        remoteSegmentStoreDirectory.acquireLock(primaryTerm, generation, snapshotId);
+    }
+
+    /**
+     *
+     * @param snapshotId Snapshot UUID.
+     * @param primaryTerm current primary term.
+     * @param generation Snapshot Commit Generation.
+     * @throws IOException if there is some failure in releasing lock in remote store.
+     */
+    public void releaseLockOnCommitData(String snapshotId, long primaryTerm, long generation) throws IOException {
+        RemoteSegmentStoreDirectory remoteSegmentStoreDirectory = getRemoteSegmentDirectoryForShard();
+        remoteSegmentStoreDirectory.releaseLock(primaryTerm, generation, snapshotId);
+    }
+
+    private RemoteSegmentStoreDirectory getRemoteSegmentDirectoryForShard() {
+        FilterDirectory remoteStoreDirectory = (FilterDirectory) remoteStore.directory();
+        assert remoteStoreDirectory.getDelegate() instanceof FilterDirectory
+            : "Store.directory is not enclosing an instance of FilterDirectory";
+        FilterDirectory byteSizeCachingStoreDirectory = (FilterDirectory) remoteStoreDirectory.getDelegate();
+        final Directory remoteDirectory = byteSizeCachingStoreDirectory.getDelegate();
+        assert remoteDirectory instanceof RemoteSegmentStoreDirectory : "remoteDirectory is not an instance of RemoteSegmentStoreDirectory";
+        return ((RemoteSegmentStoreDirectory) remoteDirectory);
+    }
+
     public Optional<NRTReplicationEngine> getReplicationEngine() {
         if (getEngine() instanceof NRTReplicationEngine) {
             return Optional.of((NRTReplicationEngine) getEngine());

--- a/server/src/main/java/org/opensearch/index/snapshots/blobstore/RemoteStoreShardShallowCopySnapshot.java
+++ b/server/src/main/java/org/opensearch/index/snapshots/blobstore/RemoteStoreShardShallowCopySnapshot.java
@@ -1,0 +1,411 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.snapshots.blobstore;
+
+import org.opensearch.OpenSearchParseException;
+import org.opensearch.core.ParseField;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Remote Store based Shard snapshot metadata
+ *
+ * @opensearch.internal
+ */
+public class RemoteStoreShardShallowCopySnapshot implements ToXContentFragment {
+
+    private final String snapshot;
+    private final String version;
+    private final long indexVersion;
+    private final long startTime;
+    private final long time;
+    private final int totalFileCount;
+    private final long totalSize;
+    private final long primaryTerm;
+    private final long commitGeneration;
+    private final String remoteStoreRepository;
+    private final String repositoryBasePath;
+    private final String indexUUID;
+    private final List<String> fileNames;
+
+    static final String DEFAULT_VERSION = "1";
+    static final String NAME = "name";
+    static final String VERSION = "version";
+    static final String INDEX_VERSION = "index_version";
+    static final String START_TIME = "start_time";
+    static final String TIME = "time";
+
+    static final String INDEX_UUID = "index_uuid";
+
+    static final String REMOTE_STORE_REPOSITORY = "remote_store_repository";
+    static final String REPOSITORY_BASE_PATH = "remote_store_repository_base_path";
+    static final String FILE_NAMES = "file_names";
+
+    static final String PRIMARY_TERM = "primary_term";
+
+    static final String COMMIT_GENERATION = "commit_generation";
+
+    static final String TOTAL_FILE_COUNT = "number_of_files";
+    static final String TOTAL_SIZE = "total_size";
+
+    private static final ParseField PARSE_NAME = new ParseField(NAME);
+    private static final ParseField PARSE_VERSION = new ParseField(VERSION);
+    private static final ParseField PARSE_PRIMARY_TERM = new ParseField(PRIMARY_TERM);
+    private static final ParseField PARSE_COMMIT_GENERATION = new ParseField(COMMIT_GENERATION);
+    private static final ParseField PARSE_INDEX_VERSION = new ParseField(INDEX_VERSION, "index-version");
+    private static final ParseField PARSE_START_TIME = new ParseField(START_TIME);
+    private static final ParseField PARSE_TIME = new ParseField(TIME);
+    private static final ParseField PARSE_TOTAL_FILE_COUNT = new ParseField(TOTAL_FILE_COUNT);
+    private static final ParseField PARSE_TOTAL_SIZE = new ParseField(TOTAL_SIZE);
+    private static final ParseField PARSE_INDEX_UUID = new ParseField(INDEX_UUID);
+    private static final ParseField PARSE_REMOTE_STORE_REPOSITORY = new ParseField(REMOTE_STORE_REPOSITORY);
+    private static final ParseField PARSE_REPOSITORY_BASE_PATH = new ParseField(REPOSITORY_BASE_PATH);
+    private static final ParseField PARSE_FILE_NAMES = new ParseField(FILE_NAMES);
+
+    /**
+     * Serializes shard snapshot metadata info into JSON
+     *
+     * @param builder  XContent builder
+     * @param params   parameters
+     */
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.field(VERSION, version);
+        builder.field(NAME, snapshot);
+        builder.field(INDEX_VERSION, indexVersion);
+        builder.field(START_TIME, startTime);
+        builder.field(TIME, time);
+        builder.field(TOTAL_FILE_COUNT, totalFileCount);
+        builder.field(TOTAL_SIZE, totalSize);
+        builder.field(INDEX_UUID, indexUUID);
+        builder.field(REMOTE_STORE_REPOSITORY, remoteStoreRepository);
+        builder.field(COMMIT_GENERATION, commitGeneration);
+        builder.field(PRIMARY_TERM, primaryTerm);
+        builder.field(REPOSITORY_BASE_PATH, repositoryBasePath);
+        builder.startArray(FILE_NAMES);
+        for (String fileName : fileNames) {
+            builder.value(fileName);
+        }
+        builder.endArray();
+        return builder;
+    }
+
+    public RemoteStoreShardShallowCopySnapshot(
+        String snapshot,
+        long indexVersion,
+        long primaryTerm,
+        long commitGeneration,
+        long startTime,
+        long time,
+        int totalFileCount,
+        long totalSize,
+        String indexUUID,
+        String remoteStoreRepository,
+        String repositoryBasePath,
+        List<String> fileNames
+    ) {
+        this.version = DEFAULT_VERSION;
+        verifyParameters(
+            version,
+            snapshot,
+            indexVersion,
+            primaryTerm,
+            commitGeneration,
+            indexUUID,
+            remoteStoreRepository,
+            repositoryBasePath
+        );
+        this.snapshot = snapshot;
+        this.indexVersion = indexVersion;
+        this.primaryTerm = primaryTerm;
+        this.commitGeneration = commitGeneration;
+        this.startTime = startTime;
+        this.time = time;
+        this.totalFileCount = totalFileCount;
+        this.totalSize = totalSize;
+        this.indexUUID = indexUUID;
+        this.remoteStoreRepository = remoteStoreRepository;
+        this.repositoryBasePath = repositoryBasePath;
+        this.fileNames = fileNames;
+    }
+
+    private RemoteStoreShardShallowCopySnapshot(
+        String version,
+        String snapshot,
+        long indexVersion,
+        long primaryTerm,
+        long commitGeneration,
+        long startTime,
+        long time,
+        int totalFileCount,
+        long totalSize,
+        String indexUUID,
+        String remoteStoreRepository,
+        String repositoryBasePath,
+        List<String> fileNames
+    ) {
+        verifyParameters(
+            version,
+            snapshot,
+            indexVersion,
+            primaryTerm,
+            commitGeneration,
+            indexUUID,
+            remoteStoreRepository,
+            repositoryBasePath
+        );
+        this.version = version;
+        this.snapshot = snapshot;
+        this.indexVersion = indexVersion;
+        this.primaryTerm = primaryTerm;
+        this.commitGeneration = commitGeneration;
+        this.startTime = startTime;
+        this.time = time;
+        this.totalFileCount = totalFileCount;
+        this.totalSize = totalSize;
+        this.indexUUID = indexUUID;
+        this.remoteStoreRepository = remoteStoreRepository;
+        this.repositoryBasePath = repositoryBasePath;
+        this.fileNames = fileNames;
+    }
+
+    /**
+     * Parses shard snapshot metadata
+     *
+     * @param parser parser
+     * @return shard snapshot metadata
+     */
+    public static RemoteStoreShardShallowCopySnapshot fromXContent(XContentParser parser) throws IOException {
+        String snapshot = null;
+        String version = null;
+        long indexVersion = -1;
+        long startTime = 0;
+        long time = 0;
+        int totalFileCount = 0;
+        long totalSize = 0;
+        String indexUUID = null;
+        String remoteStoreRepository = null;
+        String repositoryBasePath = null;
+        long primaryTerm = -1;
+        long commitGeneration = -1;
+        List<String> fileNames = new ArrayList<>();
+
+        if (parser.currentToken() == null) { // fresh parser? move to the first token
+            parser.nextToken();
+        }
+        XContentParser.Token token;
+        String currentFieldName = parser.currentName();
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (token.isValue()) {
+                if (PARSE_NAME.match(currentFieldName, parser.getDeprecationHandler())) {
+                    snapshot = parser.text();
+                } else if (PARSE_VERSION.match(currentFieldName, parser.getDeprecationHandler())) {
+                    version = parser.text();
+                } else if (PARSE_INDEX_VERSION.match(currentFieldName, parser.getDeprecationHandler())) {
+                    indexVersion = parser.longValue();
+                } else if (PARSE_PRIMARY_TERM.match(currentFieldName, parser.getDeprecationHandler())) {
+                    primaryTerm = parser.longValue();
+                } else if (PARSE_COMMIT_GENERATION.match(currentFieldName, parser.getDeprecationHandler())) {
+                    commitGeneration = parser.longValue();
+                } else if (PARSE_START_TIME.match(currentFieldName, parser.getDeprecationHandler())) {
+                    startTime = parser.longValue();
+                } else if (PARSE_TIME.match(currentFieldName, parser.getDeprecationHandler())) {
+                    time = parser.longValue();
+                } else if (PARSE_TOTAL_FILE_COUNT.match(currentFieldName, parser.getDeprecationHandler())) {
+                    totalFileCount = parser.intValue();
+                } else if (PARSE_TOTAL_SIZE.match(currentFieldName, parser.getDeprecationHandler())) {
+                    totalSize = parser.longValue();
+                } else if (PARSE_INDEX_UUID.match(currentFieldName, parser.getDeprecationHandler())) {
+                    indexUUID = parser.text();
+                } else if (PARSE_REMOTE_STORE_REPOSITORY.match(currentFieldName, parser.getDeprecationHandler())) {
+                    remoteStoreRepository = parser.text();
+                } else if (PARSE_REPOSITORY_BASE_PATH.match(currentFieldName, parser.getDeprecationHandler())) {
+                    repositoryBasePath = parser.text();
+                } else {
+                    throw new OpenSearchParseException("unknown parameter [{}]", currentFieldName);
+                }
+            } else if (token == XContentParser.Token.START_ARRAY) {
+                if (PARSE_FILE_NAMES.match(currentFieldName, parser.getDeprecationHandler())) {
+                    while ((parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                        fileNames.add(parser.text());
+                    }
+                } else {
+                    parser.skipChildren();
+                }
+            } else {
+                parser.skipChildren();
+            }
+        }
+
+        return new RemoteStoreShardShallowCopySnapshot(
+            version,
+            snapshot,
+            indexVersion,
+            primaryTerm,
+            commitGeneration,
+            startTime,
+            time,
+            totalFileCount,
+            totalSize,
+            indexUUID,
+            remoteStoreRepository,
+            repositoryBasePath,
+            fileNames
+        );
+    }
+
+    /**
+     * Returns shard primary Term during snapshot creation
+     *
+     * @return primary Term
+     */
+    public long getPrimaryTerm() {
+        return primaryTerm;
+    }
+
+    /**
+     * Returns snapshot commit generation
+     *
+     * @return commit Generation
+     */
+    public long getCommitGeneration() {
+        return commitGeneration;
+    }
+
+    /**
+     * Returns Index UUID
+     *
+     * @return index UUID
+     */
+    public String getIndexUUID() {
+        return indexUUID;
+    }
+
+    /**
+     * Returns Remote Store Repository Name
+     *
+     * @return remote store Repository Name
+     */
+    public String getRemoteStoreRepository() {
+        return remoteStoreRepository;
+    }
+
+    /**
+     * Returns Remote Store Repository Base Path
+     *
+     * @return repository base path
+     */
+    public String getRepositoryBasePath() {
+        return repositoryBasePath;
+    }
+
+    /**
+     * Returns snapshot name
+     *
+     * @return snapshot name
+     */
+    public String snapshot() {
+        return snapshot;
+    }
+
+    /**
+     * Returns list of files in the shard
+     *
+     * @return list of files
+     */
+
+    /**
+     * Returns snapshot start time
+     */
+    public long startTime() {
+        return startTime;
+    }
+
+    /**
+     * Returns snapshot running time
+     */
+    public long time() {
+        return time;
+    }
+
+    /**
+     * Returns incremental of files that were snapshotted
+     */
+    public int incrementalFileCount() {
+        return 0;
+    }
+
+    /**
+     * Returns total number of files that are referenced by this snapshot
+     */
+    public int totalFileCount() {
+        return totalFileCount;
+    }
+
+    /**
+     * Returns incremental of files size that were snapshotted
+     */
+    public long incrementalSize() {
+        return 0;
+    }
+
+    /**
+     * Returns total size of all files that where snapshotted
+     */
+    public long totalSize() {
+        return totalSize;
+    }
+
+    private void verifyParameters(
+        String version,
+        String snapshot,
+        long indexVersion,
+        long primaryTerm,
+        long commitGeneration,
+        String indexUUID,
+        String remoteStoreRepository,
+        String repositoryBasePath
+    ) {
+        String exceptionStr = null;
+        if (version == null) {
+            exceptionStr = "Invalid Version Provided";
+        }
+        if (snapshot == null) {
+            exceptionStr = "Invalid/Missing Snapshot Name";
+        }
+        if (indexVersion < 0) {
+            exceptionStr = "Invalid Index Version";
+        }
+        if (primaryTerm < 0) {
+            exceptionStr = "Invalid Primary Term";
+        }
+        if (commitGeneration < 0) {
+            exceptionStr = "Invalid Commit Generation";
+        }
+        if (indexUUID == null) {
+            exceptionStr = "Invalid/Missing Index UUID";
+        }
+        if (remoteStoreRepository == null) {
+            exceptionStr = "Invalid/Missing Remote Store Repository";
+        }
+        if (repositoryBasePath == null) {
+            exceptionStr = "Invalid/Missing Repository Base Path";
+        }
+        if (exceptionStr != null) {
+            throw new IllegalArgumentException(exceptionStr);
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/repositories/FilterRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/FilterRepository.java
@@ -189,6 +189,31 @@ public class FilterRepository implements Repository {
     }
 
     @Override
+    public void snapshotRemoteStoreIndexShard(
+        Store store,
+        SnapshotId snapshotId,
+        IndexId indexId,
+        IndexCommit snapshotIndexCommit,
+        String shardStateIdentifier,
+        IndexShardSnapshotStatus snapshotStatus,
+        long primaryTerm,
+        long startTime,
+        ActionListener<String> listener
+    ) {
+        in.snapshotRemoteStoreIndexShard(
+            store,
+            snapshotId,
+            indexId,
+            snapshotIndexCommit,
+            shardStateIdentifier,
+            snapshotStatus,
+            primaryTerm,
+            startTime,
+            listener
+        );
+    }
+
+    @Override
     public void restoreShard(
         Store store,
         SnapshotId snapshotId,

--- a/server/src/main/java/org/opensearch/repositories/RepositoriesService.java
+++ b/server/src/main/java/org/opensearch/repositories/RepositoriesService.java
@@ -35,6 +35,7 @@ package org.opensearch.repositories;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.opensearch.Version;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.ActionRunnable;
 import org.opensearch.action.admin.cluster.repositories.delete.DeleteRepositoryRequest;
@@ -78,6 +79,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static org.opensearch.repositories.blobstore.BlobStoreRepository.REMOTE_STORE_INDEX_SHALLOW_COPY;
 
 /**
  * Service responsible for maintaining and providing access to snapshot repositories on nodes.
@@ -160,6 +163,7 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
 
         final RepositoryMetadata newRepositoryMetadata = new RepositoryMetadata(request.name(), request.type(), request.settings());
         validate(request.name());
+        validateRepositoryMetadataSettings(clusterService, request.name(), request.settings());
 
         final ActionListener<ClusterStateUpdateResponse> registrationListener;
         if (request.verify()) {
@@ -602,6 +606,26 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
         }
         if (Strings.validFileName(repositoryName) == false) {
             throw new RepositoryException(repositoryName, "must not contain the following characters " + Strings.INVALID_FILENAME_CHARS);
+        }
+    }
+
+    public static void validateRepositoryMetadataSettings(
+        ClusterService clusterService,
+        final String repositoryName,
+        final Settings repositoryMetadataSettings
+    ) {
+        // We can add more validations here for repository settings in the future.
+        Version minVersionInCluster = clusterService.state().getNodes().getMinNodeVersion();
+        if (REMOTE_STORE_INDEX_SHALLOW_COPY.get(repositoryMetadataSettings) && !minVersionInCluster.onOrAfter(Version.V_2_9_0)) {
+            throw new RepositoryException(
+                repositoryName,
+                "setting "
+                    + REMOTE_STORE_INDEX_SHALLOW_COPY.getKey()
+                    + " cannot be enabled as some of the nodes in cluster are on version older than "
+                    + Version.V_2_9_0
+                    + ". Minimum node version in cluster is: "
+                    + minVersionInCluster
+            );
         }
     }
 

--- a/server/src/main/java/org/opensearch/repositories/Repository.java
+++ b/server/src/main/java/org/opensearch/repositories/Repository.java
@@ -238,18 +238,18 @@ public interface Repository extends LifecycleComponent {
      * <p>
      * As snapshot process progresses, implementation of this method should update {@link IndexShardSnapshotStatus} object and check
      * {@link IndexShardSnapshotStatus#isAborted()} to see if the snapshot process should be aborted.
-     * @param store                 store to be snapshotted
-     * @param mapperService         the shards mapper service
-     * @param snapshotId            snapshot id
-     * @param indexId               id for the index being snapshotted
-     * @param snapshotIndexCommit   commit point
-     * @param shardStateIdentifier  a unique identifier of the state of the shard that is stored with the shard's snapshot and used
-     *                              to detect if the shard has changed between snapshots. If {@code null} is passed as the identifier
-     *                              snapshotting will be done by inspecting the physical files referenced by {@code snapshotIndexCommit}
-     * @param snapshotStatus        snapshot status
-     * @param repositoryMetaVersion version of the updated repository metadata to write
-     * @param userMetadata          user metadata of the snapshot found in {@link SnapshotsInProgress.Entry#userMetadata()}
-     * @param listener              listener invoked on completion
+     * @param store                    store to be snapshotted
+     * @param mapperService            the shards mapper service
+     * @param snapshotId               snapshot id
+     * @param indexId                  id for the index being snapshotted
+     * @param snapshotIndexCommit      commit point
+     * @param shardStateIdentifier     a unique identifier of the state of the shard that is stored with the shard's snapshot and used
+     *                                 to detect if the shard has changed between snapshots. If {@code null} is passed as the identifier
+     *                                 snapshotting will be done by inspecting the physical files referenced by {@code snapshotIndexCommit}
+     * @param snapshotStatus           snapshot status
+     * @param repositoryMetaVersion    version of the updated repository metadata to write
+     * @param userMetadata             user metadata of the snapshot found in {@link SnapshotsInProgress.Entry#userMetadata()}
+     * @param listener                 listener invoked on completion
      */
     void snapshotShard(
         Store store,
@@ -263,6 +263,40 @@ public interface Repository extends LifecycleComponent {
         Map<String, Object> userMetadata,
         ActionListener<String> listener
     );
+
+    /**
+     * Adds a reference of remote store data for a index commit point.
+     * <p>
+     * The index commit point can be obtained by using {@link org.opensearch.index.engine.Engine#acquireLastIndexCommit} method.
+     * Repository implementations shouldn't release the snapshot index commit point. It is done by the method caller.
+     * <p>
+     * As snapshot process progresses, implementation of this method should update {@link IndexShardSnapshotStatus} object and check
+     * {@link IndexShardSnapshotStatus#isAborted()} to see if the snapshot process should be aborted.
+     * @param store                    store to be snapshotted
+     * @param snapshotId               snapshot id
+     * @param indexId                  id for the index being snapshotted
+     * @param snapshotIndexCommit      commit point
+     * @param shardStateIdentifier     a unique identifier of the state of the shard that is stored with the shard's snapshot and used
+     *                                 to detect if the shard has changed between snapshots. If {@code null} is passed as the identifier
+     *                                 snapshotting will be done by inspecting the physical files referenced by {@code snapshotIndexCommit}
+     * @param snapshotStatus           snapshot status
+     * @param primaryTerm              current Primary Term
+     * @param startTime                start time of the snapshot commit, this will be used as the start time for snapshot.
+     * @param listener                 listener invoked on completion
+     */
+    default void snapshotRemoteStoreIndexShard(
+        Store store,
+        SnapshotId snapshotId,
+        IndexId indexId,
+        IndexCommit snapshotIndexCommit,
+        @Nullable String shardStateIdentifier,
+        IndexShardSnapshotStatus snapshotStatus,
+        long primaryTerm,
+        long startTime,
+        ActionListener<String> listener
+    ) {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * Restores snapshot of the shard.

--- a/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
@@ -107,6 +107,7 @@ import org.opensearch.index.snapshots.IndexShardRestoreFailedException;
 import org.opensearch.index.snapshots.IndexShardSnapshotFailedException;
 import org.opensearch.index.snapshots.IndexShardSnapshotStatus;
 import org.opensearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot;
+import org.opensearch.index.snapshots.blobstore.RemoteStoreShardShallowCopySnapshot;
 import org.opensearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshots;
 import org.opensearch.index.snapshots.blobstore.RateLimitingInputStream;
 import org.opensearch.index.snapshots.blobstore.SlicedInputStream;
@@ -184,6 +185,8 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
     public static final String SNAPSHOT_PREFIX = "snap-";
 
+    public static final String SHALLOW_SNAPSHOT_PREFIX = "shallow-snap-";
+
     public static final String INDEX_FILE_PREFIX = "index-";
 
     public static final String INDEX_LATEST_BLOB = "index.latest";
@@ -195,6 +198,8 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     public static final String METADATA_NAME_FORMAT = METADATA_PREFIX + "%s.dat";
 
     public static final String SNAPSHOT_NAME_FORMAT = SNAPSHOT_PREFIX + "%s.dat";
+
+    public static final String SHALLOW_SNAPSHOT_NAME_FORMAT = SHALLOW_SNAPSHOT_PREFIX + "%s.dat";
 
     private static final String SNAPSHOT_INDEX_PREFIX = "index-";
 
@@ -240,6 +245,8 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         ByteSizeValue.parseBytesSizeValue("16mb", "io_buffer_size"),
         Setting.Property.NodeScope
     );
+
+    public static final Setting<Boolean> REMOTE_STORE_INDEX_SHALLOW_COPY = Setting.boolSetting("remote_store_index_shallow_copy", false);
 
     /**
      * Setting to set batch size of stale snapshot shard blobs that will be deleted by snapshot workers as part of snapshot deletion.
@@ -313,6 +320,9 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         SNAPSHOT_NAME_FORMAT,
         BlobStoreIndexShardSnapshot::fromXContent
     );
+
+    public static final ChecksumBlobStoreFormat<RemoteStoreShardShallowCopySnapshot> REMOTE_STORE_SHARD_SHALLOW_COPY_SNAPSHOT_FORMAT =
+        new ChecksumBlobStoreFormat<>(SNAPSHOT_CODEC, SHALLOW_SNAPSHOT_NAME_FORMAT, RemoteStoreShardShallowCopySnapshot::fromXContent);
 
     public static final ChecksumBlobStoreFormat<BlobStoreIndexShardSnapshots> INDEX_SHARD_SNAPSHOTS_FORMAT = new ChecksumBlobStoreFormat<>(
         "snapshots",
@@ -2360,6 +2370,85 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     }
 
     @Override
+    public void snapshotRemoteStoreIndexShard(
+        Store store,
+        SnapshotId snapshotId,
+        IndexId indexId,
+        IndexCommit snapshotIndexCommit,
+        String shardStateIdentifier,
+        IndexShardSnapshotStatus snapshotStatus,
+        long primaryTerm,
+        long startTime,
+        ActionListener<String> listener
+    ) {
+        if (isReadOnly()) {
+            listener.onFailure(new RepositoryException(metadata.name(), "cannot snapshot shard on a readonly repository"));
+            return;
+        }
+        final ShardId shardId = store.shardId();
+        try {
+            final String generation = snapshotStatus.generation();
+            logger.info("[{}] [{}] snapshot to [{}] [{}] ...", shardId, snapshotId, metadata.name(), generation);
+            final BlobContainer shardContainer = shardContainer(indexId, shardId);
+
+            long indexTotalFileSize = 0;
+            // local store is being used here to fetch the files metadata instead of remote store as currently
+            // remote store is mirroring the local store.
+            List<String> fileNames = new ArrayList<>(snapshotIndexCommit.getFileNames());
+            Store.MetadataSnapshot commitSnapshotMetadata = store.getMetadata(snapshotIndexCommit);
+            for (String fileName : fileNames) {
+                indexTotalFileSize += commitSnapshotMetadata.get(fileName).length();
+            }
+            int indexTotalNumberOfFiles = fileNames.size();
+
+            snapshotStatus.moveToStarted(
+                startTime,
+                0, // incremental File Count is zero as we are storing the data as part of remote store.
+                indexTotalNumberOfFiles,
+                0, // incremental File Size is zero as we are storing the data as part of remote store.
+                indexTotalFileSize
+            );
+
+            final IndexShardSnapshotStatus.Copy lastSnapshotStatus = snapshotStatus.moveToFinalize(snapshotIndexCommit.getGeneration());
+
+            // now create and write the commit point
+            logger.trace("[{}] [{}] writing shard snapshot file", shardId, snapshotId);
+            try {
+                REMOTE_STORE_SHARD_SHALLOW_COPY_SNAPSHOT_FORMAT.write(
+                    new RemoteStoreShardShallowCopySnapshot(
+                        snapshotId.getName(),
+                        lastSnapshotStatus.getIndexVersion(),
+                        primaryTerm,
+                        snapshotIndexCommit.getGeneration(),
+                        lastSnapshotStatus.getStartTime(),
+                        threadPool.absoluteTimeInMillis() - lastSnapshotStatus.getStartTime(),
+                        indexTotalNumberOfFiles,
+                        indexTotalFileSize,
+                        store.indexSettings().getUUID(),
+                        store.indexSettings().getRemoteStoreRepository(),
+                        this.basePath().toString(),
+                        fileNames
+                    ),
+                    shardContainer,
+                    snapshotId.getUUID(),
+                    compressor
+                );
+            } catch (IOException e) {
+                throw new IndexShardSnapshotFailedException(
+                    shardId,
+                    "Failed to write commit point for snapshot " + snapshotId.getName() + "(" + snapshotId.getUUID() + ")",
+                    e
+                );
+            }
+            snapshotStatus.moveToDone(threadPool.absoluteTimeInMillis(), generation);
+            listener.onResponse(generation);
+
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
+    }
+
+    @Override
     public void snapshotShard(
         Store store,
         MapperService mapperService,
@@ -2988,6 +3077,24 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                     || FsBlobContainer.isTempBlobName(blob)
             )
             .collect(Collectors.toList());
+    }
+
+    /**
+     * Loads information about remote store enabled shard snapshot for remote store interop enabled snapshots
+     */
+    public RemoteStoreShardShallowCopySnapshot loadShallowCopyShardSnapshot(BlobContainer shardContainer, SnapshotId snapshotId) {
+        try {
+            return REMOTE_STORE_SHARD_SHALLOW_COPY_SNAPSHOT_FORMAT.read(shardContainer, snapshotId.getUUID(), namedXContentRegistry);
+        } catch (NoSuchFileException ex) {
+            throw new SnapshotMissingException(metadata.name(), snapshotId, ex);
+        } catch (IOException ex) {
+            throw new SnapshotException(
+                metadata.name(),
+                snapshotId,
+                "failed to read shard snapshot file for [" + shardContainer.path() + ']',
+                ex
+            );
+        }
     }
 
     /**

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotInfo.java
@@ -98,6 +98,8 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
     private static final String TOTAL_SHARDS = "total_shards";
     private static final String SUCCESSFUL_SHARDS = "successful_shards";
     private static final String INCLUDE_GLOBAL_STATE = "include_global_state";
+
+    private static final String REMOTE_STORE_INDEX_SHALLOW_COPY = "remote_store_index_shallow_copy";
     private static final String USER_METADATA = "metadata";
 
     private static final Comparator<SnapshotInfo> COMPARATOR = Comparator.comparing(SnapshotInfo::startTime)
@@ -119,6 +121,8 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         private long endTime = 0L;
         private ShardStatsBuilder shardStatsBuilder = null;
         private Boolean includeGlobalState = null;
+
+        private Boolean remoteStoreIndexShallowCopy = null;
         private Map<String, Object> userMetadata = null;
         private int version = -1;
         private List<SnapshotShardFailure> shardFailures = null;
@@ -171,6 +175,10 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
             this.version = version;
         }
 
+        private void setRemoteStoreIndexShallowCopy(Boolean remoteStoreIndexShallowCopy) {
+            this.remoteStoreIndexShallowCopy = remoteStoreIndexShallowCopy;
+        }
+
         private void setShardFailures(List<SnapshotShardFailure> shardFailures) {
             this.shardFailures = shardFailures;
         }
@@ -209,7 +217,8 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
                 successfulShards,
                 shardFailures,
                 includeGlobalState,
-                userMetadata
+                userMetadata,
+                remoteStoreIndexShallowCopy
             );
         }
     }
@@ -260,6 +269,10 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         SNAPSHOT_INFO_PARSER.declareBoolean(SnapshotInfoBuilder::setIncludeGlobalState, new ParseField(INCLUDE_GLOBAL_STATE));
         SNAPSHOT_INFO_PARSER.declareObject(SnapshotInfoBuilder::setUserMetadata, (p, c) -> p.map(), new ParseField(USER_METADATA));
         SNAPSHOT_INFO_PARSER.declareInt(SnapshotInfoBuilder::setVersion, new ParseField(VERSION_ID));
+        SNAPSHOT_INFO_PARSER.declareBoolean(
+            SnapshotInfoBuilder::setRemoteStoreIndexShallowCopy,
+            new ParseField(REMOTE_STORE_INDEX_SHALLOW_COPY)
+        );
         SNAPSHOT_INFO_PARSER.declareObjectArray(
             SnapshotInfoBuilder::setShardFailures,
             SnapshotShardFailure.SNAPSHOT_SHARD_FAILURE_PARSER,
@@ -294,6 +307,9 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
     private Boolean includeGlobalState;
 
     @Nullable
+    private Boolean remoteStoreIndexShallowCopy;
+
+    @Nullable
     private final Map<String, Object> userMetadata;
 
     @Nullable
@@ -302,11 +318,11 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
     private final List<SnapshotShardFailure> shardFailures;
 
     public SnapshotInfo(SnapshotId snapshotId, List<String> indices, List<String> dataStreams, SnapshotState state) {
-        this(snapshotId, indices, dataStreams, state, null, null, 0L, 0L, 0, 0, Collections.emptyList(), null, null);
+        this(snapshotId, indices, dataStreams, state, null, null, 0L, 0L, 0, 0, Collections.emptyList(), null, null, null);
     }
 
     public SnapshotInfo(SnapshotId snapshotId, List<String> indices, List<String> dataStreams, SnapshotState state, Version version) {
-        this(snapshotId, indices, dataStreams, state, null, version, 0L, 0L, 0, 0, Collections.emptyList(), null, null);
+        this(snapshotId, indices, dataStreams, state, null, version, 0L, 0L, 0, 0, Collections.emptyList(), null, null, null);
     }
 
     public SnapshotInfo(SnapshotsInProgress.Entry entry) {
@@ -323,7 +339,8 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
             0,
             Collections.emptyList(),
             entry.includeGlobalState(),
-            entry.userMetadata()
+            entry.userMetadata(),
+            entry.remoteStoreIndexShallowCopy()
         );
     }
 
@@ -337,7 +354,8 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         int totalShards,
         List<SnapshotShardFailure> shardFailures,
         Boolean includeGlobalState,
-        Map<String, Object> userMetadata
+        Map<String, Object> userMetadata,
+        Boolean remoteStoreIndexShallowCopy
     ) {
         this(
             snapshotId,
@@ -352,7 +370,8 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
             totalShards - shardFailures.size(),
             shardFailures,
             includeGlobalState,
-            userMetadata
+            userMetadata,
+            remoteStoreIndexShallowCopy
         );
     }
 
@@ -369,7 +388,8 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         int successfulShards,
         List<SnapshotShardFailure> shardFailures,
         Boolean includeGlobalState,
-        Map<String, Object> userMetadata
+        Map<String, Object> userMetadata,
+        Boolean remoteStoreIndexShallowCopy
     ) {
         this.snapshotId = Objects.requireNonNull(snapshotId);
         this.indices = Collections.unmodifiableList(Objects.requireNonNull(indices));
@@ -384,6 +404,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         this.shardFailures = Objects.requireNonNull(shardFailures);
         this.includeGlobalState = includeGlobalState;
         this.userMetadata = userMetadata;
+        this.remoteStoreIndexShallowCopy = remoteStoreIndexShallowCopy;
     }
 
     /**
@@ -410,6 +431,9 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
             dataStreams = in.readStringList();
         } else {
             dataStreams = Collections.emptyList();
+        }
+        if (in.getVersion().onOrAfter(Version.V_2_9_0)) {
+            remoteStoreIndexShallowCopy = in.readOptionalBoolean();
         }
     }
 
@@ -520,6 +544,10 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         return includeGlobalState;
     }
 
+    public Boolean isRemoteStoreIndexShallowCopyEnabled() {
+        return remoteStoreIndexShallowCopy;
+    }
+
     /**
      * Returns shard failures; an empty list will be returned if there were no shard
      * failures, or if {@link #state()} returns {@code null}.
@@ -585,6 +613,8 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
             + version
             + ", shardFailures="
             + shardFailures
+            + ", isRemoteStoreInteropEnabled="
+            + remoteStoreIndexShallowCopy
             + '}';
     }
 
@@ -620,6 +650,9 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         if (version != null) {
             builder.field(VERSION_ID, version.id);
             builder.field(VERSION, version.toString());
+        }
+        if (remoteStoreIndexShallowCopy != null) {
+            builder.field(REMOTE_STORE_INDEX_SHALLOW_COPY, remoteStoreIndexShallowCopy);
         }
         builder.startArray(INDICES);
         for (String index : indices) {
@@ -676,6 +709,9 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         builder.field(UUID, snapshotId.getUUID());
         assert version != null : "version must always be known when writing a snapshot metadata blob";
         builder.field(VERSION_ID, version.id);
+        if (remoteStoreIndexShallowCopy != null) {
+            builder.field(REMOTE_STORE_INDEX_SHALLOW_COPY, remoteStoreIndexShallowCopy);
+        }
         builder.startArray(INDICES);
         for (String index : indices) {
             builder.value(index);
@@ -725,6 +761,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         int totalShards = 0;
         int successfulShards = 0;
         Boolean includeGlobalState = null;
+        Boolean remoteStoreIndexShallowCopy = null;
         Map<String, Object> userMetadata = null;
         List<SnapshotShardFailure> shardFailures = Collections.emptyList();
         if (parser.currentToken() == null) { // fresh parser? move to the first token
@@ -762,6 +799,8 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
                             version = Version.fromId(parser.intValue());
                         } else if (INCLUDE_GLOBAL_STATE.equals(currentFieldName)) {
                             includeGlobalState = parser.booleanValue();
+                        } else if (REMOTE_STORE_INDEX_SHALLOW_COPY.equals(currentFieldName)) {
+                            remoteStoreIndexShallowCopy = parser.booleanValue();
                         }
                     } else if (token == XContentParser.Token.START_ARRAY) {
                         if (DATA_STREAMS.equals(currentFieldName)) {
@@ -813,7 +852,8 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
             successfulShards,
             shardFailures,
             includeGlobalState,
-            userMetadata
+            userMetadata,
+            remoteStoreIndexShallowCopy
         );
     }
 
@@ -846,6 +886,9 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
                 out.writeStringCollection(dataStreams);
             }
         }
+        if (out.getVersion().onOrAfter(Version.V_2_9_0)) {
+            out.writeOptionalBoolean(remoteStoreIndexShallowCopy);
+        }
     }
 
     private static SnapshotState snapshotState(final String reason, final List<SnapshotShardFailure> shardFailures) {
@@ -877,7 +920,8 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
             && Objects.equals(includeGlobalState, that.includeGlobalState)
             && Objects.equals(version, that.version)
             && Objects.equals(shardFailures, that.shardFailures)
-            && Objects.equals(userMetadata, that.userMetadata);
+            && Objects.equals(userMetadata, that.userMetadata)
+            && Objects.equals(remoteStoreIndexShallowCopy, that.remoteStoreIndexShallowCopy);
     }
 
     @Override
@@ -896,7 +940,8 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
             includeGlobalState,
             version,
             shardFailures,
-            userMetadata
+            userMetadata,
+            remoteStoreIndexShallowCopy
         );
     }
 }

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotShardsService.java
@@ -287,38 +287,47 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                         : "Found non-null, non-numeric shard generation ["
                             + snapshotStatus.generation()
                             + "] for snapshot with old-format compatibility";
-                    snapshot(shardId, snapshot, indexId, entry.userMetadata(), snapshotStatus, entry.version(), new ActionListener<>() {
-                        @Override
-                        public void onResponse(String newGeneration) {
-                            assert newGeneration != null;
-                            assert newGeneration.equals(snapshotStatus.generation());
-                            if (logger.isDebugEnabled()) {
-                                final IndexShardSnapshotStatus.Copy lastSnapshotStatus = snapshotStatus.asCopy();
-                                logger.debug(
-                                    "snapshot [{}] completed to [{}] with [{}] at generation [{}]",
-                                    snapshot,
-                                    snapshot.getRepository(),
-                                    lastSnapshotStatus,
-                                    snapshotStatus.generation()
-                                );
+                    snapshot(
+                        shardId,
+                        snapshot,
+                        indexId,
+                        entry.userMetadata(),
+                        snapshotStatus,
+                        entry.version(),
+                        entry.remoteStoreIndexShallowCopy(),
+                        new ActionListener<>() {
+                            @Override
+                            public void onResponse(String newGeneration) {
+                                assert newGeneration != null;
+                                assert newGeneration.equals(snapshotStatus.generation());
+                                if (logger.isDebugEnabled()) {
+                                    final IndexShardSnapshotStatus.Copy lastSnapshotStatus = snapshotStatus.asCopy();
+                                    logger.debug(
+                                        "snapshot [{}] completed to [{}] with [{}] at generation [{}]",
+                                        snapshot,
+                                        snapshot.getRepository(),
+                                        lastSnapshotStatus,
+                                        snapshotStatus.generation()
+                                    );
+                                }
+                                notifySuccessfulSnapshotShard(snapshot, shardId, newGeneration);
                             }
-                            notifySuccessfulSnapshotShard(snapshot, shardId, newGeneration);
-                        }
 
-                        @Override
-                        public void onFailure(Exception e) {
-                            final String failure;
-                            if (e instanceof AbortedSnapshotException) {
-                                failure = "aborted";
-                                logger.debug(() -> new ParameterizedMessage("[{}][{}] aborted shard snapshot", shardId, snapshot), e);
-                            } else {
-                                failure = summarizeFailure(e);
-                                logger.warn(() -> new ParameterizedMessage("[{}][{}] failed to snapshot shard", shardId, snapshot), e);
+                            @Override
+                            public void onFailure(Exception e) {
+                                final String failure;
+                                if (e instanceof AbortedSnapshotException) {
+                                    failure = "aborted";
+                                    logger.debug(() -> new ParameterizedMessage("[{}][{}] aborted shard snapshot", shardId, snapshot), e);
+                                } else {
+                                    failure = summarizeFailure(e);
+                                    logger.warn(() -> new ParameterizedMessage("[{}][{}] failed to snapshot shard", shardId, snapshot), e);
+                                }
+                                snapshotStatus.moveToFailed(threadPool.absoluteTimeInMillis(), failure);
+                                notifyFailedSnapshotShard(snapshot, shardId, failure);
                             }
-                            snapshotStatus.moveToFailed(threadPool.absoluteTimeInMillis(), failure);
-                            notifyFailedSnapshotShard(snapshot, shardId, failure);
                         }
-                    });
+                    );
                 }
             }
         });
@@ -370,6 +379,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
         final Map<String, Object> userMetadata,
         final IndexShardSnapshotStatus snapshotStatus,
         Version version,
+        final boolean remoteStoreIndexShallowCopy,
         ActionListener<String> listener
     ) {
         try {
@@ -391,21 +401,68 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
             final Repository repository = repositoriesService.repository(snapshot.getRepository());
             GatedCloseable<IndexCommit> wrappedSnapshot = null;
             try {
-                // we flush first to make sure we get the latest writes snapshotted
-                wrappedSnapshot = indexShard.acquireLastIndexCommit(true);
-                final IndexCommit snapshotIndexCommit = wrappedSnapshot.get();
-                repository.snapshotShard(
-                    indexShard.store(),
-                    indexShard.mapperService(),
-                    snapshot.getSnapshotId(),
-                    indexId,
-                    wrappedSnapshot.get(),
-                    getShardStateId(indexShard, snapshotIndexCommit),
-                    snapshotStatus,
-                    version,
-                    userMetadata,
-                    ActionListener.runBefore(listener, wrappedSnapshot::close)
-                );
+                if (remoteStoreIndexShallowCopy && indexShard.indexSettings().isRemoteStoreEnabled()) {
+                    long startTime = threadPool.relativeTimeInMillis();
+                    // we flush first to make sure we get the latest writes snapshotted
+                    wrappedSnapshot = indexShard.acquireLastIndexCommitAndRefresh(true);
+                    long primaryTerm = indexShard.getOperationPrimaryTerm();
+                    final IndexCommit snapshotIndexCommit = wrappedSnapshot.get();
+                    long commitGeneration = snapshotIndexCommit.getGeneration();
+                    indexShard.acquireLockOnCommitData(snapshot.getSnapshotId().getUUID(), primaryTerm, commitGeneration);
+                    try {
+                        repository.snapshotRemoteStoreIndexShard(
+                            indexShard.store(),
+                            snapshot.getSnapshotId(),
+                            indexId,
+                            wrappedSnapshot.get(),
+                            getShardStateId(indexShard, snapshotIndexCommit),
+                            snapshotStatus,
+                            primaryTerm,
+                            startTime,
+                            ActionListener.runBefore(listener, wrappedSnapshot::close)
+                        );
+                    } catch (IndexShardSnapshotFailedException e) {
+                        logger.error(
+                            "Shallow Copy Snapshot Failed for Shard ["
+                                + indexId.getName()
+                                + "]["
+                                + shardId.getId()
+                                + "] for snapshot "
+                                + snapshot.getSnapshotId()
+                                + ", releasing acquired lock from remote store"
+                        );
+                        indexShard.releaseLockOnCommitData(snapshot.getSnapshotId().getUUID(), primaryTerm, commitGeneration);
+                        throw e;
+                    }
+                    long endTime = threadPool.relativeTimeInMillis();
+                    logger.debug(
+                        "Time taken (in milliseconds) to complete shallow copy snapshot, "
+                            + "for index "
+                            + indexId.getName()
+                            + ", shard "
+                            + shardId.getId()
+                            + " and snapshot "
+                            + snapshot.getSnapshotId()
+                            + " is "
+                            + (endTime - startTime)
+                    );
+                } else {
+                    // we flush first to make sure we get the latest writes snapshotted
+                    wrappedSnapshot = indexShard.acquireLastIndexCommit(true);
+                    final IndexCommit snapshotIndexCommit = wrappedSnapshot.get();
+                    repository.snapshotShard(
+                        indexShard.store(),
+                        indexShard.mapperService(),
+                        snapshot.getSnapshotId(),
+                        indexId,
+                        wrappedSnapshot.get(),
+                        getShardStateId(indexShard, snapshotIndexCommit),
+                        snapshotStatus,
+                        version,
+                        userMetadata,
+                        ActionListener.runBefore(listener, wrappedSnapshot::close)
+                    );
+                }
             } catch (Exception e) {
                 IOUtils.close(wrappedSnapshot);
                 throw e;

--- a/server/src/test/java/org/opensearch/action/admin/cluster/snapshots/create/CreateSnapshotResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/snapshots/create/CreateSnapshotResponseTests.java
@@ -94,7 +94,8 @@ public class CreateSnapshotResponseTests extends AbstractXContentTestCase<Create
                 totalShards,
                 shardFailures,
                 globalState,
-                SnapshotInfoTests.randomUserMetadata()
+                SnapshotInfoTests.randomUserMetadata(),
+                false
             )
         );
     }

--- a/server/src/test/java/org/opensearch/action/admin/cluster/snapshots/get/GetSnapshotsResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/snapshots/get/GetSnapshotsResponseTests.java
@@ -76,7 +76,8 @@ public class GetSnapshotsResponseTests extends AbstractSerializingTestCase<GetSn
                     randomIntBetween(2, 3),
                     shardFailures,
                     randomBoolean(),
-                    SnapshotInfoTests.randomUserMetadata()
+                    SnapshotInfoTests.randomUserMetadata(),
+                    false
                 )
             );
         }

--- a/server/src/test/java/org/opensearch/action/admin/indices/datastream/DeleteDataStreamRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/datastream/DeleteDataStreamRequestTests.java
@@ -171,7 +171,7 @@ public class DeleteDataStreamRequestTests extends AbstractWireSerializingTestCas
             ImmutableOpenMap.of(),
             null,
             null,
-            null
+            false
         );
     }
 

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataDeleteIndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataDeleteIndexServiceTests.java
@@ -111,7 +111,8 @@ public class MetadataDeleteIndexServiceTests extends OpenSearchTestCase {
                     ImmutableOpenMap.of(),
                     null,
                     SnapshotInfoTests.randomUserMetadata(),
-                    VersionUtils.randomVersion(random())
+                    VersionUtils.randomVersion(random()),
+                    false
                 )
             )
         );

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataIndexStateServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataIndexStateServiceTests.java
@@ -530,7 +530,8 @@ public class MetadataIndexStateServiceTests extends OpenSearchTestCase {
             shardsBuilder.build(),
             null,
             SnapshotInfoTests.randomUserMetadata(),
-            VersionUtils.randomVersion(random())
+            VersionUtils.randomVersion(random()),
+            false
         );
         return ClusterState.builder(newState)
             .putCustom(SnapshotsInProgress.TYPE, SnapshotsInProgress.of(Collections.singletonList(entry)))

--- a/server/src/test/java/org/opensearch/index/snapshots/blobstore/RemoteStoreShardShallowCopySnapshotTests.java
+++ b/server/src/test/java/org/opensearch/index/snapshots/blobstore/RemoteStoreShardShallowCopySnapshotTests.java
@@ -1,0 +1,228 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.snapshots.blobstore;
+
+import org.opensearch.common.Strings;
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+import static org.hamcrest.Matchers.containsString;
+
+public class RemoteStoreShardShallowCopySnapshotTests extends OpenSearchTestCase {
+
+    public void testToXContent() throws IOException {
+        String snapshot = "test-snapshot";
+        long indexVersion = 1;
+        long primaryTerm = 3;
+        long commitGeneration = 5;
+        long startTime = 123;
+        long time = 123;
+        int totalFileCount = 5;
+        long totalSize = 5;
+        String indexUUID = "syzhajds-ashdlfj";
+        String remoteStoreRepository = "test-rs-repository";
+        String repositoryBasePath = "test-repo-basepath";
+        List<String> fileNames = new ArrayList<>(5);
+        fileNames.addAll(Arrays.asList("file1", "file2", "file3", "file4", "file5"));
+        RemoteStoreShardShallowCopySnapshot shardShallowCopySnapshot = new RemoteStoreShardShallowCopySnapshot(
+            snapshot,
+            indexVersion,
+            primaryTerm,
+            commitGeneration,
+            startTime,
+            time,
+            totalFileCount,
+            totalSize,
+            indexUUID,
+            remoteStoreRepository,
+            repositoryBasePath,
+            fileNames
+        );
+        String actual;
+        try (XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent())) {
+            builder.startObject();
+            shardShallowCopySnapshot.toXContent(builder, ToXContent.EMPTY_PARAMS);
+            builder.endObject();
+            actual = Strings.toString(builder);
+        }
+        String expectedXContent = "{\"version\":\"1\",\"name\":\"test-snapshot\",\"index_version\":1,\"start_time\":123,\"time\":123,"
+            + "\"number_of_files\":5,\"total_size\":5,\"index_uuid\":\"syzhajds-ashdlfj\",\"remote_store_repository\":"
+            + "\"test-rs-repository\",\"commit_generation\":5,\"primary_term\":3,\"remote_store_repository_base_path\":"
+            + "\"test-repo-basepath\",\"file_names\":[\"file1\",\"file2\",\"file3\",\"file4\",\"file5\"]}";
+        assert Objects.equals(actual, expectedXContent) : "xContent is " + actual;
+    }
+
+    public void testFromXContent() throws IOException {
+        String snapshot = "test-snapshot";
+        long indexVersion = 1;
+        long primaryTerm = 3;
+        long commitGeneration = 5;
+        long startTime = 123;
+        long time = 123;
+        int totalFileCount = 5;
+        long totalSize = 5;
+        String indexUUID = "syzhajds-ashdlfj";
+        String remoteStoreRepository = "test-rs-repository";
+        String repositoryBasePath = "test-repo-basepath";
+        List<String> fileNames = new ArrayList<>(5);
+        fileNames.addAll(Arrays.asList("file1", "file2", "file3", "file4", "file5"));
+        RemoteStoreShardShallowCopySnapshot expectedShardShallowCopySnapshot = new RemoteStoreShardShallowCopySnapshot(
+            snapshot,
+            indexVersion,
+            primaryTerm,
+            commitGeneration,
+            startTime,
+            time,
+            totalFileCount,
+            totalSize,
+            indexUUID,
+            remoteStoreRepository,
+            repositoryBasePath,
+            fileNames
+        );
+        String xContent = "{\"version\":\"1\",\"name\":\"test-snapshot\",\"index_version\":1,\"start_time\":123,\"time\":123,"
+            + "\"number_of_files\":5,\"total_size\":5,\"index_uuid\":\"syzhajds-ashdlfj\",\"remote_store_repository\":"
+            + "\"test-rs-repository\",\"commit_generation\":5,\"primary_term\":3,\"remote_store_repository_base_path\":"
+            + "\"test-repo-basepath\",\"file_names\":[\"file1\",\"file2\",\"file3\",\"file4\",\"file5\"]}";
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, xContent)) {
+            RemoteStoreShardShallowCopySnapshot actualShardShallowCopySnapshot = RemoteStoreShardShallowCopySnapshot.fromXContent(parser);
+            assertEquals(actualShardShallowCopySnapshot.snapshot(), expectedShardShallowCopySnapshot.snapshot());
+            assertEquals(
+                actualShardShallowCopySnapshot.getRemoteStoreRepository(),
+                expectedShardShallowCopySnapshot.getRemoteStoreRepository()
+            );
+            assertEquals(actualShardShallowCopySnapshot.getCommitGeneration(), expectedShardShallowCopySnapshot.getCommitGeneration());
+            assertEquals(actualShardShallowCopySnapshot.getPrimaryTerm(), expectedShardShallowCopySnapshot.getPrimaryTerm());
+            assertEquals(actualShardShallowCopySnapshot.startTime(), expectedShardShallowCopySnapshot.startTime());
+            assertEquals(actualShardShallowCopySnapshot.time(), expectedShardShallowCopySnapshot.time());
+            assertEquals(actualShardShallowCopySnapshot.totalSize(), expectedShardShallowCopySnapshot.totalSize());
+            assertEquals(actualShardShallowCopySnapshot.totalFileCount(), expectedShardShallowCopySnapshot.totalFileCount());
+        }
+    }
+
+    public void testFromXContentInvalid() throws IOException {
+        final int iters = scaledRandomIntBetween(1, 10);
+        for (int iter = 0; iter < iters; iter++) {
+            String snapshot = "test-snapshot";
+            long indexVersion = 1;
+            long primaryTerm = 3;
+            long commitGeneration = 5;
+            long startTime = 123;
+            long time = 123;
+            int totalFileCount = 5;
+            long totalSize = 5;
+            String indexUUID = "syzhajds-ashdlfj";
+            String remoteStoreRepository = "test-rs-repository";
+            String repositoryBasePath = "test-repo-basepath";
+            List<String> fileNames = new ArrayList<>(5);
+            fileNames.addAll(Arrays.asList("file1", "file2", "file3", "file4", "file5"));
+            String failure = null;
+            String version = RemoteStoreShardShallowCopySnapshot.DEFAULT_VERSION;
+            long length = Math.max(0, Math.abs(randomLong()));
+            // random corruption
+            switch (randomIntBetween(0, 8)) {
+                case 0:
+                    snapshot = null;
+                    failure = "Invalid/Missing Snapshot Name";
+                    break;
+                case 1:
+                    indexVersion = -Math.abs(randomLong());
+                    failure = "Invalid Index Version";
+                    break;
+                case 2:
+                    commitGeneration = -Math.abs(randomLong());
+                    failure = "Invalid Commit Generation";
+                    break;
+                case 3:
+                    primaryTerm = -Math.abs(randomLong());
+                    failure = "Invalid Primary Term";
+                    break;
+                case 4:
+                    indexUUID = null;
+                    failure = "Invalid/Missing Index UUID";
+                    break;
+                case 5:
+                    remoteStoreRepository = null;
+                    failure = "Invalid/Missing Remote Store Repository";
+                    break;
+                case 6:
+                    repositoryBasePath = null;
+                    failure = "Invalid/Missing Repository Base Path";
+                    break;
+                case 7:
+                    version = null;
+                    failure = "Invalid Version Provided";
+                    break;
+                case 8:
+                    break;
+                default:
+                    fail("shouldn't be here");
+            }
+
+            XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
+            builder.startObject();
+            builder.field(RemoteStoreShardShallowCopySnapshot.VERSION, version);
+            builder.field(RemoteStoreShardShallowCopySnapshot.NAME, snapshot);
+            builder.field(RemoteStoreShardShallowCopySnapshot.INDEX_VERSION, indexVersion);
+            builder.field(RemoteStoreShardShallowCopySnapshot.START_TIME, startTime);
+            builder.field(RemoteStoreShardShallowCopySnapshot.TIME, time);
+            builder.field(RemoteStoreShardShallowCopySnapshot.TOTAL_FILE_COUNT, totalFileCount);
+            builder.field(RemoteStoreShardShallowCopySnapshot.TOTAL_SIZE, totalSize);
+            builder.field(RemoteStoreShardShallowCopySnapshot.INDEX_UUID, indexUUID);
+            builder.field(RemoteStoreShardShallowCopySnapshot.REMOTE_STORE_REPOSITORY, remoteStoreRepository);
+            builder.field(RemoteStoreShardShallowCopySnapshot.COMMIT_GENERATION, commitGeneration);
+            builder.field(RemoteStoreShardShallowCopySnapshot.PRIMARY_TERM, primaryTerm);
+            builder.field(RemoteStoreShardShallowCopySnapshot.REPOSITORY_BASE_PATH, repositoryBasePath);
+            builder.startArray(RemoteStoreShardShallowCopySnapshot.FILE_NAMES);
+            for (String fileName : fileNames) {
+                builder.value(fileName);
+            }
+            builder.endArray();
+            builder.endObject();
+            byte[] xContent = BytesReference.toBytes(BytesReference.bytes(builder));
+
+            if (failure == null) {
+                // No failures should read as usual
+                final RemoteStoreShardShallowCopySnapshot remoteStoreShardShallowCopySnapshot;
+                try (XContentParser parser = createParser(JsonXContent.jsonXContent, xContent)) {
+                    parser.nextToken();
+                    remoteStoreShardShallowCopySnapshot = RemoteStoreShardShallowCopySnapshot.fromXContent(parser);
+                }
+                assertEquals(remoteStoreShardShallowCopySnapshot.snapshot(), snapshot);
+                assertEquals(remoteStoreShardShallowCopySnapshot.getRemoteStoreRepository(), remoteStoreRepository);
+                assertEquals(remoteStoreShardShallowCopySnapshot.getCommitGeneration(), commitGeneration);
+                assertEquals(remoteStoreShardShallowCopySnapshot.getPrimaryTerm(), primaryTerm);
+                assertEquals(remoteStoreShardShallowCopySnapshot.startTime(), startTime);
+                assertEquals(remoteStoreShardShallowCopySnapshot.time(), time);
+                assertEquals(remoteStoreShardShallowCopySnapshot.totalSize(), totalSize);
+                assertEquals(remoteStoreShardShallowCopySnapshot.totalFileCount(), totalFileCount);
+            } else {
+                try (XContentParser parser = createParser(JsonXContent.jsonXContent, xContent)) {
+                    parser.nextToken();
+                    RemoteStoreShardShallowCopySnapshot.fromXContent(parser);
+                    fail("Should have failed with [" + failure + "]");
+                } catch (IllegalArgumentException ex) {
+                    assertThat(ex.getMessage(), containsString(failure));
+                }
+            }
+        }
+    }
+}

--- a/server/src/test/java/org/opensearch/repositories/RepositoriesServiceTests.java
+++ b/server/src/test/java/org/opensearch/repositories/RepositoriesServiceTests.java
@@ -321,6 +321,21 @@ public class RepositoriesServiceTests extends OpenSearchTestCase {
         }
 
         @Override
+        public void snapshotRemoteStoreIndexShard(
+            Store store,
+            SnapshotId snapshotId,
+            IndexId indexId,
+            IndexCommit snapshotIndexCommit,
+            String shardStateIdentifier,
+            IndexShardSnapshotStatus snapshotStatus,
+            long primaryTerm,
+            long startTime,
+            ActionListener<String> listener
+        ) {
+
+        }
+
+        @Override
         public void restoreShard(
             Store store,
             SnapshotId snapshotId,

--- a/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryRestoreTests.java
+++ b/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryRestoreTests.java
@@ -212,7 +212,8 @@ public class BlobStoreRepositoryRestoreTests extends IndexShardTestCase {
                         6,
                         Collections.emptyList(),
                         true,
-                        Collections.emptyMap()
+                        Collections.emptyMap(),
+                        false
                     ),
                     Version.CURRENT,
                     Function.identity(),

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotInfoTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotInfoTests.java
@@ -73,6 +73,8 @@ public class SnapshotInfoTests extends AbstractWireSerializingTestCase<SnapshotI
 
         Map<String, Object> userMetadata = randomUserMetadata();
 
+        Boolean remoteStoreIndexShallowCopy = randomBoolean() ? null : randomBoolean();
+
         return new SnapshotInfo(
             snapshotId,
             indices,
@@ -83,7 +85,8 @@ public class SnapshotInfoTests extends AbstractWireSerializingTestCase<SnapshotI
             totalShards,
             shardFailures,
             includeGlobalState,
-            userMetadata
+            userMetadata,
+            remoteStoreIndexShallowCopy
         );
     }
 
@@ -94,7 +97,7 @@ public class SnapshotInfoTests extends AbstractWireSerializingTestCase<SnapshotI
 
     @Override
     protected SnapshotInfo mutateInstance(SnapshotInfo instance) {
-        switch (randomIntBetween(0, 8)) {
+        switch (randomIntBetween(0, 9)) {
             case 0:
                 SnapshotId snapshotId = new SnapshotId(
                     randomValueOtherThan(instance.snapshotId().getName(), () -> randomAlphaOfLength(5)),
@@ -110,7 +113,8 @@ public class SnapshotInfoTests extends AbstractWireSerializingTestCase<SnapshotI
                     instance.totalShards(),
                     instance.shardFailures(),
                     instance.includeGlobalState(),
-                    instance.userMetadata()
+                    instance.userMetadata(),
+                    instance.isRemoteStoreIndexShallowCopyEnabled()
                 );
             case 1:
                 int indicesSize = randomValueOtherThan(instance.indices().size(), () -> randomIntBetween(1, 10));
@@ -127,7 +131,8 @@ public class SnapshotInfoTests extends AbstractWireSerializingTestCase<SnapshotI
                     instance.totalShards(),
                     instance.shardFailures(),
                     instance.includeGlobalState(),
-                    instance.userMetadata()
+                    instance.userMetadata(),
+                    instance.isRemoteStoreIndexShallowCopyEnabled()
                 );
             case 2:
                 return new SnapshotInfo(
@@ -140,7 +145,8 @@ public class SnapshotInfoTests extends AbstractWireSerializingTestCase<SnapshotI
                     instance.totalShards(),
                     instance.shardFailures(),
                     instance.includeGlobalState(),
-                    instance.userMetadata()
+                    instance.userMetadata(),
+                    instance.isRemoteStoreIndexShallowCopyEnabled()
                 );
             case 3:
                 return new SnapshotInfo(
@@ -153,7 +159,8 @@ public class SnapshotInfoTests extends AbstractWireSerializingTestCase<SnapshotI
                     instance.totalShards(),
                     instance.shardFailures(),
                     instance.includeGlobalState(),
-                    instance.userMetadata()
+                    instance.userMetadata(),
+                    instance.isRemoteStoreIndexShallowCopyEnabled()
                 );
             case 4:
                 return new SnapshotInfo(
@@ -166,7 +173,8 @@ public class SnapshotInfoTests extends AbstractWireSerializingTestCase<SnapshotI
                     instance.totalShards(),
                     instance.shardFailures(),
                     instance.includeGlobalState(),
-                    instance.userMetadata()
+                    instance.userMetadata(),
+                    instance.isRemoteStoreIndexShallowCopyEnabled()
                 );
             case 5:
                 int totalShards = randomValueOtherThan(instance.totalShards(), () -> randomIntBetween(0, 100));
@@ -191,7 +199,8 @@ public class SnapshotInfoTests extends AbstractWireSerializingTestCase<SnapshotI
                     totalShards,
                     shardFailures,
                     instance.includeGlobalState(),
-                    instance.userMetadata()
+                    instance.userMetadata(),
+                    instance.isRemoteStoreIndexShallowCopyEnabled()
                 );
             case 6:
                 return new SnapshotInfo(
@@ -204,7 +213,8 @@ public class SnapshotInfoTests extends AbstractWireSerializingTestCase<SnapshotI
                     instance.totalShards(),
                     instance.shardFailures(),
                     Boolean.FALSE.equals(instance.includeGlobalState()),
-                    instance.userMetadata()
+                    instance.userMetadata(),
+                    instance.isRemoteStoreIndexShallowCopyEnabled()
                 );
             case 7:
                 return new SnapshotInfo(
@@ -217,7 +227,8 @@ public class SnapshotInfoTests extends AbstractWireSerializingTestCase<SnapshotI
                     instance.totalShards(),
                     instance.shardFailures(),
                     instance.includeGlobalState(),
-                    randomValueOtherThan(instance.userMetadata(), SnapshotInfoTests::randomUserMetadata)
+                    randomValueOtherThan(instance.userMetadata(), SnapshotInfoTests::randomUserMetadata),
+                    instance.isRemoteStoreIndexShallowCopyEnabled()
                 );
             case 8:
                 List<String> dataStreams = randomValueOtherThan(
@@ -234,7 +245,22 @@ public class SnapshotInfoTests extends AbstractWireSerializingTestCase<SnapshotI
                     instance.totalShards(),
                     instance.shardFailures(),
                     instance.includeGlobalState(),
-                    instance.userMetadata()
+                    instance.userMetadata(),
+                    instance.isRemoteStoreIndexShallowCopyEnabled()
+                );
+            case 9:
+                return new SnapshotInfo(
+                    instance.snapshotId(),
+                    instance.indices(),
+                    instance.dataStreams(),
+                    instance.startTime(),
+                    instance.reason(),
+                    instance.endTime(),
+                    instance.totalShards(),
+                    instance.shardFailures(),
+                    instance.includeGlobalState(),
+                    instance.userMetadata(),
+                    Boolean.FALSE.equals(instance.isRemoteStoreIndexShallowCopyEnabled())
                 );
             default:
                 throw new IllegalArgumentException("invalid randomization case");

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotsInProgressSerializationTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotsInProgressSerializationTests.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.snapshots;
 
+import org.opensearch.Version;
 import org.opensearch.cluster.ClusterModule;
 import org.opensearch.cluster.ClusterState.Custom;
 import org.opensearch.cluster.Diff;
@@ -40,7 +41,10 @@ import org.opensearch.cluster.SnapshotsInProgress.Entry;
 import org.opensearch.cluster.SnapshotsInProgress.ShardState;
 import org.opensearch.cluster.SnapshotsInProgress.State;
 import org.opensearch.common.collect.ImmutableOpenMap;
+import org.opensearch.common.UUIDs;
+import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.index.Index;
 import org.opensearch.index.shard.ShardId;
@@ -48,10 +52,14 @@ import org.opensearch.repositories.IndexId;
 import org.opensearch.test.AbstractDiffableWireSerializationTestCase;
 import org.opensearch.test.VersionUtils;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Collections;
 import java.util.stream.Collectors;
+
+import static org.opensearch.test.VersionUtils.randomVersion;
 
 public class SnapshotsInProgressSerializationTests extends AbstractDiffableWireSerializationTestCase<Custom> {
 
@@ -69,6 +77,7 @@ public class SnapshotsInProgressSerializationTests extends AbstractDiffableWireS
         Snapshot snapshot = new Snapshot(randomAlphaOfLength(10), new SnapshotId(randomAlphaOfLength(10), randomAlphaOfLength(10)));
         boolean includeGlobalState = randomBoolean();
         boolean partial = randomBoolean();
+        boolean remoteStoreIndexShallowCopy = randomBoolean();
         int numberOfIndices = randomIntBetween(0, 10);
         List<IndexId> indices = new ArrayList<>();
         for (int i = 0; i < numberOfIndices; i++) {
@@ -113,7 +122,8 @@ public class SnapshotsInProgressSerializationTests extends AbstractDiffableWireS
             shards,
             null,
             SnapshotInfoTests.randomUserMetadata(),
-            VersionUtils.randomVersion(random())
+            VersionUtils.randomVersion(random()),
+            remoteStoreIndexShallowCopy
         );
     }
 
@@ -172,9 +182,67 @@ public class SnapshotsInProgressSerializationTests extends AbstractDiffableWireS
         return SnapshotsInProgress.of(entries);
     }
 
+    public void testSerDeRemoteStoreIndexShallowCopy() throws IOException {
+        SnapshotsInProgress.Entry entry = new SnapshotsInProgress.Entry(
+            new Snapshot(randomName("repo"), new SnapshotId(randomName("snap"), UUIDs.randomBase64UUID())),
+            randomBoolean(),
+            randomBoolean(),
+            SnapshotsInProgressSerializationTests.randomState(ImmutableOpenMap.of()),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Math.abs(randomLong()),
+            randomIntBetween(0, 1000),
+            ImmutableOpenMap.of(),
+            null,
+            SnapshotInfoTests.randomUserMetadata(),
+            randomVersion(random()),
+            true
+        );
+        final List<SnapshotsInProgress.Entry> newEntries = new ArrayList<>();
+        newEntries.add(entry);
+        SnapshotsInProgress snapshotsInProgress = SnapshotsInProgress.of(newEntries);
+
+        SnapshotsInProgress actualSnapshotsInProgress;
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            snapshotsInProgress.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                in.setVersion(Version.V_2_7_0);
+                actualSnapshotsInProgress = new SnapshotsInProgress(in);
+                assert in.available() != 0;
+                for (Entry curr_entry : actualSnapshotsInProgress.entries()) {
+                    assert (curr_entry.remoteStoreIndexShallowCopy() == false);
+                }
+            }
+            try (StreamInput in = out.bytes().streamInput()) {
+                in.setVersion(Version.V_2_9_0);
+                actualSnapshotsInProgress = new SnapshotsInProgress(in);
+                assert in.available() == 0;
+                for (Entry curr_entry : actualSnapshotsInProgress.entries()) {
+                    assert (curr_entry.remoteStoreIndexShallowCopy() == true);
+                }
+            }
+        }
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.setVersion(Version.V_2_7_0);
+            snapshotsInProgress.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                in.setVersion(Version.V_2_7_0);
+                actualSnapshotsInProgress = new SnapshotsInProgress(in);
+                assert in.available() == 0;
+                for (Entry curr_entry : actualSnapshotsInProgress.entries()) {
+                    assert (curr_entry.remoteStoreIndexShallowCopy() == false);
+                }
+            }
+        }
+    }
+
     public static State randomState(ImmutableOpenMap<ShardId, SnapshotsInProgress.ShardSnapshotStatus> shards) {
         return SnapshotsInProgress.completed(shards.values())
             ? randomFrom(State.SUCCESS, State.FAILED)
             : randomFrom(State.STARTED, State.INIT, State.ABORTED);
+    }
+
+    private String randomName(String prefix) {
+        return prefix + UUIDs.randomBase64UUID(random());
     }
 }

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotsServiceTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotsServiceTests.java
@@ -484,7 +484,8 @@ public class SnapshotsServiceTests extends OpenSearchTestCase {
             randomNonNegativeLong(),
             shards,
             Collections.emptyMap(),
-            Version.CURRENT
+            Version.CURRENT,
+            false
         );
     }
 

--- a/server/src/test/java/org/opensearch/snapshots/mockstore/MockEventuallyConsistentRepositoryTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/mockstore/MockEventuallyConsistentRepositoryTests.java
@@ -232,7 +232,8 @@ public class MockEventuallyConsistentRepositoryTests extends OpenSearchTestCase 
                     5,
                     Collections.emptyList(),
                     true,
-                    Collections.emptyMap()
+                    Collections.emptyMap(),
+                    false
                 ),
                 Version.CURRENT,
                 Function.identity(),
@@ -257,7 +258,8 @@ public class MockEventuallyConsistentRepositoryTests extends OpenSearchTestCase 
                             6,
                             Collections.emptyList(),
                             true,
-                            Collections.emptyMap()
+                            Collections.emptyMap(),
+                            false
                         ),
                         Version.CURRENT,
                         Function.identity(),
@@ -284,7 +286,8 @@ public class MockEventuallyConsistentRepositoryTests extends OpenSearchTestCase 
                         5,
                         Collections.emptyList(),
                         true,
-                        Collections.emptyMap()
+                        Collections.emptyMap(),
+                        false
                     ),
                     Version.CURRENT,
                     Function.identity(),

--- a/test/framework/src/main/java/org/opensearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -524,7 +524,8 @@ public abstract class AbstractSnapshotIntegTestCase extends OpenSearchIntegTestC
             0,
             Collections.emptyList(),
             randomBoolean(),
-            metadata
+            metadata,
+            false
         );
         PlainActionFuture.<RepositoryData, Exception>get(
             f -> repo.finalizeSnapshot(


### PR DESCRIPTION
… for remote store interoperability.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This is a Backport request for Change #7118 . 
To Avoid BWC test failures in main branch, kept version checks against `Version.V_3_0_0`.  
now as part of this PR, backporting changes to `2.x` branch and adding changes to keep version checks against desired version (`Version.V_2_9_0`).

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
