### PR TITLE
[Remote Segment Store] Add Lucene major version to UploadedSegmentMetadata

### DIFF
--- a/server/src/main/java/org/opensearch/index/remote/RemoteStoreUtils.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStoreUtils.java
@@ -53,6 +53,12 @@ public class RemoteStoreUtils {
         return Long.MAX_VALUE - num;
     }
 
+    /**
+     * Extracts the Lucene major version from the provided DocValuesUpdates file name
+     * @param filename DocValuesUpdates file name to parse
+     * @return Lucene major version that wrote the DocValuesUpdates file
+     * @throws CorruptIndexException If the Lucene major version cannot be inferred
+     */
     public static int getLuceneVersionForDocValuesUpdates(String filename) throws CorruptIndexException {
         // TODO: The following regex could work incorrectly if both major and minor versions are double-digits.
         // This is because the major and minor versions do not have a separator in the filename currently

--- a/server/src/main/java/org/opensearch/index/remote/RemoteStoreUtils.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStoreUtils.java
@@ -8,11 +8,7 @@
 
 package org.opensearch.index.remote;
 
-import org.apache.lucene.index.CorruptIndexException;
-
 import java.util.Arrays;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Utils for remote store
@@ -54,23 +50,23 @@ public class RemoteStoreUtils {
     }
 
     /**
-     * Extracts the Lucene major version from the provided DocValuesUpdates file name
-     * @param filename DocValuesUpdates file name to parse
-     * @return Lucene major version that wrote the DocValuesUpdates file
-     * @throws CorruptIndexException If the Lucene major version cannot be inferred
+     * Extracts the segment name from the provided segment file name
+     * @param filename Segment file name to parse
+     * @return Name of the segment that the segment file belongs to
      */
-    public static int getLuceneVersionForDocValuesUpdates(String filename) throws CorruptIndexException {
-        // TODO: The following regex could work incorrectly if both major and minor versions are double-digits.
-        // This is because the major and minor versions do not have a separator in the filename currently
-        // (Lucence<major><minor>).
-        // We may need to revisit this if the filename pattern is updated in future Lucene versions.
-        Pattern docValuesUpdatesFileNamePattern = Pattern.compile("_\\d+_\\d+_Lucene(\\d+)\\d+_\\d+");
-
-        Matcher matcher = docValuesUpdatesFileNamePattern.matcher(filename);
-        if (matcher.find()) {
-            return Integer.parseInt(matcher.group(1));
-        } else {
-            throw new CorruptIndexException("Unable to infer Lucene version for segment file " + filename, filename);
+    public static String getSegmentName(String filename) {
+        // Segment file names follow patterns like "_0.cfe" or "_0_1_Lucene90_0.dvm".
+        // Here, the segment name is "_0", which is the set of characters
+        // starting with "_" until the next "_" or first ".".
+        int endIdx = filename.indexOf('_', 1);
+        if (endIdx == -1) {
+            endIdx = filename.indexOf('.');
         }
+
+        if (endIdx == -1) {
+            throw new IllegalArgumentException("Unable to infer segment name for segment file " + filename);
+        }
+
+        return filename.substring(0, endIdx);
     }
 }

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -619,20 +619,20 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
                         }
                     }
 
-                Map<String, String> uploadedSegments = new HashMap<>();
-                for (String file : segmentFiles) {
-                    if (segmentsUploadedToRemoteStore.containsKey(file)) {
-                        UploadedSegmentMetadata metadata = segmentsUploadedToRemoteStore.get(file);
-                        if (segmentToLuceneVersion.containsKey(metadata.originalFilename)) {
-                            metadata.setWrittenBy(segmentToLuceneVersion.get(metadata.originalFilename));
-                        } else if (metadata.originalFilename.equals(segmentInfosSnapshot.getSegmentsFileName())) {
-                            metadata.setWrittenBy(segmentInfosSnapshot.getCommitLuceneVersion());
-                        } else {
-                            throw new CorruptIndexException(
-                                "Lucene version is missing for segment file " + metadata.originalFilename,
-                                metadata.originalFilename
-                            );
-                        }
+                    Map<String, String> uploadedSegments = new HashMap<>();
+                    for (String file : segmentFiles) {
+                        if (segmentsUploadedToRemoteStore.containsKey(file)) {
+                            UploadedSegmentMetadata metadata = segmentsUploadedToRemoteStore.get(file);
+                            if (segmentToLuceneVersion.containsKey(metadata.originalFilename)) {
+                                metadata.setWrittenBy(segmentToLuceneVersion.get(metadata.originalFilename));
+                            } else if (metadata.originalFilename.equals(segmentInfosSnapshot.getSegmentsFileName())) {
+                                metadata.setWrittenBy(segmentInfosSnapshot.getCommitLuceneVersion());
+                            } else {
+                                throw new CorruptIndexException(
+                                    "Lucene version is missing for segment file " + metadata.originalFilename,
+                                    metadata.originalFilename
+                                );
+                            }
 
                             uploadedSegments.put(file, metadata.toString());
                         } else {

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -250,9 +250,7 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
         public static UploadedSegmentMetadata fromString(String uploadedFilename) {
             String[] values = uploadedFilename.split(SEPARATOR);
             UploadedSegmentMetadata metadata = new UploadedSegmentMetadata(values[0], values[1], values[2], Long.parseLong(values[3]));
-            if (values.length == 5) {
-                metadata.setWrittenBy(values[4]);
-            }
+            metadata.setWrittenBy(values[4]);
 
             return metadata;
         }

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStoreUtilsTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStoreUtilsTests.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.index.remote;
 
+import org.apache.lucene.index.CorruptIndexException;
 import org.opensearch.test.OpenSearchTestCase;
 
 public class RemoteStoreUtilsTests extends OpenSearchTestCase {
@@ -37,5 +38,13 @@ public class RemoteStoreUtilsTests extends OpenSearchTestCase {
             long num = randomLongBetween(1, Long.MAX_VALUE);
             assertEquals(num, RemoteStoreUtils.invertLong(RemoteStoreUtils.invertLong(num)));
         }
+    }
+
+    public void testGetLuceneVersionForDocValuesUpdates() throws CorruptIndexException {
+        assertEquals(9, RemoteStoreUtils.getLuceneVersionForDocValuesUpdates("_0_1_Lucene90_0.dvm"));
+    }
+
+    public void testGetLuceneVersionForDocValuesUpdatesException() {
+        assertThrows(CorruptIndexException.class, () -> RemoteStoreUtils.getLuceneVersionForDocValuesUpdates("_0_1_Asserting_0.dvm"));
     }
 }

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStoreUtilsTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStoreUtilsTests.java
@@ -8,7 +8,6 @@
 
 package org.opensearch.index.remote;
 
-import org.apache.lucene.index.CorruptIndexException;
 import org.opensearch.test.OpenSearchTestCase;
 
 public class RemoteStoreUtilsTests extends OpenSearchTestCase {
@@ -40,11 +39,25 @@ public class RemoteStoreUtilsTests extends OpenSearchTestCase {
         }
     }
 
-    public void testGetLuceneVersionForDocValuesUpdates() throws CorruptIndexException {
-        assertEquals(9, RemoteStoreUtils.getLuceneVersionForDocValuesUpdates("_0_1_Lucene90_0.dvm"));
+    public void testGetSegmentNameForCfeFile() {
+        assertEquals("_foo", RemoteStoreUtils.getSegmentName("_foo.cfe"));
     }
 
-    public void testGetLuceneVersionForDocValuesUpdatesException() {
-        assertThrows(CorruptIndexException.class, () -> RemoteStoreUtils.getLuceneVersionForDocValuesUpdates("_0_1_Asserting_0.dvm"));
+    public void testGetSegmentNameForDvmFile() {
+        assertEquals("_bar", RemoteStoreUtils.getSegmentName("_bar_1_Lucene90_0.dvm"));
+    }
+
+    public void testGetSegmentNameWeirdSegmentNameOnlyUnderscore() {
+        // Validate behaviour when segment name contains delimiters only
+        assertEquals("_", RemoteStoreUtils.getSegmentName("_.dvm"));
+    }
+
+    public void testGetSegmentNameUnderscoreDelimiterOverrides() {
+        // Validate behaviour when segment name contains delimiters only
+        assertEquals("_", RemoteStoreUtils.getSegmentName("___.dvm"));
+    }
+
+    public void testGetSegmentNameException() {
+        assertThrows(IllegalArgumentException.class, () -> RemoteStoreUtils.getSegmentName("dvd"));
     }
 }

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -725,8 +725,8 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         ).thenReturn(metadataFiles);
 
         Map<String, String> metadata = new HashMap<>();
-        metadata.put("_0.cfe", "_0.cfe::_0.cfe__" + UUIDs.base64UUID() + "::1234");
-        metadata.put("_0.cfs", "_0.cfs::_0.cfs__" + UUIDs.base64UUID() + "::2345");
+        metadata.put("_0.cfe", "_0.cfe::_0.cfe__" + UUIDs.base64UUID() + "::1234::" + Version.LATEST);
+        metadata.put("_0.cfs", "_0.cfs::_0.cfs__" + UUIDs.base64UUID() + "::2345::" + Version.LATEST);
 
         BytesStreamOutput output = new BytesStreamOutput();
         OutputStreamIndexOutput indexOutput = new OutputStreamIndexOutput("segment metadata", "metadata output stream", output, 4096);
@@ -748,8 +748,8 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         ).thenReturn(metadataFiles);
 
         Map<String, String> metadata = new HashMap<>();
-        metadata.put("_0.cfe", "_0.cfe::_0.cfe__" + UUIDs.base64UUID() + "::1234");
-        metadata.put("_0.cfs", "_0.cfs::_0.cfs__" + UUIDs.base64UUID() + "::2345");
+        metadata.put("_0.cfe", "_0.cfe::_0.cfe__" + UUIDs.base64UUID() + "::1234::" + Version.LATEST);
+        metadata.put("_0.cfs", "_0.cfs::_0.cfs__" + UUIDs.base64UUID() + "::2345::" + Version.LATEST);
 
         BytesStreamOutput output = new BytesStreamOutput();
         OutputStreamIndexOutput indexOutput = new OutputStreamIndexOutput("segment metadata", "metadata output stream", output, 4096);
@@ -773,8 +773,8 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         ).thenReturn(metadataFiles);
 
         Map<String, String> metadata = new HashMap<>();
-        metadata.put("_0.cfe", "_0.cfe::_0.cfe__" + UUIDs.base64UUID() + "::1234");
-        metadata.put("_0.cfs", "_0.cfs::_0.cfs__" + UUIDs.base64UUID() + "::2345");
+        metadata.put("_0.cfe", "_0.cfe::_0.cfe__" + UUIDs.base64UUID() + "::1234::" + Version.LATEST);
+        metadata.put("_0.cfs", "_0.cfs::_0.cfs__" + UUIDs.base64UUID() + "::2345::" + Version.LATEST);
 
         BytesStreamOutput output = new BytesStreamOutput();
         OutputStreamIndexOutput indexOutput = new OutputStreamIndexOutput("segment metadata", "metadata output stream", output, 4096);
@@ -798,8 +798,8 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         ).thenReturn(metadataFiles);
 
         Map<String, String> metadata = new HashMap<>();
-        metadata.put("_0.cfe", "_0.cfe::_0.cfe__" + UUIDs.base64UUID() + "::1234");
-        metadata.put("_0.cfs", "_0.cfs::_0.cfs__" + UUIDs.base64UUID() + "::2345");
+        metadata.put("_0.cfe", "_0.cfe::_0.cfe__" + UUIDs.base64UUID() + "::1234::" + Version.LATEST);
+        metadata.put("_0.cfs", "_0.cfs::_0.cfs__" + UUIDs.base64UUID() + "::2345::" + Version.LATEST);
 
         BytesStreamOutput output = new BytesStreamOutput();
         OutputStreamIndexOutput indexOutput = new OutputStreamIndexOutput("segment metadata", "metadata output stream", output, 4096);
@@ -823,8 +823,8 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         ).thenReturn(metadataFiles);
 
         Map<String, String> metadata = new HashMap<>();
-        metadata.put("_0.cfe", "_0.cfe::_0.cfe__" + UUIDs.base64UUID() + "::1234::512");
-        metadata.put("_0.cfs", "_0.cfs::_0.cfs__" + UUIDs.base64UUID() + "::2345::1024");
+        metadata.put("_0.cfe", "_0.cfe::_0.cfe__" + UUIDs.base64UUID() + "::1234::512::" + Version.LATEST);
+        metadata.put("_0.cfs", "_0.cfs::_0.cfs__" + UUIDs.base64UUID() + "::2345::1024::" + Version.LATEST);
 
         BytesStreamOutput output = new BytesStreamOutput();
         IndexOutput indexOutput = new OutputStreamIndexOutput("segment metadata", "metadata output stream", output, 4096);

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -125,8 +125,28 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
             "123456",
             1234
         );
-        metadata.setWrittenBy(Version.LATEST);
+        metadata.setWrittenByMajor(Version.LATEST.major);
         assertEquals("abc::pqr::123456::1234::" + Version.LATEST, metadata.toString());
+    }
+
+    public void testUploadedSegmentMetadataToStringExceptionTooNew() {
+        RemoteSegmentStoreDirectory.UploadedSegmentMetadata metadata = new RemoteSegmentStoreDirectory.UploadedSegmentMetadata(
+            "abc",
+            "pqr",
+            "123456",
+            1234
+        );
+        assertThrows(IllegalArgumentException.class, () -> metadata.setWrittenByMajor(Version.LATEST.major + 1));
+    }
+
+    public void testUploadedSegmentMetadataToStringExceptionTooOld() {
+        RemoteSegmentStoreDirectory.UploadedSegmentMetadata metadata = new RemoteSegmentStoreDirectory.UploadedSegmentMetadata(
+            "abc",
+            "pqr",
+            "123456",
+            1234
+        );
+        assertThrows(IllegalArgumentException.class, () -> metadata.setWrittenByMajor(Version.LATEST.major - 2));
     }
 
     public void testUploadedSegmentMetadataFromString() {

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -21,6 +21,7 @@ import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.OutputStreamIndexOutput;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.Version;
 import org.junit.After;
 import org.junit.Before;
 import org.mockito.Mockito;
@@ -124,14 +125,22 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
             "123456",
             1234
         );
-        assertEquals("abc::pqr::123456::1234", metadata.toString());
+        metadata.setWrittenBy(Version.LATEST);
+        assertEquals("abc::pqr::123456::1234::" + Version.LATEST, metadata.toString());
     }
 
     public void testUploadedSegmentMetadataFromString() {
         RemoteSegmentStoreDirectory.UploadedSegmentMetadata metadata = RemoteSegmentStoreDirectory.UploadedSegmentMetadata.fromString(
-            "_0.cfe::_0.cfe__uuidxyz::4567::372000"
+            "_0.cfe::_0.cfe__uuidxyz::4567::372000::" + Version.LATEST
         );
-        assertEquals("_0.cfe::_0.cfe__uuidxyz::4567::372000", metadata.toString());
+        assertEquals("_0.cfe::_0.cfe__uuidxyz::4567::372000::" + Version.LATEST, metadata.toString());
+    }
+
+    public void testUploadedSegmentMetadataFromStringException() {
+        assertThrows(
+            ArrayIndexOutOfBoundsException.class,
+            () -> RemoteSegmentStoreDirectory.UploadedSegmentMetadata.fromString("_0.cfe::_0.cfe__uuidxyz::4567::372000")
+        );
     }
 
     public void testGetPrimaryTermGenerationUuid() {
@@ -176,6 +185,12 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
                 + randomIntBetween(1000, 5000)
                 + "::"
                 + randomIntBetween(512000, 1024000)
+                + "::"
+                + Version.MIN_SUPPORTED_MAJOR
+                + "."
+                + "0"
+                + "."
+                + "0"
         );
         metadata.put(
             prefix + ".cfs",
@@ -188,6 +203,12 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
                 + randomIntBetween(1000, 5000)
                 + "::"
                 + randomIntBetween(512000, 1024000)
+                + "::"
+                + Version.MIN_SUPPORTED_MAJOR
+                + "."
+                + "0"
+                + "."
+                + "0"
         );
         metadata.put(
             prefix + ".si",
@@ -200,6 +221,8 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
                 + randomIntBetween(1000, 5000)
                 + "::"
                 + randomIntBetween(512000, 1024000)
+                + "::"
+                + Version.LATEST
         );
         metadata.put(
             "segments_" + commitGeneration,
@@ -213,6 +236,8 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
                 + randomIntBetween(1000, 5000)
                 + "::"
                 + randomIntBetween(1024, 5120)
+                + "::"
+                + Version.LATEST
         );
         return metadata;
     }
@@ -611,8 +636,8 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         ).thenReturn(metadataFiles);
 
         Map<String, String> metadata = new HashMap<>();
-        metadata.put("_0.cfe", "_0.cfe::_0.cfe__" + UUIDs.base64UUID() + "::1234::512");
-        metadata.put("_0.cfs", "_0.cfs::_0.cfs__" + UUIDs.base64UUID() + "::2345::1024");
+        metadata.put("_0.cfe", "_0.cfe::_0.cfe__" + UUIDs.base64UUID() + "::1234::512::" + Version.LATEST);
+        metadata.put("_0.cfs", "_0.cfs::_0.cfs__" + UUIDs.base64UUID() + "::2345::1024::" + Version.LATEST);
 
         when(remoteMetadataDirectory.openInput(metadataFilename, IOContext.DEFAULT)).thenReturn(createMetadataFileBytes(metadata, 1, 5));
 

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -126,7 +126,7 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
             1234
         );
         metadata.setWrittenByMajor(Version.LATEST.major);
-        assertEquals("abc::pqr::123456::1234::" + Version.LATEST, metadata.toString());
+        assertEquals("abc::pqr::123456::1234::" + Version.LATEST.major, metadata.toString());
     }
 
     public void testUploadedSegmentMetadataToStringExceptionTooNew() {
@@ -151,9 +151,9 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
 
     public void testUploadedSegmentMetadataFromString() {
         RemoteSegmentStoreDirectory.UploadedSegmentMetadata metadata = RemoteSegmentStoreDirectory.UploadedSegmentMetadata.fromString(
-            "_0.cfe::_0.cfe__uuidxyz::4567::372000::" + Version.LATEST
+            "_0.cfe::_0.cfe__uuidxyz::4567::372000::" + Version.LATEST.major
         );
-        assertEquals("_0.cfe::_0.cfe__uuidxyz::4567::372000::" + Version.LATEST, metadata.toString());
+        assertEquals("_0.cfe::_0.cfe__uuidxyz::4567::372000::" + Version.LATEST.major, metadata.toString());
     }
 
     public void testUploadedSegmentMetadataFromStringException() {
@@ -207,10 +207,6 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
                 + randomIntBetween(512000, 1024000)
                 + "::"
                 + Version.MIN_SUPPORTED_MAJOR
-                + "."
-                + "0"
-                + "."
-                + "0"
         );
         metadata.put(
             prefix + ".cfs",
@@ -225,10 +221,6 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
                 + randomIntBetween(512000, 1024000)
                 + "::"
                 + Version.MIN_SUPPORTED_MAJOR
-                + "."
-                + "0"
-                + "."
-                + "0"
         );
         metadata.put(
             prefix + ".si",
@@ -242,7 +234,7 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
                 + "::"
                 + randomIntBetween(512000, 1024000)
                 + "::"
-                + Version.LATEST
+                + Version.LATEST.major
         );
         metadata.put(
             "segments_" + commitGeneration,
@@ -257,7 +249,7 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
                 + "::"
                 + randomIntBetween(1024, 5120)
                 + "::"
-                + Version.LATEST
+                + Version.LATEST.major
         );
         return metadata;
     }
@@ -656,8 +648,8 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         ).thenReturn(metadataFiles);
 
         Map<String, String> metadata = new HashMap<>();
-        metadata.put("_0.cfe", "_0.cfe::_0.cfe__" + UUIDs.base64UUID() + "::1234::512::" + Version.LATEST);
-        metadata.put("_0.cfs", "_0.cfs::_0.cfs__" + UUIDs.base64UUID() + "::2345::1024::" + Version.LATEST);
+        metadata.put("_0.cfe", "_0.cfe::_0.cfe__" + UUIDs.base64UUID() + "::1234::512::" + Version.LATEST.major);
+        metadata.put("_0.cfs", "_0.cfs::_0.cfs__" + UUIDs.base64UUID() + "::2345::1024::" + Version.LATEST.major);
 
         when(remoteMetadataDirectory.openInput(metadataFilename, IOContext.DEFAULT)).thenReturn(createMetadataFileBytes(metadata, 1, 5));
 
@@ -770,8 +762,8 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         ).thenReturn(metadataFiles);
 
         Map<String, String> metadata = new HashMap<>();
-        metadata.put("_0.cfe", "_0.cfe::_0.cfe__" + UUIDs.base64UUID() + "::1234::" + Version.LATEST);
-        metadata.put("_0.cfs", "_0.cfs::_0.cfs__" + UUIDs.base64UUID() + "::2345::" + Version.LATEST);
+        metadata.put("_0.cfe", "_0.cfe::_0.cfe__" + UUIDs.base64UUID() + "::1234::" + Version.LATEST.major);
+        metadata.put("_0.cfs", "_0.cfs::_0.cfs__" + UUIDs.base64UUID() + "::2345::" + Version.LATEST.major);
 
         BytesStreamOutput output = new BytesStreamOutput();
         OutputStreamIndexOutput indexOutput = new OutputStreamIndexOutput("segment metadata", "metadata output stream", output, 4096);
@@ -793,8 +785,8 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         ).thenReturn(metadataFiles);
 
         Map<String, String> metadata = new HashMap<>();
-        metadata.put("_0.cfe", "_0.cfe::_0.cfe__" + UUIDs.base64UUID() + "::1234::" + Version.LATEST);
-        metadata.put("_0.cfs", "_0.cfs::_0.cfs__" + UUIDs.base64UUID() + "::2345::" + Version.LATEST);
+        metadata.put("_0.cfe", "_0.cfe::_0.cfe__" + UUIDs.base64UUID() + "::1234::" + Version.LATEST.major);
+        metadata.put("_0.cfs", "_0.cfs::_0.cfs__" + UUIDs.base64UUID() + "::2345::" + Version.LATEST.major);
 
         BytesStreamOutput output = new BytesStreamOutput();
         OutputStreamIndexOutput indexOutput = new OutputStreamIndexOutput("segment metadata", "metadata output stream", output, 4096);
@@ -818,8 +810,8 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         ).thenReturn(metadataFiles);
 
         Map<String, String> metadata = new HashMap<>();
-        metadata.put("_0.cfe", "_0.cfe::_0.cfe__" + UUIDs.base64UUID() + "::1234::" + Version.LATEST);
-        metadata.put("_0.cfs", "_0.cfs::_0.cfs__" + UUIDs.base64UUID() + "::2345::" + Version.LATEST);
+        metadata.put("_0.cfe", "_0.cfe::_0.cfe__" + UUIDs.base64UUID() + "::1234::" + Version.LATEST.major);
+        metadata.put("_0.cfs", "_0.cfs::_0.cfs__" + UUIDs.base64UUID() + "::2345::" + Version.LATEST.major);
 
         BytesStreamOutput output = new BytesStreamOutput();
         OutputStreamIndexOutput indexOutput = new OutputStreamIndexOutput("segment metadata", "metadata output stream", output, 4096);
@@ -843,8 +835,8 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         ).thenReturn(metadataFiles);
 
         Map<String, String> metadata = new HashMap<>();
-        metadata.put("_0.cfe", "_0.cfe::_0.cfe__" + UUIDs.base64UUID() + "::1234::" + Version.LATEST);
-        metadata.put("_0.cfs", "_0.cfs::_0.cfs__" + UUIDs.base64UUID() + "::2345::" + Version.LATEST);
+        metadata.put("_0.cfe", "_0.cfe::_0.cfe__" + UUIDs.base64UUID() + "::1234::" + Version.LATEST.major);
+        metadata.put("_0.cfs", "_0.cfs::_0.cfs__" + UUIDs.base64UUID() + "::2345::" + Version.LATEST.major);
 
         BytesStreamOutput output = new BytesStreamOutput();
         OutputStreamIndexOutput indexOutput = new OutputStreamIndexOutput("segment metadata", "metadata output stream", output, 4096);
@@ -868,8 +860,8 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         ).thenReturn(metadataFiles);
 
         Map<String, String> metadata = new HashMap<>();
-        metadata.put("_0.cfe", "_0.cfe::_0.cfe__" + UUIDs.base64UUID() + "::1234::512::" + Version.LATEST);
-        metadata.put("_0.cfs", "_0.cfs::_0.cfs__" + UUIDs.base64UUID() + "::2345::1024::" + Version.LATEST);
+        metadata.put("_0.cfe", "_0.cfe::_0.cfe__" + UUIDs.base64UUID() + "::1234::512::" + Version.LATEST.major);
+        metadata.put("_0.cfs", "_0.cfs::_0.cfs__" + UUIDs.base64UUID() + "::2345::1024::" + Version.LATEST.major);
 
         BytesStreamOutput output = new BytesStreamOutput();
         IndexOutput indexOutput = new OutputStreamIndexOutput("segment metadata", "metadata output stream", output, 4096);

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -734,9 +734,12 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
     public void testUploadMetadataNoSegmentCommitInfos() throws IOException {
         SegmentInfos segInfos = indexShard.store().readLastCommittedSegmentsInfo();
         int numSegCommitInfos = segInfos.size();
-        assert numSegCommitInfos == 0
-            : "For a fresh index, the number of SegmentCommitInfo instances associated with the SegmentInfos instance should be 0, but were found to be "
-                + numSegCommitInfos;
+        assertEquals(
+            "For a fresh index, the number of SegmentCommitInfo instances associated with the SegmentInfos instance should be 0, but were found to be "
+                + numSegCommitInfos,
+            0,
+            numSegCommitInfos
+        );
     }
 
     public void testNoMetadataHeaderCorruptIndexException() throws IOException {

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -678,7 +678,7 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         IndexOutput indexOutput = mock(IndexOutput.class);
         when(storeDirectory.createOutput(startsWith("metadata__12__o"), eq(IOContext.DEFAULT))).thenReturn(indexOutput);
 
-        Collection<String> segmentFiles = List.of("s1", "s2", "s3");
+        Collection<String> segmentFiles = List.of("_s1.si", "_s1.cfe", "_s3.cfs");
         assertThrows(
             NoSuchFileException.class,
             () -> remoteSegmentStoreDirectory.uploadMetadata(segmentFiles, segmentInfos, storeDirectory, 12L, 34L)

--- a/server/src/test/java/org/opensearch/index/store/remote/metadata/RemoteSegmentMetadataHandlerTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/metadata/RemoteSegmentMetadataHandlerTests.java
@@ -12,6 +12,7 @@ import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.store.ByteBuffersDataOutput;
 import org.apache.lucene.store.ByteBuffersIndexOutput;
 import org.apache.lucene.store.OutputStreamIndexOutput;
+import org.apache.lucene.util.Version;
 import org.junit.After;
 import org.junit.Before;
 import org.opensearch.cluster.metadata.IndexMetadata;
@@ -134,6 +135,8 @@ public class RemoteSegmentMetadataHandlerTests extends IndexShardTestCase {
                 + randomIntBetween(1000, 5000)
                 + "::"
                 + randomIntBetween(1024, 2048)
+                + "::"
+                + Version.LATEST
         );
         expectedOutput.put(
             prefix + ".cfs",
@@ -146,6 +149,8 @@ public class RemoteSegmentMetadataHandlerTests extends IndexShardTestCase {
                 + randomIntBetween(1000, 5000)
                 + "::"
                 + randomIntBetween(1024, 2048)
+                + "::"
+                + Version.LATEST
         );
         return expectedOutput;
     }

--- a/server/src/test/java/org/opensearch/index/store/remote/metadata/RemoteSegmentMetadataHandlerTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/metadata/RemoteSegmentMetadataHandlerTests.java
@@ -136,7 +136,7 @@ public class RemoteSegmentMetadataHandlerTests extends IndexShardTestCase {
                 + "::"
                 + randomIntBetween(1024, 2048)
                 + "::"
-                + Version.LATEST
+                + Version.LATEST.major
         );
         expectedOutput.put(
             prefix + ".cfs",
@@ -150,7 +150,7 @@ public class RemoteSegmentMetadataHandlerTests extends IndexShardTestCase {
                 + "::"
                 + randomIntBetween(1024, 2048)
                 + "::"
-                + Version.LATEST
+                + Version.LATEST.major
         );
         return expectedOutput;
     }


### PR DESCRIPTION
### Description
This PR associates the Lucene major version with each uploaded segment file metadata entry that is maintained in remote store. As part of the Lucene version compatibility check, this major version information stored in the metadata will be used to skip downloading the segment files unnecessarily if they were written by an incompatible Lucene version.

1. For the segment files that house the segment data (`.cfe`, `.cfs`, etc.), we track the Lucene major version as captured in the respective `SegmentInfo` instance.

2. For the `segment_N` files that house the information on segments, we track the Lucene major version used for the commit as captured in the respective `SegmentInfos` instance.

3. For the `_<segmentNumber>_<monotonicallyIncrementingCountOfUpdate>_Lucene<major><minor>_<bugfix>.dvm`, `_<segmentNumber>_<monotonicallyIncrementingCountOfUpdate>_Lucene<major><minor>_<bugfix>.dvd`, and `_<segmentNumber>_<monotonicallyIncrementingCountOfUpdate>.fnm` files, we track the Lucene major version available in the respective `.dvm`/`.dvd` file's name.


### Related Issues
Resolves #7722 
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
