### PR TITLE
Consume all params and content on extension Rest Request exception

### DIFF
--- a/server/src/main/java/org/opensearch/rest/extensions/RestSendToExtensionAction.java
+++ b/server/src/main/java/org/opensearch/rest/extensions/RestSendToExtensionAction.java
@@ -219,6 +219,10 @@ public class RestSendToExtensionAction extends BaseRestHandler {
             @Override
             public void handleException(TransportException exp) {
                 logger.debug("REST request failed", exp);
+                // On failure the original request params and content aren't consumed
+                // which gives misleading error messages, so we just consume them here
+                request.params().keySet().stream().forEach(p -> request.param(p));
+                request.content();
                 inProgressFuture.completeExceptionally(exp);
             }
 


### PR DESCRIPTION
### Description

`RestRequest` objects track the parameters and content, indented to provide users with more helpful error messages for incorrect API syntax.

When a Rest Request forwarded to an Extension fails, the `onResponse()` handler method never executes, and these "helpful" error messages end up giving the wrong reason for failure, hiding the actual exceptions.

This PR consumes all params and content to prevent this confusion, allowing the actual exception (often a timeout) to be sent to the user.

### Related Issues
Resolves https://github.com/opensearch-project/opensearch-sdk-java/issues/587

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
