### PR TITLE
[Backport 1.3] [Manual] Bump spock-core from 1.3-groovy-2.5 to 2.3-groovy-2.5 (#8119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Dependencies
 - Bump `netty` from 4.1.91.Final to 4.1.93.Final ([#7901](https://github.com/opensearch-project/OpenSearch/pull/7901))
+- Bump `spock-core` from 1.3-groovy-2.5 to 2.3-groovy-2.5 ([#8119](https://github.com/opensearch-project/OpenSearch/pull/8119))
 
 ### Changed
 ### Deprecated

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -125,7 +125,7 @@ dependencies {
   testFixturesApi gradleTestKit()
   testImplementation 'com.github.tomakehurst:wiremock-jre8-standalone:2.23.2'
   testImplementation "org.mockito:mockito-core:${props.getProperty('mockito')}"
-  integTestImplementation('org.spockframework:spock-core:1.3-groovy-2.5') {
+  integTestImplementation('org.spockframework:spock-core:2.3-groovy-2.5') {
     exclude module: "groovy"
   }
   constraints {


### PR DESCRIPTION
### Description
Manual backport of #8119

* Bump spock-core from 1.3-groovy-2.5 to 2.3-groovy-2.5

This patches CVE-2020-15250

Signed-off-by: Kartik Ganesh <gkart@amazon.com>

* Added CHANGELOG

Signed-off-by: Kartik Ganesh <gkart@amazon.com>

---------

Signed-off-by: Kartik Ganesh <gkart@amazon.com>
(cherry picked from commit 70aa15b7756bf61d2330725b962d9b3f75103a88)


### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
