### PR TITLE
Fix SegmentReplication flaky integ tests 

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -97,7 +97,7 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertSearchHits
 public class SegmentReplicationIT extends SegmentReplicationBaseIT {
 
     @Before
-    public void setup() {
+    private void setup() {
         internalCluster().startClusterManagerOnlyNode();
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -591,9 +591,10 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
      */
     public void testReplicationPostDeleteAndForceMerge() throws Exception {
         assumeFalse("Skipping the test with Remote store as its flaky.", segmentReplicationWithRemoteEnabled());
-        final String primary = internalCluster().startNode();
+        internalCluster().startClusterManagerOnlyNode();
+        final String primary = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME);
-        final String replica = internalCluster().startNode();
+        final String replica = internalCluster().startDataOnlyNode();
         ensureGreen(INDEX_NAME);
         final int initialDocCount = scaledRandomIntBetween(10, 200);
         for (int i = 0; i < initialDocCount; i++) {
@@ -743,10 +744,10 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
 
     public void testReplicaHasDiffFilesThanPrimary() throws Exception {
         internalCluster().startClusterManagerOnlyNode();
-        final String primaryNode = internalCluster().startNode();
+        final String primaryNode = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME, Settings.builder().put(indexSettings()).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1).build());
         ensureYellow(INDEX_NAME);
-        final String replicaNode = internalCluster().startNode();
+        final String replicaNode = internalCluster().startDataOnlyNode();
         ensureGreen(INDEX_NAME);
 
         final IndexShard replicaShard = getIndexShard(replicaNode, INDEX_NAME);
@@ -796,9 +797,10 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
     }
 
     public void testPressureServiceStats() throws Exception {
-        final String primaryNode = internalCluster().startNode();
+        internalCluster().startClusterManagerOnlyNode();
+        final String primaryNode = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME);
-        final String replicaNode = internalCluster().startNode();
+        final String replicaNode = internalCluster().startDataOnlyNode();
         ensureGreen(INDEX_NAME);
 
         int initialDocCount = scaledRandomIntBetween(100, 200);

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -20,6 +20,7 @@ import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.index.StandardDirectoryReader;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
+import org.junit.Before;
 import org.opensearch.action.ActionFuture;
 import org.opensearch.action.admin.indices.flush.FlushRequest;
 import org.opensearch.action.admin.indices.stats.IndicesStatsRequest;
@@ -95,11 +96,16 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertSearchHits
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
 public class SegmentReplicationIT extends SegmentReplicationBaseIT {
 
+    @Before
+    public void setup() {
+        internalCluster().startClusterManagerOnlyNode();
+    }
+
     public void testPrimaryStopped_ReplicaPromoted() throws Exception {
-        final String primary = internalCluster().startNode();
+        final String primary = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME);
         ensureYellowAndNoInitializingShards(INDEX_NAME);
-        final String replica = internalCluster().startNode();
+        final String replica = internalCluster().startDataOnlyNode();
         ensureGreen(INDEX_NAME);
 
         client().prepareIndex(INDEX_NAME).setId("1").setSource("foo", "bar").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
@@ -125,7 +131,7 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
         assertHitCount(client(replica).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 3);
 
         // start another node, index another doc and replicate.
-        String nodeC = internalCluster().startNode();
+        String nodeC = internalCluster().startDataOnlyNode();
         ensureGreen(INDEX_NAME);
         client().prepareIndex(INDEX_NAME).setId("4").setSource("baz", "baz").get();
         refresh(INDEX_NAME);
@@ -134,10 +140,10 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
     }
 
     public void testRestartPrimary() throws Exception {
-        final String primary = internalCluster().startNode();
+        final String primary = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME);
         ensureYellowAndNoInitializingShards(INDEX_NAME);
-        final String replica = internalCluster().startNode();
+        final String replica = internalCluster().startDataOnlyNode();
         ensureGreen(INDEX_NAME);
 
         assertEquals(getNodeContainingPrimaryShard().getName(), primary);
@@ -160,10 +166,10 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
 
     public void testCancelPrimaryAllocation() throws Exception {
         // this test cancels allocation on the primary - promoting the new replica and recreating the former primary as a replica.
-        final String primary = internalCluster().startNode();
+        final String primary = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME);
         ensureYellowAndNoInitializingShards(INDEX_NAME);
-        final String replica = internalCluster().startNode();
+        final String replica = internalCluster().startDataOnlyNode();
         ensureGreen(INDEX_NAME);
 
         final int initialDocCount = 1;
@@ -190,8 +196,8 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
     }
 
     public void testReplicationAfterPrimaryRefreshAndFlush() throws Exception {
-        final String nodeA = internalCluster().startNode();
-        final String nodeB = internalCluster().startNode();
+        final String nodeA = internalCluster().startDataOnlyNode();
+        final String nodeB = internalCluster().startDataOnlyNode();
         final Settings settings = Settings.builder()
             .put(indexSettings())
             .put(
@@ -233,8 +239,8 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
     }
 
     public void testIndexReopenClose() throws Exception {
-        final String primary = internalCluster().startNode();
-        final String replica = internalCluster().startNode();
+        final String primary = internalCluster().startDataOnlyNode();
+        final String replica = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME);
         ensureGreen(INDEX_NAME);
 
@@ -274,8 +280,8 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
             .put(IndexModule.INDEX_QUERY_CACHE_ENABLED_SETTING.getKey(), false)
             .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
             .build();
-        final String nodeA = internalCluster().startNode();
-        final String nodeB = internalCluster().startNode();
+        final String nodeA = internalCluster().startDataOnlyNode();
+        final String nodeB = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME, indexSettings);
         ensureGreen(INDEX_NAME);
 
@@ -310,8 +316,8 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
     }
 
     public void testReplicationAfterForceMerge() throws Exception {
-        final String nodeA = internalCluster().startNode();
-        final String nodeB = internalCluster().startNode();
+        final String nodeA = internalCluster().startDataOnlyNode();
+        final String nodeB = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME);
         ensureGreen(INDEX_NAME);
 
@@ -351,14 +357,13 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
      * This test verifies that segment replication does not fail for closed indices
      */
     public void testClosedIndices() {
-        internalCluster().startClusterManagerOnlyNode();
         List<String> nodes = new ArrayList<>();
         // start 1st node so that it contains the primary
-        nodes.add(internalCluster().startNode());
+        nodes.add(internalCluster().startDataOnlyNode());
         createIndex(INDEX_NAME, super.indexSettings());
         ensureYellowAndNoInitializingShards(INDEX_NAME);
         // start 2nd node so that it contains the replica
-        nodes.add(internalCluster().startNode());
+        nodes.add(internalCluster().startDataOnlyNode());
         ensureGreen(INDEX_NAME);
 
         logger.info("--> Close index");
@@ -373,8 +378,7 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
      * @throws Exception when issue is encountered
      */
     public void testNodeDropWithOngoingReplication() throws Exception {
-        internalCluster().startClusterManagerOnlyNode();
-        final String primaryNode = internalCluster().startNode();
+        final String primaryNode = internalCluster().startDataOnlyNode();
         createIndex(
             INDEX_NAME,
             Settings.builder()
@@ -385,7 +389,7 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
                 .build()
         );
         ensureYellow(INDEX_NAME);
-        final String replicaNode = internalCluster().startNode();
+        final String replicaNode = internalCluster().startDataOnlyNode();
         ensureGreen(INDEX_NAME);
         ClusterState state = client().admin().cluster().prepareState().execute().actionGet().getState();
         // Get replica allocation id
@@ -447,11 +451,11 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
     }
 
     public void testCancellation() throws Exception {
-        final String primaryNode = internalCluster().startNode();
+        final String primaryNode = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME, Settings.builder().put(indexSettings()).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1).build());
         ensureYellow(INDEX_NAME);
 
-        final String replicaNode = internalCluster().startNode();
+        final String replicaNode = internalCluster().startDataOnlyNode();
 
         final SegmentReplicationSourceService segmentReplicationSourceService = internalCluster().getInstance(
             SegmentReplicationSourceService.class,
@@ -506,7 +510,7 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
     }
 
     public void testStartReplicaAfterPrimaryIndexesDocs() throws Exception {
-        final String primaryNode = internalCluster().startNode();
+        final String primaryNode = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME, Settings.builder().put(indexSettings()).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0).build());
         ensureGreen(INDEX_NAME);
 
@@ -529,7 +533,7 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
                 .prepareUpdateSettings(INDEX_NAME)
                 .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1))
         );
-        final String replicaNode = internalCluster().startNode();
+        final String replicaNode = internalCluster().startDataOnlyNode();
         ensureGreen(INDEX_NAME);
 
         assertHitCount(client(primaryNode).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 2);
@@ -544,8 +548,8 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
     }
 
     public void testDeleteOperations() throws Exception {
-        final String nodeA = internalCluster().startNode();
-        final String nodeB = internalCluster().startNode();
+        final String nodeA = internalCluster().startDataOnlyNode();
+        final String nodeB = internalCluster().startDataOnlyNode();
 
         createIndex(INDEX_NAME);
         ensureGreen(INDEX_NAME);
@@ -591,7 +595,6 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
      */
     public void testReplicationPostDeleteAndForceMerge() throws Exception {
         assumeFalse("Skipping the test with Remote store as its flaky.", segmentReplicationWithRemoteEnabled());
-        internalCluster().startClusterManagerOnlyNode();
         final String primary = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME);
         final String replica = internalCluster().startDataOnlyNode();
@@ -649,7 +652,6 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
     }
 
     public void testUpdateOperations() throws Exception {
-        internalCluster().startClusterManagerOnlyNode();
         final String primary = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME);
         ensureYellow(INDEX_NAME);
@@ -703,7 +705,6 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, replica_count)
             .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
             .build();
-        final String clusterManagerNode = internalCluster().startClusterManagerOnlyNode();
         final String primaryNode = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME, settings);
         final List<String> dataNodes = internalCluster().startDataOnlyNodes(6);
@@ -743,7 +744,6 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
     }
 
     public void testReplicaHasDiffFilesThanPrimary() throws Exception {
-        internalCluster().startClusterManagerOnlyNode();
         final String primaryNode = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME, Settings.builder().put(indexSettings()).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1).build());
         ensureYellow(INDEX_NAME);
@@ -797,7 +797,6 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
     }
 
     public void testPressureServiceStats() throws Exception {
-        internalCluster().startClusterManagerOnlyNode();
         final String primaryNode = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME);
         final String replicaNode = internalCluster().startDataOnlyNode();
@@ -850,7 +849,7 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
             assertEquals(0, replicaNode_service.nodeStats().getShardStats().get(primaryShard.shardId()).getReplicaStats().size());
 
             // start another replica.
-            String replicaNode_2 = internalCluster().startNode();
+            String replicaNode_2 = internalCluster().startDataOnlyNode();
             ensureGreen(INDEX_NAME);
             String docId = String.valueOf(initialDocCount + 1);
             client().prepareIndex(INDEX_NAME).setId(docId).setSource("foo", "bar").get();
@@ -889,10 +888,10 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
     public void testScrollCreatedOnReplica() throws Exception {
         assumeFalse("Skipping the test with Remote store as its flaky.", segmentReplicationWithRemoteEnabled());
         // create the cluster with one primary node containing primary shard and replica node containing replica shard
-        final String primary = internalCluster().startNode();
+        final String primary = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME);
         ensureYellowAndNoInitializingShards(INDEX_NAME);
-        final String replica = internalCluster().startNode();
+        final String replica = internalCluster().startDataOnlyNode();
         ensureGreen(INDEX_NAME);
 
         // index 100 docs
@@ -983,7 +982,7 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
         );
 
         // create the cluster with one primary node containing primary shard and replica node containing replica shard
-        final String primary = internalCluster().startNode();
+        final String primary = internalCluster().startDataOnlyNode();
         prepareCreate(
             INDEX_NAME,
             Settings.builder()
@@ -991,7 +990,7 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
                 .put("index.refresh_interval", -1)
         ).get();
         ensureYellowAndNoInitializingShards(INDEX_NAME);
-        final String replica = internalCluster().startNode();
+        final String replica = internalCluster().startDataOnlyNode();
         ensureGreen(INDEX_NAME);
 
         final int initialDocCount = 10;
@@ -1106,10 +1105,10 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
     }
 
     public void testPitCreatedOnReplica() throws Exception {
-        final String primary = internalCluster().startNode();
+        final String primary = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME);
         ensureYellowAndNoInitializingShards(INDEX_NAME);
-        final String replica = internalCluster().startNode();
+        final String replica = internalCluster().startDataOnlyNode();
         ensureGreen(INDEX_NAME);
         client().prepareIndex(INDEX_NAME)
             .setId("1")
@@ -1236,13 +1235,13 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
      */
     public void testPrimaryReceivesDocsDuringReplicaRecovery() throws Exception {
         final List<String> nodes = new ArrayList<>();
-        final String primaryNode = internalCluster().startNode();
+        final String primaryNode = internalCluster().startDataOnlyNode();
         nodes.add(primaryNode);
         final Settings settings = Settings.builder().put(indexSettings()).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0).build();
         createIndex(INDEX_NAME, settings);
         ensureGreen(INDEX_NAME);
         // start a replica node, initially will be empty with no shard assignment.
-        final String replicaNode = internalCluster().startNode();
+        final String replicaNode = internalCluster().startDataOnlyNode();
         nodes.add(replicaNode);
 
         // index a doc.

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/SegmentReplicationRemoteStoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/SegmentReplicationRemoteStoreIT.java
@@ -8,7 +8,6 @@
 
 package org.opensearch.remotestore;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.opensearch.cluster.metadata.IndexMetadata;
@@ -26,7 +25,6 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
  * This makes sure that the constructs/flows that are being tested with Segment Replication, holds true after enabling
  * remote store.
  */
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/7643")
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
 public class SegmentReplicationRemoteStoreIT extends SegmentReplicationIT {
 

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/SegmentReplicationRemoteStoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/SegmentReplicationRemoteStoreIT.java
@@ -47,7 +47,7 @@ public class SegmentReplicationRemoteStoreIT extends SegmentReplicationIT {
     }
 
     @Before
-    public void setup() {
+    private void setup() {
         internalCluster().startClusterManagerOnlyNode();
         Path absolutePath = randomRepoPath().toAbsolutePath();
         assertAcked(

--- a/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
@@ -282,7 +282,6 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
     /**
      * Tests retry flow after snapshot and metadata files have been uploaded to remote store in the failed attempt.
      * Snapshot and metadata files created in failed attempt should not break retry.
-     * @throws Exception
      */
     public void testRefreshSuccessAfterFailureInFirstAttemptAfterSnapshotAndMetadataUpload() throws Exception {
         int succeedOnAttempt = 1;


### PR DESCRIPTION
### Description
- Posting the [comment](https://github.com/opensearch-project/OpenSearch/issues/8100#issuecomment-1597481801) as it is: The `getLatestSegmentInfosAndCheckpoint` method is eventually invoked and failing with the call to `getEngine().config().getCodec().getName()` because the engine is already closed. The method already has logic to return empty if the shard is not open, but it is shut after this check. So we need to ensure the shard is not closed while this method is invoked or if we don't want to block shard close for this catch the error and gracefully return.
- Some of the tests in `SegmentReplicationIT` are flaky. This was observed while debugging flakiness in `SegmentReplicationRemoteStoreIT` which extends SegmentReplicationIT with remote store settings.
- Reproducing the flakiness is not straightforward and using the same seed will not guarantee of failure. The only way of reproducing the issue is to run the test multiple times.
- After inspecting the logs of the failure, we found that the two nodes in the cluster are acting as data as well as cluster manager nodes. As part of test flow, when we stop one of the nodes, it may result in quorum loss issue for the cluster given only 2 nodes.
- To avoid this issue, in this PR, we have explicitly added a cluster manager only node for each test. We have also made primary and replica as data only nodes to make the tests more deterministic.

### Related Issues
- https://github.com/opensearch-project/OpenSearch/issues/8100

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
