### PR TITLE
[Backport 1.3] [Manual] Bump versions of gradle-info-plugin and nebula-publishing-plugin (#8150)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump `netty` from 4.1.91.Final to 4.1.93.Final ([#7901](https://github.com/opensearch-project/OpenSearch/pull/7901))
 - Bump `spock-core` from 1.3-groovy-2.5 to 2.3-groovy-2.5 ([#8119](https://github.com/opensearch-project/OpenSearch/pull/8119))
 - Bump `com.google.guava:guava` from 31.0.1-jre to 32.0.1-jre ([#8107](https://github.com/opensearch-project/OpenSearch/pull/8107))
+- Bump versions of gradle-info-plugin and nebula-publishing-plugin ([#8150](https://github.com/opensearch-project/OpenSearch/pull/8150))
 
 ### Changed
 ### Deprecated

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -106,8 +106,8 @@ dependencies {
   api 'org.apache.commons:commons-compress:1.21'
   api 'org.apache.ant:ant:1.10.12'
   api 'com.netflix.nebula:gradle-extra-configurations-plugin:3.0.3'
-  api 'com.netflix.nebula:nebula-publishing-plugin:4.6.0'
-  api 'com.netflix.nebula:gradle-info-plugin:7.1.3'
+  api 'com.netflix.nebula:nebula-publishing-plugin:4.7.0'
+  api 'com.netflix.nebula:gradle-info-plugin:8.2.0'
   api 'org.apache.rat:apache-rat:0.13'
   api 'commons-io:commons-io:2.7'
   api "net.java.dev.jna:jna:5.5.0"


### PR DESCRIPTION
### Description
Manual backport of #8150 

* Bump versions of gradle-info-plugin and nebula-publishing-plugin

This mitigates downstream dependencies to patch the CVE-2020-13956 vulnerability.

Signed-off-by: Kartik Ganesh <gkart@amazon.com>

* Added changelog entry

Signed-off-by: Kartik Ganesh <gkart@amazon.com>

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
