### PR TITLE
Segment Replication - Allow search idle with no replicas

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/action/search/TransportSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/search/TransportSearchIT.java
@@ -371,7 +371,7 @@ public class TransportSearchIT extends OpenSearchIntegTestCase {
         });
     }
 
-    public void testSearchIdleWithSegmentReplication() throws Exception {
+    public void testSearchIdleWithSegmentReplication() {
         int numOfReplicas = 1;
         internalCluster().ensureAtLeastNumDataNodes(numOfReplicas + 1);
         final Settings.Builder settings = Settings.builder()
@@ -390,14 +390,12 @@ public class TransportSearchIT extends OpenSearchIntegTestCase {
                 )
         );
 
-        assertBusy(() -> {
-            for (String node : internalCluster().nodesInclude("test")) {
-                final IndicesService indicesService = internalCluster().getInstance(IndicesService.class, node);
-                for (IndexShard indexShard : indicesService.indexServiceSafe(resolveIndex("test"))) {
-                    assertFalse(indexShard.isSearchIdleSupported());
-                }
+        for (String node : internalCluster().nodesInclude("test")) {
+            final IndicesService indicesService = internalCluster().getInstance(IndicesService.class, node);
+            for (IndexShard indexShard : indicesService.indexServiceSafe(resolveIndex("test"))) {
+                assertFalse(indexShard.isSearchIdleSupported());
             }
-        });
+        }
 
         assertAcked(
             client().admin()
@@ -406,14 +404,13 @@ public class TransportSearchIT extends OpenSearchIntegTestCase {
                 .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0))
         );
 
-        assertBusy(() -> {
-            for (String node : internalCluster().nodesInclude("test")) {
-                final IndicesService indicesService = internalCluster().getInstance(IndicesService.class, node);
-                for (IndexShard indexShard : indicesService.indexServiceSafe(resolveIndex("test"))) {
-                    assertTrue(indexShard.isSearchIdleSupported());
-                }
+        for (String node : internalCluster().nodesInclude("test")) {
+            final IndicesService indicesService = internalCluster().getInstance(IndicesService.class, node);
+            for (IndexShard indexShard : indicesService.indexServiceSafe(resolveIndex("test"))) {
+                assertTrue(indexShard.isSearchIdleSupported());
             }
-        });
+        }
+        ;
     }
 
     public void testCircuitBreakerReduceFail() throws Exception {

--- a/server/src/internalClusterTest/java/org/opensearch/action/search/TransportSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/search/TransportSearchIT.java
@@ -61,6 +61,7 @@ import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.query.RangeQueryBuilder;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.indices.IndicesService;
+import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.plugins.SearchPlugin;
 import org.opensearch.core.rest.RestStatus;
@@ -367,6 +368,51 @@ public class TransportSearchIT extends OpenSearchIntegTestCase {
                 .setPreFilterShardSize(randomIntBetween(1, 3))
                 .get();
             assertThat(resp.getHits().getTotalHits().value, equalTo(2L));
+        });
+    }
+
+    public void testSearchIdleWithSegmentReplication() throws Exception {
+        int numOfReplicas = 1;
+        internalCluster().ensureAtLeastNumDataNodes(numOfReplicas + 1);
+        final Settings.Builder settings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 5))
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, numOfReplicas)
+            .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT);
+        assertAcked(prepareCreate("test").setSettings(settings).setMapping("created_date", "type=date,format=yyyy-MM-dd"));
+        ensureGreen("test");
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareUpdateSettings("test")
+                .setSettings(
+                    Settings.builder()
+                        .put(IndexSettings.INDEX_SEARCH_IDLE_AFTER.getKey(), TimeValue.timeValueMillis(randomIntBetween(50, 500)))
+                )
+        );
+
+        assertBusy(() -> {
+            for (String node : internalCluster().nodesInclude("test")) {
+                final IndicesService indicesService = internalCluster().getInstance(IndicesService.class, node);
+                for (IndexShard indexShard : indicesService.indexServiceSafe(resolveIndex("test"))) {
+                    assertFalse(indexShard.isSearchIdleSupported());
+                }
+            }
+        });
+
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareUpdateSettings("test")
+                .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0))
+        );
+
+        assertBusy(() -> {
+            for (String node : internalCluster().nodesInclude("test")) {
+                final IndicesService indicesService = internalCluster().getInstance(IndicesService.class, node);
+                for (IndexShard indexShard : indicesService.indexServiceSafe(resolveIndex("test"))) {
+                    assertTrue(indexShard.isSearchIdleSupported());
+                }
+            }
         });
     }
 

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -931,7 +931,7 @@ public final class IndexSettings {
 
     private void setSearchIdleAfter(TimeValue searchIdleAfter) {
         if (this.replicationType == ReplicationType.SEGMENT && this.getNumberOfReplicas() > 0) {
-            logger.warn("Search idle is not supported for indices with replicas using 'replication.type: SEGMENT");
+            logger.warn("Search idle is not supported for indices with replicas using 'replication.type: SEGMENT'");
         }
         this.searchIdleAfter = searchIdleAfter;
     }

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -930,6 +930,9 @@ public final class IndexSettings {
     }
 
     private void setSearchIdleAfter(TimeValue searchIdleAfter) {
+        if (this.replicationType == ReplicationType.SEGMENT && this.getNumberOfReplicas() > 0) {
+            logger.warn("Search idle is disabled for indices with replicas using the Segment Replication strategy");
+        }
         this.searchIdleAfter = searchIdleAfter;
     }
 

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -931,7 +931,7 @@ public final class IndexSettings {
 
     private void setSearchIdleAfter(TimeValue searchIdleAfter) {
         if (this.replicationType == ReplicationType.SEGMENT && this.getNumberOfReplicas() > 0) {
-            logger.warn("Search idle is disabled for indices with replicas using the Segment Replication strategy");
+            logger.warn("Search idle is not supported for indices with replicas using 'replication.type: SEGMENT");
         }
         this.searchIdleAfter = searchIdleAfter;
     }

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -4282,13 +4282,9 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         boolean listenerNeedsRefresh = refreshListeners.refreshNeeded();
         if (isReadAllowed() && (listenerNeedsRefresh || getEngine().refreshNeeded())) {
             if (listenerNeedsRefresh == false // if we have a listener that is waiting for a refresh we need to force it
+                && isSearchIdleSupported()
                 && isSearchIdle()
                 && indexSettings.isExplicitRefresh() == false
-                // Indices with segrep enabled will never wait on a refresh and ignore shard idle unless there are no replicas. Primary
-                // shards push out new segments only
-                // after a refresh, so we don't want to wait for a search to trigger that cycle. Replicas will only refresh after receiving
-                // a new set of segments.
-                && (indexSettings.isSegRepEnabled() == false || indexSettings.getNumberOfReplicas() == 0)
                 && active.get()) { // it must be active otherwise we might not free up segment memory once the shard became inactive
                 // lets skip this refresh since we are search idle and
                 // don't necessarily need to refresh. the next searcher access will register a refreshListener and that will
@@ -4314,6 +4310,19 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
      */
     public final boolean isSearchIdle() {
         return (threadPool.relativeTimeInMillis() - lastSearcherAccess.get()) >= indexSettings.getSearchIdleAfter().getMillis();
+    }
+
+    /**
+     *
+     * Returns true if this shard supports search idle.
+     *
+     * Indices using Segment Replication will ignore search idle unless there are no replicas.
+     * Primary shards push out new segments only
+     * after a refresh, so we don't want to wait for a search to trigger that cycle. Replicas will only refresh after receiving
+     * a new set of segments.
+     */
+    private boolean isSearchIdleSupported() {
+        return indexSettings.isSegRepEnabled() == false || indexSettings.getNumberOfReplicas() == 0;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -4321,7 +4321,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
      * after a refresh, so we don't want to wait for a search to trigger that cycle. Replicas will only refresh after receiving
      * a new set of segments.
      */
-    private boolean isSearchIdleSupported() {
+    public final boolean isSearchIdleSupported() {
         return indexSettings.isSegRepEnabled() == false || indexSettings.getNumberOfReplicas() == 0;
     }
 

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -4284,10 +4284,11 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             if (listenerNeedsRefresh == false // if we have a listener that is waiting for a refresh we need to force it
                 && isSearchIdle()
                 && indexSettings.isExplicitRefresh() == false
-                && indexSettings.isSegRepEnabled() == false
-                // Indices with segrep enabled will never wait on a refresh and ignore shard idle. Primary shards push out new segments only
+                // Indices with segrep enabled will never wait on a refresh and ignore shard idle unless there are no replicas. Primary
+                // shards push out new segments only
                 // after a refresh, so we don't want to wait for a search to trigger that cycle. Replicas will only refresh after receiving
                 // a new set of segments.
+                && (indexSettings.isSegRepEnabled() == false || indexSettings.getNumberOfReplicas() == 0)
                 && active.get()) { // it must be active otherwise we might not free up segment memory once the shard became inactive
                 // lets skip this refresh since we are search idle and
                 // don't necessarily need to refresh. the next searcher access will register a refreshListener and that will

--- a/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
@@ -410,37 +410,68 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
     }
 
     public void testIgnoreShardIdle() throws Exception {
+        Settings updatedSettings = Settings.builder()
+            .put(settings)
+            .put(IndexSettings.INDEX_SEARCH_IDLE_AFTER.getKey(), TimeValue.ZERO)
+            .build();
+        try (ReplicationGroup shards = createGroup(1, updatedSettings, new NRTReplicationEngineFactory())) {
+            shards.startAll();
+            final IndexShard primary = shards.getPrimary();
+            final IndexShard replica = shards.getReplicas().get(0);
+            final int numDocs = shards.indexDocs(randomIntBetween(1, 10));
+            // ensure search idle conditions are met.
+            assertTrue(primary.isSearchIdle());
+            assertTrue(replica.isSearchIdle());
+
+            // invoke scheduledRefresh, returns true if refresh is immediately invoked.
+            assertTrue(primary.scheduledRefresh());
+            // replica would always return false here as there is no indexed doc to refresh on.
+            assertFalse(replica.scheduledRefresh());
+
+            // assert there is no pending refresh
+            assertFalse(primary.hasRefreshPending());
+            assertFalse(replica.hasRefreshPending());
+            shards.refresh("test");
+            replicateSegments(primary, shards.getReplicas());
+            shards.assertAllEqual(numDocs);
+        }
+    }
+
+    public void testShardIdle_Docrep() throws Exception {
+        Settings settings = Settings.builder()
+            .put(IndexSettings.INDEX_SEARCH_IDLE_AFTER.getKey(), TimeValue.ZERO)
+            .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.DOCUMENT)
+            .build();
         try (ReplicationGroup shards = createGroup(1, settings, new NRTReplicationEngineFactory())) {
             shards.startAll();
             final IndexShard primary = shards.getPrimary();
             final IndexShard replica = shards.getReplicas().get(0);
-
-            final int numDocs = shards.indexDocs(randomInt(10));
-            primary.refresh("test");
-            replicateSegments(primary, shards.getReplicas());
+            final int numDocs = shards.indexDocs(randomIntBetween(1, 10));
+            // ensure search idle conditions are met.
+            assertTrue(primary.isSearchIdle());
+            assertTrue(replica.isSearchIdle());
+            assertFalse(primary.scheduledRefresh());
+            assertFalse(replica.scheduledRefresh());
+            assertTrue(primary.hasRefreshPending());
+            assertTrue(replica.hasRefreshPending());
+            shards.refresh("test");
             shards.assertAllEqual(numDocs);
+        }
+    }
 
-            primary.scheduledRefresh();
-            replica.scheduledRefresh();
-
-            primary.awaitShardSearchActive(b -> assertFalse("A new RefreshListener should not be registered", b));
-            replica.awaitShardSearchActive(b -> assertFalse("A new RefreshListener should not be registered", b));
-
-            // Update the search_idle setting, this will put both shards into search idle.
-            Settings updatedSettings = Settings.builder()
-                .put(settings)
-                .put(IndexSettings.INDEX_SEARCH_IDLE_AFTER.getKey(), TimeValue.ZERO)
-                .build();
-            primary.indexSettings().getScopedSettings().applySettings(updatedSettings);
-            replica.indexSettings().getScopedSettings().applySettings(updatedSettings);
-
-            primary.scheduledRefresh();
-            replica.scheduledRefresh();
-
-            // Shards without segrep will register a new RefreshListener on the engine and return true when registered,
-            // assert with segrep enabled that awaitShardSearchActive does not register a listener.
-            primary.awaitShardSearchActive(b -> assertFalse("A new RefreshListener should not be registered", b));
-            replica.awaitShardSearchActive(b -> assertFalse("A new RefreshListener should not be registered", b));
+    public void testShardIdleWithNoReplicas() throws Exception {
+        Settings updatedSettings = Settings.builder()
+            .put(settings)
+            .put(IndexSettings.INDEX_SEARCH_IDLE_AFTER.getKey(), TimeValue.ZERO)
+            .build();
+        try (ReplicationGroup shards = createGroup(0, updatedSettings, new NRTReplicationEngineFactory())) {
+            shards.startAll();
+            final IndexShard primary = shards.getPrimary();
+            shards.indexDocs(randomIntBetween(1, 10));
+            // ensure search idle conditions are met.
+            assertTrue(primary.isSearchIdle());
+            assertFalse(primary.scheduledRefresh());
+            assertTrue(primary.hasRefreshPending());
         }
     }
 


### PR DESCRIPTION
This is a re-open of https://github.com/opensearch-project/OpenSearch/pull/7736.

Description
With Segment Replication enabled we generally disable shard idle. This change ensures there are replicas in the index before disabling shard idle with SR.  It will warn if a user attempts to update the search.idle.after interval with replicas configured.

Related Issues
https://github.com/opensearch-project/OpenSearch/issues/7761

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
