### PR TITLE
[Backport-2.x] Add latest local and remote refresh timestamps in the …

### DIFF
--- a/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/stats/RemoteStoreStats.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/stats/RemoteStoreStats.java
@@ -42,7 +42,8 @@ public class RemoteStoreStats implements Writeable, ToXContentFragment {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject()
             .field(Fields.SHARD_ID, remoteSegmentUploadShardStats.shardId)
-
+            .field(Fields.LOCAL_REFRESH_TIMESTAMP, remoteSegmentUploadShardStats.localRefreshClockTimeMs)
+            .field(Fields.REMOTE_REFRESH_TIMESTAMP, remoteSegmentUploadShardStats.remoteRefreshClockTimeMs)
             .field(Fields.REFRESH_TIME_LAG_IN_MILLIS, remoteSegmentUploadShardStats.refreshTimeLagMs)
             .field(Fields.REFRESH_LAG, remoteSegmentUploadShardStats.localRefreshNumber - remoteSegmentUploadShardStats.remoteRefreshNumber)
             .field(Fields.BYTES_LAG, remoteSegmentUploadShardStats.bytesLag)
@@ -103,6 +104,16 @@ public class RemoteStoreStats implements Writeable, ToXContentFragment {
          * Time in millis remote refresh is behind local refresh
          */
         static final String REFRESH_TIME_LAG_IN_MILLIS = "refresh_time_lag_in_millis";
+
+        /**
+         * Last successful local refresh timestamp in milliseconds
+         */
+        static final String LOCAL_REFRESH_TIMESTAMP = "local_refresh_timestamp_in_millis";
+
+        /**
+         * Last successful remote refresh timestamp in milliseconds
+         */
+        static final String REMOTE_REFRESH_TIMESTAMP = "remote_refresh_timestamp_in_millis";
 
         /**
          * Total write rejections due to remote store backpressure kick in

--- a/server/src/test/java/org/opensearch/action/admin/cluster/remotestore/stats/RemoteStoreStatsTestHelper.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/remotestore/stats/RemoteStoreStatsTestHelper.java
@@ -20,11 +20,16 @@ import static org.opensearch.test.OpenSearchTestCase.assertEquals;
  */
 public class RemoteStoreStatsTestHelper {
     static RemoteRefreshSegmentTracker.Stats createPressureTrackerStats(ShardId shardId) {
-        return new RemoteRefreshSegmentTracker.Stats(shardId, 100, 3, 2, 10, 5, 5, 10, 5, 5, 3, 2, 5, 2, 3, 4, 9);
+        return new RemoteRefreshSegmentTracker.Stats(shardId, 101, 102, 100, 3, 2, 10, 5, 5, 10, 5, 5, 3, 2, 5, 2, 3, 4, 9);
     }
 
     static void compareStatsResponse(Map<String, Object> statsObject, RemoteRefreshSegmentTracker.Stats pressureTrackerStats) {
         assertEquals(statsObject.get(RemoteStoreStats.Fields.SHARD_ID), pressureTrackerStats.shardId.toString());
+        assertEquals(statsObject.get(RemoteStoreStats.Fields.LOCAL_REFRESH_TIMESTAMP), (int) pressureTrackerStats.localRefreshClockTimeMs);
+        assertEquals(
+            statsObject.get(RemoteStoreStats.Fields.REMOTE_REFRESH_TIMESTAMP),
+            (int) pressureTrackerStats.remoteRefreshClockTimeMs
+        );
         assertEquals(statsObject.get(RemoteStoreStats.Fields.REFRESH_TIME_LAG_IN_MILLIS), (int) pressureTrackerStats.refreshTimeLagMs);
         assertEquals(
             statsObject.get(RemoteStoreStats.Fields.REFRESH_LAG),


### PR DESCRIPTION
…stats api response (#7922)

* Add latest local and remote refresh timestamps in the stats api response

Signed-off-by: bansvaru <bansvaru@amazon.com>

* add a separate field for clock time to allow backpressure to use nano precision fields

Signed-off-by: bansvaru <bansvaru@amazon.com>

* fix spotloss failures

Signed-off-by: bansvaru <bansvaru@amazon.com>

* correct update validation for remote refresh clock time

Signed-off-by: bansvaru <bansvaru@amazon.com>

* remove unused wall clock time lag

Signed-off-by: bansvaru <bansvaru@amazon.com>

* revert unintended changes to backtracker precision time fields

Signed-off-by: bansvaru <bansvaru@amazon.com>

* fix indentation

Signed-off-by: bansvaru <bansvaru@amazon.com>

---------

Signed-off-by: bansvaru <bansvaru@amazon.com>
(cherry picked from commit de51a496a2e727d74aef76d7fb2714b95a582169)

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
