### PR TITLE
Added transport action for bulk async shard fetch for primary shards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Allow mmap to use new JDK-19 preview APIs in Apache Lucene 9.4+ ([#5151](https://github.com/opensearch-project/OpenSearch/pull/5151))
 - Add events correlation engine plugin ([#6854](https://github.com/opensearch-project/OpenSearch/issues/6854))
 - Add support for ignoring missing Javadoc on generated code using annotation ([#7604](https://github.com/opensearch-project/OpenSearch/pull/7604))
+- Add PSA transport action for bulk async fetch of shards ([#5098](https://github.com/opensearch-project/OpenSearch/issues/5098))
 
 ### Dependencies
 - Bump `log4j-core` from 2.18.0 to 2.19.0
@@ -44,7 +45,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Change http code for DecommissioningFailedException from 500 to 400 ([#5283](https://github.com/opensearch-project/OpenSearch/pull/5283))
 - Improve summary error message for invalid setting updates ([#4792](https://github.com/opensearch-project/OpenSearch/pull/4792))
 - Pass localNode info to all plugins on node start ([#7919](https://github.com/opensearch-project/OpenSearch/pull/7919))
-
+- Modified the existing async shard fetch transport action to use the helper functions added for bulk fetching ([#5098](https://github.com/opensearch-project/OpenSearch/issues/5098))
 ### Deprecated
 
 ### Removed

--- a/server/src/main/java/org/opensearch/gateway/AsyncShardsFetchPerNode.java
+++ b/server/src/main/java/org/opensearch/gateway/AsyncShardsFetchPerNode.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.gateway;
+
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.support.nodes.BaseNodeResponse;
+import org.opensearch.action.support.nodes.BaseNodesResponse;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.lease.Releasable;
+import org.opensearch.index.shard.ShardId;
+
+import java.util.Map;
+
+/**
+ * This class is responsible for fetching shard data from nodes. It is analogous to AsyncShardFetch class since it fetches
+ * the data in asynchronous manner too.
+ * @param <T>
+ */
+public abstract class AsyncShardsFetchPerNode<T extends BaseNodeResponse> implements Releasable {
+    /**
+     * An action that lists the relevant shard data that needs to be fetched.
+     */
+    public interface Lister<NodesResponse extends BaseNodesResponse<NodeResponse>, NodeResponse extends BaseNodeResponse> {
+        void list(DiscoveryNode[] nodes, Map<ShardId, String> shardsIdMap, ActionListener<NodesResponse> listener);
+    }
+}

--- a/server/src/main/java/org/opensearch/gateway/TransportNodesBulkListGatewayStartedShards.java
+++ b/server/src/main/java/org/opensearch/gateway/TransportNodesBulkListGatewayStartedShards.java
@@ -38,6 +38,7 @@ import org.opensearch.action.ActionListener;
 import org.opensearch.action.ActionType;
 import org.opensearch.action.FailedNodeException;
 import org.opensearch.action.support.ActionFilters;
+import org.opensearch.transport.TransportRequest;
 import org.opensearch.action.support.nodes.BaseNodeResponse;
 import org.opensearch.action.support.nodes.BaseNodesRequest;
 import org.opensearch.action.support.nodes.BaseNodesResponse;
@@ -45,7 +46,6 @@ import org.opensearch.action.support.nodes.TransportNodesAction;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.common.Nullable;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -58,31 +58,32 @@ import org.opensearch.index.shard.ShardStateMetadata;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
 import org.opensearch.threadpool.ThreadPool;
-import org.opensearch.transport.TransportRequest;
 import org.opensearch.transport.TransportService;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
- * This transport action is used to fetch the shard version from each node during primary allocation in {@link GatewayAllocator}.
+ * This transport action is used to fetch  all unassigned shard version from each node during primary allocation in {@link GatewayAllocator}.
  * We use this to find out which node holds the latest shard version and which of them used to be a primary in order to allocate
  * shards after node or cluster restarts.
  *
  * @opensearch.internal
  */
-public class TransportNodesListGatewayStartedShards extends TransportNodesAction<
-    TransportNodesListGatewayStartedShards.Request,
-    TransportNodesListGatewayStartedShards.NodesGatewayStartedShards,
-    TransportNodesListGatewayStartedShards.NodeRequest,
-    TransportNodesListGatewayStartedShards.NodeGatewayStartedShards>
+public class TransportNodesBulkListGatewayStartedShards extends TransportNodesAction<
+    TransportNodesBulkListGatewayStartedShards.Request,
+    TransportNodesBulkListGatewayStartedShards.NodesGatewayStartedShards,
+    TransportNodesBulkListGatewayStartedShards.NodeRequest,
+    TransportNodesBulkListGatewayStartedShards.BulkOfNodeGatewayStartedShards>
     implements
-        AsyncShardFetch.Lister<
-            TransportNodesListGatewayStartedShards.NodesGatewayStartedShards,
-            TransportNodesListGatewayStartedShards.NodeGatewayStartedShards> {
+        AsyncShardsFetchPerNode.Lister<
+            TransportNodesBulkListGatewayStartedShards.NodesGatewayStartedShards,
+            TransportNodesBulkListGatewayStartedShards.BulkOfNodeGatewayStartedShards> {
 
-    public static final String ACTION_NAME = "internal:gateway/local/started_shards";
+    public static final String ACTION_NAME = "internal:gateway/local/bulk_started_shards";
     public static final ActionType<NodesGatewayStartedShards> TYPE = new ActionType<>(ACTION_NAME, NodesGatewayStartedShards::new);
 
     private final Settings settings;
@@ -91,7 +92,7 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesAction
     private final NamedXContentRegistry namedXContentRegistry;
 
     @Inject
-    public TransportNodesListGatewayStartedShards(
+    public TransportNodesBulkListGatewayStartedShards(
         Settings settings,
         ThreadPool threadPool,
         ClusterService clusterService,
@@ -110,7 +111,7 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesAction
             Request::new,
             NodeRequest::new,
             ThreadPool.Names.FETCH_SHARD_STARTED,
-            NodeGatewayStartedShards.class
+            BulkOfNodeGatewayStartedShards.class
         );
         this.settings = settings;
         this.nodeEnv = env;
@@ -119,8 +120,8 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesAction
     }
 
     @Override
-    public void list(ShardId shardId, String customDataPath, DiscoveryNode[] nodes, ActionListener<NodesGatewayStartedShards> listener) {
-        execute(new Request(shardId, customDataPath, nodes), listener);
+    public void list(DiscoveryNode[] nodes, Map<ShardId, String> shardsIdMap, ActionListener<NodesGatewayStartedShards> listener) {
+        execute(new Request(nodes, shardsIdMap), listener);
     }
 
     @Override
@@ -129,72 +130,84 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesAction
     }
 
     @Override
-    protected NodeGatewayStartedShards newNodeResponse(StreamInput in) throws IOException {
-        return new NodeGatewayStartedShards(in);
+    protected BulkOfNodeGatewayStartedShards newNodeResponse(StreamInput in) throws IOException {
+        return new BulkOfNodeGatewayStartedShards(in);
     }
 
     @Override
     protected NodesGatewayStartedShards newResponse(
         Request request,
-        List<NodeGatewayStartedShards> responses,
+        List<BulkOfNodeGatewayStartedShards> responses,
         List<FailedNodeException> failures
     ) {
         return new NodesGatewayStartedShards(clusterService.getClusterName(), responses, failures);
     }
 
+    /**
+     * This function is similar to nodeoperation method of {@link TransportNodesListGatewayStartedShards} we loop over
+     * the shards here to fetch the shard result in bulk.
+     *
+     * @param request
+     * @return BulkOfNodeGatewayStartedShards
+     */
     @Override
-    protected NodeGatewayStartedShards nodeOperation(NodeRequest request) {
-        try {
-            final ShardId shardId = request.getShardId();
-            logger.trace("{} loading local shard state info", shardId);
-            ShardStateMetadata shardStateMetadata = ShardStateMetadata.FORMAT.loadLatestState(
-                logger,
-                namedXContentRegistry,
-                nodeEnv.availableShardPaths(request.shardId)
-            );
-            if (shardStateMetadata != null) {
-                if (indicesService.getShardOrNull(shardId) == null) {
-                    final String customDataPath = TransportNodesGatewayStartedShardHelper.getCustomDataPathForShard(
-                        logger,
+    protected BulkOfNodeGatewayStartedShards nodeOperation(NodeRequest request) {
+        Map<ShardId, NodeGatewayStartedShards> shardsOnNode = new HashMap<>();
+        for (Map.Entry<ShardId, String> shardToCustomDataPathEntry : request.shardIdsWithCustomDataPath.entrySet()) {
+            try {
+                final ShardId shardId = shardToCustomDataPathEntry.getKey();
+                logger.trace("{} loading local shard state info", shardId);
+                ShardStateMetadata shardStateMetadata = ShardStateMetadata.FORMAT.loadLatestState(
+                    logger,
+                    namedXContentRegistry,
+                    nodeEnv.availableShardPaths(shardId)
+                );
+                if (shardStateMetadata != null) {
+                    if (indicesService.getShardOrNull(shardId) == null) {
+                        final String customDataPath = TransportNodesGatewayStartedShardHelper.getCustomDataPathForShard(
+                            logger,
+                            shardId,
+                            shardToCustomDataPathEntry.getValue(),
+                            settings,
+                            clusterService
+                        );
+                        // we don't have an open shard on the store, validate the files on disk are openable
+                        Exception shardCorruptionException = TransportNodesGatewayStartedShardHelper.getShardCorruption(
+                            logger,
+                            nodeEnv,
+                            shardId,
+                            shardStateMetadata,
+                            customDataPath
+                        );
+                        if (shardCorruptionException != null) {
+                            String allocationId = shardStateMetadata.allocationId != null ? shardStateMetadata.allocationId.getId() : null;
+                            shardsOnNode.put(
+                                shardId,
+                                new NodeGatewayStartedShards(allocationId, shardStateMetadata.primary, null, shardCorruptionException)
+                            );
+                            continue;
+                        }
+                    }
+                    logger.debug("{} shard state info found: [{}]", shardId, shardStateMetadata);
+                    String allocationId = shardStateMetadata.allocationId != null ? shardStateMetadata.allocationId.getId() : null;
+                    final IndexShard shard = indicesService.getShardOrNull(shardId);
+                    shardsOnNode.put(
                         shardId,
-                        request.getCustomDataPath(),
-                        settings,
-                        clusterService
-                    );
-                    // we don't have an open shard on the store, validate the files on disk are openable
-                    Exception exception = TransportNodesGatewayStartedShardHelper.getShardCorruption(
-                        logger,
-                        nodeEnv,
-                        shardId,
-                        shardStateMetadata,
-                        customDataPath
-                    );
-                    if (exception != null) {
-                        String allocationId = shardStateMetadata.allocationId != null ? shardStateMetadata.allocationId.getId() : null;
-                        return new NodeGatewayStartedShards(
-                            clusterService.localNode(),
+                        new NodeGatewayStartedShards(
                             allocationId,
                             shardStateMetadata.primary,
-                            null,
-                            exception
-                        );
-                    }
+                            shard != null ? shard.getLatestReplicationCheckpoint() : null
+                        )
+                    );
+                } else {
+                    logger.trace("{} no local shard info found", shardId);
+                    shardsOnNode.put(shardId, new NodeGatewayStartedShards(null, false, null));
                 }
-                logger.debug("{} shard state info found: [{}]", shardId, shardStateMetadata);
-                String allocationId = shardStateMetadata.allocationId != null ? shardStateMetadata.allocationId.getId() : null;
-                final IndexShard shard = indicesService.getShardOrNull(shardId);
-                return new NodeGatewayStartedShards(
-                    clusterService.localNode(),
-                    allocationId,
-                    shardStateMetadata.primary,
-                    shard != null ? shard.getLatestReplicationCheckpoint() : null
-                );
+            } catch (Exception e) {
+                throw new OpenSearchException("failed to load started shards", e);
             }
-            logger.trace("{} no local shard info found", shardId);
-            return new NodeGatewayStartedShards(clusterService.localNode(), null, false, null);
-        } catch (Exception e) {
-            throw new OpenSearchException("failed to load started shards", e);
         }
+        return new BulkOfNodeGatewayStartedShards(clusterService.localNode(), shardsOnNode);
     }
 
     /**
@@ -203,51 +216,35 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesAction
      * @opensearch.internal
      */
     public static class Request extends BaseNodesRequest<Request> {
-
-        private final ShardId shardId;
-        @Nullable
-        private final String customDataPath;
+        private final Map<ShardId, String> shardIdsWithCustomDataPath;
 
         public Request(StreamInput in) throws IOException {
             super(in);
-            shardId = new ShardId(in);
-            customDataPath = in.readString();
+            shardIdsWithCustomDataPath = in.readMap(ShardId::new, StreamInput::readString);
         }
 
-        public Request(ShardId shardId, String customDataPath, DiscoveryNode[] nodes) {
+        public Request(DiscoveryNode[] nodes, Map<ShardId, String> shardIdStringMap) {
             super(nodes);
-            this.shardId = Objects.requireNonNull(shardId);
-            this.customDataPath = Objects.requireNonNull(customDataPath);
-        }
-
-        public ShardId shardId() {
-            return shardId;
-        }
-
-        /**
-         * Returns the custom data path that is used to look up information for this shard.
-         * Returns an empty string if no custom data path is used for this index.
-         * Returns null if custom data path information is not available (due to BWC).
-         */
-        @Nullable
-        public String getCustomDataPath() {
-            return customDataPath;
+            this.shardIdsWithCustomDataPath = Objects.requireNonNull(shardIdStringMap);
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            shardId.writeTo(out);
-            out.writeString(customDataPath);
+            out.writeMap(shardIdsWithCustomDataPath, (o, k) -> k.writeTo(o), StreamOutput::writeString);
+        }
+
+        public Map<ShardId, String> getShardIdsMap() {
+            return shardIdsWithCustomDataPath;
         }
     }
 
     /**
-     *  The nodes response.
+     * The nodes response.
      *
      * @opensearch.internal
      */
-    public static class NodesGatewayStartedShards extends BaseNodesResponse<NodeGatewayStartedShards> {
+    public static class NodesGatewayStartedShards extends BaseNodesResponse<BulkOfNodeGatewayStartedShards> {
 
         public NodesGatewayStartedShards(StreamInput in) throws IOException {
             super(in);
@@ -255,19 +252,19 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesAction
 
         public NodesGatewayStartedShards(
             ClusterName clusterName,
-            List<NodeGatewayStartedShards> nodes,
+            List<BulkOfNodeGatewayStartedShards> nodes,
             List<FailedNodeException> failures
         ) {
             super(clusterName, nodes, failures);
         }
 
         @Override
-        protected List<NodeGatewayStartedShards> readNodesFrom(StreamInput in) throws IOException {
-            return in.readList(NodeGatewayStartedShards::new);
+        protected List<BulkOfNodeGatewayStartedShards> readNodesFrom(StreamInput in) throws IOException {
+            return in.readList(BulkOfNodeGatewayStartedShards::new);
         }
 
         @Override
-        protected void writeNodesTo(StreamOutput out, List<NodeGatewayStartedShards> nodes) throws IOException {
+        protected void writeNodesTo(StreamOutput out, List<BulkOfNodeGatewayStartedShards> nodes) throws IOException {
             out.writeList(nodes);
         }
     }
@@ -279,57 +276,38 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesAction
      */
     public static class NodeRequest extends TransportRequest {
 
-        private final ShardId shardId;
-        @Nullable
-        private final String customDataPath;
+        private final Map<ShardId, String> shardIdsWithCustomDataPath;
 
         public NodeRequest(StreamInput in) throws IOException {
             super(in);
-            shardId = new ShardId(in);
-            customDataPath = in.readString();
+            shardIdsWithCustomDataPath = in.readMap(ShardId::new, StreamInput::readString);
         }
 
         public NodeRequest(Request request) {
-            this.shardId = Objects.requireNonNull(request.shardId());
-            this.customDataPath = Objects.requireNonNull(request.getCustomDataPath());
+
+            this.shardIdsWithCustomDataPath = Objects.requireNonNull(request.getShardIdsMap());
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            shardId.writeTo(out);
-            assert customDataPath != null;
-            out.writeString(customDataPath);
+            out.writeMap(shardIdsWithCustomDataPath, (o, k) -> k.writeTo(o), StreamOutput::writeString);
         }
 
-        public ShardId getShardId() {
-            return shardId;
-        }
-
-        /**
-         * Returns the custom data path that is used to look up information for this shard.
-         * Returns an empty string if no custom data path is used for this index.
-         * Returns null if custom data path information is not available (due to BWC).
-         */
-        @Nullable
-        public String getCustomDataPath() {
-            return customDataPath;
-        }
     }
 
     /**
-     * The response.
+     * The response as stored by TransportNodesListGatewayStartedShards(to maintain backward compatibility).
      *
      * @opensearch.internal
      */
-    public static class NodeGatewayStartedShards extends BaseNodeResponse {
+    public static class NodeGatewayStartedShards {
         private final String allocationId;
         private final boolean primary;
         private final Exception storeException;
         private final ReplicationCheckpoint replicationCheckpoint;
 
         public NodeGatewayStartedShards(StreamInput in) throws IOException {
-            super(in);
             allocationId = in.readOptionalString();
             primary = in.readBoolean();
             if (in.readBoolean()) {
@@ -344,23 +322,16 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesAction
             }
         }
 
-        public NodeGatewayStartedShards(
-            DiscoveryNode node,
-            String allocationId,
-            boolean primary,
-            ReplicationCheckpoint replicationCheckpoint
-        ) {
-            this(node, allocationId, primary, replicationCheckpoint, null);
+        public NodeGatewayStartedShards(String allocationId, boolean primary, ReplicationCheckpoint replicationCheckpoint) {
+            this(allocationId, primary, replicationCheckpoint, null);
         }
 
         public NodeGatewayStartedShards(
-            DiscoveryNode node,
             String allocationId,
             boolean primary,
             ReplicationCheckpoint replicationCheckpoint,
             Exception storeException
         ) {
-            super(node);
             this.allocationId = allocationId;
             this.primary = primary;
             this.replicationCheckpoint = replicationCheckpoint;
@@ -383,7 +354,6 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesAction
             return this.storeException;
         }
 
-        @Override
         public void writeTo(StreamOutput out) throws IOException {
             TransportNodesGatewayStartedShardHelper.NodeGatewayStartedShardsWriteTo(
                 out,
@@ -430,5 +400,30 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesAction
                 replicationCheckpoint
             );
         }
+    }
+
+    public static class BulkOfNodeGatewayStartedShards extends BaseNodeResponse {
+        public Map<ShardId, NodeGatewayStartedShards> getBulkOfNodeGatewayStartedShards() {
+            return bulkOfNodeGatewayStartedShards;
+        }
+
+        private final Map<ShardId, NodeGatewayStartedShards> bulkOfNodeGatewayStartedShards;
+
+        public BulkOfNodeGatewayStartedShards(StreamInput in) throws IOException {
+            super(in);
+            this.bulkOfNodeGatewayStartedShards = in.readMap(ShardId::new, NodeGatewayStartedShards::new);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeMap(bulkOfNodeGatewayStartedShards, (o, k) -> k.writeTo(o), (o, v) -> v.writeTo(o));
+        }
+
+        public BulkOfNodeGatewayStartedShards(DiscoveryNode node, Map<ShardId, NodeGatewayStartedShards> bulkOfNodeGatewayStartedShards) {
+            super(node);
+            this.bulkOfNodeGatewayStartedShards = bulkOfNodeGatewayStartedShards;
+        }
+
     }
 }

--- a/server/src/main/java/org/opensearch/gateway/TransportNodesGatewayStartedShardHelper.java
+++ b/server/src/main/java/org/opensearch/gateway/TransportNodesGatewayStartedShardHelper.java
@@ -1,0 +1,189 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.gateway;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.opensearch.OpenSearchException;
+import org.opensearch.Version;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.env.NodeEnvironment;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.shard.ShardId;
+import org.opensearch.index.shard.ShardPath;
+import org.opensearch.index.shard.ShardStateMetadata;
+import org.opensearch.index.store.Store;
+import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
+
+import java.io.IOException;
+
+/**
+ * This class has the common code used in TransportNodesBulkListGatewayStartedShards and TransportNodesListGatewayStartedShards
+ */
+public class TransportNodesGatewayStartedShardHelper {
+
+    /**
+     * Helper function for getting the data path of the shard that is used to look up information for this shard.
+     * If the dataPathInRequest passed to the method is not empty then same is returned. Else the custom data path is returned
+     * from the indexSettings fetched from the cluster state metadata for the specified shard.
+     *
+     * @param logger
+     * @param shardId
+     * @param dataPathInRequest
+     * @param settings
+     * @param clusterService
+     * @return String
+     */
+    public static String getCustomDataPathForShard(
+        Logger logger,
+        ShardId shardId,
+        String dataPathInRequest,
+        Settings settings,
+        ClusterService clusterService
+    ) {
+        if (dataPathInRequest != null) return dataPathInRequest;
+        // TODO: Fallback for BWC with older OpenSearch versions.
+        // Remove once request.getCustomDataPath() always returns non-null
+        final IndexMetadata metadata = clusterService.state().metadata().index(shardId.getIndex());
+        if (metadata != null) {
+            return new IndexSettings(metadata, settings).customDataPath();
+        } else {
+            logger.trace("{} node doesn't have meta data for the requests index", shardId);
+            throw new OpenSearchException("node doesn't have meta data for index " + shardId.getIndex());
+        }
+    }
+
+    /**
+     * Helper function for checking if the shard file exists and is not corrupted. We return the specific exception if
+     * the shard file is corrupted. else null value is returned.
+     *
+     * @param logger
+     * @param nodeEnv
+     * @param shardId
+     * @param shardStateMetadata
+     * @param customDataPath
+     * @return Exception
+     */
+    public static Exception getShardCorruption(
+        Logger logger,
+        NodeEnvironment nodeEnv,
+        ShardId shardId,
+        ShardStateMetadata shardStateMetadata,
+        String customDataPath
+    ) {
+        ShardPath shardPath = null;
+        try {
+            shardPath = ShardPath.loadShardPath(logger, nodeEnv, shardId, customDataPath);
+            if (shardPath == null) {
+                throw new IllegalStateException(shardId + " no shard path found");
+            }
+            Store.tryOpenIndex(shardPath.resolveIndex(), shardId, nodeEnv::shardLock, logger);
+        } catch (Exception exception) {
+            final ShardPath finalShardPath = shardPath;
+            logger.trace(
+                () -> new ParameterizedMessage(
+                    "{} can't open index for shard [{}] in path [{}]",
+                    shardId,
+                    shardStateMetadata,
+                    (finalShardPath != null) ? finalShardPath.resolveIndex() : ""
+                ),
+                exception
+            );
+            return exception;
+        }
+        return null;
+    }
+
+    /**
+     * Helper function for getting the string representation of the NodeGatewayStartedShards object
+     *
+     * @param allocationId
+     * @param primary
+     * @param storeException
+     * @param replicationCheckpoint
+     * @return String
+     */
+    public static String NodeGatewayStartedShardsToString(
+        String allocationId,
+        boolean primary,
+        Exception storeException,
+        ReplicationCheckpoint replicationCheckpoint
+    ) {
+        StringBuilder buf = new StringBuilder();
+        buf.append("NodeGatewayStartedShards[").append("allocationId=").append(allocationId).append(",primary=").append(primary);
+        if (storeException != null) {
+            buf.append(",storeException=").append(storeException);
+        }
+        if (replicationCheckpoint != null) {
+            buf.append(",ReplicationCheckpoint=").append(replicationCheckpoint.toString());
+        }
+        buf.append("]");
+        return buf.toString();
+    }
+
+    /**
+     * Helper function for computing the hashcode of the NodeGatewayStartedShards object
+     *
+     * @param allocationId
+     * @param primary
+     * @param storeException
+     * @param replicationCheckpoint
+     * @return int
+     */
+    public static int NodeGatewayStartedShardsHashCode(
+        String allocationId,
+        boolean primary,
+        Exception storeException,
+        ReplicationCheckpoint replicationCheckpoint
+    ) {
+        int result = (allocationId != null ? allocationId.hashCode() : 0);
+        result = 31 * result + (primary ? 1 : 0);
+        result = 31 * result + (storeException != null ? storeException.hashCode() : 0);
+        result = 31 * result + (replicationCheckpoint != null ? replicationCheckpoint.hashCode() : 0);
+        return result;
+    }
+
+    /**
+     * Helper function for NodeGatewayStartedShardsWriteTo method
+     *
+     * @param out
+     * @param allocationId
+     * @param primary
+     * @param storeException
+     * @param replicationCheckpoint
+     * @throws IOException
+     */
+    public static void NodeGatewayStartedShardsWriteTo(
+        StreamOutput out,
+        String allocationId,
+        boolean primary,
+        Exception storeException,
+        ReplicationCheckpoint replicationCheckpoint
+    ) throws IOException {
+        out.writeOptionalString(allocationId);
+        out.writeBoolean(primary);
+        if (storeException != null) {
+            out.writeBoolean(true);
+            out.writeException(storeException);
+        } else {
+            out.writeBoolean(false);
+        }
+        if (out.getVersion().onOrAfter(Version.V_2_3_0)) {
+            if (replicationCheckpoint != null) {
+                out.writeBoolean(true);
+                replicationCheckpoint.writeTo(out);
+            } else {
+                out.writeBoolean(false);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description
This  PR for adding the transport action for  the async fetching of the shard information for bulk of shards from the nodes in a single request per node. Code is inspired by the existing transport action [TransportNodesListGatewayStartedShards.java](https://github.com/opensearch-project/OpenSearch/compare/main...Gaurav614:OpenSearch:async-shard-fetch-psatransport?expand=1#diff-21a085e8c9804d834a1aa1f647f9f81c86e40167c1e961de4dfc67289f2b12a3) which fetches just one shard information from the node per request. 
* Added transport action [TransportNodesBulkListGatewayStartedShards.java](https://github.com/opensearch-project/OpenSearch/compare/main...Gaurav614:OpenSearch:async-shard-fetch-psatransport?expand=1#diff-6efc7ab3ebdfd8e21360f3387d0669948f217531254e505124f136ea08d79a7c)  for fetching the shards data on a node in bulk. 
* Added helper class [TransportNodesGatewayStartedShardHelper.java](https://github.com/opensearch-project/OpenSearch/compare/main...Gaurav614:OpenSearch:async-shard-fetch-psatransport?expand=1#diff-e79ce5553a7d1a39b9c090d0f58714eaaba29d47c4727d165fc7237086d33641) for reducing the code duplication in new transport class [TransportNodesBulkListGatewayStartedShards.java](https://github.com/opensearch-project/OpenSearch/compare/main...Gaurav614:OpenSearch:async-shard-fetch-psatransport?expand=1#diff-6efc7ab3ebdfd8e21360f3387d0669948f217531254e505124f136ea08d79a7c) and existing transport class [TransportNodesListGatewayStartedShards.java](https://github.com/opensearch-project/OpenSearch/compare/main...Gaurav614:OpenSearch:async-shard-fetch-psatransport?expand=1#diff-21a085e8c9804d834a1aa1f647f9f81c86e40167c1e961de4dfc67289f2b12a3).
* POC code where testing was done https://github.com/opensearch-project/OpenSearch/pull/7269/files#diff-c1a7825492dba9f1ba34affffcead20eab136eb67283f89d81295fcef2a8a3ff

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
* https://github.com/opensearch-project/OpenSearch/issues/5098

### Check List
- [ Y] New functionality includes testing.
  - [ N] All tests pass (tests are failing in local without my commits as well so raising PR to check if its an issue with my setup)
- [Y ] New functionality has been documented.
  - [Y ] New functionality has javadoc added
- [Y ] Commits are signed per the DCO using --signoff
- [ Y] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
