### PR TITLE
[Segment Replication] Update segrep bwc tests to verify replica checkpoints and skip tests for 1.x bwc versions

### DIFF
--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -86,6 +86,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
       nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
       nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
     }
+    systemProperty 'tests.upgrade_from_version', baseName
     systemProperty 'tests.path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
     onlyIf { project.bwc_tests_enabled }
   }

--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -55,6 +55,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
   }
 
   String baseName = "v${bwcVersion}"
+  String bwcVersionStr = "${bwcVersion}"
 
   /* This project runs the core REST tests against a 4 node cluster where two of
      the nodes has a different minor.  */
@@ -86,7 +87,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
       nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
       nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
     }
-    systemProperty 'tests.upgrade_from_version', baseName
+    systemProperty 'tests.upgrade_from_version', bwcVersionStr
     systemProperty 'tests.path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
     onlyIf { project.bwc_tests_enabled }
   }

--- a/qa/mixed-cluster/src/test/java/org/opensearch/backwards/IndexingIT.java
+++ b/qa/mixed-cluster/src/test/java/org/opensearch/backwards/IndexingIT.java
@@ -66,6 +66,9 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class IndexingIT extends OpenSearchRestTestCase {
 
+    protected static final Version UPGRADE_FROM_VERSION = Version.fromString(System.getProperty("tests.upgrade_from_version"));
+
+
     private int indexDocs(String index, final int idStart, final int numDocs) throws IOException {
         for (int i = 0; i < numDocs; i++) {
             final int id = idStart + i;

--- a/qa/mixed-cluster/src/test/java/org/opensearch/backwards/IndexingIT.java
+++ b/qa/mixed-cluster/src/test/java/org/opensearch/backwards/IndexingIT.java
@@ -114,6 +114,10 @@ public class IndexingIT extends OpenSearchRestTestCase {
      * @throws Exception
      */
     public void testIndexingWithPrimaryOnBwcNodes() throws Exception {
+        if (UPGRADE_FROM_VERSION.before(Version.V_2_4_0)) {
+            logger.info("--> Skip test for version {} where segment replication feature is not available", UPGRADE_FROM_VERSION);
+            return;
+        }
         Nodes nodes = buildNodeAndVersions();
         assumeFalse("new nodes is empty", nodes.getNewNodes().isEmpty());
         logger.info("cluster discovered:\n {}", nodes.toString());
@@ -161,6 +165,10 @@ public class IndexingIT extends OpenSearchRestTestCase {
      * @throws Exception
      */
     public void testIndexingWithReplicaOnBwcNodes() throws Exception {
+        if (UPGRADE_FROM_VERSION.before(Version.V_2_4_0)) {
+            logger.info("--> Skip test for version {} where segment replication feature is not available", UPGRADE_FROM_VERSION);
+            return;
+        }
         Nodes nodes = buildNodeAndVersions();
         assumeFalse("new nodes is empty", nodes.getNewNodes().isEmpty());
         logger.info("cluster discovered:\n {}", nodes.toString());

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/IndexingIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/IndexingIT.java
@@ -253,6 +253,10 @@ public class IndexingIT extends AbstractRollingTestCase {
      * @throws Exception
      */
     public void testIndexingWithSegRep() throws Exception {
+        if (UPGRADE_FROM_VERSION.before(Version.V_2_4_0)) {
+            logger.info("--> Skip test for version {} where segment replication feature is not available", UPGRADE_FROM_VERSION);
+            return;
+        }
         final String indexName = "test-index-segrep";
         final int shardCount = 3;
         final int replicaCount = 2;

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/IndexingIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/IndexingIT.java
@@ -130,7 +130,7 @@ public class IndexingIT extends AbstractRollingTestCase {
                     replicaRequest.addParameter("preference", "_shards:" + shardNum + "|_only_nodes:" + replicaShardToNodeIDMap.get(shardNum));
                     Response replicaResponse = client().performRequest(replicaRequest);
                     int replicaHits = ObjectPath.createFromResponse(replicaResponse).evaluate("hits.total");
-                    assertEquals("Doc count mismatch for shard " + shardNum + " primary hits " + primaryHits + " replica hits " + replicaHits, primaryHits, replicaHits);
+                    assertEquals("Doc count mismatch for shard " + shardNum + ". Primary hits " + primaryHits + " Replica hits " + replicaHits, primaryHits, replicaHits);
                 }, 1, TimeUnit.MINUTES);
             }
         }


### PR DESCRIPTION
### Description
1. Adds segment replicatoin stats verification step by asserting `checkpoints_behind` metric from `_cat/segment_replication` API should be 0.
2. Skips test execution for 1.x bwc versions

### Related
https://github.com/opensearch-project/OpenSearch/issues/7490

### Testing
Ran test 50 times locally without any failure i.e. test is not flaky
```
for i in $(seq 0 50); do echo "running $i iteration\n";  ./gradlew :qa:rolling-upgrade:v2.9.0#upgradedClusterTest --tests "org.opensearch.upgrades.IndexingIT.testIndexingWithSegRep" >> /tmp/iteration_$i; done; &
...
ubuntu@ip-172-31-49-145:~$ grep "BUILD SUCCESS" /tmp/iteration_* | wc -l
51
```

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
