### PR TITLE
Return null for aggregations factory even if empty aggs is present in search source

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/60_empty.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/60_empty.yml
@@ -1,0 +1,29 @@
+---
+"Empty Agg Body":
+  - do:
+      index:
+        index: test
+        id: 1
+        body: { "double" : 42 }
+
+  - do:
+      index:
+        index: test
+        id: 2
+        body: { "double" : 100 }
+
+  - do:
+      index:
+        index: test
+        id: 3
+        body: { "double" : 50 }
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body: { "size" : 0, "aggs" : { } }
+
+  - match: { hits.total: 3 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/60_empty.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/60_empty.yml
@@ -1,5 +1,5 @@
 ---
-"Empty Agg Body":
+"Empty aggs Body":
   - do:
       index:
         index: test

--- a/server/src/main/java/org/opensearch/search/aggregations/AggregatorFactories.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/AggregatorFactories.java
@@ -235,7 +235,7 @@ public class AggregatorFactories {
             }
         }
 
-        return factories;
+        return factories.count() > 0 ? factories : null;
     }
 
     public static final AggregatorFactories EMPTY = new AggregatorFactories(new AggregatorFactory[0]);


### PR DESCRIPTION
### Description
Whenever `"aggs"` is passed into the request body, even if it is empty (ex. `"aggs": {},`), then this line will evaluate to true:

https://github.com/opensearch-project/OpenSearch/blob/8eea7b986453271cd227a7b98ee09e70d5e28634/server/src/main/java/org/opensearch/action/search/QueryPhaseResultConsumer.java#L117

Causing us to go down the wrong path and hit the NPE.

This behavior exists from before #7514 and was handled by various checks for the aggregators, for example like here: https://github.com/opensearch-project/OpenSearch/blob/2.8/server/src/main/java/org/opensearch/search/aggregations/AggregationPhase.java#L68-L74 where collectors are not added if the aggregators length is not 0.



### Related Issues
Resolves #8115
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
