### PR TITLE
Added transport action for bulk async shard fetch for primary shards.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Allow mmap to use new JDK-19 preview APIs in Apache Lucene 9.4+ ([#5151](https://github.com/opensearch-project/OpenSearch/pull/5151))
 - Add events correlation engine plugin ([#6854](https://github.com/opensearch-project/OpenSearch/issues/6854))
 - Add support for ignoring missing Javadoc on generated code using annotation ([#7604](https://github.com/opensearch-project/OpenSearch/pull/7604))
+- Add PSA transport action for bulk async fetch of shards ([#5098](https://github.com/opensearch-project/OpenSearch/issues/5098))
 
 ### Dependencies
 - Bump `log4j-core` from 2.18.0 to 2.19.0
@@ -44,7 +45,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Change http code for DecommissioningFailedException from 500 to 400 ([#5283](https://github.com/opensearch-project/OpenSearch/pull/5283))
 - Improve summary error message for invalid setting updates ([#4792](https://github.com/opensearch-project/OpenSearch/pull/4792))
 - Pass localNode info to all plugins on node start ([#7919](https://github.com/opensearch-project/OpenSearch/pull/7919))
-
+- Modified the existing async shard fetch transport action to use the helper functions added for bulk fetching ([#5098](https://github.com/opensearch-project/OpenSearch/issues/5098))
 ### Deprecated
 
 ### Removed

--- a/server/src/main/java/org/opensearch/gateway/AsyncShardsFetchPerNode.java
+++ b/server/src/main/java/org/opensearch/gateway/AsyncShardsFetchPerNode.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.gateway;
+
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.support.nodes.BaseNodeResponse;
+import org.opensearch.action.support.nodes.BaseNodesResponse;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.lease.Releasable;
+import org.opensearch.index.shard.ShardId;
+
+import java.util.Map;
+
+/**
+ * This class is responsible for fetching shard data from nodes. It is analogous to AsyncShardFetch class since it fetches
+ * the data in asynchronous manner too.
+ * @param <T>
+ */
+public abstract class AsyncShardsFetchPerNode<T extends BaseNodeResponse> implements Releasable {
+    /**
+     * An action that lists the relevant shard data that needs to be fetched.
+     */
+    public interface Lister<NodesResponse extends BaseNodesResponse<NodeResponse>, NodeResponse extends BaseNodeResponse> {
+        void list(DiscoveryNode[] nodes, Map<ShardId, String> shardsIdMap, ActionListener<NodesResponse> listener);
+    }
+}

--- a/server/src/main/java/org/opensearch/gateway/TransportNodesGatewayStartedShardHelper.java
+++ b/server/src/main/java/org/opensearch/gateway/TransportNodesGatewayStartedShardHelper.java
@@ -1,0 +1,189 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.gateway;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.opensearch.OpenSearchException;
+import org.opensearch.Version;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.env.NodeEnvironment;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.shard.ShardId;
+import org.opensearch.index.shard.ShardPath;
+import org.opensearch.index.shard.ShardStateMetadata;
+import org.opensearch.index.store.Store;
+import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
+
+import java.io.IOException;
+
+/**
+ * This class has the common code used in TransportNodesBulkListGatewayStartedShards and TransportNodesListGatewayStartedShards
+ */
+public class TransportNodesGatewayStartedShardHelper {
+
+    /**
+     * Helper function for getting the data path of the shard that is used to look up information for this shard.
+     * If the dataPathInRequest passed to the method is not empty then same is returned. Else the custom data path is returned
+     * from the indexSettings fetched from the cluster state metadata for the specified shard.
+     *
+     * @param logger
+     * @param shardId
+     * @param dataPathInRequest
+     * @param settings
+     * @param clusterService
+     * @return String
+     */
+    public static String getCustomDataPathForShard(
+        Logger logger,
+        ShardId shardId,
+        String dataPathInRequest,
+        Settings settings,
+        ClusterService clusterService
+    ) {
+        if (dataPathInRequest != null) return dataPathInRequest;
+        // TODO: Fallback for BWC with older OpenSearch versions.
+        // Remove once request.getCustomDataPath() always returns non-null
+        final IndexMetadata metadata = clusterService.state().metadata().index(shardId.getIndex());
+        if (metadata != null) {
+            return new IndexSettings(metadata, settings).customDataPath();
+        } else {
+            logger.trace("{} node doesn't have meta data for the requests index", shardId);
+            throw new OpenSearchException("node doesn't have meta data for index " + shardId.getIndex());
+        }
+    }
+
+    /**
+     * Helper function for checking if the shard file exists and is not corrupted. We return the specific exception if
+     * the shard file is corrupted. else null value is returned.
+     *
+     * @param logger
+     * @param nodeEnv
+     * @param shardId
+     * @param shardStateMetadata
+     * @param customDataPath
+     * @return Exception
+     */
+    public static Exception getShardCorruption(
+        Logger logger,
+        NodeEnvironment nodeEnv,
+        ShardId shardId,
+        ShardStateMetadata shardStateMetadata,
+        String customDataPath
+    ) {
+        ShardPath shardPath = null;
+        try {
+            shardPath = ShardPath.loadShardPath(logger, nodeEnv, shardId, customDataPath);
+            if (shardPath == null) {
+                throw new IllegalStateException(shardId + " no shard path found");
+            }
+            Store.tryOpenIndex(shardPath.resolveIndex(), shardId, nodeEnv::shardLock, logger);
+        } catch (Exception exception) {
+            final ShardPath finalShardPath = shardPath;
+            logger.trace(
+                () -> new ParameterizedMessage(
+                    "{} can't open index for shard [{}] in path [{}]",
+                    shardId,
+                    shardStateMetadata,
+                    (finalShardPath != null) ? finalShardPath.resolveIndex() : ""
+                ),
+                exception
+            );
+            return exception;
+        }
+        return null;
+    }
+
+    /**
+     * Helper function for getting the string representation of the NodeGatewayStartedShards object
+     *
+     * @param allocationId
+     * @param primary
+     * @param storeException
+     * @param replicationCheckpoint
+     * @return String
+     */
+    public static String NodeGatewayStartedShardsToString(
+        String allocationId,
+        boolean primary,
+        Exception storeException,
+        ReplicationCheckpoint replicationCheckpoint
+    ) {
+        StringBuilder buf = new StringBuilder();
+        buf.append("NodeGatewayStartedShards[").append("allocationId=").append(allocationId).append(",primary=").append(primary);
+        if (storeException != null) {
+            buf.append(",storeException=").append(storeException);
+        }
+        if (replicationCheckpoint != null) {
+            buf.append(",ReplicationCheckpoint=").append(replicationCheckpoint.toString());
+        }
+        buf.append("]");
+        return buf.toString();
+    }
+
+    /**
+     * Helper function for computing the hashcode of the NodeGatewayStartedShards object
+     *
+     * @param allocationId
+     * @param primary
+     * @param storeException
+     * @param replicationCheckpoint
+     * @return int
+     */
+    public static int NodeGatewayStartedShardsHashCode(
+        String allocationId,
+        boolean primary,
+        Exception storeException,
+        ReplicationCheckpoint replicationCheckpoint
+    ) {
+        int result = (allocationId != null ? allocationId.hashCode() : 0);
+        result = 31 * result + (primary ? 1 : 0);
+        result = 31 * result + (storeException != null ? storeException.hashCode() : 0);
+        result = 31 * result + (replicationCheckpoint != null ? replicationCheckpoint.hashCode() : 0);
+        return result;
+    }
+
+    /**
+     * Helper function for NodeGatewayStartedShardsWriteTo method
+     *
+     * @param out
+     * @param allocationId
+     * @param primary
+     * @param storeException
+     * @param replicationCheckpoint
+     * @throws IOException
+     */
+    public static void NodeGatewayStartedShardsWriteTo(
+        StreamOutput out,
+        String allocationId,
+        boolean primary,
+        Exception storeException,
+        ReplicationCheckpoint replicationCheckpoint
+    ) throws IOException {
+        out.writeOptionalString(allocationId);
+        out.writeBoolean(primary);
+        if (storeException != null) {
+            out.writeBoolean(true);
+            out.writeException(storeException);
+        } else {
+            out.writeBoolean(false);
+        }
+        if (out.getVersion().onOrAfter(Version.V_2_3_0)) {
+            if (replicationCheckpoint != null) {
+                out.writeBoolean(true);
+                replicationCheckpoint.writeTo(out);
+            } else {
+                out.writeBoolean(false);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description
This  PR for adding the transport action for  the async fetching of the shard information for bulk of shards from the nodes in a single request per node. Code is inspired by the existing transport action [TransportNodesListGatewayStartedShards.java](https://github.com/opensearch-project/OpenSearch/compare/main...Gaurav614:OpenSearch:async-shard-fetch-psatransport?expand=1#diff-21a085e8c9804d834a1aa1f647f9f81c86e40167c1e961de4dfc67289f2b12a3) which fetches just one shard information from the node per request. 
* Added transport action [TransportNodesBulkListGatewayStartedShards.java](https://github.com/opensearch-project/OpenSearch/compare/main...Gaurav614:OpenSearch:async-shard-fetch-psatransport?expand=1#diff-6efc7ab3ebdfd8e21360f3387d0669948f217531254e505124f136ea08d79a7c)  for fetching the shards data on a node in bulk. 
* Added helper class [TransportNodesGatewayStartedShardHelper.java](https://github.com/opensearch-project/OpenSearch/compare/main...Gaurav614:OpenSearch:async-shard-fetch-psatransport?expand=1#diff-e79ce5553a7d1a39b9c090d0f58714eaaba29d47c4727d165fc7237086d33641) for reducing the code duplication in new transport class [TransportNodesBulkListGatewayStartedShards.java](https://github.com/opensearch-project/OpenSearch/compare/main...Gaurav614:OpenSearch:async-shard-fetch-psatransport?expand=1#diff-6efc7ab3ebdfd8e21360f3387d0669948f217531254e505124f136ea08d79a7c) and existing transport class [TransportNodesListGatewayStartedShards.java](https://github.com/opensearch-project/OpenSearch/compare/main...Gaurav614:OpenSearch:async-shard-fetch-psatransport?expand=1#diff-21a085e8c9804d834a1aa1f647f9f81c86e40167c1e961de4dfc67289f2b12a3).
* POC code where testing was done https://github.com/opensearch-project/OpenSearch/pull/7269/files#diff-c1a7825492dba9f1ba34affffcead20eab136eb67283f89d81295fcef2a8a3ff

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
* https://github.com/opensearch-project/OpenSearch/issues/5098

### Check List
- [ Y] New functionality includes testing.
  - [ Y] All tests pass
- [Y ] New functionality has been documented.
  - [Y ] New functionality has javadoc added
- [Y ] Commits are signed per the DCO using --signoff
- [ Y] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
