### PR TITLE
[Extensions] Fixed duplicate extension unique id

### DIFF
--- a/server/src/main/java/org/opensearch/transport/TransportService.java
+++ b/server/src/main/java/org/opensearch/transport/TransportService.java
@@ -544,7 +544,9 @@ public class TransportService extends AbstractLifecycleComponent
     ) {
         return (newConnection, actualProfile, listener) -> {
             // We don't validate cluster names to allow for CCS connections.
-            threadPool.getThreadContext().putHeader("extension_unique_id", extensionUniqueId);
+            if (Strings.isNullOrEmpty(threadPool.getThreadContext().getHeader("extension_unique_id"))) {
+                threadPool.getThreadContext().putHeader("extension_unique_id", extensionUniqueId);
+            }
             handshake(newConnection, actualProfile.getHandshakeTimeout().millis(), cn -> true, ActionListener.map(listener, resp -> {
                 final DiscoveryNode remote = resp.discoveryNode;
 

--- a/server/src/main/java/org/opensearch/transport/TransportService.java
+++ b/server/src/main/java/org/opensearch/transport/TransportService.java
@@ -544,7 +544,8 @@ public class TransportService extends AbstractLifecycleComponent
     ) {
         return (newConnection, actualProfile, listener) -> {
             // We don't validate cluster names to allow for CCS connections.
-            if (Strings.isNullOrEmpty(threadPool.getThreadContext().getHeader("extension_unique_id"))) {
+            String currentId = threadPool.getThreadContext().getHeader("extension_unique_id");
+            if (Strings.isNullOrEmpty(currentId) || !extensionUniqueId.equals(currentId)) {
                 threadPool.getThreadContext().putHeader("extension_unique_id", extensionUniqueId);
             }
             handshake(newConnection, actualProfile.getHandshakeTimeout().millis(), cn -> true, ActionListener.map(listener, resp -> {


### PR DESCRIPTION
### Description
The header `extension_unique_id` is being set twice, in OpenSearch and [here](https://github.com/opensearch-project/opensearch-sdk-java/blob/main/src/main/java/org/opensearch/sdk/handlers/ExtensionsInitRequestHandler.java#L56) in SDK for the case when extension is getting initialized. This header helps OpenSearch to recognize node as an extension node while doing `connectToExtensionNode`. The issue was mostly with threadContext restoring the header and trying to set it again.

### Related Issues
Closes https://github.com/opensearch-project/opensearch-sdk-java/issues/771

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
