### PR TITLE
[Backport 1.3] Force nebula plugins to use latest org.bouncycastle:* artifacts (#8233)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 ### Fixed
 - Fix mapping char_filter when mapping a hashtag ([#7591](https://github.com/opensearch-project/OpenSearch/pull/7591))
+- Force nebula plugins to use latest org.bouncycastle:* artifacts ([#8233](https://github.com/opensearch-project/OpenSearch/pull/8233))
 
 ### Security
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -118,6 +118,10 @@ dependencies {
   api 'org.apache.maven:maven-model:3.6.2'
   api 'com.networknt:json-schema-validator:1.0.36'
   api "com.fasterxml.jackson.core:jackson-databind:${props.getProperty('jackson_databind')}"
+  api "org.bouncycastle:bcprov-jdk15on:${props.getProperty('bouncycastle')}"
+  api "org.bouncycastle:bcpkix-jdk15on:${props.getProperty('bouncycastle')}"
+  api "org.bouncycastle:bcpg-jdk15on:${props.getProperty('bouncycastle')}"
+  api "org.bouncycastle:bcutil-jdk15on:${props.getProperty('bouncycastle')}"
 
   testFixturesApi "junit:junit:${props.getProperty('junit')}"
   testFixturesApi "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${props.getProperty('randomizedrunner')}"


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>
(cherry picked from commit c7511718e1ca1224ffa857f8fd211f3e7c1e6a05)


### Description
- Backports #8233 to `1.3`

### Related Issues

<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
