### PR TITLE
Disabled translog fsync in remote store path

### DIFF
--- a/server/src/main/java/org/opensearch/index/translog/Checkpoint.java
+++ b/server/src/main/java/org/opensearch/index/translog/Checkpoint.java
@@ -223,12 +223,14 @@ final public class Checkpoint {
         }
     }
 
-    public static void write(FileChannel fileChannel, Path checkpointFile, Checkpoint checkpoint) throws IOException {
+    public static void write(FileChannel fileChannel, Path checkpointFile, Checkpoint checkpoint, boolean fsync) throws IOException {
         byte[] bytes = createCheckpointBytes(checkpointFile, checkpoint);
         Channels.writeToChannel(bytes, fileChannel, 0);
-        // no need to force metadata, file size stays the same and we did the full fsync
-        // when we first created the file, so the directory entry doesn't change as well
-        fileChannel.force(false);
+        if (fsync == true) {
+            // no need to force metadata, file size stays the same and we did the full fsync
+            // when we first created the file, so the directory entry doesn't change as well
+            fileChannel.force(false);
+        }
     }
 
     private static byte[] createCheckpointBytes(Path checkpointFile, Checkpoint checkpoint) throws IOException {

--- a/server/src/main/java/org/opensearch/index/translog/TranslogHeader.java
+++ b/server/src/main/java/org/opensearch/index/translog/TranslogHeader.java
@@ -213,7 +213,7 @@ final class TranslogHeader {
     /**
      * Writes this header with the latest format into the file channel
      */
-    void write(final FileChannel channel) throws IOException {
+    void write(final FileChannel channel, boolean fsync) throws IOException {
         // This output is intentionally not closed because closing it will close the FileChannel.
         @SuppressWarnings({ "IOResourceOpenedButNotSafelyClosed", "resource" })
         final BufferedChecksumStreamOutput out = new BufferedChecksumStreamOutput(
@@ -229,7 +229,9 @@ final class TranslogHeader {
         // Checksum header
         out.writeInt((int) out.getChecksum());
         out.flush();
-        channel.force(true);
+        if (fsync == true) {
+            channel.force(true);
+        }
         assert channel.position() == headerSizeInBytes : "Header is not fully written; header size ["
             + headerSizeInBytes
             + "], channel position ["

--- a/server/src/main/java/org/opensearch/index/translog/TruncateTranslogAction.java
+++ b/server/src/main/java/org/opensearch/index/translog/TruncateTranslogAction.java
@@ -258,7 +258,7 @@ public class TruncateTranslogAction {
     private static int writeEmptyTranslog(Path filename, String translogUUID) throws IOException {
         try (FileChannel fc = FileChannel.open(filename, StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW)) {
             TranslogHeader header = new TranslogHeader(translogUUID, SequenceNumbers.UNASSIGNED_PRIMARY_TERM);
-            header.write(fc);
+            header.write(fc, true);
             return header.sizeInBytes();
         }
     }

--- a/server/src/test/java/org/opensearch/index/translog/TranslogHeaderTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/TranslogHeaderTests.java
@@ -63,7 +63,7 @@ public class TranslogHeaderTests extends OpenSearchTestCase {
         final long generation = randomNonNegativeLong();
         final Path translogFile = createTempDir().resolve(Translog.getFilename(generation));
         try (FileChannel channel = FileChannel.open(translogFile, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE)) {
-            outHeader.write(channel);
+            outHeader.write(channel, true);
             assertThat(outHeader.sizeInBytes(), equalTo((int) channel.position()));
         }
         try (FileChannel channel = FileChannel.open(translogFile, StandardOpenOption.READ)) {
@@ -165,7 +165,7 @@ public class TranslogHeaderTests extends OpenSearchTestCase {
         final Path translogLocation = createTempDir();
         final Path translogFile = translogLocation.resolve(Translog.getFilename(generation));
         try (FileChannel channel = FileChannel.open(translogFile, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE)) {
-            outHeader.write(channel);
+            outHeader.write(channel, true);
             assertThat(outHeader.sizeInBytes(), equalTo((int) channel.position()));
         }
         TestTranslog.corruptFile(logger, random(), translogFile, false);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Since remote store is ensuring translog durability there is no need to fsync translog/checkpoint data in request path. Disabling fsync adds improvement of 10%-15% throughput. 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
https://github.com/opensearch-project/OpenSearch/issues/8058

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
