### PR TITLE
Remove concurrency based minimum file cache size restriction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Removed
 - Remove `COMPRESSOR` variable from `CompressorFactory` and use `DEFLATE_COMPRESSOR` instead ([7907](https://github.com/opensearch-project/OpenSearch/pull/7907))
+- Remove concurrency based minimum file cache size restriction ([#8294](https://github.com/opensearch-project/OpenSearch/pull/8294))
 
 ### Fixed
 - Fixing error: adding a new/forgotten parameter to the configuration for checking the config on startup in plugins/repository-s3 #7924

--- a/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCacheFactory.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCacheFactory.java
@@ -11,7 +11,6 @@ package org.opensearch.index.store.remote.filecache;
 import org.opensearch.common.breaker.CircuitBreaker;
 import org.opensearch.common.cache.RemovalReason;
 import org.opensearch.index.store.remote.utils.cache.SegmentedCache;
-import org.opensearch.index.store.remote.file.OnDemandBlockSnapshotIndexInput;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -39,24 +38,11 @@ import static org.opensearch.ExceptionsHelper.catchAsRuntimeException;
 public class FileCacheFactory {
 
     public static FileCache createConcurrentLRUFileCache(long capacity, CircuitBreaker circuitBreaker) {
-        return createFileCache(createDefaultBuilder().capacity(capacity).build(), circuitBreaker);
+        return new FileCache(createDefaultBuilder().capacity(capacity).build(), circuitBreaker);
     }
 
     public static FileCache createConcurrentLRUFileCache(long capacity, int concurrencyLevel, CircuitBreaker circuitBreaker) {
-        return createFileCache(createDefaultBuilder().capacity(capacity).concurrencyLevel(concurrencyLevel).build(), circuitBreaker);
-    }
-
-    private static FileCache createFileCache(SegmentedCache<Path, CachedIndexInput> segmentedCache, CircuitBreaker circuitBreaker) {
-        /*
-         * Since OnDemandBlockSnapshotIndexInput.Builder.DEFAULT_BLOCK_SIZE is not overridden then it will be upper bound for max IndexInput
-         * size on disk. A single IndexInput size should always be more than a single segment in segmented cache. A FileCache capacity might
-         * be defined with large capacity (> IndexInput block size) but due to segmentation and concurrency factor, that capacity is
-         * distributed equally across segments.
-         */
-        if (segmentedCache.getPerSegmentCapacity() <= OnDemandBlockSnapshotIndexInput.Builder.DEFAULT_BLOCK_SIZE) {
-            throw new IllegalStateException("FileSystem Cache per segment capacity is less than single IndexInput default block size");
-        }
-        return new FileCache(segmentedCache, circuitBreaker);
+        return new FileCache(createDefaultBuilder().capacity(capacity).concurrencyLevel(concurrencyLevel).build(), circuitBreaker);
     }
 
     private static SegmentedCache.Builder<Path, CachedIndexInput> createDefaultBuilder() {

--- a/server/src/test/java/org/opensearch/action/admin/indices/cache/clear/TransportClearIndicesCacheActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/cache/clear/TransportClearIndicesCacheActionTests.java
@@ -85,7 +85,7 @@ public class TransportClearIndicesCacheActionTests extends OpenSearchTestCase {
             when(shardRouting.shardId()).thenReturn(shardId);
             final ShardPath shardPath = ShardPath.loadFileCachePath(nodeEnvironment, shardId);
             final Path cacheEntryPath = shardPath.getDataPath();
-            final FileCache fileCache = FileCacheFactory.createConcurrentLRUFileCache(1024 * 1024 * 1024, 16, new NoopCircuitBreaker(""));
+            final FileCache fileCache = FileCacheFactory.createConcurrentLRUFileCache(1024 * 1024, 16, new NoopCircuitBreaker(""));
 
             when(testNode.fileCache()).thenReturn(fileCache);
             when(testNode.getNodeEnvironment()).thenReturn(nodeEnvironment);

--- a/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheCleanerTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheCleanerTests.java
@@ -48,7 +48,7 @@ public class FileCacheCleanerTests extends OpenSearchTestCase {
     );
 
     private final FileCache fileCache = FileCacheFactory.createConcurrentLRUFileCache(
-        1024 * 1024 * 1024,
+        1024 * 1024,
         1,
         new NoopCircuitBreaker(CircuitBreaker.REQUEST)
     );


### PR DESCRIPTION
### Description
- Removes concurrency based minimum file cache size restriction which limits based on per segment capacity.
- Details on #8259

### Related Issues
Resolves #8259
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
