### PR TITLE
CardinalityIT/NestedIT test failures with concurrent search enabled and AssertingCodec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add safeguard limits for file cache during node level allocation ([#8208](https://github.com/opensearch-project/OpenSearch/pull/8208))
 - Move span actions to Scope ([#8411](https://github.com/opensearch-project/OpenSearch/pull/8411))
 - Add wrapper tracer implementation ([#8565](https://github.com/opensearch-project/OpenSearch/pull/8565))
+- Perform aggregation postCollection in ContextIndexSearcher after searching leaves ([#8303](https://github.com/opensearch-project/OpenSearch/pull/8303))
 
 ### Deprecated
 

--- a/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
@@ -65,6 +65,7 @@ import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.search.NestedHelper;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.similarity.SimilarityService;
+import org.opensearch.search.aggregations.BucketCollectorProcessor;
 import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.SearchContextAggregations;
 import org.opensearch.search.builder.SearchSourceBuilder;
@@ -176,7 +177,7 @@ final class DefaultSearchContext extends SearchContext {
     private SuggestionSearchContext suggest;
     private List<RescoreContext> rescore;
     private Profilers profilers;
-
+    private BucketCollectorProcessor bucketCollectorProcessor = NO_OP_BUCKET_COLLECTOR_PROCESSOR;
     private final Map<String, SearchExtBuilder> searchExtBuilders = new HashMap<>();
     private final Map<Class<?>, CollectorManager<? extends Collector, ReduceableSearchResult>> queryCollectorManagers = new HashMap<>();
     private final QueryShardContext queryShardContext;
@@ -918,5 +919,15 @@ final class DefaultSearchContext extends SearchContext {
     @Override
     public InternalAggregation.ReduceContext partial() {
         return requestToAggReduceContextBuilder.apply(request.source()).forPartialReduction();
+    }
+
+    @Override
+    public void setBucketCollectorProcessor(BucketCollectorProcessor bucketCollectorProcessor) {
+        this.bucketCollectorProcessor = bucketCollectorProcessor;
+    }
+
+    @Override
+    public BucketCollectorProcessor bucketCollectorProcessor() {
+        return bucketCollectorProcessor;
     }
 }

--- a/server/src/main/java/org/opensearch/search/aggregations/AggregationCollectorManager.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/AggregationCollectorManager.java
@@ -77,7 +77,7 @@ class AggregationCollectorManager implements CollectorManager<Collector, Reducea
         context.aggregations().resetBucketMultiConsumer();
         for (Aggregator aggregator : aggregators) {
             try {
-                aggregator.postCollection();
+                // post collection is called in ContextIndexSearcher after search on leaves are completed
                 internals.add(aggregator.buildTopLevel());
             } catch (IOException e) {
                 throw new AggregationExecutionException("Failed to build aggregation [" + aggregator.name() + "]", e);

--- a/server/src/main/java/org/opensearch/search/aggregations/BucketCollectorProcessor.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/BucketCollectorProcessor.java
@@ -1,0 +1,105 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.aggregations;
+
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.MultiCollector;
+import org.opensearch.common.lucene.MinimumScoreCollector;
+import org.opensearch.search.internal.SearchContext;
+import org.opensearch.search.profile.query.InternalProfileCollector;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+
+/**
+ * Processor to perform collector level processing specific to {@link BucketCollector} in different stages like: a) PostCollection
+ * after search on each leaf is completed and b) process the collectors to perform reduce after collection is completed
+ */
+public class BucketCollectorProcessor {
+
+    /**
+     * Performs {@link BucketCollector#postCollection()} on all the {@link BucketCollector} in the given {@link Collector} collector tree
+     * after the collection of documents on a leaf is completed. This method will be called by different slice threads on its own collector
+     * tree instance in case of concurrent segment search such that postCollection happens on the same slice thread which initialize and
+     * perform collection of the documents for a leaf segment. For sequential search case, there is always a single search thread which
+     * performs both collection and postCollection on {@link BucketCollector}.
+     * <p>
+     * This was originally done in {@link org.opensearch.search.aggregations.AggregationProcessor#postProcess(SearchContext)}. But with
+     * concurrent segment search path this needs to be performed here. There are AssertingCodecs in lucene which validates that the
+     * DocValues created for a field is always used by the same thread for a request. In concurrent segment search case, the DocValues
+     * gets initialized on different threads for different segments (or slices). Whereas the postProcess happens as part of reduce phase
+     * and is performed on the separate thread which is from search threadpool and not from slice threadpool. So two different threads
+     * performs the access on the DocValues causing the AssertingCodec to fail. From functionality perspective, there is no issue as
+     * DocValues for each segment is always accessed by a single thread at a time but those threads may be different (e.g. slice thread
+     * during collection and then search thread during reduce)
+     * </p>
+     * <p>
+     * NOTE: We can evaluate and deprecate this postCollection processing once lucene release the changes described in the
+     * <a href="https://github.com/apache/lucene/issues/12375">issue-12375</a>. With this new change we should be able to implement
+     * {@link BucketCollector#postCollection()} functionality using the lucene interface directly such that postCollection gets called
+     * from the slice thread by lucene itself
+     * </p>
+     * @param collectorTree collector tree used by calling thread
+     */
+    public void processPostCollection(Collector collectorTree) throws IOException {
+        final Queue<Collector> collectors = new LinkedList<>();
+        collectors.offer(collectorTree);
+        while (!collectors.isEmpty()) {
+            Collector currentCollector = collectors.poll();
+            if (currentCollector instanceof InternalProfileCollector) {
+                collectors.offer(((InternalProfileCollector) currentCollector).getCollector());
+            } else if (currentCollector instanceof MinimumScoreCollector) {
+                collectors.offer(((MinimumScoreCollector) currentCollector).getCollector());
+            } else if (currentCollector instanceof MultiCollector) {
+                for (Collector innerCollector : ((MultiCollector) currentCollector).getCollectors()) {
+                    collectors.offer(innerCollector);
+                }
+            } else if (currentCollector instanceof BucketCollector) {
+                ((BucketCollector) currentCollector).postCollection();
+            }
+        }
+    }
+
+    /**
+     * Unwraps the input collection of {@link Collector} to get the list of the {@link Aggregator} used by different slice threads. The
+     * input is expected to contain the collectors related to Aggregations only as that is passed to {@link AggregationCollectorManager}
+     * during the reduce phase. This list of {@link Aggregator} is used to create {@link InternalAggregation} and optionally perform
+     * reduce at shard level before returning response to coordinator
+     * @param collectors collection of aggregation collectors to reduce
+     * @return list of unwrapped {@link Aggregator}
+     */
+    public List<Aggregator> toAggregators(Collection<Collector> collectors) {
+        List<Aggregator> aggregators = new ArrayList<>();
+
+        final Deque<Collector> allCollectors = new LinkedList<>(collectors);
+        while (!allCollectors.isEmpty()) {
+            final Collector currentCollector = allCollectors.pop();
+            if (currentCollector instanceof Aggregator) {
+                aggregators.add((Aggregator) currentCollector);
+            } else if (currentCollector instanceof InternalProfileCollector) {
+                if (((InternalProfileCollector) currentCollector).getCollector() instanceof Aggregator) {
+                    aggregators.add((Aggregator) ((InternalProfileCollector) currentCollector).getCollector());
+                } else if (((InternalProfileCollector) currentCollector).getCollector() instanceof MultiBucketCollector) {
+                    allCollectors.addAll(
+                        Arrays.asList(((MultiBucketCollector) ((InternalProfileCollector) currentCollector).getCollector()).getCollectors())
+                    );
+                }
+            } else if (currentCollector instanceof MultiBucketCollector) {
+                allCollectors.addAll(Arrays.asList(((MultiBucketCollector) currentCollector).getCollectors()));
+            }
+        }
+        return aggregators;
+    }
+}

--- a/server/src/main/java/org/opensearch/search/aggregations/ConcurrentAggregationProcessor.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/ConcurrentAggregationProcessor.java
@@ -28,12 +28,16 @@ import java.util.Collections;
  * avoid the increase in aggregation result sets returned by each shard to coordinator where final reduce happens for results received from
  * all the shards
  */
-public class ConcurrentAggregationProcessor extends DefaultAggregationProcessor {
+public class ConcurrentAggregationProcessor implements AggregationProcessor {
+
+    private final BucketCollectorProcessor bucketCollectorProcessor = new BucketCollectorProcessor();
 
     @Override
     public void preProcess(SearchContext context) {
         try {
             if (context.aggregations() != null) {
+                // update the bucket collector process as there is aggregation in the request
+                context.setBucketCollectorProcessor(bucketCollectorProcessor);
                 if (context.aggregations().factories().hasNonGlobalAggregator()) {
                     context.queryCollectorManagers().put(NonGlobalAggCollectorManager.class, new NonGlobalAggCollectorManager(context));
                 }

--- a/server/src/main/java/org/opensearch/search/aggregations/DefaultAggregationProcessor.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/DefaultAggregationProcessor.java
@@ -24,10 +24,14 @@ import java.util.List;
  */
 public class DefaultAggregationProcessor implements AggregationProcessor {
 
+    private final BucketCollectorProcessor bucketCollectorProcessor = new BucketCollectorProcessor();
+
     @Override
     public void preProcess(SearchContext context) {
         try {
             if (context.aggregations() != null) {
+                // update the bucket collector process as there is aggregation in the request
+                context.setBucketCollectorProcessor(bucketCollectorProcessor);
                 if (context.aggregations().factories().hasNonGlobalAggregator()) {
                     context.queryCollectorManagers()
                         .put(NonGlobalAggCollectorManager.class, new NonGlobalAggCollectorManagerWithSingleCollector(context));

--- a/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
@@ -46,7 +46,6 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.LeafCollector;
-import org.apache.lucene.search.MultiCollector;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryCache;
 import org.apache.lucene.search.QueryCachingPolicy;
@@ -64,16 +63,13 @@ import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.CombinedBitSet;
 import org.apache.lucene.util.SparseFixedBitSet;
 import org.opensearch.cluster.metadata.DataStream;
-import org.opensearch.common.lucene.MinimumScoreCollector;
 import org.opensearch.common.lucene.search.TopDocsAndMaxScore;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.SearchService;
-import org.opensearch.search.aggregations.BucketCollector;
 import org.opensearch.search.dfs.AggregatedDfs;
 import org.opensearch.search.profile.ContextualProfileBreakdown;
 import org.opensearch.search.profile.Timer;
-import org.opensearch.search.profile.query.InternalProfileCollector;
 import org.opensearch.search.profile.query.ProfileWeight;
 import org.opensearch.search.profile.query.QueryProfiler;
 import org.opensearch.search.profile.query.QueryTimingType;
@@ -86,10 +82,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.Executor;
 
@@ -282,38 +276,7 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
                 searchLeaf(leaves.get(i), weight, collector);
             }
         }
-        postCollection(collector);
-    }
-
-    /**
-     * Performs the postCollection on the {@link BucketCollector} which is used to collect documents for Aggregation. This was originally
-     * done in {@link org.opensearch.search.aggregations.AggregationProcessor#postProcess(SearchContext)}. But with concurrent segment
-     * search path this needs to be performed here. There are AssertingCodecs in lucene which validates that the DocValues created for a
-     * field is always used by the same thread for a request. In concurrent segment search case, the DocValues gets initialized on
-     * different threads for different segments (or slices). Whereas the postProcess happens as part of reduce phase and is performed on
-     * the separate thread which is from search threadpool and not from slice threadpool. So two different threads performs the access on
-     * the DocValues causing the AssertingCodec to fail. From functionality perspective, there is no issue as DocValues for each segment
-     * is always accessed by a single thread at a time but those threads may be different (e.g. slice thread during collection and then
-     * search thread during reduce)
-     * @param collector input collector tree used for search
-     */
-    private void postCollection(Collector collector) throws IOException {
-        final Queue<Collector> collectors = new LinkedList<>();
-        collectors.offer(collector);
-        while (!collectors.isEmpty()) {
-            Collector currentCollector = collectors.poll();
-            if (currentCollector instanceof InternalProfileCollector) {
-                collectors.offer(((InternalProfileCollector) currentCollector).getCollector());
-            } else if (currentCollector instanceof MinimumScoreCollector) {
-                collectors.offer(((MinimumScoreCollector) currentCollector).getCollector());
-            } else if (currentCollector instanceof MultiCollector) {
-                for (Collector innerCollector : ((MultiCollector) currentCollector).getCollectors()) {
-                    collectors.offer(innerCollector);
-                }
-            } else if (currentCollector instanceof BucketCollector) {
-                ((BucketCollector) currentCollector).postCollection();
-            }
-        }
+        searchContext.bucketCollectorProcessor().processPostCollection(collector);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/search/internal/FilteredSearchContext.java
+++ b/server/src/main/java/org/opensearch/search/internal/FilteredSearchContext.java
@@ -50,6 +50,7 @@ import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.similarity.SimilarityService;
 import org.opensearch.search.SearchExtBuilder;
 import org.opensearch.search.SearchShardTarget;
+import org.opensearch.search.aggregations.BucketCollectorProcessor;
 import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.SearchContextAggregations;
 import org.opensearch.search.collapse.CollapseContext;
@@ -547,5 +548,15 @@ public abstract class FilteredSearchContext extends SearchContext {
     @Override
     public InternalAggregation.ReduceContext partial() {
         return in.partial();
+    }
+
+    @Override
+    public void setBucketCollectorProcessor(BucketCollectorProcessor bucketCollectorProcessor) {
+        in.setBucketCollectorProcessor(bucketCollectorProcessor);
+    }
+
+    @Override
+    public BucketCollectorProcessor bucketCollectorProcessor() {
+        return in.bucketCollectorProcessor();
     }
 }

--- a/server/src/test/java/org/opensearch/search/internal/ContextIndexSearcherTests.java
+++ b/server/src/test/java/org/opensearch/search/internal/ContextIndexSearcherTests.java
@@ -259,6 +259,7 @@ public class ContextIndexSearcherTests extends OpenSearchTestCase {
         SearchContext searchContext = mock(SearchContext.class);
         IndexShard indexShard = mock(IndexShard.class);
         when(searchContext.indexShard()).thenReturn(indexShard);
+        when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
         ContextIndexSearcher searcher = new ContextIndexSearcher(
             filteredReader,
             IndexSearcher.getDefaultSimilarity(),

--- a/server/src/test/java/org/opensearch/search/profile/query/QueryProfilerTests.java
+++ b/server/src/test/java/org/opensearch/search/profile/query/QueryProfilerTests.java
@@ -120,6 +120,7 @@ public class QueryProfilerTests extends OpenSearchTestCase {
         SearchContext searchContext = mock(SearchContext.class);
         IndexShard indexShard = mock(IndexShard.class);
         when(searchContext.indexShard()).thenReturn(indexShard);
+        when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
         searcher = new ContextIndexSearcher(
             reader,
             IndexSearcher.getDefaultSimilarity(),

--- a/server/src/test/java/org/opensearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/opensearch/search/query/QueryPhaseTests.java
@@ -1207,6 +1207,7 @@ public class QueryPhaseTests extends IndexShardTestCase {
         SearchContext searchContext = mock(SearchContext.class);
         IndexShard indexShard = mock(IndexShard.class);
         when(searchContext.indexShard()).thenReturn(indexShard);
+        when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
         return new ContextIndexSearcher(
             reader,
             IndexSearcher.getDefaultSimilarity(),
@@ -1223,6 +1224,7 @@ public class QueryPhaseTests extends IndexShardTestCase {
         SearchContext searchContext = mock(SearchContext.class);
         IndexShard indexShard = mock(IndexShard.class);
         when(searchContext.indexShard()).thenReturn(indexShard);
+        when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
         return new ContextIndexSearcher(
             reader,
             IndexSearcher.getDefaultSimilarity(),

--- a/server/src/test/java/org/opensearch/search/query/QueryProfilePhaseTests.java
+++ b/server/src/test/java/org/opensearch/search/query/QueryProfilePhaseTests.java
@@ -1427,6 +1427,7 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
         SearchContext searchContext = mock(SearchContext.class);
         IndexShard indexShard = mock(IndexShard.class);
         when(searchContext.indexShard()).thenReturn(indexShard);
+        when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
         return new ContextIndexSearcher(
             reader,
             IndexSearcher.getDefaultSimilarity(),
@@ -1443,6 +1444,7 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
         SearchContext searchContext = mock(SearchContext.class);
         IndexShard indexShard = mock(IndexShard.class);
         when(searchContext.indexShard()).thenReturn(indexShard);
+        when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
         return new ContextIndexSearcher(
             reader,
             IndexSearcher.getDefaultSimilarity(),

--- a/test/framework/src/main/java/org/opensearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/search/aggregations/AggregatorTestCase.java
@@ -349,6 +349,7 @@ public abstract class AggregatorTestCase extends OpenSearchTestCase {
         when(searchContext.indexShard()).thenReturn(indexShard);
         when(searchContext.aggregations()).thenReturn(new SearchContextAggregations(AggregatorFactories.EMPTY, bucketConsumer));
         when(searchContext.query()).thenReturn(query);
+        when(searchContext.bucketCollectorProcessor()).thenReturn(new BucketCollectorProcessor());
         /*
          * Always use the circuit breaking big arrays instance so that the CircuitBreakerService
          * we're passed gets a chance to break.

--- a/test/framework/src/main/java/org/opensearch/test/TestSearchContext.java
+++ b/test/framework/src/main/java/org/opensearch/test/TestSearchContext.java
@@ -52,6 +52,7 @@ import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.similarity.SimilarityService;
 import org.opensearch.search.SearchExtBuilder;
 import org.opensearch.search.SearchShardTarget;
+import org.opensearch.search.aggregations.BucketCollectorProcessor;
 import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.SearchContextAggregations;
 import org.opensearch.search.collapse.CollapseContext;
@@ -116,6 +117,7 @@ public class TestSearchContext extends SearchContext {
     private Profilers profilers;
     private CollapseContext collapse;
     protected boolean concurrentSegmentSearchEnabled;
+    private BucketCollectorProcessor bucketCollectorProcessor = NO_OP_BUCKET_COLLECTOR_PROCESSOR;
 
     /**
      * Sets the concurrent segment search enabled field
@@ -659,6 +661,16 @@ public class TestSearchContext extends SearchContext {
     @Override
     public InternalAggregation.ReduceContext partial() {
         return InternalAggregationTestCase.emptyReduceContextBuilder().forPartialReduction();
+    }
+
+    @Override
+    public void setBucketCollectorProcessor(BucketCollectorProcessor bucketCollectorProcessor) {
+        this.bucketCollectorProcessor = bucketCollectorProcessor;
+    }
+
+    @Override
+    public BucketCollectorProcessor bucketCollectorProcessor() {
+        return bucketCollectorProcessor;
     }
 
     /**


### PR DESCRIPTION
### Description
The tests were failing because during the concurrent segment search for each slice the codec producers for the leafs were initialized by the slice thread. Later in reduce phase, the post collection happens over those codec producers on the search thread. With AssertingCodec it verifies that all access is done by the same thread causing the failures. More details are in #8095 

### Related Issues
Resolves #8095

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
