### PR TITLE
[Mute] SegRepUsingRemoteStoreIT.testPressureServiceStats

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/SegmentReplicationUsingRemoteStoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/SegmentReplicationUsingRemoteStoreIT.java
@@ -63,4 +63,10 @@ public class SegmentReplicationUsingRemoteStoreIT extends SegmentReplicationIT {
     public void teardown() {
         assertAcked(clusterAdmin().prepareDeleteRepository(REPOSITORY_NAME));
     }
+
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/7592")
+    @Override
+    public void testPressureServiceStats() throws Exception {
+        super.testPressureServiceStats();
+    }
 }


### PR DESCRIPTION
Mutes `SegmentReplicationUsingRemoteStoreIT.testPressureServiceStats` which has repeatedly failed and loss a lot of unrelated PR time.

relates #7592 