### PR TITLE
[Backport -2.x] Check UTF16 string size before converting to String to avoid OOME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Refactor] Metadata members from ImmutableOpenMap to j.u.Map ([#7165](https://github.com/opensearch-project/OpenSearch/pull/7165))
 - [Refactor] more ImmutableOpenMap to jdk Map in cluster package ([#7301](https://github.com/opensearch-project/OpenSearch/pull/7301))
 - [Refactor] ImmutableOpenMap to j.u.Map in IndexMetadata ([#7306](https://github.com/opensearch-project/OpenSearch/pull/7306))
+- Check UTF16 string size before converting to String to avoid OOME ([#7963](https://github.com/opensearch-project/OpenSearch/pull/7963))
 
 ### Deprecated
 

--- a/test/framework/src/main/java/org/opensearch/common/bytes/AbstractBytesReferenceTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/common/bytes/AbstractBytesReferenceTestCase.java
@@ -478,6 +478,45 @@ public abstract class AbstractBytesReferenceTestCase extends OpenSearchTestCase 
         // TODO: good way to test?
     }
 
+    public void testUTF8toString_ExceedsMaxLength() {
+        AbstractBytesReference abr = new TestAbstractBytesReference();
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, abr::utf8ToString);
+        assertTrue(e.getMessage().contains("UTF16 String size is"));
+        assertTrue(e.getMessage().contains("should be less than"));
+    }
+
+    static class TestAbstractBytesReference extends AbstractBytesReference {
+        @Override
+        public byte get(int index) {
+            return 0;
+        }
+
+        @Override
+        public int length() {
+            return 0;
+        }
+
+        @Override
+        public BytesReference slice(int from, int length) {
+            return null;
+        }
+
+        @Override
+        public long ramBytesUsed() {
+            return 0;
+        }
+
+        @Override
+        public BytesRef toBytesRef() {
+            return new BytesRef("UTF16 length exceed test");
+        }
+
+        @Override
+        public int getMaxUTF16Length() {
+            return 1;
+        }
+    }
+
     public void testToBytesRef() throws IOException {
         int length = randomIntBetween(0, PAGE_SIZE);
         BytesReference pbr = newBytesReference(length);


### PR DESCRIPTION

* Check UTF16 string size before converting to string to avoid OOME

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Backport - https://github.com/opensearch-project/OpenSearch/pull/7963

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
