### PR TITLE
[Remote Store] Update Translog Metadata file name

### DIFF
--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -385,6 +385,7 @@ public class RemoteFsTranslog extends Translog {
         }
         if (generationsToDelete.isEmpty() == false) {
             deleteRemoteGeneration(generationsToDelete);
+            translogTransferManager.deleteStaleTranslogMetadataFilesAsync(remoteGenerationDeletionPermits::release);
             deleteStaleRemotePrimaryTermsAndMetadataFiles();
         } else {
             remoteGenerationDeletionPermits.release(REMOTE_DELETION_PERMITS);
@@ -418,8 +419,6 @@ public class RemoteFsTranslog extends Translog {
             assert readers.isEmpty() == false : "Expected non-empty readers";
             long minimumReferencedPrimaryTerm = readers.stream().map(BaseTranslogReader::getPrimaryTerm).min(Long::compare).get();
             translogTransferManager.deletePrimaryTermsAsync(minimumReferencedPrimaryTerm);
-            // Second we delete all stale metadata files from remote store
-            translogTransferManager.deleteStaleTranslogMetadataFilesAsync();
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -386,7 +386,7 @@ public class RemoteFsTranslog extends Translog {
         if (generationsToDelete.isEmpty() == false) {
             deleteRemoteGeneration(generationsToDelete);
             translogTransferManager.deleteStaleTranslogMetadataFilesAsync(remoteGenerationDeletionPermits::release);
-            deleteStaleRemotePrimaryTermsAndMetadataFiles();
+            deleteStaleRemotePrimaryTerms();
         } else {
             remoteGenerationDeletionPermits.release(REMOTE_DELETION_PERMITS);
         }
@@ -410,7 +410,7 @@ public class RemoteFsTranslog extends Translog {
      * <br>
      * This will also delete all stale translog metadata files from remote except the latest basis the metadata file comparator.
      */
-    private void deleteStaleRemotePrimaryTermsAndMetadataFiles() {
+    private void deleteStaleRemotePrimaryTerms() {
         // The deletion of older translog files in remote store is on best-effort basis, there is a possibility that there
         // are older files that are no longer needed and should be cleaned up. In here, we delete all files that are part
         // of older primary term.

--- a/server/src/main/java/org/opensearch/index/translog/transfer/BlobStoreTransferService.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/BlobStoreTransferService.java
@@ -133,7 +133,7 @@ public class BlobStoreTransferService implements TransferService {
         });
     }
 
-    public void listAllInSortedOrder(Iterable<String> path, int limit, ActionListener<List<BlobMetadata>> listener) throws IOException {
+    public void listAllInSortedOrder(Iterable<String> path, int limit, ActionListener<List<BlobMetadata>> listener) {
         blobStore.blobContainer((BlobPath) path).listBlobsByPrefixInSortedOrder("", limit, LEXICOGRAPHIC, listener);
     }
 
@@ -143,13 +143,7 @@ public class BlobStoreTransferService implements TransferService {
         int limit,
         ActionListener<List<BlobMetadata>> listener
     ) {
-        threadPool.executor(threadpoolName).execute(() -> {
-            try {
-                listAllInSortedOrder(path, limit, listener);
-            } catch (IOException e) {
-                listener.onFailure(e);
-            }
-        });
+        threadPool.executor(threadpoolName).execute(() -> { listAllInSortedOrder(path, limit, listener); });
     }
 
 }

--- a/server/src/main/java/org/opensearch/index/translog/transfer/BlobStoreTransferService.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/BlobStoreTransferService.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.ActionRunnable;
+import org.opensearch.common.blobstore.BlobMetadata;
 import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.common.blobstore.BlobStore;
 import org.opensearch.index.translog.transfer.FileSnapshot.TransferFileSnapshot;
@@ -140,4 +141,9 @@ public class BlobStoreTransferService implements TransferService {
             }
         });
     }
+
+    public void listBlobsInSortedOrder(Iterable<String> path, int limit, ActionListener<List<BlobMetadata>> listener) throws IOException {
+        blobStore.blobContainer((BlobPath) path).listBlobsByPrefixInLexicographicOrder("", limit, listener);
+    }
+
 }

--- a/server/src/main/java/org/opensearch/index/translog/transfer/BlobStoreTransferService.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/BlobStoreTransferService.java
@@ -24,6 +24,8 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Set;
 
+import static org.opensearch.common.blobstore.BlobContainer.BlobNameSortOrder.LEXICOGRAPHIC;
+
 /**
  * Service that handles remote transfer of translog and checkpoint files
  *
@@ -116,17 +118,6 @@ public class BlobStoreTransferService implements TransferService {
     }
 
     @Override
-    public void listAllAsync(String threadpoolName, Iterable<String> path, ActionListener<Set<String>> listener) {
-        threadPool.executor(threadpoolName).execute(() -> {
-            try {
-                listener.onResponse(listAll(path));
-            } catch (IOException e) {
-                listener.onFailure(e);
-            }
-        });
-    }
-
-    @Override
     public Set<String> listFolders(Iterable<String> path) throws IOException {
         return blobStore.blobContainer((BlobPath) path).children().keySet();
     }
@@ -142,8 +133,23 @@ public class BlobStoreTransferService implements TransferService {
         });
     }
 
-    public void listBlobsInSortedOrder(Iterable<String> path, int limit, ActionListener<List<BlobMetadata>> listener) throws IOException {
-        blobStore.blobContainer((BlobPath) path).listBlobsByPrefixInLexicographicOrder("", limit, listener);
+    public void listAllInSortedOrder(Iterable<String> path, int limit, ActionListener<List<BlobMetadata>> listener) throws IOException {
+        blobStore.blobContainer((BlobPath) path).listBlobsByPrefixInSortedOrder("", limit, LEXICOGRAPHIC, listener);
+    }
+
+    public void listAllInSortedOrderAsync(
+        String threadpoolName,
+        Iterable<String> path,
+        int limit,
+        ActionListener<List<BlobMetadata>> listener
+    ) {
+        threadPool.executor(threadpoolName).execute(() -> {
+            try {
+                listAllInSortedOrder(path, limit, listener);
+            } catch (IOException e) {
+                listener.onFailure(e);
+            }
+        });
     }
 
 }

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TransferService.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TransferService.java
@@ -107,7 +107,7 @@ public interface TransferService {
      */
     InputStream downloadBlob(Iterable<String> path, String fileName) throws IOException;
 
-    void listAllInSortedOrder(Iterable<String> path, int limit, ActionListener<List<BlobMetadata>> listener) throws IOException;
+    void listAllInSortedOrder(Iterable<String> path, int limit, ActionListener<List<BlobMetadata>> listener);
 
     void listAllInSortedOrderAsync(String threadpoolName, Iterable<String> path, int limit, ActionListener<List<BlobMetadata>> listener);
 

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TransferService.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TransferService.java
@@ -82,14 +82,6 @@ public interface TransferService {
     Set<String> listAll(Iterable<String> path) throws IOException;
 
     /**
-     * Lists the files and invokes the listener on success or failure
-     * @param threadpoolName threadpool type which will be used to list all files asynchronously.
-     * @param path the path to list
-     * @param listener the callback to be invoked once list operation completes successfully/fails.
-     */
-    void listAllAsync(String threadpoolName, Iterable<String> path, ActionListener<Set<String>> listener);
-
-    /**
      * Lists the folders inside the path.
      * @param path : the path
      * @return list of folders inside the path
@@ -115,6 +107,8 @@ public interface TransferService {
      */
     InputStream downloadBlob(Iterable<String> path, String fileName) throws IOException;
 
-    void listBlobsInSortedOrder(Iterable<String> path, int limit, ActionListener<List<BlobMetadata>> listener) throws IOException;
+    void listAllInSortedOrder(Iterable<String> path, int limit, ActionListener<List<BlobMetadata>> listener) throws IOException;
+
+    void listAllInSortedOrderAsync(String threadpoolName, Iterable<String> path, int limit, ActionListener<List<BlobMetadata>> listener);
 
 }

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TransferService.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TransferService.java
@@ -9,6 +9,7 @@
 package org.opensearch.index.translog.transfer;
 
 import org.opensearch.action.ActionListener;
+import org.opensearch.common.blobstore.BlobMetadata;
 import org.opensearch.index.translog.transfer.FileSnapshot.TransferFileSnapshot;
 
 import java.io.IOException;
@@ -113,5 +114,7 @@ public interface TransferService {
      * @throws IOException the exception while reading the data
      */
     InputStream downloadBlob(Iterable<String> path, String fileName) throws IOException;
+
+    void listBlobsInSortedOrder(Iterable<String> path, int limit, ActionListener<List<BlobMetadata>> listener) throws IOException;
 
 }

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
@@ -209,7 +209,7 @@ public class TranslogTransferManager {
         try {
             transferService.listAllInSortedOrder(remoteMetadataTransferPath, 1, latchedActionListener);
             latch.await();
-        } catch (InterruptedException | IOException e) {
+        } catch (InterruptedException e) {
             throw new IOException("Exception while reading/downloading metadafile", e);
         }
 

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
@@ -371,6 +371,7 @@ public class TranslogTransferManager {
                         List<String> sortedMetadataFiles = blobMetadata.stream().map(BlobMetadata::name).collect(Collectors.toList());
                         if (sortedMetadataFiles.size() <= 1) {
                             logger.trace("Remote Metadata file count is {}, so skipping deletion", sortedMetadataFiles.size());
+                            onCompletion.run();
                             return;
                         }
                         List<String> metadataFilesToDelete = sortedMetadataFiles.subList(1, sortedMetadataFiles.size());
@@ -381,11 +382,13 @@ public class TranslogTransferManager {
                     @Override
                     public void onFailure(Exception e) {
                         logger.error("Exception occurred while listing translog metadata files from remote store", e);
+                        onCompletion.run();
                     }
                 }
             );
         } catch (Exception e) {
             logger.error("Exception occurred while listing translog metadata files from remote store", e);
+            onCompletion.run();
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
@@ -439,14 +439,6 @@ public class TranslogTransferManager {
     }
 
     /**
-     * Deletes metadata files asynchronously using the {@code REMOTE_PURGE} threadpool.
-     * @param metadataFilesToDelete list of metadata files to be deleted.
-     */
-    private void deleteMetadataFilesAsync(List<String> metadataFilesToDelete) {
-        deleteMetadataFilesAsync(metadataFilesToDelete, () -> {});
-    }
-
-    /**
      * Deletes metadata files asynchronously using the {@code REMOTE_PURGE} threadpool. On success or failure, runs {@code onCompletion}.
      *
      * @param files list of metadata files to be deleted.

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
@@ -76,7 +76,16 @@ public class TranslogTransferMetadata {
     }
 
     public static String getFileName(long primaryTerm, long generation) {
-        return String.join(METADATA_SEPARATOR, Arrays.asList(String.valueOf(primaryTerm), String.valueOf(generation)));
+        return String.join(
+            METADATA_SEPARATOR,
+            Arrays.asList(
+                String.valueOf(Long.MAX_VALUE - primaryTerm),
+                String.valueOf(Long.MAX_VALUE - generation),
+                String.valueOf(Long.MAX_VALUE - System.currentTimeMillis()),
+                String.valueOf(primaryTerm),
+                String.valueOf(generation)
+            )
+        );
     }
 
     @Override
@@ -95,11 +104,11 @@ public class TranslogTransferMetadata {
     private static class MetadataFilenameComparator implements Comparator<String> {
         @Override
         public int compare(String first, String second) {
-            // Format of metadata filename is <Primary Term>__<Generation>
+            // Format of metadata filename is <Inv Primary Term>__<Inv Generation>__<Inv Timestamp>__<Primary Term>__<Generation>
             String[] filenameTokens1 = first.split(METADATA_SEPARATOR);
             String[] filenameTokens2 = second.split(METADATA_SEPARATOR);
-            // Here, we are comparing only primary term and generation.
-            for (int i = 0; i < filenameTokens1.length; i++) {
+            // Here, we are comparing only inverted primary term and inv generation.
+            for (int i = 0; i < 2; i++) {
                 if (filenameTokens1[i].equals(filenameTokens2[i]) == false) {
                     return Long.compare(Long.parseLong(filenameTokens1[i]), Long.parseLong(filenameTokens2[i]));
                 }

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
@@ -9,9 +9,9 @@
 package org.opensearch.index.translog.transfer;
 
 import org.opensearch.common.SetOnce;
+import org.opensearch.index.remote.RemoteStoreUtils;
 
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.Map;
 import java.util.Objects;
 
@@ -42,13 +42,14 @@ public class TranslogTransferMetadata {
 
     static final String METADATA_CODEC = "md";
 
-    public static final Comparator<String> METADATA_FILENAME_COMPARATOR = new MetadataFilenameComparator();
+    private final long createdAt;
 
     public TranslogTransferMetadata(long primaryTerm, long generation, long minTranslogGeneration, int count) {
         this.primaryTerm = primaryTerm;
         this.generation = generation;
         this.minTranslogGeneration = minTranslogGeneration;
         this.count = count;
+        this.createdAt = System.currentTimeMillis();
     }
 
     public long getPrimaryTerm() {
@@ -75,13 +76,16 @@ public class TranslogTransferMetadata {
         return generationToPrimaryTermMapper.get();
     }
 
-    public static String getFileName(long primaryTerm, long generation) {
+    /*
+    This should be used only at the time of creation.
+     */
+    public String getFileName() {
         return String.join(
             METADATA_SEPARATOR,
             Arrays.asList(
-                String.valueOf(Long.MAX_VALUE - primaryTerm),
-                String.valueOf(Long.MAX_VALUE - generation),
-                String.valueOf(Long.MAX_VALUE - System.currentTimeMillis()),
+                RemoteStoreUtils.invertLong(primaryTerm),
+                RemoteStoreUtils.invertLong(generation),
+                RemoteStoreUtils.invertLong(createdAt),
                 String.valueOf(primaryTerm),
                 String.valueOf(generation)
             )
@@ -99,23 +103,5 @@ public class TranslogTransferMetadata {
         if (o == null || getClass() != o.getClass()) return false;
         TranslogTransferMetadata other = (TranslogTransferMetadata) o;
         return Objects.equals(this.primaryTerm, other.primaryTerm) && Objects.equals(this.generation, other.generation);
-    }
-
-    private static class MetadataFilenameComparator implements Comparator<String> {
-        @Override
-        public int compare(String first, String second) {
-            // Format of metadata filename is <Inv Primary Term>__<Inv Generation>__<Inv Timestamp>__<Primary Term>__<Generation>
-            String[] filenameTokens1 = first.split(METADATA_SEPARATOR);
-            String[] filenameTokens2 = second.split(METADATA_SEPARATOR);
-            // Here, we are comparing only inverted primary term and inv generation.
-            for (int i = 0; i < 2; i++) {
-                if (filenameTokens1[i].equals(filenameTokens2[i]) == false) {
-                    return Long.compare(Long.parseLong(filenameTokens1[i]), Long.parseLong(filenameTokens2[i]));
-                }
-            }
-            throw new IllegalArgumentException(
-                "TranslogTransferMetadata files " + first + " and " + second + " have same primary term and generation"
-            );
-        }
     }
 }

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
@@ -86,8 +86,7 @@ public class TranslogTransferMetadata {
                 RemoteStoreUtils.invertLong(primaryTerm),
                 RemoteStoreUtils.invertLong(generation),
                 RemoteStoreUtils.invertLong(createdAt),
-                String.valueOf(primaryTerm),
-                String.valueOf(generation)
+                String.valueOf(CURRENT_VERSION)
             )
         );
     }

--- a/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
@@ -32,6 +32,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -246,6 +248,16 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
         when(transferService.downloadBlob(any(BlobPath.class), eq(mdFilename))).thenThrow(new IOException("Something went wrong"));
 
         assertThrows(IOException.class, translogTransferManager::readMetadata);
+    }
+
+    public void testMetadataFileNameOrder() throws IOException {
+        // asserting that new primary followed new generation are lexicographically smallest
+        String mdFilenameGen1 = new TranslogTransferMetadata(1, 1, 1, 2).getFileName();
+        String mdFilenameGen2 = new TranslogTransferMetadata(1, 2, 1, 2).getFileName();
+        String mdFilenamePrimary2 = new TranslogTransferMetadata(2, 1, 1, 2).getFileName();
+        List<String> metadataFiles = Arrays.asList(mdFilenameGen1, mdFilenameGen2, mdFilenamePrimary2);
+        Collections.sort(metadataFiles);
+        assertEquals(Arrays.asList(mdFilenamePrimary2, mdFilenameGen2, mdFilenameGen1), metadataFiles);
     }
 
     public void testReadMetadataListException() throws IOException {

--- a/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
@@ -42,6 +42,7 @@ import org.mockito.Mockito;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.Version;
 import org.opensearch.action.ActionListener;
+import org.opensearch.action.LatchedActionListener;
 import org.opensearch.action.admin.indices.flush.FlushRequest;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.support.PlainActionFuture;
@@ -61,6 +62,7 @@ import org.opensearch.common.CheckedFunction;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.blobstore.BlobContainer;
+import org.opensearch.common.blobstore.BlobMetadata;
 import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.common.blobstore.BlobStore;
 import org.opensearch.common.blobstore.fs.FsBlobContainer;
@@ -68,14 +70,14 @@ import org.opensearch.common.blobstore.fs.FsBlobStore;
 import org.opensearch.common.bytes.BytesArray;
 import org.opensearch.common.concurrent.GatedCloseable;
 import org.opensearch.common.io.PathUtils;
+import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.lucene.uid.Versions;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.ByteSizeValue;
 import org.opensearch.common.util.BigArrays;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.common.util.io.IOUtils;
-import org.opensearch.common.lease.Releasable;
+import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.env.NodeEnvironment;
 import org.opensearch.index.Index;
 import org.opensearch.index.IndexSettings;
@@ -98,18 +100,18 @@ import org.opensearch.index.seqno.RetentionLeaseSyncer;
 import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.index.similarity.SimilarityService;
 import org.opensearch.index.snapshots.IndexShardSnapshotStatus;
+import org.opensearch.index.store.RemoteBufferedOutputDirectory;
 import org.opensearch.index.store.RemoteDirectory;
 import org.opensearch.index.store.RemoteSegmentStoreDirectory;
 import org.opensearch.index.store.Store;
 import org.opensearch.index.store.StoreFileMetadata;
 import org.opensearch.index.store.lockmanager.RemoteStoreLockManager;
 import org.opensearch.index.store.lockmanager.RemoteStoreMetadataLockManager;
-import org.opensearch.index.store.RemoteBufferedOutputDirectory;
 import org.opensearch.index.translog.InternalTranslogFactory;
 import org.opensearch.index.translog.RemoteBlobStoreInternalTranslogFactory;
 import org.opensearch.index.translog.Translog;
-import org.opensearch.indices.IndicesService;
 import org.opensearch.index.translog.TranslogFactory;
+import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.breaker.CircuitBreakerService;
 import org.opensearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.opensearch.indices.recovery.AsyncRecoveryTarget;
@@ -172,6 +174,8 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.cluster.routing.TestShardRouting.newShardRouting;
@@ -645,6 +649,17 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
         when(repository.basePath()).thenReturn(new BlobPath());
         BlobStore blobStore = Mockito.mock(BlobStore.class);
         BlobContainer blobContainer = Mockito.mock(BlobContainer.class);
+        doAnswer(invocation -> {
+            LatchedActionListener<List<BlobMetadata>> listener = invocation.getArgument(3);
+            listener.onResponse(new ArrayList<>());
+            return null;
+        }).when(blobContainer)
+            .listBlobsByPrefixInSortedOrder(
+                any(String.class),
+                anyInt(),
+                any(BlobContainer.BlobNameSortOrder.class),
+                any(ActionListener.class)
+            );
         when(blobStore.blobContainer(any())).thenReturn(blobContainer);
         when(repository.blobStore()).thenReturn(blobStore);
         when(repositoriesService.repository(any(String.class))).thenReturn(repository);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

We are changing translog metadata file name to  

<inverted_primary_term>-- <inverted_generation>--<inverted_timestamp>--<version>

This would enable us to use lexicographic sort given by remote stores and find the latest metadata in just one list call, instead of doing pagination .

With this change, we are also deleting the older metadata files with every cleanup operation. 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
