### PR TITLE
Fix search.aggregation/60_empty.yml test case (fails on BWC runs)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/60_empty.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/60_empty.yml
@@ -1,5 +1,8 @@
 ---
 "Empty aggs Body":
+  - skip:
+      version: "- 2.8.99"
+      reason: "the fix was introduced in 2.9.0"
   - do:
       index:
         index: test


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fix search.aggregation/60_empty.yml test case (fails on BWC runs):

```
java.lang.AssertionError: Failure at [search.aggregation/60_empty:24]: expected [2xx] status code but api [search] returned [500 Internal Server Error] [{"error":{"root_cause":[{"type":"response_handler_failure_transport_exception","reason":"java.lang.NullPointerException","stack_trace":"ResponseHandlerFailureTransportException[java.lang.NullPointerException]; nested: NullPointerException;\nCaused by: java.lang.NullPointerException
at org.opensearch.action.search.QueryPhaseResultConsumer$PendingMerges.ramBytesUsedQueryResult(QueryPhaseResultConsumer.java:319)
at org.opensearch.action.search.QueryPhaseResultConsumer$PendingMerges.consume(QueryPhaseResultConsumer.java:358)
at org.opensearch.action.search.QueryPhaseResultConsumer.consumeResult(QueryPhaseResultConsumer.java:130)\n\tat org.opensearch.action.search.AbstractSearchAsyncAction.onShardResult(AbstractSearchAsyncAction.java:546)\n\tat 
```

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/8335

<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
