### PR TITLE
Fix HDFS fixture by excluding BouncyCastle

### DIFF
--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     exclude module: 'guava'
     exclude module: 'protobuf-java'
     exclude group: 'org.codehaus.jackson'
+    exclude group: "org.bouncycastle"
   }
   api "org.codehaus.jettison:jettison:${versions.jettison}"
   api "org.apache.commons:commons-compress:1.23.0"
@@ -51,7 +52,6 @@ dependencies {
   api "org.apache.logging.log4j:log4j-core:${versions.log4j}"
   api "io.netty:netty-all:${versions.netty}"
   api 'com.google.code.gson:gson:2.10.1'
-  api "org.bouncycastle:bcpkix-jdk15to18:${versions.bouncycastle}"
   api "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:${versions.jackson}"
   api "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
   api "com.fasterxml.woodstox:woodstox-core:${versions.woodstox}"
@@ -65,4 +65,5 @@ dependencies {
   api "org.apache.commons:commons-text:1.10.0"
   api "commons-net:commons-net:3.9.0"
   runtimeOnly "com.google.guava:guava:${versions.guava}"
+
 }


### PR DESCRIPTION
### Description
Fix HDFS fixture by excluding BouncyCastle
 
### Issues Resolved

After https://github.com/opensearch-project/OpenSearch/pull/8247 got merged, we found out that `hdfs-fixture` transitivity bring `xxx-jdk15on` artifacts nonetheless, excluding them:

```
org.bouncycastle:bcpkix-jdk15on:1.68
   variant "runtime" [
      org.gradle.status              = release (not requested)
      org.gradle.usage               = java-runtime
      org.gradle.libraryelements     = jar
      org.gradle.category            = library

      Requested attributes not found in the selected variant:
         org.gradle.dependency.bundling = external
         org.gradle.jvm.version         = 8
   ]

org.bouncycastle:bcpkix-jdk15on:1.68
\--- org.apache.hadoop:hadoop-yarn-server-web-proxy:3.3.5
     +--- org.apache.hadoop:hadoop-minicluster:3.3.5
     |    \--- runtimeClasspath
     +--- org.apache.hadoop:hadoop-mapreduce-client-app:3.3.5
     |    +--- org.apache.hadoop:hadoop-minicluster:3.3.5 (*)
     |    \--- org.apache.hadoop:hadoop-mapreduce-client-hs:3.3.5
     |         \--- org.apache.hadoop:hadoop-minicluster:3.3.5 (*)
     \--- org.apache.hadoop:hadoop-yarn-server-resourcemanager:3.3.5
          \--- org.apache.hadoop:hadoop-yarn-server-tests:3.3.5
               \--- org.apache.hadoop:hadoop-minicluster:3.3.5 (*)

org.bouncycastle:bcpkix-jdk15to18:1.75
   variant "runtime" [
      org.gradle.status              = release (not requested)
      org.gradle.usage               = java-runtime
      org.gradle.libraryelements     = jar
      org.gradle.category            = library

      Requested attributes not found in the selected variant:
         org.gradle.dependency.bundling = external
         org.gradle.jvm.version         = 8
   ]

org.bouncycastle:bcpkix-jdk15to18:1.75
\--- runtimeClasspath

org.bouncycastle:bcprov-jdk15on:1.68
   variant "runtime" [
      org.gradle.status              = release (not requested)
      org.gradle.usage               = java-runtime
      org.gradle.libraryelements     = jar
      org.gradle.category            = library

      Requested attributes not found in the selected variant:
         org.gradle.dependency.bundling = external
         org.gradle.jvm.version         = 8
   ]

org.bouncycastle:bcprov-jdk15on:1.68
+--- org.apache.hadoop:hadoop-yarn-server-web-proxy:3.3.5
|    +--- org.apache.hadoop:hadoop-minicluster:3.3.5
|    |    \--- runtimeClasspath
|    +--- org.apache.hadoop:hadoop-mapreduce-client-app:3.3.5
|    |    +--- org.apache.hadoop:hadoop-minicluster:3.3.5 (*)
|    |    \--- org.apache.hadoop:hadoop-mapreduce-client-hs:3.3.5
|    |         \--- org.apache.hadoop:hadoop-minicluster:3.3.5 (*)
|    \--- org.apache.hadoop:hadoop-yarn-server-resourcemanager:3.3.5
|         \--- org.apache.hadoop:hadoop-yarn-server-tests:3.3.5
|              \--- org.apache.hadoop:hadoop-minicluster:3.3.5 (*)
\--- org.bouncycastle:bcpkix-jdk15on:1.68
     \--- org.apache.hadoop:hadoop-yarn-server-web-proxy:3.3.5 (*)

org.bouncycastle:bcprov-jdk15to18:1.75
   variant "runtime" [
      org.gradle.status              = release (not requested)
      org.gradle.usage               = java-runtime
      org.gradle.libraryelements     = jar
      org.gradle.category            = library

      Requested attributes not found in the selected variant:
         org.gradle.dependency.bundling = external
         org.gradle.jvm.version         = 8
   ]

org.bouncycastle:bcprov-jdk15to18:1.75
+--- org.bouncycastle:bcpkix-jdk15to18:1.75
|    \--- runtimeClasspath
\--- org.bouncycastle:bcutil-jdk15to18:1.75
     \--- org.bouncycastle:bcpkix-jdk15to18:1.75 (*)

org.bouncycastle:bcutil-jdk15to18:1.75
   variant "runtime" [
      org.gradle.status              = release (not requested)
      org.gradle.usage               = java-runtime
      org.gradle.libraryelements     = jar
      org.gradle.category            = library

      Requested attributes not found in the selected variant:
         org.gradle.dependency.bundling = external
         org.gradle.jvm.version         = 8
   ]

org.bouncycastle:bcutil-jdk15to18:1.75
\--- org.bouncycastle:bcpkix-jdk15to18:1.75
     \--- runtimeClasspath
```
 
### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
