### PR TITLE
[Backport] [2.x] Fix HDFS fixture by excluding BouncyCastle (#8359) 

### DIFF
--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     exclude module: 'netty'
     exclude module: 'guava'
     exclude group: 'org.codehaus.jackson'
+    exclude group: "org.bouncycastle"
   }
   api "org.codehaus.jettison:jettison:${versions.jettison}"
   api "org.apache.commons:commons-compress:1.23.0"
@@ -50,7 +51,6 @@ dependencies {
   api "org.apache.logging.log4j:log4j-core:${versions.log4j}"
   api "io.netty:netty-all:${versions.netty}"
   api 'com.google.code.gson:gson:2.9.0'
-  api "org.bouncycastle:bcpkix-jdk15to18:${versions.bouncycastle}"
   api "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:${versions.jackson}"
   api "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
   api "com.fasterxml.woodstox:woodstox-core:${versions.woodstox}"
@@ -64,4 +64,5 @@ dependencies {
   api "org.apache.commons:commons-text:1.10.0"
   api "commons-net:commons-net:3.9.0"
   runtimeOnly "com.google.guava:guava:${versions.guava}"
+
 }


### PR DESCRIPTION
Backport #8359 for f2fbd17457170d1c734c97afa82445acf06cc6cf