### PR TITLE
Fix primary balance flaky test

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationAllocationIT.java
@@ -96,7 +96,6 @@ public class SegmentReplicationAllocationIT extends SegmentReplicationBaseIT {
      * This test in general passes without primary shard balance as well due to nature of allocation algorithm which
      * assigns all primary shards first followed by replica copies.
      */
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/7751")
     public void testPerIndexPrimaryAllocation() throws Exception {
         internalCluster().startClusterManagerOnlyNode();
         final int maxReplicaCount = 2;
@@ -234,7 +233,7 @@ public class SegmentReplicationAllocationIT extends SegmentReplicationBaseIT {
             RoutingNodes nodes = currentState.getRoutingNodes();
             for (final Map.Entry<String, IndexRoutingTable> index : currentState.getRoutingTable().indicesRouting().entrySet()) {
                 final int totalPrimaryShards = index.getValue().primaryShardsActive();
-                final int avgPrimaryShardsPerNode = (int) Math.ceil(totalPrimaryShards * 1f / currentState.getRoutingNodes().size());
+                final int avgPrimaryShardsPerNode = (int) Math.floor(totalPrimaryShards * 1f / currentState.getRoutingNodes().size());
                 for (RoutingNode node : nodes) {
                     final int primaryCount = node.shardsWithState(index.getKey(), STARTED)
                         .stream()
@@ -250,7 +249,8 @@ public class SegmentReplicationAllocationIT extends SegmentReplicationBaseIT {
                             avgPrimaryShardsPerNode
                         );
                     }
-                    assertTrue(primaryCount <= avgPrimaryShardsPerNode);
+                    // Asserts value is within the variance threshold (-1/+1 of the average value).
+                    assertTrue(avgPrimaryShardsPerNode - 1 <= primaryCount && primaryCount <= avgPrimaryShardsPerNode + 1);
                 }
             }
         }, 60, TimeUnit.SECONDS);


### PR DESCRIPTION
### Description
- Fix primary balance flaky test
- Asserts for a window within threshold of -1 and +1 of the average value because of the general variance

Tested with the following seeds from the failure mentions
- CC0A02835F66CD86 (https://build.ci.opensearch.org/job/gradle-check/16741/testReport/org.opensearch.indices.replication/SegmentReplicationAllocationIT/testPerIndexPrimaryAllocation_4/)
- 9631830FBDB9647 (https://build.ci.opensearch.org/job/gradle-check/16211/testReport/junit/org.opensearch.indices.replication/SegmentReplicationAllocationIT/testPerIndexPrimaryAllocation/) 
- 2F83A4C6F3228287 (https://build.ci.opensearch.org/job/gradle-check/17287/testReport/org.opensearch.indices.replication/SegmentReplicationAllocationIT/testPerIndexPrimaryAllocation/)

### Related Issues
Resolves #7751

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
