### PR TITLE
[Remote Store] Add remote store utils useful to name metadata files

### DIFF
--- a/server/src/main/java/org/opensearch/index/remote/RemoteStoreUtils.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStoreUtils.java
@@ -12,6 +12,8 @@ import java.util.Arrays;
 
 /**
  * Utils for remote store
+ *
+ * @opensearch.internal
  */
 public class RemoteStoreUtils {
     public static final int LONG_MAX_LENGTH = String.valueOf(Long.MAX_VALUE).length();

--- a/server/src/main/java/org/opensearch/index/remote/RemoteStoreUtils.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStoreUtils.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.remote;
+
+import java.util.Arrays;
+
+/**
+ * Utils for remote store
+ */
+public class RemoteStoreUtils {
+    public static final int LONG_MAX_LENGTH = String.valueOf(Long.MAX_VALUE).length();
+
+    /**
+     * This method subtracts given numbers from Long.MAX_VALUE and returns a string representation of the result.
+     * The resultant string is guaranteed to be of the same length that of Long.MAX_VALUE. If shorter, we add left padding
+     * of 0s to the string.
+     * @param num number to get the inverted long string for
+     * @return String value of Long.MAX_VALUE - num
+     */
+    public static String invertLong(long num) {
+        if (num < 0) {
+            throw new IllegalArgumentException("Negative long values are not allowed");
+        }
+        String invertedLong = String.valueOf(Long.MAX_VALUE - num);
+        char[] characterArray = new char[LONG_MAX_LENGTH - invertedLong.length()];
+        Arrays.fill(characterArray, '0');
+
+        return new String(characterArray) + invertedLong;
+    }
+
+    /**
+     * This method converts the given string into long and subtracts it from Long.MAX_VALUE
+     * @param str long in string format to be inverted
+     * @return long value of the invert result
+     */
+    public static long invertLong(String str) {
+        long num = Long.parseLong(str);
+        if (num < 0) {
+            throw new IllegalArgumentException("Strings representing negative long values are not allowed");
+        }
+        return Long.MAX_VALUE - num;
+    }
+}

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStoreUtilsTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStoreUtilsTests.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.remote;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+public class RemoteStoreUtilsTests extends OpenSearchTestCase {
+
+    public void testInvertToStrInvalid() {
+        assertThrows(IllegalArgumentException.class, () -> RemoteStoreUtils.invertLong(-1));
+    }
+
+    public void testInvertToStrValid() {
+        assertEquals("9223372036854774573", RemoteStoreUtils.invertLong(1234));
+        assertEquals("0000000000000001234", RemoteStoreUtils.invertLong(9223372036854774573L));
+    }
+
+    public void testInvertToLongInvalid() {
+        assertThrows(IllegalArgumentException.class, () -> RemoteStoreUtils.invertLong("-5"));
+    }
+
+    public void testInvertToLongValid() {
+        assertEquals(1234, RemoteStoreUtils.invertLong("9223372036854774573"));
+        assertEquals(9223372036854774573L, RemoteStoreUtils.invertLong("0000000000000001234"));
+    }
+
+    public void testinvert() {
+        assertEquals(0, RemoteStoreUtils.invertLong(RemoteStoreUtils.invertLong(0)));
+        assertEquals(Long.MAX_VALUE, RemoteStoreUtils.invertLong(RemoteStoreUtils.invertLong(Long.MAX_VALUE)));
+        for (int i = 0; i < 10; i++) {
+            long num = randomLongBetween(1, Long.MAX_VALUE);
+            assertEquals(num, RemoteStoreUtils.invertLong(RemoteStoreUtils.invertLong(num)));
+        }
+    }
+}


### PR DESCRIPTION
### Description
- In order to efficiently search latest metadata files, metadata files in remote store would be named with following format:
```
metadata_<Inverted Primary Term>_<Inverted Commit Generation>_<Inverted Translog Generation>_<Timestamp>
```
- Here, each inverted number is represented as Long.MAX_VALUE - original number padded with 0s at the front to make the length consistent with that of Long.MAX_VALUE.
- The reason behind using inverted values is to make use of Lexicographic sort order that is supported in majority of the blob stores that remote store feature supports.
- In this PR, we introduce utility methods to convert a given number into inverted format and vice versa.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
