### PR TITLE
Support extension additional settings with extension REST initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add API to initialize extensions ([#8029]()https://github.com/opensearch-project/OpenSearch/pull/8029)
 - Add distributed tracing framework ([#7543](https://github.com/opensearch-project/OpenSearch/issues/7543))
 - Enable Point based optimization for custom comparators ([#8168](https://github.com/opensearch-project/OpenSearch/pull/8168))
+- [Extensions] Support extension additional settings with extension REST initialization ([#8414](https://github.com/opensearch-project/OpenSearch/pull/8414))
 
 ### Dependencies
 - Bump `com.azure:azure-storage-common` from 12.21.0 to 12.21.1 (#7566, #7814)

--- a/server/src/main/java/org/opensearch/extensions/ExtensionDependency.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionDependency.java
@@ -16,10 +16,6 @@ import org.opensearch.Version;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
-import org.opensearch.core.common.Strings;
-import org.opensearch.core.xcontent.XContentParser;
-
-import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
 /**
  * This class handles the dependent extensions information
@@ -58,39 +54,6 @@ public class ExtensionDependency implements Writeable {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(uniqueId);
         out.writeVersion(version);
-    }
-
-    public static ExtensionDependency parse(XContentParser parser) throws IOException {
-        String uniqueId = null;
-        Version version = null;
-        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
-        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
-            String fieldName = parser.currentName();
-            parser.nextToken();
-
-            switch (fieldName) {
-                case UNIQUE_ID:
-                    uniqueId = parser.text();
-                    break;
-                case VERSION:
-                    try {
-                        version = Version.fromString(parser.text());
-                    } catch (IllegalArgumentException e) {
-                        throw e;
-                    }
-                    break;
-                default:
-                    parser.skipChildren();
-                    break;
-            }
-        }
-        if (Strings.isNullOrEmpty(uniqueId)) {
-            throw new IOException("Required field [uniqueId] is missing in the request for the dependent extension");
-        } else if (version == null) {
-            throw new IOException("Required field [version] is missing in the request for the dependent extension");
-        }
-        return new ExtensionDependency(uniqueId, version);
-
     }
 
     /**

--- a/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
@@ -504,4 +504,8 @@ public class ExtensionsManager {
     Settings getEnvironmentSettings() {
         return environmentSettings;
     }
+
+    public Set<Setting<?>> getAdditionalSettings() {
+        return this.additionalSettings;
+    }
 }

--- a/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
@@ -105,7 +105,7 @@ public class ExtensionsManager {
     /**
      * Instantiate a new ExtensionsManager object to handle requests and responses from extensions. This is called during Node bootstrap.
      *
-     * @param additionalSettings  Additional settings to read in from extensions.yml
+     * @param additionalSettings  Additional settings to read in from extension initialization request
      * @throws IOException  If the extensions discovery file is not properly retrieved.
      */
     public ExtensionsManager(Set<Setting<?>> additionalSettings) throws IOException {

--- a/server/src/main/java/org/opensearch/extensions/rest/RestInitializeExtensionAction.java
+++ b/server/src/main/java/org/opensearch/extensions/rest/RestInitializeExtensionAction.java
@@ -8,9 +8,13 @@
 
 package org.opensearch.extensions.rest;
 
+import org.opensearch.Version;
 import org.opensearch.client.node.NodeClient;
+import org.opensearch.common.collect.Tuple;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.core.xcontent.MediaType;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.extensions.ExtensionDependency;
 import org.opensearch.extensions.ExtensionScopedSettings;
 import org.opensearch.extensions.ExtensionsManager;
@@ -23,12 +27,16 @@ import org.opensearch.transport.ConnectTransportException;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
-import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.rest.RestRequest.Method.POST;
 
 /**
@@ -62,36 +70,73 @@ public class RestInitializeExtensionAction extends BaseRestHandler {
         String openSearchVersion = null;
         String minimumCompatibleVersion = null;
         List<ExtensionDependency> dependencies = new ArrayList<>();
+        Set<String> additionalSettingsKeys = extensionsManager.getAdditionalSettings()
+            .stream()
+            .map(s -> s.getKey())
+            .collect(Collectors.toSet());
 
-        try (XContentParser parser = request.contentParser()) {
-            parser.nextToken();
-            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
-            while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
-                String currentFieldName = parser.currentName();
-                parser.nextToken();
-                if ("name".equals(currentFieldName)) {
-                    name = parser.text();
-                } else if ("uniqueId".equals(currentFieldName)) {
-                    uniqueId = parser.text();
-                } else if ("hostAddress".equals(currentFieldName)) {
-                    hostAddress = parser.text();
-                } else if ("port".equals(currentFieldName)) {
-                    port = parser.text();
-                } else if ("version".equals(currentFieldName)) {
-                    version = parser.text();
-                } else if ("opensearchVersion".equals(currentFieldName)) {
-                    openSearchVersion = parser.text();
-                } else if ("minimumCompatibleVersion".equals(currentFieldName)) {
-                    minimumCompatibleVersion = parser.text();
-                } else if ("dependencies".equals(currentFieldName)) {
-                    ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
-                    while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
-                        dependencies.add(ExtensionDependency.parse(parser));
-                    }
+        Tuple<? extends MediaType, Map<String, Object>> unreadExtensionTuple = XContentHelper.convertToMap(
+            request.content(),
+            false,
+            request.getXContentType().xContent().mediaType()
+        );
+        Map<String, Object> extensionMap = unreadExtensionTuple.v2();
+
+        ExtensionScopedSettings extAdditionalSettings = new ExtensionScopedSettings(extensionsManager.getAdditionalSettings());
+
+        try {
+            // checking to see whether any required fields are missing from extension.yml file or not
+            String[] requiredFields = {
+                "name",
+                "uniqueId",
+                "hostAddress",
+                "port",
+                "version",
+                "opensearchVersion",
+                "minimumCompatibleVersion" };
+            List<String> missingFields = Arrays.stream(requiredFields)
+                .filter(field -> !extensionMap.containsKey(field))
+                .collect(Collectors.toList());
+            if (!missingFields.isEmpty()) {
+                throw new IOException("Extension is missing these required fields : " + missingFields);
+            }
+
+            // Parse extension dependencies
+            List<ExtensionDependency> extensionDependencyList = new ArrayList<ExtensionDependency>();
+            if (extensionMap.get("dependencies") != null) {
+                List<HashMap<String, ?>> extensionDependencies = new ArrayList<>(
+                    (Collection<HashMap<String, ?>>) extensionMap.get("dependencies")
+                );
+                for (HashMap<String, ?> dependency : extensionDependencies) {
+                    extensionDependencyList.add(
+                        new ExtensionDependency(
+                            dependency.get("uniqueId").toString(),
+                            Version.fromString(dependency.get("version").toString())
+                        )
+                    );
                 }
             }
+
+            Map<String, ?> additionalSettingsMap = extensionMap.entrySet()
+                .stream()
+                .filter(kv -> additionalSettingsKeys.contains(kv.getKey()))
+                .collect(Collectors.toMap(map -> map.getKey(), map -> map.getValue()));
+
+            Settings.Builder output = Settings.builder();
+            output.loadFromMap(additionalSettingsMap);
+            extAdditionalSettings.applySettings(output.build());
+
+            // Create extension read from yml config
+            name = extensionMap.get("name").toString();
+            uniqueId = extensionMap.get("uniqueId").toString();
+            hostAddress = extensionMap.get("hostAddress").toString();
+            port = extensionMap.get("port").toString();
+            version = extensionMap.get("version").toString();
+            openSearchVersion = extensionMap.get("opensearchVersion").toString();
+            minimumCompatibleVersion = extensionMap.get("minimumCompatibleVersion").toString();
+            dependencies = extensionDependencyList;
         } catch (IOException e) {
-            throw new IOException("Missing attribute", e);
+            logger.warn("loading extension has been failed because of exception : " + e.getMessage());
         }
 
         Extension extension = new Extension(
@@ -103,8 +148,7 @@ public class RestInitializeExtensionAction extends BaseRestHandler {
             openSearchVersion,
             minimumCompatibleVersion,
             dependencies,
-            // TODO add this to the API (https://github.com/opensearch-project/OpenSearch/issues/8032)
-            new ExtensionScopedSettings(Collections.emptySet())
+            extAdditionalSettings
         );
         try {
             extensionsManager.loadExtension(extension);

--- a/server/src/main/java/org/opensearch/extensions/rest/RestInitializeExtensionAction.java
+++ b/server/src/main/java/org/opensearch/extensions/rest/RestInitializeExtensionAction.java
@@ -126,7 +126,7 @@ public class RestInitializeExtensionAction extends BaseRestHandler {
             output.loadFromMap(additionalSettingsMap);
             extAdditionalSettings.applySettings(output.build());
 
-            // Create extension read from yml config
+            // Create extension read from initialization request
             name = extensionMap.get("name").toString();
             uniqueId = extensionMap.get("uniqueId").toString();
             hostAddress = extensionMap.get("hostAddress").toString();

--- a/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
+++ b/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
@@ -45,8 +45,6 @@ import org.opensearch.action.admin.cluster.state.ClusterStateResponse;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.cluster.ClusterSettingsResponse;
 import org.opensearch.common.util.FeatureFlags;
-import org.opensearch.common.xcontent.json.JsonXContent;
-import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.env.EnvironmentSettingsResponse;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -396,16 +394,6 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
                 assertEquals(expectedVersion, dependency.getVersion());
             }
         }
-    }
-
-    public void testParseExtensionDependency() throws Exception {
-        XContentParser parser = createParser(JsonXContent.jsonXContent, "{\"uniqueId\": \"test1\", \"version\": \"2.0.0\"}");
-
-        assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
-        ExtensionDependency dependency = ExtensionDependency.parse(parser);
-
-        assertEquals("test1", dependency.getUniqueId());
-        assertEquals(Version.fromString("2.0.0"), dependency.getVersion());
     }
 
     public void testInitialize() throws Exception {

--- a/server/src/test/java/org/opensearch/extensions/rest/RestInitializeExtensionActionTests.java
+++ b/server/src/test/java/org/opensearch/extensions/rest/RestInitializeExtensionActionTests.java
@@ -97,8 +97,12 @@ public class RestInitializeExtensionActionTests extends OpenSearchTestCase {
         ExtensionsManager extensionsManager = mock(ExtensionsManager.class);
         RestInitializeExtensionAction restInitializeExtensionAction = new RestInitializeExtensionAction(extensionsManager);
         final String content = "{\"name\":\"ad-extension\",\"uniqueId\":\"ad-extension\",\"hostAddress\":\"127.0.0.1\","
-            + "\"port\":\"4532\",\"version\":\"1.0\",\"opensearchVersion\":\"3.0.0\","
-            + "\"minimumCompatibleVersion\":\"3.0.0\"}";
+            + "\"port\":\"4532\",\"version\":\"1.0\",\"opensearchVersion\":\""
+            + Version.CURRENT.toString()
+            + "\","
+            + "\"minimumCompatibleVersion\":\""
+            + Version.CURRENT.minimumCompatibilityVersion().toString()
+            + "\"}";
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withContent(new BytesArray(content), XContentType.JSON)
             .withMethod(RestRequest.Method.POST)
             .build();
@@ -115,8 +119,12 @@ public class RestInitializeExtensionActionTests extends OpenSearchTestCase {
         RestInitializeExtensionAction restInitializeExtensionAction = new RestInitializeExtensionAction(extensionsManager);
 
         final String content = "{\"name\":\"ad-extension\",\"uniqueId\":\"\",\"hostAddress\":\"127.0.0.1\","
-            + "\"port\":\"4532\",\"version\":\"1.0\",\"opensearchVersion\":\"3.0.0\","
-            + "\"minimumCompatibleVersion\":\"3.0.0\"}";
+            + "\"port\":\"4532\",\"version\":\"1.0\",\"opensearchVersion\":\""
+            + Version.CURRENT.toString()
+            + "\","
+            + "\"minimumCompatibleVersion\":\""
+            + Version.CURRENT.minimumCompatibilityVersion().toString()
+            + "\"}";
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withContent(new BytesArray(content), XContentType.JSON)
             .withMethod(RestRequest.Method.POST)
             .build();
@@ -152,7 +160,9 @@ public class RestInitializeExtensionActionTests extends OpenSearchTestCase {
             + "\"port\":\"4532\",\"version\":\"1.0\",\"opensearchVersion\":\""
             + Version.CURRENT.toString()
             + "\","
-            + "\"minimumCompatibleVersion\":\"3.0.0\",\"boolSetting\":true,\"stringSetting\":\"customSetting\",\"intSetting\":5,\"listSetting\":[\"one\",\"two\",\"three\"]}";
+            + "\"minimumCompatibleVersion\":\""
+            + Version.CURRENT.minimumCompatibilityVersion().toString()
+            + "\",\"boolSetting\":true,\"stringSetting\":\"customSetting\",\"intSetting\":5,\"listSetting\":[\"one\",\"two\",\"three\"]}";
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withContent(new BytesArray(content), XContentType.JSON)
             .withMethod(RestRequest.Method.POST)
             .build();
@@ -197,7 +207,9 @@ public class RestInitializeExtensionActionTests extends OpenSearchTestCase {
             + "\"port\":\"4532\",\"version\":\"1.0\",\"opensearchVersion\":\""
             + Version.CURRENT.toString()
             + "\","
-            + "\"minimumCompatibleVersion\":\"3.0.0\"}";
+            + "\"minimumCompatibleVersion\":\""
+            + Version.CURRENT.minimumCompatibilityVersion().toString()
+            + "\"}";
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withContent(new BytesArray(content), XContentType.JSON)
             .withMethod(RestRequest.Method.POST)
             .build();

--- a/server/src/test/java/org/opensearch/extensions/rest/RestInitializeExtensionActionTests.java
+++ b/server/src/test/java/org/opensearch/extensions/rest/RestInitializeExtensionActionTests.java
@@ -97,8 +97,12 @@ public class RestInitializeExtensionActionTests extends OpenSearchTestCase {
         ExtensionsManager extensionsManager = mock(ExtensionsManager.class);
         RestInitializeExtensionAction restInitializeExtensionAction = new RestInitializeExtensionAction(extensionsManager);
         final String content = "{\"name\":\"ad-extension\",\"uniqueId\":\"ad-extension\",\"hostAddress\":\"127.0.0.1\","
-            + "\"port\":\"4532\",\"version\":\"1.0\",\"opensearchVersion\":\"3.0.0\","
-            + "\"minimumCompatibleVersion\":\"3.0.0\"}";
+            + "\"port\":\"4532\",\"version\":\"1.0\",\"opensearchVersion\":\""
+            + Version.CURRENT.toString()
+            + "\","
+            + "\"minimumCompatibleVersion\":\""
+            + Version.CURRENT.toString()
+            + "\"}";
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withContent(new BytesArray(content), XContentType.JSON)
             .withMethod(RestRequest.Method.POST)
             .build();
@@ -115,8 +119,12 @@ public class RestInitializeExtensionActionTests extends OpenSearchTestCase {
         RestInitializeExtensionAction restInitializeExtensionAction = new RestInitializeExtensionAction(extensionsManager);
 
         final String content = "{\"name\":\"ad-extension\",\"uniqueId\":\"\",\"hostAddress\":\"127.0.0.1\","
-            + "\"port\":\"4532\",\"version\":\"1.0\",\"opensearchVersion\":\"3.0.0\","
-            + "\"minimumCompatibleVersion\":\"3.0.0\"}";
+            + "\"port\":\"4532\",\"version\":\"1.0\",\"opensearchVersion\":\""
+            + Version.CURRENT.toString()
+            + "\","
+            + "\"minimumCompatibleVersion\":\""
+            + Version.CURRENT.toString()
+            + "\"}";
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withContent(new BytesArray(content), XContentType.JSON)
             .withMethod(RestRequest.Method.POST)
             .build();
@@ -152,7 +160,9 @@ public class RestInitializeExtensionActionTests extends OpenSearchTestCase {
             + "\"port\":\"4532\",\"version\":\"1.0\",\"opensearchVersion\":\""
             + Version.CURRENT.toString()
             + "\","
-            + "\"minimumCompatibleVersion\":\"3.0.0\",\"boolSetting\":true,\"stringSetting\":\"customSetting\",\"intSetting\":5,\"listSetting\":[\"one\",\"two\",\"three\"]}";
+            + "\"minimumCompatibleVersion\":\""
+            + Version.CURRENT.toString()
+            + "\",\"boolSetting\":true,\"stringSetting\":\"customSetting\",\"intSetting\":5,\"listSetting\":[\"one\",\"two\",\"three\"]}";
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withContent(new BytesArray(content), XContentType.JSON)
             .withMethod(RestRequest.Method.POST)
             .build();
@@ -197,7 +207,9 @@ public class RestInitializeExtensionActionTests extends OpenSearchTestCase {
             + "\"port\":\"4532\",\"version\":\"1.0\",\"opensearchVersion\":\""
             + Version.CURRENT.toString()
             + "\","
-            + "\"minimumCompatibleVersion\":\"3.0.0\"}";
+            + "\"minimumCompatibleVersion\":\""
+            + Version.CURRENT.toString()
+            + "\"}";
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withContent(new BytesArray(content), XContentType.JSON)
             .withMethod(RestRequest.Method.POST)
             .build();

--- a/server/src/test/java/org/opensearch/extensions/rest/RestInitializeExtensionActionTests.java
+++ b/server/src/test/java/org/opensearch/extensions/rest/RestInitializeExtensionActionTests.java
@@ -149,7 +149,9 @@ public class RestInitializeExtensionActionTests extends OpenSearchTestCase {
         Mockito.doNothing().when(spy).initialize();
         RestInitializeExtensionAction restInitializeExtensionAction = new RestInitializeExtensionAction(spy);
         final String content = "{\"name\":\"ad-extension\",\"uniqueId\":\"ad-extension\",\"hostAddress\":\"127.0.0.1\","
-            + "\"port\":\"4532\",\"version\":\"1.0\",\"opensearchVersion\":\"3.0.0\","
+            + "\"port\":\"4532\",\"version\":\"1.0\",\"opensearchVersion\":\""
+            + Version.CURRENT.toString()
+            + "\","
             + "\"minimumCompatibleVersion\":\"3.0.0\",\"boolSetting\":true,\"stringSetting\":\"customSetting\",\"intSetting\":5,\"listSetting\":[\"one\",\"two\",\"three\"]}";
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withContent(new BytesArray(content), XContentType.JSON)
             .withMethod(RestRequest.Method.POST)
@@ -192,7 +194,9 @@ public class RestInitializeExtensionActionTests extends OpenSearchTestCase {
         Mockito.doNothing().when(spy).initialize();
         RestInitializeExtensionAction restInitializeExtensionAction = new RestInitializeExtensionAction(spy);
         final String content = "{\"name\":\"ad-extension\",\"uniqueId\":\"ad-extension\",\"hostAddress\":\"127.0.0.1\","
-            + "\"port\":\"4532\",\"version\":\"1.0\",\"opensearchVersion\":\"3.0.0\","
+            + "\"port\":\"4532\",\"version\":\"1.0\",\"opensearchVersion\":\""
+            + Version.CURRENT.toString()
+            + "\","
             + "\"minimumCompatibleVersion\":\"3.0.0\"}";
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withContent(new BytesArray(content), XContentType.JSON)
             .withMethod(RestRequest.Method.POST)

--- a/server/src/test/java/org/opensearch/extensions/rest/RestInitializeExtensionActionTests.java
+++ b/server/src/test/java/org/opensearch/extensions/rest/RestInitializeExtensionActionTests.java
@@ -97,12 +97,8 @@ public class RestInitializeExtensionActionTests extends OpenSearchTestCase {
         ExtensionsManager extensionsManager = mock(ExtensionsManager.class);
         RestInitializeExtensionAction restInitializeExtensionAction = new RestInitializeExtensionAction(extensionsManager);
         final String content = "{\"name\":\"ad-extension\",\"uniqueId\":\"ad-extension\",\"hostAddress\":\"127.0.0.1\","
-            + "\"port\":\"4532\",\"version\":\"1.0\",\"opensearchVersion\":\""
-            + Version.CURRENT.toString()
-            + "\","
-            + "\"minimumCompatibleVersion\":\""
-            + Version.CURRENT.toString()
-            + "\"}";
+            + "\"port\":\"4532\",\"version\":\"1.0\",\"opensearchVersion\":\"3.0.0\","
+            + "\"minimumCompatibleVersion\":\"3.0.0\"}";
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withContent(new BytesArray(content), XContentType.JSON)
             .withMethod(RestRequest.Method.POST)
             .build();
@@ -119,12 +115,8 @@ public class RestInitializeExtensionActionTests extends OpenSearchTestCase {
         RestInitializeExtensionAction restInitializeExtensionAction = new RestInitializeExtensionAction(extensionsManager);
 
         final String content = "{\"name\":\"ad-extension\",\"uniqueId\":\"\",\"hostAddress\":\"127.0.0.1\","
-            + "\"port\":\"4532\",\"version\":\"1.0\",\"opensearchVersion\":\""
-            + Version.CURRENT.toString()
-            + "\","
-            + "\"minimumCompatibleVersion\":\""
-            + Version.CURRENT.toString()
-            + "\"}";
+            + "\"port\":\"4532\",\"version\":\"1.0\",\"opensearchVersion\":\"3.0.0\","
+            + "\"minimumCompatibleVersion\":\"3.0.0\"}";
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withContent(new BytesArray(content), XContentType.JSON)
             .withMethod(RestRequest.Method.POST)
             .build();
@@ -160,9 +152,7 @@ public class RestInitializeExtensionActionTests extends OpenSearchTestCase {
             + "\"port\":\"4532\",\"version\":\"1.0\",\"opensearchVersion\":\""
             + Version.CURRENT.toString()
             + "\","
-            + "\"minimumCompatibleVersion\":\""
-            + Version.CURRENT.toString()
-            + "\",\"boolSetting\":true,\"stringSetting\":\"customSetting\",\"intSetting\":5,\"listSetting\":[\"one\",\"two\",\"three\"]}";
+            + "\"minimumCompatibleVersion\":\"3.0.0\",\"boolSetting\":true,\"stringSetting\":\"customSetting\",\"intSetting\":5,\"listSetting\":[\"one\",\"two\",\"three\"]}";
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withContent(new BytesArray(content), XContentType.JSON)
             .withMethod(RestRequest.Method.POST)
             .build();
@@ -207,9 +197,7 @@ public class RestInitializeExtensionActionTests extends OpenSearchTestCase {
             + "\"port\":\"4532\",\"version\":\"1.0\",\"opensearchVersion\":\""
             + Version.CURRENT.toString()
             + "\","
-            + "\"minimumCompatibleVersion\":\""
-            + Version.CURRENT.toString()
-            + "\"}";
+            + "\"minimumCompatibleVersion\":\"3.0.0\"}";
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withContent(new BytesArray(content), XContentType.JSON)
             .withMethod(RestRequest.Method.POST)
             .build();

--- a/server/src/test/java/org/opensearch/extensions/rest/RestInitializeExtensionActionTests.java
+++ b/server/src/test/java/org/opensearch/extensions/rest/RestInitializeExtensionActionTests.java
@@ -9,24 +9,31 @@
 package org.opensearch.extensions.rest;
 
 import java.util.Collections;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 import org.junit.After;
 import org.junit.Before;
+import org.mockito.Mockito;
 import org.opensearch.Version;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.bytes.BytesArray;
 import org.opensearch.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.common.network.NetworkService;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.PageCacheRecycler;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.extensions.ExtensionsManager;
+import org.opensearch.extensions.ExtensionsSettings;
 import org.opensearch.indices.breaker.NoneCircuitBreakerService;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.RestStatus;
@@ -119,6 +126,62 @@ public class RestInitializeExtensionActionTests extends OpenSearchTestCase {
         assertTrue(
             channel.capturedResponse().content().utf8ToString().contains("Required field [extension uniqueId] is missing in the request")
         );
+    }
+
+    public void testRestInitializeExtensionActionResponseWithAdditionalSettings() throws Exception {
+        Setting boolSetting = Setting.boolSetting("boolSetting", false, Setting.Property.ExtensionScope);
+        ExtensionsManager extensionsManager = new ExtensionsManager(Set.of(boolSetting));
+        ExtensionsManager spy = spy(extensionsManager);
+
+        // optionally, you can stub out some methods:
+        when(spy.getAdditionalSettings()).thenCallRealMethod();
+        Mockito.doCallRealMethod().when(spy).loadExtension(any(ExtensionsSettings.Extension.class));
+        Mockito.doNothing().when(spy).initialize();
+        RestInitializeExtensionAction restInitializeExtensionAction = new RestInitializeExtensionAction(spy);
+        final String content = "{\"name\":\"ad-extension\",\"uniqueId\":\"ad-extension\",\"hostAddress\":\"127.0.0.1\","
+            + "\"port\":\"4532\",\"version\":\"1.0\",\"opensearchVersion\":\"3.0.0\","
+            + "\"minimumCompatibleVersion\":\"3.0.0\",\"boolSetting\":true}";
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withContent(new BytesArray(content), XContentType.JSON)
+            .withMethod(RestRequest.Method.POST)
+            .build();
+
+        FakeRestChannel channel = new FakeRestChannel(request, false, 0);
+        restInitializeExtensionAction.handleRequest(request, channel, null);
+
+        assertEquals(channel.capturedResponse().status(), RestStatus.ACCEPTED);
+        assertTrue(channel.capturedResponse().content().utf8ToString().contains("A request to initialize an extension has been sent."));
+
+        Optional<ExtensionsSettings.Extension> extension = spy.lookupExtensionSettingsById("ad-extension");
+        assertTrue(extension.isPresent());
+        assertEquals(true, extension.get().getAdditionalSettings().get(boolSetting));
+    }
+
+    public void testRestInitializeExtensionActionResponseWithAdditionalSettingsUsingDefault() throws Exception {
+        Setting boolSetting = Setting.boolSetting("boolSetting", false, Setting.Property.ExtensionScope);
+        ExtensionsManager extensionsManager = new ExtensionsManager(Set.of(boolSetting));
+        ExtensionsManager spy = spy(extensionsManager);
+
+        // optionally, you can stub out some methods:
+        when(spy.getAdditionalSettings()).thenCallRealMethod();
+        Mockito.doCallRealMethod().when(spy).loadExtension(any(ExtensionsSettings.Extension.class));
+        Mockito.doNothing().when(spy).initialize();
+        RestInitializeExtensionAction restInitializeExtensionAction = new RestInitializeExtensionAction(spy);
+        final String content = "{\"name\":\"ad-extension\",\"uniqueId\":\"ad-extension\",\"hostAddress\":\"127.0.0.1\","
+            + "\"port\":\"4532\",\"version\":\"1.0\",\"opensearchVersion\":\"3.0.0\","
+            + "\"minimumCompatibleVersion\":\"3.0.0\"}";
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withContent(new BytesArray(content), XContentType.JSON)
+            .withMethod(RestRequest.Method.POST)
+            .build();
+
+        FakeRestChannel channel = new FakeRestChannel(request, false, 0);
+        restInitializeExtensionAction.handleRequest(request, channel, null);
+
+        assertEquals(channel.capturedResponse().status(), RestStatus.ACCEPTED);
+        assertTrue(channel.capturedResponse().content().utf8ToString().contains("A request to initialize an extension has been sent."));
+
+        Optional<ExtensionsSettings.Extension> extension = spy.lookupExtensionSettingsById("ad-extension");
+        assertTrue(extension.isPresent());
+        assertEquals(false, extension.get().getAdditionalSettings().get(boolSetting));
     }
 
 }


### PR DESCRIPTION
### Description

This PR modifies the `RestInitializeExtensionAction` to extract any additional settings supplied from ExtensionAwarePlugin.getExtensionSettings <- utilized by the security plugin to define security settings for extensions.

I tested this change by running an extension locally and defining settings from the Security plugin and calling on the API to initialize an extension. I plan to test different types of settings, booleans, strings, arrays, etc to verify this works with different types of settings. ~~I was not able to modify the test to show this working from a test case, but plan to add an automated test ASAP.~~ This PR uses Mockito to partially mock ExtensionsManager to show how additional settings work with the REST endpoint for extension initialization.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/8032

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
