### PR TITLE
[Backport 2.x] Fix SegmentReplication flaky integ tests

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -20,6 +20,7 @@ import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.index.StandardDirectoryReader;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
+import org.junit.Before;
 import org.opensearch.action.ActionFuture;
 import org.opensearch.action.admin.indices.flush.FlushRequest;
 import org.opensearch.action.admin.indices.stats.IndicesStatsRequest;
@@ -97,11 +98,16 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertSearchHits
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
 public class SegmentReplicationIT extends SegmentReplicationBaseIT {
 
+    @Before
+    private void setup() {
+        internalCluster().startClusterManagerOnlyNode();
+    }
+
     public void testPrimaryStopped_ReplicaPromoted() throws Exception {
-        final String primary = internalCluster().startNode();
+        final String primary = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME);
         ensureYellowAndNoInitializingShards(INDEX_NAME);
-        final String replica = internalCluster().startNode();
+        final String replica = internalCluster().startDataOnlyNode();
         ensureGreen(INDEX_NAME);
 
         client().prepareIndex(INDEX_NAME).setId("1").setSource("foo", "bar").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
@@ -127,7 +133,7 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
         assertHitCount(client(replica).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 3);
 
         // start another node, index another doc and replicate.
-        String nodeC = internalCluster().startNode();
+        String nodeC = internalCluster().startDataOnlyNode();
         ensureGreen(INDEX_NAME);
         client().prepareIndex(INDEX_NAME).setId("4").setSource("baz", "baz").get();
         refresh(INDEX_NAME);
@@ -136,10 +142,10 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
     }
 
     public void testRestartPrimary() throws Exception {
-        final String primary = internalCluster().startNode();
+        final String primary = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME);
         ensureYellowAndNoInitializingShards(INDEX_NAME);
-        final String replica = internalCluster().startNode();
+        final String replica = internalCluster().startDataOnlyNode();
         ensureGreen(INDEX_NAME);
 
         assertEquals(getNodeContainingPrimaryShard().getName(), primary);
@@ -162,10 +168,10 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
 
     public void testCancelPrimaryAllocation() throws Exception {
         // this test cancels allocation on the primary - promoting the new replica and recreating the former primary as a replica.
-        final String primary = internalCluster().startNode();
+        final String primary = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME);
         ensureYellowAndNoInitializingShards(INDEX_NAME);
-        final String replica = internalCluster().startNode();
+        final String replica = internalCluster().startDataOnlyNode();
         ensureGreen(INDEX_NAME);
 
         final int initialDocCount = 1;
@@ -192,8 +198,8 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
     }
 
     public void testReplicationAfterPrimaryRefreshAndFlush() throws Exception {
-        final String nodeA = internalCluster().startNode();
-        final String nodeB = internalCluster().startNode();
+        final String nodeA = internalCluster().startDataOnlyNode();
+        final String nodeB = internalCluster().startDataOnlyNode();
         final Settings settings = Settings.builder()
             .put(indexSettings())
             .put(
@@ -235,8 +241,8 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
     }
 
     public void testIndexReopenClose() throws Exception {
-        final String primary = internalCluster().startNode();
-        final String replica = internalCluster().startNode();
+        final String primary = internalCluster().startDataOnlyNode();
+        final String replica = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME);
         ensureGreen(INDEX_NAME);
 
@@ -329,8 +335,8 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
             .put(IndexModule.INDEX_QUERY_CACHE_ENABLED_SETTING.getKey(), false)
             .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
             .build();
-        final String nodeA = internalCluster().startNode();
-        final String nodeB = internalCluster().startNode();
+        final String nodeA = internalCluster().startDataOnlyNode();
+        final String nodeB = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME, indexSettings);
         ensureGreen(INDEX_NAME);
 
@@ -365,8 +371,8 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
     }
 
     public void testReplicationAfterForceMerge() throws Exception {
-        final String nodeA = internalCluster().startNode();
-        final String nodeB = internalCluster().startNode();
+        final String nodeA = internalCluster().startDataOnlyNode();
+        final String nodeB = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME);
         ensureGreen(INDEX_NAME);
 
@@ -406,14 +412,13 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
      * This test verifies that segment replication does not fail for closed indices
      */
     public void testClosedIndices() {
-        internalCluster().startClusterManagerOnlyNode();
         List<String> nodes = new ArrayList<>();
         // start 1st node so that it contains the primary
-        nodes.add(internalCluster().startNode());
+        nodes.add(internalCluster().startDataOnlyNode());
         createIndex(INDEX_NAME, super.indexSettings());
         ensureYellowAndNoInitializingShards(INDEX_NAME);
         // start 2nd node so that it contains the replica
-        nodes.add(internalCluster().startNode());
+        nodes.add(internalCluster().startDataOnlyNode());
         ensureGreen(INDEX_NAME);
 
         logger.info("--> Close index");
@@ -428,8 +433,7 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
      * @throws Exception when issue is encountered
      */
     public void testNodeDropWithOngoingReplication() throws Exception {
-        internalCluster().startClusterManagerOnlyNode();
-        final String primaryNode = internalCluster().startNode();
+        final String primaryNode = internalCluster().startDataOnlyNode();
         createIndex(
             INDEX_NAME,
             Settings.builder()
@@ -440,7 +444,7 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
                 .build()
         );
         ensureYellow(INDEX_NAME);
-        final String replicaNode = internalCluster().startNode();
+        final String replicaNode = internalCluster().startDataOnlyNode();
         ensureGreen(INDEX_NAME);
         ClusterState state = client().admin().cluster().prepareState().execute().actionGet().getState();
         // Get replica allocation id
@@ -503,11 +507,11 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
     }
 
     public void testCancellation() throws Exception {
-        final String primaryNode = internalCluster().startNode();
+        final String primaryNode = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME, Settings.builder().put(indexSettings()).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1).build());
         ensureYellow(INDEX_NAME);
 
-        final String replicaNode = internalCluster().startNode();
+        final String replicaNode = internalCluster().startDataOnlyNode();
 
         final SegmentReplicationSourceService segmentReplicationSourceService = internalCluster().getInstance(
             SegmentReplicationSourceService.class,
@@ -563,7 +567,7 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
 
     @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/5669")
     public void testStartReplicaAfterPrimaryIndexesDocs() throws Exception {
-        final String primaryNode = internalCluster().startNode();
+        final String primaryNode = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME, Settings.builder().put(indexSettings()).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0).build());
         ensureGreen(INDEX_NAME);
 
@@ -586,7 +590,7 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
                 .prepareUpdateSettings(INDEX_NAME)
                 .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1))
         );
-        final String replicaNode = internalCluster().startNode();
+        final String replicaNode = internalCluster().startDataOnlyNode();
         ensureGreen(INDEX_NAME);
 
         assertHitCount(client(primaryNode).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 2);
@@ -601,8 +605,8 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
     }
 
     public void testDeleteOperations() throws Exception {
-        final String nodeA = internalCluster().startNode();
-        final String nodeB = internalCluster().startNode();
+        final String nodeA = internalCluster().startDataOnlyNode();
+        final String nodeB = internalCluster().startDataOnlyNode();
 
         createIndex(INDEX_NAME);
         ensureGreen(INDEX_NAME);
@@ -648,9 +652,9 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
      */
     public void testReplicationPostDeleteAndForceMerge() throws Exception {
         assumeFalse("Skipping the test with Remote store as its flaky.", segmentReplicationWithRemoteEnabled());
-        final String primary = internalCluster().startNode();
+        final String primary = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME);
-        final String replica = internalCluster().startNode();
+        final String replica = internalCluster().startDataOnlyNode();
         ensureGreen(INDEX_NAME);
         final int initialDocCount = scaledRandomIntBetween(10, 200);
         for (int i = 0; i < initialDocCount; i++) {
@@ -705,7 +709,6 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
     }
 
     public void testUpdateOperations() throws Exception {
-        internalCluster().startClusterManagerOnlyNode();
         final String primary = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME);
         ensureYellow(INDEX_NAME);
@@ -759,7 +762,6 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, replica_count)
             .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
             .build();
-        final String clusterManagerNode = internalCluster().startClusterManagerOnlyNode();
         final String primaryNode = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME, settings);
         final List<String> dataNodes = internalCluster().startDataOnlyNodes(6);
@@ -800,11 +802,10 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
     }
 
     public void testReplicaHasDiffFilesThanPrimary() throws Exception {
-        internalCluster().startClusterManagerOnlyNode();
-        final String primaryNode = internalCluster().startNode();
+        final String primaryNode = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME, Settings.builder().put(indexSettings()).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1).build());
         ensureYellow(INDEX_NAME);
-        final String replicaNode = internalCluster().startNode();
+        final String replicaNode = internalCluster().startDataOnlyNode();
         ensureGreen(INDEX_NAME);
 
         final IndexShard replicaShard = getIndexShard(replicaNode, INDEX_NAME);
@@ -854,9 +855,9 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
     }
 
     public void testPressureServiceStats() throws Exception {
-        final String primaryNode = internalCluster().startNode();
+        final String primaryNode = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME);
-        final String replicaNode = internalCluster().startNode();
+        final String replicaNode = internalCluster().startDataOnlyNode();
         ensureGreen(INDEX_NAME);
 
         int initialDocCount = scaledRandomIntBetween(100, 200);
@@ -906,7 +907,7 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
             assertEquals(0, replicaNode_service.nodeStats().getShardStats().get(primaryShard.shardId()).getReplicaStats().size());
 
             // start another replica.
-            String replicaNode_2 = internalCluster().startNode();
+            String replicaNode_2 = internalCluster().startDataOnlyNode();
             ensureGreen(INDEX_NAME);
             String docId = String.valueOf(initialDocCount + 1);
             client().prepareIndex(INDEX_NAME).setId(docId).setSource("foo", "bar").get();
@@ -945,10 +946,10 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
     public void testScrollCreatedOnReplica() throws Exception {
         assumeFalse("Skipping the test with Remote store as its flaky.", segmentReplicationWithRemoteEnabled());
         // create the cluster with one primary node containing primary shard and replica node containing replica shard
-        final String primary = internalCluster().startNode();
+        final String primary = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME);
         ensureYellowAndNoInitializingShards(INDEX_NAME);
-        final String replica = internalCluster().startNode();
+        final String replica = internalCluster().startDataOnlyNode();
         ensureGreen(INDEX_NAME);
 
         // index 100 docs
@@ -1039,7 +1040,7 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
         );
 
         // create the cluster with one primary node containing primary shard and replica node containing replica shard
-        final String primary = internalCluster().startNode();
+        final String primary = internalCluster().startDataOnlyNode();
         prepareCreate(
             INDEX_NAME,
             Settings.builder()
@@ -1047,7 +1048,7 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
                 .put("index.refresh_interval", -1)
         ).get();
         ensureYellowAndNoInitializingShards(INDEX_NAME);
-        final String replica = internalCluster().startNode();
+        final String replica = internalCluster().startDataOnlyNode();
         ensureGreen(INDEX_NAME);
 
         final int initialDocCount = 10;
@@ -1162,10 +1163,10 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
     }
 
     public void testPitCreatedOnReplica() throws Exception {
-        final String primary = internalCluster().startNode();
+        final String primary = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME);
         ensureYellowAndNoInitializingShards(INDEX_NAME);
-        final String replica = internalCluster().startNode();
+        final String replica = internalCluster().startDataOnlyNode();
         ensureGreen(INDEX_NAME);
         client().prepareIndex(INDEX_NAME)
             .setId("1")
@@ -1292,13 +1293,13 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
      */
     public void testPrimaryReceivesDocsDuringReplicaRecovery() throws Exception {
         final List<String> nodes = new ArrayList<>();
-        final String primaryNode = internalCluster().startNode();
+        final String primaryNode = internalCluster().startDataOnlyNode();
         nodes.add(primaryNode);
         final Settings settings = Settings.builder().put(indexSettings()).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0).build();
         createIndex(INDEX_NAME, settings);
         ensureGreen(INDEX_NAME);
         // start a replica node, initially will be empty with no shard assignment.
-        final String replicaNode = internalCluster().startNode();
+        final String replicaNode = internalCluster().startDataOnlyNode();
         nodes.add(replicaNode);
 
         // index a doc.

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/SegmentReplicationRemoteStoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/SegmentReplicationRemoteStoreIT.java
@@ -8,7 +8,6 @@
 
 package org.opensearch.remotestore;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.opensearch.cluster.metadata.IndexMetadata;
@@ -26,7 +25,6 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
  * This makes sure that the constructs/flows that are being tested with Segment Replication, holds true after enabling
  * remote store.
  */
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/7643")
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
 public class SegmentReplicationRemoteStoreIT extends SegmentReplicationIT {
 
@@ -49,7 +47,7 @@ public class SegmentReplicationRemoteStoreIT extends SegmentReplicationIT {
     }
 
     @Before
-    public void setup() {
+    private void setup() {
         internalCluster().startClusterManagerOnlyNode();
         Path absolutePath = randomRepoPath().toAbsolutePath();
         assertAcked(

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1575,13 +1575,21 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         if (indexSettings.isSegRepEnabled() == false) {
             return null;
         }
+
+        Tuple<GatedCloseable<SegmentInfos>, ReplicationCheckpoint> nullSegmentInfosEmptyCheckpoint = new Tuple<>(
+            new GatedCloseable<>(null, () -> {}),
+            ReplicationCheckpoint.empty(shardId, getDefaultCodecName())
+        );
+
         if (getEngineOrNull() == null) {
-            return new Tuple<>(new GatedCloseable<>(null, () -> {}), ReplicationCheckpoint.empty(shardId, getDefaultCodecName()));
+            return nullSegmentInfosEmptyCheckpoint;
         }
         // do not close the snapshot - caller will close it.
-        final GatedCloseable<SegmentInfos> snapshot = getSegmentInfosSnapshot();
-        return Optional.ofNullable(snapshot.get()).map(segmentInfos -> {
-            try {
+        GatedCloseable<SegmentInfos> snapshot = null;
+        try {
+            snapshot = getSegmentInfosSnapshot();
+            if (snapshot.get() != null) {
+                SegmentInfos segmentInfos = snapshot.get();
                 return new Tuple<>(
                     snapshot,
                     new ReplicationCheckpoint(
@@ -1597,10 +1605,18 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                         getEngine().config().getCodec().getName()
                     )
                 );
-            } catch (IOException e) {
-                throw new OpenSearchException("Error Fetching SegmentInfos and latest checkpoint", e);
             }
-        }).orElseGet(() -> new Tuple<>(new GatedCloseable<>(null, () -> {}), ReplicationCheckpoint.empty(shardId, getDefaultCodecName())));
+        } catch (IOException | AlreadyClosedException e) {
+            logger.error("Error Fetching SegmentInfos and latest checkpoint", e);
+            if (snapshot != null) {
+                try {
+                    snapshot.close();
+                } catch (IOException ex) {
+                    throw new OpenSearchException("Error Closing SegmentInfos Snapshot", e);
+                }
+            }
+        }
+        return nullSegmentInfosEmptyCheckpoint;
     }
 
     /**

--- a/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
@@ -276,7 +276,6 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
     /**
      * Tests retry flow after snapshot and metadata files have been uploaded to remote store in the failed attempt.
      * Snapshot and metadata files created in failed attempt should not break retry.
-     * @throws Exception
      */
     public void testRefreshSuccessAfterFailureInFirstAttemptAfterSnapshotAndMetadataUpload() throws Exception {
         int succeedOnAttempt = 1;


### PR DESCRIPTION
Backport https://github.com/opensearch-project/OpenSearch/commit/0c7ba945806893ab07c705324de890f21bd623cc from https://github.com/opensearch-project/OpenSearch/pull/8134.