### PR TITLE
Unmute remote store test testPressureServiceStats

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/SegmentReplicationUsingRemoteStoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/SegmentReplicationUsingRemoteStoreIT.java
@@ -64,7 +64,6 @@ public class SegmentReplicationUsingRemoteStoreIT extends SegmentReplicationIT {
         assertAcked(clusterAdmin().prepareDeleteRepository(REPOSITORY_NAME));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/7592")
     @Override
     public void testPressureServiceStats() throws Exception {
         super.testPressureServiceStats();


### PR DESCRIPTION
### Description
- Unmutes `SegmentReplicationUsingRemoteStoreIT.testPressureServiceStats()` as it does not fail with the linked seeds
- Tested with the following seeds: 

```
- 6FBC0417BD6F56E8 (https://build.ci.opensearch.org/job/gradle-check/15525)
- 9E739B916891FC83 (https://build.ci.opensearch.org/job/gradle-check/18400/) 
- 6D4AC220FB10A7F1 (https://build.ci.opensearch.org/job/gradle-check/15780/)
- 7F31E8DDB5E9A165 (https://build.ci.opensearch.org/job/gradle-check/15533)
- 8D757DA0D0D145D2 (https://build.ci.opensearch.org/job/gradle-check/17783/)
- 73A2F9AEDE71F705 (https://build.ci.opensearch.org/job/gradle-check/17803)
- 7C703462CB16D721 (https://build.ci.opensearch.org/job/gradle-check/17824)
- 1392808F9FD4A3EF (https://build.ci.opensearch.org/job/gradle-check/17927/)
- F32B62765BE17A94 (https://build.ci.opensearch.org/job/gradle-check/17882)
- C2A08952AF8618F3 (https://build.ci.opensearch.org/job/gradle-check/17943)
- 50087ABEA0EF2155 (https://build.ci.opensearch.org/job/gradle-check/17945)
- F63042758D4497E1 (https://build.ci.opensearch.org/job/gradle-check/18130)
- 86C25DA47FA4C58B (https://build.ci.opensearch.org/job/gradle-check/18292)
- F3475375E31DC89D (https://build.ci.opensearch.org/job/gradle-check/18214)
- 9E739B916891FC83 (https://build.ci.opensearch.org/job/gradle-check/18400) 
```
- Fixes to remote store and segrep integration seems to have fixed the test

### Related Issues
Resolves #7592 
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
