### PR TITLE
configure SMILE default encoding with LENIENT_UTF_ENCODING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add self-organizing hash table to improve the performance of bucket aggregations ([#7652](https://github.com/opensearch-project/OpenSearch/pull/7652))
 - Check UTF16 string size before converting to String to avoid OOME ([#7963](https://github.com/opensearch-project/OpenSearch/pull/7963))
 - Move ZSTD compression codecs out of the sandbox ([#7908](https://github.com/opensearch-project/OpenSearch/pull/7908))
+- Configure SMILE default encoding with LENIENT_UTF_ENCODING set as true instead of false
 
 
 ### Deprecated

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/smile/SmileXContent.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/smile/SmileXContent.java
@@ -79,6 +79,7 @@ public class SmileXContent implements XContent {
         smileFactory.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true);
         smileFactory.setStreamReadConstraints(StreamReadConstraints.builder().maxStringLength(DEFAULT_MAX_STRING_LEN).build());
         smileFactory.configure(StreamReadFeature.USE_FAST_DOUBLE_PARSER.mappedFeature(), true);
+        smileFactory.configure(SmileGenerator.Feature.LENIENT_UTF_ENCODING, true);
         smileXContent = new SmileXContent();
     }
 

--- a/server/src/test/java/org/opensearch/common/xcontent/BaseXContentTestCase.java
+++ b/server/src/test/java/org/opensearch/common/xcontent/BaseXContentTestCase.java
@@ -1027,6 +1027,25 @@ public abstract class BaseXContentTestCase extends OpenSearchTestCase {
         }
     }
 
+    protected void doTestInvalidSurrogatePair(JsonGenerator generator, ByteArrayOutputStream os) throws Exception {
+        String field = "ퟀ\uDD6Dlog_processeddetail٣{r";
+        generator.writeStartObject();
+        generator.writeFieldName(field);
+        generator.writeString("foo");
+        generator.writeEndObject();
+        generator.flush();
+        byte[] serialized = os.toByteArray();
+
+        try (
+            XContentParser parser = xcontentType().xContent()
+                .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, serialized)
+        ) {
+
+            Map<String, Object> map = parser.map();
+            assertNotEquals(field, map.keySet().stream().findFirst().get());
+        }
+    }
+
     public void testEnsureNameNotNull() {
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> XContentBuilder.ensureNameNotNull(null));
         assertThat(e.getMessage(), containsString("Field name cannot be null"));

--- a/server/src/test/java/org/opensearch/common/xcontent/cbor/CborXContentTests.java
+++ b/server/src/test/java/org/opensearch/common/xcontent/cbor/CborXContentTests.java
@@ -32,9 +32,11 @@
 
 package org.opensearch.common.xcontent.cbor;
 
+import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
 
+import com.fasterxml.jackson.dataformat.cbor.CBORGenerator;
 import org.opensearch.common.xcontent.BaseXContentTestCase;
 import org.opensearch.common.xcontent.XContentType;
 
@@ -51,5 +53,18 @@ public class CborXContentTests extends BaseXContentTestCase {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         JsonGenerator generator = new CBORFactory().createGenerator(os);
         doTestBigInteger(generator, os);
+    }
+
+    public void testInvalidSurrogatePair() throws Exception {
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        CBORFactory cborFactory = new CBORFactory();
+        JsonGenerator generator = cborFactory.createGenerator(os);
+        // default case throws an exception
+        expectThrows(JsonGenerationException.class, () -> generator.writeFieldName("ퟀ\uDD6Dlog_processeddetail٣{r"));
+
+        // LENIENT_UTF_ENCODING doesn't throw any exception
+        cborFactory.configure(CBORGenerator.Feature.LENIENT_UTF_ENCODING, true);
+        JsonGenerator generator2 = cborFactory.createGenerator(os);
+        doTestInvalidSurrogatePair(generator2, os);
     }
 }

--- a/server/src/test/java/org/opensearch/common/xcontent/smile/SmileXContentTests.java
+++ b/server/src/test/java/org/opensearch/common/xcontent/smile/SmileXContentTests.java
@@ -32,14 +32,15 @@
 
 package org.opensearch.common.xcontent.smile;
 
+import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.dataformat.smile.SmileFactory;
 
+import com.fasterxml.jackson.dataformat.smile.SmileGenerator;
 import org.opensearch.common.xcontent.BaseXContentTestCase;
 import org.opensearch.common.xcontent.XContentType;
 
 import java.io.ByteArrayOutputStream;
-
 public class SmileXContentTests extends BaseXContentTestCase {
 
     @Override
@@ -51,5 +52,18 @@ public class SmileXContentTests extends BaseXContentTestCase {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         JsonGenerator generator = new SmileFactory().createGenerator(os);
         doTestBigInteger(generator, os);
+    }
+
+    public void testInvalidSurrogatePair() throws Exception {
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        SmileFactory smileFactory = new SmileFactory();
+        JsonGenerator generator = smileFactory.createGenerator(os);
+        // default case throws an exception
+        expectThrows(JsonGenerationException.class, () -> generator.writeFieldName("ퟀ\uDD6Dlog_processeddetail٣{r"));
+
+        // LENIENT_UTF_ENCODING doesn't throw any exception
+        smileFactory.configure(SmileGenerator.Feature.LENIENT_UTF_ENCODING, true);
+        JsonGenerator generator2 = smileFactory.createGenerator(os);
+        doTestInvalidSurrogatePair(generator2, os);
     }
 }

--- a/server/src/test/java/org/opensearch/common/xcontent/smile/SmileXContentTests.java
+++ b/server/src/test/java/org/opensearch/common/xcontent/smile/SmileXContentTests.java
@@ -41,6 +41,7 @@ import org.opensearch.common.xcontent.BaseXContentTestCase;
 import org.opensearch.common.xcontent.XContentType;
 
 import java.io.ByteArrayOutputStream;
+
 public class SmileXContentTests extends BaseXContentTestCase {
 
     @Override


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The snapshot creation is failing while serializing the index mapping metadata because of the index mappings have broken surrogate pairs in the field names of the index. The SMILE encoding fails on the surrogate pair as by default LENIENT_UTF_ENCODING is set to false.

Setting the LENIENT_UTF_ENCODING to true would essentially not fail the snapshot creation for the broken surrogate pairs.
ref: https://github.com/FasterXML/jackson-dataformats-binary/blob/2.16/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileGenerator.java#L98
This feature is enabled since [jackson-dataformats-binary](https://github.com/FasterXML/jackson-dataformats-binary) version 2.13

### Related Issues
Resolves #[6453](https://github.com/opensearch-project/OpenSearch/issues/6453)

### Check List
- [-] New functionality includes testing.
  - [- ] All tests pass
- [- ] New functionality has been documented.
  - [- ] New functionality has javadoc added
- [- ] Commits are signed per the DCO using --signoff
- [ -] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
