### PR TITLE
Fix bug where ReplicationListeners would not complete on cancellation.

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationSuiteIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationSuiteIT.java
@@ -1,0 +1,88 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.indices.replication;
+
+import org.junit.Before;
+import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.indices.replication.common.ReplicationType;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, minNumDataNodes = 2)
+public class SegmentReplicationSuiteIT extends SegmentReplicationBaseIT {
+
+    @Before
+    public void setup() {
+        internalCluster().startClusterManagerOnlyNode();
+        createIndex(INDEX_NAME);
+    }
+
+    @Override
+    public Settings indexSettings() {
+        final Settings.Builder builder = Settings.builder()
+            .put(super.indexSettings())
+            // reset shard & replica count to random values set by OpenSearchIntegTestCase.
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numberOfShards())
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, numberOfReplicas())
+            .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT);
+
+        // TODO: Randomly enable remote store on these tests.
+        return builder.build();
+    }
+
+    public void testBasicReplication() throws Exception {
+        final int docCount = scaledRandomIntBetween(10, 200);
+        for (int i = 0; i < docCount; i++) {
+            client().prepareIndex(INDEX_NAME).setId(Integer.toString(i)).setSource("field", "value" + i).execute().get();
+        }
+        refresh();
+        ensureGreen(INDEX_NAME);
+        verifyStoreContent();
+    }
+
+    public void testDropRandomNodeDuringReplication() throws Exception {
+        internalCluster().ensureAtLeastNumDataNodes(2);
+        internalCluster().startClusterManagerOnlyNodes(1);
+
+        final int docCount = scaledRandomIntBetween(10, 200);
+        for (int i = 0; i < docCount; i++) {
+            client().prepareIndex(INDEX_NAME).setId(Integer.toString(i)).setSource("field", "value" + i).execute().get();
+        }
+        refresh();
+
+        internalCluster().restartRandomDataNode();
+
+        ensureYellow(INDEX_NAME);
+        client().prepareIndex(INDEX_NAME).setId(Integer.toString(docCount)).setSource("field", "value" + docCount).execute().get();
+        internalCluster().startDataOnlyNode();
+        client().admin().indices().delete(new DeleteIndexRequest(INDEX_NAME)).actionGet();
+    }
+
+    public void testDeleteIndexWhileReplicating() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        final int docCount = scaledRandomIntBetween(10, 200);
+        for (int i = 0; i < docCount; i++) {
+            client().prepareIndex(INDEX_NAME).setId(Integer.toString(i)).setSource("field", "value" + i).execute().get();
+        }
+        refresh(INDEX_NAME);
+        client().admin().indices().delete(new DeleteIndexRequest(INDEX_NAME)).actionGet();
+    }
+
+    public void testFullRestartDuringReplication() throws Exception {
+        internalCluster().startNode();
+        final int docCount = scaledRandomIntBetween(10, 200);
+        for (int i = 0; i < docCount; i++) {
+            client().prepareIndex(INDEX_NAME).setId(Integer.toString(i)).setSource("field", "value" + i).execute().get();
+        }
+        refresh(INDEX_NAME);
+        internalCluster().fullRestart();
+        ensureGreen(INDEX_NAME);
+    }
+}

--- a/server/src/main/java/org/opensearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/RecoverySourceHandler.java
@@ -835,7 +835,7 @@ public abstract class RecoverySourceHandler {
             } else {
                 // Force round of segment replication to update its checkpoint to primary's
                 if (shard.indexSettings().isSegRepEnabled()) {
-                    recoveryTarget.forceSegmentFileSync();
+                    cancellableThreads.execute(recoveryTarget::forceSegmentFileSync);
                 }
             }
             stopWatch.stop();

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationState.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationState.java
@@ -45,8 +45,7 @@ public class SegmentReplicationState implements ReplicationState, ToXContentFrag
         GET_CHECKPOINT_INFO((byte) 3),
         FILE_DIFF((byte) 4),
         GET_FILES((byte) 5),
-        FINALIZE_REPLICATION((byte) 6),
-        CANCELLED((byte) 7);
+        FINALIZE_REPLICATION((byte) 6);
 
         private static final Stage[] STAGES = new Stage[Stage.values().length];
 
@@ -242,14 +241,6 @@ public class SegmentReplicationState implements ReplicationState, ToXContentFrag
             case DONE:
                 validateAndSetStage(Stage.FINALIZE_REPLICATION, stage);
                 // add the overall timing data
-                overallTimer.stop();
-                timingData.put("OVERALL", overallTimer.time());
-                break;
-            case CANCELLED:
-                if (this.stage == Stage.DONE) {
-                    throw new IllegalStateException("can't move replication to Cancelled state from Done.");
-                }
-                this.stage = Stage.CANCELLED;
                 overallTimer.stop();
                 timingData.put("OVERALL", overallTimer.time());
                 break;

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTarget.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTarget.java
@@ -12,16 +12,15 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.IndexFormatTooNewException;
 import org.apache.lucene.index.IndexFormatTooOldException;
-import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.BufferedChecksumIndexInput;
 import org.apache.lucene.store.ByteBuffersDataInput;
 import org.apache.lucene.store.ByteBuffersIndexInput;
 import org.apache.lucene.store.ChecksumIndexInput;
-import org.opensearch.ExceptionsHelper;
+import org.opensearch.OpenSearchCorruptionException;
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.StepListener;
-import org.opensearch.common.CheckedConsumer;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.lucene.Lucene;
@@ -39,6 +38,8 @@ import org.opensearch.indices.replication.common.ReplicationTarget;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
 
 /**
  * Represents the target of a replication event.
@@ -102,17 +103,11 @@ public class SegmentReplicationTarget extends ReplicationTarget {
 
     @Override
     public String description() {
-        return "Segment replication from " + source.toString();
+        return String.format(Locale.ROOT, "Id:[%d] Shard:[%s] Source:[%s]", getId(), shardId(), source.getDescription());
     }
 
     @Override
     public void notifyListener(ReplicationFailedException e, boolean sendShardFailure) {
-        // Cancellations still are passed to our SegmentReplicationListener as failures, if we have failed because of cancellation
-        // update the stage.
-        final Throwable cancelledException = ExceptionsHelper.unwrap(e, CancellableThreads.ExecutionCancelledException.class);
-        if (cancelledException != null) {
-            state.setStage(SegmentReplicationState.Stage.CANCELLED);
-        }
         listener.onFailure(state(), e, sendShardFailure);
     }
 
@@ -141,141 +136,115 @@ public class SegmentReplicationTarget extends ReplicationTarget {
 
     /**
      * Start the Replication event.
+     *
      * @param listener {@link ActionListener} listener.
      */
     public void startReplication(ActionListener<Void> listener) {
         cancellableThreads.setOnCancel((reason, beforeCancelEx) -> {
-            // This method only executes when cancellation is triggered by this node and caught by a call to checkForCancel,
-            // SegmentReplicationSource does not share CancellableThreads.
-            final CancellableThreads.ExecutionCancelledException executionCancelledException =
-                new CancellableThreads.ExecutionCancelledException("replication was canceled reason [" + reason + "]");
-            notifyListener(new ReplicationFailedException("Segment replication failed", executionCancelledException), false);
-            throw executionCancelledException;
+            throw new CancellableThreads.ExecutionCancelledException("replication was canceled reason [" + reason + "]");
         });
+        // TODO: Remove this useless state.
         state.setStage(SegmentReplicationState.Stage.REPLICATING);
         final StepListener<CheckpointInfoResponse> checkpointInfoListener = new StepListener<>();
         final StepListener<GetSegmentFilesResponse> getFilesListener = new StepListener<>();
-        final StepListener<Void> finalizeListener = new StepListener<>();
 
-        cancellableThreads.checkForCancel();
-        logger.trace("[shardId {}] Replica starting replication [id {}]", shardId().getId(), getId());
+        logger.trace(new ParameterizedMessage("Starting Replication Target: {}", description()));
         // Get list of files to copy from this checkpoint.
         state.setStage(SegmentReplicationState.Stage.GET_CHECKPOINT_INFO);
+        cancellableThreads.checkForCancel();
         source.getCheckpointMetadata(getId(), checkpoint, checkpointInfoListener);
 
-        checkpointInfoListener.whenComplete(checkpointInfo -> getFiles(checkpointInfo, getFilesListener), listener::onFailure);
-        getFilesListener.whenComplete(
-            response -> finalizeReplication(checkpointInfoListener.result(), finalizeListener),
-            listener::onFailure
-        );
-        finalizeListener.whenComplete(r -> listener.onResponse(null), listener::onFailure);
+        checkpointInfoListener.whenComplete(checkpointInfo -> {
+            final List<StoreFileMetadata> filesToFetch = getFiles(checkpointInfo);
+            state.setStage(SegmentReplicationState.Stage.GET_FILES);
+            cancellableThreads.checkForCancel();
+            source.getSegmentFiles(getId(), checkpointInfo.getCheckpoint(), filesToFetch, indexShard, getFilesListener);
+        }, listener::onFailure);
+
+        getFilesListener.whenComplete(response -> {
+            finalizeReplication(checkpointInfoListener.result());
+            listener.onResponse(null);
+        }, listener::onFailure);
     }
 
-    private void getFiles(CheckpointInfoResponse checkpointInfo, StepListener<GetSegmentFilesResponse> getFilesListener)
-        throws IOException {
+    private List<StoreFileMetadata> getFiles(CheckpointInfoResponse checkpointInfo) throws IOException {
         cancellableThreads.checkForCancel();
         state.setStage(SegmentReplicationState.Stage.FILE_DIFF);
         final Store.RecoveryDiff diff = Store.segmentReplicationDiff(checkpointInfo.getMetadataMap(), indexShard.getSegmentMetadataMap());
-        logger.trace("Replication diff for checkpoint {} {}", checkpointInfo.getCheckpoint(), diff);
+        logger.trace(() -> new ParameterizedMessage("Replication diff for checkpoint {} {}", checkpointInfo.getCheckpoint(), diff));
         /*
          * Segments are immutable. So if the replica has any segments with the same name that differ from the one in the incoming
          * snapshot from source that means the local copy of the segment has been corrupted/changed in some way and we throw an
          * IllegalStateException to fail the shard
          */
         if (diff.different.isEmpty() == false) {
-            IllegalStateException illegalStateException = new IllegalStateException(
+            throw new OpenSearchCorruptionException(
                 new ParameterizedMessage(
                     "Shard {} has local copies of segments that differ from the primary {}",
                     indexShard.shardId(),
                     diff.different
                 ).getFormattedMessage()
             );
-            ReplicationFailedException rfe = new ReplicationFailedException(
-                indexShard.shardId(),
-                "different segment files",
-                illegalStateException
-            );
-            fail(rfe, true);
-            throw rfe;
         }
 
         for (StoreFileMetadata file : diff.missing) {
             state.getIndex().addFileDetail(file.name(), file.length(), false);
         }
-        // always send a req even if not fetching files so the primary can clear the copyState for this shard.
-        state.setStage(SegmentReplicationState.Stage.GET_FILES);
-        cancellableThreads.checkForCancel();
-        source.getSegmentFiles(getId(), checkpointInfo.getCheckpoint(), diff.missing, indexShard, getFilesListener);
+        return diff.missing;
     }
 
-    private void finalizeReplication(CheckpointInfoResponse checkpointInfoResponse, ActionListener<Void> listener) {
+    private void finalizeReplication(CheckpointInfoResponse checkpointInfoResponse) throws OpenSearchCorruptionException {
         // TODO: Refactor the logic so that finalize doesn't have to be invoked for remote store as source
         if (source instanceof RemoteStoreReplicationSource) {
-            ActionListener.completeWith(listener, () -> {
-                state.setStage(SegmentReplicationState.Stage.FINALIZE_REPLICATION);
-                return null;
-            });
+            state.setStage(SegmentReplicationState.Stage.FINALIZE_REPLICATION);
             return;
         }
-        ActionListener.completeWith(listener, () -> {
-            cancellableThreads.checkForCancel();
-            state.setStage(SegmentReplicationState.Stage.FINALIZE_REPLICATION);
-            Store store = null;
+        cancellableThreads.checkForCancel();
+        state.setStage(SegmentReplicationState.Stage.FINALIZE_REPLICATION);
+        Store store = null;
+        try {
+            store = store();
+            store.incRef();
+            store.buildInfosFromBytes(
+                multiFileWriter.getTempFileNames(),
+                checkpointInfoResponse.getInfosBytes(),
+                checkpointInfoResponse.getCheckpoint().getSegmentsGen(),
+                indexShard::finalizeReplication
+            );
+        } catch (CorruptIndexException | IndexFormatTooNewException | IndexFormatTooOldException ex) {
+            // this is a fatal exception at this stage.
+            // this means we transferred files from the remote that have not be checksummed and they are
+            // broken. We have to clean up this shard entirely, remove all files and bubble it up to the
+            // source shard since this index might be broken there as well? The Source can handle this and checks
+            // its content on disk if possible.
             try {
-                store = store();
-                store.incRef();
-                CheckedConsumer<SegmentInfos, IOException> finalizeReplication = indexShard::finalizeReplication;
-                store.buildInfosFromBytes(
-                    multiFileWriter.getTempFileNames(),
-                    checkpointInfoResponse.getInfosBytes(),
-                    checkpointInfoResponse.getCheckpoint().getSegmentsGen(),
-                    finalizeReplication
-                );
-            } catch (CorruptIndexException | IndexFormatTooNewException | IndexFormatTooOldException ex) {
-                // this is a fatal exception at this stage.
-                // this means we transferred files from the remote that have not be checksummed and they are
-                // broken. We have to clean up this shard entirely, remove all files and bubble it up to the
-                // source shard since this index might be broken there as well? The Source can handle this and checks
-                // its content on disk if possible.
                 try {
-                    try {
-                        store.removeCorruptionMarker();
-                    } finally {
-                        Lucene.cleanLuceneIndex(store.directory()); // clean up and delete all files
-                    }
-                } catch (Exception e) {
-                    logger.debug("Failed to clean lucene index", e);
-                    ex.addSuppressed(e);
+                    store.removeCorruptionMarker();
+                } finally {
+                    Lucene.cleanLuceneIndex(store.directory()); // clean up and delete all files
                 }
-                ReplicationFailedException rfe = new ReplicationFailedException(
-                    indexShard.shardId(),
-                    "failed to clean after replication",
-                    ex
-                );
-                fail(rfe, true);
-                throw rfe;
-            } catch (OpenSearchException ex) {
-                /*
-                 Ignore closed replication target as it can happen due to index shard closed event in a separate thread.
-                 In such scenario, ignore the exception
-                 */
-                assert cancellableThreads.isCancelled() : "Replication target closed but segment replication not cancelled";
-                logger.info("Replication target closed", ex);
-            } catch (Exception ex) {
-                ReplicationFailedException rfe = new ReplicationFailedException(
-                    indexShard.shardId(),
-                    "failed to clean after replication",
-                    ex
-                );
-                fail(rfe, true);
-                throw rfe;
-            } finally {
-                if (store != null) {
-                    store.decRef();
-                }
+            } catch (Exception e) {
+                logger.debug("Failed to clean lucene index", e);
+                ex.addSuppressed(e);
             }
-            return null;
-        });
+            throw new OpenSearchCorruptionException(ex);
+        } catch (AlreadyClosedException ex) {
+            // In this case the shard is closed at some point while updating the reader.
+            // This can happen when the engine is closed in a separate thread.
+            logger.warn("Shard is already closed, closing replication");
+        } catch (OpenSearchException ex) {
+            /*
+             Ignore closed replication target as it can happen due to index shard closed event in a separate thread.
+             In such scenario, ignore the exception
+             */
+            assert cancellableThreads.isCancelled() : "Replication target closed but segment replication not cancelled";
+        } catch (Exception ex) {
+            throw new OpenSearchCorruptionException(ex);
+        } finally {
+            if (store != null) {
+                store.decRef();
+            }
+        }
     }
 
     /**
@@ -288,10 +257,15 @@ public class SegmentReplicationTarget extends ReplicationTarget {
         );
     }
 
+    /**
+     * Trigger a cancellation, this method will not close the target a subsequent call to #fail is required from target service.
+     */
     @Override
-    protected void onCancel(String reason) {
-        cancellableThreads.cancel(reason);
-        source.cancel();
-        multiFileWriter.close();
+    public void cancel(String reason) {
+        if (finished.get() == false) {
+            logger.trace(new ParameterizedMessage("Cancelling replication for target {}", description()));
+            cancellableThreads.cancel(reason);
+            source.cancel();
+        }
     }
 }

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
@@ -166,7 +166,7 @@ public class SegmentReplicationTargetService implements IndexEventListener {
     @Override
     public void shardRoutingChanged(IndexShard indexShard, @Nullable ShardRouting oldRouting, ShardRouting newRouting) {
         if (oldRouting != null && indexShard.indexSettings().isSegRepEnabled() && oldRouting.primary() == false && newRouting.primary()) {
-            onGoingReplications.requestCancel(indexShard.shardId(), "Shard closing");
+            onGoingReplications.requestCancel(indexShard.shardId(), "Shard has been promoted to primary");
             latestReceivedCheckpoint.remove(indexShard.shardId());
         }
     }

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
@@ -11,14 +11,15 @@ package org.opensearch.indices.replication;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.opensearch.ExceptionsHelper;
+import org.opensearch.OpenSearchCorruptionException;
 import org.opensearch.action.ActionListener;
+import org.opensearch.action.support.ChannelActionListener;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.util.CancellableThreads;
+import org.opensearch.common.util.concurrent.AbstractRunnable;
 import org.opensearch.common.util.concurrent.ConcurrentCollections;
 import org.opensearch.index.shard.IndexEventListener;
 import org.opensearch.index.shard.IndexShard;
@@ -43,10 +44,8 @@ import org.opensearch.transport.TransportRequestOptions;
 import org.opensearch.transport.TransportResponse;
 import org.opensearch.transport.TransportService;
 
-import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.opensearch.indices.replication.SegmentReplicationSourceService.Actions.UPDATE_VISIBLE_CHECKPOINT;
@@ -145,7 +144,7 @@ public class SegmentReplicationTargetService implements IndexEventListener {
     @Override
     public void beforeIndexShardClosed(ShardId shardId, @Nullable IndexShard indexShard, Settings indexSettings) {
         if (indexShard != null && indexShard.indexSettings().isSegRepEnabled()) {
-            onGoingReplications.cancelForShard(shardId, "shard closed");
+            onGoingReplications.requestCancel(indexShard.shardId(), "Shard closing");
             latestReceivedCheckpoint.remove(shardId);
         }
     }
@@ -167,7 +166,7 @@ public class SegmentReplicationTargetService implements IndexEventListener {
     @Override
     public void shardRoutingChanged(IndexShard indexShard, @Nullable ShardRouting oldRouting, ShardRouting newRouting) {
         if (oldRouting != null && indexShard.indexSettings().isSegRepEnabled() && oldRouting.primary() == false && newRouting.primary()) {
-            onGoingReplications.cancelForShard(indexShard.shardId(), "shard has been promoted to primary");
+            onGoingReplications.requestCancel(indexShard.shardId(), "Shard closing");
             latestReceivedCheckpoint.remove(indexShard.shardId());
         }
     }
@@ -221,14 +220,17 @@ public class SegmentReplicationTargetService implements IndexEventListener {
         if (replicaShard.state().equals(IndexShardState.STARTED) == true) {
             // Checks if received checkpoint is already present and ahead then it replaces old received checkpoint
             SegmentReplicationTarget ongoingReplicationTarget = onGoingReplications.getOngoingReplicationTarget(replicaShard.shardId());
+
             if (ongoingReplicationTarget != null) {
                 if (ongoingReplicationTarget.getCheckpoint().getPrimaryTerm() < receivedCheckpoint.getPrimaryTerm()) {
                     logger.trace(
-                        "Cancelling ongoing replication from old primary with primary term {}",
-                        ongoingReplicationTarget.getCheckpoint().getPrimaryTerm()
+                        () -> new ParameterizedMessage(
+                            "Cancelling ongoing replication {} from old primary with primary term {}",
+                            ongoingReplicationTarget.description(),
+                            ongoingReplicationTarget.getCheckpoint().getPrimaryTerm()
+                        )
                     );
-                    onGoingReplications.cancel(ongoingReplicationTarget.getId(), "Cancelling stuck target after new primary");
-                    completedReplications.put(replicaShard.shardId(), ongoingReplicationTarget);
+                    ongoingReplicationTarget.cancel("Cancelling stuck target after new primary");
                 } else {
                     logger.trace(
                         () -> new ParameterizedMessage(
@@ -268,21 +270,20 @@ public class SegmentReplicationTargetService implements IndexEventListener {
                         ReplicationFailedException e,
                         boolean sendShardFailure
                     ) {
-                        logger.trace(
+                        logger.error(
                             () -> new ParameterizedMessage(
                                 "[shardId {}] [replication id {}] Replication failed, timing data: {}",
                                 replicaShard.shardId().getId(),
                                 state.getReplicationId(),
                                 state.getTimingData()
-                            )
+                            ),
+                            e
                         );
                         if (sendShardFailure == true) {
-                            logger.error("replication failure", e);
-                            replicaShard.failShard("replication failure", e);
+                            failShard(e, replicaShard);
                         }
                     }
                 });
-
             }
         } else {
             logger.trace(
@@ -305,7 +306,14 @@ public class SegmentReplicationTargetService implements IndexEventListener {
         final TransportRequestOptions options = TransportRequestOptions.builder()
             .withTimeout(recoverySettings.internalActionTimeout())
             .build();
-        logger.debug("Updating replication checkpoint to {}", request.getCheckpoint());
+        logger.trace(
+            () -> new ParameterizedMessage(
+                "Updating Primary shard that replica {}-{} is synced to checkpoint {}",
+                replicaShard.shardId(),
+                replicaShard.routingEntry().allocationId(),
+                request.getCheckpoint()
+            )
+        );
         RetryableTransportClient transportClient = new RetryableTransportClient(
             transportService,
             getPrimaryNode(primaryShard),
@@ -315,19 +323,23 @@ public class SegmentReplicationTargetService implements IndexEventListener {
         final ActionListener<Void> listener = new ActionListener<>() {
             @Override
             public void onResponse(Void unused) {
-                logger.debug(
-                    "Successfully updated replication checkpoint {} for replica {}",
-                    replicaShard.shardId(),
-                    request.getCheckpoint()
+                logger.trace(
+                    () -> new ParameterizedMessage(
+                        "Successfully updated replication checkpoint {} for replica {}",
+                        replicaShard.shardId(),
+                        request.getCheckpoint()
+                    )
                 );
             }
 
             @Override
             public void onFailure(Exception e) {
                 logger.error(
-                    "Failed to update visible checkpoint for replica {}, {}: {}",
-                    replicaShard.shardId(),
-                    request.getCheckpoint(),
+                    () -> new ParameterizedMessage(
+                        "Failed to update visible checkpoint for replica {}, {}:",
+                        replicaShard.shardId(),
+                        request.getCheckpoint()
+                    ),
                     e
                 );
             }
@@ -350,6 +362,13 @@ public class SegmentReplicationTargetService implements IndexEventListener {
     protected boolean processLatestReceivedCheckpoint(IndexShard replicaShard, Thread thread) {
         final ReplicationCheckpoint latestPublishedCheckpoint = latestReceivedCheckpoint.get(replicaShard.shardId());
         if (latestPublishedCheckpoint != null && latestPublishedCheckpoint.isAheadOf(replicaShard.getLatestReplicationCheckpoint())) {
+            logger.trace(
+                () -> new ParameterizedMessage(
+                    "Processing latest received checkpoint for shard {} {}",
+                    replicaShard.shardId(),
+                    latestPublishedCheckpoint
+                )
+            );
             Runnable runnable = () -> onNewCheckpoint(latestReceivedCheckpoint.get(replicaShard.shardId()), replicaShard);
             // Checks if we are using same thread and forks if necessary.
             if (thread == Thread.currentThread()) {
@@ -381,7 +400,15 @@ public class SegmentReplicationTargetService implements IndexEventListener {
 
     // pkg-private for integration tests
     void startReplication(final SegmentReplicationTarget target) {
-        final long replicationId = onGoingReplications.start(target, recoverySettings.activityTimeout());
+        final long replicationId;
+        try {
+            replicationId = onGoingReplications.startSafe(target, recoverySettings.activityTimeout());
+        } catch (ReplicationFailedException e) {
+            // replication already running for shard.
+            target.fail(e, false);
+            return;
+        }
+        logger.trace(() -> new ParameterizedMessage("Added new replication to collection {}", target.description()));
         threadPool.generic().execute(new ReplicationRunner(replicationId));
     }
 
@@ -410,7 +437,7 @@ public class SegmentReplicationTargetService implements IndexEventListener {
     /**
      * Runnable implementation to trigger a replication event.
      */
-    private class ReplicationRunner implements Runnable {
+    private class ReplicationRunner extends AbstractRunnable {
 
         final long replicationId;
 
@@ -419,47 +446,49 @@ public class SegmentReplicationTargetService implements IndexEventListener {
         }
 
         @Override
-        public void run() {
+        public void onFailure(Exception e) {
+            try (final ReplicationRef<SegmentReplicationTarget> ref = onGoingReplications.get(replicationId)) {
+                logger.error(() -> new ParameterizedMessage("Error during segment replication, {}", ref.get().description()), e);
+            }
+            onGoingReplications.fail(replicationId, new ReplicationFailedException("Unexpected Error during replication"), false);
+        }
+
+        @Override
+        public void doRun() {
             start(replicationId);
         }
     }
 
     private void start(final long replicationId) {
+        final SegmentReplicationTarget target;
         try (ReplicationRef<SegmentReplicationTarget> replicationRef = onGoingReplications.get(replicationId)) {
             // This check is for handling edge cases where the reference is removed before the ReplicationRunner is started by the
             // threadpool.
             if (replicationRef == null) {
                 return;
             }
-            SegmentReplicationTarget target = onGoingReplications.getTarget(replicationId);
-            replicationRef.get().startReplication(new ActionListener<>() {
-                @Override
-                public void onResponse(Void o) {
-                    onGoingReplications.markAsDone(replicationId);
-                    if (target.state().getIndex().recoveredFileCount() != 0 && target.state().getIndex().recoveredBytes() != 0) {
-                        completedReplications.put(target.shardId(), target);
-                    }
-
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    Throwable cause = ExceptionsHelper.unwrapCause(e);
-                    if (cause instanceof CancellableThreads.ExecutionCancelledException) {
-                        if (onGoingReplications.getTarget(replicationId) != null) {
-                            IndexShard indexShard = onGoingReplications.getTarget(replicationId).indexShard();
-                            // if the target still exists in our collection, the primary initiated the cancellation, fail the replication
-                            // but do not fail the shard. Cancellations initiated by this node from Index events will be removed with
-                            // onGoingReplications.cancel and not appear in the collection when this listener resolves.
-                            onGoingReplications.fail(replicationId, new ReplicationFailedException(indexShard, cause), false);
-                            completedReplications.put(target.shardId(), target);
-                        }
-                    } else {
-                        onGoingReplications.fail(replicationId, new ReplicationFailedException("Segment Replication failed", e), false);
-                    }
-                }
-            });
+            target = onGoingReplications.getTarget(replicationId);
         }
+        target.startReplication(new ActionListener<>() {
+            @Override
+            public void onResponse(Void o) {
+                logger.trace(() -> new ParameterizedMessage("Finished replicating {} marking as done.", target.description()));
+                onGoingReplications.markAsDone(replicationId);
+                if (target.state().getIndex().recoveredFileCount() != 0 && target.state().getIndex().recoveredBytes() != 0) {
+                    completedReplications.put(target.shardId(), target);
+                }
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                logger.error(() -> new ParameterizedMessage("Exception replicating {} marking as failed.", target.description()), e);
+                if (e instanceof OpenSearchCorruptionException) {
+                    onGoingReplications.fail(replicationId, new ReplicationFailedException("Store corruption during replication", e), true);
+                    return;
+                }
+                onGoingReplications.fail(replicationId, new ReplicationFailedException("Segment Replication failed", e), false);
+            }
+        });
     }
 
     private class FileChunkTransportRequestHandler implements TransportRequestHandler<FileChunkRequest> {
@@ -484,27 +513,31 @@ public class SegmentReplicationTargetService implements IndexEventListener {
     private class ForceSyncTransportRequestHandler implements TransportRequestHandler<ForceSyncRequest> {
         @Override
         public void messageReceived(final ForceSyncRequest request, TransportChannel channel, Task task) throws Exception {
-            assert indicesService != null;
-            final IndexShard indexShard = indicesService.getShardOrNull(request.getShardId());
-            // Proceed with round of segment replication only when it is allowed
-            if (indexShard == null || indexShard.getReplicationEngine().isEmpty()) {
-                logger.info("Ignore force segment replication sync as it is not allowed");
-                channel.sendResponse(TransportResponse.Empty.INSTANCE);
-                return;
-            }
+            forceReplication(request, new ChannelActionListener<>(channel, Actions.FORCE_SYNC, request));
+        }
+    }
+
+    private void forceReplication(ForceSyncRequest request, ActionListener<TransportResponse> listener) {
+        final ShardId shardId = request.getShardId();
+        assert indicesService != null;
+        final IndexShard indexShard = indicesService.getShardOrNull(shardId);
+        // Proceed with round of segment replication only when it is allowed
+        if (indexShard == null || indexShard.getReplicationEngine().isEmpty()) {
+            listener.onResponse(TransportResponse.Empty.INSTANCE);
+        } else {
             startReplication(indexShard, new SegmentReplicationTargetService.SegmentReplicationListener() {
                 @Override
                 public void onReplicationDone(SegmentReplicationState state) {
-                    logger.trace(
-                        () -> new ParameterizedMessage(
-                            "[shardId {}] [replication id {}] Replication complete to {}, timing data: {}",
-                            indexShard.shardId().getId(),
-                            state.getReplicationId(),
-                            indexShard.getLatestReplicationCheckpoint(),
-                            state.getTimingData()
-                        )
-                    );
                     try {
+                        logger.trace(
+                            () -> new ParameterizedMessage(
+                                "[shardId {}] [replication id {}] Force replication Sync complete to {}, timing data: {}",
+                                shardId,
+                                state.getReplicationId(),
+                                indexShard.getLatestReplicationCheckpoint(),
+                                state.getTimingData()
+                            )
+                        );
                         // Promote engine type for primary target
                         if (indexShard.recoveryState().getPrimary() == true) {
                             indexShard.resetToWriteableEngine();
@@ -512,32 +545,39 @@ public class SegmentReplicationTargetService implements IndexEventListener {
                             // Update the replica's checkpoint on primary's replication tracker.
                             updateVisibleCheckpoint(state.getReplicationId(), indexShard);
                         }
-                        channel.sendResponse(TransportResponse.Empty.INSTANCE);
-                    } catch (InterruptedException | TimeoutException | IOException e) {
-                        throw new RuntimeException(e);
+                        listener.onResponse(TransportResponse.Empty.INSTANCE);
+                    } catch (Exception e) {
+                        logger.error("Error while marking replication completed", e);
+                        listener.onFailure(e);
                     }
                 }
 
                 @Override
                 public void onReplicationFailure(SegmentReplicationState state, ReplicationFailedException e, boolean sendShardFailure) {
-                    logger.trace(
+                    logger.error(
                         () -> new ParameterizedMessage(
                             "[shardId {}] [replication id {}] Replication failed, timing data: {}",
                             indexShard.shardId().getId(),
                             state.getReplicationId(),
                             state.getTimingData()
-                        )
+                        ),
+                        e
                     );
-                    if (sendShardFailure == true) {
-                        indexShard.failShard("replication failure", e);
+                    if (sendShardFailure) {
+                        failShard(e, indexShard);
                     }
-                    try {
-                        channel.sendResponse(e);
-                    } catch (IOException ex) {
-                        throw new RuntimeException(ex);
-                    }
+                    listener.onFailure(e);
                 }
             });
+        }
+    }
+
+    private void failShard(ReplicationFailedException e, IndexShard indexShard) {
+        try {
+            indexShard.failShard("unrecoverable replication failure", e);
+        } catch (Exception inner) {
+            logger.error("Error attempting to fail shard", inner);
+            e.addSuppressed(inner);
         }
     }
 

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
@@ -220,7 +220,6 @@ public class SegmentReplicationTargetService implements IndexEventListener {
         if (replicaShard.state().equals(IndexShardState.STARTED) == true) {
             // Checks if received checkpoint is already present and ahead then it replaces old received checkpoint
             SegmentReplicationTarget ongoingReplicationTarget = onGoingReplications.getOngoingReplicationTarget(replicaShard.shardId());
-
             if (ongoingReplicationTarget != null) {
                 if (ongoingReplicationTarget.getCheckpoint().getPrimaryTerm() < receivedCheckpoint.getPrimaryTerm()) {
                     logger.trace(

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
@@ -449,7 +449,7 @@ public class SegmentReplicationTargetService implements IndexEventListener {
             try (final ReplicationRef<SegmentReplicationTarget> ref = onGoingReplications.get(replicationId)) {
                 logger.error(() -> new ParameterizedMessage("Error during segment replication, {}", ref.get().description()), e);
             }
-            onGoingReplications.fail(replicationId, new ReplicationFailedException("Unexpected Error during replication"), false);
+            onGoingReplications.fail(replicationId, new ReplicationFailedException("Unexpected Error during replication", e), false);
         }
 
         @Override
@@ -466,7 +466,7 @@ public class SegmentReplicationTargetService implements IndexEventListener {
             if (replicationRef == null) {
                 return;
             }
-            target = onGoingReplications.getTarget(replicationId);
+            target = replicationRef.get();
         }
         target.startReplication(new ActionListener<>() {
             @Override

--- a/server/src/main/java/org/opensearch/indices/replication/common/ReplicationTarget.java
+++ b/server/src/main/java/org/opensearch/indices/replication/common/ReplicationTarget.java
@@ -173,6 +173,7 @@ public abstract class ReplicationTarget extends AbstractRefCounted {
     public void fail(ReplicationFailedException e, boolean sendShardFailure) {
         if (finished.compareAndSet(false, true)) {
             try {
+                logger.debug("marking target " + description() + " as failed", e);
                 notifyListener(e, sendShardFailure);
             } finally {
                 try {

--- a/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
@@ -10,6 +10,7 @@ package org.opensearch.index.shard;
 
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.store.AlreadyClosedException;
 import org.junit.Assert;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.ActionListener;
@@ -86,11 +87,12 @@ import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.spy;
 
 public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelReplicationTestCase {
 
@@ -1156,6 +1158,125 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
         }
     }
 
+    public void testCloseShardDuringFinalize() throws Exception {
+        try (ReplicationGroup shards = createGroup(1, settings, new NRTReplicationEngineFactory())) {
+            shards.startAll();
+            IndexShard primary = shards.getPrimary();
+            final IndexShard replica = shards.getReplicas().get(0);
+            final IndexShard replicaSpy = spy(replica);
+
+            primary.refresh("Test");
+
+            doThrow(AlreadyClosedException.class).when(replicaSpy).finalizeReplication(any());
+
+            replicateSegments(primary, List.of(replicaSpy));
+        }
+    }
+
+    public void testCloseShardWhileGettingCheckpoint() throws Exception {
+        try (ReplicationGroup shards = createGroup(1, settings, new NRTReplicationEngineFactory())) {
+            shards.startAll();
+            IndexShard primary = shards.getPrimary();
+            final IndexShard replica = shards.getReplicas().get(0);
+
+            primary.refresh("Test");
+
+            final SegmentReplicationSourceFactory sourceFactory = mock(SegmentReplicationSourceFactory.class);
+            final SegmentReplicationTargetService targetService = newTargetService(sourceFactory);
+            SegmentReplicationSource source = new TestReplicationSource() {
+
+                ActionListener<CheckpointInfoResponse> listener;
+
+                @Override
+                public void getCheckpointMetadata(
+                    long replicationId,
+                    ReplicationCheckpoint checkpoint,
+                    ActionListener<CheckpointInfoResponse> listener
+                ) {
+                    // set the listener, we will only fail it once we cancel the source.
+                    this.listener = listener;
+                    // shard is closing while we are copying files.
+                    targetService.beforeIndexShardClosed(replica.shardId, replica, Settings.EMPTY);
+                }
+
+                @Override
+                public void getSegmentFiles(
+                    long replicationId,
+                    ReplicationCheckpoint checkpoint,
+                    List<StoreFileMetadata> filesToFetch,
+                    IndexShard indexShard,
+                    ActionListener<GetSegmentFilesResponse> listener
+                ) {
+                    Assert.fail("Unreachable");
+                }
+
+                @Override
+                public void cancel() {
+                    // simulate listener resolving, but only after we have issued a cancel from beforeIndexShardClosed .
+                    final RuntimeException exception = new CancellableThreads.ExecutionCancelledException("retryable action was cancelled");
+                    listener.onFailure(exception);
+                }
+            };
+            when(sourceFactory.get(any())).thenReturn(source);
+            startReplicationAndAssertCancellation(replica, targetService);
+
+            shards.removeReplica(replica);
+            closeShards(replica);
+        }
+    }
+
+    public void testBeforeIndexShardClosedWhileCopyingFiles() throws Exception {
+        try (ReplicationGroup shards = createGroup(1, settings, new NRTReplicationEngineFactory())) {
+            shards.startAll();
+            IndexShard primary = shards.getPrimary();
+            final IndexShard replica = shards.getReplicas().get(0);
+
+            primary.refresh("Test");
+
+            final SegmentReplicationSourceFactory sourceFactory = mock(SegmentReplicationSourceFactory.class);
+            final SegmentReplicationTargetService targetService = newTargetService(sourceFactory);
+            SegmentReplicationSource source = new TestReplicationSource() {
+
+                ActionListener<GetSegmentFilesResponse> listener;
+
+                @Override
+                public void getCheckpointMetadata(
+                    long replicationId,
+                    ReplicationCheckpoint checkpoint,
+                    ActionListener<CheckpointInfoResponse> listener
+                ) {
+                    resolveCheckpointInfoResponseListener(listener, primary);
+                }
+
+                @Override
+                public void getSegmentFiles(
+                    long replicationId,
+                    ReplicationCheckpoint checkpoint,
+                    List<StoreFileMetadata> filesToFetch,
+                    IndexShard indexShard,
+                    ActionListener<GetSegmentFilesResponse> listener
+                ) {
+                    // set the listener, we will only fail it once we cancel the source.
+                    this.listener = listener;
+                    // shard is closing while we are copying files.
+                    targetService.beforeIndexShardClosed(replica.shardId, replica, Settings.EMPTY);
+                }
+
+                @Override
+                public void cancel() {
+                    // simulate listener resolving, but only after we have issued a cancel from beforeIndexShardClosed .
+                    final RuntimeException exception = new CancellableThreads.ExecutionCancelledException("retryable action was cancelled");
+                    listener.onFailure(exception);
+                }
+            };
+            when(sourceFactory.get(any())).thenReturn(source);
+            startReplicationAndAssertCancellation(replica, targetService);
+
+            shards.removeReplica(replica);
+            closeShards(replica);
+        }
+    }
+
     public void testPrimaryCancelsExecution() throws Exception {
         try (ReplicationGroup shards = createGroup(1, settings, new NRTReplicationEngineFactory())) {
             shards.startAll();
@@ -1245,7 +1366,6 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
                 @Override
                 public void onReplicationFailure(SegmentReplicationState state, ReplicationFailedException e, boolean sendShardFailure) {
                     assertFalse(sendShardFailure);
-                    assertEquals(SegmentReplicationState.Stage.CANCELLED, state.getStage());
                     latch.countDown();
                 }
             }

--- a/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetServiceTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetServiceTests.java
@@ -8,8 +8,8 @@
 
 package org.opensearch.indices.replication;
 
+import org.apache.lucene.store.AlreadyClosedException;
 import org.junit.Assert;
-import org.mockito.Mockito;
 import org.opensearch.OpenSearchException;
 import org.opensearch.Version;
 import org.opensearch.action.ActionListener;
@@ -49,6 +49,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
@@ -62,7 +63,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
-import static org.opensearch.indices.replication.SegmentReplicationState.Stage.CANCELLED;
 
 public class SegmentReplicationTargetServiceTests extends IndexShardTestCase {
 
@@ -240,71 +240,82 @@ public class SegmentReplicationTargetServiceTests extends IndexShardTestCase {
         verify(spy, times(0)).startReplication(any(), any());
     }
 
-    public void testShardAlreadyReplicating() throws InterruptedException {
-        // Create a spy of Target Service so that we can verify invocation of startReplication call with specific checkpoint on it.
-        SegmentReplicationTargetService serviceSpy = spy(sut);
-        final SegmentReplicationTarget target = new SegmentReplicationTarget(
-            replicaShard,
-            replicationSource,
-            mock(SegmentReplicationTargetService.SegmentReplicationListener.class)
-        );
-        // Create a Mockito spy of target to stub response of few method calls.
-        final SegmentReplicationTarget targetSpy = Mockito.spy(target);
-        CountDownLatch latch = new CountDownLatch(1);
-        // Mocking response when startReplication is called on targetSpy we send a new checkpoint to serviceSpy and later reduce countdown
-        // of latch.
-        doAnswer(invocation -> {
-            final ActionListener<Void> listener = invocation.getArgument(0);
-            // a new checkpoint arrives before we've completed.
-            serviceSpy.onNewCheckpoint(aheadCheckpoint, replicaShard);
-            listener.onResponse(null);
-            latch.countDown();
-            return null;
-        }).when(targetSpy).startReplication(any());
-        doNothing().when(targetSpy).onDone();
+    public void testShardAlreadyReplicating() {
+        sut.startReplication(replicaShard, mock(SegmentReplicationTargetService.SegmentReplicationListener.class));
+        sut.startReplication(replicaShard, new SegmentReplicationTargetService.SegmentReplicationListener() {
+            @Override
+            public void onReplicationDone(SegmentReplicationState state) {
+                Assert.fail("Should not succeed");
+            }
 
-        // start replication of this shard the first time.
-        serviceSpy.startReplication(targetSpy);
-
-        // wait for the new checkpoint to arrive, before the listener completes.
-        latch.await(30, TimeUnit.SECONDS);
-        verify(targetSpy, times(0)).cancel(any());
-        verify(serviceSpy, times(0)).startReplication(eq(replicaShard), any());
+            @Override
+            public void onReplicationFailure(SegmentReplicationState state, ReplicationFailedException e, boolean sendShardFailure) {
+                assertEquals("Shard " + replicaShard.shardId() + " is already replicating", e.getMessage());
+                assertFalse(sendShardFailure);
+            }
+        });
     }
 
-    public void testOnNewCheckpointFromNewPrimaryCancelOngoingReplication() throws IOException, InterruptedException {
+    public void testOnNewCheckpointFromNewPrimaryCancelOngoingReplication() throws InterruptedException {
         // Create a spy of Target Service so that we can verify invocation of startReplication call with specific checkpoint on it.
         SegmentReplicationTargetService serviceSpy = spy(sut);
+        doNothing().when(serviceSpy).updateVisibleCheckpoint(anyLong(), any());
+        // skip post replication actions so we can assert execution counts. This will continue to process bc replica's pterm is not advanced
+        // post replication.
+        doReturn(true).when(serviceSpy).processLatestReceivedCheckpoint(any(), any());
         // Create a Mockito spy of target to stub response of few method calls.
-        final SegmentReplicationTarget targetSpy = spy(
-            new SegmentReplicationTarget(
-                replicaShard,
-                replicationSource,
-                mock(SegmentReplicationTargetService.SegmentReplicationListener.class)
-            )
-        );
 
         CountDownLatch latch = new CountDownLatch(1);
-        // Mocking response when startReplication is called on targetSpy we send a new checkpoint to serviceSpy and later reduce countdown
-        // of latch.
-        doAnswer(invocation -> {
-            // short circuit loop on new checkpoint request
-            doReturn(null).when(serviceSpy).startReplication(eq(replicaShard), any());
-            // a new checkpoint arrives before we've completed.
-            serviceSpy.onNewCheckpoint(newPrimaryCheckpoint, replicaShard);
-            try {
-                invocation.callRealMethod();
-            } catch (CancellableThreads.ExecutionCancelledException e) {
+        SegmentReplicationSource source = new TestReplicationSource() {
+
+            ActionListener<CheckpointInfoResponse> listener;
+
+            @Override
+            public void getCheckpointMetadata(
+                long replicationId,
+                ReplicationCheckpoint checkpoint,
+                ActionListener<CheckpointInfoResponse> listener
+            ) {
+                // set the listener, we will only fail it once we cancel the source.
+                logger.info("In test source");
+                this.listener = listener;
                 latch.countDown();
+                // do not resolve this listener yet, wait for cancel to hit.
             }
-            return null;
-        }).when(targetSpy).startReplication(any());
+
+            @Override
+            public void getSegmentFiles(
+                long replicationId,
+                ReplicationCheckpoint checkpoint,
+                List<StoreFileMetadata> filesToFetch,
+                IndexShard indexShard,
+                ActionListener<GetSegmentFilesResponse> listener
+            ) {
+                Assert.fail("Unreachable");
+            }
+
+            @Override
+            public void cancel() {
+                // simulate listener resolving, but only after we have issued a cancel from beforeIndexShardClosed .
+                final RuntimeException exception = new CancellableThreads.ExecutionCancelledException("retryable action was cancelled");
+                listener.onFailure(exception);
+            }
+        };
+
+        final SegmentReplicationTarget targetSpy = spy(
+            new SegmentReplicationTarget(replicaShard, source, mock(SegmentReplicationTargetService.SegmentReplicationListener.class))
+        );
 
         // start replication. This adds the target to on-ongoing replication collection
         serviceSpy.startReplication(targetSpy);
+
+        // wait until we get to getCheckpoint step.
         latch.await();
-        // wait for the new checkpoint to arrive, before the listener completes.
-        assertEquals(CANCELLED, targetSpy.state().getStage());
+
+        // new checkpoint arrives with higher pterm.
+        serviceSpy.onNewCheckpoint(newPrimaryCheckpoint, replicaShard);
+
+        // ensure the old target is cancelled. and new iteration kicks off.
         verify(targetSpy, times(1)).cancel("Cancelling stuck target after new primary");
         verify(serviceSpy, times(1)).startReplication(eq(replicaShard), any());
     }
@@ -467,6 +478,7 @@ public class SegmentReplicationTargetServiceTests extends IndexShardTestCase {
     }
 
     public void testForceSegmentSyncHandlerWithFailure() throws Exception {
+        allowShardFailures();
         IndexShard spyReplicaShard = spy(replicaShard);
         ForceSyncRequest forceSyncRequest = new ForceSyncRequest(1L, 1L, replicaShard.shardId());
         when(indicesService.getShardOrNull(forceSyncRequest.getShardId())).thenReturn(spyReplicaShard);
@@ -487,5 +499,24 @@ public class SegmentReplicationTargetServiceTests extends IndexShardTestCase {
         Throwable nestedException = finalizeException.getCause().getCause();
         assertTrue(nestedException instanceof IOException);
         assertTrue(nestedException.getMessage().contains("dummy failure"));
+    }
+
+    public void testForceSegmentSyncHandlerWithFailure_AlreadyClosedException_swallowed() throws Exception {
+        IndexShard spyReplicaShard = spy(replicaShard);
+        ForceSyncRequest forceSyncRequest = new ForceSyncRequest(1L, 1L, replicaShard.shardId());
+        when(indicesService.getShardOrNull(forceSyncRequest.getShardId())).thenReturn(spyReplicaShard);
+
+        AlreadyClosedException exception = new AlreadyClosedException("shard closed");
+        doThrow(exception).when(spyReplicaShard).finalizeReplication(any());
+
+        // prevent shard failure to avoid test setup assertion
+        doNothing().when(spyReplicaShard).failShard(eq("replication failure"), any());
+        transportService.submitRequest(
+            localNode,
+            SegmentReplicationTargetService.Actions.FORCE_SYNC,
+            forceSyncRequest,
+            TransportRequestOptions.builder().withTimeout(TRANSPORT_TIMEOUT).build(),
+            EmptyTransportResponseHandler.INSTANCE_SAME
+        ).txGet();
     }
 }

--- a/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetServiceTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetServiceTests.java
@@ -277,7 +277,6 @@ public class SegmentReplicationTargetServiceTests extends IndexShardTestCase {
                 ActionListener<CheckpointInfoResponse> listener
             ) {
                 // set the listener, we will only fail it once we cancel the source.
-                logger.info("In test source");
                 this.listener = listener;
                 latch.countDown();
                 // do not resolve this listener yet, wait for cancel to hit.

--- a/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetTests.java
@@ -27,6 +27,7 @@ import org.apache.lucene.util.Version;
 import org.junit.Assert;
 import org.mockito.Mockito;
 import org.opensearch.ExceptionsHelper;
+import org.opensearch.OpenSearchCorruptionException;
 import org.opensearch.action.ActionListener;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
@@ -373,8 +374,9 @@ public class SegmentReplicationTargetTests extends IndexShardTestCase {
 
             @Override
             public void onFailure(Exception e) {
-                assert (e instanceof ReplicationFailedException);
-                assert (e.getMessage().contains("different segment files"));
+                assertTrue(e instanceof OpenSearchCorruptionException);
+                assertTrue(e.getMessage().contains("has local copies of segments that differ from the primary"));
+                segrepTarget.fail(new ReplicationFailedException(e), false);
             }
         });
     }

--- a/server/src/test/java/org/opensearch/recovery/ReplicationCollectionTests.java
+++ b/server/src/test/java/org/opensearch/recovery/ReplicationCollectionTests.java
@@ -38,12 +38,15 @@ import org.opensearch.index.replication.OpenSearchIndexLevelReplicationTestCase;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.shard.ShardId;
 import org.opensearch.index.store.Store;
+import org.opensearch.indices.replication.SegmentReplicationSource;
+import org.opensearch.indices.replication.SegmentReplicationTarget;
 import org.opensearch.indices.replication.common.ReplicationCollection;
 import org.opensearch.indices.replication.common.ReplicationFailedException;
 import org.opensearch.indices.replication.common.ReplicationListener;
 import org.opensearch.indices.replication.common.ReplicationState;
 import org.opensearch.indices.recovery.RecoveryState;
 import org.opensearch.indices.recovery.RecoveryTarget;
+import org.opensearch.indices.replication.common.ReplicationTarget;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -51,6 +54,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
+import static org.mockito.Mockito.mock;
 
 public class ReplicationCollectionTests extends OpenSearchIndexLevelReplicationTestCase {
     static final ReplicationListener listener = new ReplicationListener() {
@@ -108,7 +112,30 @@ public class ReplicationCollectionTests extends OpenSearchIndexLevelReplicationT
         }
     }
 
-    public void testMultiReplicationsForSingleShard() throws Exception {
+    public void testStartMultipleReplicationsForSingleShard() throws Exception {
+        try (ReplicationGroup shards = createGroup(0)) {
+            shards.startAll();
+            final ReplicationCollection<ReplicationTarget> collection = new ReplicationCollection<>(logger, threadPool);
+            final IndexShard shard = shards.addReplica();
+            shards.recoverReplica(shard);
+            final SegmentReplicationTarget target1 = new SegmentReplicationTarget(
+                shard,
+                mock(SegmentReplicationSource.class),
+                mock(ReplicationListener.class)
+            );
+            final SegmentReplicationTarget target2 = new SegmentReplicationTarget(
+                shard,
+                mock(SegmentReplicationSource.class),
+                mock(ReplicationListener.class)
+            );
+            collection.startSafe(target1, TimeValue.timeValueMinutes(30));
+            assertThrows(ReplicationFailedException.class, () -> collection.startSafe(target2, TimeValue.timeValueMinutes(30)));
+            target1.decRef();
+            target2.decRef();
+        }
+    }
+
+    public void testGetReplicationTargetMultiReplicationsForSingleShard() throws Exception {
         try (ReplicationGroup shards = createGroup(0)) {
             final ReplicationCollection<RecoveryTarget> collection = new ReplicationCollection<>(logger, threadPool);
             final IndexShard shard1 = shards.addReplica();


### PR DESCRIPTION
### Description
This change updates Segment Replication to ensure all listeners are cleaned up during cancellation.  This happens because of a race condition with beforeIndexShardClosed cancelling with RecoveriesCollection#cancelForShard and the target failing.  CancelForShard immediately removes the target from the collection and then invokes cancel.  When cancel would complete, it relies on another call to fail to remove it from the collection & notify the listeners, but it had already been removed.  This PR fixes this by introducing a new method to RecoveriesCollection to request cancellation only.

This change includes tests using suite scope to catch for any open tasks. This caught other locations where this was possible:
1. On a replica during force sync if the shard was closed while resolving its listeners, it would never call back to the primary. - Fixed by refactoring those paths to use a ChannelActionListener.
2. On the primary during forceSync, the primary makes a synchronous call to forceSync that was not wrapped in cancellableThreads.  So it relies on the replica to send cancellation in order to proceed.
3. During cancellation when pterm is greater on an incoming checkpoint, we would remove from collection but the target could still be open - fixed by waiting for the cancelled target to be closed before proceeding.  Also added method to ReplicationTarget to guarantee only a single target can be added to the collection.

### Related Issues
closes #8292

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
