### PR TITLE
[Manual Backport 2.x] Updating default compression level for ZStandard Codecs (#8471)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Refactor] Stream Reader and Write Generics ([#7465](https://github.com/opensearch-project/OpenSearch/pull/7465))
 - [Refactor] OpenSearchException and ExceptionsHelper foundation to base class ([#7508](https://github.com/opensearch-project/OpenSearch/pull/7508))
 - Move ZSTD compression codecs out of the sandbox ([#7908](https://github.com/opensearch-project/OpenSearch/pull/7908))
+- Update ZSTD default compression level ([#8471](https://github.com/opensearch-project/OpenSearch/pull/8471))
 
 ### Deprecated
 

--- a/server/src/main/java/org/opensearch/index/codec/customcodecs/Lucene95CustomCodec.java
+++ b/server/src/main/java/org/opensearch/index/codec/customcodecs/Lucene95CustomCodec.java
@@ -23,7 +23,7 @@ import org.opensearch.index.mapper.MapperService;
  * @opensearch.internal
  */
 public abstract class Lucene95CustomCodec extends FilterCodec {
-    public static final int DEFAULT_COMPRESSION_LEVEL = 6;
+    public static final int DEFAULT_COMPRESSION_LEVEL = 3;
 
     /** Each mode represents a compression algorithm. */
     public enum Mode {


### PR DESCRIPTION
Signed-off-by: Sarthak Aggarwal <sarthagg@amazon.com>
(cherry picked from commit eca5a6cbc4f8454afaebd35e81f4d3c23071d92d)

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Backport of #8471 

### Related Issues
Resolves:
Optimization for #7555

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
