### PR TITLE
Add workflow to check compatibility

### DIFF
--- a/.github/workflows/check-compatibility.yml
+++ b/.github/workflows/check-compatibility.yml
@@ -30,6 +30,6 @@ jobs:
       - name: Add comment on the PR
         uses: peter-evans/create-or-update-comment@v3
         with:
-          token: ${{ SECRETS.TOKEN }}
-          issue-number: ${{ steps.github_app_token.outputs.token }}
+          token: ${{ steps.github_app_token.outputs.token }}
+          issue-number: ${{ github.event.number }}
           body-path: "${{ github.workspace }}/results.txt"

--- a/.github/workflows/check-compatibility.yml
+++ b/.github/workflows/check-compatibility.yml
@@ -1,0 +1,31 @@
+---
+name: checkCompatibility
+
+on:
+  pull_request_target
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run compatibility task
+        run: ./gradlew checkCompatibility | tee $HOME/gradlew-check.out
+      - name: Get results
+        run: |
+          echo 'Compatibility status:' > ${{ github.workspace }}/results.txt && echo '```' >> ${{ github.workspace }}/results.txt
+          grep -e 'Compatible components' -e 'Incompatible components' -e 'Components skipped' -A 2 -B 3 $HOME/gradlew-check.out >> "${{ github.workspace }}/results.txt"
+          echo '```' >> ${{ github.workspace }}/results.txt
+      - name: GitHub App token
+        id: github_app_token
+        uses: tibdex/github-app-token@v1.6.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          installation_id: 22958780
+      - name: Add comment on the PR
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          token: ${{ SECRETS.TOKEN }}
+          issue-number: ${{ steps.github_app_token.outputs.token }}
+          body-path: "${{ github.workspace }}/results.txt"

--- a/.github/workflows/check-compatibility.yml
+++ b/.github/workflows/check-compatibility.yml
@@ -1,5 +1,5 @@
 ---
-name: checkCompatibility
+name: Check Compatibility
 
 on:
   pull_request_target
@@ -9,13 +9,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: Run compatibility task
         run: ./gradlew checkCompatibility | tee $HOME/gradlew-check.out
+
       - name: Get results
         run: |
           echo 'Compatibility status:' > ${{ github.workspace }}/results.txt && echo '```' >> ${{ github.workspace }}/results.txt
           grep -e 'Compatible components' -e 'Incompatible components' -e 'Components skipped' -A 2 -B 3 $HOME/gradlew-check.out >> "${{ github.workspace }}/results.txt"
           echo '```' >> ${{ github.workspace }}/results.txt
+
       - name: GitHub App token
         id: github_app_token
         uses: tibdex/github-app-token@v1.6.0
@@ -23,6 +26,7 @@ jobs:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
           installation_id: 22958780
+
       - name: Add comment on the PR
         uses: peter-evans/create-or-update-comment@v3
         with:

--- a/buildSrc/src/main/groovy/org/opensearch/gradle/CheckCompatibilityTask.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/gradle/CheckCompatibilityTask.groovy
@@ -40,8 +40,8 @@ class CheckCompatibilityTask extends DefaultTask {
 
     @TaskAction
     void checkCompatibility() {
-        logger.info("Checking compatibility for: $repositoryUrls for $ref")
         repositoryUrls.parallelStream().forEach { repositoryUrl ->
+            logger.lifecycle("Checking compatibility for: $repositoryUrl with ref: $ref")
             def tempDir = File.createTempDir()
             try {
                 if (cloneAndCheckout(repositoryUrl, tempDir)) {
@@ -82,7 +82,15 @@ class CheckCompatibilityTask extends DefaultTask {
     protected static List getRepoUrls() {
         def json = new JsonSlurper().parse(REPO_URL.toURL())
         def labels = json.projects.values()
-        return labels as List
+        def repoUrls = replaceSshWithHttps(labels as List)
+        return repoUrls
+    }
+
+    protected static replaceSshWithHttps(List<String> inputList) {
+        inputList.replaceAll { element ->
+            element.replace("git@github.com:", "https://github.com/")
+        }
+        return inputList
     }
 
     protected boolean cloneAndCheckout(repoUrl, directory) {

--- a/buildSrc/src/main/groovy/org/opensearch/gradle/CheckCompatibilityTask.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/gradle/CheckCompatibilityTask.groovy
@@ -81,16 +81,16 @@ class CheckCompatibilityTask extends DefaultTask {
 
     protected static List getRepoUrls() {
         def json = new JsonSlurper().parse(REPO_URL.toURL())
-        def labels = json.projects.values()
-        def repoUrls = replaceSshWithHttps(labels as List)
+        def repository = json.projects.values()
+        def repoUrls = replaceSshWithHttps(repository as List)
         return repoUrls
     }
 
-    protected static replaceSshWithHttps(List<String> inputList) {
-        inputList.replaceAll { element ->
+    protected static replaceSshWithHttps(List<String> repoList) {
+        repoList.replaceAll { element ->
             element.replace("git@github.com:", "https://github.com/")
         }
-        return inputList
+        return repoList
     }
 
     protected boolean cloneAndCheckout(repoUrl, directory) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->


**_All the issues linked here confirmed that all plugins have passing `gradle assemble` and `mavenlocal()` as their first repository in build.gradle are closed now: https://github.com/opensearch-project/opensearch-devops/issues/114_**

### Description
This change adds a workflow to check the compatibility with all the plugins in opensearch-project. It adds a comment if any component is incompatible. Example: https://github.com/gaiksaya/OpenSearch/pull/7#issuecomment-1623129382


### Related Issues
https://github.com/opensearch-project/opensearch-devops/issues/114

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
