### PR TITLE
[Backport 2.x] [Segment Replication] Remove Restriction of strictly using only docrep for system indices and hidden indices

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationClusterSettingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationClusterSettingIT.java
@@ -15,16 +15,8 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.index.Index;
 import org.opensearch.index.IndexModule;
 import org.opensearch.indices.IndicesService;
-import org.opensearch.indices.SystemIndexDescriptor;
 import org.opensearch.indices.replication.common.ReplicationType;
-import org.opensearch.plugins.Plugin;
-import org.opensearch.plugins.SystemIndexPlugin;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.transport.MockTransportService;
-
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Arrays;
 
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REPLICATION_TYPE;
 import static org.opensearch.indices.IndicesService.CLUSTER_SETTING_REPLICATION_TYPE;
@@ -58,40 +50,6 @@ public class SegmentReplicationClusterSettingIT extends OpenSearchIntegTestCase 
             .put(super.nodeSettings(nodeOrdinal))
             .put(CLUSTER_SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
             .build();
-    }
-
-    public static class TestPlugin extends Plugin implements SystemIndexPlugin {
-        @Override
-        public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings settings) {
-            return Collections.singletonList(
-                new SystemIndexDescriptor(SYSTEM_INDEX_NAME, "System index for [" + getTestClass().getName() + ']')
-            );
-        }
-    }
-
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return Arrays.asList(SegmentReplicationClusterSettingIT.TestPlugin.class, MockTransportService.TestPlugin.class);
-    }
-
-    public void testSystemIndexWithSegmentReplicationClusterSetting() throws Exception {
-
-        // Starting two nodes with primary and replica shards respectively.
-        final String primaryNode = internalCluster().startNode();
-        createIndex(SYSTEM_INDEX_NAME);
-        ensureYellowAndNoInitializingShards(SYSTEM_INDEX_NAME);
-        final String replicaNode = internalCluster().startNode();
-        ensureGreen(SYSTEM_INDEX_NAME);
-        final GetSettingsResponse response = client().admin()
-            .indices()
-            .getSettings(new GetSettingsRequest().indices(SYSTEM_INDEX_NAME).includeDefaults(true))
-            .actionGet();
-        assertEquals(response.getSetting(SYSTEM_INDEX_NAME, SETTING_REPLICATION_TYPE), ReplicationType.DOCUMENT.toString());
-
-        // Verify index setting isSegRepEnabled is false.
-        Index index = resolveIndex(SYSTEM_INDEX_NAME);
-        IndicesService indicesService = internalCluster().getInstance(IndicesService.class, primaryNode);
-        assertEquals(indicesService.indexService(index).getIndexSettings().isSegRepEnabled(), false);
     }
 
     public void testIndexReplicationSettingOverridesSegRepClusterSetting() throws Exception {
@@ -163,30 +121,6 @@ public class SegmentReplicationClusterSettingIT extends OpenSearchIntegTestCase 
         IndicesService indicesService = internalCluster().getInstance(IndicesService.class, primaryNode);
         assertEquals(indicesService.indexService(index).getIndexSettings().isSegRepEnabled(), true);
         assertEquals(indicesService.indexService(anotherIndex).getIndexSettings().isSegRepEnabled(), false);
-    }
-
-    public void testHiddenIndicesWithReplicationStrategyClusterSetting() throws Exception {
-        final String primaryNode = internalCluster().startNode();
-        final String replicaNode = internalCluster().startNode();
-        prepareCreate(
-            INDEX_NAME,
-            Settings.builder()
-                // we want to set index as hidden
-                .put("index.hidden", true)
-        ).get();
-        ensureGreen(INDEX_NAME);
-
-        // Verify that document replication strategy is used for hidden indices.
-        final GetSettingsResponse response = client().admin()
-            .indices()
-            .getSettings(new GetSettingsRequest().indices(INDEX_NAME).includeDefaults(true))
-            .actionGet();
-        assertEquals(response.getSetting(INDEX_NAME, SETTING_REPLICATION_TYPE), ReplicationType.DOCUMENT.toString());
-
-        // Verify index setting isSegRepEnabled.
-        Index index = resolveIndex(INDEX_NAME);
-        IndicesService indicesService = internalCluster().getInstance(IndicesService.class, primaryNode);
-        assertEquals(indicesService.indexService(index).getIndexSettings().isSegRepEnabled(), false);
     }
 
 }

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/CreateRemoteIndexIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/CreateRemoteIndexIT.java
@@ -12,23 +12,14 @@ import org.junit.After;
 import org.junit.Before;
 import org.opensearch.action.admin.indices.get.GetIndexRequest;
 import org.opensearch.action.admin.indices.get.GetIndexResponse;
-import org.opensearch.action.admin.indices.settings.get.GetSettingsRequest;
-import org.opensearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.FeatureFlags;
-import org.opensearch.indices.SystemIndexDescriptor;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.indices.replication.common.ReplicationType;
-import org.opensearch.plugins.Plugin;
-import org.opensearch.plugins.SystemIndexPlugin;
 import org.opensearch.test.FeatureFlagSetter;
 import org.opensearch.test.OpenSearchIntegTestCase;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REMOTE_STORE_ENABLED;
@@ -66,20 +57,6 @@ public class CreateRemoteIndexIT extends OpenSearchIntegTestCase {
             .put(CLUSTER_REMOTE_TRANSLOG_REPOSITORY_SETTING.getKey(), "my-translog-repo-1")
             .put(settings);
         return builder.build();
-    }
-
-    public static class TestPlugin extends Plugin implements SystemIndexPlugin {
-        @Override
-        public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings settings) {
-            return Collections.singletonList(
-                new SystemIndexDescriptor(SYSTEM_INDEX_NAME, "System index for [" + getTestClass().getName() + ']')
-            );
-        }
-    }
-
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return Arrays.asList(CreateRemoteIndexIT.TestPlugin.class);
     }
 
     @Override
@@ -128,35 +105,6 @@ public class CreateRemoteIndexIT extends OpenSearchIntegTestCase {
             ReplicationType.SEGMENT.toString(),
             IndexSettings.DEFAULT_REMOTE_TRANSLOG_BUFFER_INTERVAL
         );
-    }
-
-    private static final String SYSTEM_INDEX_NAME = ".test-system-index";
-
-    public void testSystemIndexWithRemoteStoreClusterSetting() throws Exception {
-        createIndex(SYSTEM_INDEX_NAME);
-        ensureGreen(SYSTEM_INDEX_NAME);
-        final GetSettingsResponse response = client().admin()
-            .indices()
-            .getSettings(new GetSettingsRequest().indices(SYSTEM_INDEX_NAME).includeDefaults(true))
-            .actionGet();
-        // Verify that Document replication strategy is used
-        assertEquals(response.getSetting(SYSTEM_INDEX_NAME, SETTING_REPLICATION_TYPE), ReplicationType.DOCUMENT.toString());
-        assertEquals(response.getSetting(SYSTEM_INDEX_NAME, SETTING_REMOTE_STORE_ENABLED), "false");
-    }
-
-    public void testSystemIndexWithRemoteStoreIndexSettings() throws Exception {
-        prepareCreate(
-            SYSTEM_INDEX_NAME,
-            Settings.builder().put(SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT).put(SETTING_REMOTE_STORE_ENABLED, true)
-        ).get();
-        ensureGreen(SYSTEM_INDEX_NAME);
-        final GetSettingsResponse response = client().admin()
-            .indices()
-            .getSettings(new GetSettingsRequest().indices(SYSTEM_INDEX_NAME).includeDefaults(true))
-            .actionGet();
-        // Verify that Document replication strategy is used
-        assertEquals(response.getSetting(SYSTEM_INDEX_NAME, SETTING_REPLICATION_TYPE), ReplicationType.DOCUMENT.toString());
-        assertEquals(response.getSetting(SYSTEM_INDEX_NAME, SETTING_REMOTE_STORE_ENABLED), "false");
     }
 
     public void testRemoteStoreDisabledByUser() throws Exception {

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -73,7 +73,6 @@ import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.settings.IndexScopedSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
@@ -138,7 +137,6 @@ import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REMOTE_TRANS
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REMOTE_TRANSLOG_STORE_REPOSITORY;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REPLICATION_TYPE;
 import static org.opensearch.cluster.metadata.Metadata.DEFAULT_REPLICA_COUNT_SETTING;
-import static org.opensearch.common.util.FeatureFlags.REMOTE_STORE;
 import static org.opensearch.indices.IndicesService.CLUSTER_REMOTE_STORE_REPOSITORY_SETTING;
 import static org.opensearch.indices.IndicesService.CLUSTER_REMOTE_TRANSLOG_REPOSITORY_SETTING;
 import static org.opensearch.indices.IndicesService.CLUSTER_REMOTE_STORE_ENABLED_SETTING;
@@ -586,8 +584,7 @@ public class MetadataCreateIndexService {
             settings,
             indexScopedSettings,
             shardLimitValidator,
-            indexSettingProviders,
-            systemIndices.validateSystemIndex(request.index())
+            indexSettingProviders
         );
         int routingNumShards = getIndexNumberOfRoutingShards(aggregatedIndexSettings, null);
         IndexMetadata tmpImd = buildAndValidateTemporaryIndexMetadata(currentState, aggregatedIndexSettings, request, routingNumShards);
@@ -651,8 +648,7 @@ public class MetadataCreateIndexService {
             settings,
             indexScopedSettings,
             shardLimitValidator,
-            indexSettingProviders,
-            systemIndices.validateSystemIndex(request.index())
+            indexSettingProviders
         );
         int routingNumShards = getIndexNumberOfRoutingShards(aggregatedIndexSettings, null);
         IndexMetadata tmpImd = buildAndValidateTemporaryIndexMetadata(currentState, aggregatedIndexSettings, request, routingNumShards);
@@ -732,8 +728,7 @@ public class MetadataCreateIndexService {
             settings,
             indexScopedSettings,
             shardLimitValidator,
-            indexSettingProviders,
-            sourceMetadata.isSystem()
+            indexSettingProviders
         );
         final int routingNumShards = getIndexNumberOfRoutingShards(aggregatedIndexSettings, sourceMetadata);
         IndexMetadata tmpImd = buildAndValidateTemporaryIndexMetadata(currentState, aggregatedIndexSettings, request, routingNumShards);
@@ -816,8 +811,7 @@ public class MetadataCreateIndexService {
         Settings settings,
         IndexScopedSettings indexScopedSettings,
         ShardLimitValidator shardLimitValidator,
-        Set<IndexSettingProvider> indexSettingProviders,
-        boolean isSystemIndex
+        Set<IndexSettingProvider> indexSettingProviders
     ) {
         // Create builders for the template and request settings. We transform these into builders
         // because we may want settings to be "removed" from these prior to being set on the new
@@ -907,18 +901,8 @@ public class MetadataCreateIndexService {
         indexSettingsBuilder.put(IndexMetadata.SETTING_INDEX_PROVIDED_NAME, request.getProvidedName());
         indexSettingsBuilder.put(SETTING_INDEX_UUID, UUIDs.randomBase64UUID());
 
-        if (isSystemIndex || IndexMetadata.INDEX_HIDDEN_SETTING.get(request.settings())) {
-            logger.warn(
-                "Setting replication.type: DOCUMENT will be used for Index until Segment Replication supports System and Hidden indices"
-            );
-            indexSettingsBuilder.put(SETTING_REPLICATION_TYPE, ReplicationType.DOCUMENT);
-            if (FeatureFlags.isEnabled(REMOTE_STORE)) {
-                indexSettingsBuilder.put(SETTING_REMOTE_STORE_ENABLED, false);
-            }
-        } else {
-            updateReplicationStrategy(indexSettingsBuilder, request.settings(), settings);
-            updateRemoteStoreSettings(indexSettingsBuilder, request.settings(), settings);
-        }
+        updateReplicationStrategy(indexSettingsBuilder, request.settings(), settings);
+        updateRemoteStoreSettings(indexSettingsBuilder, request.settings(), settings);
 
         if (sourceMetadata != null) {
             assert request.resizeType() != null;

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -826,8 +826,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
             Settings.EMPTY,
             IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
             randomShardLimitService(),
-            Collections.emptySet(),
-            false
+            Collections.emptySet()
         );
 
         assertThat(aggregatedIndexSettings.get("template_setting"), equalTo("value1"));
@@ -889,8 +888,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
             Settings.EMPTY,
             IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
             randomShardLimitService(),
-            Collections.emptySet(),
-            false
+            Collections.emptySet()
         );
 
         assertThat(resolvedAliases.get(0).getSearchRouting(), equalTo("fromRequest"));
@@ -912,8 +910,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
             Settings.EMPTY,
             IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
             randomShardLimitService(),
-            Collections.emptySet(),
-            false
+            Collections.emptySet()
         );
 
         assertThat(aggregatedIndexSettings.get(SETTING_NUMBER_OF_SHARDS), equalTo("1"));
@@ -928,8 +925,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
             Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 15).build(),
             IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
             randomShardLimitService(),
-            Collections.emptySet(),
-            false
+            Collections.emptySet()
         );
 
         assertThat(aggregatedIndexSettings.get(SETTING_NUMBER_OF_SHARDS), equalTo("15"));
@@ -966,8 +962,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
             Settings.EMPTY,
             IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
             randomShardLimitService(),
-            Collections.emptySet(),
-            false
+            Collections.emptySet()
         );
         List<AliasMetadata> resolvedAliases = resolveAndValidateAliases(
             request.index(),
@@ -1006,8 +1001,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
             Settings.EMPTY,
             IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
             randomShardLimitService(),
-            Collections.emptySet(),
-            false
+            Collections.emptySet()
         );
 
         assertThat(aggregatedIndexSettings.get("templateSetting"), is(nullValue()));
@@ -1229,8 +1223,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
                 settings,
                 IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
                 randomShardLimitService(),
-                Collections.emptySet(),
-                false
+                Collections.emptySet()
             )
         );
         assertThat(
@@ -1261,8 +1254,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
             settings,
             IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
             randomShardLimitService(),
-            Collections.emptySet(),
-            false
+            Collections.emptySet()
         );
         verifyRemoteStoreIndexSettings(
             indexSettings,
@@ -1294,8 +1286,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
             settings,
             IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
             randomShardLimitService(),
-            Collections.emptySet(),
-            false
+            Collections.emptySet()
         );
         verifyRemoteStoreIndexSettings(
             indexSettings,
@@ -1329,8 +1320,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
             settings,
             IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
             randomShardLimitService(),
-            Collections.emptySet(),
-            false
+            Collections.emptySet()
         );
         verifyRemoteStoreIndexSettings(
             indexSettings,
@@ -1364,8 +1354,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
             settings,
             IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
             randomShardLimitService(),
-            Collections.emptySet(),
-            false
+            Collections.emptySet()
         );
         verifyRemoteStoreIndexSettings(
             indexSettings,
@@ -1402,8 +1391,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
             settings,
             IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
             randomShardLimitService(),
-            Collections.emptySet(),
-            false
+            Collections.emptySet()
         );
         verifyRemoteStoreIndexSettings(
             indexSettings,
@@ -1437,8 +1425,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
             settings,
             IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
             randomShardLimitService(),
-            Collections.emptySet(),
-            false
+            Collections.emptySet()
         );
         verifyRemoteStoreIndexSettings(
             indexSettings,
@@ -1472,8 +1459,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
             settings,
             IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
             randomShardLimitService(),
-            Collections.emptySet(),
-            false
+            Collections.emptySet()
         );
         verifyRemoteStoreIndexSettings(
             indexSettings,
@@ -1555,8 +1541,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
                 Settings.EMPTY,
                 IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
                 randomShardLimitService(),
-                Collections.emptySet(),
-                false
+                Collections.emptySet()
             );
         });
         assertThat(
@@ -1585,8 +1570,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
             Settings.EMPTY,
             IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
             randomShardLimitService(),
-            Collections.emptySet(),
-            false
+            Collections.emptySet()
         );
         assertWarnings(
             "Translog retention settings [index.translog.retention.age] "
@@ -1633,8 +1617,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
             Settings.EMPTY,
             IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
             randomShardLimitService(),
-            Collections.emptySet(),
-            false
+            Collections.emptySet()
         );
         assertWarnings(
             "[simplefs] is deprecated and will be removed in 2.0. Use [niofs], which offers equal "
@@ -1653,8 +1636,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
             settings,
             IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
             randomShardLimitService(),
-            Collections.emptySet(),
-            false
+            Collections.emptySet()
         );
         assertEquals(ReplicationType.SEGMENT.toString(), indexSettings.get(SETTING_REPLICATION_TYPE));
     }
@@ -1674,82 +1656,9 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
             settings,
             IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
             randomShardLimitService(),
-            Collections.emptySet(),
-            false
+            Collections.emptySet()
         );
         // Verify if index setting overrides cluster replication setting
-        assertEquals(ReplicationType.DOCUMENT.toString(), indexSettings.get(SETTING_REPLICATION_TYPE));
-    }
-
-    public void testHiddenIndexUsesDocumentReplication() {
-        Settings settings = Settings.builder().put(CLUSTER_REPLICATION_TYPE_SETTING.getKey(), ReplicationType.SEGMENT).build();
-        request = new CreateIndexClusterStateUpdateRequest("create index", "test", "test");
-        final Settings.Builder requestSettings = Settings.builder();
-        // Set index setting replication type as DOCUMENT
-        requestSettings.put("index.hidden", true);
-        request.settings(requestSettings.build());
-        Settings indexSettings = aggregateIndexSettings(
-            ClusterState.EMPTY_STATE,
-            request,
-            Settings.EMPTY,
-            null,
-            settings,
-            IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
-            randomShardLimitService(),
-            Collections.emptySet(),
-            false
-        );
-        // Verify replication type is Document Replication
-        assertEquals(ReplicationType.DOCUMENT.toString(), indexSettings.get(SETTING_REPLICATION_TYPE));
-    }
-
-    public void testSystemIndexUsesDocumentReplication() {
-        Settings settings = Settings.builder().put(CLUSTER_REPLICATION_TYPE_SETTING.getKey(), ReplicationType.SEGMENT).build();
-        request = new CreateIndexClusterStateUpdateRequest("create index", "test", "test");
-        final Settings.Builder requestSettings = Settings.builder();
-        request.settings(requestSettings.build());
-        // set isSystemIndex parameter as true
-        Settings indexSettings = aggregateIndexSettings(
-            ClusterState.EMPTY_STATE,
-            request,
-            Settings.EMPTY,
-            null,
-            settings,
-            IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
-            randomShardLimitService(),
-            Collections.emptySet(),
-            true
-        );
-        // Verify replication type is Document Replication
-        assertEquals(ReplicationType.DOCUMENT.toString(), indexSettings.get(SETTING_REPLICATION_TYPE));
-    }
-
-    public void testRemoteStoreDisabledForSystemIndices() {
-        Settings settings = Settings.builder()
-            .put(CLUSTER_REPLICATION_TYPE_SETTING.getKey(), ReplicationType.SEGMENT)
-            .put(CLUSTER_REMOTE_STORE_ENABLED_SETTING.getKey(), true)
-            .put(CLUSTER_REMOTE_STORE_REPOSITORY_SETTING.getKey(), "my-segment-repo-1")
-            .put(CLUSTER_REMOTE_TRANSLOG_STORE_ENABLED_SETTING.getKey(), true)
-            .put(CLUSTER_REMOTE_TRANSLOG_REPOSITORY_SETTING.getKey(), "my-translog-repo-1")
-            .build();
-        FeatureFlagSetter.set(FeatureFlags.REMOTE_STORE);
-        request = new CreateIndexClusterStateUpdateRequest("create index", "test", "test");
-        final Settings.Builder requestSettings = Settings.builder();
-        request.settings(requestSettings.build());
-        // set isSystemIndex parameter as true
-        Settings indexSettings = aggregateIndexSettings(
-            ClusterState.EMPTY_STATE,
-            request,
-            Settings.EMPTY,
-            null,
-            settings,
-            IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
-            randomShardLimitService(),
-            Collections.emptySet(),
-            true
-        );
-        // Verify that remote store is disabled.
-        assertEquals(indexSettings.get(SETTING_REMOTE_STORE_ENABLED), "false");
         assertEquals(ReplicationType.DOCUMENT.toString(), indexSettings.get(SETTING_REPLICATION_TYPE));
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR backports #8200 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
