### PR TITLE
Default to mmapfs within hybridfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `aws-actions/configure-aws-credentials` from 1 to 2 ([#9302](https://github.com/opensearch-project/OpenSearch/pull/9302))
 
 ### Changed
+- Default to mmapfs within hybridfs ([#8508](https://github.com/opensearch-project/OpenSearch/pull/8508))
 - Perform aggregation postCollection in ContextIndexSearcher after searching leaves ([#8303](https://github.com/opensearch-project/OpenSearch/pull/8303))
 - Make Span exporter configurable ([#8620](https://github.com/opensearch-project/OpenSearch/issues/8620))
 - Change InternalSignificantTerms to sum shard-level superset counts only in final reduce ([#8735](https://github.com/opensearch-project/OpenSearch/pull/8735))

--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -183,6 +183,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 IndexModule.INDEX_STORE_TYPE_SETTING,
                 IndexModule.INDEX_STORE_PRE_LOAD_SETTING,
                 IndexModule.INDEX_STORE_HYBRID_MMAP_EXTENSIONS,
+                IndexModule.INDEX_STORE_HYBRID_NIO_EXTENSIONS,
                 IndexModule.INDEX_RECOVERY_TYPE_SETTING,
                 IndexModule.INDEX_QUERY_CACHE_ENABLED_SETTING,
                 FsDirectoryFactory.INDEX_LOCK_FACTOR_SETTING,

--- a/server/src/main/java/org/opensearch/index/IndexModule.java
+++ b/server/src/main/java/org/opensearch/index/IndexModule.java
@@ -166,6 +166,35 @@ public final class IndexModule {
         "index.store.hybrid.mmap.extensions",
         List.of("nvd", "dvd", "tim", "tip", "dim", "kdd", "kdi", "cfs", "doc"),
         Function.identity(),
+        new Setting.Validator<List<String>>() {
+
+            @Override
+            public void validate(final List<String> value) {}
+
+            @Override
+            public void validate(final List<String> value, final Map<Setting<?>, Object> settings) {
+                if (value.equals(INDEX_STORE_HYBRID_MMAP_EXTENSIONS.getDefault(Settings.EMPTY)) == false) {
+                    final List<String> nioExtensions = (List<String>) settings.get(INDEX_STORE_HYBRID_NIO_EXTENSIONS);
+                    final List<String> defaultNioExtensions = INDEX_STORE_HYBRID_NIO_EXTENSIONS.getDefault(Settings.EMPTY);
+                    if (nioExtensions.equals(defaultNioExtensions) == false) {
+                        throw new IllegalArgumentException(
+                            "Settings "
+                                + INDEX_STORE_HYBRID_NIO_EXTENSIONS.getKey()
+                                + " & "
+                                + INDEX_STORE_HYBRID_MMAP_EXTENSIONS.getKey()
+                                + " cannot both be set. Use "
+                                + INDEX_STORE_HYBRID_NIO_EXTENSIONS.getKey()
+                                + " only."
+                        );
+                    }
+                }
+            }
+
+            @Override
+            public Iterator<Setting<?>> settings() {
+                return List.<Setting<?>>of(INDEX_STORE_HYBRID_NIO_EXTENSIONS).iterator();
+            }
+        },
         Property.IndexScope,
         Property.NodeScope
     );
@@ -176,7 +205,25 @@ public final class IndexModule {
      */
     public static final Setting<List<String>> INDEX_STORE_HYBRID_NIO_EXTENSIONS = Setting.listSetting(
         "index.store.hybrid.nio.extensions",
-        Collections.emptyList(),
+        List.of(
+            "segments_N",
+            "write.lock",
+            "si",
+            "cfe",
+            "fnm",
+            "fdx",
+            "fdt",
+            "pos",
+            "pay",
+            "nvm",
+            "dvm",
+            "tvx",
+            "tvd",
+            "liv",
+            "dii",
+            "vec",
+            "vem"
+        ),
         Function.identity(),
         new Setting.Validator<List<String>>() {
 
@@ -185,10 +232,10 @@ public final class IndexModule {
 
             @Override
             public void validate(final List<String> value, final Map<Setting<?>, Object> settings) {
-                if (!value.isEmpty()) {
+                if (value.equals(INDEX_STORE_HYBRID_NIO_EXTENSIONS.getDefault(Settings.EMPTY)) == false) {
                     final List<String> mmapExtensions = (List<String>) settings.get(INDEX_STORE_HYBRID_MMAP_EXTENSIONS);
                     final List<String> defaultMmapExtensions = INDEX_STORE_HYBRID_MMAP_EXTENSIONS.getDefault(Settings.EMPTY);
-                    if (!mmapExtensions.equals(defaultMmapExtensions)) {
+                    if (mmapExtensions.equals(defaultMmapExtensions) == false) {
                         throw new IllegalArgumentException(
                             "Settings "
                                 + INDEX_STORE_HYBRID_NIO_EXTENSIONS.getKey()

--- a/server/src/main/java/org/opensearch/index/IndexModule.java
+++ b/server/src/main/java/org/opensearch/index/IndexModule.java
@@ -159,7 +159,7 @@ public final class IndexModule {
      *  This is an expert setting.
      *  @see <a href="https://lucene.apache.org/core/9_5_0/core/org/apache/lucene/codecs/lucene95/package-summary.html#file-names">Lucene File Extensions</a>.
      *
-     * @deprecated This setting will be removed in OpenSearch 4.x. Use {@link #INDEX_STORE_HYBRID_NIO_EXTENSIONS} instead.
+     * @deprecated This setting will be removed in OpenSearch 3.x. Use {@link #INDEX_STORE_HYBRID_NIO_EXTENSIONS} instead.
      */
     @Deprecated
     public static final Setting<List<String>> INDEX_STORE_HYBRID_MMAP_EXTENSIONS = Setting.listSetting(
@@ -196,7 +196,8 @@ public final class IndexModule {
             }
         },
         Property.IndexScope,
-        Property.NodeScope
+        Property.NodeScope,
+        Property.Deprecated
     );
 
     /** Which lucene file extensions to load with nio. All others will default to mmap. Takes precedence over {@link #INDEX_STORE_HYBRID_MMAP_EXTENSIONS}.

--- a/server/src/main/java/org/opensearch/index/IndexModule.java
+++ b/server/src/main/java/org/opensearch/index/IndexModule.java
@@ -187,7 +187,8 @@ public final class IndexModule {
             public void validate(final List<String> value, final Map<Setting<?>, Object> settings) {
                 if (!value.isEmpty()) {
                     final List<String> mmapExtensions = (List<String>) settings.get(INDEX_STORE_HYBRID_MMAP_EXTENSIONS);
-                    if (!mmapExtensions.equals(List.of("nvd", "dvd", "tim", "tip", "dim", "kdd", "kdi", "cfs", "doc"))) {
+                    final List<String> defaultMmapExtensions = INDEX_STORE_HYBRID_MMAP_EXTENSIONS.getDefault(Settings.EMPTY);
+                    if (!mmapExtensions.equals(defaultMmapExtensions)) {
                         throw new IllegalArgumentException(
                             "Settings "
                                 + INDEX_STORE_HYBRID_NIO_EXTENSIONS.getKey()
@@ -203,8 +204,7 @@ public final class IndexModule {
 
             @Override
             public Iterator<Setting<?>> settings() {
-                final List<Setting<?>> settings = Collections.singletonList(INDEX_STORE_HYBRID_MMAP_EXTENSIONS);
-                return settings.iterator();
+                return List.<Setting<?>>of(INDEX_STORE_HYBRID_MMAP_EXTENSIONS).iterator();
             }
         },
         Property.IndexScope,

--- a/server/src/main/java/org/opensearch/index/IndexModule.java
+++ b/server/src/main/java/org/opensearch/index/IndexModule.java
@@ -154,13 +154,28 @@ public final class IndexModule {
         Property.NodeScope
     );
 
-    /** Which lucene file extensions to load with the mmap directory when using hybridfs store.
+    /** Which lucene file extensions to load with the mmap directory when using hybridfs store. This settings is ignored if {@link #INDEX_STORE_HYBRID_NIO_EXTENSIONS} is set.
      *  This is an expert setting.
-     *  @see <a href="https://lucene.apache.org/core/9_2_0/core/org/apache/lucene/codecs/lucene92/package-summary.html#file-names">Lucene File Extensions</a>.
+     *  @see <a href="https://lucene.apache.org/core/9_5_0/core/org/apache/lucene/codecs/lucene95/package-summary.html#file-names">Lucene File Extensions</a>.
+     *
+     * @deprecated This setting will be removed in OpenSearch 4.x. Use {@link #INDEX_STORE_HYBRID_NIO_EXTENSIONS} instead.
      */
+    @Deprecated
     public static final Setting<List<String>> INDEX_STORE_HYBRID_MMAP_EXTENSIONS = Setting.listSetting(
         "index.store.hybrid.mmap.extensions",
         List.of("nvd", "dvd", "tim", "tip", "dim", "kdd", "kdi", "cfs", "doc"),
+        Function.identity(),
+        Property.IndexScope,
+        Property.NodeScope
+    );
+
+    /** Which lucene file extensions to load with nio. All others will default to mmap. Takes precedence over {@link #INDEX_STORE_HYBRID_MMAP_EXTENSIONS}.
+     *  This is an expert setting.
+     *  @see <a href="https://lucene.apache.org/core/9_5_0/core/org/apache/lucene/codecs/lucene95/package-summary.html#file-names">Lucene File Extensions</a>.
+     */
+    public static final Setting<List<String>> INDEX_STORE_HYBRID_NIO_EXTENSIONS = Setting.listSetting(
+        "index.store.hybrid.nio.extensions",
+        Collections.emptyList(),
         Function.identity(),
         Property.IndexScope,
         Property.NodeScope

--- a/server/src/main/java/org/opensearch/index/IndexModule.java
+++ b/server/src/main/java/org/opensearch/index/IndexModule.java
@@ -95,6 +95,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
 import java.util.function.BooleanSupplier;
@@ -177,6 +178,35 @@ public final class IndexModule {
         "index.store.hybrid.nio.extensions",
         Collections.emptyList(),
         Function.identity(),
+        new Setting.Validator<List<String>>() {
+
+            @Override
+            public void validate(final List<String> value) {}
+
+            @Override
+            public void validate(final List<String> value, final Map<Setting<?>, Object> settings) {
+                if (!value.isEmpty()) {
+                    final List<String> mmapExtensions = (List<String>) settings.get(INDEX_STORE_HYBRID_MMAP_EXTENSIONS);
+                    if (!mmapExtensions.equals(List.of("nvd", "dvd", "tim", "tip", "dim", "kdd", "kdi", "cfs", "doc"))) {
+                        throw new IllegalArgumentException(
+                            "Settings "
+                                + INDEX_STORE_HYBRID_NIO_EXTENSIONS.getKey()
+                                + " & "
+                                + INDEX_STORE_HYBRID_MMAP_EXTENSIONS.getKey()
+                                + " cannot both be set. Use "
+                                + INDEX_STORE_HYBRID_NIO_EXTENSIONS.getKey()
+                                + " only."
+                        );
+                    }
+                }
+            }
+
+            @Override
+            public Iterator<Setting<?>> settings() {
+                final List<Setting<?>> settings = Collections.singletonList(INDEX_STORE_HYBRID_MMAP_EXTENSIONS);
+                return settings.iterator();
+            }
+        },
         Property.IndexScope,
         Property.NodeScope
     );

--- a/server/src/main/java/org/opensearch/index/store/FsDirectoryFactory.java
+++ b/server/src/main/java/org/opensearch/index/store/FsDirectoryFactory.java
@@ -55,7 +55,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -100,11 +99,9 @@ public class FsDirectoryFactory implements IndexStorePlugin.DirectoryFactory {
                 // Use Lucene defaults
                 final FSDirectory primaryDirectory = FSDirectory.open(location, lockFactory);
                 Set<String> nioExtensions = new HashSet<>(indexSettings.getValue(IndexModule.INDEX_STORE_HYBRID_NIO_EXTENSIONS));
-                final List<String> mmapExtensions = new ArrayList<>(indexSettings.getValue(IndexModule.INDEX_STORE_HYBRID_MMAP_EXTENSIONS));
                 if (nioExtensions.isEmpty()) {
-                    List<String> allExtensions = new ArrayList<>(INDEX_STORE_HYBRID_ALL_EXTENSIONS);
-                    allExtensions.removeAll(mmapExtensions);
-                    nioExtensions = new HashSet<>(allExtensions);
+                    nioExtensions.addAll(INDEX_STORE_HYBRID_ALL_EXTENSIONS);
+                    nioExtensions.removeAll(indexSettings.getValue(IndexModule.INDEX_STORE_HYBRID_MMAP_EXTENSIONS));
                 }
                 if (primaryDirectory instanceof MMapDirectory) {
                     MMapDirectory mMapDirectory = (MMapDirectory) primaryDirectory;

--- a/server/src/main/java/org/opensearch/index/store/FsDirectoryFactory.java
+++ b/server/src/main/java/org/opensearch/index/store/FsDirectoryFactory.java
@@ -44,6 +44,7 @@ import org.apache.lucene.store.NIOFSDirectory;
 import org.apache.lucene.store.NativeFSLockFactory;
 import org.apache.lucene.store.SimpleFSLockFactory;
 import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.index.IndexModule;
@@ -99,8 +100,9 @@ public class FsDirectoryFactory implements IndexStorePlugin.DirectoryFactory {
                 // Use Lucene defaults
                 final FSDirectory primaryDirectory = FSDirectory.open(location, lockFactory);
                 Set<String> nioExtensions = new HashSet<>(indexSettings.getValue(IndexModule.INDEX_STORE_HYBRID_NIO_EXTENSIONS));
-                if (nioExtensions.isEmpty()) {
-                    nioExtensions.addAll(INDEX_STORE_HYBRID_ALL_EXTENSIONS);
+                if (indexSettings.getValue(IndexModule.INDEX_STORE_HYBRID_MMAP_EXTENSIONS)
+                    .equals(IndexModule.INDEX_STORE_HYBRID_MMAP_EXTENSIONS.getDefault(Settings.EMPTY)) == false) {
+                    nioExtensions = new HashSet<>(INDEX_STORE_HYBRID_ALL_EXTENSIONS);
                     nioExtensions.removeAll(indexSettings.getValue(IndexModule.INDEX_STORE_HYBRID_MMAP_EXTENSIONS));
                 }
                 if (primaryDirectory instanceof MMapDirectory) {
@@ -174,7 +176,7 @@ public class FsDirectoryFactory implements IndexStorePlugin.DirectoryFactory {
 
         boolean useDelegate(String name) {
             final String extension = FileSwitchDirectory.getExtension(name);
-            return !nioExtensions.contains(extension);
+            return nioExtensions.contains(extension) == false;
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/index/store/FsDirectoryFactory.java
+++ b/server/src/main/java/org/opensearch/index/store/FsDirectoryFactory.java
@@ -105,12 +105,6 @@ public class FsDirectoryFactory implements IndexStorePlugin.DirectoryFactory {
                     List<String> allExtensions = new ArrayList<>(INDEX_STORE_HYBRID_ALL_EXTENSIONS);
                     allExtensions.removeAll(mmapExtensions);
                     nioExtensions = new HashSet<>(allExtensions);
-                } else {
-                    if (!mmapExtensions.equals(List.of("nvd", "dvd", "tim", "tip", "dim", "kdd", "kdi", "cfs", "doc"))) {
-                        throw new IllegalArgumentException(
-                            "INDEX_STORE_HYBRID_MMAP_EXTENSIONS and INDEX_STORE_HYBRID_NIO_EXTENSIONS are both defined. Use INDEX_STORE_HYBRID_NIO_EXTENSIONS only"
-                        );
-                    }
                 }
                 if (primaryDirectory instanceof MMapDirectory) {
                     MMapDirectory mMapDirectory = (MMapDirectory) primaryDirectory;

--- a/server/src/main/java/org/opensearch/index/store/FsDirectoryFactory.java
+++ b/server/src/main/java/org/opensearch/index/store/FsDirectoryFactory.java
@@ -56,8 +56,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Factory for a filesystem directory
@@ -102,7 +103,10 @@ public class FsDirectoryFactory implements IndexStorePlugin.DirectoryFactory {
                 Set<String> nioExtensions = new HashSet<>(indexSettings.getValue(IndexModule.INDEX_STORE_HYBRID_NIO_EXTENSIONS));
                 if (indexSettings.getValue(IndexModule.INDEX_STORE_HYBRID_MMAP_EXTENSIONS)
                     .equals(IndexModule.INDEX_STORE_HYBRID_MMAP_EXTENSIONS.getDefault(Settings.EMPTY)) == false) {
-                    nioExtensions = new HashSet<>(INDEX_STORE_HYBRID_ALL_EXTENSIONS);
+                    nioExtensions = Stream.concat(
+                        IndexModule.INDEX_STORE_HYBRID_NIO_EXTENSIONS.getDefault(Settings.EMPTY).stream(),
+                        IndexModule.INDEX_STORE_HYBRID_MMAP_EXTENSIONS.getDefault(Settings.EMPTY).stream()
+                    ).collect(Collectors.toSet());
                     nioExtensions.removeAll(indexSettings.getValue(IndexModule.INDEX_STORE_HYBRID_MMAP_EXTENSIONS));
                 }
                 if (primaryDirectory instanceof MMapDirectory) {
@@ -239,33 +243,4 @@ public class FsDirectoryFactory implements IndexStorePlugin.DirectoryFactory {
             return delegate;
         }
     }
-
-    private static List<String> INDEX_STORE_HYBRID_ALL_EXTENSIONS = List.of(
-        "nvd", // mmap defaults start
-        "dvd",
-        "tim",
-        "tip",
-        "dim",
-        "kdd",
-        "kdi",
-        "cfs",
-        "doc", // mmap defaults end
-        "segments_N", // nio defaults start
-        "write.lock",
-        "si",
-        "cfe",
-        "fnm",
-        "fdx",
-        "fdt",
-        "pos",
-        "pay",
-        "nvm",
-        "dvm",
-        "tvx",
-        "tvd",
-        "liv",
-        "dii",
-        "vec",
-        "vem" // nio defaults end
-    );
 }

--- a/server/src/test/java/org/opensearch/index/store/FsDirectoryFactoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/FsDirectoryFactoryTests.java
@@ -154,8 +154,8 @@ public class FsDirectoryFactoryTests extends OpenSearchTestCase {
             newDirectory(build);
         } catch (final Exception e) {
             assertEquals(
-                e.getMessage(),
-                "INDEX_STORE_HYBRID_MMAP_EXTENSIONS and INDEX_STORE_HYBRID_NIO_EXTENSIONS are both defined. Use INDEX_STORE_HYBRID_NIO_EXTENSIONS only"
+                "Settings index.store.hybrid.nio.extensions & index.store.hybrid.mmap.extensions cannot both be set. Use index.store.hybrid.nio.extensions only.",
+                e.getMessage()
             );
         }
     }

--- a/server/src/test/java/org/opensearch/index/store/FsDirectoryFactoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/FsDirectoryFactoryTests.java
@@ -147,6 +147,10 @@ public class FsDirectoryFactoryTests extends OpenSearchTestCase {
             assertFalse(hybridDirectory.useDelegate("foo.doc"));
             MMapDirectory delegate = hybridDirectory.getDelegate();
             assertThat(delegate, Matchers.instanceOf(FsDirectoryFactory.PreLoadMMapDirectory.class));
+            assertWarnings(
+                "[index.store.hybrid.mmap.extensions] setting was deprecated in OpenSearch and will be removed in a future release!"
+                    + " See the breaking changes documentation for the next major version."
+            );
         }
         build = Settings.builder()
             .put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), IndexModule.Type.HYBRIDFS.name().toLowerCase(Locale.ROOT))


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Currently OpenSearch code contains an explicit list of file extensions which load using mmap from hybridfs. Other file extensions default to nio. This PR flips the logic to keep a list of nio file extensions while all others default to mmap. This will prevent any future regressions in case Lucene adds new segment file type that should be using mmap.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/8297

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
