### PR TITLE
[Backport 2.x] [Search Pipelines] Adding the SearchPhaseResultsProcessor interface in Search Pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 2.x]
 ### Added
+- [SearchPipeline] Add new search pipeline processor type, SearchPhaseResultsProcessor, that can modify the result of one search phase before starting the next phase.([#7283](https://github.com/opensearch-project/OpenSearch/pull/7283))
 - Add task cancellation monitoring service ([#7642](https://github.com/opensearch-project/OpenSearch/pull/7642))
 - Add TokenManager Interface ([#7452](https://github.com/opensearch-project/OpenSearch/pull/7452))
 - Add Remote store as a segment replication source ([#7653](https://github.com/opensearch-project/OpenSearch/pull/7653))

--- a/modules/search-pipeline-common/src/yamlRestTest/resources/rest-api-spec/test/search_pipeline/50_script_processor.yml
+++ b/modules/search-pipeline-common/src/yamlRestTest/resources/rest-api-spec/test/search_pipeline/50_script_processor.yml
@@ -39,7 +39,7 @@ teardown:
               {
                 "script" : {
                   "lang" : "painless",
-                  "source" : "ctx._source['size'] += 10; ctx._source['from'] -= 1; ctx._source['explain'] = !ctx._source['explain']; ctx._source['version'] = !ctx._source['version']; ctx._source['seq_no_primary_term'] = !ctx._source['seq_no_primary_term']; ctx._source['track_scores'] = !ctx._source['track_scores']; ctx._source['track_total_hits'] = 1; ctx._source['min_score'] -= 0.9; ctx._source['terminate_after'] += 2; ctx._source['profile'] = !ctx._source['profile'];"
+                  "source" : "ctx._source['size'] += 10; ctx._source['from'] = ctx._source['from'] <= 0 ? ctx._source['from'] : ctx._source['from'] - 1 ; ctx._source['explain'] = !ctx._source['explain']; ctx._source['version'] = !ctx._source['version']; ctx._source['seq_no_primary_term'] = !ctx._source['seq_no_primary_term']; ctx._source['track_scores'] = !ctx._source['track_scores']; ctx._source['track_total_hits'] = 1; ctx._source['min_score'] -= 0.9; ctx._source['terminate_after'] += 2; ctx._source['profile'] = !ctx._source['profile'];"
                 }
               }
             ]

--- a/server/src/main/java/org/opensearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/opensearch/action/search/AbstractSearchAsyncAction.java
@@ -57,6 +57,7 @@ import org.opensearch.search.internal.AliasFilter;
 import org.opensearch.search.internal.InternalSearchResponse;
 import org.opensearch.search.internal.SearchContext;
 import org.opensearch.search.internal.ShardSearchRequest;
+import org.opensearch.search.pipeline.PipelinedRequest;
 import org.opensearch.transport.Transport;
 
 import java.util.ArrayDeque;
@@ -696,7 +697,11 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
      * @see #onShardResult(SearchPhaseResult, SearchShardIterator)
      */
     final void onPhaseDone() {  // as a tribute to @kimchy aka. finishHim()
-        executeNextPhase(this, getNextPhase(results, this));
+        final SearchPhase nextPhase = getNextPhase(results, this);
+        if (request instanceof PipelinedRequest && nextPhase != null) {
+            ((PipelinedRequest) request).transformSearchPhaseResults(results, this, this.getName(), nextPhase.getName());
+        }
+        executeNextPhase(this, nextPhase);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/search/ArraySearchPhaseResults.java
+++ b/server/src/main/java/org/opensearch/action/search/ArraySearchPhaseResults.java
@@ -66,7 +66,7 @@ class ArraySearchPhaseResults<Result extends SearchPhaseResult> extends SearchPh
     }
 
     @Override
-    AtomicArray<Result> getAtomicArray() {
+    public AtomicArray<Result> getAtomicArray() {
         return results;
     }
 }

--- a/server/src/main/java/org/opensearch/action/search/CanMatchPreFilterSearchPhase.java
+++ b/server/src/main/java/org/opensearch/action/search/CanMatchPreFilterSearchPhase.java
@@ -94,7 +94,7 @@ final class CanMatchPreFilterSearchPhase extends AbstractSearchAsyncAction<CanMa
     ) {
         // We set max concurrent shard requests to the number of shards so no throttling happens for can_match requests
         super(
-            "can_match",
+            SearchPhaseName.CAN_MATCH.getName(),
             logger,
             searchTransportService,
             nodeIdToConnection,

--- a/server/src/main/java/org/opensearch/action/search/DfsQueryPhase.java
+++ b/server/src/main/java/org/opensearch/action/search/DfsQueryPhase.java
@@ -69,7 +69,7 @@ final class DfsQueryPhase extends SearchPhase {
         Function<ArraySearchPhaseResults<SearchPhaseResult>, SearchPhase> nextPhaseFactory,
         SearchPhaseContext context
     ) {
-        super("dfs_query");
+        super(SearchPhaseName.DFS_QUERY.getName());
         this.progressListener = context.getTask().getProgressListener();
         this.queryResult = queryResult;
         this.searchResults = searchResults;

--- a/server/src/main/java/org/opensearch/action/search/ExpandSearchPhase.java
+++ b/server/src/main/java/org/opensearch/action/search/ExpandSearchPhase.java
@@ -62,7 +62,7 @@ final class ExpandSearchPhase extends SearchPhase {
     private final AtomicArray<SearchPhaseResult> queryResults;
 
     ExpandSearchPhase(SearchPhaseContext context, InternalSearchResponse searchResponse, AtomicArray<SearchPhaseResult> queryResults) {
-        super("expand");
+        super(SearchPhaseName.EXPAND.getName());
         this.context = context;
         this.searchResponse = searchResponse;
         this.queryResults = queryResults;

--- a/server/src/main/java/org/opensearch/action/search/FetchSearchPhase.java
+++ b/server/src/main/java/org/opensearch/action/search/FetchSearchPhase.java
@@ -92,7 +92,7 @@ final class FetchSearchPhase extends SearchPhase {
         SearchPhaseContext context,
         BiFunction<InternalSearchResponse, AtomicArray<SearchPhaseResult>, SearchPhase> nextPhaseFactory
     ) {
-        super("fetch");
+        super(SearchPhaseName.FETCH.getName());
         if (context.getNumShards() != resultConsumer.getNumShards()) {
             throw new IllegalStateException(
                 "number of shards must match the length of the query results but doesn't:"

--- a/server/src/main/java/org/opensearch/action/search/SearchPhase.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchPhase.java
@@ -34,6 +34,7 @@ package org.opensearch.action.search;
 import org.opensearch.common.CheckedRunnable;
 
 import java.io.IOException;
+import java.util.Locale;
 import java.util.Objects;
 
 /**
@@ -53,5 +54,14 @@ abstract class SearchPhase implements CheckedRunnable<IOException> {
      */
     public String getName() {
         return name;
+    }
+
+    /**
+     * Returns the SearchPhase name as {@link SearchPhaseName}. Exception will come if SearchPhase name is not defined
+     * in {@link SearchPhaseName}
+     * @return {@link SearchPhaseName}
+     */
+    public SearchPhaseName getSearchPhaseName() {
+        return SearchPhaseName.valueOf(name.toUpperCase(Locale.ROOT));
     }
 }

--- a/server/src/main/java/org/opensearch/action/search/SearchPhaseContext.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchPhaseContext.java
@@ -50,7 +50,7 @@ import java.util.concurrent.Executor;
  *
  * @opensearch.internal
  */
-interface SearchPhaseContext extends Executor {
+public interface SearchPhaseContext extends Executor {
     // TODO maybe we can make this concrete later - for now we just implement this in the base class for all initial phases
 
     /**

--- a/server/src/main/java/org/opensearch/action/search/SearchPhaseName.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchPhaseName.java
@@ -1,0 +1,31 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.search;
+
+/**
+ * Enum for different Search Phases in OpenSearch
+ * @opensearch.internal
+ */
+public enum SearchPhaseName {
+    QUERY("query"),
+    FETCH("fetch"),
+    DFS_QUERY("dfs_query"),
+    EXPAND("expand"),
+    CAN_MATCH("can_match");
+
+    private final String name;
+
+    SearchPhaseName(final String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/server/src/main/java/org/opensearch/action/search/SearchPhaseResults.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchPhaseResults.java
@@ -42,7 +42,7 @@ import java.util.stream.Stream;
  *
  * @opensearch.internal
  */
-abstract class SearchPhaseResults<Result extends SearchPhaseResult> {
+public abstract class SearchPhaseResults<Result extends SearchPhaseResult> {
     private final int numShards;
 
     SearchPhaseResults(int numShards) {
@@ -75,7 +75,13 @@ abstract class SearchPhaseResults<Result extends SearchPhaseResult> {
 
     void consumeShardFailure(int shardIndex) {}
 
-    AtomicArray<Result> getAtomicArray() {
+    /**
+     * Returns an {@link AtomicArray} of {@link Result}, which are nothing but the SearchPhaseResults
+     * for shards. The {@link Result} are of type {@link SearchPhaseResult}
+     *
+     * @return an {@link AtomicArray} of {@link Result}
+     */
+    public AtomicArray<Result> getAtomicArray() {
         throw new UnsupportedOperationException();
     }
 

--- a/server/src/main/java/org/opensearch/action/search/SearchScrollAsyncAction.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchScrollAsyncAction.java
@@ -266,7 +266,7 @@ abstract class SearchScrollAsyncAction<T extends SearchPhaseResult> implements R
         SearchPhaseController.ReducedQueryPhase queryPhase,
         final AtomicArray<? extends SearchPhaseResult> fetchResults
     ) {
-        return new SearchPhase("fetch") {
+        return new SearchPhase(SearchPhaseName.FETCH.getName()) {
             @Override
             public void run() throws IOException {
                 sendResponse(queryPhase, fetchResults);

--- a/server/src/main/java/org/opensearch/action/search/SearchScrollQueryThenFetchAsyncAction.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchScrollQueryThenFetchAsyncAction.java
@@ -92,7 +92,7 @@ final class SearchScrollQueryThenFetchAsyncAction extends SearchScrollAsyncActio
 
     @Override
     protected SearchPhase moveToNextPhase(BiFunction<String, String, DiscoveryNode> clusterNodeLookup) {
-        return new SearchPhase("fetch") {
+        return new SearchPhase(SearchPhaseName.FETCH.getName()) {
             @Override
             public void run() {
                 final SearchPhaseController.ReducedQueryPhase reducedQueryPhase = searchPhaseController.reducedScrollQueryPhase(

--- a/server/src/main/java/org/opensearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/opensearch/action/search/TransportSearchAction.java
@@ -390,13 +390,12 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
             relativeStartNanos,
             System::nanoTime
         );
-        SearchRequest searchRequest;
+        PipelinedRequest searchRequest;
         ActionListener<SearchResponse> listener;
         try {
-            PipelinedRequest pipelinedRequest = searchPipelineService.resolvePipeline(originalSearchRequest);
-            searchRequest = pipelinedRequest.transformedRequest();
+            searchRequest = searchPipelineService.resolvePipeline(originalSearchRequest);
             listener = ActionListener.wrap(
-                r -> originalListener.onResponse(pipelinedRequest.transformResponse(r)),
+                r -> originalListener.onResponse(searchRequest.transformResponse(r)),
                 originalListener::onFailure
             );
         } catch (Exception e) {

--- a/server/src/main/java/org/opensearch/plugins/SearchPipelinePlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/SearchPipelinePlugin.java
@@ -9,6 +9,7 @@
 package org.opensearch.plugins;
 
 import org.opensearch.search.pipeline.Processor;
+import org.opensearch.search.pipeline.SearchPhaseResultsProcessor;
 import org.opensearch.search.pipeline.SearchRequestProcessor;
 import org.opensearch.search.pipeline.SearchResponseProcessor;
 
@@ -40,6 +41,17 @@ public interface SearchPipelinePlugin {
      * to create the processor from a given pipeline configuration.
      */
     default Map<String, Processor.Factory<SearchResponseProcessor>> getResponseProcessors(Processor.Parameters parameters) {
+        return Collections.emptyMap();
+    }
+
+    /**
+     * Returns additional search pipeline search phase results processor types added by this plugin.
+     *
+     * The key of the returned {@link Map} is the unique name for the processor which is specified
+     * in pipeline configurations, and the value is a {@link org.opensearch.search.pipeline.Processor.Factory}
+     * to create the processor from a given pipeline configuration.
+     */
+    default Map<String, Processor.Factory<SearchPhaseResultsProcessor>> getSearchPhaseResultsProcessors(Processor.Parameters parameters) {
         return Collections.emptyMap();
     }
 }

--- a/server/src/main/java/org/opensearch/search/pipeline/PipelineWithMetrics.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/PipelineWithMetrics.java
@@ -43,12 +43,22 @@ class PipelineWithMetrics extends Pipeline {
         Integer version,
         List<SearchRequestProcessor> requestProcessors,
         List<SearchResponseProcessor> responseProcessors,
+        List<SearchPhaseResultsProcessor> phaseResultsProcessors,
         NamedWriteableRegistry namedWriteableRegistry,
         OperationMetrics totalRequestMetrics,
         OperationMetrics totalResponseMetrics,
         LongSupplier relativeTimeSupplier
     ) {
-        super(id, description, version, requestProcessors, responseProcessors, namedWriteableRegistry, relativeTimeSupplier);
+        super(
+            id,
+            description,
+            version,
+            requestProcessors,
+            responseProcessors,
+            phaseResultsProcessors,
+            namedWriteableRegistry,
+            relativeTimeSupplier
+        );
         this.totalRequestMetrics = totalRequestMetrics;
         this.totalResponseMetrics = totalResponseMetrics;
         for (Processor requestProcessor : getSearchRequestProcessors()) {
@@ -64,6 +74,7 @@ class PipelineWithMetrics extends Pipeline {
         Map<String, Object> config,
         Map<String, Processor.Factory<SearchRequestProcessor>> requestProcessorFactories,
         Map<String, Processor.Factory<SearchResponseProcessor>> responseProcessorFactories,
+        Map<String, Processor.Factory<SearchPhaseResultsProcessor>> phaseResultsProcessorFactories,
         NamedWriteableRegistry namedWriteableRegistry,
         OperationMetrics totalRequestProcessingMetrics,
         OperationMetrics totalResponseProcessingMetrics
@@ -79,6 +90,16 @@ class PipelineWithMetrics extends Pipeline {
             RESPONSE_PROCESSORS_KEY
         );
         List<SearchResponseProcessor> responseProcessors = readProcessors(responseProcessorFactories, responseProcessorConfigs);
+        List<Map<String, Object>> phaseResultsProcessorConfigs = ConfigurationUtils.readOptionalList(
+            null,
+            null,
+            config,
+            PHASE_PROCESSORS_KEY
+        );
+        List<SearchPhaseResultsProcessor> phaseResultsProcessors = readProcessors(
+            phaseResultsProcessorFactories,
+            phaseResultsProcessorConfigs
+        );
         if (config.isEmpty() == false) {
             throw new OpenSearchParseException(
                 "pipeline ["
@@ -93,6 +114,7 @@ class PipelineWithMetrics extends Pipeline {
             version,
             requestProcessors,
             responseProcessors,
+            phaseResultsProcessors,
             namedWriteableRegistry,
             totalRequestProcessingMetrics,
             totalResponseProcessingMetrics,

--- a/server/src/main/java/org/opensearch/search/pipeline/PipelinedRequest.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/PipelinedRequest.java
@@ -8,29 +8,36 @@
 
 package org.opensearch.search.pipeline;
 
+import org.opensearch.action.search.SearchPhaseContext;
+import org.opensearch.action.search.SearchPhaseResults;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.search.SearchPhaseResult;
 
 /**
  * Groups a search pipeline based on a request and the request after being transformed by the pipeline.
  *
  * @opensearch.internal
  */
-public final class PipelinedRequest {
+public final class PipelinedRequest extends SearchRequest {
     private final Pipeline pipeline;
-    private final SearchRequest transformedRequest;
 
     PipelinedRequest(Pipeline pipeline, SearchRequest transformedRequest) {
+        super(transformedRequest);
         this.pipeline = pipeline;
-        this.transformedRequest = transformedRequest;
     }
 
     public SearchResponse transformResponse(SearchResponse response) {
-        return pipeline.transformResponse(transformedRequest, response);
+        return pipeline.transformResponse(this, response);
     }
 
-    public SearchRequest transformedRequest() {
-        return transformedRequest;
+    public <Result extends SearchPhaseResult> void transformSearchPhaseResults(
+        final SearchPhaseResults<Result> searchPhaseResult,
+        final SearchPhaseContext searchPhaseContext,
+        final String currentPhase,
+        final String nextPhase
+    ) {
+        pipeline.runSearchPhaseResultsTransformer(searchPhaseResult, searchPhaseContext, currentPhase, nextPhase);
     }
 
     // Visible for testing

--- a/server/src/main/java/org/opensearch/search/pipeline/SearchPhaseResultsProcessor.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/SearchPhaseResultsProcessor.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.pipeline;
+
+import org.opensearch.action.search.SearchPhaseContext;
+import org.opensearch.action.search.SearchPhaseName;
+import org.opensearch.action.search.SearchPhaseResults;
+import org.opensearch.search.SearchPhaseResult;
+import org.opensearch.search.internal.SearchContext;
+
+/**
+ * Creates a processor that runs between Phases of the Search.
+ * @opensearch.api
+ */
+public interface SearchPhaseResultsProcessor extends Processor {
+
+    /**
+     * Processes the {@link SearchPhaseResults} obtained from a SearchPhase which will be returned to next
+     * SearchPhase.
+     * @param searchPhaseResult {@link SearchPhaseResults}
+     * @param searchPhaseContext {@link SearchContext}
+     * @param <Result> {@link SearchPhaseResult}
+     */
+    <Result extends SearchPhaseResult> void process(
+        final SearchPhaseResults<Result> searchPhaseResult,
+        final SearchPhaseContext searchPhaseContext
+    );
+
+    /**
+     * The phase which should have run before, this processor can start executing.
+     * @return {@link SearchPhaseName}
+     */
+    SearchPhaseName getBeforePhase();
+
+    /**
+     * The phase which should run after, this processor execution.
+     * @return {@link SearchPhaseName}
+     */
+    SearchPhaseName getAfterPhase();
+
+}

--- a/server/src/main/java/org/opensearch/search/pipeline/SearchPipelineService.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/SearchPipelineService.java
@@ -73,6 +73,7 @@ public class SearchPipelineService implements ClusterStateApplier, ReportingServ
     private final ScriptService scriptService;
     private final Map<String, Processor.Factory<SearchRequestProcessor>> requestProcessorFactories;
     private final Map<String, Processor.Factory<SearchResponseProcessor>> responseProcessorFactories;
+    private final Map<String, Processor.Factory<SearchPhaseResultsProcessor>> phaseInjectorProcessorFactories;
     private volatile Map<String, PipelineHolder> pipelines = Collections.emptyMap();
     private final ThreadPool threadPool;
     private final List<Consumer<ClusterState>> searchPipelineClusterStateListeners = new CopyOnWriteArrayList<>();
@@ -116,6 +117,10 @@ public class SearchPipelineService implements ClusterStateApplier, ReportingServ
         );
         this.requestProcessorFactories = processorFactories(searchPipelinePlugins, p -> p.getRequestProcessors(parameters));
         this.responseProcessorFactories = processorFactories(searchPipelinePlugins, p -> p.getResponseProcessors(parameters));
+        this.phaseInjectorProcessorFactories = processorFactories(
+            searchPipelinePlugins,
+            p -> p.getSearchPhaseResultsProcessors(parameters)
+        );
         putPipelineTaskKey = clusterService.registerClusterManagerTask(ClusterManagerTaskKeys.PUT_SEARCH_PIPELINE_KEY, true);
         deletePipelineTaskKey = clusterService.registerClusterManagerTask(ClusterManagerTaskKeys.DELETE_SEARCH_PIPELINE_KEY, true);
         this.isEnabled = isEnabled;
@@ -181,6 +186,7 @@ public class SearchPipelineService implements ClusterStateApplier, ReportingServ
                     newConfiguration.getConfigAsMap(),
                     requestProcessorFactories,
                     responseProcessorFactories,
+                    phaseInjectorProcessorFactories,
                     namedWriteableRegistry,
                     totalRequestProcessingMetrics,
                     totalResponseProcessingMetrics
@@ -280,6 +286,7 @@ public class SearchPipelineService implements ClusterStateApplier, ReportingServ
             pipelineConfig,
             requestProcessorFactories,
             responseProcessorFactories,
+            phaseInjectorProcessorFactories,
             namedWriteableRegistry,
             new OperationMetrics(), // Use ephemeral metrics for validation
             new OperationMetrics()
@@ -359,7 +366,7 @@ public class SearchPipelineService implements ClusterStateApplier, ReportingServ
         return newState.build();
     }
 
-    public PipelinedRequest resolvePipeline(SearchRequest searchRequest) throws Exception {
+    public PipelinedRequest resolvePipeline(SearchRequest searchRequest) {
         Pipeline pipeline = Pipeline.NO_OP_PIPELINE;
 
         if (isEnabled == false) {
@@ -378,6 +385,7 @@ public class SearchPipelineService implements ClusterStateApplier, ReportingServ
                     searchRequest.source().searchPipelineSource(),
                     requestProcessorFactories,
                     responseProcessorFactories,
+                    phaseInjectorProcessorFactories,
                     namedWriteableRegistry,
                     totalRequestProcessingMetrics,
                     totalResponseProcessingMetrics

--- a/server/src/test/java/org/opensearch/search/pipeline/SearchPipelineServiceTests.java
+++ b/server/src/test/java/org/opensearch/search/pipeline/SearchPipelineServiceTests.java
@@ -10,13 +10,22 @@ package org.opensearch.search.pipeline;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
 import org.junit.Before;
 import org.opensearch.OpenSearchParseException;
 import org.opensearch.ResourceNotFoundException;
 import org.opensearch.Version;
 import org.opensearch.action.search.DeleteSearchPipelineRequest;
+import org.opensearch.action.search.MockSearchPhaseContext;
 import org.opensearch.action.search.PutSearchPipelineRequest;
+import org.opensearch.action.search.QueryPhaseResultConsumer;
+import org.opensearch.action.search.SearchPhaseContext;
+import org.opensearch.action.search.SearchPhaseController;
+import org.opensearch.action.search.SearchPhaseName;
+import org.opensearch.action.search.SearchPhaseResults;
+import org.opensearch.action.search.SearchProgressListener;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchResponseSections;
@@ -28,10 +37,14 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.breaker.CircuitBreaker;
+import org.opensearch.common.breaker.NoopCircuitBreaker;
 import org.opensearch.common.bytes.BytesArray;
 import org.opensearch.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.common.lucene.search.TopDocsAndMaxScore;
 import org.opensearch.common.metrics.OperationStats;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.AtomicArray;
 import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.IndexSettings;
@@ -40,7 +53,10 @@ import org.opensearch.plugins.SearchPipelinePlugin;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.SearchModule;
+import org.opensearch.search.SearchPhaseResult;
 import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.query.QuerySearchResult;
+import org.opensearch.test.InternalAggregationTestCase;
 import org.opensearch.test.MockLogAppender;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
@@ -67,6 +83,13 @@ public class SearchPipelineServiceTests extends OpenSearchTestCase {
 
         public Map<String, Processor.Factory<SearchResponseProcessor>> getResponseProcessors(Processor.Parameters parameters) {
             return Map.of("bar", (factories, tag, description, config) -> null);
+        }
+
+        @Override
+        public Map<String, Processor.Factory<SearchPhaseResultsProcessor>> getSearchPhaseResultsProcessors(
+            Processor.Parameters parameters
+        ) {
+            return Map.of("zoe", (factories, tag, description, config) -> null);
         }
     };
 
@@ -178,13 +201,13 @@ public class SearchPipelineServiceTests extends OpenSearchTestCase {
         SearchRequest searchRequest = new SearchRequest("my_index").source(SearchSourceBuilder.searchSource().size(5));
         PipelinedRequest pipelinedRequest = service.resolvePipeline(searchRequest);
         assertEquals("p1", pipelinedRequest.getPipeline().getId());
-        assertEquals(10, pipelinedRequest.transformedRequest().source().size());
+        assertEquals(10, pipelinedRequest.source().size());
 
         // Bypass the default pipeline
         searchRequest.pipeline("_none");
         pipelinedRequest = service.resolvePipeline(searchRequest);
         assertEquals("_none", pipelinedRequest.getPipeline().getId());
-        assertEquals(5, pipelinedRequest.transformedRequest().source().size());
+        assertEquals(5, pipelinedRequest.source().size());
     }
 
     private static abstract class FakeProcessor implements Processor {
@@ -244,6 +267,40 @@ public class SearchPipelineServiceTests extends OpenSearchTestCase {
         }
     }
 
+    private static class FakeSearchPhaseResultsProcessor extends FakeProcessor implements SearchPhaseResultsProcessor {
+        private Consumer<SearchPhaseResult> querySearchResultConsumer;
+
+        public FakeSearchPhaseResultsProcessor(
+            String type,
+            String tag,
+            String description,
+            Consumer<SearchPhaseResult> querySearchResultConsumer
+        ) {
+            super(type, tag, description);
+            this.querySearchResultConsumer = querySearchResultConsumer;
+        }
+
+        @Override
+        public <Result extends SearchPhaseResult> void process(
+            SearchPhaseResults<Result> searchPhaseResult,
+            SearchPhaseContext searchPhaseContext
+        ) {
+            List<Result> resultAtomicArray = searchPhaseResult.getAtomicArray().asList();
+            // updating the maxScore
+            resultAtomicArray.forEach(querySearchResultConsumer);
+        }
+
+        @Override
+        public SearchPhaseName getBeforePhase() {
+            return SearchPhaseName.QUERY;
+        }
+
+        @Override
+        public SearchPhaseName getAfterPhase() {
+            return SearchPhaseName.FETCH;
+        }
+    }
+
     private SearchPipelineService createWithProcessors() {
         Map<String, Processor.Factory<SearchRequestProcessor>> requestProcessors = new HashMap<>();
         requestProcessors.put("scale_request_size", (processorFactories, tag, description, config) -> {
@@ -260,7 +317,15 @@ public class SearchPipelineServiceTests extends OpenSearchTestCase {
             float score = ((Number) config.remove("score")).floatValue();
             return new FakeResponseProcessor("fixed_score", tag, description, rsp -> rsp.getHits().forEach(h -> h.score(score)));
         });
-        return createWithProcessors(requestProcessors, responseProcessors);
+
+        Map<String, Processor.Factory<SearchPhaseResultsProcessor>> searchPhaseProcessors = new HashMap<>();
+        searchPhaseProcessors.put("max_score", (processorFactories, tag, description, config) -> {
+            final float finalScore = config.containsKey("score") ? ((Number) config.remove("score")).floatValue() : 100f;
+            final Consumer<SearchPhaseResult> querySearchResultConsumer = (result) -> result.queryResult().topDocs().maxScore = finalScore;
+            return new FakeSearchPhaseResultsProcessor("max_score", tag, description, querySearchResultConsumer);
+        });
+
+        return createWithProcessors(requestProcessors, responseProcessors, searchPhaseProcessors);
     }
 
     @Override
@@ -271,7 +336,8 @@ public class SearchPipelineServiceTests extends OpenSearchTestCase {
 
     private SearchPipelineService createWithProcessors(
         Map<String, Processor.Factory<SearchRequestProcessor>> requestProcessors,
-        Map<String, Processor.Factory<SearchResponseProcessor>> responseProcessors
+        Map<String, Processor.Factory<SearchResponseProcessor>> responseProcessors,
+        Map<String, Processor.Factory<SearchPhaseResultsProcessor>> phaseProcessors
     ) {
         Client client = mock(Client.class);
         ThreadPool threadPool = mock(ThreadPool.class);
@@ -296,6 +362,14 @@ public class SearchPipelineServiceTests extends OpenSearchTestCase {
                 public Map<String, Processor.Factory<SearchResponseProcessor>> getResponseProcessors(Processor.Parameters parameters) {
                     return responseProcessors;
                 }
+
+                @Override
+                public Map<String, Processor.Factory<SearchPhaseResultsProcessor>> getSearchPhaseResultsProcessors(
+                    Processor.Parameters parameters
+                ) {
+                    return phaseProcessors;
+                }
+
             }),
             client,
             true
@@ -314,7 +388,8 @@ public class SearchPipelineServiceTests extends OpenSearchTestCase {
             new BytesArray(
                 "{ "
                     + "\"request_processors\" : [ { \"scale_request_size\": { \"scale\" : 2 } } ], "
-                    + "\"response_processors\" : [ { \"fixed_score\" : { \"score\" : 1.0 } } ]"
+                    + "\"response_processors\" : [ { \"fixed_score\" : { \"score\" : 1.0 } } ],"
+                    + "\"phase_results_processors\" : [ { \"max_score\" : { \"score\": 100 } } ]"
                     + "}"
             ),
             XContentType.JSON
@@ -331,6 +406,11 @@ public class SearchPipelineServiceTests extends OpenSearchTestCase {
         assertEquals(
             "scale_request_size",
             searchPipelineService.getPipelines().get("_id").pipeline.getSearchRequestProcessors().get(0).getType()
+        );
+        assertEquals(1, searchPipelineService.getPipelines().get("_id").pipeline.getSearchPhaseResultsProcessors().size());
+        assertEquals(
+            "max_score",
+            searchPipelineService.getPipelines().get("_id").pipeline.getSearchPhaseResultsProcessors().get(0).getType()
         );
         assertEquals(1, searchPipelineService.getPipelines().get("_id").pipeline.getSearchResponseProcessors().size());
         assertEquals(
@@ -369,6 +449,7 @@ public class SearchPipelineServiceTests extends OpenSearchTestCase {
         assertEquals("empty pipeline", pipeline.pipeline.getDescription());
         assertEquals(0, pipeline.pipeline.getSearchRequestProcessors().size());
         assertEquals(0, pipeline.pipeline.getSearchResponseProcessors().size());
+        assertEquals(0, pipeline.pipeline.getSearchPhaseResultsProcessors().size());
     }
 
     public void testPutInvalidPipeline() throws IllegalAccessException {
@@ -506,17 +587,14 @@ public class SearchPipelineServiceTests extends OpenSearchTestCase {
         SearchRequest request = new SearchRequest("_index").source(sourceBuilder).pipeline("p1");
 
         PipelinedRequest pipelinedRequest = searchPipelineService.resolvePipeline(request);
-        SearchRequest transformedRequest = pipelinedRequest.transformedRequest();
 
-        assertEquals(2 * size, transformedRequest.source().size());
+        assertEquals(2 * size, pipelinedRequest.source().size());
         assertEquals(size, request.source().size());
 
         // This request doesn't specify a pipeline, it doesn't get transformed.
         request = new SearchRequest("_index").source(sourceBuilder);
         pipelinedRequest = searchPipelineService.resolvePipeline(request);
-        SearchRequest notTransformedRequest = pipelinedRequest.transformedRequest();
-        assertEquals(size, notTransformedRequest.source().size());
-        assertSame(request, notTransformedRequest);
+        assertEquals(size, pipelinedRequest.source().size());
     }
 
     public void testTransformResponse() throws Exception {
@@ -565,6 +643,89 @@ public class SearchPipelineServiceTests extends OpenSearchTestCase {
         }
     }
 
+    public void testTransformSearchPhase() {
+        SearchPipelineService searchPipelineService = createWithProcessors();
+        SearchPipelineMetadata metadata = new SearchPipelineMetadata(
+            Map.of(
+                "p1",
+                new PipelineConfiguration(
+                    "p1",
+                    new BytesArray("{\"phase_results_processors\" : [ { \"max_score\" : { } } ]}"),
+                    XContentType.JSON
+                )
+            )
+        );
+        ClusterState clusterState = ClusterState.builder(new ClusterName("_name")).build();
+        ClusterState previousState = clusterState;
+        clusterState = ClusterState.builder(clusterState)
+            .metadata(Metadata.builder().putCustom(SearchPipelineMetadata.TYPE, metadata))
+            .build();
+        searchPipelineService.applyClusterState(new ClusterChangedEvent("", clusterState, previousState));
+        SearchPhaseController controller = new SearchPhaseController(
+            writableRegistry(),
+            s -> InternalAggregationTestCase.emptyReduceContextBuilder()
+        );
+        SearchPhaseContext searchPhaseContext = new MockSearchPhaseContext(10);
+        QueryPhaseResultConsumer searchPhaseResults = new QueryPhaseResultConsumer(
+            searchPhaseContext.getRequest(),
+            OpenSearchExecutors.newDirectExecutorService(),
+            new NoopCircuitBreaker(CircuitBreaker.REQUEST),
+            controller,
+            SearchProgressListener.NOOP,
+            writableRegistry(),
+            2,
+            exc -> {}
+        );
+
+        final QuerySearchResult querySearchResult = new QuerySearchResult();
+        querySearchResult.setShardIndex(1);
+        querySearchResult.topDocs(new TopDocsAndMaxScore(new TopDocs(null, new ScoreDoc[1]), 1f), null);
+        searchPhaseResults.consumeResult(querySearchResult, () -> {});
+
+        // First try without specifying a pipeline, which should be a no-op.
+        SearchRequest searchRequest = new SearchRequest();
+        PipelinedRequest pipelinedRequest = searchPipelineService.resolvePipeline(searchRequest);
+        AtomicArray<SearchPhaseResult> notTransformedSearchPhaseResults = searchPhaseResults.getAtomicArray();
+        pipelinedRequest.transformSearchPhaseResults(
+            searchPhaseResults,
+            searchPhaseContext,
+            SearchPhaseName.QUERY.getName(),
+            SearchPhaseName.FETCH.getName()
+        );
+        assertSame(searchPhaseResults.getAtomicArray(), notTransformedSearchPhaseResults);
+
+        // Now set the pipeline as p1
+        searchRequest = new SearchRequest().pipeline("p1");
+        pipelinedRequest = searchPipelineService.resolvePipeline(searchRequest);
+
+        pipelinedRequest.transformSearchPhaseResults(
+            searchPhaseResults,
+            searchPhaseContext,
+            SearchPhaseName.QUERY.getName(),
+            SearchPhaseName.FETCH.getName()
+        );
+
+        List<SearchPhaseResult> resultAtomicArray = searchPhaseResults.getAtomicArray().asList();
+        assertEquals(1, resultAtomicArray.size());
+        // updating the maxScore
+        for (SearchPhaseResult result : resultAtomicArray) {
+            assertEquals(100f, result.queryResult().topDocs().maxScore, 0);
+        }
+
+        // Check Processor doesn't run for between other phases
+        searchRequest = new SearchRequest().pipeline("p1");
+        pipelinedRequest = searchPipelineService.resolvePipeline(searchRequest);
+        AtomicArray<SearchPhaseResult> notTransformedSearchPhaseResult = searchPhaseResults.getAtomicArray();
+        pipelinedRequest.transformSearchPhaseResults(
+            searchPhaseResults,
+            searchPhaseContext,
+            SearchPhaseName.DFS_QUERY.getName(),
+            SearchPhaseName.QUERY.getName()
+        );
+
+        assertSame(searchPhaseResults.getAtomicArray(), notTransformedSearchPhaseResult);
+    }
+
     public void testGetPipelines() {
         //
         assertEquals(0, SearchPipelineService.innerGetPipelines(null, "p1").size());
@@ -582,16 +743,23 @@ public class SearchPipelineServiceTests extends OpenSearchTestCase {
                     "p2",
                     new BytesArray("{\"response_processors\" : [ { \"fixed_score\": { \"score\" : 2 } } ] }"),
                     XContentType.JSON
+                ),
+                "p3",
+                new PipelineConfiguration(
+                    "p3",
+                    new BytesArray("{\"phase_results_processors\" : [ { \"max_score\" : { } } ]}"),
+                    XContentType.JSON
                 )
             )
         );
 
         // Return all when no ids specified
         List<PipelineConfiguration> pipelines = SearchPipelineService.innerGetPipelines(metadata);
-        assertEquals(2, pipelines.size());
+        assertEquals(3, pipelines.size());
         pipelines.sort(Comparator.comparing(PipelineConfiguration::getId));
         assertEquals("p1", pipelines.get(0).getId());
         assertEquals("p2", pipelines.get(1).getId());
+        assertEquals("p3", pipelines.get(2).getId());
 
         // Get specific pipeline
         pipelines = SearchPipelineService.innerGetPipelines(metadata, "p1");
@@ -607,17 +775,19 @@ public class SearchPipelineServiceTests extends OpenSearchTestCase {
 
         // Match all
         pipelines = SearchPipelineService.innerGetPipelines(metadata, "*");
-        assertEquals(2, pipelines.size());
+        assertEquals(3, pipelines.size());
         pipelines.sort(Comparator.comparing(PipelineConfiguration::getId));
         assertEquals("p1", pipelines.get(0).getId());
         assertEquals("p2", pipelines.get(1).getId());
+        assertEquals("p3", pipelines.get(2).getId());
 
         // Match prefix
         pipelines = SearchPipelineService.innerGetPipelines(metadata, "p*");
-        assertEquals(2, pipelines.size());
+        assertEquals(3, pipelines.size());
         pipelines.sort(Comparator.comparing(PipelineConfiguration::getId));
         assertEquals("p1", pipelines.get(0).getId());
         assertEquals("p2", pipelines.get(1).getId());
+        assertEquals("p3", pipelines.get(2).getId());
     }
 
     public void testValidatePipeline() throws Exception {
@@ -625,6 +795,7 @@ public class SearchPipelineServiceTests extends OpenSearchTestCase {
 
         ProcessorInfo reqProcessor = new ProcessorInfo("scale_request_size");
         ProcessorInfo rspProcessor = new ProcessorInfo("fixed_score");
+        ProcessorInfo injProcessor = new ProcessorInfo("max_score");
         DiscoveryNode n1 = new DiscoveryNode("n1", buildNewFakeTransportAddress(), Version.CURRENT);
         DiscoveryNode n2 = new DiscoveryNode("n2", buildNewFakeTransportAddress(), Version.CURRENT);
         PutSearchPipelineRequest putRequest = new PutSearchPipelineRequest(
@@ -632,7 +803,8 @@ public class SearchPipelineServiceTests extends OpenSearchTestCase {
             new BytesArray(
                 "{"
                     + "\"request_processors\": [{ \"scale_request_size\": { \"scale\" : 2 } }],"
-                    + "\"response_processors\": [{ \"fixed_score\": { \"score\" : 2 } }]"
+                    + "\"response_processors\": [{ \"fixed_score\": { \"score\" : 2 } }],"
+                    + "\"phase_results_processors\" : [ { \"max_score\" : { } } ]"
                     + "}"
             ),
             XContentType.JSON
@@ -699,8 +871,7 @@ public class SearchPipelineServiceTests extends OpenSearchTestCase {
         assertEquals(1, pipeline.getSearchResponseProcessors().size());
 
         // Verify that pipeline transforms request
-        SearchRequest transformedRequest = pipelinedRequest.transformedRequest();
-        assertEquals(200, transformedRequest.source().size());
+        assertEquals(200, pipelinedRequest.source().size());
 
         int size = 10;
         SearchHit[] hits = new SearchHit[size];
@@ -730,7 +901,7 @@ public class SearchPipelineServiceTests extends OpenSearchTestCase {
             "bad_factory",
             (pf, t, f, c) -> { throw new RuntimeException(); }
         );
-        SearchPipelineService searchPipelineService = createWithProcessors(badFactory, Collections.emptyMap());
+        SearchPipelineService searchPipelineService = createWithProcessors(badFactory, Collections.emptyMap(), Collections.emptyMap());
 
         Map<String, Object> pipelineSourceMap = new HashMap<>();
         pipelineSourceMap.put(Pipeline.REQUEST_PROCESSORS_KEY, List.of(Map.of("bad_factory", Collections.emptyMap())));
@@ -752,7 +923,11 @@ public class SearchPipelineServiceTests extends OpenSearchTestCase {
             (pf, t, f, c) -> throwingRequestProcessor
         );
 
-        SearchPipelineService searchPipelineService = createWithProcessors(throwingRequestProcessorFactory, Collections.emptyMap());
+        SearchPipelineService searchPipelineService = createWithProcessors(
+            throwingRequestProcessorFactory,
+            Collections.emptyMap(),
+            Collections.emptyMap()
+        );
 
         Map<String, Object> pipelineSourceMap = new HashMap<>();
         pipelineSourceMap.put(Pipeline.REQUEST_PROCESSORS_KEY, List.of(Map.of("throwing_request", Collections.emptyMap())));
@@ -773,7 +948,11 @@ public class SearchPipelineServiceTests extends OpenSearchTestCase {
             (pf, t, f, c) -> throwingResponseProcessor
         );
 
-        SearchPipelineService searchPipelineService = createWithProcessors(Collections.emptyMap(), throwingResponseProcessorFactory);
+        SearchPipelineService searchPipelineService = createWithProcessors(
+            Collections.emptyMap(),
+            throwingResponseProcessorFactory,
+            Collections.emptyMap()
+        );
 
         Map<String, Object> pipelineSourceMap = new HashMap<>();
         pipelineSourceMap.put(Pipeline.RESPONSE_PROCESSORS_KEY, List.of(Map.of("throwing_response", Collections.emptyMap())));
@@ -807,7 +986,7 @@ public class SearchPipelineServiceTests extends OpenSearchTestCase {
             "throwing_response",
             (pf, t, f, c) -> throwingResponseProcessor
         );
-        SearchPipelineService searchPipelineService = createWithProcessors(requestProcessors, responseProcessors);
+        SearchPipelineService searchPipelineService = createWithProcessors(requestProcessors, responseProcessors, Collections.emptyMap());
 
         SearchPipelineMetadata metadata = new SearchPipelineMetadata(
             Map.of(


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Add new search pipeline processor type, SearchPhaseResultsProcessor, that can modify the result of one search phase before starting the next phase.

Along with this, added the code to resolve the Search pipeline once and added new SearchRequest type PipelinedRequest.

Backport of PR: https://github.com/opensearch-project/OpenSearch/pull/7283

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
RFC: https://github.com/opensearch-project/neural-search/issues/152

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
