### PR TITLE
[Remote Segment Store] Fix flaky RemoteStoreIT.testStaleCommitDeletion tests

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
@@ -285,7 +285,6 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
         verifyRemoteStoreCleanup(true);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/8504")
     public void testStaleCommitDeletionWithInvokeFlush() throws Exception {
         internalCluster().startDataOnlyNodes(3);
         createIndex(INDEX_NAME, remoteStoreIndexSettings(1, 10000l));
@@ -301,16 +300,15 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
         assertBusy(() -> {
             int actualFileCount = getFileCount(indexPath);
             if (numberOfIterations <= RemoteStoreRefreshListener.LAST_N_METADATA_FILES_TO_KEEP) {
-                assertEquals(numberOfIterations, actualFileCount);
+                assertTrue(numberOfIterations == actualFileCount || (numberOfIterations + 1) == actualFileCount);
             } else {
                 // As delete is async its possible that the file gets created before the deletion or after
                 // deletion.
-                assertTrue(actualFileCount >= 10 || actualFileCount <= 11);
+                assertTrue(actualFileCount == 10 || actualFileCount == 11);
             }
         }, 30, TimeUnit.SECONDS);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/8504")
     public void testStaleCommitDeletionWithoutInvokeFlush() throws Exception {
         internalCluster().startDataOnlyNodes(3);
         createIndex(INDEX_NAME, remoteStoreIndexSettings(1, 10000l));
@@ -322,6 +320,8 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
             .get()
             .getSetting(INDEX_NAME, IndexMetadata.SETTING_INDEX_UUID);
         Path indexPath = Path.of(String.valueOf(absolutePath), indexUUID, "/0/segments/metadata");
-        assertEquals(numberOfIterations, getFileCount(indexPath));
+        int actualFileCount = getFileCount(indexPath);
+        // We also allow (numberOfIterations + 1) as index creation also triggers refresh.
+        assertTrue(numberOfIterations == actualFileCount || (numberOfIterations + 1) == actualFileCount);
     }
 }

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.remotestore;
 
+import org.hamcrest.MatcherAssert;
 import org.junit.Before;
 import org.opensearch.action.admin.cluster.remotestore.restore.RestoreRemoteStoreRequest;
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
@@ -35,6 +36,8 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.comparesEqualTo;
+import static org.hamcrest.Matchers.oneOf;
+import static org.hamcrest.Matchers.is;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
 
@@ -300,11 +303,11 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
         assertBusy(() -> {
             int actualFileCount = getFileCount(indexPath);
             if (numberOfIterations <= RemoteStoreRefreshListener.LAST_N_METADATA_FILES_TO_KEEP) {
-                assertTrue(numberOfIterations == actualFileCount || (numberOfIterations + 1) == actualFileCount);
+                MatcherAssert.assertThat(actualFileCount, is(oneOf(numberOfIterations, numberOfIterations + 1)));
             } else {
                 // As delete is async its possible that the file gets created before the deletion or after
                 // deletion.
-                assertTrue(actualFileCount == 10 || actualFileCount == 11);
+                MatcherAssert.assertThat(actualFileCount, is(oneOf(10, 11)));
             }
         }, 30, TimeUnit.SECONDS);
     }
@@ -322,6 +325,6 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
         Path indexPath = Path.of(String.valueOf(absolutePath), indexUUID, "/0/segments/metadata");
         int actualFileCount = getFileCount(indexPath);
         // We also allow (numberOfIterations + 1) as index creation also triggers refresh.
-        assertTrue(numberOfIterations == actualFileCount || (numberOfIterations + 1) == actualFileCount);
+        MatcherAssert.assertThat(actualFileCount, is(oneOf(numberOfIterations, numberOfIterations + 1)));
     }
 }


### PR DESCRIPTION
### Description
- `RemoteStoreIT.testStaleCommitDeletion*` tests validate number of metadata files created as part of number of iterations of data ingestion.
- As part of these tests, index is created. Index creation involves flush which uploads a metadata file. We have an optimization to prevent empty refreshes so based on test parameters it is possible to have metadata files which are same as number of iterations or (number of iterations + 1)

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/8504

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
