### PR TITLE
Bump com.google.guava:guava from 32.0.1-jre to 32.1.1-jre in /distribution/tools/upgrade-cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Dependencies
 - Bump `com.azure:azure-storage-common` from 12.21.0 to 12.21.1 (#7566, #7814)
-- Bump `com.google.guava:guava` from 30.1.1-jre to 32.0.0-jre (#7565, #7811, #7807, #7808)
+- Bump `com.google.guava:guava` from 30.1.1-jre to 32.1.1-jre (#7565, #7811, #7807, #7808, #8402)
 - Bump `net.minidev:json-smart` from 2.4.10 to 2.4.11 (#7660, #7812)
 - Bump `org.gradle.test-retry` from 1.5.2 to 1.5.3 (#7810)
 - Bump `com.diffplug.spotless` from 6.17.0 to 6.18.0 (#7896)

--- a/distribution/tools/upgrade-cli/build.gradle
+++ b/distribution/tools/upgrade-cli/build.gradle
@@ -21,9 +21,8 @@ dependencies {
   implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
   testImplementation project(":test:framework")
   testImplementation 'com.google.jimfs:jimfs:1.2'
-  testRuntimeOnly 'com.google.guava:guava:32.1.1-jre'
-  configurations.all {
-    resolutionStrategy.force("org.mockito:mockito-core:${versions.mockito}")
+  testRuntimeOnly('com.google.guava:guava:32.1.1-jre') {
+    transitive = false
   }
 }
 

--- a/distribution/tools/upgrade-cli/build.gradle
+++ b/distribution/tools/upgrade-cli/build.gradle
@@ -21,7 +21,10 @@ dependencies {
   implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
   testImplementation project(":test:framework")
   testImplementation 'com.google.jimfs:jimfs:1.2'
-  testRuntimeOnly 'com.google.guava:guava:32.0.1-jre'
+  testRuntimeOnly 'com.google.guava:guava:32.1.1-jre'
+  configurations.all {
+    resolutionStrategy.force("org.mockito:mockito-core:${versions.mockito}")
+  }
 }
 
 tasks.named("dependencyLicenses").configure {


### PR DESCRIPTION
Handled https://github.com/opensearch-project/OpenSearch/pull/8402 here by setting transitive dependencies as false.

### Description
Bumps [com.google.guava:guava](https://github.com/google/guava) from 32.0.1-jre to 32.1.1-jre.

guava 32.1.1-jre brings up `4.11.0` of mockito-core as a transitive dependency: https://mvnrepository.com/artifact/com.google.guava/guava-parent/32.1.1-jre whereas OpenSearch is having `5.4.0` of [mockito](https://github.com/opensearch-project/OpenSearch/blob/main/buildSrc/version.properties#L56). 

```

* What went wrong:
Could not determine the dependencies of task ':distribution:tools:plugin-cli:forbiddenApisTest'.
> Could not resolve all task dependencies for configuration ':distribution:tools:plugin-cli:testRuntimeClasspath'.
   > Conflict(s) found for the following module(s):
       - org.mockito:mockito-core between versions 5.4.0 and 4.11.0
     Run with:
         --scan or
         :distribution:tools:plugin-cli:dependencyInsight --configuration testRuntimeClasspath --dependency org.mockito:mockito-core
     to get more insight on how to solve the conflict.
```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
