### PR TITLE
Fix flakyness in RemoteStoreRefreshListenerTests

### DIFF
--- a/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
@@ -21,9 +21,9 @@ import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.concurrent.GatedCloseable;
+import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.lease.Releasable;
 import org.opensearch.index.engine.InternalEngineFactory;
 import org.opensearch.index.remote.RemoteRefreshSegmentPressureService;
 import org.opensearch.index.remote.RemoteRefreshSegmentTracker;
@@ -249,10 +249,7 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
         assertBusy(() -> assertEquals(0, successLatch.getCount()));
         RemoteRefreshSegmentPressureService pressureService = tuple.v2();
         RemoteRefreshSegmentTracker segmentTracker = pressureService.getRemoteRefreshSegmentTracker(indexShard.shardId());
-        assertEquals(0, segmentTracker.getBytesLag());
-        assertEquals(0, segmentTracker.getRefreshSeqNoLag());
-        assertEquals(0, segmentTracker.getTimeMsLag());
-        assertEquals(0, segmentTracker.getTotalUploadsFailed());
+        assertNoLagAndTotalUploadsFailed(segmentTracker, 0);
     }
 
     public void testRefreshSuccessOnSecondAttempt() throws Exception {
@@ -273,10 +270,7 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
         assertBusy(() -> assertEquals(0, successLatch.getCount()));
         RemoteRefreshSegmentPressureService pressureService = tuple.v2();
         RemoteRefreshSegmentTracker segmentTracker = pressureService.getRemoteRefreshSegmentTracker(indexShard.shardId());
-        assertEquals(0, segmentTracker.getBytesLag());
-        assertEquals(0, segmentTracker.getRefreshSeqNoLag());
-        assertEquals(0, segmentTracker.getTimeMsLag());
-        assertEquals(1, segmentTracker.getTotalUploadsFailed());
+        assertNoLagAndTotalUploadsFailed(segmentTracker, 1);
     }
 
     /**
@@ -304,7 +298,7 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
         assertBusy(() -> assertEquals(0, reachedCheckpointPublishLatch.getCount()));
     }
 
-    public void testRefreshSuccessOnThirdAttemptAttempt() throws Exception {
+    public void testRefreshSuccessOnThirdAttempt() throws Exception {
         // This covers 3 cases - 1) isRetry=false, shouldRetry=true 2) isRetry=true, shouldRetry=false 3) isRetry=True, shouldRetry=true
         // Succeed on 3rd attempt
         int succeedOnAttempt = 3;
@@ -322,11 +316,15 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
         assertBusy(() -> assertEquals(0, successLatch.getCount()));
         RemoteRefreshSegmentPressureService pressureService = tuple.v2();
         RemoteRefreshSegmentTracker segmentTracker = pressureService.getRemoteRefreshSegmentTracker(indexShard.shardId());
+        assertNoLagAndTotalUploadsFailed(segmentTracker, 2);
+    }
+
+    private void assertNoLagAndTotalUploadsFailed(RemoteRefreshSegmentTracker segmentTracker, long totalUploadsFailed) throws Exception {
         assertBusy(() -> {
             assertEquals(0, segmentTracker.getBytesLag());
             assertEquals(0, segmentTracker.getRefreshSeqNoLag());
             assertEquals(0, segmentTracker.getTimeMsLag());
-            assertEquals(2, segmentTracker.getTotalUploadsFailed());
+            assertEquals(totalUploadsFailed, segmentTracker.getTotalUploadsFailed());
         });
     }
 

--- a/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
@@ -322,11 +322,12 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
         assertBusy(() -> assertEquals(0, successLatch.getCount()));
         RemoteRefreshSegmentPressureService pressureService = tuple.v2();
         RemoteRefreshSegmentTracker segmentTracker = pressureService.getRemoteRefreshSegmentTracker(indexShard.shardId());
-        assertEquals(0, segmentTracker.getBytesLag());
-        assertEquals(0, segmentTracker.getRefreshSeqNoLag());
-        assertEquals(0, segmentTracker.getTimeMsLag());
-        assertEquals(2, segmentTracker.getTotalUploadsFailed());
-
+        assertBusy(() -> {
+            assertEquals(0, segmentTracker.getBytesLag());
+            assertEquals(0, segmentTracker.getRefreshSeqNoLag());
+            assertEquals(0, segmentTracker.getTimeMsLag());
+            assertEquals(2, segmentTracker.getTotalUploadsFailed());
+        });
     }
 
     public void testTrackerData() throws Exception {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fix flakyness in `RemoteStoreRefreshListenerTests` -> `testRefreshSuccessOnThirdAttemptAttempt`

### Related Issues
Resolves #8549

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
