### PR TITLE
[Segment Replication] Add logic back to update tracking replication checkpoint on source

### DIFF
--- a/server/src/main/java/org/opensearch/indices/replication/OngoingSegmentReplications.java
+++ b/server/src/main/java/org/opensearch/indices/replication/OngoingSegmentReplications.java
@@ -120,11 +120,7 @@ class OngoingSegmentReplications {
                     removeCopyState(sourceHandler.getCopyState());
                 }
             });
-            if (request.getFilesToFetch().isEmpty()) {
-                wrappedListener.onResponse(new GetSegmentFilesResponse(Collections.emptyList()));
-            } else {
-                handler.sendFiles(request, wrappedListener);
-            }
+            handler.sendFiles(request, wrappedListener);
         } else {
             listener.onResponse(new GetSegmentFilesResponse(Collections.emptyList()));
         }

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceHandler.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceHandler.java
@@ -187,8 +187,8 @@ class SegmentReplicationSourceHandler {
         }
     }
 
-    // Replication checkpoint update for remote store indices happens via subsequent UPDATE_VISIBLE_CHECKPOINT transport call .
-    // For node-node, checkpoint update is done as part of this i.e. GET_SEGMENT_FILES call.
+    // Update target replication checkpoint on source for node-node communication. For remote store enabled indices, checkpoint
+    // update on source is performed via separate UPDATE_VISIBLE_CHECKPOINT transport call
     private void updateVisibleCheckpointForShard(String allocationId, ReplicationCheckpoint replicationCheckpoint) {
         if (shard.indexSettings().isRemoteStoreEnabled() == false) {
             // update visible checkpoint to primary

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
@@ -292,6 +292,11 @@ public class SegmentReplicationTargetService implements IndexEventListener {
     }
 
     protected void updateVisibleCheckpoint(long replicationId, IndexShard replicaShard) {
+        // Update replication checkpoint on source via transport call only supported for remote store integration. For node-
+        // node communication, checkpoint update is piggy-backed to GET_SEGMENT_FILES transport call
+        if (replicaShard.indexSettings().isRemoteStoreEnabled() == false) {
+            return;
+        }
         ShardRouting primaryShard = clusterService.state().routingTable().shardRoutingTable(replicaShard.shardId()).primaryShard();
 
         final UpdateVisibleCheckpointRequest request = new UpdateVisibleCheckpointRequest(


### PR DESCRIPTION
### Description
This PR adds back logic to update target's replication checkpoint on source which was removed as part of https://github.com/opensearch-project/OpenSearch/pull/8020, which was breaking change for backward compatibility for released versions. This change now allows the primary to update the visible ReplicationCheckpoint of replica shards with node-node communication. Current state:
1. Node-Node communication. Source updates replication checkpoint as part of `get_segment_files` handling
2. Remote store. Source expects replica shard to make `update_visible_checkpoint` transport call. 

### Related Issues
Resolves #https://github.com/opensearch-project/OpenSearch/issues/8322
Related: #8202 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
