### PR TITLE
Fix methods in InternalEngine to access translog methods via TranslogManager

### DIFF
--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -596,7 +596,7 @@ public class InternalEngine extends Engine {
 
     @Override
     public boolean isTranslogSyncNeeded() {
-        return translogManager.getTranslog().syncNeeded();
+        return translogManager.isTranslogSyncNeeded();
     }
 
     @Override
@@ -611,7 +611,7 @@ public class InternalEngine extends Engine {
 
     @Override
     public TranslogStats getTranslogStats() {
-        return translogManager.getTranslog().stats();
+        return translogManager.getTranslogStats();
     }
 
     @Override
@@ -1892,31 +1892,10 @@ public class InternalEngine extends Engine {
         final long localCheckpointOfLastCommit = Long.parseLong(
             lastCommittedSegmentInfos.userData.get(SequenceNumbers.LOCAL_CHECKPOINT_KEY)
         );
-        final long translogGenerationOfLastCommit = translogManager.getTranslog()
-            .getMinGenerationForSeqNo(localCheckpointOfLastCommit + 1).translogFileGeneration;
-        final long flushThreshold = config().getIndexSettings().getFlushThresholdSize().getBytes();
-        if (translogManager.getTranslog().sizeInBytesByMinGen(translogGenerationOfLastCommit) < flushThreshold) {
-            return false;
-        }
-        /*
-         * We flush to reduce the size of uncommitted translog but strictly speaking the uncommitted size won't always be
-         * below the flush-threshold after a flush. To avoid getting into an endless loop of flushing, we only enable the
-         * periodically flush condition if this condition is disabled after a flush. The condition will change if the new
-         * commit points to the later generation the last commit's(eg. gen-of-last-commit < gen-of-new-commit)[1].
-         *
-         * When the local checkpoint equals to max_seqno, and translog-gen of the last commit equals to translog-gen of
-         * the new commit, we know that the last generation must contain operations because its size is above the flush
-         * threshold and the flush-threshold is guaranteed to be higher than an empty translog by the setting validation.
-         * This guarantees that the new commit will point to the newly rolled generation. In fact, this scenario only
-         * happens when the generation-threshold is close to or above the flush-threshold; otherwise we have rolled
-         * generations as the generation-threshold was reached, then the first condition (eg. [1]) is already satisfied.
-         *
-         * This method is to maintain translog only, thus IndexWriter#hasUncommittedChanges condition is not considered.
-         */
-        final long translogGenerationOfNewCommit = translogManager.getTranslog()
-            .getMinGenerationForSeqNo(localCheckpointTracker.getProcessedCheckpoint() + 1).translogFileGeneration;
-        return translogGenerationOfLastCommit < translogGenerationOfNewCommit
-            || localCheckpointTracker.getProcessedCheckpoint() == localCheckpointTracker.getMaxSeqNo();
+        return translogManager.shouldPeriodicallyFlush(
+            localCheckpointOfLastCommit,
+            config().getIndexSettings().getFlushThresholdSize().getBytes()
+        );
     }
 
     @Override
@@ -1955,7 +1934,7 @@ public class InternalEngine extends Engine {
                     )) {
                     translogManager.ensureCanFlush();
                     try {
-                        translogManager.getTranslog().rollGeneration();
+                        translogManager.rollTranslogGeneration();
                         logger.trace("starting commit for flush; commitTranslog=true");
                         commitIndexWriter(indexWriter, translogManager.getTranslog());
                         logger.trace("finished commit for flush");
@@ -2247,8 +2226,8 @@ public class InternalEngine extends Engine {
             }
             failEngine("already closed by tragic event on the index writer", tragicException);
             engineFailed = true;
-        } else if (translogManager.getTranslog().isOpen() == false && translogManager.getTranslog().getTragicException() != null) {
-            failEngine("already closed by tragic event on the translog", translogManager.getTranslog().getTragicException());
+        } else if (translogManager.getTragicExceptionIfClosed() != null) {
+            failEngine("already closed by tragic event on the translog", translogManager.getTragicExceptionIfClosed());
             engineFailed = true;
         } else if (failedEngine.get() == null && isClosed.get() == false) { // we are closed but the engine is not failed yet?
             // this smells like a bug - we only expect ACE if we are in a fatal case ie. either translog or IW is closed by
@@ -2273,7 +2252,7 @@ public class InternalEngine extends Engine {
             return failOnTragicEvent((AlreadyClosedException) e);
         } else if (e != null
             && ((indexWriter.isOpen() == false && indexWriter.getTragicException() == e)
-                || (translogManager.getTranslog().isOpen() == false && translogManager.getTranslog().getTragicException() == e))) {
+                || (translogManager.getTragicExceptionIfClosed() == e))) {
                     // this spot on - we are handling the tragic event exception here so we have to fail the engine
                     // right away
                     failEngine(source, e);
@@ -2381,7 +2360,7 @@ public class InternalEngine extends Engine {
                     logger.warn("Failed to close ReaderManager", e);
                 }
                 try {
-                    IOUtils.close(translogManager.getTranslog());
+                    IOUtils.close(translogManager);
                 } catch (Exception e) {
                     logger.warn("Failed to close translog", e);
                 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR fixes methods in InternalEngine to access translog methods via TranslogManager. This PR removes few translogManager.getTranslog() occurrences in `InternalEngine` of 2.x branch. 

All of the occurrences in InternalEngine cannot be removed in this PR as they will cause breaking change in InternalEngine.
Few occurrences like : 
```
-> commitIndexWriter(indexWriter, translogManager.getTranslog())
-> translogManager.getTranslog().currentFileGeneration()
-> translogManager.getTranslog().newSnapshot(localCheckpoint + 1, recoverUpToSeqNo))
```

are left out.

### Related Issues
Resolves #8443 
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
