### PR TITLE
Add wrapped tracer implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Pass localNode info to all plugins on node start ([#7919](https://github.com/opensearch-project/OpenSearch/pull/7919))
 - Improved performance of parsing floating point numbers ([#7909](https://github.com/opensearch-project/OpenSearch/pull/7909))
 - Move span actions to Scope ([#8411](https://github.com/opensearch-project/OpenSearch/pull/8411))
+- Add wrapper tracer implementation
 
 ### Deprecated
 

--- a/server/src/main/java/org/opensearch/telemetry/tracing/WrappedTracer.java
+++ b/server/src/main/java/org/opensearch/telemetry/tracing/WrappedTracer.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.telemetry.tracing;
+
+import org.opensearch.telemetry.TelemetrySettings;
+import org.opensearch.telemetry.tracing.noop.NoopTracer;
+
+import java.io.IOException;
+
+/**
+ * Wrapper implementation of Tracer. This delegates call to right tracer based on the tracer settings
+ */
+public class WrappedTracer implements Tracer {
+
+    private final Tracer defaultTracer;
+    private final TelemetrySettings telemetrySettings;
+
+    /**
+     * Creates WrappedTracer instance
+     *
+     * @param telemetrySettings telemetry settings
+     * @param defaultTracer default tracer instance
+     */
+    public WrappedTracer(TelemetrySettings telemetrySettings, Tracer defaultTracer) {
+        this.defaultTracer = defaultTracer;
+        this.telemetrySettings = telemetrySettings;
+    }
+
+    @Override
+    public SpanScope startSpan(String spanName) {
+        Tracer delegateTracer = getDelegateTracer();
+        return delegateTracer.startSpan(spanName);
+    }
+
+    @Override
+    public void close() throws IOException {
+        defaultTracer.close();
+    }
+
+    // visible for testing
+    Tracer getDelegateTracer() {
+        return telemetrySettings.isTracingEnabled() ? defaultTracer : NoopTracer.INSTANCE;
+    }
+}


### PR DESCRIPTION
### Description
This change adds a wrapper tracer implementation. 

TracerFactor now returns this wrapped tracer if the telemetry plugin is installed. The wrapped tracer checks the telemetry settings before returning the right tracer object

### Related Issues
Resolves #[8561]


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
