### PR TITLE
[Snapshot Interop] Keep API parameters behind remote store experiment…

### DIFF
--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -41,6 +41,7 @@ import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -150,7 +151,7 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
         if (in.getVersion().onOrAfter(Version.V_2_7_0)) {
             storageType = in.readEnum(StorageType.class);
         }
-        if (in.getVersion().onOrAfter(Version.V_2_9_0)) {
+        if (FeatureFlags.isEnabled(FeatureFlags.REMOTE_STORE) && in.getVersion().onOrAfter(Version.V_2_9_0)) {
             sourceRemoteStoreRepository = in.readOptionalString();
         }
     }
@@ -174,7 +175,7 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
         if (out.getVersion().onOrAfter(Version.V_2_7_0)) {
             out.writeEnum(storageType);
         }
-        if (out.getVersion().onOrAfter(Version.V_2_9_0)) {
+        if (FeatureFlags.isEnabled(FeatureFlags.REMOTE_STORE) && out.getVersion().onOrAfter(Version.V_2_9_0)) {
             out.writeOptionalString(sourceRemoteStoreRepository);
         }
     }
@@ -614,6 +615,11 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
                 }
 
             } else if (name.equals("source_remote_store_repository")) {
+                if (!FeatureFlags.isEnabled(FeatureFlags.REMOTE_STORE)) {
+                    throw new IllegalArgumentException(
+                        "Unsupported parameter " + name + ". Please enable remote store feature flag for this experimental feature"
+                    );
+                }
                 if (entry.getValue() instanceof String) {
                     setSourceRemoteStoreRepository((String) entry.getValue());
                 } else {
@@ -664,7 +670,7 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
         if (storageType != null) {
             storageType.toXContent(builder);
         }
-        if (sourceRemoteStoreRepository != null) {
+        if (FeatureFlags.isEnabled(FeatureFlags.REMOTE_STORE) && sourceRemoteStoreRepository != null) {
             builder.field("source_remote_store_repository", sourceRemoteStoreRepository);
         }
         builder.endObject();
@@ -681,7 +687,7 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         RestoreSnapshotRequest that = (RestoreSnapshotRequest) o;
-        return waitForCompletion == that.waitForCompletion
+        boolean equals = waitForCompletion == that.waitForCompletion
             && includeGlobalState == that.includeGlobalState
             && partial == that.partial
             && includeAliases == that.includeAliases
@@ -694,27 +700,48 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
             && Objects.equals(indexSettings, that.indexSettings)
             && Arrays.equals(ignoreIndexSettings, that.ignoreIndexSettings)
             && Objects.equals(snapshotUuid, that.snapshotUuid)
-            && Objects.equals(storageType, that.storageType)
-            && Objects.equals(sourceRemoteStoreRepository, that.sourceRemoteStoreRepository);
+            && Objects.equals(storageType, that.storageType);
+        if (FeatureFlags.isEnabled(FeatureFlags.REMOTE_STORE)) {
+            equals = Objects.equals(sourceRemoteStoreRepository, that.sourceRemoteStoreRepository);
+        }
+        return equals;
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(
-            snapshot,
-            repository,
-            indicesOptions,
-            renamePattern,
-            renameReplacement,
-            waitForCompletion,
-            includeGlobalState,
-            partial,
-            includeAliases,
-            indexSettings,
-            snapshotUuid,
-            storageType,
-            sourceRemoteStoreRepository
-        );
+        int result;
+        if (FeatureFlags.isEnabled(FeatureFlags.REMOTE_STORE)) {
+            result = Objects.hash(
+                snapshot,
+                repository,
+                indicesOptions,
+                renamePattern,
+                renameReplacement,
+                waitForCompletion,
+                includeGlobalState,
+                partial,
+                includeAliases,
+                indexSettings,
+                snapshotUuid,
+                storageType,
+                sourceRemoteStoreRepository
+            );
+        } else {
+            result = Objects.hash(
+                snapshot,
+                repository,
+                indicesOptions,
+                renamePattern,
+                renameReplacement,
+                waitForCompletion,
+                includeGlobalState,
+                partial,
+                includeAliases,
+                indexSettings,
+                snapshotUuid,
+                storageType
+            );
+        }
         result = 31 * result + Arrays.hashCode(indices);
         result = 31 * result + Arrays.hashCode(ignoreIndexSettings);
         return result;

--- a/server/src/main/java/org/opensearch/repositories/RepositoriesService.java
+++ b/server/src/main/java/org/opensearch/repositories/RepositoriesService.java
@@ -63,6 +63,7 @@ import org.opensearch.common.regex.Regex;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.common.util.concurrent.ConcurrentCollections;
 import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.repositories.blobstore.MeteredBlobStoreRepository;
@@ -625,6 +626,12 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
                     + Version.V_2_9_0
                     + ". Minimum node version in cluster is: "
                     + minVersionInCluster
+            );
+        }
+        if (REMOTE_STORE_INDEX_SHALLOW_COPY.get(repositoryMetadataSettings) && !FeatureFlags.isEnabled(FeatureFlags.REMOTE_STORE)) {
+            throw new RepositoryException(
+                repositoryName,
+                "setting " + REMOTE_STORE_INDEX_SHALLOW_COPY.getKey() + " cannot be enabled, as remote store feature is not enabled."
             );
         }
     }

--- a/server/src/main/java/org/opensearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/opensearch/snapshots/RestoreService.java
@@ -453,6 +453,12 @@ public class RestoreService implements ClusterStateApplier {
                                 final boolean isRemoteStoreShallowCopy = Boolean.TRUE.equals(
                                     snapshotInfo.isRemoteStoreIndexShallowCopyEnabled()
                                 ) && metadata.index(index).getSettings().getAsBoolean(SETTING_REMOTE_STORE_ENABLED, false);
+                                if (isSearchableSnapshot && isRemoteStoreShallowCopy) {
+                                    throw new SnapshotRestoreException(
+                                        snapshot,
+                                        "Shallow copy snapshot cannot be restored as searchable snapshot."
+                                    );
+                                }
                                 if (isRemoteStoreShallowCopy && !currentState.getNodes().getMinNodeVersion().onOrAfter(Version.V_2_9_0)) {
                                     throw new SnapshotRestoreException(
                                         snapshot,


### PR DESCRIPTION
…al feature flag.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Documentation Changes for Snapshot Interop Project are still not merged. 
We will be launching Snapshot Interop Feature with Remote Store Feature, so as part of this PR we are keeping all the Snapshot Interop related API parameters behind the Remote Store Feature Flag.

<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
