### PR TITLE
Add logs for remote store metadata intermittent read failures

### DIFF
--- a/server/src/main/java/org/opensearch/common/io/VersionedCodecStreamWrapper.java
+++ b/server/src/main/java/org/opensearch/common/io/VersionedCodecStreamWrapper.java
@@ -63,8 +63,7 @@ public class VersionedCodecStreamWrapper<T> {
                     "Error while validating header/footer for [{}]. Total data length [{}]",
                     indexInput.toString(),
                     indexInput.length()
-                ),
-                cie
+                )
             );
             throw cie;
         }

--- a/server/src/main/java/org/opensearch/common/io/VersionedCodecStreamWrapper.java
+++ b/server/src/main/java/org/opensearch/common/io/VersionedCodecStreamWrapper.java
@@ -10,7 +10,11 @@ package org.opensearch.common.io;
 
 import java.io.IOException;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
@@ -22,6 +26,8 @@ import org.apache.lucene.store.IndexOutput;
  * @opensearch.internal
  */
 public class VersionedCodecStreamWrapper<T> {
+    private static final Logger logger = LogManager.getLogger(VersionedCodecStreamWrapper.class);
+
     // TODO This can be updated to hold a streamReadWriteHandlerFactory and get relevant handler based on the stream versions
     private final IndexIOStreamHandler<T> indexIOStreamHandler;
     private final int currentVersion;
@@ -46,10 +52,22 @@ public class VersionedCodecStreamWrapper<T> {
      * @return stream content parsed into {@link T}
      */
     public T readStream(IndexInput indexInput) throws IOException {
-        CodecUtil.checksumEntireFile(indexInput);
-        int readStreamVersion = checkHeader(indexInput);
-        T content = getHandlerForVersion(readStreamVersion).readContent(indexInput);
-        return content;
+        logger.debug("Reading input stream [{}] of length - [{}]", indexInput.toString(), indexInput.length());
+        try {
+            CodecUtil.checksumEntireFile(indexInput);
+            int readStreamVersion = checkHeader(indexInput);
+            return getHandlerForVersion(readStreamVersion).readContent(indexInput);
+        } catch (CorruptIndexException cie) {
+            logger.error(
+                () -> new ParameterizedMessage(
+                    "Error while validating header/footer for [{}]. Total data length [{}]",
+                    indexInput.toString(),
+                    indexInput.length()
+                ),
+                cie
+            );
+            throw cie;
+        }
     }
 
     /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Adds logs to understand metadata checksum validation intermittent failures.

### Related Issues
Helps with https://github.com/opensearch-project/OpenSearch/issues/8491
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
