### PR TITLE
[Backport-2.x] Cluster State Update Optimization (#7853)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Move span actions to Scope ([#8411](https://github.com/opensearch-project/OpenSearch/pull/8411))
 - Add wrapper tracer implementation ([#8565](https://github.com/opensearch-project/OpenSearch/pull/8565))
 - Fix painless casting bug, which crashes the OpenSearch process ([#8315](https://github.com/opensearch-project/OpenSearch/pull/8315))
+- Optimize Metadata build() to skip redundant computations as part of ClusterState build ([#7853](https://github.com/opensearch-project/OpenSearch/pull/7853))
 
 ### Deprecated
 

--- a/server/src/main/java/org/opensearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/Metadata.java
@@ -1150,12 +1150,14 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         private final Map<String, IndexMetadata> indices;
         private final Map<String, IndexTemplateMetadata> templates;
         private final Map<String, Custom> customs;
+        private final Metadata previousMetadata;
 
         public Builder() {
             clusterUUID = UNKNOWN_CLUSTER_UUID;
             indices = new HashMap<>();
             templates = new HashMap<>();
             customs = new HashMap<>();
+            previousMetadata = null;
             indexGraveyard(IndexGraveyard.builder().build()); // create new empty index graveyard to initialize
         }
 
@@ -1170,6 +1172,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             this.indices = new HashMap<>(metadata.indices);
             this.templates = new HashMap<>(metadata.templates);
             this.customs = new HashMap<>(metadata.customs);
+            this.previousMetadata = metadata;
         }
 
         public Builder put(IndexMetadata.Builder indexMetadataBuilder) {
@@ -1454,6 +1457,44 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         }
 
         public Metadata build() {
+            DataStreamMetadata dataStreamMetadata = (DataStreamMetadata) this.customs.get(DataStreamMetadata.TYPE);
+            DataStreamMetadata previousDataStreamMetadata = (previousMetadata != null)
+                ? (DataStreamMetadata) this.previousMetadata.customs.get(DataStreamMetadata.TYPE)
+                : null;
+
+            boolean recomputeRequiredforIndicesLookups = (previousMetadata == null)
+                || (indices.equals(previousMetadata.indices) == false)
+                || (previousDataStreamMetadata != null && previousDataStreamMetadata.equals(dataStreamMetadata) == false)
+                || (dataStreamMetadata != null && dataStreamMetadata.equals(previousDataStreamMetadata) == false);
+
+            return (recomputeRequiredforIndicesLookups == false)
+                ? buildMetadataWithPreviousIndicesLookups()
+                : buildMetadataWithRecomputedIndicesLookups();
+        }
+
+        protected Metadata buildMetadataWithPreviousIndicesLookups() {
+            return new Metadata(
+                clusterUUID,
+                clusterUUIDCommitted,
+                version,
+                coordinationMetadata,
+                transientSettings,
+                persistentSettings,
+                hashesOfConsistentSettings,
+                indices,
+                templates,
+                customs,
+                Arrays.copyOf(previousMetadata.allIndices, previousMetadata.allIndices.length),
+                Arrays.copyOf(previousMetadata.visibleIndices, previousMetadata.visibleIndices.length),
+                Arrays.copyOf(previousMetadata.allOpenIndices, previousMetadata.allOpenIndices.length),
+                Arrays.copyOf(previousMetadata.visibleOpenIndices, previousMetadata.visibleOpenIndices.length),
+                Arrays.copyOf(previousMetadata.allClosedIndices, previousMetadata.allClosedIndices.length),
+                Arrays.copyOf(previousMetadata.visibleClosedIndices, previousMetadata.visibleClosedIndices.length),
+                Collections.unmodifiableSortedMap(previousMetadata.indicesLookup)
+            );
+        }
+
+        protected Metadata buildMetadataWithRecomputedIndicesLookups() {
             // TODO: We should move these datastructures to IndexNameExpressionResolver, this will give the following benefits:
             // 1) The datastructures will be rebuilt only when needed. Now during serializing we rebuild these datastructures
             // while these datastructures aren't even used.
@@ -1615,8 +1656,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                 IndexAbstraction existing = indicesLookup.put(indexMetadata.getIndex().getName(), index);
                 assert existing == null : "duplicate for " + indexMetadata.getIndex();
 
-                for (final AliasMetadata aliasCursor : indexMetadata.getAliases().values()) {
-                    AliasMetadata aliasMetadata = aliasCursor;
+                for (final AliasMetadata aliasMetadata : indexMetadata.getAliases().values()) {
                     indicesLookup.compute(aliasMetadata.getAlias(), (aliasName, alias) -> {
                         if (alias == null) {
                             return new IndexAbstraction.Alias(aliasMetadata, indexMetadata);

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataTests.java
@@ -58,6 +58,7 @@ import org.opensearch.test.OpenSearchTestCase;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -76,6 +77,10 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class MetadataTests extends OpenSearchTestCase {
 
@@ -1364,6 +1369,62 @@ public class MetadataTests extends OpenSearchTestCase {
         }
     }
 
+    public void testMetadataBuildInvocations() {
+        final Metadata previousMetadata = randomMetadata();
+        Metadata builtMetadata;
+        Metadata.Builder spyBuilder;
+
+        // previous Metadata state was not provided to Builder during assignment - indices lookups should get re-computed
+        spyBuilder = spy(Metadata.builder());
+        builtMetadata = spyBuilder.build();
+        verify(spyBuilder, times(1)).buildMetadataWithRecomputedIndicesLookups();
+        verify(spyBuilder, times(0)).buildMetadataWithPreviousIndicesLookups();
+        compareMetadata(Metadata.EMPTY_METADATA, builtMetadata, true, true, false);
+
+        // no changes in builder method after initialization from previous Metadata - indices lookups should not be re-computed
+        spyBuilder = spy(Metadata.builder(previousMetadata));
+        builtMetadata = spyBuilder.version(previousMetadata.version() + 1).build();
+        verify(spyBuilder, times(0)).buildMetadataWithRecomputedIndicesLookups();
+        verify(spyBuilder, times(1)).buildMetadataWithPreviousIndicesLookups();
+        compareMetadata(previousMetadata, builtMetadata, true, true, true);
+        reset(spyBuilder);
+
+        // adding new index - all indices lookups should get re-computed
+        spyBuilder = spy(Metadata.builder(previousMetadata));
+        String index = "new_index_" + randomAlphaOfLength(3);
+        builtMetadata = spyBuilder.indices(
+            Collections.singletonMap(
+                index,
+                IndexMetadata.builder(index).settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1).build()
+            )
+        ).build();
+        verify(spyBuilder, times(1)).buildMetadataWithRecomputedIndicesLookups();
+        verify(spyBuilder, times(0)).buildMetadataWithPreviousIndicesLookups();
+        compareMetadata(previousMetadata, builtMetadata, false, true, false);
+        reset(spyBuilder);
+
+        // adding new templates - indices lookups should not get recomputed
+        spyBuilder = spy(Metadata.builder(previousMetadata));
+        builtMetadata = spyBuilder.put("component_template_new_" + randomAlphaOfLength(3), ComponentTemplateTests.randomInstance())
+            .put("index_template_v2_new_" + randomAlphaOfLength(3), ComposableIndexTemplateTests.randomInstance())
+            .build();
+        verify(spyBuilder, times(0)).buildMetadataWithRecomputedIndicesLookups();
+        verify(spyBuilder, times(1)).buildMetadataWithPreviousIndicesLookups();
+        compareMetadata(previousMetadata, builtMetadata, true, false, false);
+        reset(spyBuilder);
+
+        // adding new data stream - indices lookups should get re-computed
+        spyBuilder = spy(Metadata.builder(previousMetadata));
+        DataStream dataStream = DataStreamTests.randomInstance();
+        for (Index backingIndex : dataStream.getIndices()) {
+            spyBuilder.put(DataStreamTestHelper.getIndexMetadataBuilderForIndex(backingIndex));
+        }
+        builtMetadata = spyBuilder.put(dataStream).version(previousMetadata.version() + 1).build();
+        verify(spyBuilder, times(1)).buildMetadataWithRecomputedIndicesLookups();
+        verify(spyBuilder, times(0)).buildMetadataWithPreviousIndicesLookups();
+        compareMetadata(previousMetadata, builtMetadata, false, true, true);
+    }
+
     public static Metadata randomMetadata() {
         Metadata.Builder md = Metadata.builder()
             .put(buildIndexMetadata("index", "alias", randomBoolean() ? null : randomBoolean()).build(), randomBoolean())
@@ -1433,6 +1494,48 @@ public class MetadataTests extends OpenSearchTestCase {
             this.indices = indices;
             this.backingIndices = backingIndices;
             this.metadata = metadata;
+        }
+    }
+
+    private static void compareMetadata(
+        final Metadata previousMetadata,
+        final Metadata newMetadata,
+        final boolean compareIndicesLookups,
+        final boolean compareTemplates,
+        final boolean checkVersionIncrement
+    ) {
+        assertEquals(previousMetadata.clusterUUID(), newMetadata.clusterUUID());
+        assertEquals(previousMetadata.clusterUUIDCommitted(), newMetadata.clusterUUIDCommitted());
+        assertEquals(previousMetadata.coordinationMetadata(), newMetadata.coordinationMetadata());
+        assertEquals(previousMetadata.settings(), newMetadata.settings());
+        assertEquals(previousMetadata.transientSettings(), newMetadata.transientSettings());
+        assertEquals(previousMetadata.persistentSettings(), newMetadata.persistentSettings());
+        assertEquals(previousMetadata.hashesOfConsistentSettings(), newMetadata.hashesOfConsistentSettings());
+
+        if (compareIndicesLookups == true) {
+            assertEquals(previousMetadata.indices(), newMetadata.indices());
+            assertEquals(previousMetadata.getConcreteAllIndices(), newMetadata.getConcreteAllIndices());
+            assertEquals(previousMetadata.getConcreteAllClosedIndices(), newMetadata.getConcreteAllClosedIndices());
+            assertEquals(previousMetadata.getConcreteAllOpenIndices(), newMetadata.getConcreteAllOpenIndices());
+            assertEquals(previousMetadata.getConcreteVisibleIndices(), newMetadata.getConcreteVisibleIndices());
+            assertEquals(previousMetadata.getConcreteVisibleClosedIndices(), newMetadata.getConcreteVisibleClosedIndices());
+            assertEquals(previousMetadata.getConcreteVisibleOpenIndices(), newMetadata.getConcreteVisibleOpenIndices());
+            assertEquals(previousMetadata.getIndicesLookup(), newMetadata.getIndicesLookup());
+            assertEquals(previousMetadata.getCustoms().get(DataStreamMetadata.TYPE), newMetadata.getCustoms().get(DataStreamMetadata.TYPE));
+        }
+
+        if (compareTemplates == true) {
+            assertEquals(previousMetadata.templates(), newMetadata.templates());
+            assertEquals(previousMetadata.templatesV2(), newMetadata.templatesV2());
+            assertEquals(previousMetadata.componentTemplates(), newMetadata.componentTemplates());
+        }
+
+        if (compareIndicesLookups == true && compareTemplates == true) {
+            assertEquals(previousMetadata.getCustoms(), newMetadata.getCustoms());
+        }
+
+        if (checkVersionIncrement == true) {
+            assertEquals(previousMetadata.version() + 1, newMetadata.version());
         }
     }
 }


### PR DESCRIPTION
* Cluster State Update Optimization - Optimize Metadata build() to skip redundant computations of indicesLookup as part of ClusterState build

Signed-off-by: Sandesh Kumar <sandeshkr419@gmail.com>

---------

Signed-off-by: Sandesh Kumar <sandeshkr419@gmail.com>
(cherry picked from commit cb0d13b9cab950b39269eb28691e6075cd9cf1aa)

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Backporting https://github.com/opensearch-project/OpenSearch/pull/7853 to 2.x branch

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/7002

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
