### PR TITLE
extension distinguished name implementation

### DIFF
--- a/server/src/main/java/org/opensearch/discovery/InitializeExtensionResponse.java
+++ b/server/src/main/java/org/opensearch/discovery/InitializeExtensionResponse.java
@@ -48,6 +48,7 @@ import java.util.List;
  */
 public class InitializeExtensionResponse extends TransportResponse {
     private String name;
+    private String distinguishedNames;
     private List<String> implementedInterfaces;
 
     public InitializeExtensionResponse(String name, List<String> implementedInterfaces) {
@@ -72,6 +73,14 @@ public class InitializeExtensionResponse extends TransportResponse {
 
     public String getName() {
         return this.name;
+    }
+
+    public String getDistinguishedNames() {
+        return distinguishedNames;
+    }
+
+    public void setDistinguishedNames(String distinguishedNames) {
+        this.distinguishedNames = distinguishedNames;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/extensions/DiscoveryExtensionNode.java
+++ b/server/src/main/java/org/opensearch/extensions/DiscoveryExtensionNode.java
@@ -32,9 +32,27 @@ import java.util.Map;
  */
 public class DiscoveryExtensionNode extends DiscoveryNode implements Writeable, ToXContentFragment {
 
+    private String distinguishedNames;
     private Version minimumCompatibleVersion;
     private List<ExtensionDependency> dependencies = Collections.emptyList();
     private List<String> implementedInterfaces = Collections.emptyList();
+
+    public DiscoveryExtensionNode(
+        String name,
+        String id,
+        TransportAddress address,
+        Map<String, String> attributes,
+        Version version,
+        String distinguishedNames,
+        Version minimumCompatibleVersion,
+        List<ExtensionDependency> dependencies
+    ) {
+        super(name, id, address, attributes, DiscoveryNodeRole.BUILT_IN_ROLES, version);
+        this.distinguishedNames = distinguishedNames;
+        this.minimumCompatibleVersion = minimumCompatibleVersion;
+        this.dependencies = dependencies;
+        validate();
+    }
 
     public DiscoveryExtensionNode(
         String name,
@@ -55,6 +73,7 @@ public class DiscoveryExtensionNode extends DiscoveryNode implements Writeable, 
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeVersion(minimumCompatibleVersion);
+        out.writeString(distinguishedNames);
         out.writeVInt(dependencies.size());
         for (ExtensionDependency dependency : dependencies) {
             dependency.writeTo(out);
@@ -70,11 +89,20 @@ public class DiscoveryExtensionNode extends DiscoveryNode implements Writeable, 
     public DiscoveryExtensionNode(final StreamInput in) throws IOException {
         super(in);
         minimumCompatibleVersion = in.readVersion();
+        distinguishedNames = in.readString();
         int size = in.readVInt();
         dependencies = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
             dependencies.add(new ExtensionDependency(in));
         }
+    }
+
+    public String getDistinguishedNames() {
+        return distinguishedNames;
+    }
+
+    public void setDistinguishedNames(String distinguishedNames) {
+        this.distinguishedNames = distinguishedNames;
     }
 
     public List<ExtensionDependency> getDependencies() {

--- a/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
@@ -299,6 +299,7 @@ public class ExtensionsManager {
             new TransportAddress(InetAddress.getByName(extension.getHostAddress()), Integer.parseInt(extension.getPort())),
             new HashMap<String, String>(),
             Version.fromString(extension.getOpensearchVersion()),
+            extension.getDistinguishedName(),
             Version.fromString(extension.getMinimumCompatibleVersion()),
             extension.getDependencies()
         );

--- a/server/src/main/java/org/opensearch/extensions/ExtensionsSettings.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionsSettings.java
@@ -43,6 +43,7 @@ public class ExtensionsSettings {
         private String version;
         private String opensearchVersion;
         private String minimumCompatibleVersion;
+        private String distinguishedName;
         private List<ExtensionDependency> dependencies = Collections.emptyList();
         private ExtensionScopedSettings additionalSettings;
 
@@ -54,6 +55,7 @@ public class ExtensionsSettings {
             String version,
             String opensearchVersion,
             String minimumCompatibleVersion,
+            String distinguishedName,
             List<ExtensionDependency> dependencies,
             ExtensionScopedSettings additionalSettings
         ) {
@@ -64,6 +66,7 @@ public class ExtensionsSettings {
             this.version = version;
             this.opensearchVersion = opensearchVersion;
             this.minimumCompatibleVersion = minimumCompatibleVersion;
+            this.distinguishedName = distinguishedName;
             this.dependencies = dependencies;
             this.additionalSettings = additionalSettings;
         }
@@ -126,6 +129,10 @@ public class ExtensionsSettings {
             this.opensearchVersion = opensearchVersion;
         }
 
+        public String getDistinguishedName() {
+            return distinguishedName;
+        }
+
         public List<ExtensionDependency> getDependencies() {
             return dependencies;
         }
@@ -158,6 +165,8 @@ public class ExtensionsSettings {
                 + opensearchVersion
                 + ", minimumCompatibleVersion="
                 + minimumCompatibleVersion
+                + ", distinguishedNames="
+                + distinguishedName
                 + "]";
         }
 

--- a/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
+++ b/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
@@ -216,6 +216,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
             "0.0.7",
             "3.0.0",
             "3.0.0",
+            "CN=extension-01,OU=SECURITY,O=OPENSEARCH,L=BROOKLYN,ST=NEW YORK,C=US",
             Collections.emptyList(),
             extensionScopedSettings
         );
@@ -227,6 +228,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
             "0.0.7",
             "2.0.0",
             "2.0.0",
+            "CN=extension-02,OU=SECURITY,O=OPENSEARCH,L=BROOKLYN,ST=NEW YORK,C=US",
             List.of(dependentExtension),
             extensionScopedSettings
         );
@@ -287,6 +289,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
             "0.0.7",
             "3.0.0",
             "3.0.0",
+            "CN=extension-01,OU=SECURITY,O=OPENSEARCH,L=BROOKLYN,ST=NEW YORK,C=US",
             Collections.emptyList(),
             null
         );
@@ -298,6 +301,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
             "0.0.7",
             "3.0.0",
             "3.0.0",
+            "CN=extension-01,OU=SECURITY,O=OPENSEARCH,L=BROOKLYN,ST=NEW YORK,C=US",
             null,
             null
         );
@@ -339,7 +343,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
 
     public void testMissingRequiredFieldsWhileLoadingExtension() throws Exception {
 
-        Extension firstExtension = new Extension("firstExtension", "uniqueid1", "127.0.0.0", "9300", "0.0.7", "3.0.0", "", null, null);
+        Extension firstExtension = new Extension("firstExtension", "uniqueid1", "127.0.0.0", "9300", "0.0.7", "3.0.0", "", null, null,null);
         ExtensionsManager extensionsManager = new ExtensionsManager(Set.of());
 
         IOException exception = expectThrows(IOException.class, () -> extensionsManager.loadExtension(firstExtension));
@@ -809,6 +813,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
             "0.0.7",
             "3.0.0",
             "3.99.0",
+            "CN=extension-01,OU=SECURITY,O=OPENSEARCH,L=BROOKLYN,ST=NEW YORK,C=US",
             List.of(),
             null
         );
@@ -837,6 +842,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
             "0.0.7",
             "3.0.0",
             "3.0.0",
+            "CN=extension-01,OU=SECURITY,O=OPENSEARCH,L=BROOKLYN,ST=NEW YORK,C=US",
             List.of(),
             extensionScopedSettings
         );
@@ -875,6 +881,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
             "0.0.7",
             "2.0.0",
             "2.0.0",
+            "CN=extension-01,OU=SECURITY,O=OPENSEARCH,L=BROOKLYN,ST=NEW YORK,C=US",
             List.of(),
             extensionScopedSettings
         );


### PR DESCRIPTION
Description

Add support for extension domain name, similar to how it's done for security plugin. More about that in the task: https://github.com/opensearch-project/security/issues/2730
Issues Resolved

https://github.com/opensearch-project/security/issues/2730

Currently the implementation looks like this:

    During extension initialization via REST call, DNs are passed in the request body:

curl -XPOST -k -u user:password "https://localhost:9200/_extensions/initialize" -H "Content-Type:application/json" --data '{ "name":"hello-world", "uniqueId":"hello-world2", "hostAddress":"127.0.0.1", "port":"4500", "version":"1.0", "opensearchVersion":"3.0.0", "minimumCompatibleVersion":"3.0.0", "dependencies":[{"uniqueId":"test1","version":"2.0.0"},{"uniqueId":"test2","version":"3.0.0"}], "extension_dn": "CN=extension-0.example.com,OU=node,O=node,L=test,DC=de" }'

    Request gets parsed and forwarded to extension node, extension_dn get's sent with InitializeExtensionRequest object
    At this point on the extension side after SSL handshake the DNs get compared, error is thrown if it's incorrect

PR on openserch-sdk-java side: https://github.com/opensearch-project/opensearch-sdk-java/pull/879

I'm in the process of writing tests. Main issue I'm facing right now is that I'm wondering if the overall process looks good. Is the validation logic on the right side? Maybe core side should wait for extension response and then accept/reject call?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).