### PR TITLE
[Segment Replication] Create a separate thread pool for Segment Replication events

### DIFF
--- a/server/src/main/java/org/opensearch/index/SegmentReplicationPressureService.java
+++ b/server/src/main/java/org/opensearch/index/SegmentReplicationPressureService.java
@@ -272,7 +272,7 @@ public class SegmentReplicationPressureService implements Closeable {
 
         @Override
         protected String getThreadPool() {
-            return ThreadPool.Names.GENERIC;
+            return ThreadPool.Names.SEGMENT_REPLICATION;
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/index/SegmentReplicationPressureService.java
+++ b/server/src/main/java/org/opensearch/index/SegmentReplicationPressureService.java
@@ -272,7 +272,7 @@ public class SegmentReplicationPressureService implements Closeable {
 
         @Override
         protected String getThreadPool() {
-            return ThreadPool.Names.SEGMENT_REPLICATION;
+            return ThreadPool.Names.GENERIC;
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceService.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceService.java
@@ -81,19 +81,19 @@ public class SegmentReplicationSourceService extends AbstractLifecycleComponent 
         this.ongoingSegmentReplications = ongoingSegmentReplications;
         transportService.registerRequestHandler(
             Actions.GET_CHECKPOINT_INFO,
-            ThreadPool.Names.GENERIC,
+            ThreadPool.Names.SEGMENT_REPLICATION,
             CheckpointInfoRequest::new,
             new CheckpointInfoRequestHandler()
         );
         transportService.registerRequestHandler(
             Actions.GET_SEGMENT_FILES,
-            ThreadPool.Names.GENERIC,
+            ThreadPool.Names.SEGMENT_REPLICATION,
             GetSegmentFilesRequest::new,
             new GetSegmentFilesRequestHandler()
         );
         transportService.registerRequestHandler(
             Actions.UPDATE_VISIBLE_CHECKPOINT,
-            ThreadPool.Names.GENERIC,
+            ThreadPool.Names.SEGMENT_REPLICATION,
             UpdateVisibleCheckpointRequest::new,
             new UpdateVisibleCheckpointRequestHandler()
         );

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
@@ -126,13 +126,13 @@ public class SegmentReplicationTargetService implements IndexEventListener {
 
         transportService.registerRequestHandler(
             Actions.FILE_CHUNK,
-            ThreadPool.Names.GENERIC,
+            ThreadPool.Names.SEGMENT_REPLICATION,
             FileChunkRequest::new,
             new FileChunkTransportRequestHandler()
         );
         transportService.registerRequestHandler(
             Actions.FORCE_SYNC,
-            ThreadPool.Names.GENERIC,
+            ThreadPool.Names.SEGMENT_REPLICATION,
             ForceSyncRequest::new,
             new ForceSyncTransportRequestHandler()
         );

--- a/server/src/main/java/org/opensearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/opensearch/threadpool/ThreadPool.java
@@ -113,6 +113,8 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         public static final String TRANSLOG_SYNC = "translog_sync";
         public static final String REMOTE_PURGE = "remote_purge";
         public static final String REMOTE_REFRESH = "remote_refresh";
+
+        public static final String SEGMENT_REPLICATION = "segment_replication";
         public static final String INDEX_SEARCHER = "index_searcher";
     }
 
@@ -182,6 +184,7 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         map.put(Names.TRANSLOG_SYNC, ThreadPoolType.FIXED);
         map.put(Names.REMOTE_PURGE, ThreadPoolType.SCALING);
         map.put(Names.REMOTE_REFRESH, ThreadPoolType.SCALING);
+        map.put(Names.SEGMENT_REPLICATION, ThreadPoolType.SCALING);
         if (FeatureFlags.isEnabled(FeatureFlags.CONCURRENT_SEGMENT_SEARCH)) {
             map.put(Names.INDEX_SEARCHER, ThreadPoolType.RESIZABLE);
         }
@@ -266,6 +269,10 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         builders.put(
             Names.REMOTE_REFRESH,
             new ScalingExecutorBuilder(Names.REMOTE_REFRESH, 1, halfProcMaxAt10, TimeValue.timeValueMinutes(5))
+        );
+        builders.put(
+            Names.SEGMENT_REPLICATION,
+            new ScalingExecutorBuilder(Names.SEGMENT_REPLICATION, 1, halfProcMaxAt10, TimeValue.timeValueMinutes(5))
         );
         if (FeatureFlags.isEnabled(FeatureFlags.CONCURRENT_SEGMENT_SEARCH)) {
             builders.put(

--- a/server/src/test/java/org/opensearch/threadpool/ScalingThreadPoolTests.java
+++ b/server/src/test/java/org/opensearch/threadpool/ScalingThreadPoolTests.java
@@ -136,6 +136,7 @@ public class ScalingThreadPoolTests extends OpenSearchThreadPoolTestCase {
         sizes.put(ThreadPool.Names.TRANSLOG_SYNC, n -> 4 * n);
         sizes.put(ThreadPool.Names.REMOTE_PURGE, ThreadPool::halfAllocatedProcessorsMaxFive);
         sizes.put(ThreadPool.Names.REMOTE_REFRESH, ThreadPool::halfAllocatedProcessorsMaxTen);
+        sizes.put(ThreadPool.Names.SEGMENT_REPLICATION, ThreadPool::halfAllocatedProcessorsMaxTen);
         return sizes.get(threadPoolName).apply(numberOfProcessors);
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR creates a new threadpool for segment replication.

### Related Issues
Resolves #8118 
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
