### PR TITLE
[Remote Store] Use GatedRefreshListener to drain ongoing tasks on relocation

### DIFF
--- a/server/src/main/java/org/opensearch/index/shard/CheckpointRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/CheckpointRefreshListener.java
@@ -21,7 +21,7 @@ import java.io.IOException;
  *
  * @opensearch.internal
  */
-public class CheckpointRefreshListener implements ReferenceManager.RefreshListener {
+public class CheckpointRefreshListener extends GatedRefreshListener {
 
     protected static Logger logger = LogManager.getLogger(CheckpointRefreshListener.class);
 
@@ -40,11 +40,13 @@ public class CheckpointRefreshListener implements ReferenceManager.RefreshListen
 
     @Override
     public void afterRefresh(boolean didRefresh) throws IOException {
-        if (didRefresh
-            && shard.state() == IndexShardState.STARTED
-            && shard.getReplicationTracker().isPrimaryMode()
-            && !shard.indexSettings.isSegRepWithRemoteEnabled()) {
-            publisher.publish(shard, shard.getLatestReplicationCheckpoint());
-        }
+        getPermitWrappedTask(() -> {
+            if (didRefresh
+                && shard.state() == IndexShardState.STARTED
+                && shard.getReplicationTracker().isPrimaryMode()
+                && !shard.indexSettings.isSegRepWithRemoteEnabled()) {
+                publisher.publish(shard, shard.getLatestReplicationCheckpoint());
+            }
+        }).run();
     }
 }

--- a/server/src/main/java/org/opensearch/index/shard/GatedRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/GatedRefreshListener.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.shard;
+
+import org.apache.lucene.search.ReferenceManager;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public abstract class GatedRefreshListener implements ReferenceManager.RefreshListener, Closeable {
+
+    private final AtomicBoolean closed = new AtomicBoolean();
+
+    private static final int TOTAL_PERMITS = Integer.MAX_VALUE;
+
+    private final Semaphore semaphore = new Semaphore(TOTAL_PERMITS);
+
+    protected Runnable getPermitWrappedTask(Runnable runnable) {
+        if (closed.get() == false && semaphore.tryAcquire()) {
+            return () -> {
+                try {
+                    runnable.run();
+                } finally {
+                    semaphore.release();
+                }
+            };
+        }
+        return () -> {};
+    }
+
+    @Override
+    public final void close() throws IOException {
+        try {
+            if (semaphore.tryAcquire(TOTAL_PERMITS, 10, TimeUnit.MINUTES)) {
+                boolean result = closed.compareAndSet(false, true);
+                assert result;
+                assert semaphore.availablePermits() == 0;
+            }
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Failed to close the gated listener due to ", e);
+        }
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
RefreshListeners are async in nature and are triggered after segments are refreshed. Today, during relocation handoff, it is possible that the remote segments upload are happening from the older primary while the relocation has happened. Now, we are introducing a `GatedRefreshListener` which will be extended by `RemoteStoreRefreshListener` and `CheckpointRefreshListener`. The GatedRefreshListener has capabilities to be closed which guarantees that refreshes would not trigger any activity on these listeners once closed.

### Related Issues
Resolves #8345
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
