### PR TITLE
Fix RemoteStoreReplicationSourceTests.testGetCheckpointMetadataEmpty.

### DIFF
--- a/server/src/test/java/org/opensearch/indices/replication/RemoteStoreReplicationSourceTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/RemoteStoreReplicationSourceTests.java
@@ -45,18 +45,16 @@ public class RemoteStoreReplicationSourceTests extends OpenSearchIndexLevelRepli
 
     private Store remoteStore;
 
+    private final Settings settings = Settings.builder()
+        .put(IndexMetadata.SETTING_REMOTE_STORE_ENABLED, true)
+        .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+        .build();
+
     @Override
     public void setUp() throws Exception {
         super.setUp();
 
-        indexShard = newStartedShard(
-            true,
-            Settings.builder()
-                .put(IndexMetadata.SETTING_REMOTE_STORE_ENABLED, true)
-                .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
-                .build(),
-            new InternalEngineFactory()
-        );
+        indexShard = newStartedShard(true, settings, new InternalEngineFactory());
 
         indexDoc(indexShard, "_doc", "1");
         indexDoc(indexShard, "_doc", "2");
@@ -133,7 +131,7 @@ public class RemoteStoreReplicationSourceTests extends OpenSearchIndexLevelRepli
         try {
             emptyIndexShard = newStartedShard(
                 true,
-                Settings.builder().put(IndexMetadata.SETTING_REMOTE_STORE_ENABLED, true).build(),
+                settings,
                 new InternalEngineFactory()
             );
             RemoteSegmentStoreDirectory remoteSegmentStoreDirectory =


### PR DESCRIPTION
### Description
This change fixes RemoteStoreReplicationSourceTests.testGetCheckpointMetadataEmpty by properly setting replication type on primary shards.

### Related Issues
resolves #8699

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
