### PR TITLE
[Backport 2.x] Fix RemoteStoreReplicationSourceTests.testGetCheckpointMetadataEmpty (#8704)

### DIFF
--- a/server/src/test/java/org/opensearch/indices/replication/RemoteStoreReplicationSourceTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/RemoteStoreReplicationSourceTests.java
@@ -22,6 +22,7 @@ import org.opensearch.index.shard.RemoteStoreRefreshListenerTests;
 import org.opensearch.index.store.RemoteSegmentStoreDirectory;
 import org.opensearch.index.store.Store;
 import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
+import org.opensearch.indices.replication.common.ReplicationType;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -44,14 +45,16 @@ public class RemoteStoreReplicationSourceTests extends OpenSearchIndexLevelRepli
 
     private Store remoteStore;
 
+    private final Settings settings = Settings.builder()
+        .put(IndexMetadata.SETTING_REMOTE_STORE_ENABLED, true)
+        .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+        .build();
+
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        indexShard = newStartedShard(
-            true,
-            Settings.builder().put(IndexMetadata.SETTING_REMOTE_STORE_ENABLED, true).build(),
-            new InternalEngineFactory()
-        );
+
+        indexShard = newStartedShard(true, settings, new InternalEngineFactory());
 
         indexDoc(indexShard, "_doc", "1");
         indexDoc(indexShard, "_doc", "2");
@@ -128,7 +131,7 @@ public class RemoteStoreReplicationSourceTests extends OpenSearchIndexLevelRepli
         try {
             emptyIndexShard = newStartedShard(
                 true,
-                Settings.builder().put(IndexMetadata.SETTING_REMOTE_STORE_ENABLED, true).build(),
+                settings,
                 new InternalEngineFactory()
             );
             RemoteSegmentStoreDirectory remoteSegmentStoreDirectory =


### PR DESCRIPTION
Manual backport of (#8704)