### PR TITLE
Indexing: add Doc status counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Telemetry-Otel] Added support for OtlpGrpcSpanExporter exporter ([#9666](https://github.com/opensearch-project/OpenSearch/pull/9666))
 - Async blob read support for encrypted containers ([#10131](https://github.com/opensearch-project/OpenSearch/pull/10131))
 - Add capability to restrict async durability mode for remote indexes ([#10189](https://github.com/opensearch-project/OpenSearch/pull/10189))
+- Add Doc Status Counter for Indexing Engine ([#4562](https://github.com/opensearch-project/OpenSearch/issues/4562))
 
 ### Dependencies
 - Bump `peter-evans/create-or-update-comment` from 2 to 3 ([#9575](https://github.com/opensearch-project/OpenSearch/pull/9575))

--- a/libs/core/src/main/java/org/opensearch/core/rest/RestStatus.java
+++ b/libs/core/src/main/java/org/opensearch/core/rest/RestStatus.java
@@ -527,6 +527,15 @@ public enum RestStatus {
         return status;
     }
 
+    /**
+     * Get category class of a rest status code.
+     *
+     * @return Integer representing class category of the concrete rest status code
+     */
+    public int getStatusFamilyCode() {
+        return status / 100;
+    }
+
     public static RestStatus readFrom(StreamInput in) throws IOException {
         return RestStatus.valueOf(in.readString());
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.stats/11_indices_metrics.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.stats/11_indices_metrics.yml
@@ -138,6 +138,35 @@
   - is_false:  nodes.$node_id.indices.translog
   - is_false:  nodes.$node_id.indices.recovery
 
+---
+"Metric - indexing doc_status":
+  - skip:
+      version: " - 2.99.99"
+      reason: "To be introduced in future release :: TODO: change if/when we backport to 2.x"
+  - do:
+      nodes.info: {}
+  - set:
+      nodes._arbitrary_key_: node_id
+
+  - do:
+      nodes.stats: { metric: indices, index_metric: indexing }
+
+  - is_false: nodes.$node_id.indices.docs
+  - is_false: nodes.$node_id.indices.store
+  - is_true: nodes.$node_id.indices.indexing
+  - is_true: nodes.$node_id.indices.indexing.doc_status
+  - is_false: nodes.$node_id.indices.get
+  - is_false: nodes.$node_id.indices.search
+  - is_false: nodes.$node_id.indices.merges
+  - is_false: nodes.$node_id.indices.refresh
+  - is_false: nodes.$node_id.indices.flush
+  - is_false: nodes.$node_id.indices.warmer
+  - is_false: nodes.$node_id.indices.query_cache
+  - is_false: nodes.$node_id.indices.fielddata
+  - is_false: nodes.$node_id.indices.completion
+  - is_false: nodes.$node_id.indices.segments
+  - is_false: nodes.$node_id.indices.translog
+  - is_false: nodes.$node_id.indices.recovery
 
 ---
 "Metric - recovery":

--- a/server/src/internalClusterTest/java/org/opensearch/nodestats/NodeStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/nodestats/NodeStatsIT.java
@@ -1,0 +1,276 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.nodestats;
+
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.action.DocWriteResponse;
+import org.opensearch.action.bulk.BulkItemResponse;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.action.delete.DeleteRequest;
+import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.update.UpdateRequest;
+import org.opensearch.action.update.UpdateResponse;
+import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.index.engine.DocumentMissingException;
+import org.opensearch.index.engine.VersionConflictEngineException;
+import org.opensearch.index.shard.IndexingStats.Stats.DocStatusStats;
+import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.test.OpenSearchIntegTestCase.ClusterScope;
+import org.opensearch.test.OpenSearchIntegTestCase.Scope;
+import org.hamcrest.MatcherAssert;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static java.util.Collections.singletonMap;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+@ClusterScope(scope = Scope.TEST, numDataNodes = 1, numClientNodes = 0, supportsDedicatedMasters = false)
+public class NodeStatsIT extends OpenSearchIntegTestCase {
+
+    private final DocStatusStats expectedDocStatusStats = new DocStatusStats();
+    private static final String FIELD = "dummy_field";
+    private static final String VALUE = "dummy_value";
+    private static final Map<String, Object> SOURCE = singletonMap(FIELD, VALUE);
+
+    public void testNodeIndicesStatsDocStatusStatsIndexBulk() {
+        {  // Testing Index
+            final String INDEX = "test_index";
+            final String ID = "id";
+            {  // Testing Normal Index
+                IndexResponse response = client().index(new IndexRequest(INDEX).id(ID).source(SOURCE)).actionGet();
+                updateExpectedDocStatusCounter(response);
+
+                MatcherAssert.assertThat(response.getResult(), equalTo(DocWriteResponse.Result.CREATED));
+                assertDocStatusStats();
+            }
+            {  // Testing Missing Alias
+                updateExpectedDocStatusCounter(
+                    expectThrows(
+                        IndexNotFoundException.class,
+                        () -> client().index(new IndexRequest(INDEX).id("missing_alias").setRequireAlias(true).source(SOURCE)).actionGet()
+                    )
+                );
+                assertDocStatusStats();
+            }
+            {
+                // Test Missing Pipeline: Ingestion failure, not Indexing failure
+                expectThrows(
+                    IllegalArgumentException.class,
+                    () -> client().index(new IndexRequest(INDEX).id("missing_pipeline").setPipeline("missing").source(SOURCE)).actionGet()
+                );
+                assertDocStatusStats();
+            }
+            {  // Testing Version Conflict
+                final String docId = "version_conflict";
+
+                updateExpectedDocStatusCounter(client().index(new IndexRequest(INDEX).id(docId).source(SOURCE)).actionGet());
+                updateExpectedDocStatusCounter(
+                    expectThrows(
+                        VersionConflictEngineException.class,
+                        () -> client().index(new IndexRequest(INDEX).id(docId).source(SOURCE).setIfSeqNo(1L).setIfPrimaryTerm(99L))
+                            .actionGet()
+                    )
+                );
+                assertDocStatusStats();
+            }
+        }
+        {  // Testing Bulk
+            final String INDEX = "bulk_index";
+
+            int sizeOfIndexRequests = scaledRandomIntBetween(10, 20);
+            int sizeOfDeleteRequests = scaledRandomIntBetween(5, sizeOfIndexRequests);
+            int sizeOfNotFoundRequests = scaledRandomIntBetween(5, sizeOfIndexRequests);
+
+            BulkRequest bulkRequest = new BulkRequest();
+
+            for (int i = 0; i < sizeOfIndexRequests; ++i) {
+                bulkRequest.add(new IndexRequest(INDEX).id(String.valueOf(i)).source(SOURCE));
+            }
+
+            BulkResponse response = client().bulk(bulkRequest).actionGet();
+
+            MatcherAssert.assertThat(response.hasFailures(), equalTo(false));
+            MatcherAssert.assertThat(response.getItems().length, equalTo(sizeOfIndexRequests));
+
+            for (BulkItemResponse itemResponse : response.getItems()) {
+                updateExpectedDocStatusCounter(itemResponse.getResponse());
+            }
+
+            refresh(INDEX);
+            bulkRequest.requests().clear();
+
+            for (int i = 0; i < sizeOfDeleteRequests; ++i) {
+                bulkRequest.add(new DeleteRequest(INDEX, String.valueOf(i)));
+            }
+            for (int i = 0; i < sizeOfNotFoundRequests; ++i) {
+                bulkRequest.add(new DeleteRequest(INDEX, String.valueOf(25 + i)));
+            }
+
+            response = client().bulk(bulkRequest).actionGet();
+
+            MatcherAssert.assertThat(response.hasFailures(), equalTo(false));
+            MatcherAssert.assertThat(response.getItems().length, equalTo(sizeOfDeleteRequests + sizeOfNotFoundRequests));
+
+            for (BulkItemResponse itemResponse : response.getItems()) {
+                updateExpectedDocStatusCounter(itemResponse.getResponse());
+            }
+
+            refresh(INDEX);
+            assertDocStatusStats();
+        }
+    }
+
+    public void testNodeIndicesStatsDocStatusStatsCreateDeleteUpdate() {
+        {  // Testing Create
+            final String INDEX = "create_index";
+            final String ID = "id";
+            {  // Testing Creation
+                IndexResponse response = client().index(new IndexRequest(INDEX).id(ID).source(SOURCE).create(true)).actionGet();
+                updateExpectedDocStatusCounter(response);
+
+                MatcherAssert.assertThat(response.getResult(), equalTo(DocWriteResponse.Result.CREATED));
+                assertDocStatusStats();
+            }
+            {  // Testing Version Conflict
+                final String docId = "version_conflict";
+
+                updateExpectedDocStatusCounter(client().index(new IndexRequest(INDEX).id(docId).source(SOURCE)).actionGet());
+                updateExpectedDocStatusCounter(
+                    expectThrows(
+                        VersionConflictEngineException.class,
+                        () -> client().index(new IndexRequest(INDEX).id(docId).source(SOURCE).create(true)).actionGet()
+                    )
+                );
+                assertDocStatusStats();
+            }
+        }
+        {  // Testing Delete
+            final String INDEX = "delete_index";
+            final String ID = "id";
+            {  // Testing Deletion
+                IndexResponse response = client().index(new IndexRequest(INDEX).id(ID).source(SOURCE)).actionGet();
+                updateExpectedDocStatusCounter(response);
+
+                DeleteResponse deleteResponse = client().delete(new DeleteRequest(INDEX, ID)).actionGet();
+                updateExpectedDocStatusCounter(deleteResponse);
+
+                MatcherAssert.assertThat(response.getSeqNo(), greaterThanOrEqualTo(0L));
+                MatcherAssert.assertThat(deleteResponse.getResult(), equalTo(DocWriteResponse.Result.DELETED));
+                assertDocStatusStats();
+            }
+            {  // Testing Non-Existing Doc
+                updateExpectedDocStatusCounter(client().delete(new DeleteRequest(INDEX, "does_not_exist")).actionGet());
+                assertDocStatusStats();
+            }
+            {  // Testing Version Conflict
+                final String docId = "version_conflict";
+
+                updateExpectedDocStatusCounter(client().index(new IndexRequest(INDEX).id(docId).source(SOURCE)).actionGet());
+                updateExpectedDocStatusCounter(
+                    expectThrows(
+                        VersionConflictEngineException.class,
+                        () -> client().delete(new DeleteRequest(INDEX, docId).setIfSeqNo(2L).setIfPrimaryTerm(99L)).actionGet()
+                    )
+                );
+
+                assertDocStatusStats();
+            }
+        }
+        {  // Testing Update
+            final String INDEX = "update_index";
+            final String ID = "id";
+            {  // Testing Not Found
+                updateExpectedDocStatusCounter(
+                    expectThrows(
+                        DocumentMissingException.class,
+                        () -> client().update(new UpdateRequest(INDEX, ID).doc(SOURCE)).actionGet()
+                    )
+                );
+                assertDocStatusStats();
+            }
+            {  // Testing NoOp Update
+                updateExpectedDocStatusCounter(client().index(new IndexRequest(INDEX).id(ID).source(SOURCE)).actionGet());
+
+                UpdateResponse response = client().update(new UpdateRequest(INDEX, ID).doc(SOURCE)).actionGet();
+                updateExpectedDocStatusCounter(response);
+
+                MatcherAssert.assertThat(response.getResult(), equalTo(DocWriteResponse.Result.NOOP));
+                assertDocStatusStats();
+            }
+            {  // Testing Update
+                final String UPDATED_VALUE = "updated_value";
+                UpdateResponse response = client().update(new UpdateRequest(INDEX, ID).doc(singletonMap(FIELD, UPDATED_VALUE))).actionGet();
+                updateExpectedDocStatusCounter(response);
+
+                MatcherAssert.assertThat(response.getResult(), equalTo(DocWriteResponse.Result.UPDATED));
+                assertDocStatusStats();
+            }
+            {  // Testing Missing Alias
+                updateExpectedDocStatusCounter(
+                    expectThrows(
+                        IndexNotFoundException.class,
+                        () -> client().update(new UpdateRequest(INDEX, ID).setRequireAlias(true).doc(new IndexRequest().source(SOURCE)))
+                            .actionGet()
+                    )
+                );
+                assertDocStatusStats();
+            }
+            {  // Testing Version Conflict
+                final String docId = "version_conflict";
+
+                updateExpectedDocStatusCounter(client().index(new IndexRequest(INDEX).id(docId).source(SOURCE)).actionGet());
+                updateExpectedDocStatusCounter(
+                    expectThrows(
+                        VersionConflictEngineException.class,
+                        () -> client().update(new UpdateRequest(INDEX, docId).doc(SOURCE).setIfSeqNo(2L).setIfPrimaryTerm(99L)).actionGet()
+                    )
+                );
+                assertDocStatusStats();
+            }
+        }
+    }
+
+    private void assertDocStatusStats() {
+        DocStatusStats docStatusStats = client().admin()
+            .cluster()
+            .prepareNodesStats()
+            .execute()
+            .actionGet()
+            .getNodes()
+            .get(0)
+            .getIndices()
+            .getIndexing()
+            .getTotal()
+            .getDocStatusStats();
+
+        assertTrue(
+            Arrays.equals(
+                docStatusStats.getDocStatusCounter(),
+                expectedDocStatusStats.getDocStatusCounter(),
+                Comparator.comparingLong(AtomicLong::longValue)
+            )
+        );
+    }
+
+    private void updateExpectedDocStatusCounter(DocWriteResponse r) {
+        expectedDocStatusStats.inc(r.status());
+    }
+
+    private void updateExpectedDocStatusCounter(Exception e) {
+        expectedDocStatusStats.inc(ExceptionsHelper.status(e));
+    }
+
+}

--- a/server/src/main/java/org/opensearch/index/shard/IndexingStats.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexingStats.java
@@ -37,6 +37,7 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.ToXContentFragment;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -44,6 +45,7 @@ import org.opensearch.index.mapper.MapperService;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Tracks indexing statistics
@@ -59,6 +61,89 @@ public class IndexingStats implements Writeable, ToXContentFragment {
      */
     public static class Stats implements Writeable, ToXContentFragment {
 
+        /**
+         * Tracks item level rest category class codes during indexing
+         *
+         * @opensearch.internal
+         */
+        public static class DocStatusStats implements Writeable, ToXContentFragment {
+
+            final AtomicLong[] docStatusCounter;
+
+            public DocStatusStats() {
+                docStatusCounter = new AtomicLong[5];
+                for (int i = 0; i < docStatusCounter.length; ++i) {
+                    docStatusCounter[i] = new AtomicLong(0);
+                }
+            }
+
+            public DocStatusStats(StreamInput in) throws IOException {
+                docStatusCounter = in.readArray(i -> new AtomicLong(i.readLong()), AtomicLong[]::new);
+
+                assert docStatusCounter.length == 5 : "Length of incoming array should be 5! Got " + docStatusCounter.length;
+            }
+
+            /**
+             * Increment counter for status
+             *
+             * @param status {@link RestStatus}
+             */
+            public void inc(final RestStatus status) {
+                add(status, 1L);
+            }
+
+            /**
+             * Increment counter for status by count
+             *
+             * @param status {@link RestStatus}
+             * @param delta The value to add
+             */
+            void add(final RestStatus status, final long delta) {
+                docStatusCounter[status.getStatusFamilyCode() - 1].addAndGet(delta);
+            }
+
+            /**
+             * Accumulate stats from the passed Object
+             *
+             * @param stats Instance storing {@link DocStatusStats}
+             */
+            public void add(final DocStatusStats stats) {
+                if (null == stats) {
+                    return;
+                }
+
+                for (int i = 0; i < docStatusCounter.length; ++i) {
+                    docStatusCounter[i].addAndGet(stats.docStatusCounter[i].longValue());
+                }
+            }
+
+            public AtomicLong[] getDocStatusCounter() {
+                return docStatusCounter;
+            }
+
+            @Override
+            public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+                builder.startObject(Fields.DOC_STATUS);
+
+                for (int i = 0; i < docStatusCounter.length; ++i) {
+                    long value = docStatusCounter[i].longValue();
+
+                    if (value > 0) {
+                        String key = i + 1 + "xx";
+                        builder.field(key, value);
+                    }
+                }
+
+                return builder.endObject();
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                out.writeArray((o, v) -> o.writeLong(v.longValue()), docStatusCounter);
+            }
+
+        }
+
         private long indexCount;
         private long indexTimeInMillis;
         private long indexCurrent;
@@ -69,8 +154,11 @@ public class IndexingStats implements Writeable, ToXContentFragment {
         private long noopUpdateCount;
         private long throttleTimeInMillis;
         private boolean isThrottled;
+        private final DocStatusStats docStatusStats;
 
-        Stats() {}
+        Stats() {
+            docStatusStats = new DocStatusStats();
+        }
 
         public Stats(StreamInput in) throws IOException {
             indexCount = in.readVLong();
@@ -83,6 +171,12 @@ public class IndexingStats implements Writeable, ToXContentFragment {
             noopUpdateCount = in.readVLong();
             isThrottled = in.readBoolean();
             throttleTimeInMillis = in.readLong();
+
+            if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+                docStatusStats = in.readOptionalWriteable(DocStatusStats::new);
+            } else {
+                docStatusStats = null;
+            }
         }
 
         public Stats(
@@ -95,7 +189,8 @@ public class IndexingStats implements Writeable, ToXContentFragment {
             long deleteCurrent,
             long noopUpdateCount,
             boolean isThrottled,
-            long throttleTimeInMillis
+            long throttleTimeInMillis,
+            DocStatusStats docStatusStats
         ) {
             this.indexCount = indexCount;
             this.indexTimeInMillis = indexTimeInMillis;
@@ -107,6 +202,7 @@ public class IndexingStats implements Writeable, ToXContentFragment {
             this.noopUpdateCount = noopUpdateCount;
             this.isThrottled = isThrottled;
             this.throttleTimeInMillis = throttleTimeInMillis;
+            this.docStatusStats = docStatusStats;
         }
 
         public void add(Stats stats) {
@@ -121,8 +217,10 @@ public class IndexingStats implements Writeable, ToXContentFragment {
 
             noopUpdateCount += stats.noopUpdateCount;
             throttleTimeInMillis += stats.throttleTimeInMillis;
-            if (isThrottled != stats.isThrottled) {
-                isThrottled = true; // When combining if one is throttled set result to throttled.
+            isThrottled |= stats.isThrottled; // When combining if one is throttled set result to throttled.
+
+            if (getDocStatusStats() != null) {
+                getDocStatusStats().add(stats.getDocStatusStats());
             }
         }
 
@@ -193,6 +291,10 @@ public class IndexingStats implements Writeable, ToXContentFragment {
             return noopUpdateCount;
         }
 
+        public DocStatusStats getDocStatusStats() {
+            return docStatusStats;
+        }
+
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeVLong(indexCount);
@@ -206,6 +308,9 @@ public class IndexingStats implements Writeable, ToXContentFragment {
             out.writeBoolean(isThrottled);
             out.writeLong(throttleTimeInMillis);
 
+            if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+                out.writeOptionalWriteable(docStatusStats);
+            }
         }
 
         @Override
@@ -223,8 +328,14 @@ public class IndexingStats implements Writeable, ToXContentFragment {
 
             builder.field(Fields.IS_THROTTLED, isThrottled);
             builder.humanReadableField(Fields.THROTTLED_TIME_IN_MILLIS, Fields.THROTTLED_TIME, getThrottleTime());
+
+            if (getDocStatusStats() != null) {
+                getDocStatusStats().toXContent(builder, params);
+            }
+
             return builder;
         }
+
     }
 
     private final Stats totalStats;
@@ -279,7 +390,7 @@ public class IndexingStats implements Writeable, ToXContentFragment {
      *
      * @opensearch.internal
      */
-    static final class Fields {
+    private static final class Fields {
         static final String INDEXING = "indexing";
         static final String INDEX_TOTAL = "index_total";
         static final String INDEX_TIME = "index_time";
@@ -294,6 +405,7 @@ public class IndexingStats implements Writeable, ToXContentFragment {
         static final String IS_THROTTLED = "is_throttled";
         static final String THROTTLED_TIME_IN_MILLIS = "throttle_time_in_millis";
         static final String THROTTLED_TIME = "throttle_time";
+        static final String DOC_STATUS = "doc_status";
     }
 
     @Override
@@ -303,4 +415,5 @@ public class IndexingStats implements Writeable, ToXContentFragment {
             out.writeBoolean(false);
         }
     }
+
 }

--- a/server/src/main/java/org/opensearch/index/shard/InternalIndexingStats.java
+++ b/server/src/main/java/org/opensearch/index/shard/InternalIndexingStats.java
@@ -154,7 +154,8 @@ final class InternalIndexingStats implements IndexingOperationListener {
                 deleteCurrent.count(),
                 noopUpdates.count(),
                 isThrottled,
-                TimeUnit.MILLISECONDS.toMillis(currentThrottleMillis)
+                TimeUnit.MILLISECONDS.toMillis(currentThrottleMillis),
+                new IndexingStats.Stats.DocStatusStats()
             );
         }
     }

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -133,6 +133,7 @@ import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.shard.IndexShardState;
 import org.opensearch.index.shard.IndexingOperationListener;
 import org.opensearch.index.shard.IndexingStats;
+import org.opensearch.index.shard.IndexingStats.Stats.DocStatusStats;
 import org.opensearch.index.store.remote.filecache.FileCacheCleaner;
 import org.opensearch.index.translog.InternalTranslogFactory;
 import org.opensearch.index.translog.RemoteBlobStoreInternalTranslogFactory;
@@ -1056,6 +1057,15 @@ public class IndicesService extends AbstractLifecycleComponent
 
     public IndicesQueryCache getIndicesQueryCache() {
         return indicesQueryCache;
+    }
+
+    /**
+     * Accumulate stats from the passed Object
+     *
+     * @param stats Instance storing {@link DocStatusStats}
+     */
+    public void addDocStatusStats(final DocStatusStats stats) {
+        oldShardsStats.indexingStats.getTotal().getDocStatusStats().add(stats);
     }
 
     /**

--- a/server/src/test/java/org/opensearch/action/bulk/TransportBulkActionIndicesThatCannotBeCreatedTests.java
+++ b/server/src/test/java/org/opensearch/action/bulk/TransportBulkActionIndicesThatCannotBeCreatedTests.java
@@ -154,6 +154,7 @@ public class TransportBulkActionIndicesThatCannotBeCreatedTests extends OpenSear
                 Settings.EMPTY,
                 new ClusterService(Settings.EMPTY, new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS), null)
             ),
+            null,
             new SystemIndices(emptyMap())
         ) {
             @Override

--- a/server/src/test/java/org/opensearch/action/bulk/TransportBulkActionIngestTests.java
+++ b/server/src/test/java/org/opensearch/action/bulk/TransportBulkActionIngestTests.java
@@ -171,6 +171,7 @@ public class TransportBulkActionIngestTests extends OpenSearchTestCase {
                     SETTINGS,
                     new ClusterService(SETTINGS, new ClusterSettings(SETTINGS, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS), null)
                 ),
+                null,
                 new SystemIndices(emptyMap())
             );
         }

--- a/server/src/test/java/org/opensearch/action/bulk/TransportBulkActionTests.java
+++ b/server/src/test/java/org/opensearch/action/bulk/TransportBulkActionTests.java
@@ -60,6 +60,7 @@ import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.IndexingPressureService;
 import org.opensearch.index.VersionType;
+import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.SystemIndexDescriptor;
 import org.opensearch.indices.SystemIndices;
 import org.opensearch.telemetry.tracing.noop.NoopTracer;
@@ -88,6 +89,7 @@ import static org.opensearch.cluster.metadata.MetadataCreateDataStreamServiceTes
 import static org.opensearch.test.ClusterServiceUtils.createClusterService;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
 
 public class TransportBulkActionTests extends OpenSearchTestCase {
 
@@ -115,6 +117,7 @@ public class TransportBulkActionTests extends OpenSearchTestCase {
                 new Resolver(),
                 new AutoCreateIndex(Settings.EMPTY, clusterService.getClusterSettings(), new Resolver(), new SystemIndices(emptyMap())),
                 new IndexingPressureService(Settings.EMPTY, clusterService),
+                mock(IndicesService.class),
                 new SystemIndices(emptyMap())
             );
         }

--- a/server/src/test/java/org/opensearch/action/bulk/TransportBulkActionTookTests.java
+++ b/server/src/test/java/org/opensearch/action/bulk/TransportBulkActionTookTests.java
@@ -280,6 +280,7 @@ public class TransportBulkActionTookTests extends OpenSearchTestCase {
                 indexNameExpressionResolver,
                 autoCreateIndex,
                 new IndexingPressureService(Settings.EMPTY, clusterService),
+                null,
                 new SystemIndices(emptyMap()),
                 relativeTimeProvider
             );

--- a/server/src/test/java/org/opensearch/core/RestStatusTests.java
+++ b/server/src/test/java/org/opensearch/core/RestStatusTests.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.core;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.action.ShardOperationFailedException;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.PriorityQueue;
+
+public class RestStatusTests extends OpenSearchTestCase {
+
+    public void testStatusReturns200ForNoFailures() {
+        int totalShards = randomIntBetween(1, 100);
+        int successfulShards = randomIntBetween(1, totalShards);
+
+        assertEquals(RestStatus.OK, RestStatus.status(successfulShards, totalShards));
+    }
+
+    public void testStatusReturns503ForUnavailableShards() {
+        int totalShards = randomIntBetween(1, 100);
+        int successfulShards = 0;
+
+        assertEquals(RestStatus.SERVICE_UNAVAILABLE, RestStatus.status(successfulShards, totalShards));
+    }
+
+    public void testStatusReturnsFailureStatusWhenFailuresExist() {
+        int totalShards = randomIntBetween(1, 100);
+        int successfulShards = 0;
+
+        TestException[] failures = new TestException[totalShards];
+        PriorityQueue<TestException> heapOfFailures = new PriorityQueue<>((x, y) -> y.status().compareTo(x.status()));
+
+        for (int i = 0; i < totalShards; ++i) {
+            /*
+             * Status here doesn't need to convey failure and is not as per rest
+             * contract. We're not testing the contract, but if status() returns
+             * the greatest rest code from the failures selection
+             */
+            RestStatus status = randomFrom(RestStatus.values());
+            TestException failure = new TestException(status);
+
+            failures[i] = failure;
+            heapOfFailures.add(failure);
+        }
+
+        assertEquals(heapOfFailures.peek().status(), RestStatus.status(successfulShards, totalShards, failures));
+    }
+
+    public void testSerialization() throws IOException {
+        final RestStatus status = randomFrom(RestStatus.values());
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            RestStatus.writeTo(out, status);
+
+            try (StreamInput in = out.bytes().streamInput()) {
+                RestStatus deserializedStatus = RestStatus.readFrom(in);
+
+                assertEquals(status, deserializedStatus);
+            }
+        }
+    }
+
+    private static class TestException extends ShardOperationFailedException {
+        TestException(final RestStatus status) {
+            super("super-idx", randomInt(), "gone-fishing", status, new Throwable("cake"));
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            throw new IOException("not implemented");
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            throw new IOException("not implemented");
+        }
+    }
+
+}

--- a/server/src/test/java/org/opensearch/index/shard/IndexingStatsTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexingStatsTests.java
@@ -1,0 +1,141 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.shard;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class IndexingStatsTests extends OpenSearchTestCase {
+
+    public void testSerialization() throws IOException {
+        IndexingStats stats = createTestInstance();
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            stats.writeTo(out);
+
+            try (StreamInput in = out.bytes().streamInput()) {
+                IndexingStats deserializedStats = new IndexingStats(in);
+
+                if (stats.getTotal() == null) {
+                    assertNull(deserializedStats.getTotal());
+                    return;
+                }
+
+                IndexingStats.Stats totalStats = stats.getTotal();
+                IndexingStats.Stats deserializedTotalStats = deserializedStats.getTotal();
+
+                assertEquals(totalStats.getIndexCount(), deserializedTotalStats.getIndexCount());
+                assertEquals(totalStats.getIndexTime(), deserializedTotalStats.getIndexTime());
+                assertEquals(totalStats.getIndexCurrent(), deserializedTotalStats.getIndexCurrent());
+                assertEquals(totalStats.getIndexFailedCount(), deserializedTotalStats.getIndexFailedCount());
+                assertEquals(totalStats.getDeleteCount(), deserializedTotalStats.getDeleteCount());
+                assertEquals(totalStats.getDeleteTime(), deserializedTotalStats.getDeleteTime());
+                assertEquals(totalStats.getDeleteCurrent(), deserializedTotalStats.getDeleteCurrent());
+                assertEquals(totalStats.getNoopUpdateCount(), deserializedTotalStats.getNoopUpdateCount());
+                assertEquals(totalStats.isThrottled(), deserializedTotalStats.isThrottled());
+                assertEquals(totalStats.getThrottleTime(), deserializedTotalStats.getThrottleTime());
+
+                if (totalStats.getDocStatusStats() == null) {
+                    assertNull(deserializedTotalStats.getDocStatusStats());
+                    return;
+                }
+
+                IndexingStats.Stats.DocStatusStats docStatusStats = totalStats.getDocStatusStats();
+                IndexingStats.Stats.DocStatusStats deserializedDocStatusStats = deserializedTotalStats.getDocStatusStats();
+
+                assertTrue(
+                    Arrays.equals(
+                        docStatusStats.getDocStatusCounter(),
+                        deserializedDocStatusStats.getDocStatusCounter(),
+                        Comparator.comparingLong(AtomicLong::longValue)
+                    )
+                );
+            }
+        }
+    }
+
+    public void testToXContentForIndexingStats() throws IOException {
+        IndexingStats stats = createTestInstance();
+        IndexingStats.Stats totalStats = stats.getTotal();
+        AtomicLong[] counter = totalStats.getDocStatusStats().getDocStatusCounter();
+
+        String expected = "{\"indexing\":{\"index_total\":"
+            + totalStats.getIndexCount()
+            + ",\"index_time_in_millis\":"
+            + totalStats.getIndexTime().getMillis()
+            + ",\"index_current\":"
+            + totalStats.getIndexCurrent()
+            + ",\"index_failed\":"
+            + totalStats.getIndexFailedCount()
+            + ",\"delete_total\":"
+            + totalStats.getDeleteCount()
+            + ",\"delete_time_in_millis\":"
+            + totalStats.getDeleteTime().getMillis()
+            + ",\"delete_current\":"
+            + totalStats.getDeleteCurrent()
+            + ",\"noop_update_total\":"
+            + totalStats.getNoopUpdateCount()
+            + ",\"is_throttled\":"
+            + totalStats.isThrottled()
+            + ",\"throttle_time_in_millis\":"
+            + totalStats.getThrottleTime().getMillis()
+            + ",\"doc_status\":{\"1xx\":"
+            + counter[0]
+            + ",\"2xx\":"
+            + counter[1]
+            + ",\"3xx\":"
+            + counter[2]
+            + ",\"4xx\":"
+            + counter[3]
+            + ",\"5xx\":"
+            + counter[4]
+            + "}}}";
+
+        XContentBuilder xContentBuilder = MediaTypeRegistry.contentBuilder(MediaTypeRegistry.JSON);
+        xContentBuilder.startObject();
+        xContentBuilder = stats.toXContent(xContentBuilder, ToXContent.EMPTY_PARAMS);
+        xContentBuilder.endObject();
+
+        assertEquals(expected, xContentBuilder.toString());
+    }
+
+    private IndexingStats createTestInstance() {
+        IndexingStats.Stats.DocStatusStats docStatusStats = new IndexingStats.Stats.DocStatusStats();
+        for (int i = 1; i < 6; ++i) {
+            docStatusStats.add(RestStatus.fromCode(i * 100), randomNonNegativeLong());
+        }
+
+        IndexingStats.Stats stats = new IndexingStats.Stats(
+            randomNonNegativeLong(),
+            randomNonNegativeLong(),
+            randomNonNegativeLong(),
+            randomNonNegativeLong(),
+            randomNonNegativeLong(),
+            randomNonNegativeLong(),
+            randomNonNegativeLong(),
+            randomNonNegativeLong(),
+            randomBoolean(),
+            randomNonNegativeLong(),
+            docStatusStats
+        );
+
+        return new IndexingStats(stats);
+    }
+
+}

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -2210,6 +2210,7 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                         indexNameExpressionResolver,
                         new AutoCreateIndex(settings, clusterSettings, indexNameExpressionResolver, new SystemIndices(emptyMap())),
                         new IndexingPressureService(settings, clusterService),
+                        mock(IndicesService.class),
                         new SystemIndices(emptyMap())
                     )
                 );


### PR DESCRIPTION
### Description

Currently, Opensearch returns a 200 OK response code for a Bulk API call, even though there can be partial/complete failures within the request E2E. Tracking these failures requires client to parse the response on their side and make sense of them. But, a general idea around trend in growth of different rest status codes at item level can provide insights on how indexing engine is performing.

### Related Issues

Resolves #4562 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

<details>

<summary>Benchmarks!</summary>

# DocStatusCounter Benchmarking

**Configuration:**

- 3 Data Nodes: r6g.4xlarge
- 3 Manager Nodes: c6g.2xlarge
- Heap: 64 GB
- Indexed 160,000,000 (160M) docs using [opensearch-benchmark](https://github.com/opensearch-project/opensearch-benchmark)
- CPU Utilization > 90% each run

|Metric	|Unit	|Task	|String Keys	|Baseline	|Short Keys	|ThreadLocalMap|AtomicLong[]
|-|-|-|-|-|-|-|-|
|  Cumulative indexing time of primary shards 	|min	|	|185.26433	|173.42567	|176.12467	|176.21833|169.801
|  Min cumulative indexing time across primary shards 	|min	|	|6.67E-05	|55.43687	|55.61673	|56.04497|55.348
|  Median cumulative indexing time across primary shards 	|min	|	|59.04873	|57.10593	|58.50937	|58.2993|55.5361
|  Max cumulative indexing time across primary shards 	|min	|	|67.16667	|60.88293	|61.9988	|61.87413|58.917
|  Cumulative indexing throttle time of primary shards 	|min	|	|0	|0	|0	|0|0
|  Min cumulative indexing throttle time across primary shards 	|min	|	|0	|0	|0	|0|0
| Median cumulative indexing throttle time across primary shards 	|min	|	|0	|0	|0	|0|0
|  Max cumulative indexing throttle time across primary shards 	|min	|	|0	|0	|0	|0|0
|  Cumulative merge time of primary shards 	|min	|	|53.6561	|53.96897	|51.88953	|55.65487|47.0504
|  Cumulative merge count of primary shards 	|	|	|113.33333	|107.33333	|105.66667	|107.66667|105
|  Min cumulative merge time across primary shards 	|min	|	|0	|16.16687	|16.6941	|16.01773|12.6753
|  Median cumulative merge time across primary shards 	|min	|	|17.10093	|18.38877	|16.9021	|18.06377|17.0686
|  Max cumulative merge time across primary shards 	|min	|	|19.45427	|19.41333	|18.2934	|21.57333|17.3066
|  Cumulative merge throttle time of primary shards 	|min	|	|14.49533	|16.94427	|14.9402	|16.39743|12.676
|  Min cumulative merge throttle time across primary shards 	|min	|	|0	|4.72383	|4.03366	|4.01268|3.78305
|  Median cumulative merge throttle time across primary shards 	|min	|	|4.3005	|5.36746	|5.16321	|5.4102|4.10685
|  Max cumulative merge throttle time across primary shards 	|min	|	|5.89435	|6.85298	|5.74337	|6.97451|4.78612
|  Cumulative refresh time of primary shards 	|min	|	|4.53589	|4.42749	|4.32285	|4.26004|4.27837
|  Cumulative refresh count of primary shards 	|	|	|143	|126.66667	|126.33333	|128.66667|120
|  Min cumulative refresh time across primary shards 	|min	|	|0.00018	|1.39173	|1.35457	|1.32311|1.41253
|  Median cumulative refresh time across primary shards 	|min	|	|1.48191	|1.43236	|1.46172	|1.4063|1.41697
|  Max cumulative refresh time across primary shards 	|min	|	|1.57189	|1.6034	|1.50656	|1.53063|1.44887
|  Cumulative flush time of primary shards 	|min	|	|2.12778	|2.24693	|2.20361	|2.09975|2.38865
|  Cumulative flush count of primary shards 	|	|	|31.33333	|30.66667	|28.66667	|29.33333|28
|  Min cumulative flush time across primary shards 	|min	|	|0.00015	|0.65804	|0.62011	|0.62618|0.75745
|  Median cumulative flush time across primary shards 	|min	|	|0.68019	|0.77672	|0.75957	|0.67874|0.7731
|  Max cumulative flush time across primary shards 	|min	|	|0.76725	|0.81217	|0.82393	|0.79483|0.8581
|  Total Young Gen GC time 	|s	|	|38.75267	|34.86833	|36.069	|33.21967|36.447
|  Total Young Gen GC count 	|s	|	|502	|486.33333	|495.66667	|447|542
|  Total Old Gen GC time 	|GB	|	|0	|0	|0	|0|0
|  Total Old Gen GC count 	|GB	|	|0	|0	|0	|0|0
|  Store size 	|MB	|	|63.48167	|52.1122	|57.52483	|52.37343|72.8811
|  Translog size 	|MB	|	|5.63E-07	|4.61E-07	|4.61E-07	|4.61E-07|4.61E-07
|  Heap used for segments 	|MB	|	|0	|0	|0	|0|0
|  Heap used for doc values 	|MB	|	|0	|0	|0	|0|0
|  Heap used for terms 	|MB	|	|0	|0	|0	|0|0
|  Heap used for norms 	|MB	|	|0	|0	|0	|0|0
|  Heap used for points 	|	|	|0	|0	|0	|0|0
|  Heap used for stored fields 	|docs/s	|index	|0	|0	|0	|0|0
|  Segment count 	|docs/s	|index	|86	|89.33333	|88.33333	|85.33333|73
|  Min Throughput 	|docs/s	|index	|188963	|190996.66667	|188393.66667	|202766|168622
|  Mean Throughput 	|ms	|index	|202721.66667	|215656.33333	|212218	|213985|219714
|  Median Throughput 	|ms	|index	|199066.33333	|214909	|210353	|211633.66667|220747
|  Max Throughput 	|ms	|index	|243293.66667	|241402.66667	|240322	|247813|229924
|  50th percentile latency 	|ms	|index	|4956.15667	|4532.03	|4584.96667	|4653.31333|4191.51
|  90th percentile latency 	|ms	|index	|7005.88667	|6453.49333	|6649.78	|6524.09667|6210.21
|  99th percentile latency 	|ms	|index	|9844.68333	|9437.39333	|9771.28	|9136.64667|9669.73
|  99.9th percentile latency 	|ms	|index	|11722.83333	|11428.73333	|11919.23333	|10853.76667|12189.8
|  100th percentile latency 	|ms	|index	|13378.36667	|13292.16667	|13863.46667	|11733.63333|12971.5
|  50th percentile service time 	|ms	|index	|4956.15667	|4532.03	|4584.96667	|4653.31333|4191.51
|  90th percentile service time 	|ms	|index	|7005.88667	|6453.49333	|6649.78	|6524.09667|6210.21
|  99th percentile service time 	|ms	|index	|9844.68333	|9437.39333	|9771.28	|9136.64667|9669.73
|  99.9th percentile service time 	|ms	|	|11722.83333	|11428.73333	|11919.23333	|10853.76667|12189.8
|  100th percentile service time 	|ms	|	|13378.36667	|13292.16667	|13863.46667	|11733.63333|12971.5
|  error rate 	|%	|	|0	|0	|0	|0|0

</details>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
