### PR TITLE
Prioritize snapshot builds in distribution downloader

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/DistributionDownloadPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/DistributionDownloadPlugin.java
@@ -181,16 +181,23 @@ public class DistributionDownloadPlugin implements Plugin<Project> {
         String distributionDownloadType = customDistributionDownloadType != null
             && customDistributionDownloadType.toString().equals("bundle") ? "bundle" : "min";
         if (customDistributionUrl != null) {
-            addIvyRepo(project, DOWNLOAD_REPO_NAME, customDistributionUrl.toString(), FAKE_IVY_GROUP, "");
             addIvyRepo(project, SNAPSHOT_REPO_NAME, customDistributionUrl.toString(), FAKE_SNAPSHOT_IVY_GROUP, "");
+            addIvyRepo(project, DOWNLOAD_REPO_NAME, customDistributionUrl.toString(), FAKE_IVY_GROUP, "");
             return;
         }
         switch (distributionDownloadType) {
             case "bundle":
-                addIvyRepo(project, DOWNLOAD_REPO_NAME, "https://ci.opensearch.org", FAKE_IVY_GROUP, BUNDLE_PATTERN_LAYOUT);
                 addIvyRepo(project, SNAPSHOT_REPO_NAME, "https://ci.opensearch.org", FAKE_SNAPSHOT_IVY_GROUP, BUNDLE_PATTERN_LAYOUT);
+                addIvyRepo(project, DOWNLOAD_REPO_NAME, "https://ci.opensearch.org", FAKE_IVY_GROUP, BUNDLE_PATTERN_LAYOUT);
                 break;
             case "min":
+                addIvyRepo(
+                    project,
+                    SNAPSHOT_REPO_NAME,
+                    "https://artifacts.opensearch.org",
+                    FAKE_SNAPSHOT_IVY_GROUP,
+                    SNAPSHOT_PATTERN_LAYOUT
+                );
                 addIvyRepo(
                     project,
                     DOWNLOAD_REPO_NAME,
@@ -198,13 +205,6 @@ public class DistributionDownloadPlugin implements Plugin<Project> {
                     FAKE_IVY_GROUP,
                     "/releases" + RELEASE_PATTERN_LAYOUT,
                     "/release-candidates" + RELEASE_PATTERN_LAYOUT
-                );
-                addIvyRepo(
-                    project,
-                    SNAPSHOT_REPO_NAME,
-                    "https://artifacts.opensearch.org",
-                    FAKE_SNAPSHOT_IVY_GROUP,
-                    SNAPSHOT_PATTERN_LAYOUT
                 );
                 break;
             default:


### PR DESCRIPTION
### Description
In the Security plugin's BWC tests there have been an issue with stale artifacts, when troubleshooting we noticed that a release candidate for OpenSearch 3.0.0 was being picked up in priority before the latest snapshot build.  This was causing build failures preventing our tests from running.

### Related Issues
- Related https://github.com/opensearch-project/security/issues/3020

### Check List
- [ ] ~New functionality includes testing.~
  - [ ] ~All tests pass~
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [X] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
