### PR TITLE
Fix local segments stats update in RemoteStoreRefreshListener

### DIFF
--- a/server/src/main/java/org/opensearch/index/remote/RemoteSegmentTransferTracker.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteSegmentTransferTracker.java
@@ -8,6 +8,10 @@
 
 package org.opensearch.index.remote;
 
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.opensearch.common.CheckedFunction;
+import org.opensearch.common.logging.Loggers;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
@@ -18,7 +22,8 @@ import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.store.DirectoryFileTransferTracker;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -26,12 +31,16 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
+import static org.opensearch.index.shard.RemoteStoreRefreshListener.EXCLUDE_FILES;
+
 /**
  * Keeps track of remote refresh which happens in {@link org.opensearch.index.shard.RemoteStoreRefreshListener}. This consist of multiple critical metrics.
  *
  * @opensearch.internal
  */
 public class RemoteSegmentTransferTracker {
+
+    private final Logger logger;
 
     /**
      * ShardId for which this instance tracks the remote segment upload metadata.
@@ -124,14 +133,15 @@ public class RemoteSegmentTransferTracker {
     private final Map<String, AtomicLong> rejectionCountMap = ConcurrentCollections.newConcurrentMap();
 
     /**
-     * Map of name to size of the segment files created as part of the most recent refresh.
+     * Keeps track of segment files and their size in bytes which are part of the most recent refresh.
      */
-    private volatile Map<String, Long> latestLocalFileNameLengthMap;
+    private final Map<String, Long> latestLocalFileNameLengthMap = ConcurrentCollections.newConcurrentMap();
 
     /**
-     * Set of names of segment files that were uploaded as part of the most recent remote refresh.
+     * This contains the files from the last successful remote refresh and ongoing uploads. This gets reset to just the
+     * last successful remote refresh state on successful remote refresh.
      */
-    private final Set<String> latestUploadedFiles = new HashSet<>();
+    private final Set<String> latestUploadedFiles = ConcurrentCollections.newConcurrentSet();
 
     /**
      * Keeps the bytes lag computed so that we do not compute it for every request.
@@ -182,6 +192,7 @@ public class RemoteSegmentTransferTracker {
         int uploadBytesPerSecMovingAverageWindowSize,
         int uploadTimeMsMovingAverageWindowSize
     ) {
+        logger = Loggers.getLogger(getClass(), shardId);
         this.shardId = shardId;
         // Both the local refresh time and remote refresh time are set with current time to give consistent view of time lag when it arises.
         long currentClockTimeMs = System.currentTimeMillis();
@@ -193,8 +204,6 @@ public class RemoteSegmentTransferTracker {
         uploadBytesMovingAverageReference = new AtomicReference<>(new MovingAverage(uploadBytesMovingAverageWindowSize));
         uploadBytesPerSecMovingAverageReference = new AtomicReference<>(new MovingAverage(uploadBytesPerSecMovingAverageWindowSize));
         uploadTimeMsMovingAverageReference = new AtomicReference<>(new MovingAverage(uploadTimeMsMovingAverageWindowSize));
-
-        latestLocalFileNameLengthMap = new HashMap<>();
         this.directoryFileTransferTracker = directoryFileTransferTracker;
     }
 
@@ -206,7 +215,8 @@ public class RemoteSegmentTransferTracker {
         return localRefreshSeqNo;
     }
 
-    public void updateLocalRefreshSeqNo(long localRefreshSeqNo) {
+    // Visible for testing
+    void updateLocalRefreshSeqNo(long localRefreshSeqNo) {
         assert localRefreshSeqNo >= this.localRefreshSeqNo : "newLocalRefreshSeqNo="
             + localRefreshSeqNo
             + " < "
@@ -224,7 +234,17 @@ public class RemoteSegmentTransferTracker {
         return localRefreshClockTimeMs;
     }
 
-    public void updateLocalRefreshTimeMs(long localRefreshTimeMs) {
+    /**
+     * Updates the last refresh time and refresh seq no which is seen by local store.
+     */
+    public void updateLocalRefreshTimeAndSeqNo() {
+        updateLocalRefreshClockTimeMs(System.currentTimeMillis());
+        updateLocalRefreshTimeMs(System.nanoTime() / 1_000_000L);
+        updateLocalRefreshSeqNo(getLocalRefreshSeqNo() + 1);
+    }
+
+    // Visible for testing
+    void updateLocalRefreshTimeMs(long localRefreshTimeMs) {
         assert localRefreshTimeMs >= this.localRefreshTimeMs : "newLocalRefreshTimeMs="
             + localRefreshTimeMs
             + " < "
@@ -234,7 +254,7 @@ public class RemoteSegmentTransferTracker {
         computeTimeMsLag();
     }
 
-    public void updateLocalRefreshClockTimeMs(long localRefreshClockTimeMs) {
+    private void updateLocalRefreshClockTimeMs(long localRefreshClockTimeMs) {
         this.localRefreshClockTimeMs = localRefreshClockTimeMs;
     }
 
@@ -369,12 +389,36 @@ public class RemoteSegmentTransferTracker {
         return rejectionCountMap.get(rejectionReason).get();
     }
 
-    Map<String, Long> getLatestLocalFileNameLengthMap() {
-        return latestLocalFileNameLengthMap;
+    public Map<String, Long> getLatestLocalFileNameLengthMap() {
+        return Collections.unmodifiableMap(latestLocalFileNameLengthMap);
     }
 
-    public void setLatestLocalFileNameLengthMap(Map<String, Long> latestLocalFileNameLengthMap) {
-        this.latestLocalFileNameLengthMap = latestLocalFileNameLengthMap;
+    /**
+     * Updates the latestLocalFileNameLengthMap by adding file name and it's size to the map. The method is given a function as an argument which is used for determining the file size (length in bytes). This method is also provided the collection of segment files which are the latest refresh local segment files. This method also removes the stale segment files from the map that are not part of the input segment files.
+     *
+     * @param segmentFiles     list of local refreshed segment files
+     * @param fileSizeFunction function is used to determine the file size in bytes
+     */
+    public void updateLatestLocalFileNameLengthMap(
+        Collection<String> segmentFiles,
+        CheckedFunction<String, Long, IOException> fileSizeFunction
+    ) {
+        // Update the map
+        segmentFiles.stream()
+            .filter(file -> EXCLUDE_FILES.contains(file) == false)
+            .filter(file -> latestLocalFileNameLengthMap.containsKey(file) == false || latestLocalFileNameLengthMap.get(file) == 0)
+            .forEach(file -> {
+                long fileSize = 0;
+                try {
+                    fileSize = fileSizeFunction.apply(file);
+                } catch (IOException e) {
+                    logger.warn(new ParameterizedMessage("Exception while reading the fileLength of file={}", file), e);
+                }
+                latestLocalFileNameLengthMap.put(file, fileSize);
+            });
+        Set<String> fileSet = new HashSet<>(segmentFiles);
+        // Remove keys from the fileSizeMap that do not exist in the latest segment files
+        latestLocalFileNameLengthMap.entrySet().removeIf(entry -> fileSet.contains(entry.getKey()) == false);
         computeBytesLag();
     }
 
@@ -390,7 +434,7 @@ public class RemoteSegmentTransferTracker {
     }
 
     private void computeBytesLag() {
-        if (latestLocalFileNameLengthMap == null || latestLocalFileNameLengthMap.isEmpty()) {
+        if (latestLocalFileNameLengthMap.isEmpty()) {
             return;
         }
         Set<String> filesNotYetUploaded = latestLocalFileNameLengthMap.keySet()

--- a/server/src/main/java/org/opensearch/index/shard/CheckpointRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/CheckpointRefreshListener.java
@@ -39,7 +39,7 @@ public class CheckpointRefreshListener extends CloseableRetryableRefreshListener
     }
 
     @Override
-    protected boolean performAfterRefresh(boolean didRefresh, boolean isRetry) {
+    protected boolean performAfterRefreshWithPermit(boolean didRefresh) {
         if (didRefresh
             && shard.state() == IndexShardState.STARTED
             && shard.getReplicationTracker().isPrimaryMode()

--- a/server/src/main/java/org/opensearch/index/shard/CloseableRetryableRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/CloseableRetryableRefreshListener.java
@@ -15,8 +15,10 @@ import org.opensearch.threadpool.ThreadPool;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Objects;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -27,10 +29,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public abstract class CloseableRetryableRefreshListener implements ReferenceManager.RefreshListener, Closeable {
 
     /**
-     * Total permits = 1 ensures that there is only single instance of performAfterRefresh that is running at a time.
+     * Total permits = 1 ensures that there is only single instance of runAfterRefreshWithPermit that is running at a time.
      * In case there are use cases where concurrency is required, the total permit variable can be put inside the ctor.
      */
     private static final int TOTAL_PERMITS = 1;
+
+    private final AtomicBoolean closed = new AtomicBoolean(false);
 
     private final Semaphore semaphore = new Semaphore(TOTAL_PERMITS);
 
@@ -46,57 +50,80 @@ public abstract class CloseableRetryableRefreshListener implements ReferenceMana
     }
 
     public CloseableRetryableRefreshListener(ThreadPool threadPool) {
+        assert Objects.nonNull(threadPool);
         this.threadPool = threadPool;
     }
 
     @Override
     public final void afterRefresh(boolean didRefresh) throws IOException {
-        boolean successful;
-        boolean permitAcquired = semaphore.tryAcquire();
-        try {
-            successful = permitAcquired && performAfterRefresh(didRefresh, false);
-        } finally {
-            if (permitAcquired) {
-                semaphore.release();
-            }
-        }
-        scheduleRetry(successful, didRefresh, permitAcquired);
-    }
-
-    protected String getRetryThreadPoolName() {
-        return null;
-    }
-
-    protected TimeValue getNextRetryInterval() {
-        return null;
-    }
-
-    private void scheduleRetry(TimeValue interval, String retryThreadPoolName, boolean didRefresh, boolean isRetry) {
-        if (this.threadPool == null
-            || interval == null
-            || retryThreadPoolName == null
-            || ThreadPool.THREAD_POOL_TYPES.containsKey(retryThreadPoolName) == false
-            || interval == TimeValue.MINUS_ONE
-            || retryScheduled.compareAndSet(false, true) == false) {
+        if (closed.get()) {
             return;
         }
+        runAfterRefreshExactlyOnce(didRefresh);
+        runAfterRefreshWithPermit(didRefresh, () -> {});
+    }
+
+    /**
+     * The code in this method is executed exactly once. This is done for running non-idempotent function which needs to be
+     * executed immediately when afterRefresh method is invoked.
+     *
+     * @param didRefresh if the refresh did open a new reference then didRefresh will be true
+     */
+    protected void runAfterRefreshExactlyOnce(boolean didRefresh) {
+        // No-op: The implementor would be providing the code
+    }
+
+    /**
+     * The implementor has the option to override the retry thread pool name. This will be used for scheduling the retries.
+     * The method would be invoked each time when a retry is required. By default, it uses the same threadpool for retry.
+     *
+     * @return the name of the retry thread pool.
+     */
+    protected String getRetryThreadPoolName() {
+        return ThreadPool.Names.SAME;
+    }
+
+    /**
+     * By default, the retry interval is returned as 1s. The implementor has the option to override the retry interval.
+     * This is used for scheduling the next retry. The method would be invoked each time when a retry is required. The
+     * implementor can choose any retry strategy and return the next retry interval accordingly.
+     *
+     * @return the interval for the next retry.
+     */
+    protected TimeValue getNextRetryInterval() {
+        return TimeValue.timeValueSeconds(1);
+    }
+
+    /**
+     * This method is used to schedule retry which internally calls the performAfterRefresh method under the available permits.
+     *
+     * @param interval            interval after which the retry would be invoked
+     * @param retryThreadPoolName the thread pool name to be used for retry
+     * @param didRefresh          if didRefresh is true
+     */
+    private void scheduleRetry(TimeValue interval, String retryThreadPoolName, boolean didRefresh) {
+        // If the underlying listener has closed, then we do not allow even the retry to be scheduled
+        if (closed.get() || isRetryEnabled() == false) {
+            return;
+        }
+
+        assert Objects.nonNull(interval) && ThreadPool.THREAD_POOL_TYPES.containsKey(retryThreadPoolName);
+
+        // If the retryScheduled is already true, then we return from here itself. If not, then we proceed with scheduling
+        // the retry.
+        if (retryScheduled.getAndSet(true)) {
+            return;
+        }
+
         boolean scheduled = false;
         try {
-            this.threadPool.schedule(() -> {
-                boolean successful;
-                boolean permitAcquired = semaphore.tryAcquire();
-                try {
-                    successful = permitAcquired && performAfterRefresh(didRefresh, isRetry);
-                } finally {
-                    if (permitAcquired) {
-                        semaphore.release();
-                    }
-                    retryScheduled.set(false);
-                }
-                scheduleRetry(successful, didRefresh, isRetry || permitAcquired);
-            }, interval, retryThreadPoolName);
+            this.threadPool.schedule(
+                () -> runAfterRefreshWithPermit(didRefresh, () -> retryScheduled.set(false)),
+                interval,
+                retryThreadPoolName
+            );
             scheduled = true;
-            getLogger().info("Scheduled retry with didRefresh={} isRetry={}", didRefresh, isRetry);
+            getLogger().info("Scheduled retry with didRefresh={}", didRefresh);
         } finally {
             if (scheduled == false) {
                 retryScheduled.set(false);
@@ -105,39 +132,81 @@ public abstract class CloseableRetryableRefreshListener implements ReferenceMana
     }
 
     /**
+     * This returns if the retry is enabled or not. By default, the retries are not enabled.
+     * @return true if retry is enabled.
+     */
+    protected boolean isRetryEnabled() {
+        return false;
+    }
+
+    /**
+     * Runs the performAfterRefresh method under permit. If there are no permits available, then it is no-op. It also hits
+     * the scheduleRetry method with the result value of the performAfterRefresh method invocation.
+     * The synchronised block ensures that if there is a retry or afterRefresh waiting, then it waits until the previous
+     * execution finishes.
+     */
+    private synchronized void runAfterRefreshWithPermit(boolean didRefresh, Runnable runFinally) {
+        if (closed.get()) {
+            return;
+        }
+        boolean successful;
+        boolean permitAcquired = semaphore.tryAcquire();
+        try {
+            successful = permitAcquired && performAfterRefreshWithPermit(didRefresh);
+        } finally {
+            if (permitAcquired) {
+                semaphore.release();
+            }
+            runFinally.run();
+        }
+        scheduleRetry(successful, didRefresh);
+    }
+
+    /**
      * Schedules the retry based on the {@code afterRefreshSuccessful} value.
      *
      * @param afterRefreshSuccessful is sent true if the performAfterRefresh(..) is successful.
      * @param didRefresh             if the refresh did open a new reference then didRefresh will be true
-     * @param isRetry                if this is a failure or permit was not acquired.
      */
-    private void scheduleRetry(boolean afterRefreshSuccessful, boolean didRefresh, boolean isRetry) {
+    private void scheduleRetry(boolean afterRefreshSuccessful, boolean didRefresh) {
         if (afterRefreshSuccessful == false) {
-            scheduleRetry(getNextRetryInterval(), getRetryThreadPoolName(), didRefresh, isRetry);
+            scheduleRetry(getNextRetryInterval(), getRetryThreadPoolName(), didRefresh);
         }
     }
 
     /**
-     * This method needs to be overridden and be provided with what needs to be run on after refresh.
+     * This method needs to be overridden and be provided with what needs to be run on after refresh with permits.
      *
      * @param didRefresh true if the refresh opened a new reference
-     * @param isRetry    true if this is a retry attempt
      * @return true if a retry is needed else false.
      */
-    protected abstract boolean performAfterRefresh(boolean didRefresh, boolean isRetry);
+    protected abstract boolean performAfterRefreshWithPermit(boolean didRefresh);
 
     @Override
     public final void close() throws IOException {
         try {
             if (semaphore.tryAcquire(TOTAL_PERMITS, 10, TimeUnit.MINUTES)) {
-                assert semaphore.availablePermits() == 0;
+                boolean result = closed.compareAndSet(false, true);
+                assert result && semaphore.availablePermits() == 0;
+                getLogger().info("Closed");
             } else {
-                throw new RuntimeException("timeout while closing gated refresh listener");
+                throw new TimeoutException("timeout while closing gated refresh listener");
             }
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
+        } catch (InterruptedException | TimeoutException e) {
+            throw new RuntimeException("Failed to close the closeable retryable listener", e);
         }
     }
 
     protected abstract Logger getLogger();
+
+    // Visible for testing
+
+    /**
+     * Returns if the retry is scheduled or not.
+     *
+     * @return boolean as mentioned above.
+     */
+    boolean getRetryScheduledStatus() {
+        return retryScheduled.get();
+    }
 }

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -25,7 +25,6 @@ import org.opensearch.common.concurrent.GatedCloseable;
 import org.opensearch.common.logging.Loggers;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.UploadListener;
-import org.opensearch.common.util.concurrent.ConcurrentCollections;
 import org.opensearch.index.engine.EngineException;
 import org.opensearch.index.engine.InternalEngine;
 import org.opensearch.index.remote.RemoteSegmentTransferTracker;
@@ -40,7 +39,6 @@ import org.opensearch.threadpool.ThreadPool;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
@@ -79,8 +77,7 @@ public final class RemoteStoreRefreshListener extends CloseableRetryableRefreshL
         REMOTE_REFRESH_RETRY_MAX_INTERVAL_MILLIS
     );
 
-    // Visible for testing
-    static final Set<String> EXCLUDE_FILES = Set.of("write.lock");
+    public static final Set<String> EXCLUDE_FILES = Set.of("write.lock");
     // Visible for testing
     public static final int LAST_N_METADATA_FILES_TO_KEEP = 10;
 
@@ -91,14 +88,7 @@ public final class RemoteStoreRefreshListener extends CloseableRetryableRefreshL
     private final Map<String, String> localSegmentChecksumMap;
     private long primaryTerm;
     private volatile Iterator<TimeValue> backoffDelayIterator;
-
-    /**
-     * Keeps track of segment files and their size in bytes which are part of the most recent refresh.
-     */
-    private final Map<String, Long> latestFileNameSizeOnLocalMap = ConcurrentCollections.newConcurrentMap();
-
     private final SegmentReplicationCheckpointPublisher checkpointPublisher;
-
     private final UploadListener statsListener;
 
     public RemoteStoreRefreshListener(
@@ -122,7 +112,7 @@ public final class RemoteStoreRefreshListener extends CloseableRetryableRefreshL
             }
         }
         // initializing primary term with the primary term of latest metadata in remote store.
-        // if no metadata is present, this value will be initilized with -1.
+        // if no metadata is present, this value will be initialized with -1.
         this.primaryTerm = remoteSegmentMetadata != null ? remoteSegmentMetadata.getPrimaryTerm() : INVALID_PRIMARY_TERM;
         this.segmentTracker = segmentTracker;
         resetBackOffDelayIterator();
@@ -131,26 +121,45 @@ public final class RemoteStoreRefreshListener extends CloseableRetryableRefreshL
             @Override
             public void beforeUpload(String file) {
                 // Start tracking the upload bytes started
-                segmentTracker.addUploadBytesStarted(latestFileNameSizeOnLocalMap.get(file));
+                segmentTracker.addUploadBytesStarted(segmentTracker.getLatestLocalFileNameLengthMap().get(file));
             }
 
             @Override
             public void onSuccess(String file) {
                 // Track upload success
-                segmentTracker.addUploadBytesSucceeded(latestFileNameSizeOnLocalMap.get(file));
+                segmentTracker.addUploadBytesSucceeded(segmentTracker.getLatestLocalFileNameLengthMap().get(file));
                 segmentTracker.addToLatestUploadedFiles(file);
             }
 
             @Override
             public void onFailure(String file) {
                 // Track upload failure
-                segmentTracker.addUploadBytesFailed(latestFileNameSizeOnLocalMap.get(file));
+                segmentTracker.addUploadBytesFailed(segmentTracker.getLatestLocalFileNameLengthMap().get(file));
             }
         };
     }
 
     @Override
     public void beforeRefresh() throws IOException {}
+
+    @Override
+    protected void runAfterRefreshExactlyOnce(boolean didRefresh) {
+        if (shouldSync(didRefresh)) {
+            segmentTracker.updateLocalRefreshTimeAndSeqNo();
+            try {
+                if (this.primaryTerm != indexShard.getOperationPrimaryTerm()) {
+                    this.primaryTerm = indexShard.getOperationPrimaryTerm();
+                    this.remoteDirectory.init();
+                }
+                try (GatedCloseable<SegmentInfos> segmentInfosGatedCloseable = indexShard.getSegmentInfosSnapshot()) {
+                    Collection<String> localSegmentsPostRefresh = segmentInfosGatedCloseable.get().files(true);
+                    updateLocalSizeMapAndTracker(localSegmentsPostRefresh);
+                }
+            } catch (Throwable t) {
+                logger.error("Exception in runAfterRefreshExactlyOnce() method", t);
+            }
+        }
+    }
 
     /**
      * Upload new segment files created as part of the last refresh to the remote segment store.
@@ -160,14 +169,11 @@ public final class RemoteStoreRefreshListener extends CloseableRetryableRefreshL
      * @return true if the method runs successfully.
      */
     @Override
-    protected boolean performAfterRefresh(boolean didRefresh, boolean isRetry) {
-        if (didRefresh && isRetry == false) {
-            updateLocalRefreshTimeAndSeqNo();
-        }
+    protected boolean performAfterRefreshWithPermit(boolean didRefresh) {
         boolean successful;
-        if (this.primaryTerm != indexShard.getOperationPrimaryTerm()
-            || didRefresh
-            || remoteDirectory.getSegmentsUploadedToRemoteStore().isEmpty()) {
+        // The third condition exists for uploading the zero state segments where the refresh has not changed the reader reference, but it
+        // is important to upload the zero state segments so that the restore does not break.
+        if (shouldSync(didRefresh)) {
             successful = syncSegments();
         } else {
             successful = true;
@@ -175,7 +181,13 @@ public final class RemoteStoreRefreshListener extends CloseableRetryableRefreshL
         return successful;
     }
 
-    private synchronized boolean syncSegments() {
+    private boolean shouldSync(boolean didRefresh) {
+        return this.primaryTerm != indexShard.getOperationPrimaryTerm()
+            || didRefresh
+            || remoteDirectory.getSegmentsUploadedToRemoteStore().isEmpty();
+    }
+
+    private boolean syncSegments() {
         if (indexShard.getReplicationTracker().isPrimaryMode() == false || indexShard.state() == IndexShardState.CLOSED) {
             logger.info(
                 "Skipped syncing segments with primaryMode={} indexShardState={}",
@@ -192,10 +204,6 @@ public final class RemoteStoreRefreshListener extends CloseableRetryableRefreshL
         final AtomicBoolean successful = new AtomicBoolean(false);
 
         try {
-            if (this.primaryTerm != indexShard.getOperationPrimaryTerm()) {
-                this.primaryTerm = indexShard.getOperationPrimaryTerm();
-                this.remoteDirectory.init();
-            }
             try {
                 // if a new segments_N file is present in local that is not uploaded to remote store yet, it
                 // is considered as a first refresh post commit. A cleanup of stale commit files is triggered.
@@ -296,7 +304,7 @@ public final class RemoteStoreRefreshListener extends CloseableRetryableRefreshL
         ReplicationCheckpoint checkpoint
     ) {
         // Update latest uploaded segment files name in segment tracker
-        segmentTracker.setLatestUploadedFiles(latestFileNameSizeOnLocalMap.keySet());
+        segmentTracker.setLatestUploadedFiles(segmentTracker.getLatestLocalFileNameLengthMap().keySet());
         // Update the remote refresh time and refresh seq no
         updateRemoteRefreshTimeAndSeqNo(refreshTimeMs, refreshClockTimeMs, refreshSeqNo);
         // Reset the backoffDelayIterator for the future failures
@@ -411,15 +419,6 @@ public final class RemoteStoreRefreshListener extends CloseableRetryableRefreshL
     }
 
     /**
-     * Updates the last refresh time and refresh seq no which is seen by local store.
-     */
-    private void updateLocalRefreshTimeAndSeqNo() {
-        segmentTracker.updateLocalRefreshClockTimeMs(System.currentTimeMillis());
-        segmentTracker.updateLocalRefreshTimeMs(System.nanoTime() / 1_000_000L);
-        segmentTracker.updateLocalRefreshSeqNo(segmentTracker.getLocalRefreshSeqNo() + 1);
-    }
-
-    /**
      * Updates the last refresh time and refresh seq no which is seen by remote store.
      */
     private void updateRemoteRefreshTimeAndSeqNo(long refreshTimeMs, long refreshClockTimeMs, long refreshSeqNo) {
@@ -429,33 +428,12 @@ public final class RemoteStoreRefreshListener extends CloseableRetryableRefreshL
     }
 
     /**
-     * Updates map of file name to size of the input segment files. Tries to reuse existing information by caching the size
-     * data, otherwise uses {@code storeDirectory.fileLength(file)} to get the size. This method also removes from the map
-     * such files that are not present in the list of segment files given in the input.
+     * Updates map of file name to size of the input segment files in the segment tracker. Uses {@code storeDirectory.fileLength(file)} to get the size.
      *
-     * @param segmentFiles list of segment files for which size needs to be known
+     * @param segmentFiles list of segment files that are part of the most recent local refresh.
      */
     private void updateLocalSizeMapAndTracker(Collection<String> segmentFiles) {
-
-        // Update the map
-        segmentFiles.stream()
-            .filter(file -> !EXCLUDE_FILES.contains(file))
-            .filter(file -> !latestFileNameSizeOnLocalMap.containsKey(file) || latestFileNameSizeOnLocalMap.get(file) == 0)
-            .forEach(file -> {
-                long fileSize = 0;
-                try {
-                    fileSize = storeDirectory.fileLength(file);
-                } catch (IOException e) {
-                    logger.warn(new ParameterizedMessage("Exception while reading the fileLength of file={}", file), e);
-                }
-                latestFileNameSizeOnLocalMap.put(file, fileSize);
-            });
-
-        Set<String> fileSet = new HashSet<>(segmentFiles);
-        // Remove keys from the fileSizeMap that do not exist in the latest segment files
-        latestFileNameSizeOnLocalMap.entrySet().removeIf(entry -> fileSet.contains(entry.getKey()) == false);
-        // Update the tracker
-        segmentTracker.setLatestLocalFileNameLengthMap(latestFileNameSizeOnLocalMap);
+        segmentTracker.updateLatestLocalFileNameLengthMap(segmentFiles, storeDirectory::fileLength);
     }
 
     private void updateFinalStatusInSegmentTracker(boolean uploadStatus, long bytesBeforeUpload, long startTimeInNS) {
@@ -474,5 +452,10 @@ public final class RemoteStoreRefreshListener extends CloseableRetryableRefreshL
     @Override
     protected Logger getLogger() {
         return logger;
+    }
+
+    @Override
+    protected boolean isRetryEnabled() {
+        return true;
     }
 }

--- a/server/src/test/java/org/opensearch/index/remote/RemoteRefreshSegmentPressureServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteRefreshSegmentPressureServiceTests.java
@@ -13,11 +13,11 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException;
+import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.shard.IndexShard;
-import org.opensearch.core.index.shard.ShardId;
-import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.index.store.Store;
+import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.test.IndexSettingsModule;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
@@ -131,13 +131,14 @@ public class RemoteRefreshSegmentPressureServiceTests extends OpenSearchTestCase
         avg = (double) sum.get() / 20;
         Map<String, Long> nameSizeMap = new HashMap<>();
         nameSizeMap.put("a", (long) (12 * avg));
-        pressureTracker.setLatestLocalFileNameLengthMap(nameSizeMap);
+        pressureTracker.updateLatestLocalFileNameLengthMap(nameSizeMap.keySet(), nameSizeMap::get);
         e = assertThrows(OpenSearchRejectedExecutionException.class, () -> pressureService.validateSegmentsUploadLag(shardId));
         assertTrue(e.getMessage().contains("due to remote segments lagging behind local segments"));
         assertTrue(e.getMessage().contains("bytes_lag:114 dynamic_bytes_lag_threshold:95.0"));
 
-        nameSizeMap.put("a", (long) (2 * avg));
-        pressureTracker.setLatestLocalFileNameLengthMap(nameSizeMap);
+        nameSizeMap.clear();
+        nameSizeMap.put("b", (long) (2 * avg));
+        pressureTracker.updateLatestLocalFileNameLengthMap(nameSizeMap.keySet(), nameSizeMap::get);
         pressureService.validateSegmentsUploadLag(shardId);
 
         // 3. Consecutive failures more than the limit

--- a/server/src/test/java/org/opensearch/index/remote/RemoteSegmentTransferTrackerTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteSegmentTransferTrackerTests.java
@@ -10,9 +10,9 @@ package org.opensearch.index.remote;
 
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.io.stream.BytesStreamOutput;
-import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.store.DirectoryFileTransferTracker;
 import org.opensearch.test.OpenSearchTestCase;
@@ -389,14 +389,14 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         Map<String, Long> fileSizeMap = new HashMap<>();
         fileSizeMap.put("a", 100L);
         fileSizeMap.put("b", 105L);
-        pressureTracker.setLatestLocalFileNameLengthMap(fileSizeMap);
+        pressureTracker.updateLatestLocalFileNameLengthMap(fileSizeMap.keySet(), fileSizeMap::get);
         assertEquals(205L, pressureTracker.getBytesLag());
 
         pressureTracker.addToLatestUploadedFiles("a");
         assertEquals(105L, pressureTracker.getBytesLag());
 
         fileSizeMap.put("c", 115L);
-        pressureTracker.setLatestLocalFileNameLengthMap(fileSizeMap);
+        pressureTracker.updateLatestLocalFileNameLengthMap(fileSizeMap.keySet(), fileSizeMap::get);
         assertEquals(220L, pressureTracker.getBytesLag());
 
         pressureTracker.addToLatestUploadedFiles("b");
@@ -573,7 +573,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
     /**
      * Tests whether RemoteSegmentTransferTracker.Stats object serialize and deserialize is working fine.
      * This comes into play during internode data transfer.
-     * */
+     */
     public void testStatsObjectCreationViaStream() throws IOException {
         pressureTracker = constructTracker();
         RemoteSegmentTransferTracker.Stats pressureTrackerStats = pressureTracker.stats();

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -13,8 +13,6 @@ import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.IndexFormatTooNewException;
 import org.apache.lucene.index.IndexFormatTooOldException;
 import org.apache.lucene.index.SegmentInfos;
-import org.apache.lucene.store.ByteBuffersDataOutput;
-import org.apache.lucene.store.ByteBuffersIndexOutput;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
@@ -43,7 +41,6 @@ import org.opensearch.index.shard.IndexShardTestCase;
 import org.opensearch.index.store.lockmanager.RemoteStoreMetadataLockManager;
 import org.opensearch.index.store.remote.metadata.RemoteSegmentMetadata;
 import org.opensearch.index.store.remote.metadata.RemoteSegmentMetadataHandler;
-import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
 import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.threadpool.ThreadPool;
 
@@ -56,20 +53,22 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.startsWith;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.doReturn;
 import static org.hamcrest.CoreMatchers.is;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.startsWith;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.test.RemoteStoreTestUtils.createMetadataFileBytes;
+import static org.opensearch.test.RemoteStoreTestUtils.getDummyMetadata;
 
 public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
     private RemoteDirectory remoteDataDirectory;
@@ -194,93 +193,6 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         assertEquals(Set.of(), actualCache.keySet());
     }
 
-    private Map<String, String> getDummyMetadata(String prefix, int commitGeneration) {
-        Map<String, String> metadata = new HashMap<>();
-
-        metadata.put(
-            prefix + ".cfe",
-            prefix
-                + ".cfe::"
-                + prefix
-                + ".cfe__"
-                + UUIDs.base64UUID()
-                + "::"
-                + randomIntBetween(1000, 5000)
-                + "::"
-                + randomIntBetween(512000, 1024000)
-                + "::"
-                + Version.MIN_SUPPORTED_MAJOR
-        );
-        metadata.put(
-            prefix + ".cfs",
-            prefix
-                + ".cfs::"
-                + prefix
-                + ".cfs__"
-                + UUIDs.base64UUID()
-                + "::"
-                + randomIntBetween(1000, 5000)
-                + "::"
-                + randomIntBetween(512000, 1024000)
-                + "::"
-                + Version.MIN_SUPPORTED_MAJOR
-        );
-        metadata.put(
-            prefix + ".si",
-            prefix
-                + ".si::"
-                + prefix
-                + ".si__"
-                + UUIDs.base64UUID()
-                + "::"
-                + randomIntBetween(1000, 5000)
-                + "::"
-                + randomIntBetween(512000, 1024000)
-                + "::"
-                + Version.LATEST.major
-        );
-        metadata.put(
-            "segments_" + commitGeneration,
-            "segments_"
-                + commitGeneration
-                + "::segments_"
-                + commitGeneration
-                + "__"
-                + UUIDs.base64UUID()
-                + "::"
-                + randomIntBetween(1000, 5000)
-                + "::"
-                + randomIntBetween(1024, 5120)
-                + "::"
-                + Version.LATEST.major
-        );
-        return metadata;
-    }
-
-    /**
-     * Prepares metadata file bytes with header and footer
-     * @param segmentFilesMap: actual metadata content
-     * @return ByteArrayIndexInput: metadata file bytes with header and footer
-     * @throws IOException IOException
-     */
-    private ByteArrayIndexInput createMetadataFileBytes(Map<String, String> segmentFilesMap, ReplicationCheckpoint replicationCheckpoint)
-        throws IOException {
-        ByteBuffersDataOutput byteBuffersIndexOutput = new ByteBuffersDataOutput();
-        segmentInfos.write(new ByteBuffersIndexOutput(byteBuffersIndexOutput, "", ""));
-        byte[] byteArray = byteBuffersIndexOutput.toArrayCopy();
-
-        BytesStreamOutput output = new BytesStreamOutput();
-        OutputStreamIndexOutput indexOutput = new OutputStreamIndexOutput("segment metadata", "metadata output stream", output, 4096);
-        CodecUtil.writeHeader(indexOutput, RemoteSegmentMetadata.METADATA_CODEC, RemoteSegmentMetadata.CURRENT_VERSION);
-        indexOutput.writeMapOfStrings(segmentFilesMap);
-        RemoteSegmentMetadata.writeCheckpointToIndexOutput(replicationCheckpoint, indexOutput);
-        indexOutput.writeLong(byteArray.length);
-        indexOutput.writeBytes(byteArray, byteArray.length);
-        CodecUtil.writeFooter(indexOutput);
-        indexOutput.close();
-        return new ByteArrayIndexInput("segment metadata", BytesReference.toBytes(output.bytes()));
-    }
-
     private Map<String, Map<String, String>> populateMetadata() throws IOException {
         List<String> metadataFiles = new ArrayList<>();
 
@@ -311,13 +223,25 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         );
 
         when(remoteMetadataDirectory.openInput(metadataFilename, IOContext.DEFAULT)).thenAnswer(
-            I -> createMetadataFileBytes(metadataFilenameContentMapping.get(metadataFilename), indexShard.getLatestReplicationCheckpoint())
+            I -> createMetadataFileBytes(
+                metadataFilenameContentMapping.get(metadataFilename),
+                indexShard.getLatestReplicationCheckpoint(),
+                segmentInfos
+            )
         );
         when(remoteMetadataDirectory.openInput(metadataFilename2, IOContext.DEFAULT)).thenAnswer(
-            I -> createMetadataFileBytes(metadataFilenameContentMapping.get(metadataFilename2), indexShard.getLatestReplicationCheckpoint())
+            I -> createMetadataFileBytes(
+                metadataFilenameContentMapping.get(metadataFilename2),
+                indexShard.getLatestReplicationCheckpoint(),
+                segmentInfos
+            )
         );
         when(remoteMetadataDirectory.openInput(metadataFilename3, IOContext.DEFAULT)).thenAnswer(
-            I -> createMetadataFileBytes(metadataFilenameContentMapping.get(metadataFilename3), indexShard.getLatestReplicationCheckpoint())
+            I -> createMetadataFileBytes(
+                metadataFilenameContentMapping.get(metadataFilename3),
+                indexShard.getLatestReplicationCheckpoint(),
+                segmentInfos
+            )
         );
 
         return metadataFilenameContentMapping;
@@ -654,7 +578,7 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         metadata.put("_0.cfs", "_0.cfs::_0.cfs__" + UUIDs.base64UUID() + "::2345::1024::" + Version.LATEST.major);
 
         when(remoteMetadataDirectory.openInput(metadataFilename, IOContext.DEFAULT)).thenReturn(
-            createMetadataFileBytes(metadata, indexShard.getLatestReplicationCheckpoint())
+            createMetadataFileBytes(metadata, indexShard.getLatestReplicationCheckpoint(), segmentInfos)
         );
 
         remoteSegmentStoreDirectory.init();
@@ -717,7 +641,11 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
             getDummyMetadata("_0", (int) generation)
         );
         when(remoteMetadataDirectory.openInput(latestMetadataFileName, IOContext.DEFAULT)).thenReturn(
-            createMetadataFileBytes(metadataFilenameContentMapping.get(latestMetadataFileName), indexShard.getLatestReplicationCheckpoint())
+            createMetadataFileBytes(
+                metadataFilenameContentMapping.get(latestMetadataFileName),
+                indexShard.getLatestReplicationCheckpoint(),
+                segmentInfos
+            )
         );
 
         remoteSegmentStoreDirectory.init();

--- a/test/framework/src/main/java/org/opensearch/test/RemoteStoreTestUtils.java
+++ b/test/framework/src/main/java/org/opensearch/test/RemoteStoreTestUtils.java
@@ -1,0 +1,129 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.test;
+
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.store.ByteBuffersDataOutput;
+import org.apache.lucene.store.ByteBuffersIndexOutput;
+import org.apache.lucene.store.OutputStreamIndexOutput;
+import org.apache.lucene.util.Version;
+import org.opensearch.common.UUIDs;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.lucene.store.ByteArrayIndexInput;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.index.store.remote.metadata.RemoteSegmentMetadata;
+import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.opensearch.test.OpenSearchTestCase.randomIntBetween;
+
+/**
+ * Utilities for remote store related operations used across one or more tests.
+ */
+public final class RemoteStoreTestUtils {
+
+    private RemoteStoreTestUtils() {
+
+    }
+
+    /**
+     * Prepares metadata file bytes with header and footer
+     *
+     * @param segmentFilesMap: actual metadata content
+     * @return ByteArrayIndexInput: metadata file bytes with header and footer
+     * @throws IOException IOException
+     */
+    public static ByteArrayIndexInput createMetadataFileBytes(
+        Map<String, String> segmentFilesMap,
+        ReplicationCheckpoint replicationCheckpoint,
+        SegmentInfos segmentInfos
+    ) throws IOException {
+        ByteBuffersDataOutput byteBuffersIndexOutput = new ByteBuffersDataOutput();
+        segmentInfos.write(new ByteBuffersIndexOutput(byteBuffersIndexOutput, "", ""));
+        byte[] byteArray = byteBuffersIndexOutput.toArrayCopy();
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        OutputStreamIndexOutput indexOutput = new OutputStreamIndexOutput("segment metadata", "metadata output stream", output, 4096);
+        CodecUtil.writeHeader(indexOutput, RemoteSegmentMetadata.METADATA_CODEC, RemoteSegmentMetadata.CURRENT_VERSION);
+        indexOutput.writeMapOfStrings(segmentFilesMap);
+        RemoteSegmentMetadata.writeCheckpointToIndexOutput(replicationCheckpoint, indexOutput);
+        indexOutput.writeLong(byteArray.length);
+        indexOutput.writeBytes(byteArray, byteArray.length);
+        CodecUtil.writeFooter(indexOutput);
+        indexOutput.close();
+        return new ByteArrayIndexInput("segment metadata", BytesReference.toBytes(output.bytes()));
+    }
+
+    public static Map<String, String> getDummyMetadata(String prefix, int commitGeneration) {
+        Map<String, String> metadata = new HashMap<>();
+
+        metadata.put(
+            prefix + ".cfe",
+            prefix
+                + ".cfe::"
+                + prefix
+                + ".cfe__"
+                + UUIDs.base64UUID()
+                + "::"
+                + randomIntBetween(1000, 5000)
+                + "::"
+                + randomIntBetween(512000, 1024000)
+                + "::"
+                + Version.MIN_SUPPORTED_MAJOR
+        );
+        metadata.put(
+            prefix + ".cfs",
+            prefix
+                + ".cfs::"
+                + prefix
+                + ".cfs__"
+                + UUIDs.base64UUID()
+                + "::"
+                + randomIntBetween(1000, 5000)
+                + "::"
+                + randomIntBetween(512000, 1024000)
+                + "::"
+                + Version.MIN_SUPPORTED_MAJOR
+        );
+        metadata.put(
+            prefix + ".si",
+            prefix
+                + ".si::"
+                + prefix
+                + ".si__"
+                + UUIDs.base64UUID()
+                + "::"
+                + randomIntBetween(1000, 5000)
+                + "::"
+                + randomIntBetween(512000, 1024000)
+                + "::"
+                + Version.LATEST.major
+        );
+        metadata.put(
+            "segments_" + commitGeneration,
+            "segments_"
+                + commitGeneration
+                + "::segments_"
+                + commitGeneration
+                + "__"
+                + UUIDs.base64UUID()
+                + "::"
+                + randomIntBetween(1000, 5000)
+                + "::"
+                + randomIntBetween(1024, 5120)
+                + "::"
+                + Version.LATEST.major
+        );
+        return metadata;
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Today, if a refresh occurs for an IndexShard, the afterRefresh method of `ReferenceManager.RefreshListener` (Lucene class) objects are invoked. RemoteStoreRefreshListener, currently, has the responsibility of updating the segment tracker with the upto date information of segment files which are part of the most recent refresh. It also has the responsibility of uploading the segments to the remote store after each refresh and then updating the segment tracker with the relevant information about the upload. This information is exposed via remote store stats api and is also used for rejection incoming write requests when there is a lag between the local store and the remote store (remote segment backpressure). While updating the tracker with local state happens at the beginning of the `performAfterRefresh`, there can be cases where the retry could have been blocking the performAfterRefresh (& hence the local state update in segment tracker). This would lead to incorrect information being saved in tracker due to the tight coupling. 

With this PR, we aim to introduce a new method inside the `CloseableRetryableRefreshListener` which gets executed exactly once. The idempotent logic can continue to reside in the `performAfterRefreshWithPermit` method. We are also adding tests for existing classes that covers more flows.

### Related Issues
Resolves #8717
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
