### PR TITLE
Fix search pipeline bwc test

### DIFF
--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -65,9 +65,6 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
       numberOfNodes = 4
 
       setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
-      if (bwcVersion.onOrAfter("2.7.0")) {
-        setting 'opensearch.experimental.feature.search_pipeline.enabled', 'true'
-      }
     }
   }
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search_pipeline/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search_pipeline/10_basic.yml
@@ -1,8 +1,12 @@
 ---
+# Only send sanity request to nodes in >=2.9 versions because search pipeline is GA in 2.9.0.
+# Nodes from earlier versions (before 2.9.0) will submit the request to nodes from 2.9.0
+# or later during the "mixedClusterTest," but this will fail because 2.9.0 removed the feature flag setting.
+
 "Test basic pipeline crud":
   - skip:
-      version: " - 2.6.99"
-      reason: "Added in 2.7.0"
+      version: " - 2.8.99"
+      reason: "Only send sanity request to nodes in >=2.9 versions"
   - do:
       search_pipeline.put:
         id: "my_pipeline"
@@ -32,8 +36,8 @@
 ---
 "Test Put Versioned Pipeline":
   - skip:
-      version: " - 2.6.99"
-      reason: "Added in 2.7.0"
+      version: " - 2.8.99"
+      reason: "Only send sanity request to nodes in >=2.9 versions"
   - do:
       search_pipeline.put:
         id: "my_pipeline"
@@ -125,8 +129,8 @@
 ---
 "Test Get All Pipelines":
   - skip:
-      version: " - 2.6.99"
-      reason: "Added in 2.7.0"
+      version: " - 2.8.99"
+      reason: "Only send sanity request to nodes in >=2.9 versions"
   - do:
       search_pipeline.put:
         id: "first_pipeline"
@@ -152,8 +156,8 @@
 ---
 "Test invalid config":
   - skip:
-      version: " - 2.6.99"
-      reason: "Added in 2.7.0"
+      version: " - 2.8.99"
+      reason: "Only send sanity request to nodes in >=2.9 versions"
   - do:
       catch: /parse_exception/
       search_pipeline.put:


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Address ./gradlew ':qa:mixed-cluster:v2.9.0#mixedClusterTest' failure issue, when bwc version is 2.9.0, and flag is true in build.gradle. The node with new code can't find the flag setting from the node with old code. On the other hand, when flag is fully removed or the bwc version is included, the node with old code has the flag default set to false will reject the request sent from node with new code. Related issue: https://github.com/opensearch-project/OpenSearch/issues/8070

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/8070

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
