### PR TITLE
extension distinguished name implementation

### DIFF
--- a/server/src/main/java/org/opensearch/extensions/ExtensionsSettings.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionsSettings.java
@@ -43,6 +43,7 @@ public class ExtensionsSettings {
         private String version;
         private String opensearchVersion;
         private String minimumCompatibleVersion;
+        private List<String> distinguishedNames;
         private List<ExtensionDependency> dependencies = Collections.emptyList();
         private ExtensionScopedSettings additionalSettings;
 
@@ -54,6 +55,7 @@ public class ExtensionsSettings {
             String version,
             String opensearchVersion,
             String minimumCompatibleVersion,
+            List<String> distinguishedNames,
             List<ExtensionDependency> dependencies,
             ExtensionScopedSettings additionalSettings
         ) {
@@ -64,6 +66,7 @@ public class ExtensionsSettings {
             this.version = version;
             this.opensearchVersion = opensearchVersion;
             this.minimumCompatibleVersion = minimumCompatibleVersion;
+            this.distinguishedNames = distinguishedNames;
             this.dependencies = dependencies;
             this.additionalSettings = additionalSettings;
         }
@@ -126,6 +129,10 @@ public class ExtensionsSettings {
             this.opensearchVersion = opensearchVersion;
         }
 
+        public List<String> getDistinguishedNames() {
+            return distinguishedNames;
+        }
+
         public List<ExtensionDependency> getDependencies() {
             return dependencies;
         }
@@ -158,6 +165,8 @@ public class ExtensionsSettings {
                 + opensearchVersion
                 + ", minimumCompatibleVersion="
                 + minimumCompatibleVersion
+                + ", distinguishedNames="
+                + distinguishedNames
                 + "]";
         }
 

--- a/server/src/main/java/org/opensearch/extensions/rest/RestInitializeExtensionAction.java
+++ b/server/src/main/java/org/opensearch/extensions/rest/RestInitializeExtensionAction.java
@@ -71,6 +71,8 @@ public class RestInitializeExtensionAction extends BaseRestHandler {
         String version = null;
         String openSearchVersion = null;
         String minimumCompatibleVersion = null;
+        List<String> distinguishedNames = new ArrayList<>();
+        ;
         List<ExtensionDependency> dependencies = new ArrayList<>();
         Set<String> additionalSettingsKeys = extensionsManager.getAdditionalSettings()
             .stream()
@@ -141,6 +143,7 @@ public class RestInitializeExtensionAction extends BaseRestHandler {
             version = extensionMap.get("version").toString();
             openSearchVersion = extensionMap.get("opensearchVersion").toString();
             minimumCompatibleVersion = extensionMap.get("minimumCompatibleVersion").toString();
+            distinguishedNames = new ArrayList<>((Collection<String>) extensionMap.get("distinguishedNames"));
             dependencies = extensionDependencyList;
         } catch (IOException e) {
             logger.warn("loading extension has been failed because of exception : " + e.getMessage());
@@ -155,6 +158,7 @@ public class RestInitializeExtensionAction extends BaseRestHandler {
             version,
             openSearchVersion,
             minimumCompatibleVersion,
+            distinguishedNames,
             dependencies,
             extAdditionalSettings
         );

--- a/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
+++ b/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
@@ -190,6 +190,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
             "0.0.7",
             "3.0.0",
             "3.0.0",
+            List.of("CN=extension-01,OU=SECURITY,O=OPENSEARCH,L=BROOKLYN,ST=NEW YORK,C=US"),
             Collections.emptyList(),
             extensionScopedSettings
         );
@@ -201,6 +202,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
             "0.0.7",
             "2.0.0",
             "2.0.0",
+            List.of("CN=extension-02,OU=SECURITY,O=OPENSEARCH,L=BROOKLYN,ST=NEW YORK,C=US"),
             List.of(dependentExtension),
             extensionScopedSettings
         );
@@ -261,6 +263,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
             "0.0.7",
             "3.0.0",
             "3.0.0",
+            List.of("CN=extension-01,OU=SECURITY,O=OPENSEARCH,L=BROOKLYN,ST=NEW YORK,C=US"),
             Collections.emptyList(),
             null
         );
@@ -272,6 +275,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
             "0.0.7",
             "3.0.0",
             "3.0.0",
+            List.of("CN=extension-01,OU=SECURITY,O=OPENSEARCH,L=BROOKLYN,ST=NEW YORK,C=US"),
             null,
             null
         );
@@ -313,7 +317,18 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
 
     public void testMissingRequiredFieldsWhileLoadingExtension() throws Exception {
 
-        Extension firstExtension = new Extension("firstExtension", "uniqueid1", "127.0.0.0", "9300", "0.0.7", "3.0.0", "", null, null);
+        Extension firstExtension = new Extension(
+            "firstExtension",
+            "uniqueid1",
+            "127.0.0.0",
+            "9300",
+            "0.0.7",
+            "3.0.0",
+            "",
+            null,
+            null,
+            null
+        );
         ExtensionsManager extensionsManager = new ExtensionsManager(Set.of());
 
         IOException exception = expectThrows(IOException.class, () -> extensionsManager.loadExtension(firstExtension));
@@ -783,6 +798,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
             "0.0.7",
             "3.0.0",
             "3.99.0",
+            List.of("CN=extension-01,OU=SECURITY,O=OPENSEARCH,L=BROOKLYN,ST=NEW YORK,C=US"),
             List.of(),
             null
         );
@@ -811,6 +827,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
             "0.0.7",
             "3.0.0",
             "3.0.0",
+            List.of("CN=extension-01,OU=SECURITY,O=OPENSEARCH,L=BROOKLYN,ST=NEW YORK,C=US"),
             List.of(),
             extensionScopedSettings
         );
@@ -849,6 +866,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
             "0.0.7",
             "2.0.0",
             "2.0.0",
+            List.of("CN=extension-01,OU=SECURITY,O=OPENSEARCH,L=BROOKLYN,ST=NEW YORK,C=US"),
             List.of(),
             extensionScopedSettings
         );


### PR DESCRIPTION
Description

Add support for extension domain name check, similar to how it's done for admin certificate or for nodes from different clusters. More about that in the task: https://github.com/opensearch-project/security/issues/2730
Issues Resolved

https://github.com/opensearch-project/security/issues/2730

Currently the implementation looks like this:

During extension initialization via REST call, DNs are passed in the request body:

curl -XPOST -k -u user:password "https://localhost:9200/_extensions/initialize" -H "Content-Type:application/json" --data '{ "name":"hello-world", "uniqueId":"hello-world2", "hostAddress":"127.0.0.1", "port":"4500", "version":"1.0", "opensearchVersion":"3.0.0", "minimumCompatibleVersion":"3.0.0", "dependencies":[{"uniqueId":"test1","version":"2.0.0"},{"uniqueId":"test2","version":"3.0.0"}], "distinguishedNames": ["CN=extension-0.example.com,OU=node,O=node,L=test,DC=de"] }'

In next iterations I'd like to store configuration in index and make it dynamic.

PR on openserch-security side: https://github.com/opensearch-project/security/pull/3031
Here's old PR that I created at the beginning of working on the task, additional input from @cwperks is there.: https://github.com/opensearch-project/opensearch-sdk-java/pull/879

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).