### PR TITLE
Index Level Encryption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add getter for path field in NestedQueryBuilder ([#4636](https://github.com/opensearch-project/OpenSearch/pull/4636))
 - Allow mmap to use new JDK-19 preview APIs in Apache Lucene 9.4+ ([#5151](https://github.com/opensearch-project/OpenSearch/pull/5151))
 - Add events correlation engine plugin ([#6854](https://github.com/opensearch-project/OpenSearch/issues/6854))
-- Index level encryption features ([#8791])
+- Index level encryption features (.[#8791](https://github.com/opensearch-project/OpenSearch/pull/8791))
 
 ### Dependencies
 - Bump `log4j-core` from 2.18.0 to 2.19.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add getter for path field in NestedQueryBuilder ([#4636](https://github.com/opensearch-project/OpenSearch/pull/4636))
 - Allow mmap to use new JDK-19 preview APIs in Apache Lucene 9.4+ ([#5151](https://github.com/opensearch-project/OpenSearch/pull/5151))
 - Add events correlation engine plugin ([#6854](https://github.com/opensearch-project/OpenSearch/issues/6854))
-- Index level encryption features ([#9999])
+- Index level encryption features ([#8791])
 
 ### Dependencies
 - Bump `log4j-core` from 2.18.0 to 2.19.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add getter for path field in NestedQueryBuilder ([#4636](https://github.com/opensearch-project/OpenSearch/pull/4636))
 - Allow mmap to use new JDK-19 preview APIs in Apache Lucene 9.4+ ([#5151](https://github.com/opensearch-project/OpenSearch/pull/5151))
 - Add events correlation engine plugin ([#6854](https://github.com/opensearch-project/OpenSearch/issues/6854))
+- Index level encryption features ([#9999])
 
 ### Dependencies
 - Bump `log4j-core` from 2.18.0 to 2.19.0

--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -200,6 +200,12 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 IndexSettings.INDEX_MERGE_ON_FLUSH_POLICY,
                 IndexSettings.DEFAULT_SEARCH_PIPELINE,
 
+                // Settings for Encryption
+                FsDirectoryFactory.INDEX_CRYPTO_PROVIDER_SETTING,
+                FsDirectoryFactory.INDEX_KMS_PATH_SETTING,
+                FsDirectoryFactory.INDEX_KMS_ALIAS_SETTING,
+                FsDirectoryFactory.INDEX_KMS_PASSWORD_SETTING,
+
                 // Settings for Searchable Snapshots
                 IndexSettings.SEARCHABLE_SNAPSHOT_REPOSITORY,
                 IndexSettings.SEARCHABLE_SNAPSHOT_INDEX_ID,

--- a/server/src/main/java/org/opensearch/index/IndexModule.java
+++ b/server/src/main/java/org/opensearch/index/IndexModule.java
@@ -408,6 +408,7 @@ public final class IndexModule {
         MMAPFS("mmapfs"),
         SIMPLEFS("simplefs"),
         FS("fs"),
+        CRYPTOFS("cryptofs"),
         REMOTE_SNAPSHOT("remote_snapshot");
 
         private final String settingsKey;
@@ -675,6 +676,7 @@ public final class IndexModule {
                 case NIOFS:
                 case FS:
                 case MMAPFS:
+                case CRYPTOFS:
                 case SIMPLEFS:
                     factories.put(type.getSettingsKey(), DEFAULT_DIRECTORY_FACTORY);
                     break;

--- a/server/src/main/java/org/opensearch/index/store/CryptoDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/CryptoDirectory.java
@@ -1,0 +1,670 @@
+/* * SPDX-License-Identifier: Apache-2.0 *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.index.store;
+
+import org.apache.lucene.store.BufferedIndexInput;
+import org.apache.lucene.store.FileSwitchDirectory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.LockFactory;
+import org.apache.lucene.store.MMapDirectory;
+import org.apache.lucene.store.NIOFSDirectory;
+import org.apache.lucene.store.OutputStreamIndexOutput;
+import org.opensearch.common.Randomness;
+import org.opensearch.common.util.io.IOUtils;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.FilterOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.Channels;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.Map;
+
+import javax.crypto.Cipher;
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.ShortBufferException;
+import javax.crypto.spec.IvParameterSpec;
+
+import java.util.function.Supplier;
+
+/**
+ * A hybrid directory implementation that encrypts files
+ * to be stored based on a user supplied key
+ *
+ * @opensearch.internal
+ */
+public final class CryptoDirectory extends NIOFSDirectory {
+    private final MMapDirectory delegate;
+    private final Set<String> mmapExtensions;
+    private Key dataKey;
+    private ConcurrentSkipListMap<String, String> ivMap;
+    private final Provider provider;
+
+    private final AtomicLong nextTempFileCounter = new AtomicLong();
+
+    CryptoDirectory(
+        LockFactory lockFactory,
+        MMapDirectory delegate,
+        Set<String> mmapExtensions,
+        Provider provider,
+        String alias,
+        Supplier<String> passwordSupplier,
+        String keyStorePath
+    ) throws IOException {
+        super(delegate.getDirectory(), lockFactory);
+        this.delegate = delegate;
+        this.mmapExtensions = mmapExtensions;
+        ivMap = new ConcurrentSkipListMap<>();
+        IndexInput in;
+        this.provider = provider;
+        try {
+            in = super.openInput("ivMap", new IOContext());
+        } catch (java.nio.file.NoSuchFileException nsfe) {
+            in = null;
+        }
+        LocalKeyStoreManager keyStore = LocalKeyStoreManager.load(keyStorePath, alias, passwordSupplier);
+        if (in != null) {
+            Map<String, String> tmp = in.readMapOfStrings();
+            ivMap.putAll(tmp);
+            in.close();
+            dataKey = keyStore.decryptDataKey(getWrappedKey());
+        } else {
+            dataKey = keyStore.generateDataKey();
+            storeWrappedKey(keyStore.wrapDataKey(dataKey));
+        }
+    }
+
+    private void storeWrappedKey(byte[] wrappedKey) {
+        try {
+            IndexOutput out = super.createOutput("keyfile", new IOContext());
+            out.writeInt(wrappedKey.length);
+            out.writeBytes(wrappedKey, 0, wrappedKey.length);
+            out.close();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private byte[] getWrappedKey() {
+        try {
+            IndexInput in = super.openInput("keyfile", new IOContext());
+            int size = in.readInt();
+            byte[] ret = new byte[size];
+            in.readBytes(ret, 0, size);
+            return ret;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void rename(String source, String dest) throws IOException {
+        if (!(source.contains("segments_") || source.endsWith(".si"))) ivMap.put(
+            getDirectory() + "/" + dest,
+            ivMap.remove(getDirectory() + "/" + source)
+        );
+        super.rename(source, dest);
+    }
+
+    @Override
+    public IndexInput openInput(String name, IOContext context) throws IOException {
+        if (name.contains("segments_") || name.endsWith(".si")) return super.openInput(name, context);
+        ensureOpen();
+        ensureCanRead(name);
+        Path path = getDirectory().resolve(name);
+        FileChannel fc = FileChannel.open(path, StandardOpenOption.READ);
+        boolean success = false;
+        try {
+            Cipher cipher = CipherFactory.getCipher(provider);
+            String ivEntry = ivMap.get(getDirectory() + "/" + name);
+            Objects.requireNonNull(ivEntry, "Failed to open file");
+            byte[] iv = Base64.getDecoder().decode(ivEntry);
+            CipherFactory.initCipher(cipher, this, Optional.of(iv), Cipher.DECRYPT_MODE, 0);
+            final IndexInput indexInput;
+            if (useDelegate(name)) {
+                indexInput = new CryptoMMapIndexInput(
+                    delegate.openInput(name, context),
+                    "CryptoMMapIndexInput(path=\"" + getDirectory().resolve(name) + "\")",
+                    cipher,
+                    this
+                );
+                success = true;
+            } else {
+                indexInput = new DecryptingFSIndexInput("DecryptingFSIndexInput(path=\"" + path + "\")", fc, context, cipher, this);
+                success = true;
+            }
+            return indexInput;
+        } finally {
+            if (success == false) {
+                IOUtils.closeWhileHandlingException(fc);
+            }
+        }
+    }
+
+    @Override
+    public IndexOutput createOutput(String name, IOContext context) throws IOException {
+        if (name.contains("segments_") || name.endsWith(".si")) return super.createOutput(name, context);
+        ensureOpen();
+        // maybeDeletePendingFiles();
+        // If this file was pending delete, we are now bringing it back to life:
+        // if (pendingDeletes.remove(name)) {
+        // privateDeleteFile(name, true); // try again to delete it - this is best effort
+        // pendingDeletes.remove(name); // watch out - if the delete fails it put
+        // }
+        OutputStream fos = Files.newOutputStream(directory.resolve(name), StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW);
+        Cipher cipher = CipherFactory.getCipher(provider);
+        SecureRandom random = Randomness.createSecure();
+        byte[] iv = new byte[16];
+        random.nextBytes(iv);
+        if (dataKey == null) throw new RuntimeException("dataKey is null!");
+        CipherFactory.initCipher(cipher, this, Optional.of(iv), Cipher.ENCRYPT_MODE, 0);
+        ivMap.put(getDirectory() + "/" + name, Base64.getEncoder().encodeToString(iv));
+        return new EncryptingFSIndexOutput(name, fos, cipher);
+    }
+
+    @Override
+    public IndexOutput createTempOutput(String prefix, String suffix, IOContext context) throws IOException {
+        if (prefix.contains("segments_") || prefix.endsWith(".si")) return super.createTempOutput(prefix, suffix, context);
+        ensureOpen();
+        // maybeDeletePendingFiles();
+        String name;
+        while (true) {
+            // try {
+            name = getTempFileName(prefix, suffix, nextTempFileCounter.getAndIncrement());
+            // if (pendingDeletes.contains(name)) {
+            // continue;
+            // }
+            // } catch (
+            // @SuppressWarnings("unused")
+            // FileAlreadyExistsException faee) {
+            // Retry with next incremented name
+            // }
+            OutputStream fos = Files.newOutputStream(directory.resolve(name), StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW);
+
+            Cipher cipher = CipherFactory.getCipher(provider);
+            SecureRandom random = Randomness.createSecure();
+            byte[] iv = new byte[16];
+            random.nextBytes(iv);
+            CipherFactory.initCipher(cipher, this, Optional.of(iv), Cipher.ENCRYPT_MODE, 0);
+            ivMap.put(getDirectory() + "/" + name, Base64.getEncoder().encodeToString(iv));
+            return new EncryptingFSIndexOutput(name, fos, cipher);
+        }
+    }
+
+    boolean useDelegate(String name) {
+        final String extension = FileSwitchDirectory.getExtension(name);
+        return mmapExtensions.contains(extension);
+    }
+
+    @Override
+    public synchronized void close() throws IOException {
+        try {
+            deleteFile("ivMap");
+        } catch (java.nio.file.NoSuchFileException fnfe) {
+
+        }
+        IndexOutput out = super.createOutput("ivMap", new IOContext());
+        out.writeMapOfStrings(ivMap);
+        out.close();
+        isOpen = false;
+        deletePendingFiles();
+        dataKey = null;
+    }
+
+    @Override
+    public void deleteFile(String name) throws IOException {
+        ivMap.remove(getDirectory() + "/" + name);
+        super.deleteFile(name);
+    }
+
+    MMapDirectory getDelegate() {
+        return delegate;
+    }
+
+    /**
+     * An IndexInput implementation that wraps an existing
+     * ByteBufferIndexInput and decrypts data for reading
+     *
+     * @opensearch.internal
+     */
+    final class CryptoMMapIndexInput extends IndexInput {
+        private IndexInput in;
+        private Cipher cipher;
+        private CryptoDirectory directory;
+        long offset;
+        long length;
+        byte[] tmp;
+
+        public CryptoMMapIndexInput(IndexInput in, String description, Cipher cipher, CryptoDirectory directory) {
+            super(description);
+            this.in = in;
+            this.cipher = cipher;
+            this.directory = directory;
+            offset = 0;
+            tmp = new byte[8];
+        }
+
+        public CryptoMMapIndexInput(IndexInput in, String description, Cipher old, CryptoDirectory directory, long offset, long length) {
+            super(description);
+            this.in = in;
+            this.directory = directory;
+            this.offset = offset;
+            this.length = length;
+            tmp = new byte[8];
+            cipher = CipherFactory.getCipher(provider);
+            CipherFactory.initCipher(cipher, directory, Optional.of(old.getIV()), Cipher.DECRYPT_MODE, offset);
+        }
+
+        @Override
+        public IndexInput clone() {
+            return new CryptoMMapIndexInput(in.clone(), getFullSliceDescription(""), cipher, directory, this.offset, length());
+        }
+
+        @Override
+        public void seek(long pos) throws IOException {
+            if (pos < 0 || pos > length()) {
+                throw new EOFException(
+                    Thread.currentThread().getId() + " read past EOF: pos=" + pos + " vs length=" + length() + ": " + this
+                );
+            }
+            long current = getFilePointer();
+            if (current <= pos && (pos + offset) / 16 == (current + offset) / 16) {
+                cipher.update(new byte[(int) (pos - current)]);
+                in.seek(pos);
+                return;
+            }
+            in.seek(pos);
+            CipherFactory.initCipher(cipher, directory, Optional.empty(), Cipher.DECRYPT_MODE, pos + offset);
+        }
+
+        @Override
+        public long getFilePointer() {
+            return in.getFilePointer();
+        }
+
+        @Override
+        public long length() {
+            return in.length();
+        }
+
+        @Override
+        public void close() throws IOException {
+            in.close();
+        }
+
+        @Override
+        public byte readByte() throws IOException {
+            return cipher.update(new byte[] { in.readByte() })[0];
+        }
+
+        @Override
+        public void readBytes(byte[] b, int offset, int len) throws IOException {
+            byte[] tmp = new byte[len];
+            in.readBytes(tmp, 0, len);
+            try {
+                cipher.update(tmp, 0, len, b, offset);
+            } catch (ShortBufferException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public void readBytes(byte[] b, int offset, int len, boolean useBuffer) throws IOException {
+            byte[] tmp = new byte[len];
+            in.readBytes(tmp, 0, len, useBuffer);
+            try {
+                cipher.update(tmp, 0, len, b, offset);
+            } catch (ShortBufferException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public int readInt() throws IOException {
+            readBytes(tmp, 0, 4);
+            return ((tmp[3] & 0xFF) << 24) | ((tmp[2] & 0xFF) << 16) | ((tmp[1] & 0xFF) << 8) | (tmp[0] & 0xFF);
+        }
+
+        @Override
+        public long readLong() throws IOException {
+            readBytes(tmp, 0, 8);
+            return ((tmp[7] & 0xFFL) << 56) | ((tmp[6] & 0xFFL) << 48) | ((tmp[5] & 0xFFL) << 40) | ((tmp[4] & 0xFFL) << 32) | ((tmp[3]
+                & 0xFFL) << 24) | ((tmp[2] & 0xFFL) << 16) | ((tmp[1] & 0xFFL) << 8) | (tmp[0] & 0xFFL);
+        }
+
+        @Override
+        public void skipBytes(long numBytes) throws IOException {
+            seek(getFilePointer() + numBytes);
+        }
+
+        @Override
+        public CryptoMMapIndexInput slice(String sliceDescription, long offset, long newLength) throws IOException {
+            if (offset < 0 || newLength < 0 || offset + newLength > this.length()) throw new RuntimeException(
+                "bad slice! current offset: " + this.offset + " length: " + length() + " newOffset: " + offset + " newLength: " + newLength
+            );
+            return new CryptoMMapIndexInput(
+                in.slice(sliceDescription, offset, newLength),
+                getFullSliceDescription(sliceDescription),
+                cipher,
+                directory,
+                this.offset + offset,
+                newLength
+            );
+        }
+    }
+
+    /**
+     * An IndexInput implementation that decrypts data for reading
+     *
+     * @opensearch.internal
+     */
+    final class DecryptingFSIndexInput extends BufferedIndexInput {
+        /** The maximum chunk size for reads of 16384 bytes. */
+        private static final int CHUNK_SIZE = 16384;
+        ByteBuffer tmpBuffer = ByteBuffer.allocate(CHUNK_SIZE);
+
+        /** the file channel we will read from */
+        protected final FileChannel channel;
+        /** is this instance a clone and hence does not own the file to close it */
+        boolean isClone = false;
+        /** start offset: non-zero in the slice case */
+        protected final long off;
+        /** end offset (start+length) */
+        protected final long end;
+        InputStream stream;
+        Cipher cipher;
+        CryptoDirectory directory;
+
+        public DecryptingFSIndexInput(String resourceDesc, FileChannel fc, IOContext context, Cipher cipher, CryptoDirectory directory)
+            throws IOException {
+            super(resourceDesc, context);
+            this.channel = fc;
+            this.off = 0L;
+            this.end = fc.size();
+            this.stream = Channels.newInputStream(channel);
+            this.cipher = cipher;
+            this.directory = directory;
+        }
+
+        public DecryptingFSIndexInput(
+            String resourceDesc,
+            FileChannel fc,
+            long off,
+            long length,
+            int bufferSize,
+            Cipher old,
+            CryptoDirectory directory,
+            InputStream stream
+        ) throws IOException {
+            super(resourceDesc, bufferSize);
+            this.channel = fc;
+            this.off = off;
+            this.end = off + length;
+            this.isClone = true;
+            this.directory = directory;
+            this.stream = stream;
+            cipher = CipherFactory.getCipher(old.getProvider());
+            CipherFactory.initCipher(cipher, directory, Optional.of(old.getIV()), Cipher.DECRYPT_MODE, off);
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (!isClone) {
+                stream.close();
+            }
+        }
+
+        @Override
+        public DecryptingFSIndexInput clone() {
+            try {
+                DecryptingFSIndexInput clone = new DecryptingFSIndexInput(
+                    getFullSliceDescription(""),
+                    channel,
+                    off,
+                    length(),
+                    getBufferSize(),
+                    cipher,
+                    directory,
+                    stream
+                );
+                clone.isClone = true;
+                return clone;
+            } catch (IOException e) {
+                throw new RuntimeException(e.getMessage());
+            }
+        }
+
+        @Override
+        public IndexInput slice(String sliceDescription, long offset, long length) throws IOException {
+            if (offset < 0 || length < 0 || offset + length > this.length()) {
+                throw new IllegalArgumentException(
+                    "slice() "
+                        + sliceDescription
+                        + " out of bounds: offset="
+                        + offset
+                        + ",length="
+                        + length
+                        + ",fileLength="
+                        + this.length()
+                        + ": "
+                        + this
+                );
+            }
+            return new DecryptingFSIndexInput(
+                getFullSliceDescription(sliceDescription),
+                channel,
+                off + offset,
+                length,
+                getBufferSize(),
+                cipher,
+                directory,
+                stream
+            );
+        }
+
+        @Override
+        public final long length() {
+            return end - off;
+        }
+
+        private int read(ByteBuffer dst, long position) throws IOException {
+            int ret;
+            int i;
+            tmpBuffer.rewind();
+            channel.position(position);
+            i = stream.read(tmpBuffer.array(), 0, dst.remaining());
+            tmpBuffer.limit(i);
+            try {
+                if (end - position > i) ret = cipher.update(tmpBuffer, dst);
+                else ret = cipher.doFinal(tmpBuffer, dst);
+            } catch (ShortBufferException | IllegalBlockSizeException | BadPaddingException ex) {
+                throw new IOException("failed to decrypt blck.", ex);
+            }
+            return ret;
+        }
+
+        @Override
+        protected void readInternal(ByteBuffer b) throws IOException {
+            long pos = getFilePointer() + off;
+
+            if (pos + b.remaining() > end) {
+                throw new EOFException(
+                    Thread.currentThread().getId()
+                        + " read past EOF: "
+                        + this
+                        + " isClone? "
+                        + isClone
+                        + " off: "
+                        + off
+                        + " pos: "
+                        + pos
+                        + " end: "
+                        + end
+                );
+            }
+
+            try {
+                int readLength = b.remaining();
+                while (readLength > 0) {
+                    final int toRead = Math.min(CHUNK_SIZE, readLength);
+                    b.limit(b.position() + toRead);
+                    assert b.remaining() == toRead;
+                    final int i = read(b, pos);
+                    if (i < 0) {
+                        throw new EOFException("read past EOF: " + this + " buffer: " + b + " chunkLen: " + toRead + " end: " + end);
+                    }
+                    assert i > 0 : "FileChannel.read with non zero-length bb.remaining() must always read at least "
+                        + "one byte (FileChannel is in blocking mode, see spec of ReadableByteChannel)";
+                    pos += i;
+                    readLength -= i;
+                }
+                assert readLength == 0;
+            } catch (IOException ioe) {
+                throw new IOException(ioe.getMessage() + ": " + this, ioe);
+            }
+        }
+
+        @Override
+        protected void seekInternal(long pos) throws IOException {
+            if (pos > length()) {
+                throw new EOFException(
+                    Thread.currentThread().getId() + " read past EOF: pos=" + pos + " vs length=" + length() + ": " + this
+                );
+            }
+            CipherFactory.initCipher(cipher, directory, Optional.empty(), Cipher.DECRYPT_MODE, pos + off);
+        }
+    }
+
+    /**
+     * An IndexOutput implementation that encrypts data before writing
+     *
+     * @opensearch.internal
+     */
+    final class EncryptingFSIndexOutput extends OutputStreamIndexOutput {
+        /**
+         * The maximum chunk size is 8192 bytes, because file channel mallocs a native buffer outside of
+         * stack if the write buffer size is larger.
+         */
+        static final int CHUNK_SIZE = 8192;
+        Cipher cipher;
+
+        public EncryptingFSIndexOutput(String name, OutputStream os, Cipher cipher) throws IOException {
+            super("FSIndexOutput(path=\"" + directory.resolve(name) + "\")", name, new FilterOutputStream(os) {
+
+                @Override
+                public void close() throws IOException {
+                    try {
+                        out.write(cipher.doFinal());
+                    } catch (IllegalBlockSizeException | BadPaddingException e) {
+                        throw new RuntimeException(e);
+                    }
+                    super.close();
+                }
+
+                @Override
+                public void write(byte[] b, int offset, int length) throws IOException {
+                    int count = 0;
+                    byte[] res;
+                    while (length > 0) {
+                        count++;
+                        final int chunk = Math.min(length, CHUNK_SIZE);
+                        try {
+                            res = cipher.update(b, offset, chunk);
+                            if (res != null) out.write(res);
+                        } catch (IllegalStateException e) {
+                            throw new IllegalStateException("count is " + count + " " + e.getMessage());
+                        }
+                        length -= chunk;
+                        offset += chunk;
+                    }
+                }
+            }, CHUNK_SIZE);
+            this.cipher = cipher;
+        }
+    }
+
+    static class CipherFactory {
+        static final int AES_BLOCK_SIZE = 16;
+
+        public static Cipher getCipher(Provider provider) {
+            try {
+                return Cipher.getInstance("AES/CTR/NoPadding", provider);
+            } catch (NoSuchPaddingException | NoSuchAlgorithmException e) {
+                throw new RuntimeException();
+            }
+        }
+
+        public static void initCipher(Cipher cipher, CryptoDirectory directory, Optional<byte[]> ivarray, int opmode, long newPosition) {
+            try {
+                byte[] iv = ivarray.isPresent() ? ivarray.get() : cipher.getIV();
+                if (newPosition == 0) {
+                    Arrays.fill(iv, 12, 16, (byte) 0);
+                } else {
+                    int counter = (int) (newPosition / AES_BLOCK_SIZE);
+                    for (int i = 15; i >= 12; i--) {
+                        iv[i] = (byte) counter;
+                        counter = counter >>> Byte.SIZE;
+                    }
+                }
+                IvParameterSpec spec = new IvParameterSpec(iv);
+                cipher.init(opmode, directory.dataKey, spec);
+                int bytesToRead = (int) (newPosition % AES_BLOCK_SIZE);
+                if (bytesToRead > 0) {
+                    cipher.update(new byte[bytesToRead]);
+                }
+            } catch (InvalidAlgorithmParameterException | InvalidKeyException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/index/store/CryptoDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/CryptoDirectory.java
@@ -162,7 +162,7 @@ public final class CryptoDirectory extends NIOFSDirectory {
         ensureOpen();
         ensureCanRead(name);
         Path path = getDirectory().resolve(name);
-        FileChannel fc = FileChannel.open(path, StandardOpenOption.READ);
+        FileChannel fc = null;
         boolean success = false;
         try {
             Cipher cipher = CipherFactory.getCipher(provider);
@@ -180,12 +180,13 @@ public final class CryptoDirectory extends NIOFSDirectory {
                 );
                 success = true;
             } else {
+                fc = FileChannel.open(path, StandardOpenOption.READ);
                 indexInput = new DecryptingFSIndexInput("DecryptingFSIndexInput(path=\"" + path + "\")", fc, context, cipher, this);
                 success = true;
             }
             return indexInput;
         } finally {
-            if (success == false) {
+            if (success == false && fc != null) {
                 IOUtils.closeWhileHandlingException(fc);
             }
         }
@@ -258,6 +259,7 @@ public final class CryptoDirectory extends NIOFSDirectory {
         out.close();
         isOpen = false;
         deletePendingFiles();
+        IOUtils.close(delegate);
         dataKey = null;
     }
 

--- a/server/src/main/java/org/opensearch/index/store/CryptoDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/CryptoDirectory.java
@@ -125,25 +125,31 @@ public final class CryptoDirectory extends NIOFSDirectory {
     }
 
     private void storeWrappedKey(byte[] wrappedKey) {
+        IndexOutput out = null;
         try {
-            IndexOutput out = super.createOutput("keyfile", new IOContext());
+            out = super.createOutput("keyfile", new IOContext());
             out.writeInt(wrappedKey.length);
             out.writeBytes(wrappedKey, 0, wrappedKey.length);
             out.close();
         } catch (IOException e) {
             throw new RuntimeException(e);
+        } finally {
+            if (out != null) IOUtils.closeWhileHandlingException(out);
         }
     }
 
     private byte[] getWrappedKey() {
+        IndexInput in = null;
         try {
-            IndexInput in = super.openInput("keyfile", new IOContext());
+            in = super.openInput("keyfile", new IOContext());
             int size = in.readInt();
             byte[] ret = new byte[size];
             in.readBytes(ret, 0, size);
             return ret;
         } catch (IOException e) {
             throw new RuntimeException(e);
+        } finally {
+            if (in != null) IOUtils.closeWhileHandlingException(in);
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/store/KeyStoreManager.java
+++ b/server/src/main/java/org/opensearch/index/store/KeyStoreManager.java
@@ -1,0 +1,56 @@
+/* * SPDX-License-Identifier: Apache-2.0 *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.index.store;
+
+import java.security.Key;
+
+/**
+ * Interface for key management stores
+ *
+ * @opensearch.internal
+ */
+public interface KeyStoreManager {
+
+    /**
+     *  Creates and returns a data key
+     */
+    public Key generateDataKey();
+
+    /**
+     *  Encrypts the provided data key
+     */
+    public byte[] wrapDataKey(Key key);
+
+    /**
+     *  Decrypts the provided data key
+     */
+    public Key decryptDataKey(byte[] wrappedKey);
+}

--- a/server/src/main/java/org/opensearch/index/store/LocalKeyStoreManager.java
+++ b/server/src/main/java/org/opensearch/index/store/LocalKeyStoreManager.java
@@ -1,0 +1,133 @@
+/* * SPDX-License-Identifier: Apache-2.0 *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.index.store;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.security.cert.CertificateException;
+import java.security.InvalidKeyException;
+import java.security.UnrecoverableKeyException;
+import java.security.Key;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.KeyGenerator;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.security.auth.DestroyFailedException;
+import java.util.function.Supplier;
+import java.util.Objects;
+
+/**
+ * A Dummy implementation of a Key Store based on a user provided
+ * {@link java.security.KeyStore} containing the master key
+ *
+ * @opensearch.internal
+ */
+public class LocalKeyStoreManager implements KeyStoreManager {
+    private final KeyStore keystore;
+    private final String alias;
+    private final Supplier<String> keyPass;
+
+    public static LocalKeyStoreManager load(String keyStorePath, String alias, Supplier<String> pass) throws IOException {
+        try {
+            Objects.requireNonNull(alias);
+            Objects.requireNonNull(keyStorePath);
+            Objects.requireNonNull(pass.get());
+        } catch (NullPointerException npe) {
+            throw new IOException("Failed to open local keystore. Check keystore parameters");
+        }
+        return new LocalKeyStoreManager(keyStorePath, alias, pass);
+    }
+
+    private LocalKeyStoreManager(String keyStorePath, String alias, Supplier<String> pass) throws IOException {
+        try (InputStream in = Files.newInputStream(Path.of(keyStorePath), StandardOpenOption.READ)) {
+            keystore = KeyStore.getInstance("PKCS12");
+            keystore.load(in, pass.get().toCharArray());
+            this.alias = alias;
+            this.keyPass = pass;
+        } catch (java.security.AccessControlException | KeyStoreException | CertificateException | NoSuchAlgorithmException e) {
+            throw new IOException("Failed to open local keystore.", e);
+        }
+    }
+
+    public Key generateDataKey() {
+        try {
+            KeyGenerator keyGenerator = KeyGenerator.getInstance("AES");
+            keyGenerator.init(256);
+            return keyGenerator.generateKey();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException();
+        }
+    }
+
+    public byte[] wrapDataKey(Key key) {
+        try {
+            SecretKey master = (SecretKey) keystore.getKey(alias, keyPass.get().toCharArray());
+            Cipher cipher = Cipher.getInstance("AESWRAP");
+            cipher.init(Cipher.WRAP_MODE, master);
+            byte[] wrappedKey = cipher.wrap(key);
+            try {
+                master.destroy();
+            } catch (DestroyFailedException dfe) {
+                master = null;
+            }
+            return wrappedKey;
+        } catch (InvalidKeyException | IllegalBlockSizeException | NoSuchPaddingException | NoSuchAlgorithmException
+            | UnrecoverableKeyException | KeyStoreException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Key decryptDataKey(byte[] wrappedKey) {
+        try {
+            SecretKey master = (SecretKey) keystore.getKey(alias, keyPass.get().toCharArray());
+            Cipher cipher = Cipher.getInstance("AESWRAP");
+            cipher.init(Cipher.UNWRAP_MODE, master);
+            Key key = (Key) cipher.unwrap(wrappedKey, "AES", Cipher.SECRET_KEY);
+            try {
+                master.destroy();
+            } catch (DestroyFailedException dfe) {
+                master = null;
+            }
+            return key;
+        } catch (InvalidKeyException | NoSuchPaddingException | NoSuchAlgorithmException | UnrecoverableKeyException
+            | KeyStoreException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/index/store/LocalKeyStoreManager.java
+++ b/server/src/main/java/org/opensearch/index/store/LocalKeyStoreManager.java
@@ -33,6 +33,7 @@ package org.opensearch.index.store;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.security.cert.CertificateException;
@@ -80,7 +81,8 @@ public class LocalKeyStoreManager implements KeyStoreManager {
             keystore.load(in, pass.get().toCharArray());
             this.alias = alias;
             this.keyPass = pass;
-        } catch (java.security.AccessControlException | KeyStoreException | CertificateException | NoSuchAlgorithmException e) {
+        } catch (java.security.AccessControlException | KeyStoreException | CertificateException | NoSuchAlgorithmException
+            | NoSuchFileException e) {
             throw new IOException("Failed to open local keystore.", e);
         }
     }

--- a/server/src/test/java/org/opensearch/index/store/CryptoDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/CryptoDirectoryTests.java
@@ -1,0 +1,759 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.index.store;
+
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.index.IndexFormatTooNewException;
+import org.apache.lucene.index.IndexFormatTooOldException;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.NoDeletionPolicy;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.store.ChecksumIndexInput;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FilterDirectory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.tests.analysis.MockAnalyzer;
+import org.apache.lucene.tests.store.BaseDirectoryWrapper;
+import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.Version;
+import org.hamcrest.Matchers;
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.UUIDs;
+import org.opensearch.common.lucene.Lucene;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.io.IOUtils;
+import org.opensearch.core.common.io.stream.InputStreamStreamInput;
+import org.opensearch.core.common.io.stream.OutputStreamStreamOutput;
+import org.opensearch.core.index.Index;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.env.ShardLock;
+import org.opensearch.index.IndexModule;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.engine.Engine;
+import org.opensearch.indices.replication.common.ReplicationType;
+import org.opensearch.test.DummyShardLock;
+import org.opensearch.test.IndexSettingsModule;
+import org.opensearch.test.OpenSearchTestCase;
+import org.apache.lucene.store.FSLockFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.Collections.unmodifiableMap;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+import static org.opensearch.test.VersionUtils.randomVersion;
+
+import javax.crypto.SecretKey;
+import org.opensearch.common.Randomness;
+import java.security.cert.CertificateException;
+import java.security.NoSuchAlgorithmException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import org.junit.BeforeClass;
+
+public class CryptoDirectoryTests extends OpenSearchTestCase {
+
+    private static IndexSettings INDEX_SETTINGS;
+    private static String KEYSTORE_PATH;
+
+    IndexSettings SEGMENT_REPLICATION_INDEX_SETTINGS = new IndexSettings(
+        INDEX_SETTINGS.getIndexMetadata(),
+        Settings.builder().put(INDEX_SETTINGS.getSettings()).put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT).build()
+    );
+
+    private static final Version MIN_SUPPORTED_LUCENE_VERSION = org.opensearch.Version.CURRENT
+        .minimumIndexCompatibilityVersion().luceneVersion;
+
+    private static void setupIndexSettings() {
+        KEYSTORE_PATH = createTempDir().toString() + "/keystore.ks";
+        INDEX_SETTINGS = IndexSettingsModule.newIndexSettings(
+            "index",
+            Settings.builder()
+                .put(IndexMetadata.SETTING_VERSION_CREATED, org.opensearch.Version.CURRENT)
+                .put(FsDirectoryFactory.INDEX_KMS_ALIAS_SETTING.getKey(), "cryptotest")
+                .put(FsDirectoryFactory.INDEX_KMS_PASSWORD_SETTING.getKey(), "cryptopass")
+                .put(FsDirectoryFactory.INDEX_KMS_PATH_SETTING.getKey(), KEYSTORE_PATH)
+                .put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), "cryptofs")
+                .build()
+        );
+    }
+
+    @BeforeClass
+    private static void setupLocalKeyStore() throws IOException {
+        setupIndexSettings();
+        try {
+            KeyStore keystore = KeyStore.getInstance("PKCS12");
+            byte[] keyMaterial = new byte[32];
+            java.util.Random rnd = Randomness.get();
+            rnd.nextBytes(keyMaterial);
+            SecretKey master = new javax.crypto.spec.SecretKeySpec(keyMaterial, "AES");
+            String alias = "cryptotest";
+            String keyPass = "cryptopass";
+            keystore.load(null, keyPass.toCharArray());
+            keystore.setEntry(alias, new KeyStore.SecretKeyEntry(master), new KeyStore.PasswordProtection(keyPass.toCharArray()));
+            String keyStorePath = INDEX_SETTINGS.getValue(FsDirectoryFactory.INDEX_KMS_PATH_SETTING);
+            try (OutputStream os = Files.newOutputStream(Path.of(keyStorePath), StandardOpenOption.CREATE)) {
+                keystore.store(os, keyPass.toCharArray());
+            }
+
+        } catch (java.security.AccessControlException | KeyStoreException | CertificateException | NoSuchAlgorithmException e) {
+            throw new IOException(e.getMessage());
+        }
+    }
+
+    private Directory newCryptoDirectory() {
+        return newCryptoDirectory(createTempDir());
+    }
+
+    private Directory newCryptoDirectory(Path dir) {
+        try {
+            return new FsDirectoryFactory().newFSDirectory(dir, FSLockFactory.getDefault(), INDEX_SETTINGS);
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    public void testRefCount() {
+        final ShardId shardId = new ShardId("index", "_na_", 1);
+        IndexSettings indexSettings = INDEX_SETTINGS;
+        Store store = new Store(shardId, indexSettings, newCryptoDirectory(), new DummyShardLock(shardId));
+        int incs = randomIntBetween(1, 100);
+        for (int i = 0; i < incs; i++) {
+            if (randomBoolean()) {
+                store.incRef();
+            } else {
+                assertTrue(store.tryIncRef());
+            }
+            store.ensureOpen();
+        }
+
+        for (int i = 0; i < incs; i++) {
+            store.decRef();
+            store.ensureOpen();
+        }
+
+        store.incRef();
+        store.close();
+        for (int i = 0; i < incs; i++) {
+            if (randomBoolean()) {
+                store.incRef();
+            } else {
+                assertTrue(store.tryIncRef());
+            }
+            store.ensureOpen();
+        }
+
+        for (int i = 0; i < incs; i++) {
+            store.decRef();
+            store.ensureOpen();
+        }
+
+        store.decRef();
+        assertThat(store.refCount(), Matchers.equalTo(0));
+        assertFalse(store.tryIncRef());
+        expectThrows(IllegalStateException.class, store::incRef);
+        expectThrows(IllegalStateException.class, store::ensureOpen);
+    }
+
+    public void testVerifyingIndexOutput() throws IOException {
+        Directory dir = newCryptoDirectory();
+        IndexOutput output = dir.createOutput("foo.bar", IOContext.DEFAULT);
+        int iters = scaledRandomIntBetween(10, 100);
+        for (int i = 0; i < iters; i++) {
+            BytesRef bytesRef = new BytesRef(TestUtil.randomRealisticUnicodeString(random(), 10, 1024));
+            output.writeBytes(bytesRef.bytes, bytesRef.offset, bytesRef.length);
+        }
+        CodecUtil.writeFooter(output);
+        output.close();
+        IndexInput indexInput = dir.openInput("foo.bar", IOContext.DEFAULT);
+        String checksum = Store.digestToString(CodecUtil.retrieveChecksum(indexInput));
+        indexInput.seek(0);
+        BytesRef ref = new BytesRef(scaledRandomIntBetween(1, 1024));
+        long length = indexInput.length();
+        IndexOutput verifyingOutput = new Store.LuceneVerifyingIndexOutput(
+            new StoreFileMetadata("foo1.bar", length, checksum, MIN_SUPPORTED_LUCENE_VERSION),
+            dir.createOutput("foo1.bar", IOContext.DEFAULT)
+        );
+        while (length > 0) {
+            if (random().nextInt(10) == 0) {
+                verifyingOutput.writeByte(indexInput.readByte());
+                length--;
+            } else {
+                int min = (int) Math.min(length, ref.bytes.length);
+                indexInput.readBytes(ref.bytes, ref.offset, min);
+                verifyingOutput.writeBytes(ref.bytes, ref.offset, min);
+                length -= min;
+            }
+        }
+        Store.verify(verifyingOutput);
+        try {
+            appendRandomData(verifyingOutput);
+            fail("should be a corrupted index");
+        } catch (CorruptIndexException | IndexFormatTooOldException | IndexFormatTooNewException ex) {
+            // ok
+        }
+        try {
+            Store.verify(verifyingOutput);
+            fail("should be a corrupted index");
+        } catch (CorruptIndexException | IndexFormatTooOldException | IndexFormatTooNewException ex) {
+            // ok
+        }
+
+        IOUtils.close(indexInput, verifyingOutput, dir);
+    }
+
+    public void testVerifyingIndexOutputOnEmptyFile() throws IOException {
+        Directory dir = newCryptoDirectory();
+        IndexOutput verifyingOutput = new Store.LuceneVerifyingIndexOutput(
+            new StoreFileMetadata("foo.bar", 0, Store.digestToString(0), MIN_SUPPORTED_LUCENE_VERSION),
+            dir.createOutput("foo1.bar", IOContext.DEFAULT)
+        );
+        try {
+            Store.verify(verifyingOutput);
+            fail("should be a corrupted index");
+        } catch (CorruptIndexException | IndexFormatTooOldException | IndexFormatTooNewException ex) {
+            // ok
+        }
+        IOUtils.close(verifyingOutput, dir);
+    }
+
+    public void testChecksumCorrupted() throws IOException {
+        Directory dir = newCryptoDirectory();
+        IndexOutput output = dir.createOutput("foo.bar", IOContext.DEFAULT);
+        int iters = scaledRandomIntBetween(10, 100);
+        for (int i = 0; i < iters; i++) {
+            BytesRef bytesRef = new BytesRef(TestUtil.randomRealisticUnicodeString(random(), 10, 1024));
+            output.writeBytes(bytesRef.bytes, bytesRef.offset, bytesRef.length);
+        }
+        CodecUtil.writeBEInt(output, CodecUtil.FOOTER_MAGIC);
+        CodecUtil.writeBEInt(output, 0);
+        String checksum = Store.digestToString(output.getChecksum());
+        CodecUtil.writeBELong(output, output.getChecksum() + 1); // write a wrong checksum to the file
+        output.close();
+
+        IndexInput indexInput = dir.openInput("foo.bar", IOContext.DEFAULT);
+        indexInput.seek(0);
+        BytesRef ref = new BytesRef(scaledRandomIntBetween(1, 1024));
+        long length = indexInput.length();
+        IndexOutput verifyingOutput = new Store.LuceneVerifyingIndexOutput(
+            new StoreFileMetadata("foo1.bar", length, checksum, MIN_SUPPORTED_LUCENE_VERSION),
+            dir.createOutput("foo1.bar", IOContext.DEFAULT)
+        );
+        length -= 8; // we write the checksum in the try / catch block below
+        while (length > 0) {
+            if (random().nextInt(10) == 0) {
+                verifyingOutput.writeByte(indexInput.readByte());
+                length--;
+            } else {
+                int min = (int) Math.min(length, ref.bytes.length);
+                indexInput.readBytes(ref.bytes, ref.offset, min);
+                verifyingOutput.writeBytes(ref.bytes, ref.offset, min);
+                length -= min;
+            }
+        }
+
+        try {
+            BytesRef checksumBytes = new BytesRef(8);
+            checksumBytes.length = 8;
+            indexInput.readBytes(checksumBytes.bytes, checksumBytes.offset, checksumBytes.length);
+            if (randomBoolean()) {
+                verifyingOutput.writeBytes(checksumBytes.bytes, checksumBytes.offset, checksumBytes.length);
+            } else {
+                for (int i = 0; i < checksumBytes.length; i++) {
+                    verifyingOutput.writeByte(checksumBytes.bytes[i]);
+                }
+            }
+            fail("should be a corrupted index");
+        } catch (CorruptIndexException | IndexFormatTooOldException | IndexFormatTooNewException ex) {
+            // ok
+        }
+        IOUtils.close(indexInput, verifyingOutput, dir);
+    }
+
+    private void appendRandomData(IndexOutput output) throws IOException {
+        int numBytes = randomIntBetween(1, 1024);
+        final BytesRef ref = new BytesRef(scaledRandomIntBetween(1, numBytes));
+        ref.length = ref.bytes.length;
+        while (numBytes > 0) {
+            if (random().nextInt(10) == 0) {
+                output.writeByte(randomByte());
+                numBytes--;
+            } else {
+                for (int i = 0; i < ref.length; i++) {
+                    ref.bytes[i] = randomByte();
+                }
+                final int min = Math.min(numBytes, ref.bytes.length);
+                output.writeBytes(ref.bytes, ref.offset, min);
+                numBytes -= min;
+            }
+        }
+    }
+
+    public void testVerifyingIndexOutputWithBogusInput() throws IOException {
+        Directory dir = newCryptoDirectory();
+        int length = scaledRandomIntBetween(10, 1024);
+        IndexOutput verifyingOutput = new Store.LuceneVerifyingIndexOutput(
+            new StoreFileMetadata("foo1.bar", length, "", MIN_SUPPORTED_LUCENE_VERSION),
+            dir.createOutput("foo1.bar", IOContext.DEFAULT)
+        );
+        try {
+            while (length > 0) {
+                verifyingOutput.writeByte((byte) random().nextInt());
+                length--;
+            }
+            fail("should be a corrupted index");
+        } catch (CorruptIndexException | IndexFormatTooOldException | IndexFormatTooNewException ex) {
+            // ok
+        }
+        IOUtils.close(verifyingOutput, dir);
+    }
+
+    public void testCheckIntegrity() throws IOException {
+        Directory dir = newCryptoDirectory();
+        long luceneFileLength = 0;
+        try (IndexOutput output = dir.createOutput("lucene_checksum.bin", IOContext.DEFAULT)) {
+            int iters = scaledRandomIntBetween(10, 100);
+            for (int i = 0; i < iters; i++) {
+                BytesRef bytesRef = new BytesRef(TestUtil.randomRealisticUnicodeString(random(), 10, 1024));
+                output.writeBytes(bytesRef.bytes, bytesRef.offset, bytesRef.length);
+                luceneFileLength += bytesRef.length;
+            }
+            CodecUtil.writeFooter(output);
+            luceneFileLength += CodecUtil.footerLength();
+
+        }
+
+        try (IndexInput indexInput = dir.openInput("lucene_checksum.bin", IOContext.DEFAULT)) {
+            assertEquals(luceneFileLength, indexInput.length());
+        }
+        dir.close();
+    }
+
+    public void testVerifyingIndexInput() throws IOException {
+        Directory dir = newCryptoDirectory();
+        IndexOutput output = dir.createOutput("foo.bar", IOContext.DEFAULT);
+        int iters = scaledRandomIntBetween(10, 100);
+        for (int i = 0; i < iters; i++) {
+            BytesRef bytesRef = new BytesRef(TestUtil.randomRealisticUnicodeString(random(), 10, 1024));
+            output.writeBytes(bytesRef.bytes, bytesRef.offset, bytesRef.length);
+        }
+        CodecUtil.writeFooter(output);
+        output.close();
+
+        // Check file
+        IndexInput indexInput = dir.openInput("foo.bar", IOContext.DEFAULT);
+        long checksum = CodecUtil.retrieveChecksum(indexInput);
+        indexInput.seek(0);
+        IndexInput verifyingIndexInput = new Store.VerifyingIndexInput(dir.openInput("foo.bar", IOContext.DEFAULT));
+        readIndexInputFullyWithRandomSeeks(verifyingIndexInput);
+        Store.verify(verifyingIndexInput);
+        assertThat(checksum, equalTo(((ChecksumIndexInput) verifyingIndexInput).getChecksum()));
+        IOUtils.close(indexInput, verifyingIndexInput);
+
+        // Corrupt file and check again
+        corruptFile(dir, "foo.bar", "foo1.bar");
+        verifyingIndexInput = new Store.VerifyingIndexInput(dir.openInput("foo1.bar", IOContext.DEFAULT));
+        readIndexInputFullyWithRandomSeeks(verifyingIndexInput);
+        try {
+            Store.verify(verifyingIndexInput);
+            fail("should be a corrupted index");
+        } catch (CorruptIndexException | IndexFormatTooOldException | IndexFormatTooNewException ex) {
+            // ok
+        }
+        IOUtils.close(verifyingIndexInput);
+        IOUtils.close(dir);
+    }
+
+    public void testConfidentiality() throws IOException {
+        Path tempDir = createTempDir();
+        Directory dir = newCryptoDirectory(tempDir);
+        IndexOutput output = dir.createOutput("foo.bar", IOContext.DEFAULT);
+        int iters = scaledRandomIntBetween(10, 100);
+        for (int i = 0; i < iters; i++) {
+            BytesRef bytesRef = new BytesRef(TestUtil.randomRealisticUnicodeString(random(), 10, 1024));
+            output.writeBytes(bytesRef.bytes, bytesRef.offset, bytesRef.length);
+        }
+        CodecUtil.writeFooter(output);
+        output.close();
+
+        // Check file
+        IndexInput indexInput = dir.openInput("foo.bar", IOContext.DEFAULT);
+        long checksum = CodecUtil.retrieveChecksum(indexInput);
+        indexInput.seek(0);
+        IndexInput verifyingIndexInput = new Store.VerifyingIndexInput(dir.openInput("foo.bar", IOContext.DEFAULT));
+        readIndexInputFullyWithRandomSeeks(verifyingIndexInput);
+        Store.verify(verifyingIndexInput);
+        assertThat(checksum, equalTo(((ChecksumIndexInput) verifyingIndexInput).getChecksum()));
+        IOUtils.close(indexInput, verifyingIndexInput);
+
+        // use non crypto directory and try again
+        final BaseDirectoryWrapper newDir = newFSDirectory(tempDir);
+        verifyingIndexInput = new Store.VerifyingIndexInput(newDir.openInput("foo.bar", IOContext.DEFAULT));
+        readIndexInputFullyWithRandomSeeks(verifyingIndexInput);
+        try {
+            Store.verify(verifyingIndexInput);
+            fail("should be a corrupted index");
+        } catch (CorruptIndexException | IndexFormatTooOldException | IndexFormatTooNewException ex) {
+            // ok
+        }
+        IOUtils.close(verifyingIndexInput);
+        IOUtils.close(dir, newDir);
+    }
+
+    private void readIndexInputFullyWithRandomSeeks(IndexInput indexInput) throws IOException {
+        BytesRef ref = new BytesRef(scaledRandomIntBetween(1, 1024));
+        long pos = 0;
+        while (pos < indexInput.length()) {
+            assertEquals(pos, indexInput.getFilePointer());
+            int op = random().nextInt(5);
+            if (op == 0) {
+                int shift = 100 - randomIntBetween(0, 200);
+                pos = Math.min(indexInput.length() - 1, Math.max(0, pos + shift));
+                indexInput.seek(pos);
+            } else if (op == 1) {
+                indexInput.readByte();
+                pos++;
+            } else {
+                int min = (int) Math.min(indexInput.length() - pos, ref.bytes.length);
+                indexInput.readBytes(ref.bytes, ref.offset, min);
+                pos += min;
+            }
+        }
+    }
+
+    private void corruptFile(Directory dir, String fileIn, String fileOut) throws IOException {
+        IndexInput input = dir.openInput(fileIn, IOContext.READONCE);
+        IndexOutput output = dir.createOutput(fileOut, IOContext.DEFAULT);
+        long len = input.length();
+        byte[] b = new byte[1024];
+        long broken = randomInt((int) len - 1);
+        long pos = 0;
+        while (pos < len) {
+            int min = (int) Math.min(input.length() - pos, b.length);
+            input.readBytes(b, 0, min);
+            if (broken >= pos && broken < pos + min) {
+                // Flip one byte
+                int flipPos = (int) (broken - pos);
+                b[flipPos] = (byte) (b[flipPos] ^ 42);
+            }
+            output.writeBytes(b, min);
+            pos += min;
+        }
+        IOUtils.close(input, output);
+
+    }
+
+    public void assertDeleteContent(Store store, Directory dir) throws IOException {
+        deleteContent(store.directory());
+        assertThat(Arrays.toString(store.directory().listAll()), store.directory().listAll().length, equalTo(0));
+        assertThat(store.stats(0L).sizeInBytes(), equalTo(0L));
+        assertThat(dir.listAll().length, equalTo(0));
+    }
+
+    public static void assertConsistent(Store store, Store.MetadataSnapshot metadata) throws IOException {
+        final String KEY_FILE_NAME = "keyfile";
+        for (String file : store.directory().listAll()) {
+            if (IndexWriter.WRITE_LOCK_NAME.equals(file) == false && file.startsWith("extra") == false) {
+                // Ignore keyfile as it is not present in metadata
+                if (file.equals(KEY_FILE_NAME)) continue;
+                assertTrue(
+                    file + " is not in the map: " + metadata.asMap().size() + " vs. " + store.directory().listAll().length,
+                    metadata.asMap().containsKey(file)
+                );
+            } else {
+                // Ignore keyfile as it is not present in metadata
+                if (file.equals(KEY_FILE_NAME)) continue;
+                assertFalse(
+                    file + " is not in the map: " + metadata.asMap().size() + " vs. " + store.directory().listAll().length,
+                    metadata.asMap().containsKey(file)
+                );
+            }
+        }
+    }
+
+    public void testOnCloseCallback() throws IOException {
+        final ShardId shardId = new ShardId(
+            new Index(randomRealisticUnicodeOfCodepointLengthBetween(1, 10), "_na_"),
+            randomIntBetween(0, 100)
+        );
+        final AtomicInteger count = new AtomicInteger(0);
+        final ShardLock lock = new DummyShardLock(shardId);
+
+        Store store = new Store(shardId, INDEX_SETTINGS, newCryptoDirectory(), lock, theLock -> {
+            assertEquals(shardId, theLock.getShardId());
+            assertEquals(lock, theLock);
+            count.incrementAndGet();
+        });
+        assertEquals(count.get(), 0);
+
+        final int iters = randomIntBetween(1, 10);
+        for (int i = 0; i < iters; i++) {
+            store.close();
+        }
+
+        assertEquals(count.get(), 1);
+    }
+
+    public static void deleteContent(Directory directory) throws IOException {
+        final String[] files = directory.listAll();
+        final List<IOException> exceptions = new ArrayList<>();
+        for (String file : files) {
+            try {
+                directory.deleteFile(file);
+            } catch (NoSuchFileException | FileNotFoundException e) {
+                // ignore
+            } catch (IOException e) {
+                exceptions.add(e);
+            }
+        }
+        ExceptionsHelper.rethrowAndSuppress(exceptions);
+    }
+
+    public int numNonExtraFiles(Store store) throws IOException {
+        int numNonExtra = 0;
+        for (String file : store.directory().listAll()) {
+            if (file.startsWith("extra") == false) {
+                numNonExtra++;
+            }
+        }
+        return numNonExtra;
+    }
+
+    public void testMetadataSnapshotStreaming() throws Exception {
+        Store.MetadataSnapshot outMetadataSnapshot = createMetadataSnapshot();
+        org.opensearch.Version targetNodeVersion = randomVersion(random());
+
+        ByteArrayOutputStream outBuffer = new ByteArrayOutputStream();
+        OutputStreamStreamOutput out = new OutputStreamStreamOutput(outBuffer);
+        out.setVersion(targetNodeVersion);
+        outMetadataSnapshot.writeTo(out);
+
+        ByteArrayInputStream inBuffer = new ByteArrayInputStream(outBuffer.toByteArray());
+        InputStreamStreamInput in = new InputStreamStreamInput(inBuffer);
+        in.setVersion(targetNodeVersion);
+        Store.MetadataSnapshot inMetadataSnapshot = new Store.MetadataSnapshot(in);
+        Map<String, StoreFileMetadata> origEntries = new HashMap<>();
+        origEntries.putAll(outMetadataSnapshot.asMap());
+        for (Map.Entry<String, StoreFileMetadata> entry : inMetadataSnapshot.asMap().entrySet()) {
+            assertThat(entry.getValue().name(), equalTo(origEntries.remove(entry.getKey()).name()));
+        }
+        assertThat(origEntries.size(), equalTo(0));
+        assertThat(inMetadataSnapshot.getCommitUserData(), equalTo(outMetadataSnapshot.getCommitUserData()));
+    }
+
+    protected Store.MetadataSnapshot createMetadataSnapshot() {
+        StoreFileMetadata storeFileMetadata1 = new StoreFileMetadata("segments", 1, "666", MIN_SUPPORTED_LUCENE_VERSION);
+        StoreFileMetadata storeFileMetadata2 = new StoreFileMetadata("no_segments", 1, "666", MIN_SUPPORTED_LUCENE_VERSION);
+        Map<String, StoreFileMetadata> storeFileMetadataMap = new HashMap<>();
+        storeFileMetadataMap.put(storeFileMetadata1.name(), storeFileMetadata1);
+        storeFileMetadataMap.put(storeFileMetadata2.name(), storeFileMetadata2);
+        Map<String, String> commitUserData = new HashMap<>();
+        commitUserData.put("userdata_1", "test");
+        commitUserData.put("userdata_2", "test");
+        return new Store.MetadataSnapshot(unmodifiableMap(storeFileMetadataMap), unmodifiableMap(commitUserData), 0);
+    }
+
+    public void testDeserializeCorruptionException() throws IOException {
+        final ShardId shardId = new ShardId("index", "_na_", 1);
+        final Directory dir = newCryptoDirectory();
+        Store store = new Store(shardId, INDEX_SETTINGS, dir, new DummyShardLock(shardId));
+        CorruptIndexException ex = new CorruptIndexException("foo", "bar");
+        store.markStoreCorrupted(ex);
+        try {
+            store.failIfCorrupted();
+            fail("should be corrupted");
+        } catch (CorruptIndexException e) {
+            assertEquals(ex.getMessage(), e.getMessage());
+            assertEquals(ex.toString(), e.toString());
+            assertArrayEquals(ex.getStackTrace(), e.getStackTrace());
+        }
+
+        store.removeCorruptionMarker();
+        assertFalse(store.isMarkedCorrupted());
+        FileNotFoundException ioe = new FileNotFoundException("foobar");
+        store.markStoreCorrupted(ioe);
+        try {
+            store.failIfCorrupted();
+            fail("should be corrupted");
+        } catch (CorruptIndexException e) {
+            assertEquals("foobar (resource=preexisting_corruption)", e.getMessage());
+            assertArrayEquals(ioe.getStackTrace(), e.getCause().getStackTrace());
+        }
+        store.close();
+    }
+
+    public void testCorruptionMarkerVersionCheck() throws IOException {
+        final ShardId shardId = new ShardId("index", "_na_", 1);
+        final Directory dir = newCryptoDirectory();
+
+        try (Store store = new Store(shardId, INDEX_SETTINGS, dir, new DummyShardLock(shardId))) {
+            final String corruptionMarkerName = Store.CORRUPTED_MARKER_NAME_PREFIX + UUIDs.randomBase64UUID();
+            try (IndexOutput output = dir.createOutput(corruptionMarkerName, IOContext.DEFAULT)) {
+                CodecUtil.writeHeader(output, Store.CODEC, Store.CORRUPTED_MARKER_CODEC_VERSION + randomFrom(1, 2, -1, -2, -3));
+                // we only need the header to trigger the exception
+            }
+            final IOException ioException = expectThrows(IOException.class, store::failIfCorrupted);
+            assertThat(ioException, anyOf(instanceOf(IndexFormatTooOldException.class), instanceOf(IndexFormatTooNewException.class)));
+            assertThat(ioException.getMessage(), containsString(corruptionMarkerName));
+        }
+    }
+
+    public void testEnsureIndexHasHistoryUUID() throws IOException {
+        final ShardId shardId = new ShardId("index", "_na_", 1);
+        try (Store store = new Store(shardId, INDEX_SETTINGS, newCryptoDirectory(), new DummyShardLock(shardId))) {
+
+            store.createEmpty(Version.LATEST);
+
+            // remove the history uuid
+            IndexWriterConfig iwc = new IndexWriterConfig(null).setCommitOnClose(false)
+                // we don't want merges to happen here - we call maybe merge on the engine
+                // later once we stared it up otherwise we would need to wait for it here
+                // we also don't specify a codec here and merges should use the engines for this index
+                .setMergePolicy(NoMergePolicy.INSTANCE)
+                .setOpenMode(IndexWriterConfig.OpenMode.APPEND);
+            try (IndexWriter writer = new IndexWriter(store.directory(), iwc)) {
+                Map<String, String> newCommitData = new HashMap<>();
+                for (Map.Entry<String, String> entry : writer.getLiveCommitData()) {
+                    if (entry.getKey().equals(Engine.HISTORY_UUID_KEY) == false) {
+                        newCommitData.put(entry.getKey(), entry.getValue());
+                    }
+                }
+                writer.setLiveCommitData(newCommitData.entrySet());
+                writer.commit();
+            }
+
+            store.ensureIndexHasHistoryUUID();
+
+            SegmentInfos segmentInfos = Lucene.readSegmentInfos(store.directory());
+            assertThat(segmentInfos.getUserData(), hasKey(Engine.HISTORY_UUID_KEY));
+        }
+    }
+
+    public void testHistoryUUIDCanBeForced() throws IOException {
+        final ShardId shardId = new ShardId("index", "_na_", 1);
+        try (Store store = new Store(shardId, INDEX_SETTINGS, newCryptoDirectory(), new DummyShardLock(shardId))) {
+
+            store.createEmpty(Version.LATEST);
+
+            SegmentInfos segmentInfos = Lucene.readSegmentInfos(store.directory());
+            assertThat(segmentInfos.getUserData(), hasKey(Engine.HISTORY_UUID_KEY));
+            final String oldHistoryUUID = segmentInfos.getUserData().get(Engine.HISTORY_UUID_KEY);
+
+            store.bootstrapNewHistory();
+
+            segmentInfos = Lucene.readSegmentInfos(store.directory());
+            assertThat(segmentInfos.getUserData(), hasKey(Engine.HISTORY_UUID_KEY));
+            assertThat(segmentInfos.getUserData().get(Engine.HISTORY_UUID_KEY), not(equalTo(oldHistoryUUID)));
+        }
+    }
+
+    public void testGetPendingFiles() throws IOException {
+        final ShardId shardId = new ShardId("index", "_na_", 1);
+        final String testfile = "testfile";
+        try (Store store = new Store(shardId, INDEX_SETTINGS, newCryptoDirectory(), new DummyShardLock(shardId))) {
+            store.directory().createOutput(testfile, IOContext.DEFAULT).close();
+            try (IndexInput input = store.directory().openInput(testfile, IOContext.DEFAULT)) {
+                store.directory().deleteFile(testfile);
+                assertEquals(FilterDirectory.unwrap(store.directory()).getPendingDeletions(), store.directory().getPendingDeletions());
+            }
+        }
+    }
+
+    public void testGetMetadataWithSegmentInfos() throws IOException {
+        final ShardId shardId = new ShardId("index", "_na_", 1);
+        Store store = new Store(shardId, INDEX_SETTINGS, newCryptoDirectory(), new DummyShardLock(shardId));
+        store.createEmpty(Version.LATEST);
+        SegmentInfos segmentInfos = Lucene.readSegmentInfos(store.directory());
+        Store.MetadataSnapshot metadataSnapshot = store.getMetadata(segmentInfos);
+        // loose check for equality
+        assertEquals(segmentInfos.getSegmentsFileName(), metadataSnapshot.getSegmentsFile().name());
+        store.close();
+    }
+
+    private void commitRandomDocs(Store store) throws IOException {
+        IndexWriter writer = indexRandomDocs(store);
+        writer.commit();
+        writer.close();
+    }
+
+    private IndexWriter indexRandomDocs(Store store) throws IOException {
+        IndexWriterConfig indexWriterConfig = newIndexWriterConfig(random(), new MockAnalyzer(random())).setCodec(
+            TestUtil.getDefaultCodec()
+        );
+        indexWriterConfig.setCommitOnClose(false);
+        indexWriterConfig.setIndexDeletionPolicy(NoDeletionPolicy.INSTANCE);
+        IndexWriter writer = new IndexWriter(store.directory(), indexWriterConfig);
+        int docs = 1 + random().nextInt(100);
+        writer.commit();
+        Document doc = new Document();
+        doc.add(new TextField("id", "" + docs++, random().nextBoolean() ? Field.Store.YES : Field.Store.NO));
+        doc.add(
+            new TextField(
+                "body",
+                TestUtil.randomRealisticUnicodeString(random()),
+                random().nextBoolean() ? Field.Store.YES : Field.Store.NO
+            )
+        );
+        doc.add(new SortedDocValuesField("dv", new BytesRef(TestUtil.randomRealisticUnicodeString(random()))));
+        writer.addDocument(doc);
+        return writer;
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This pull request adds index level encryption features to OpenSearch based on the issue #3469. Each OpenSearch index is individually encrypted based on user provided encryption keys. A new cryptofs store type `index.store.type` is introduced which instantiates a CryptoDirectory (a hybrid directory) that encrypts and decrypts files as they are written and read respectively

### Related Issues
#3469 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
