### PR TITLE
[Remote Store] Add support to restore only unassigned shards of an index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Change http code on create index API with bad input raising NotXContentException from 500 to 400 ([#4773](https://github.com/opensearch-project/OpenSearch/pull/4773))
 - Improve summary error message for invalid setting updates ([#4792](https://github.com/opensearch-project/OpenSearch/pull/4792))
 - Remote Segment Store Repository setting moved from `index.remote_store.repository` to `index.remote_store.segment.repository` and `cluster.remote_store.repository` to `cluster.remote_store.segment.repository` respectively for Index and Cluster level settings ([#8719](https://github.com/opensearch-project/OpenSearch/pull/8719))
+- [Remote Store] Add support to restore only unassigned shards of an index ([#8792](https://github.com/opensearch-project/OpenSearch/pull/8792))
 
 ### Deprecated
 

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreBaseIntegTestCase.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreBaseIntegTestCase.java
@@ -26,6 +26,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
@@ -37,6 +38,13 @@ public class RemoteStoreBaseIntegTestCase extends OpenSearchIntegTestCase {
     protected static final int REPLICA_COUNT = 1;
     protected Path absolutePath;
     protected Path absolutePath2;
+    private final List<String> documentKeys = List.of(
+        randomAlphaOfLength(5),
+        randomAlphaOfLength(5),
+        randomAlphaOfLength(5),
+        randomAlphaOfLength(5),
+        randomAlphaOfLength(5)
+    );
 
     @Override
     protected boolean addMockInternalEngine() {
@@ -59,7 +67,7 @@ public class RemoteStoreBaseIntegTestCase extends OpenSearchIntegTestCase {
     IndexResponse indexSingleDoc(String indexName) {
         return client().prepareIndex(indexName)
             .setId(UUIDs.randomBase64UUID())
-            .setSource(randomAlphaOfLength(5), randomAlphaOfLength(5))
+            .setSource(documentKeys.get(randomIntBetween(0, documentKeys.size() - 1)), randomAlphaOfLength(5))
             .get();
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreForceMergeIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreForceMergeIT.java
@@ -104,9 +104,17 @@ public class RemoteStoreForceMergeIT extends RemoteStoreBaseIntegTestCase {
         Map<String, Long> indexStats = indexData(numberOfIterations, invokeFlush, flushAfterMerge, deletedDocs);
 
         internalCluster().stopRandomNode(InternalTestCluster.nameFilter(primaryNodeName(INDEX_NAME)));
-        assertAcked(client().admin().indices().prepareClose(INDEX_NAME));
 
-        client().admin().cluster().restoreRemoteStore(new RestoreRemoteStoreRequest().indices(INDEX_NAME), PlainActionFuture.newFuture());
+        boolean restoreAllShards = randomBoolean();
+        if (restoreAllShards) {
+            assertAcked(client().admin().indices().prepareClose(INDEX_NAME));
+        }
+        client().admin()
+            .cluster()
+            .restoreRemoteStore(
+                new RestoreRemoteStoreRequest().indices(INDEX_NAME).restoreAllShards(restoreAllShards),
+                PlainActionFuture.newFuture()
+            );
         ensureGreen(INDEX_NAME);
 
         if (deletedDocs == -1) {

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
@@ -42,7 +42,7 @@ import static org.hamcrest.Matchers.is;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
 
-@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, numDataNodes = 0)
 public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
 
     private static final String INDEX_NAME = "remote-store-test-idx-1";
@@ -178,8 +178,11 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
         ensureRed(INDEX_NAME);
         internalCluster().startDataOnlyNodes(2);
 
-        assertAcked(client().admin().indices().prepareClose(INDEX_NAME));
-        client().admin().cluster().restoreRemoteStore(new RestoreRemoteStoreRequest().indices(INDEX_NAME), PlainActionFuture.newFuture());
+        boolean restoreAllShards = randomBoolean();
+        if (restoreAllShards) {
+            assertAcked(client().admin().indices().prepareClose(INDEX_NAME));
+        }
+        client().admin().cluster().restoreRemoteStore(new RestoreRemoteStoreRequest().indices(INDEX_NAME).restoreAllShards(restoreAllShards), PlainActionFuture.newFuture());
 
         ensureGreen(INDEX_NAME);
 
@@ -220,10 +223,13 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
         ensureRed(indices);
         internalCluster().startDataOnlyNodes(3);
 
-        assertAcked(client().admin().indices().prepareClose(indices));
+        boolean restoreAllShards = randomBoolean();
+        if (restoreAllShards) {
+            assertAcked(client().admin().indices().prepareClose(indices));
+        }
         client().admin()
             .cluster()
-            .restoreRemoteStore(new RestoreRemoteStoreRequest().indices(INDEX_NAMES_WILDCARD.split(",")), PlainActionFuture.newFuture());
+            .restoreRemoteStore(new RestoreRemoteStoreRequest().indices(INDEX_NAMES_WILDCARD.split(",")).restoreAllShards(restoreAllShards), PlainActionFuture.newFuture());
         ensureGreen(indices);
         for (String index : indices) {
             assertEquals(shardCount, getNumShards(index).totalNumShards);
@@ -349,10 +355,13 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
         ensureRed(indices);
         internalCluster().startDataOnlyNodes(3);
 
-        assertAcked(client().admin().indices().prepareClose(indices));
+        boolean restoreAllShards = randomBoolean();
+        if (restoreAllShards) {
+            assertAcked(client().admin().indices().prepareClose(indices));
+        }
         client().admin()
             .cluster()
-            .restoreRemoteStore(new RestoreRemoteStoreRequest().indices(new String[] {}), PlainActionFuture.newFuture());
+            .restoreRemoteStore(new RestoreRemoteStoreRequest().indices(new String[] {}).restoreAllShards(restoreAllShards), PlainActionFuture.newFuture());
         ensureGreen(indices);
 
         for (String index : indices) {
@@ -389,10 +398,13 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
         ensureRed(indices);
         internalCluster().startDataOnlyNodes(3);
 
-        assertAcked(client().admin().indices().prepareClose(indices[0], indices[1]));
+        boolean restoreAllShards = randomBoolean();
+        if (restoreAllShards) {
+            assertAcked(client().admin().indices().prepareClose(indices[0], indices[1]));
+        }
         client().admin()
             .cluster()
-            .restoreRemoteStore(new RestoreRemoteStoreRequest().indices(indices[0], indices[1]), PlainActionFuture.newFuture());
+            .restoreRemoteStore(new RestoreRemoteStoreRequest().indices(indices[0], indices[1]).restoreAllShards(restoreAllShards), PlainActionFuture.newFuture());
         ensureGreen(indices[0], indices[1]);
         assertEquals(shardCount, getNumShards(indices[0]).totalNumShards);
         verifyRestoredData(indicesStats.get(indices[0]), true, indices[0]);
@@ -435,10 +447,13 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
         ensureRed(indices);
         internalCluster().startDataOnlyNodes(3);
 
-        assertAcked(client().admin().indices().prepareClose(indices[0], indices[1]));
+        boolean restoreAllShards = randomBoolean();
+        if (restoreAllShards) {
+            assertAcked(client().admin().indices().prepareClose(indices[0], indices[1]));
+        }
         client().admin()
             .cluster()
-            .restoreRemoteStore(new RestoreRemoteStoreRequest().indices("*", "-remote-store-test-index-*"), PlainActionFuture.newFuture());
+            .restoreRemoteStore(new RestoreRemoteStoreRequest().indices("*", "-remote-store-test-index-*").restoreAllShards(restoreAllShards), PlainActionFuture.newFuture());
         ensureGreen(indices[0], indices[1]);
         assertEquals(shardCount, getNumShards(indices[0]).totalNumShards);
         verifyRestoredData(indicesStats.get(indices[0]), true, indices[0]);

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
@@ -37,7 +37,9 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.oneOf;
+import static org.hamcrest.Matchers.comparesEqualTo;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
 
@@ -169,8 +171,7 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
      * @param invokeFlush If true, a flush is invoked. Otherwise, a refresh is invoked.
      * @throws IOException IO Exception.
      */
-    private void testRestoreFlowBothPrimaryReplicasDown(int numberOfIterations, boolean invokeFlush, int shardCount)
-        throws IOException {
+    private void testRestoreFlowBothPrimaryReplicasDown(int numberOfIterations, boolean invokeFlush, int shardCount) throws IOException {
         prepareCluster(1, 2, INDEX_NAME, 1, shardCount);
         Map<String, Long> indexStats = indexData(numberOfIterations, invokeFlush, INDEX_NAME);
         assertEquals(shardCount, getNumShards(INDEX_NAME).totalNumShards);

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
@@ -144,8 +144,16 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
         internalCluster().stopRandomNode(InternalTestCluster.nameFilter(primaryNodeName(INDEX_NAME)));
         ensureRed(INDEX_NAME);
 
-        assertAcked(client().admin().indices().prepareClose(INDEX_NAME));
-        client().admin().cluster().restoreRemoteStore(new RestoreRemoteStoreRequest().indices(INDEX_NAME), PlainActionFuture.newFuture());
+        boolean restoreAllShards = randomBoolean();
+        if (restoreAllShards) {
+            assertAcked(client().admin().indices().prepareClose(INDEX_NAME));
+        }
+        client().admin()
+            .cluster()
+            .restoreRemoteStore(
+                new RestoreRemoteStoreRequest().indices(INDEX_NAME).restoreAllShards(restoreAllShards),
+                PlainActionFuture.newFuture()
+            );
 
         ensureGreen(INDEX_NAME);
         assertEquals(shardCount, getNumShards(INDEX_NAME).totalNumShards);

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/RestoreSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/RestoreSnapshotIT.java
@@ -276,7 +276,10 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         assertAcked(client.admin().indices().prepareClose(restoredIndexName1));
         client.admin()
             .cluster()
-            .restoreRemoteStore(new RestoreRemoteStoreRequest().indices(restoredIndexName1), PlainActionFuture.newFuture());
+            .restoreRemoteStore(
+                new RestoreRemoteStoreRequest().indices(restoredIndexName1).restoreAllShards(true),
+                PlainActionFuture.newFuture()
+            );
         ensureYellowAndNoInitializingShards(restoredIndexName1);
         ensureGreen(restoredIndexName1);
         assertDocsPresentInIndex(client(), restoredIndexName1, numDocsInIndex1);
@@ -434,7 +437,9 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         // Re-initialize client to make sure we are not using client from stopped node.
         client = client(clusterManagerNode);
         assertAcked(client.admin().indices().prepareClose(indexName1));
-        client.admin().cluster().restoreRemoteStore(new RestoreRemoteStoreRequest().indices(indexName1), PlainActionFuture.newFuture());
+        client.admin()
+            .cluster()
+            .restoreRemoteStore(new RestoreRemoteStoreRequest().indices(indexName1).restoreAllShards(true), PlainActionFuture.newFuture());
         ensureYellowAndNoInitializingShards(indexName1);
         ensureGreen(indexName1);
         assertDocsPresentInIndex(client(), indexName1, numDocsInIndex1);
@@ -515,7 +520,10 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         assertAcked(client.admin().indices().prepareClose(restoredIndexName1));
         client.admin()
             .cluster()
-            .restoreRemoteStore(new RestoreRemoteStoreRequest().indices(restoredIndexName1), PlainActionFuture.newFuture());
+            .restoreRemoteStore(
+                new RestoreRemoteStoreRequest().indices(restoredIndexName1).restoreAllShards(true),
+                PlainActionFuture.newFuture()
+            );
         ensureYellowAndNoInitializingShards(restoredIndexName1);
         ensureGreen(restoredIndexName1);
         // indexing some new docs and validating

--- a/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/restore/RestoreRemoteStoreRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/restore/RestoreRemoteStoreRequest.java
@@ -122,9 +122,10 @@ public class RestoreRemoteStoreRequest extends ClusterManagerNodeRequest<Restore
     }
 
     /**
-     * If this parameter is set to true the operation will restore all the shards of the given indices
+     * Set the value for restoreAllShards, denoting whether to restore all shards or only unassigned shards
      *
-     * @param restoreAllShards if true the operation will restore all the shards
+     * @param restoreAllShards If true, the operation will restore all the shards of the given indices.
+     *                         If false, the operation will restore only the unassigned shards of the given indices.
      * @return this request
      */
     public RestoreRemoteStoreRequest restoreAllShards(boolean restoreAllShards) {

--- a/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/restore/RestoreRemoteStoreRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/restore/RestoreRemoteStoreRequest.java
@@ -35,8 +35,8 @@ import static org.opensearch.action.ValidateActions.addValidationError;
 public class RestoreRemoteStoreRequest extends ClusterManagerNodeRequest<RestoreRemoteStoreRequest> implements ToXContentObject {
 
     private String[] indices = Strings.EMPTY_ARRAY;
-    private Boolean waitForCompletion;
-    private Boolean restoreAllShards;
+    private Boolean waitForCompletion = false;
+    private Boolean restoreAllShards = false;
 
     public RestoreRemoteStoreRequest() {}
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/restore/RestoreRemoteStoreRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/restore/RestoreRemoteStoreRequest.java
@@ -190,7 +190,9 @@ public class RestoreRemoteStoreRequest extends ClusterManagerNodeRequest<Restore
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         RestoreRemoteStoreRequest that = (RestoreRemoteStoreRequest) o;
-        return waitForCompletion == that.waitForCompletion && restoreAllShards == that.restoreAllShards && Arrays.equals(indices, that.indices);
+        return waitForCompletion == that.waitForCompletion
+            && restoreAllShards == that.restoreAllShards
+            && Arrays.equals(indices, that.indices);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/restore/RestoreRemoteStoreRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/restore/RestoreRemoteStoreRequest.java
@@ -36,6 +36,7 @@ public class RestoreRemoteStoreRequest extends ClusterManagerNodeRequest<Restore
 
     private String[] indices = Strings.EMPTY_ARRAY;
     private Boolean waitForCompletion;
+    private Boolean restoreAllShards;
 
     public RestoreRemoteStoreRequest() {}
 
@@ -43,6 +44,7 @@ public class RestoreRemoteStoreRequest extends ClusterManagerNodeRequest<Restore
         super(in);
         indices = in.readStringArray();
         waitForCompletion = in.readOptionalBoolean();
+        restoreAllShards = in.readOptionalBoolean();
     }
 
     @Override
@@ -50,6 +52,7 @@ public class RestoreRemoteStoreRequest extends ClusterManagerNodeRequest<Restore
         super.writeTo(out);
         out.writeStringArray(indices);
         out.writeOptionalBoolean(waitForCompletion);
+        out.writeOptionalBoolean(restoreAllShards);
     }
 
     @Override
@@ -119,6 +122,26 @@ public class RestoreRemoteStoreRequest extends ClusterManagerNodeRequest<Restore
     }
 
     /**
+     * If this parameter is set to true the operation will restore all the shards of the given indices
+     *
+     * @param restoreAllShards if true the operation will restore all the shards
+     * @return this request
+     */
+    public RestoreRemoteStoreRequest restoreAllShards(boolean restoreAllShards) {
+        this.restoreAllShards = restoreAllShards;
+        return this;
+    }
+
+    /**
+     * Returns restoreAllShards setting
+     *
+     * @return true if the operation will restore all the shards of the given indices
+     */
+    public boolean restoreAllShards() {
+        return restoreAllShards;
+    }
+
+    /**
      * Parses restore definition
      *
      * @param source restore definition
@@ -167,12 +190,12 @@ public class RestoreRemoteStoreRequest extends ClusterManagerNodeRequest<Restore
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         RestoreRemoteStoreRequest that = (RestoreRemoteStoreRequest) o;
-        return waitForCompletion == that.waitForCompletion && Arrays.equals(indices, that.indices);
+        return waitForCompletion == that.waitForCompletion && restoreAllShards == that.restoreAllShards && Arrays.equals(indices, that.indices);
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(waitForCompletion);
+        int result = Objects.hash(waitForCompletion, restoreAllShards);
         result = 31 * result + Arrays.hashCode(indices);
         return result;
     }
@@ -181,4 +204,5 @@ public class RestoreRemoteStoreRequest extends ClusterManagerNodeRequest<Restore
     public String toString() {
         return org.opensearch.common.Strings.toString(XContentType.JSON, this);
     }
+
 }

--- a/server/src/main/java/org/opensearch/cluster/routing/IndexRoutingTable.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/IndexRoutingTable.java
@@ -450,7 +450,11 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
         /**
          * Initializes an existing index, to be restored from remote store
          */
-        public Builder initializeAsRemoteStoreRestore(IndexMetadata indexMetadata, RemoteStoreRecoverySource recoverySource, Map<ShardId, ShardRouting> activeShards) {
+        public Builder initializeAsRemoteStoreRestore(
+            IndexMetadata indexMetadata,
+            RemoteStoreRecoverySource recoverySource,
+            Map<ShardId, ShardRouting> activeShards
+        ) {
             final UnassignedInfo unassignedInfo = new UnassignedInfo(
                 UnassignedInfo.Reason.EXISTING_INDEX_RESTORED,
                 "restore_source[remote_store]"

--- a/server/src/main/java/org/opensearch/cluster/routing/IndexRoutingTable.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/IndexRoutingTable.java
@@ -453,7 +453,7 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
         public Builder initializeAsRemoteStoreRestore(
             IndexMetadata indexMetadata,
             RemoteStoreRecoverySource recoverySource,
-            Map<ShardId, ShardRouting> activeShards
+            Map<ShardId, ShardRouting> activeInitializingShards
         ) {
             final UnassignedInfo unassignedInfo = new UnassignedInfo(
                 UnassignedInfo.Reason.EXISTING_INDEX_RESTORED,
@@ -466,8 +466,8 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
             for (int shardNumber = 0; shardNumber < indexMetadata.getNumberOfShards(); shardNumber++) {
                 ShardId shardId = new ShardId(index, shardNumber);
                 IndexShardRoutingTable.Builder indexShardRoutingBuilder = new IndexShardRoutingTable.Builder(shardId);
-                if (activeShards.containsKey(shardId)) {
-                    indexShardRoutingBuilder.addShard(activeShards.get(shardId));
+                if (activeInitializingShards.containsKey(shardId)) {
+                    indexShardRoutingBuilder.addShard(activeInitializingShards.get(shardId));
                 } else {
                     indexShardRoutingBuilder.addShard(ShardRouting.newUnassigned(shardId, true, recoverySource, unassignedInfo));
                 }

--- a/server/src/main/java/org/opensearch/cluster/routing/IndexRoutingTable.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/IndexRoutingTable.java
@@ -450,7 +450,7 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
         /**
          * Initializes an existing index, to be restored from remote store
          */
-        public Builder initializeAsRemoteStoreRestore(IndexMetadata indexMetadata, RemoteStoreRecoverySource recoverySource) {
+        public Builder initializeAsRemoteStoreRestore(IndexMetadata indexMetadata, RemoteStoreRecoverySource recoverySource, Map<ShardId, ShardRouting> activeShards) {
             final UnassignedInfo unassignedInfo = new UnassignedInfo(
                 UnassignedInfo.Reason.EXISTING_INDEX_RESTORED,
                 "restore_source[remote_store]"
@@ -462,7 +462,11 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
             for (int shardNumber = 0; shardNumber < indexMetadata.getNumberOfShards(); shardNumber++) {
                 ShardId shardId = new ShardId(index, shardNumber);
                 IndexShardRoutingTable.Builder indexShardRoutingBuilder = new IndexShardRoutingTable.Builder(shardId);
-                indexShardRoutingBuilder.addShard(ShardRouting.newUnassigned(shardId, true, recoverySource, unassignedInfo));
+                if (activeShards.containsKey(shardId)) {
+                    indexShardRoutingBuilder.addShard(activeShards.get(shardId));
+                } else {
+                    indexShardRoutingBuilder.addShard(ShardRouting.newUnassigned(shardId, true, recoverySource, unassignedInfo));
+                }
                 shards.put(shardNumber, indexShardRoutingBuilder.build());
             }
             return this;

--- a/server/src/main/java/org/opensearch/cluster/routing/RoutingTable.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RoutingTable.java
@@ -562,9 +562,9 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
             return add(indexRoutingBuilder);
         }
 
-        public Builder addAsRemoteStoreRestore(IndexMetadata indexMetadata, RemoteStoreRecoverySource recoverySource) {
+        public Builder addAsRemoteStoreRestore(IndexMetadata indexMetadata, RemoteStoreRecoverySource recoverySource, Map<ShardId, ShardRouting> activeShards) {
             IndexRoutingTable.Builder indexRoutingBuilder = new IndexRoutingTable.Builder(indexMetadata.getIndex())
-                .initializeAsRemoteStoreRestore(indexMetadata, recoverySource);
+                .initializeAsRemoteStoreRestore(indexMetadata, recoverySource, activeShards);
             add(indexRoutingBuilder);
             return this;
         }

--- a/server/src/main/java/org/opensearch/cluster/routing/RoutingTable.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RoutingTable.java
@@ -562,7 +562,11 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
             return add(indexRoutingBuilder);
         }
 
-        public Builder addAsRemoteStoreRestore(IndexMetadata indexMetadata, RemoteStoreRecoverySource recoverySource, Map<ShardId, ShardRouting> activeShards) {
+        public Builder addAsRemoteStoreRestore(
+            IndexMetadata indexMetadata,
+            RemoteStoreRecoverySource recoverySource,
+            Map<ShardId, ShardRouting> activeShards
+        ) {
             IndexRoutingTable.Builder indexRoutingBuilder = new IndexRoutingTable.Builder(indexMetadata.getIndex())
                 .initializeAsRemoteStoreRestore(indexMetadata, recoverySource, activeShards);
             add(indexRoutingBuilder);

--- a/server/src/main/java/org/opensearch/cluster/routing/RoutingTable.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RoutingTable.java
@@ -565,10 +565,10 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
         public Builder addAsRemoteStoreRestore(
             IndexMetadata indexMetadata,
             RemoteStoreRecoverySource recoverySource,
-            Map<ShardId, ShardRouting> activeShards
+            Map<ShardId, ShardRouting> activeInitializingShards
         ) {
             IndexRoutingTable.Builder indexRoutingBuilder = new IndexRoutingTable.Builder(indexMetadata.getIndex())
-                .initializeAsRemoteStoreRestore(indexMetadata, recoverySource, activeShards);
+                .initializeAsRemoteStoreRestore(indexMetadata, recoverySource, activeInitializingShards);
             add(indexRoutingBuilder);
             return this;
         }

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestRestoreRemoteStoreAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestRestoreRemoteStoreAction.java
@@ -44,6 +44,7 @@ public final class RestRestoreRemoteStoreAction extends BaseRestHandler {
             request.paramAsTime("cluster_manager_timeout", restoreRemoteStoreRequest.masterNodeTimeout())
         );
         restoreRemoteStoreRequest.waitForCompletion(request.paramAsBoolean("wait_for_completion", false));
+        restoreRemoteStoreRequest.restoreAllShards(request.paramAsBoolean("restore_all_shards", false));
         request.applyContentParser(p -> restoreRemoteStoreRequest.source(p.mapOrdered()));
         return channel -> client.admin().cluster().restoreRemoteStore(restoreRemoteStoreRequest, new RestToXContentListener<>(channel));
     }

--- a/server/src/main/java/org/opensearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/opensearch/snapshots/RestoreService.java
@@ -260,7 +260,12 @@ public class RestoreService implements ClusterStateApplier {
                             updatedIndexMetadata.getCreationVersion(),
                             indexId
                         );
-                        Map<ShardId, ShardRouting> activeShards = currentState.routingTable().index(index).randomAllActiveShardsIt().getShardRoutings().stream().collect(Collectors.toMap(ShardRouting::shardId, Function.identity()));
+                        Map<ShardId, ShardRouting> activeShards = currentState.routingTable()
+                            .index(index)
+                            .randomAllActiveShardsIt()
+                            .getShardRoutings()
+                            .stream()
+                            .collect(Collectors.toMap(ShardRouting::shardId, Function.identity()));
                         rtBuilder.addAsRemoteStoreRestore(updatedIndexMetadata, recoverySource, activeShards);
                         blocks.updateBlocks(updatedIndexMetadata);
                         mdBuilder.put(updatedIndexMetadata, true);

--- a/server/src/main/java/org/opensearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/opensearch/snapshots/RestoreService.java
@@ -234,37 +234,38 @@ public class RestoreService implements ClusterStateApplier {
                         continue;
                     }
                     if (currentIndexMetadata.getSettings().getAsBoolean(SETTING_REMOTE_STORE_ENABLED, false)) {
-                        /*if (currentIndexMetadata.getState() != IndexMetadata.State.CLOSE) {
-                            throw new IllegalStateException(
-                                "cannot restore index ["
-                                    + index
-                                    + "] because an open index "
-                                    + "with same name already exists in the cluster. Close the existing index"
-                            );
-                        }*/
-                        /*
-                        IndexMetadata updatedIndexMetadata = IndexMetadata.builder(currentIndexMetadata)
-                            .state(IndexMetadata.State.OPEN)
-                            .version(1 + currentIndexMetadata.getVersion())
-                            .mappingVersion(1 + currentIndexMetadata.getMappingVersion())
-                            .settingsVersion(1 + currentIndexMetadata.getSettingsVersion())
-                            .aliasesVersion(1 + currentIndexMetadata.getAliasesVersion())
-                            .build();
-                         */
+                        IndexMetadata updatedIndexMetadata = currentIndexMetadata;
+                        if (request.restoreAllShards()) {
+                            if (currentIndexMetadata.getState() != IndexMetadata.State.CLOSE) {
+                                throw new IllegalStateException(
+                                    "cannot restore index ["
+                                        + index
+                                        + "] because an open index "
+                                        + "with same name already exists in the cluster. Close the existing index"
+                                );
+                            }
+                            updatedIndexMetadata = IndexMetadata.builder(currentIndexMetadata)
+                                .state(IndexMetadata.State.OPEN)
+                                .version(1 + currentIndexMetadata.getVersion())
+                                .mappingVersion(1 + currentIndexMetadata.getMappingVersion())
+                                .settingsVersion(1 + currentIndexMetadata.getSettingsVersion())
+                                .aliasesVersion(1 + currentIndexMetadata.getAliasesVersion())
+                                .build();
+                        }
 
-                        IndexId indexId = new IndexId(index, currentIndexMetadata.getIndexUUID());
+                        IndexId indexId = new IndexId(index, updatedIndexMetadata.getIndexUUID());
 
                         RemoteStoreRecoverySource recoverySource = new RemoteStoreRecoverySource(
                             restoreUUID,
-                            currentIndexMetadata.getCreationVersion(),
+                            updatedIndexMetadata.getCreationVersion(),
                             indexId
                         );
                         Map<ShardId, ShardRouting> activeShards = currentState.routingTable().index(index).randomAllActiveShardsIt().getShardRoutings().stream().collect(Collectors.toMap(ShardRouting::shardId, Function.identity()));
-                        rtBuilder.addAsRemoteStoreRestore(currentIndexMetadata, recoverySource, activeShards);
-                        blocks.updateBlocks(currentIndexMetadata);
-                        mdBuilder.put(currentIndexMetadata, true);
+                        rtBuilder.addAsRemoteStoreRestore(updatedIndexMetadata, recoverySource, activeShards);
+                        blocks.updateBlocks(updatedIndexMetadata);
+                        mdBuilder.put(updatedIndexMetadata, true);
                         indicesToBeRestored.add(index);
-                        totalShards += currentIndexMetadata.getNumberOfShards();
+                        totalShards += updatedIndexMetadata.getNumberOfShards();
                     } else {
                         logger.warn("Remote store is not enabled for index: {}", index);
                     }

--- a/server/src/test/java/org/opensearch/action/admin/cluster/remotestore/restore/RestoreRemoteStoreRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/remotestore/restore/RestoreRemoteStoreRequestTests.java
@@ -38,6 +38,7 @@ public class RestoreRemoteStoreRequestTests extends AbstractWireSerializingTestC
         }
 
         instance.waitForCompletion(randomBoolean());
+        instance.restoreAllShards(randomBoolean());
 
         if (randomBoolean()) {
             instance.masterNodeTimeout(randomTimeValue());
@@ -76,6 +77,7 @@ public class RestoreRemoteStoreRequestTests extends AbstractWireSerializingTestC
         RestoreRemoteStoreRequest processed = new RestoreRemoteStoreRequest();
         processed.masterNodeTimeout(original.masterNodeTimeout());
         processed.waitForCompletion(original.waitForCompletion());
+        processed.restoreAllShards(original.restoreAllShards());
         processed.source(map);
 
         assertEquals(original, processed);

--- a/server/src/test/java/org/opensearch/cluster/routing/RoutingTableTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/RoutingTableTests.java
@@ -49,6 +49,7 @@ import org.opensearch.core.index.shard.ShardId;
 import org.junit.Before;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.function.Predicate;
@@ -502,8 +503,11 @@ public class RoutingTableTests extends OpenSearchAllocationTestCase {
             Version.CURRENT,
             new IndexId(TEST_INDEX_1, "1")
         );
-        final RoutingTable routingTable = new RoutingTable.Builder().addAsRemoteStoreRestore(indexMetadata, remoteStoreRecoverySource)
-            .build();
+        final RoutingTable routingTable = new RoutingTable.Builder().addAsRemoteStoreRestore(
+            indexMetadata,
+            remoteStoreRecoverySource,
+            new HashMap<>()
+        ).build();
         assertTrue(routingTable.hasIndex(TEST_INDEX_1));
         assertEquals(this.numberOfShards, routingTable.allShards(TEST_INDEX_1).size());
         assertEquals(this.numberOfShards, routingTable.index(TEST_INDEX_1).shardsWithState(UNASSIGNED).size());

--- a/server/src/test/java/org/opensearch/cluster/routing/RoutingTableTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/RoutingTableTests.java
@@ -522,18 +522,21 @@ public class RoutingTableTests extends OpenSearchAllocationTestCase {
             Version.CURRENT,
             new IndexId(TEST_INDEX_1, "1")
         );
-        Map<ShardId, ShardRouting> activeShards = new HashMap<>();
+        Map<ShardId, ShardRouting> activeInitializingShards = new HashMap<>();
         for (int i = 0; i < randomIntBetween(1, this.numberOfShards); i++) {
-            activeShards.put(new ShardId(indexMetadata.getIndex(), i), mock(ShardRouting.class));
+            activeInitializingShards.put(new ShardId(indexMetadata.getIndex(), i), mock(ShardRouting.class));
         }
         final RoutingTable routingTable = new RoutingTable.Builder().addAsRemoteStoreRestore(
             indexMetadata,
             remoteStoreRecoverySource,
-            activeShards
+            activeInitializingShards
         ).build();
         assertTrue(routingTable.hasIndex(TEST_INDEX_1));
         assertEquals(this.numberOfShards, routingTable.allShards(TEST_INDEX_1).size());
-        assertEquals(this.numberOfShards - activeShards.size(), routingTable.index(TEST_INDEX_1).shardsWithState(UNASSIGNED).size());
+        assertEquals(
+            this.numberOfShards - activeInitializingShards.size(),
+            routingTable.index(TEST_INDEX_1).shardsWithState(UNASSIGNED).size()
+        );
     }
 
     /** reverse engineer the in sync aid based on the given indexRoutingTable **/

--- a/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
@@ -184,7 +184,6 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
      * reader close operation on replica shard deletes the segment files copied in current round of segment replication.
      * It does this by blocking the finalizeReplication on replica shard and performing close operation on acquired
      * searcher that triggers the reader close operation.
-     * @throws Exception
      */
     public void testSegmentReplication_With_ReaderClosedConcurrently() throws Exception {
         String mappings = "{ \"" + MapperService.SINGLE_MAPPING_NAME + "\": { \"properties\": { \"foo\": { \"type\": \"keyword\"} }}}";
@@ -234,7 +233,6 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
     /**
      * Similar to test above, this test shows the issue where an engine close operation during active segment replication
      * can result in Lucene CorruptIndexException.
-     * @throws Exception
      */
     public void testSegmentReplication_With_EngineClosedConcurrently() throws Exception {
         String mappings = "{ \"" + MapperService.SINGLE_MAPPING_NAME + "\": { \"properties\": { \"foo\": { \"type\": \"keyword\"} }}}";
@@ -283,7 +281,6 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
     /**
      * Verifies that commits on replica engine resulting from engine or reader close does not cleanup the temporary
      * replication files from ongoing round of segment replication
-     * @throws Exception
      */
     public void testTemporaryFilesNotCleanup() throws Exception {
         String mappings = "{ \"" + MapperService.SINGLE_MAPPING_NAME + "\": { \"properties\": { \"foo\": { \"type\": \"keyword\"} }}}";


### PR DESCRIPTION
### Description
- Currently, [remote store restore API ](https://opensearch.org/docs/latest/tuning-your-cluster/availability-and-recovery/remote-store/index/#restoring-from-a-backup)restores all the shards of a given index irrespective of the shard state.
- This approach is not optimized for scenarios where only few of the shards are unassigned. Restore will still download data for all the shards in order to restore them.
- We also need to close the index before calling remote store restore API. This impacts the index availability during the restore.
- Ideally, we should be able to restore only those shards that are unassigned and that too without closing the index.
- In restore API execution, while marking shards to be restored, we filter shards based on existing [ShardRoutingState](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/cluster/routing/ShardRoutingState.java).
- We pick only shards that are in UNASSIGNED state as shards to be restored.
- User do not need to provide shard info in the API request. API signature would remain same which accepts index/indices to be restored. API implementation internally picks up only unassigned shards to restore.
- We also provided a query parameter restore_all_shards which, as the name suggests, will restore all the shards of the given index. As some of the shards can be active, to avoid an inconsistent state, when restore_all_shards=true is passed, index needs to be in closed state.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/8836

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
