### PR TITLE
fixtures: fix read-only krb5kdc composeBuild failure

### DIFF
--- a/test/fixtures/krb5kdc-fixture/Dockerfile
+++ b/test/fixtures/krb5kdc-fixture/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:14.04
 RUN apt update -y
 RUN apt upgrade -y
 ADD . /fixture
-RUN echo kerberos.build.opensearch.org > /etc/hostname && echo "127.0.0.1 kerberos.build.opensearch.org" >> /etc/hosts
+RUN echo kerberos.build.opensearch.org > /etc/hostname
 RUN bash /fixture/src/main/resources/provision/installkdc.sh
 
 EXPOSE 88


### PR DESCRIPTION
### Description

Running composeBuild task for krb5kdc-fixture throws read-only file system error while writing hostname to local hosts file. Since, hostname resolution is already present and pointing to local node, let's remove writing it again from the Dockerfile.

Resolves: #8761

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))