### PR TITLE
Skip gradle run when no opensearch cluster is configured

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/testclusters/RunTask.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/testclusters/RunTask.java
@@ -201,10 +201,15 @@ public class RunTask extends DefaultTestClustersTask {
 
     @TaskAction
     public void runAndWait() throws IOException {
+        if (getClusters() == null || getClusters().isEmpty()) {
+            logger.lifecycle("No opensearch cluster is configured.");
+            return;
+        }
         List<BufferedReader> toRead = new ArrayList<>();
         List<BooleanSupplier> aliveChecks = new ArrayList<>();
         try {
             for (OpenSearchCluster cluster : getClusters()) {
+                logger.lifecycle("Starting opensearch cluster {}", cluster.getName());
                 for (OpenSearchNode node : cluster.getNodes()) {
                     BufferedReader reader = Files.newBufferedReader(node.getOpensearchStdoutFile());
                     toRead.add(reader);


### PR DESCRIPTION
### Description
when we run `./gradlew run`, if there is no cluster is configured, Run task will fall into infinite loop. We can enhance the run task to add a check on this case and just skip the task execution.

### Related Issues
Resolves https://github.com/opensearch-project/notifications/issues/709
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
