### PR TITLE
Fix flaky test - org.opensearch.repositories.blobstore.BlobStoreRepos…

### DIFF
--- a/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryTests.java
+++ b/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryTests.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.repositories.blobstore;
 
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.opensearch.Version;
 import org.opensearch.action.admin.cluster.repositories.get.GetRepositoriesResponse;
 import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
@@ -90,6 +91,7 @@ import static org.opensearch.repositories.RepositoryDataTests.generateRandomRepo
 /**
  * Tests for the {@link BlobStoreRepository} and its subclasses.
  */
+@LuceneTestCase.SuppressFileSystems("ExtrasFS")
 public class BlobStoreRepositoryTests extends OpenSearchSingleNodeTestCase {
 
     static final String REPO_TYPE = "fsLike";


### PR DESCRIPTION
…itoryTests

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
- Recently we mandated the remote indices be created with remote translog and segment store both.
- Before this change the BlobStoreRepositoryTests were creating remote indices with just segment store and not translog. 
- With Translog enabled remote indices in BlobStoreRepositoryTests, with certain seed the repo had an empty extra0 file in translog metadata dir which was causing the CorruptIndexException while reading metadata file for translog
- With this change we ensure no extra0 file is created in translog metadata dir

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/8834

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
