### PR TITLE
[Segment Replication] Prioritize replica shard movement during shard relocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [distribution/archives] [Linux] [x64] Provide the variant of the distributions bundled with JRE ([#8195]()https://github.com/opensearch-project/OpenSearch/pull/8195)
 - Add configuration for file cache size to max remote data ratio to prevent oversubscription of file cache ([#8606](https://github.com/opensearch-project/OpenSearch/pull/8606))
 - Disallow compression level to be set for default and best_compression index codecs ([#8737]()https://github.com/opensearch-project/OpenSearch/pull/8737)
+- Prioritize replica shard movement during shard relocation ([#8875](https://github.com/opensearch-project/OpenSearch/pull/8875))
 
 ### Dependencies
 - Bump `org.apache.logging.log4j:log4j-core` from 2.17.1 to 2.20.0 ([#8307](https://github.com/opensearch-project/OpenSearch/pull/8307))

--- a/server/src/main/java/org/opensearch/cluster/ClusterModule.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterModule.java
@@ -359,7 +359,7 @@ public class ClusterModule extends AbstractModule {
         addAllocationDecider(deciders, new ConcurrentRebalanceAllocationDecider(settings, clusterSettings));
         addAllocationDecider(deciders, new ConcurrentRecoveriesAllocationDecider(settings, clusterSettings));
         addAllocationDecider(deciders, new EnableAllocationDecider(settings, clusterSettings));
-        addAllocationDecider(deciders, new NodeVersionAllocationDecider());
+        addAllocationDecider(deciders, new NodeVersionAllocationDecider(settings));
         addAllocationDecider(deciders, new SnapshotInProgressAllocationDecider());
         addAllocationDecider(deciders, new RestoreInProgressAllocationDecider());
         addAllocationDecider(deciders, new FilterAllocationDecider(settings, clusterSettings));

--- a/server/src/main/java/org/opensearch/cluster/routing/ShardMovementStrategy.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/ShardMovementStrategy.java
@@ -17,6 +17,8 @@ import java.util.Locale;
  *
  * ShardMovementStrategy values or rather their string representation to be used with
  * {@link BalancedShardsAllocator#SHARD_MOVEMENT_STRATEGY_SETTING} via cluster settings.
+ *
+ * @opensearch.internal
  */
 public enum ShardMovementStrategy {
     /**

--- a/server/src/main/java/org/opensearch/cluster/routing/ShardMovementStrategy.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/ShardMovementStrategy.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.routing;
+
+import org.opensearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
+
+import java.util.Locale;
+
+/**
+ * ShardMovementStrategy defines the order in which shard movement occurs.
+ *
+ * ShardMovementStrategy values or rather their string representation to be used with
+ * {@link BalancedShardsAllocator#SHARD_MOVEMENT_STRATEGY_SETTING} via cluster settings.
+ */
+public enum ShardMovementStrategy {
+    /**
+     * default behavior in which order of shard movement doesn't matter.
+     */
+    NO_PREFERENCE,
+
+    /**
+     * primary shards are moved first
+     */
+    PRIMARY_FIRST,
+
+    /**
+     * replica shards are moved first
+     */
+    REPLICA_FIRST;
+
+    public static ShardMovementStrategy parse(String strValue) {
+        if (strValue == null) {
+            return null;
+        } else {
+            strValue = strValue.toUpperCase(Locale.ROOT);
+            try {
+                return ShardMovementStrategy.valueOf(strValue);
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("Illegal allocation.shard_movement_strategy value [" + strValue + "]");
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+
+}

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -108,37 +108,22 @@ public class BalancedShardsAllocator implements ShardsAllocator {
         "cluster.routing.allocation.move.primary_first",
         false,
         Property.Dynamic,
-        Property.NodeScope
-    );
-
-    public static final Setting<ShardMovementStrategy> SHARD_MOVEMENT_STRATEGY_SETTING = new Setting<ShardMovementStrategy>(
-        "cluster.routing.allocation.shard_movement_strategy",
-        ShardMovementStrategy.NO_PREFERENCE.toString(),
-        ShardMovementStrategy::parse,
-        Property.Dynamic,
-        Property.NodeScope
-    );
-    public static final Setting<Float> THRESHOLD_SETTING = Setting.floatSetting(
-        "cluster.routing.allocation.balance.threshold",
-        1.0f,
-        0.0f,
-        Property.Dynamic,
-        Property.NodeScope
+        Property.NodeScope,
+        Property.Deprecated
     );
 
     /**
-     * This setting governs whether primary shards balance is desired during allocation. This is used by {@link ConstraintTypes#isPerIndexPrimaryShardsPerNodeBreached()}
-     * and {@link ConstraintTypes#isPrimaryShardsPerNodeBreached} which is used during unassigned shard allocation
-     * {@link LocalShardsBalancer#allocateUnassigned()} and shard re-balance/relocation to a different node via {@link LocalShardsBalancer#balance()} .
+     * ShardMovementStrategy defines the order in which shard movement occurs.
+     * <p>
+     * Allocation settings can have the following values (non-casesensitive):
+     *  <ul>
+     *      <li> <code>NO_PREFERENCE</code> - default behavior in which order of shard movement doesn't matter.
+     *      <li> <code>PRIMARY_FIRST</code> - primary shards are moved first.
+     *      <li> <code>REPLICA_FIRST</code> - replica shards are moved first.
+     *  </ul>
+     * ShardMovementStrategy values or rather their string representation to be used with
+     * {@link BalancedShardsAllocator#SHARD_MOVEMENT_STRATEGY_SETTING} via cluster settings.
      */
-
-    public static final Setting<Boolean> PREFER_PRIMARY_SHARD_BALANCE = Setting.boolSetting(
-        "cluster.routing.allocation.balance.prefer_primary",
-        false,
-        Property.Dynamic,
-        Property.NodeScope
-    );
-
     public enum ShardMovementStrategy {
         NO_PREFERENCE,
         PRIMARY_FIRST,
@@ -163,6 +148,39 @@ public class BalancedShardsAllocator implements ShardsAllocator {
         }
 
     }
+
+    /**
+     * Decides order in which to move shards from node when shards can not stay on node anymore. {@link LocalShardsBalancer#moveShards()}
+     * Encapsulates behavior of above SHARD_MOVE_PRIMARY_FIRST_SETTING.
+     */
+    public static final Setting<ShardMovementStrategy> SHARD_MOVEMENT_STRATEGY_SETTING = new Setting<ShardMovementStrategy>(
+        "cluster.routing.allocation.shard_movement_strategy",
+        ShardMovementStrategy.NO_PREFERENCE.toString(),
+        ShardMovementStrategy::parse,
+        Property.Dynamic,
+        Property.NodeScope
+    );
+
+    public static final Setting<Float> THRESHOLD_SETTING = Setting.floatSetting(
+        "cluster.routing.allocation.balance.threshold",
+        1.0f,
+        0.0f,
+        Property.Dynamic,
+        Property.NodeScope
+    );
+
+    /**
+     * This setting governs whether primary shards balance is desired during allocation. This is used by {@link ConstraintTypes#isPerIndexPrimaryShardsPerNodeBreached()}
+     * and {@link ConstraintTypes#isPrimaryShardsPerNodeBreached} which is used during unassigned shard allocation
+     * {@link LocalShardsBalancer#allocateUnassigned()} and shard re-balance/relocation to a different node via {@link LocalShardsBalancer#balance()} .
+     */
+
+    public static final Setting<Boolean> PREFER_PRIMARY_SHARD_BALANCE = Setting.boolSetting(
+        "cluster.routing.allocation.balance.prefer_primary",
+        false,
+        Property.Dynamic,
+        Property.NodeScope
+    );
 
     private volatile boolean movePrimaryFirst;
     private volatile ShardMovementStrategy shardMovementStrategy;

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -37,6 +37,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.IntroSorter;
 import org.opensearch.cluster.routing.RoutingNode;
 import org.opensearch.cluster.routing.RoutingNodes;
+import org.opensearch.cluster.routing.ShardMovementStrategy;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.UnassignedInfo;
 import org.opensearch.cluster.routing.UnassignedInfo.AllocationStatus;
@@ -56,7 +57,6 @@ import org.opensearch.common.settings.Settings;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -111,43 +111,6 @@ public class BalancedShardsAllocator implements ShardsAllocator {
         Property.NodeScope,
         Property.Deprecated
     );
-
-    /**
-     * ShardMovementStrategy defines the order in which shard movement occurs.
-     * <p>
-     * Allocation settings can have the following values (non-casesensitive):
-     *  <ul>
-     *      <li> <code>NO_PREFERENCE</code> - default behavior in which order of shard movement doesn't matter.
-     *      <li> <code>PRIMARY_FIRST</code> - primary shards are moved first.
-     *      <li> <code>REPLICA_FIRST</code> - replica shards are moved first.
-     *  </ul>
-     * ShardMovementStrategy values or rather their string representation to be used with
-     * {@link BalancedShardsAllocator#SHARD_MOVEMENT_STRATEGY_SETTING} via cluster settings.
-     */
-    public enum ShardMovementStrategy {
-        NO_PREFERENCE,
-        PRIMARY_FIRST,
-        REPLICA_FIRST;
-
-        public static ShardMovementStrategy parse(String strValue) {
-            if (strValue == null) {
-                return null;
-            } else {
-                strValue = strValue.toUpperCase(Locale.ROOT);
-                try {
-                    return ShardMovementStrategy.valueOf(strValue);
-                } catch (IllegalArgumentException e) {
-                    throw new IllegalArgumentException("Illegal allocation.shard_movement_strategy value [" + strValue + "]");
-                }
-            }
-        }
-
-        @Override
-        public String toString() {
-            return name().toLowerCase(Locale.ROOT);
-        }
-
-    }
 
     /**
      * Decides order in which to move shards from node when shards can not stay on node anymore. {@link LocalShardsBalancer#moveShards()}

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancer.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancer.java
@@ -58,6 +58,7 @@ public class LocalShardsBalancer extends ShardsBalancer {
     private final RoutingAllocation allocation;
     private final RoutingNodes routingNodes;
     private final boolean movePrimaryFirst;
+    private final BalancedShardsAllocator.ShardMovementStrategy shardMovementStrategy;
 
     private final boolean preferPrimaryBalance;
     private final BalancedShardsAllocator.WeightFunction weight;
@@ -74,6 +75,7 @@ public class LocalShardsBalancer extends ShardsBalancer {
         Logger logger,
         RoutingAllocation allocation,
         boolean movePrimaryFirst,
+        BalancedShardsAllocator.ShardMovementStrategy shardMovementStrategy,
         BalancedShardsAllocator.WeightFunction weight,
         float threshold,
         boolean preferPrimaryBalance
@@ -93,6 +95,7 @@ public class LocalShardsBalancer extends ShardsBalancer {
         sorter = newNodeSorter();
         inEligibleTargetNode = new HashSet<>();
         this.preferPrimaryBalance = preferPrimaryBalance;
+        this.shardMovementStrategy = shardMovementStrategy;
     }
 
     /**
@@ -528,6 +531,22 @@ public class LocalShardsBalancer extends ShardsBalancer {
     }
 
     /**
+     * Returns the correct Shard movement strategy to use.
+     * If users are still using deprecated setting "move_primary_first", we want behavior to remain unchanged.
+     * In the event of changing ShardMovementStrategy setting from default setting NO_PREFERENCE to either PRIMARY_FIRST or REPLICA_FIRST, we want that
+     * to have priority over values set in move_primary_first setting.
+     */
+    private BalancedShardsAllocator.ShardMovementStrategy getShardMovementStrategy() {
+        if (shardMovementStrategy != BalancedShardsAllocator.ShardMovementStrategy.NO_PREFERENCE) {
+            return shardMovementStrategy;
+        }
+        if (movePrimaryFirst) {
+            return BalancedShardsAllocator.ShardMovementStrategy.PRIMARY_FIRST;
+        }
+        return BalancedShardsAllocator.ShardMovementStrategy.NO_PREFERENCE;
+    }
+
+    /**
      * Move started shards that can not be allocated to a node anymore
      *
      * For each shard to be moved this function executes a move operation
@@ -549,7 +568,8 @@ public class LocalShardsBalancer extends ShardsBalancer {
             checkAndAddInEligibleTargetNode(currentNode.getRoutingNode());
         }
         boolean primariesThrottled = false;
-        for (Iterator<ShardRouting> it = allocation.routingNodes().nodeInterleavedShardIterator(movePrimaryFirst); it.hasNext();) {
+        for (Iterator<ShardRouting> it = allocation.routingNodes().nodeInterleavedShardIterator(getShardMovementStrategy()); it
+            .hasNext();) {
             // Verify if the cluster concurrent recoveries have been reached.
             if (allocation.deciders().canMoveAnyShard(allocation).type() != Decision.Type.YES) {
                 logger.info(
@@ -574,7 +594,9 @@ public class LocalShardsBalancer extends ShardsBalancer {
             }
 
             // Ensure that replicas don't relocate if primaries are being throttled and primary first is enabled
-            if (movePrimaryFirst && primariesThrottled && !shardRouting.primary()) {
+            if ((movePrimaryFirst || shardMovementStrategy == BalancedShardsAllocator.ShardMovementStrategy.PRIMARY_FIRST)
+                && primariesThrottled
+                && !shardRouting.primary()) {
                 logger.info(
                     "Cannot move any replica shard in the cluster as movePrimaryFirst is enabled and primary shards"
                         + "are being throttled. Skipping shard iteration"

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancer.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancer.java
@@ -593,8 +593,8 @@ public class LocalShardsBalancer extends ShardsBalancer {
                 continue;
             }
 
-            // Ensure that replicas don't relocate if primaries are being throttled and primary first is enabled
-            if ((movePrimaryFirst || shardMovementStrategy == BalancedShardsAllocator.ShardMovementStrategy.PRIMARY_FIRST)
+            // Ensure that replicas don't relocate if primaries are being throttled and primary first shard movement strategy is enabled
+            if ((shardMovementStrategy == BalancedShardsAllocator.ShardMovementStrategy.PRIMARY_FIRST)
                 && primariesThrottled
                 && !shardRouting.primary()) {
                 logger.info(

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -240,6 +240,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 BalancedShardsAllocator.SHARD_BALANCE_FACTOR_SETTING,
                 BalancedShardsAllocator.PREFER_PRIMARY_SHARD_BALANCE,
                 BalancedShardsAllocator.SHARD_MOVE_PRIMARY_FIRST_SETTING,
+                BalancedShardsAllocator.SHARD_MOVEMENT_STRATEGY_SETTING,
                 BalancedShardsAllocator.THRESHOLD_SETTING,
                 BreakerSettings.CIRCUIT_BREAKER_LIMIT_SETTING,
                 BreakerSettings.CIRCUIT_BREAKER_OVERHEAD_SETTING,

--- a/server/src/test/java/org/opensearch/cluster/routing/RoutingNodesTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/RoutingNodesTests.java
@@ -41,6 +41,7 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.routing.allocation.AllocationService;
+import org.opensearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
 import org.opensearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider;
 import org.opensearch.common.settings.Settings;
 
@@ -124,7 +125,7 @@ public class RoutingNodesTests extends OpenSearchAllocationTestCase {
             .numberOfShards(this.numberOfShards);
     }
 
-    public void testInterleavedShardIterator() {
+    public void testInterleavedShardIteratorPrimaryFirst() {
         // Initialize all the shards for test index 1 and 2
         initPrimaries();
         startInitializingShards(TEST_INDEX_1);
@@ -147,7 +148,8 @@ public class RoutingNodesTests extends OpenSearchAllocationTestCase {
         }
 
         // Get primary first shard iterator and assert primary shards are iterated over first
-        final Iterator<ShardRouting> iterator = this.clusterState.getRoutingNodes().nodeInterleavedShardIterator(true);
+        final Iterator<ShardRouting> iterator = this.clusterState.getRoutingNodes()
+            .nodeInterleavedShardIterator(BalancedShardsAllocator.ShardMovementStrategy.PRIMARY_FIRST);
         boolean iteratingPrimary = true;
         int shardCount = 0;
         while (iterator.hasNext()) {
@@ -156,6 +158,63 @@ public class RoutingNodesTests extends OpenSearchAllocationTestCase {
                 iteratingPrimary = shard.primary();
             } else {
                 assert shard.primary() == false;
+            }
+            shardCount++;
+        }
+        assert shardCount == this.totalNumberOfShards;
+    }
+
+    public void testInterleavedShardIteratorNoPreference() {
+        // Initialize all the shards for test index 1 and 2
+        initPrimaries();
+        startInitializingShards(TEST_INDEX_1);
+        startInitializingShards(TEST_INDEX_1);
+        startInitializingShards(TEST_INDEX_2);
+        startInitializingShards(TEST_INDEX_2);
+
+        final Iterator<ShardRouting> iterator = this.clusterState.getRoutingNodes()
+            .nodeInterleavedShardIterator(BalancedShardsAllocator.ShardMovementStrategy.NO_PREFERENCE);
+        int shardCount = 0;
+        while (iterator.hasNext()) {
+            final ShardRouting shard = iterator.next();
+            shardCount++;
+        }
+        assert shardCount == this.totalNumberOfShards;
+    }
+
+    public void testInterleavedShardIteratorReplicaFirst() {
+        // Initialize all the shards for test index 1 and 2
+        initPrimaries();
+        startInitializingShards(TEST_INDEX_1);
+        startInitializingShards(TEST_INDEX_1);
+        startInitializingShards(TEST_INDEX_2);
+        startInitializingShards(TEST_INDEX_2);
+
+        // Create primary shard count imbalance between two nodes
+        final RoutingNode node0 = this.clusterState.getRoutingNodes().node("node0");
+        final RoutingNode node1 = this.clusterState.getRoutingNodes().node("node1");
+        final List<ShardRouting> shardRoutingList = node0.shardsWithState(TEST_INDEX_1, ShardRoutingState.STARTED);
+        for (ShardRouting routing : shardRoutingList) {
+            if (routing.primary()) {
+                node0.remove(routing);
+                ShardRouting swap = node1.getByShardId(routing.shardId());
+                node0.add(swap);
+                node1.remove(swap);
+                node1.add(routing);
+            }
+        }
+
+        // Get replica first shard iterator and assert replica shards are iterated over first
+        final Iterator<ShardRouting> iterator = this.clusterState.getRoutingNodes()
+            .nodeInterleavedShardIterator(BalancedShardsAllocator.ShardMovementStrategy.REPLICA_FIRST);
+        boolean iteratingReplica = true;
+        int shardCount = 0;
+        while (iterator.hasNext()) {
+            final ShardRouting shard = iterator.next();
+            if (iteratingReplica) {
+                iteratingReplica = shard.primary() == false;
+            } else {
+                assert shard.primary() == true;
             }
             shardCount++;
         }

--- a/server/src/test/java/org/opensearch/cluster/routing/RoutingNodesTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/RoutingNodesTests.java
@@ -41,7 +41,6 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.routing.allocation.AllocationService;
-import org.opensearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
 import org.opensearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider;
 import org.opensearch.common.settings.Settings;
 
@@ -149,7 +148,7 @@ public class RoutingNodesTests extends OpenSearchAllocationTestCase {
 
         // Get primary first shard iterator and assert primary shards are iterated over first
         final Iterator<ShardRouting> iterator = this.clusterState.getRoutingNodes()
-            .nodeInterleavedShardIterator(BalancedShardsAllocator.ShardMovementStrategy.PRIMARY_FIRST);
+            .nodeInterleavedShardIterator(ShardMovementStrategy.PRIMARY_FIRST);
         boolean iteratingPrimary = true;
         int shardCount = 0;
         while (iterator.hasNext()) {
@@ -173,7 +172,7 @@ public class RoutingNodesTests extends OpenSearchAllocationTestCase {
         startInitializingShards(TEST_INDEX_2);
 
         final Iterator<ShardRouting> iterator = this.clusterState.getRoutingNodes()
-            .nodeInterleavedShardIterator(BalancedShardsAllocator.ShardMovementStrategy.NO_PREFERENCE);
+            .nodeInterleavedShardIterator(ShardMovementStrategy.NO_PREFERENCE);
         int shardCount = 0;
         while (iterator.hasNext()) {
             final ShardRouting shard = iterator.next();
@@ -192,7 +191,7 @@ public class RoutingNodesTests extends OpenSearchAllocationTestCase {
 
         // Get replica first shard iterator and assert replica shards are iterated over first
         final Iterator<ShardRouting> iterator = this.clusterState.getRoutingNodes()
-            .nodeInterleavedShardIterator(BalancedShardsAllocator.ShardMovementStrategy.REPLICA_FIRST);
+            .nodeInterleavedShardIterator(ShardMovementStrategy.REPLICA_FIRST);
         boolean iteratingReplica = true;
         int shardCount = 0;
         while (iterator.hasNext()) {

--- a/server/src/test/java/org/opensearch/cluster/routing/RoutingNodesTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/RoutingNodesTests.java
@@ -190,20 +190,6 @@ public class RoutingNodesTests extends OpenSearchAllocationTestCase {
         startInitializingShards(TEST_INDEX_2);
         startInitializingShards(TEST_INDEX_2);
 
-        // Create primary shard count imbalance between two nodes
-        final RoutingNode node0 = this.clusterState.getRoutingNodes().node("node0");
-        final RoutingNode node1 = this.clusterState.getRoutingNodes().node("node1");
-        final List<ShardRouting> shardRoutingList = node0.shardsWithState(TEST_INDEX_1, ShardRoutingState.STARTED);
-        for (ShardRouting routing : shardRoutingList) {
-            if (routing.primary()) {
-                node0.remove(routing);
-                ShardRouting swap = node1.getByShardId(routing.shardId());
-                node0.add(swap);
-                node1.remove(swap);
-                node1.add(routing);
-            }
-        }
-
         // Get replica first shard iterator and assert replica shards are iterated over first
         final Iterator<ShardRouting> iterator = this.clusterState.getRoutingNodes()
             .nodeInterleavedShardIterator(BalancedShardsAllocator.ShardMovementStrategy.REPLICA_FIRST);

--- a/server/src/test/java/org/opensearch/cluster/routing/RoutingNodesTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/RoutingNodesTests.java
@@ -156,11 +156,11 @@ public class RoutingNodesTests extends OpenSearchAllocationTestCase {
             if (iteratingPrimary) {
                 iteratingPrimary = shard.primary();
             } else {
-                assert shard.primary() == false;
+                assertFalse(shard.primary());
             }
             shardCount++;
         }
-        assert shardCount == this.totalNumberOfShards;
+        assertEquals(shardCount, this.totalNumberOfShards);
     }
 
     public void testInterleavedShardIteratorNoPreference() {
@@ -178,7 +178,7 @@ public class RoutingNodesTests extends OpenSearchAllocationTestCase {
             final ShardRouting shard = iterator.next();
             shardCount++;
         }
-        assert shardCount == this.totalNumberOfShards;
+        assertEquals(shardCount, this.totalNumberOfShards);
     }
 
     public void testInterleavedShardIteratorReplicaFirst() {
@@ -199,11 +199,11 @@ public class RoutingNodesTests extends OpenSearchAllocationTestCase {
             if (iteratingReplica) {
                 iteratingReplica = shard.primary() == false;
             } else {
-                assert shard.primary() == true;
+                assertTrue(shard.primary());
             }
             shardCount++;
         }
-        assert shardCount == this.totalNumberOfShards;
+        assertEquals(shardCount, this.totalNumberOfShards);
     }
 
     public void testSwapPrimaryWithReplica() {

--- a/server/src/test/java/org/opensearch/cluster/routing/ShardMovementStrategyTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/ShardMovementStrategyTests.java
@@ -11,7 +11,6 @@ package org.opensearch.cluster.routing;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.opensearch.cluster.ClusterStateListener;
-import org.opensearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.test.InternalTestCluster;
 import org.opensearch.test.OpenSearchIntegTestCase;
@@ -49,43 +48,37 @@ public class ShardMovementStrategyTests extends OpenSearchIntegTestCase {
         flushAndRefresh(index);
     }
 
-    private static Settings.Builder getSettings(
-        BalancedShardsAllocator.ShardMovementStrategy shardMovementStrategy,
-        boolean movePrimaryFirst
-    ) {
+    private static Settings.Builder getSettings(ShardMovementStrategy shardMovementStrategy, boolean movePrimaryFirst) {
         return Settings.builder()
             .put("cluster.routing.allocation.shard_movement_strategy", shardMovementStrategy)
             .put("cluster.routing.allocation.move.primary_first", movePrimaryFirst);
     }
 
     public void testClusterGreenAfterPartialRelocationPrimaryFirstShardMovementMovePrimarySettingEnabled() throws InterruptedException {
-        testClusterGreenAfterPartialRelocation(BalancedShardsAllocator.ShardMovementStrategy.PRIMARY_FIRST, true);
+        testClusterGreenAfterPartialRelocation(ShardMovementStrategy.PRIMARY_FIRST, true);
     }
 
     public void testClusterGreenAfterPartialRelocationPrimaryFirstShardMovementMovePrimarySettingDisabled() throws InterruptedException {
-        testClusterGreenAfterPartialRelocation(BalancedShardsAllocator.ShardMovementStrategy.PRIMARY_FIRST, false);
+        testClusterGreenAfterPartialRelocation(ShardMovementStrategy.PRIMARY_FIRST, false);
     }
 
     public void testClusterGreenAfterPartialRelocationReplicaFirstShardMovementPrimaryFirstEnabled() throws InterruptedException {
-        testClusterGreenAfterPartialRelocation(BalancedShardsAllocator.ShardMovementStrategy.REPLICA_FIRST, true);
+        testClusterGreenAfterPartialRelocation(ShardMovementStrategy.REPLICA_FIRST, true);
     }
 
     public void testClusterGreenAfterPartialRelocationReplicaFirstShardMovementPrimaryFirstDisabled() throws InterruptedException {
-        testClusterGreenAfterPartialRelocation(BalancedShardsAllocator.ShardMovementStrategy.REPLICA_FIRST, false);
+        testClusterGreenAfterPartialRelocation(ShardMovementStrategy.REPLICA_FIRST, false);
     }
 
     public void testClusterGreenAfterPartialRelocationNoPreferenceShardMovementPrimaryFirstEnabled() throws InterruptedException {
-        testClusterGreenAfterPartialRelocation(BalancedShardsAllocator.ShardMovementStrategy.NO_PREFERENCE, true);
+        testClusterGreenAfterPartialRelocation(ShardMovementStrategy.NO_PREFERENCE, true);
     }
 
-    private boolean shouldMovePrimaryShardsFirst(
-        BalancedShardsAllocator.ShardMovementStrategy shardMovementStrategy,
-        boolean movePrimaryFirst
-    ) {
-        if (shardMovementStrategy == BalancedShardsAllocator.ShardMovementStrategy.NO_PREFERENCE && movePrimaryFirst) {
+    private boolean shouldMovePrimaryShardsFirst(ShardMovementStrategy shardMovementStrategy, boolean movePrimaryFirst) {
+        if (shardMovementStrategy == ShardMovementStrategy.NO_PREFERENCE && movePrimaryFirst) {
             return true;
         }
-        return shardMovementStrategy == BalancedShardsAllocator.ShardMovementStrategy.PRIMARY_FIRST;
+        return shardMovementStrategy == ShardMovementStrategy.PRIMARY_FIRST;
     }
 
     /**
@@ -95,10 +88,8 @@ public class ShardMovementStrategyTests extends OpenSearchIntegTestCase {
      * nodes in zone1. Depending on the shard movement strategy, we check whether the
      * primary or replica shards are moved first, and zone2 nodes have all the shards
      */
-    private void testClusterGreenAfterPartialRelocation(
-        BalancedShardsAllocator.ShardMovementStrategy shardMovementStrategy,
-        boolean movePrimaryFirst
-    ) throws InterruptedException {
+    private void testClusterGreenAfterPartialRelocation(ShardMovementStrategy shardMovementStrategy, boolean movePrimaryFirst)
+        throws InterruptedException {
         internalCluster().startClusterManagerOnlyNodes(1);
         final String z1 = "zone-1", z2 = "zone-2";
         final int primaryShardCount = 6;


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
When some node or set of nodes is excluded, the shards are moved away in random order. When segment replication is enabled for a cluster, we might end up in a mixed version state where replicas will be on lower version and unable to read segments sent from higher version primaries and fail.

To avoid this, we could prioritize replica shard movement to avoid entering this situation.

Adding a new setting called shard movement strategy - `SHARD_MOVEMENT_STRATEGY_SETTING` - that will allow us to specify in which order we want to move our shards: `NO_PREFERENCE` (default), `PRIMARY_FIRST` or `REPLICA_FIRST`. 

The `PRIMARY_FIRST` option will perform the same behavior as the previous setting `SHARD_MOVE_PRIMARY_FIRST_SETTING` which will be now deprecated in favor of the shard movement strategy setting. 

Expected behavior: 

If `SHARD_MOVEMENT_STRATEGY_SETTING` is changed from its default behavior to be either `PRIMARY_FIRST` or `REPLICA_FIRST` then we perform this behavior whether or not `SHARD_MOVE_PRIMARY_FIRST_SETTING` is enabled. 

If `SHARD_MOVEMENT_STRATEGY_SETTING` is still at its default setting of `NO_PREFERENCE` and `SHARD_MOVE_PRIMARY_FIRST_SETTING` is enabled we move the primary shards first. This ensures that users still using this setting will not see any changes in behavior. 

Reference: https://github.com/opensearch-project/OpenSearch/pull/1445

Parent issue: https://github.com/opensearch-project/OpenSearch/issues/3881

### Related Issues
Resolves #8265 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
