### PR TITLE
Skip testPitCreatedOnReplica IT with remote store

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -1177,6 +1177,10 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
     }
 
     public void testPitCreatedOnReplica() throws Exception {
+        assumeFalse(
+            "Skipping the test as its not compatible with segment replication with remote store yet.",
+            segmentReplicationWithRemoteEnabled()
+        );
         final String primary = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME);
         ensureYellowAndNoInitializingShards(INDEX_NAME);

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -1178,7 +1178,7 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
 
     public void testPitCreatedOnReplica() throws Exception {
         assumeFalse(
-            "Skipping the test as its not compatible with segment replication with remote store yet.",
+            "Skipping the test as it is flaky with remote store. Tracking issue https://github.com/opensearch-project/OpenSearch/issues/8850",
             segmentReplicationWithRemoteEnabled()
         );
         final String primary = internalCluster().startDataOnlyNode();


### PR DESCRIPTION
### Description
Mute `testPitCreatedOnReplica` test causing a higher gradle check failures in recent runs. Based on issue description and linked PRs which failed, it seems it is failing mostly on 2.x branch.

### Related Issues
Related #https://github.com/opensearch-project/OpenSearch/issues/8850

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
