### PR TITLE
Introduce new setting search.concurrent.max_slice to control the slice computation for concurrent segment search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Add server version as REST response header [#6583](https://github.com/opensearch-project/OpenSearch/issues/6583)
 - Start replication checkpointTimers on primary before segments upload to remote store. ([#8221]()https://github.com/opensearch-project/OpenSearch/pull/8221)
-- Introduce new static cluster setting to control slice computation for concurrent segment search. ([#8847](https://github.com/opensearch-project/OpenSearch/pull/8847))
+- Introduce new static cluster setting to control slice computation for concurrent segment search. ([#8847](https://github.com/opensearch-project/OpenSearch/pull/8884))
 
 ### Dependencies
 - Bump `org.apache.logging.log4j:log4j-core` from 2.17.1 to 2.20.0 ([#8307](https://github.com/opensearch-project/OpenSearch/pull/8307))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Add server version as REST response header [#6583](https://github.com/opensearch-project/OpenSearch/issues/6583)
 - Start replication checkpointTimers on primary before segments upload to remote store. ([#8221]()https://github.com/opensearch-project/OpenSearch/pull/8221)
+- Introduce new static cluster setting to control slice computation for concurrent segment search. ([#8847](https://github.com/opensearch-project/OpenSearch/pull/8847))
 
 ### Dependencies
 - Bump `org.apache.logging.log4j:log4j-core` from 2.17.1 to 2.20.0 ([#8307](https://github.com/opensearch-project/OpenSearch/pull/8307))

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -495,7 +495,6 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 SearchService.MAX_OPEN_SCROLL_CONTEXT,
                 SearchService.MAX_OPEN_PIT_CONTEXT,
                 SearchService.MAX_PIT_KEEPALIVE_SETTING,
-                SearchBootstrapSettings.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING,
                 CreatePitController.PIT_INIT_KEEP_ALIVE,
                 Node.WRITE_PORTS_FILE_SETTING,
                 Node.NODE_NAME_SETTING,
@@ -679,7 +678,10 @@ public final class ClusterSettings extends AbstractScopedSettings {
             IndicesService.CLUSTER_REMOTE_TRANSLOG_REPOSITORY_SETTING
         ),
         List.of(FeatureFlags.CONCURRENT_SEGMENT_SEARCH),
-        List.of(SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING),
+        List.of(
+            SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING,
+            SearchBootstrapSettings.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING
+        ),
         List.of(FeatureFlags.TELEMETRY),
         List.of(TelemetrySettings.TRACER_ENABLED_SETTING)
     );

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -45,6 +45,7 @@ import org.opensearch.index.SegmentReplicationPressureService;
 import org.opensearch.index.ShardIndexingPressureMemoryManager;
 import org.opensearch.index.ShardIndexingPressureSettings;
 import org.opensearch.index.ShardIndexingPressureStore;
+import org.opensearch.search.SearchBootstrapSettings;
 import org.opensearch.search.backpressure.settings.NodeDuressSettings;
 import org.opensearch.search.backpressure.settings.SearchBackpressureSettings;
 import org.opensearch.search.backpressure.settings.SearchShardTaskSettings;
@@ -494,6 +495,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 SearchService.MAX_OPEN_SCROLL_CONTEXT,
                 SearchService.MAX_OPEN_PIT_CONTEXT,
                 SearchService.MAX_PIT_KEEPALIVE_SETTING,
+                SearchBootstrapSettings.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING,
                 CreatePitController.PIT_INIT_KEEP_ALIVE,
                 Node.WRITE_PORTS_FILE_SETTING,
                 Node.NODE_NAME_SETTING,

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -58,6 +58,7 @@ import org.opensearch.monitor.fs.FsInfo;
 import org.opensearch.monitor.fs.FsProbe;
 import org.opensearch.plugins.ExtensionAwarePlugin;
 import org.opensearch.plugins.SearchPipelinePlugin;
+import org.opensearch.search.SearchBootstrapSettings;
 import org.opensearch.telemetry.tracing.NoopTracerFactory;
 import org.opensearch.telemetry.tracing.Tracer;
 import org.opensearch.telemetry.tracing.TracerFactory;
@@ -468,6 +469,7 @@ public class Node implements Closeable {
 
             // Ensure to initialize Feature Flags via the settings from opensearch.yml
             FeatureFlags.initializeFeatureFlags(settings);
+            SearchBootstrapSettings.initialize(settings);
 
             final List<IdentityPlugin> identityPlugins = new ArrayList<>();
             if (FeatureFlags.isEnabled(FeatureFlags.IDENTITY)) {

--- a/server/src/main/java/org/opensearch/search/SearchBootstrapSettings.java
+++ b/server/src/main/java/org/opensearch/search/SearchBootstrapSettings.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search;
+
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+
+/**
+ * Keeps track of all the search related node level settings which can be accessed via static methods
+ */
+public class SearchBootstrapSettings {
+    // settings to configure maximum slice created per search request using OS custom slice computation mechanism. Default lucene
+    // mechanism will not be used if this setting is set with value > 0
+    public static final String CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_KEY = "search.concurrent.max_slice";
+    public static final int CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_DEFAULT_VALUE = -1;
+
+    // value <= 0 means lucene slice computation will be used
+    public static final Setting<Integer> CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING = Setting.intSetting(
+        CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_KEY,
+        CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_DEFAULT_VALUE,
+        Setting.Property.NodeScope
+    );
+    private static Settings settings;
+
+    public static void initialize(Settings openSearchSettings) {
+        settings = openSearchSettings;
+    }
+
+    public static int getValueAsInt(String settingName, int defaultValue) {
+        return (settings != null) ? settings.getAsInt(settingName, defaultValue) : defaultValue;
+    }
+}

--- a/server/src/main/java/org/opensearch/search/SearchBootstrapSettings.java
+++ b/server/src/main/java/org/opensearch/search/SearchBootstrapSettings.java
@@ -13,6 +13,8 @@ import org.opensearch.common.settings.Settings;
 
 /**
  * Keeps track of all the search related node level settings which can be accessed via static methods
+ *
+ * @opensearch.internal
  */
 public class SearchBootstrapSettings {
     // settings to configure maximum slice created per search request using OS custom slice computation mechanism. Default lucene
@@ -21,6 +23,7 @@ public class SearchBootstrapSettings {
     public static final int CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_DEFAULT_VALUE = -1;
 
     // value <= 0 means lucene slice computation will be used
+    // this setting will be updated to dynamic setting as part of https://github.com/opensearch-project/OpenSearch/issues/8870
     public static final Setting<Integer> CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING = Setting.intSetting(
         CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_KEY,
         CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_DEFAULT_VALUE,
@@ -32,7 +35,12 @@ public class SearchBootstrapSettings {
         settings = openSearchSettings;
     }
 
-    public static int getValueAsInt(String settingName, int defaultValue) {
-        return (settings != null) ? settings.getAsInt(settingName, defaultValue) : defaultValue;
+    public static int getTargetMaxSlice() {
+        return (settings != null)
+            ? settings.getAsInt(
+                CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_KEY,
+                CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_DEFAULT_VALUE
+            )
+            : CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_DEFAULT_VALUE;
     }
 }

--- a/server/src/main/java/org/opensearch/search/SearchBootstrapSettings.java
+++ b/server/src/main/java/org/opensearch/search/SearchBootstrapSettings.java
@@ -20,12 +20,13 @@ public class SearchBootstrapSettings {
     // settings to configure maximum slice created per search request using OS custom slice computation mechanism. Default lucene
     // mechanism will not be used if this setting is set with value > 0
     public static final String CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_KEY = "search.concurrent.max_slice";
-    public static final int CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_DEFAULT_VALUE = -1;
+    public static final int CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_DEFAULT_VALUE = 0;
 
-    // value <= 0 means lucene slice computation will be used
+    // value == 0 means lucene slice computation will be used
     // this setting will be updated to dynamic setting as part of https://github.com/opensearch-project/OpenSearch/issues/8870
     public static final Setting<Integer> CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING = Setting.intSetting(
         CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_KEY,
+        CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_DEFAULT_VALUE,
         CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_DEFAULT_VALUE,
         Setting.Property.NodeScope
     );

--- a/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
@@ -539,7 +539,7 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
     // package-private for testing
     LeafSlice[] slicesInternal(List<LeafReaderContext> leaves, int targetMaxSlice) {
         LeafSlice[] leafSlices;
-        if (targetMaxSlice <= 0) {
+        if (targetMaxSlice == 0) {
             // use the default lucene slice calculation
             leafSlices = super.slices(leaves);
             logger.debug("Slice count using lucene default [{}]", leafSlices.length);

--- a/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
@@ -451,11 +451,9 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
      */
     @Override
     public LeafSlice[] slices(List<LeafReaderContext> leaves) {
-        final int target_max_slices = SearchBootstrapSettings.getValueAsInt(
-            SearchBootstrapSettings.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_KEY,
-            SearchBootstrapSettings.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_DEFAULT_VALUE
-        );
-        return slicesInternal(leaves, target_max_slices);
+        // For now using the static setting to get the targetMaxSlice value. It will be updated to dynamic mechanism as part of
+        // https://github.com/opensearch-project/OpenSearch/issues/8870 when lucene changes are available
+        return slicesInternal(leaves, SearchBootstrapSettings.getTargetMaxSlice());
     }
 
     public DirectoryReader getDirectoryReader() {
@@ -539,15 +537,15 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
     }
 
     // package-private for testing
-    LeafSlice[] slicesInternal(List<LeafReaderContext> leaves, int target_max_slices) {
+    LeafSlice[] slicesInternal(List<LeafReaderContext> leaves, int targetMaxSlice) {
         LeafSlice[] leafSlices;
-        if (target_max_slices <= 0) {
+        if (targetMaxSlice <= 0) {
             // use the default lucene slice calculation
             leafSlices = super.slices(leaves);
             logger.debug("Slice count using lucene default [{}]", leafSlices.length);
         } else {
-            // use the custom slice calculation based on target_max_slices. It will sort
-            leafSlices = MaxTargetSliceSupplier.getSlices(leaves, target_max_slices);
+            // use the custom slice calculation based on targetMaxSlice
+            leafSlices = MaxTargetSliceSupplier.getSlices(leaves, targetMaxSlice);
             logger.debug("Slice count using max target slice supplier [{}]", leafSlices.length);
         }
         return leafSlices;

--- a/server/src/main/java/org/opensearch/search/internal/MaxTargetSliceSupplier.java
+++ b/server/src/main/java/org/opensearch/search/internal/MaxTargetSliceSupplier.java
@@ -21,16 +21,18 @@ import java.util.List;
  * all the leaves based on document count and then assign each leaf in round-robin fashion to the target slice count slices. Based on
  * experiment results as shared in <a href=https://github.com/opensearch-project/OpenSearch/issues/7358>issue-7358</a>
  * we can see this mechanism helps to achieve better tail/median latency over default lucene slice computation.
+ *
+ * @opensearch.internal
  */
 public class MaxTargetSliceSupplier {
 
-    public static IndexSearcher.LeafSlice[] getSlices(List<LeafReaderContext> leaves, int target_max_slice) {
-        if (target_max_slice <= 0) {
-            throw new IllegalArgumentException("MaxTargetSliceSupplier called with unexpected slice count of " + target_max_slice);
+    public static IndexSearcher.LeafSlice[] getSlices(List<LeafReaderContext> leaves, int targetMaxSlice) {
+        if (targetMaxSlice <= 0) {
+            throw new IllegalArgumentException("MaxTargetSliceSupplier called with unexpected slice count of " + targetMaxSlice);
         }
 
         // slice count should not exceed the segment count
-        int target_slice_count = Math.min(target_max_slice, leaves.size());
+        int targetSliceCount = Math.min(targetMaxSlice, leaves.size());
 
         // Make a copy so we can sort:
         List<LeafReaderContext> sortedLeaves = new ArrayList<>(leaves);
@@ -39,23 +41,15 @@ public class MaxTargetSliceSupplier {
         sortedLeaves.sort(Collections.reverseOrder(Comparator.comparingInt(l -> l.reader().maxDoc())));
 
         final List<List<LeafReaderContext>> groupedLeaves = new ArrayList<>();
-        for (int i = 0; i < target_slice_count; ++i) {
+        for (int i = 0; i < targetSliceCount; ++i) {
             groupedLeaves.add(new ArrayList<>());
         }
         // distribute the slices in round-robin fashion
-        List<LeafReaderContext> group;
         for (int idx = 0; idx < sortedLeaves.size(); ++idx) {
-            int currentGroup = idx % target_slice_count;
-            group = groupedLeaves.get(currentGroup);
-            group.add(sortedLeaves.get(idx));
+            int currentGroup = idx % targetSliceCount;
+            groupedLeaves.get(currentGroup).add(sortedLeaves.get(idx));
         }
 
-        IndexSearcher.LeafSlice[] slices = new IndexSearcher.LeafSlice[target_slice_count];
-        int upto = 0;
-        for (List<LeafReaderContext> currentLeaf : groupedLeaves) {
-            slices[upto] = new IndexSearcher.LeafSlice(currentLeaf);
-            ++upto;
-        }
-        return slices;
+        return groupedLeaves.stream().map(IndexSearcher.LeafSlice::new).toArray(IndexSearcher.LeafSlice[]::new);
     }
 }

--- a/server/src/main/java/org/opensearch/search/internal/MaxTargetSliceSupplier.java
+++ b/server/src/main/java/org/opensearch/search/internal/MaxTargetSliceSupplier.java
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.internal;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.IndexSearcher;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Supplier to compute leaf slices based on passed in leaves and max target slice count to limit the number of computed slices. It sorts
+ * all the leaves based on document count and then assign each leaf in round-robin fashion to the target slice count slices. Based on
+ * experiment results as shared in <a href=https://github.com/opensearch-project/OpenSearch/issues/7358>issue-7358</a>
+ * we can see this mechanism helps to achieve better tail/median latency over default lucene slice computation.
+ */
+public class MaxTargetSliceSupplier {
+
+    public static IndexSearcher.LeafSlice[] getSlices(List<LeafReaderContext> leaves, int target_max_slice) {
+        if (target_max_slice <= 0) {
+            throw new IllegalArgumentException("MaxTargetSliceSupplier called with unexpected slice count of " + target_max_slice);
+        }
+
+        // slice count should not exceed the segment count
+        int target_slice_count = Math.min(target_max_slice, leaves.size());
+
+        // Make a copy so we can sort:
+        List<LeafReaderContext> sortedLeaves = new ArrayList<>(leaves);
+
+        // Sort by maxDoc, descending:
+        sortedLeaves.sort(Collections.reverseOrder(Comparator.comparingInt(l -> l.reader().maxDoc())));
+
+        final List<List<LeafReaderContext>> groupedLeaves = new ArrayList<>();
+        for (int i = 0; i < target_slice_count; ++i) {
+            groupedLeaves.add(new ArrayList<>());
+        }
+        // distribute the slices in round-robin fashion
+        List<LeafReaderContext> group;
+        for (int idx = 0; idx < sortedLeaves.size(); ++idx) {
+            int currentGroup = idx % target_slice_count;
+            group = groupedLeaves.get(currentGroup);
+            group.add(sortedLeaves.get(idx));
+        }
+
+        IndexSearcher.LeafSlice[] slices = new IndexSearcher.LeafSlice[target_slice_count];
+        int upto = 0;
+        for (List<LeafReaderContext> currentLeaf : groupedLeaves) {
+            slices[upto] = new IndexSearcher.LeafSlice(currentLeaf);
+            ++upto;
+        }
+        return slices;
+    }
+}

--- a/server/src/main/java/org/opensearch/search/internal/MaxTargetSliceSupplier.java
+++ b/server/src/main/java/org/opensearch/search/internal/MaxTargetSliceSupplier.java
@@ -24,9 +24,9 @@ import java.util.List;
  *
  * @opensearch.internal
  */
-public class MaxTargetSliceSupplier {
+final class MaxTargetSliceSupplier {
 
-    public static IndexSearcher.LeafSlice[] getSlices(List<LeafReaderContext> leaves, int targetMaxSlice) {
+    static IndexSearcher.LeafSlice[] getSlices(List<LeafReaderContext> leaves, int targetMaxSlice) {
         if (targetMaxSlice <= 0) {
             throw new IllegalArgumentException("MaxTargetSliceSupplier called with unexpected slice count of " + targetMaxSlice);
         }

--- a/server/src/test/java/org/opensearch/common/settings/SettingsModuleTests.java
+++ b/server/src/test/java/org/opensearch/common/settings/SettingsModuleTests.java
@@ -37,6 +37,7 @@ import org.opensearch.common.settings.Setting.Property;
 import org.hamcrest.Matchers;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.index.IndexSettings;
+import org.opensearch.search.SearchBootstrapSettings;
 import org.opensearch.search.SearchService;
 import org.opensearch.test.FeatureFlagSetter;
 
@@ -334,5 +335,37 @@ public class SettingsModuleTests extends ModuleTestCase {
             update,
             "node"
         );
+    }
+
+    public void testMaxSliceCountClusterSettingsForConcurrentSearch() {
+        // Test that we throw an exception without the feature flag
+        Settings settings = Settings.builder()
+            .put(SearchBootstrapSettings.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING.getKey(), true)
+            .build();
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> new SettingsModule(settings));
+        assertTrue(
+            ex.getMessage()
+                .contains("unknown setting [" + SearchBootstrapSettings.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING.getKey())
+        );
+
+        // Test that the settings updates correctly with the feature flag
+        FeatureFlagSetter.set(FeatureFlags.CONCURRENT_SEGMENT_SEARCH);
+        int settingValue = randomIntBetween(0, 10);
+        Settings settingsWithFeatureFlag = Settings.builder()
+            .put(SearchBootstrapSettings.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING.getKey(), settingValue)
+            .build();
+        SettingsModule settingsModule = new SettingsModule(settingsWithFeatureFlag);
+        assertEquals(
+            settingValue,
+            (int) SearchBootstrapSettings.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING.get(settingsModule.getSettings())
+        );
+
+        // Test that negative value is not allowed
+        settingValue = -1;
+        final Settings settingsWithFeatureFlag_2 = Settings.builder()
+            .put(SearchBootstrapSettings.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING.getKey(), settingValue)
+            .build();
+        ex = expectThrows(IllegalArgumentException.class, () -> new SettingsModule(settingsWithFeatureFlag_2));
+        assertTrue(ex.getMessage().contains(SearchBootstrapSettings.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING.getKey()));
     }
 }

--- a/server/src/test/java/org/opensearch/search/internal/ContextIndexSearcherTests.java
+++ b/server/src/test/java/org/opensearch/search/internal/ContextIndexSearcherTests.java
@@ -82,6 +82,7 @@ import org.opensearch.index.IndexSettings;
 import org.opensearch.index.cache.bitset.BitsetFilterCache;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.shard.IndexShard;
+import org.opensearch.search.SearchBootstrapSettings;
 import org.opensearch.search.aggregations.LeafBucketCollector;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.IndexSettingsModule;
@@ -332,7 +333,10 @@ public class ContextIndexSearcherTests extends OpenSearchTestCase {
             searchContext
         );
         // Case 1: Verify the slice count when lucene default slice computation is used
-        IndexSearcher.LeafSlice[] slices = searcher.slicesInternal(leaves, -1);
+        IndexSearcher.LeafSlice[] slices = searcher.slicesInternal(
+            leaves,
+            SearchBootstrapSettings.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_DEFAULT_VALUE
+        );
         int expectedSliceCount = 2;
         // 2 slices will be created since max segment per slice of 5 will be reached
         assertEquals(expectedSliceCount, slices.length);

--- a/server/src/test/java/org/opensearch/search/internal/IndexReaderUtils.java
+++ b/server/src/test/java/org/opensearch/search/internal/IndexReaderUtils.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.internal;
+
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.store.Directory;
+
+import java.util.List;
+
+import static org.apache.lucene.tests.util.LuceneTestCase.newDirectory;
+
+public class IndexReaderUtils {
+
+    /**
+     * Utility to create leafCount number of {@link LeafReaderContext}
+     * @param leafCount count of leaves to create
+     * @return created leaves
+     */
+    public static List<LeafReaderContext> getLeaves(int leafCount) throws Exception {
+        final Directory directory = newDirectory();
+        IndexWriter iw = new IndexWriter(directory, new IndexWriterConfig(new StandardAnalyzer()).setMergePolicy(NoMergePolicy.INSTANCE));
+        for (int i = 0; i < leafCount; ++i) {
+            Document document = new Document();
+            final String fieldValue = "value" + i;
+            document.add(new StringField("field1", fieldValue, Field.Store.NO));
+            document.add(new StringField("field2", fieldValue, Field.Store.NO));
+            iw.addDocument(document);
+            iw.commit();
+        }
+        iw.close();
+        DirectoryReader directoryReader = DirectoryReader.open(directory);
+        List<LeafReaderContext> leaves = directoryReader.leaves();
+        directoryReader.close();
+        directory.close();
+        return leaves;
+    }
+}

--- a/server/src/test/java/org/opensearch/search/internal/MaxTargetSliceSupplierTests.java
+++ b/server/src/test/java/org/opensearch/search/internal/MaxTargetSliceSupplierTests.java
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.internal;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.IndexSearcher;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.opensearch.search.internal.IndexReaderUtils.getLeaves;
+
+public class MaxTargetSliceSupplierTests extends OpenSearchTestCase {
+
+    public void testSliceCountGreaterThanLeafCount() throws Exception {
+        int expectedSliceCount = 2;
+        IndexSearcher.LeafSlice[] slices = MaxTargetSliceSupplier.getSlices(getLeaves(expectedSliceCount), 5);
+        // verify slice count is same as leaf count
+        assertEquals(expectedSliceCount, slices.length);
+        for (int i = 0; i < expectedSliceCount; ++i) {
+            assertEquals(1, slices[i].leaves.length);
+        }
+    }
+
+    public void testNegativeSliceCount() {
+        assertThrows(IllegalArgumentException.class, () -> MaxTargetSliceSupplier.getSlices(new ArrayList<>(), randomIntBetween(-3, 0)));
+    }
+
+    public void testSingleSliceWithMultipleLeaves() throws Exception {
+        int leafCount = randomIntBetween(1, 10);
+        IndexSearcher.LeafSlice[] slices = MaxTargetSliceSupplier.getSlices(getLeaves(leafCount), 1);
+        assertEquals(1, slices.length);
+        assertEquals(leafCount, slices[0].leaves.length);
+    }
+
+    public void testSliceCountLessThanLeafCount() throws Exception {
+        int leafCount = 12;
+        List<LeafReaderContext> leaves = getLeaves(leafCount);
+
+        // Case 1: test with equal number of leaves per slice
+        int expectedSliceCount = 3;
+        IndexSearcher.LeafSlice[] slices = MaxTargetSliceSupplier.getSlices(leaves, expectedSliceCount);
+        int expectedLeavesPerSlice = leafCount / expectedSliceCount;
+
+        assertEquals(expectedSliceCount, slices.length);
+        for (int i = 0; i < expectedSliceCount; ++i) {
+            assertEquals(expectedLeavesPerSlice, slices[i].leaves.length);
+        }
+
+        // Case 2: test with first 2 slice more leaves than others
+        expectedSliceCount = 5;
+        slices = MaxTargetSliceSupplier.getSlices(leaves, expectedSliceCount);
+        int expectedLeavesInFirst2Slice = 3;
+        int expectedLeavesInOtherSlice = 2;
+
+        assertEquals(expectedSliceCount, slices.length);
+        for (int i = 0; i < expectedSliceCount; ++i) {
+            if (i < 2) {
+                assertEquals(expectedLeavesInFirst2Slice, slices[i].leaves.length);
+            } else {
+                assertEquals(expectedLeavesInOtherSlice, slices[i].leaves.length);
+            }
+        }
+    }
+
+    public void testEmptyLeaves() {
+        IndexSearcher.LeafSlice[] slices = MaxTargetSliceSupplier.getSlices(new ArrayList<>(), 2);
+        assertEquals(0, slices.length);
+    }
+}

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
@@ -152,6 +152,7 @@ import org.opensearch.rest.action.RestCancellableNodeClient;
 import org.opensearch.script.MockScriptService;
 import org.opensearch.script.ScriptMetadata;
 import org.opensearch.search.MockSearchService;
+import org.opensearch.search.SearchBootstrapSettings;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchService;
 import org.opensearch.test.client.RandomizingClient;
@@ -1941,7 +1942,11 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
             .put(SearchService.LOW_LEVEL_CANCELLATION_SETTING.getKey(), randomBoolean())
             .putList(DISCOVERY_SEED_HOSTS_SETTING.getKey()) // empty list disables a port scan for other nodes
             .putList(DISCOVERY_SEED_PROVIDERS_SETTING.getKey(), "file")
-            .put(featureFlagSettings());
+            .put(featureFlagSettings())
+            // By default, for tests we will put the target slice count of 2. This will increase the probability of having multiple slices
+            // when tests are run with concurrent segment search enabled. When concurrent segment search is disabled then it's a no-op as
+            // slices are not used
+            .put(SearchBootstrapSettings.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_KEY, 2);
         if (rarely()) {
             // Sometimes adjust the minimum search thread pool size, causing
             // QueueResizingOpenSearchThreadPoolExecutor to be used instead of a regular

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
@@ -1926,6 +1926,7 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
      * In other words subclasses must ensure this method is idempotent.
      */
     protected Settings nodeSettings(int nodeOrdinal) {
+        final Settings featureFlagSettings = featureFlagSettings();
         Settings.Builder builder = Settings.builder()
             // Default the watermarks to absurdly low to prevent the tests
             // from failing on nodes without enough disk space
@@ -1941,17 +1942,19 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
             // randomly enable low-level search cancellation to make sure it does not alter results
             .put(SearchService.LOW_LEVEL_CANCELLATION_SETTING.getKey(), randomBoolean())
             .putList(DISCOVERY_SEED_HOSTS_SETTING.getKey()) // empty list disables a port scan for other nodes
-            .putList(DISCOVERY_SEED_PROVIDERS_SETTING.getKey(), "file")
-            .put(featureFlagSettings())
-            // By default, for tests we will put the target slice count of 2. This will increase the probability of having multiple slices
-            // when tests are run with concurrent segment search enabled. When concurrent segment search is disabled then it's a no-op as
-            // slices are not used
-            .put(SearchBootstrapSettings.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_KEY, 2);
+            .putList(DISCOVERY_SEED_PROVIDERS_SETTING.getKey(), "file");
+        // add all the featureFlagSettings set by the test
+        builder.put(featureFlagSettings);
         if (rarely()) {
             // Sometimes adjust the minimum search thread pool size, causing
             // QueueResizingOpenSearchThreadPoolExecutor to be used instead of a regular
             // fixed thread pool
             builder.put("thread_pool.search.min_queue_size", 100);
+        }
+        if (FeatureFlags.CONCURRENT_SEGMENT_SEARCH_SETTING.get(featureFlagSettings)) {
+            // By default, for tests we will put the target slice count of 2. This will increase the probability of having multiple slices
+            // when tests are run with concurrent segment search enabled
+            builder.put(SearchBootstrapSettings.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_KEY, 2);
         }
         return builder.build();
     }

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchSingleNodeTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchSingleNodeTestCase.java
@@ -212,10 +212,7 @@ public abstract class OpenSearchSingleNodeTestCase extends OpenSearchTestCase {
 
     /** Additional settings to add when creating the node. Also allows overriding the default settings. */
     protected Settings nodeSettings() {
-        // By default, for tests we will put the target slice count of 2. This will increase the probability of having multiple slices
-        // when tests are run with concurrent segment search enabled. When concurrent segment search is disabled then it's a no-op as
-        // slices are not used
-        return Settings.builder().put(SearchBootstrapSettings.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_KEY, 2).build();
+        return Settings.EMPTY;
     }
 
     /** True if a dummy http transport should be used, or false if the real http transport should be used. */
@@ -251,6 +248,10 @@ public abstract class OpenSearchSingleNodeTestCase extends OpenSearchTestCase {
             .putList(INITIAL_CLUSTER_MANAGER_NODES_SETTING.getKey(), nodeName)
             .put(FeatureFlags.TELEMETRY_SETTING.getKey(), true)
             .put(TelemetrySettings.TRACER_ENABLED_SETTING.getKey(), true)
+            // By default, for tests we will put the target slice count of 2. This will increase the probability of having multiple slices
+            // when tests are run with concurrent segment search enabled. When concurrent segment search is disabled then it's a no-op as
+            // slices are not used
+            .put(SearchBootstrapSettings.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_KEY, 2)
             .put(nodeSettings()) // allow test cases to provide their own settings or override these
             .build();
 

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchSingleNodeTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchSingleNodeTestCase.java
@@ -224,7 +224,7 @@ public abstract class OpenSearchSingleNodeTestCase extends OpenSearchTestCase {
         final Path tempDir = createTempDir();
         final String nodeName = nodeSettings().get(Node.NODE_NAME_SETTING.getKey(), "node_s_0");
 
-        Settings settings = Settings.builder()
+        Settings.Builder settingsBuilder = Settings.builder()
             .put(ClusterName.CLUSTER_NAME_SETTING.getKey(), InternalTestCluster.clusterName("single-node-cluster", random().nextLong()))
             .put(Environment.PATH_HOME_SETTING.getKey(), tempDir)
             .put(Environment.PATH_REPO_SETTING.getKey(), tempDir.resolve("repo"))
@@ -247,13 +247,16 @@ public abstract class OpenSearchSingleNodeTestCase extends OpenSearchTestCase {
             .putList(DISCOVERY_SEED_HOSTS_SETTING.getKey()) // empty list disables a port scan for other nodes
             .putList(INITIAL_CLUSTER_MANAGER_NODES_SETTING.getKey(), nodeName)
             .put(FeatureFlags.TELEMETRY_SETTING.getKey(), true)
-            .put(TelemetrySettings.TRACER_ENABLED_SETTING.getKey(), true)
-            // By default, for tests we will put the target slice count of 2. This will increase the probability of having multiple slices
-            // when tests are run with concurrent segment search enabled. When concurrent segment search is disabled then it's a no-op as
-            // slices are not used
-            .put(SearchBootstrapSettings.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_KEY, 2)
-            .put(nodeSettings()) // allow test cases to provide their own settings or override these
-            .build();
+            .put(TelemetrySettings.TRACER_ENABLED_SETTING.getKey(), true);
+        // allow test cases to provide their own settings or override these
+        settingsBuilder.put(nodeSettings());
+
+        if (Boolean.parseBoolean(settingsBuilder.get(FeatureFlags.CONCURRENT_SEGMENT_SEARCH))
+            && (settingsBuilder.get(SearchBootstrapSettings.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_KEY) == null)) {
+            // By default, for tests we will put the target slice count of 2 if not explicitly set. This will increase the probability of
+            // having multiple slices when tests are run with concurrent segment search enabled
+            settingsBuilder.put(SearchBootstrapSettings.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_KEY, 2);
+        }
 
         Collection<Class<? extends Plugin>> plugins = getPlugins();
         if (plugins.contains(getTestTransportPlugin()) == false) {
@@ -265,7 +268,7 @@ public abstract class OpenSearchSingleNodeTestCase extends OpenSearchTestCase {
         }
         plugins.add(MockScriptService.TestPlugin.class);
         plugins.add(MockTelemetryPlugin.class);
-        Node node = new MockNode(settings, plugins, forbidPrivateIndexSettings());
+        Node node = new MockNode(settingsBuilder.build(), plugins, forbidPrivateIndexSettings());
         try {
             node.start();
         } catch (NodeValidationException e) {

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchSingleNodeTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchSingleNodeTestCase.java
@@ -66,6 +66,7 @@ import org.opensearch.node.Node;
 import org.opensearch.node.NodeValidationException;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.script.MockScriptService;
+import org.opensearch.search.SearchBootstrapSettings;
 import org.opensearch.search.internal.SearchContext;
 import org.opensearch.telemetry.TelemetrySettings;
 import org.opensearch.test.telemetry.MockTelemetryPlugin;
@@ -211,7 +212,10 @@ public abstract class OpenSearchSingleNodeTestCase extends OpenSearchTestCase {
 
     /** Additional settings to add when creating the node. Also allows overriding the default settings. */
     protected Settings nodeSettings() {
-        return Settings.EMPTY;
+        // By default, for tests we will put the target slice count of 2. This will increase the probability of having multiple slices
+        // when tests are run with concurrent segment search enabled. When concurrent segment search is disabled then it's a no-op as
+        // slices are not used
+        return Settings.builder().put(SearchBootstrapSettings.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_KEY, 2).build();
     }
 
     /** True if a dummy http transport should be used, or false if the real http transport should be used. */


### PR DESCRIPTION
### Description
Introduces a static setting in 2.x to control slice computation using lucene default or max target slice mechanism for concurrent segment search. This is replacement of PR https://github.com/opensearch-project/OpenSearch/pull/8847

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/7358

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
