### PR TITLE
[Backport 2.x] Replace the deprecated IndexReader APIs with new storedFields() & termVectors()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Change InternalSignificantTerms to sum shard-level superset counts only in final reduce ([#8735](https://github.com/opensearch-project/OpenSearch/pull/8735))
 - Exclude 'benchmarks' from codecov report ([#8805](https://github.com/opensearch-project/OpenSearch/pull/8805))
 - Create separate SourceLookup instance per segment slice in SignificantTextAggregatorFactory ([#8807](https://github.com/opensearch-project/OpenSearch/pull/8807))
+- Replace the deprecated IndexReader APIs with new storedFields() & termVectors() ([#7792](https://github.com/opensearch-project/OpenSearch/pull/7792))
 
 ### Deprecated
 

--- a/server/src/main/java/org/opensearch/common/lucene/search/XMoreLikeThis.java
+++ b/server/src/main/java/org/opensearch/common/lucene/search/XMoreLikeThis.java
@@ -56,7 +56,9 @@ import org.apache.lucene.index.Fields;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.PostingsEnum;
+import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.index.TermVectors;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.search.BooleanClause;
@@ -808,8 +810,10 @@ public final class XMoreLikeThis {
      */
     private PriorityQueue<ScoreTerm> retrieveTerms(int docNum) throws IOException {
         Map<String, Int> termFreqMap = new HashMap<>();
+        final TermVectors termVectors = ir.termVectors();
+        final StoredFields storedFields = ir.storedFields();
         for (String fieldName : fieldNames) {
-            final Fields vectors = ir.getTermVectors(docNum);
+            final Fields vectors = termVectors.get(docNum);
             final Terms vector;
             if (vectors != null) {
                 vector = vectors.terms(fieldName);
@@ -819,7 +823,7 @@ public final class XMoreLikeThis {
 
             // field does not store term vector info
             if (vector == null) {
-                Document d = ir.document(docNum);
+                Document d = storedFields.document(docNum);
                 IndexableField fields[] = d.getFields(fieldName);
                 for (IndexableField field : fields) {
                     final String stringValue = field.stringValue();

--- a/server/src/main/java/org/opensearch/gateway/PersistedClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/PersistedClusterStateService.java
@@ -45,6 +45,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SerialMergeScheduler;
+import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
@@ -507,12 +508,11 @@ public class PersistedClusterStateService {
                 final Bits liveDocs = leafReaderContext.reader().getLiveDocs();
                 final IntPredicate isLiveDoc = liveDocs == null ? i -> true : liveDocs::get;
                 final DocIdSetIterator docIdSetIterator = scorer.iterator();
+                final StoredFields storedFields = leafReaderContext.reader().storedFields();
                 while (docIdSetIterator.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
                     if (isLiveDoc.test(docIdSetIterator.docID())) {
                         logger.trace("processing doc {}", docIdSetIterator.docID());
-                        bytesRefConsumer.accept(
-                            leafReaderContext.reader().document(docIdSetIterator.docID()).getBinaryValue(DATA_FIELD_NAME)
-                        );
+                        bytesRefConsumer.accept(storedFields.document(docIdSetIterator.docID()).getBinaryValue(DATA_FIELD_NAME));
                     }
                 }
             }

--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -50,6 +50,7 @@ import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.index.ShuffleForcedMergePolicy;
 import org.apache.lucene.index.SoftDeletesRetentionMergePolicy;
 import org.apache.lucene.index.StandardDirectoryReader;
+import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
@@ -3053,6 +3054,7 @@ public class InternalEngine extends Engine {
             final CombinedDocValues dv = new CombinedDocValues(leaf.reader());
             final IdOnlyFieldVisitor idFieldVisitor = new IdOnlyFieldVisitor();
             final DocIdSetIterator iterator = scorer.iterator();
+            final StoredFields storedFields = leaf.reader().storedFields();
             int docId;
             while ((docId = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
                 final long primaryTerm = dv.docPrimaryTerm(docId);
@@ -3060,7 +3062,7 @@ public class InternalEngine extends Engine {
                 localCheckpointTracker.markSeqNoAsProcessed(seqNo);
                 localCheckpointTracker.markSeqNoAsPersisted(seqNo);
                 idFieldVisitor.reset();
-                leaf.reader().document(docId, idFieldVisitor);
+                storedFields.document(docId, idFieldVisitor);
                 if (idFieldVisitor.getId() == null) {
                     assert dv.isTombstone(docId);
                     continue;

--- a/server/src/main/java/org/opensearch/index/engine/LuceneChangesSnapshot.java
+++ b/server/src/main/java/org/opensearch/index/engine/LuceneChangesSnapshot.java
@@ -289,7 +289,7 @@ final class LuceneChangesSnapshot implements Translog.Snapshot {
             ? SourceFieldMapper.RECOVERY_SOURCE_NAME
             : SourceFieldMapper.NAME;
         final FieldsVisitor fields = new FieldsVisitor(true, sourceField);
-        leaf.reader().document(segmentDocID, fields);
+        leaf.reader().storedFields().document(segmentDocID, fields);
 
         final Translog.Operation op;
         final boolean isTombstone = parallelArray.isTombStone[docIndex];

--- a/server/src/main/java/org/opensearch/index/engine/TranslogLeafReader.java
+++ b/server/src/main/java/org/opensearch/index/engine/TranslogLeafReader.java
@@ -221,28 +221,33 @@ public final class TranslogLeafReader extends LeafReader {
 
     @Override
     public void document(int docID, StoredFieldVisitor visitor) throws IOException {
-        if (docID != 0) {
-            throw new IllegalArgumentException("no such doc ID " + docID);
-        }
-        if (visitor.needsField(FAKE_SOURCE_FIELD) == StoredFieldVisitor.Status.YES) {
-            assert operation.source().toBytesRef().offset == 0;
-            assert operation.source().toBytesRef().length == operation.source().toBytesRef().bytes.length;
-            visitor.binaryField(FAKE_SOURCE_FIELD, operation.source().toBytesRef().bytes);
-        }
-        if (operation.routing() != null && visitor.needsField(FAKE_ROUTING_FIELD) == StoredFieldVisitor.Status.YES) {
-            visitor.stringField(FAKE_ROUTING_FIELD, operation.routing());
-        }
-        if (visitor.needsField(FAKE_ID_FIELD) == StoredFieldVisitor.Status.YES) {
-            BytesRef bytesRef = Uid.encodeId(operation.id());
-            final byte[] id = new byte[bytesRef.length];
-            System.arraycopy(bytesRef.bytes, bytesRef.offset, id, 0, bytesRef.length);
-            visitor.binaryField(FAKE_ID_FIELD, id);
-        }
+        storedFields().document(docID, visitor);
     }
 
     @Override
     public StoredFields storedFields() throws IOException {
-        throw new UnsupportedOperationException();
+        return new StoredFields() {
+            @Override
+            public void document(int docID, StoredFieldVisitor visitor) throws IOException {
+                if (docID != 0) {
+                    throw new IllegalArgumentException("no such doc ID " + docID);
+                }
+                if (visitor.needsField(FAKE_SOURCE_FIELD) == StoredFieldVisitor.Status.YES) {
+                    assert operation.source().toBytesRef().offset == 0;
+                    assert operation.source().toBytesRef().length == operation.source().toBytesRef().bytes.length;
+                    visitor.binaryField(FAKE_SOURCE_FIELD, operation.source().toBytesRef().bytes);
+                }
+                if (operation.routing() != null && visitor.needsField(FAKE_ROUTING_FIELD) == StoredFieldVisitor.Status.YES) {
+                    visitor.stringField(FAKE_ROUTING_FIELD, operation.routing());
+                }
+                if (visitor.needsField(FAKE_ID_FIELD) == StoredFieldVisitor.Status.YES) {
+                    BytesRef bytesRef = Uid.encodeId(operation.id());
+                    final byte[] id = new byte[bytesRef.length];
+                    System.arraycopy(bytesRef.bytes, bytesRef.offset, id, 0, bytesRef.length);
+                    visitor.binaryField(FAKE_ID_FIELD, id);
+                }
+            }
+        };
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/get/ShardGetService.java
+++ b/server/src/main/java/org/opensearch/index/get/ShardGetService.java
@@ -276,7 +276,7 @@ public final class ShardGetService extends AbstractIndexShardComponent {
         );
         if (fieldVisitor != null) {
             try {
-                docIdAndVersion.reader.document(docIdAndVersion.docId, fieldVisitor);
+                docIdAndVersion.reader.storedFields().document(docIdAndVersion.docId, fieldVisitor);
             } catch (IOException e) {
                 throw new OpenSearchException("Failed to get id [" + id + "]", e);
             }

--- a/server/src/main/java/org/opensearch/index/shard/ShardSplittingQuery.java
+++ b/server/src/main/java/org/opensearch/index/shard/ShardSplittingQuery.java
@@ -286,7 +286,7 @@ final class ShardSplittingQuery extends Query {
         boolean matches(int doc) throws IOException {
             routing = id = null;
             leftToVisit = 2;
-            leafReader.document(doc, this);
+            leafReader.storedFields().document(doc, this);
             assert id != null : "docID must not be null - we might have hit a nested document";
             int targetShardId = OperationRouting.generateShardId(indexMetadata, id, routing);
             return targetShardId != shardId;

--- a/server/src/main/java/org/opensearch/index/termvectors/TermVectorsService.java
+++ b/server/src/main/java/org/opensearch/index/termvectors/TermVectorsService.java
@@ -39,6 +39,7 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.MultiTerms;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.index.TermVectors;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.memory.MemoryIndex;
 import org.opensearch.OpenSearchException;
@@ -127,7 +128,8 @@ public class TermVectorsService {
             /* or from an existing document */
             else if (docIdAndVersion != null) {
                 // fields with stored term vectors
-                termVectorsByField = docIdAndVersion.reader.getTermVectors(docIdAndVersion.docId);
+                TermVectors termVectors = docIdAndVersion.reader.termVectors();
+                termVectorsByField = termVectors.get(docIdAndVersion.docId);
                 Set<String> selectedFields = request.selectedFields();
                 // generate tvs for fields where analyzer is overridden
                 if (selectedFields == null && request.perFieldAnalyzer() != null) {
@@ -322,7 +324,8 @@ public class TermVectorsService {
             }
         }
         /* and read vectors from it */
-        return index.createSearcher().getIndexReader().getTermVectors(0);
+        TermVectors termVectors = index.createSearcher().getIndexReader().termVectors();
+        return termVectors.get(0);
     }
 
     private static Fields generateTermVectorsFromDoc(IndexShard indexShard, TermVectorsRequest request) throws IOException {

--- a/server/src/main/java/org/opensearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/opensearch/search/fetch/FetchPhase.java
@@ -159,7 +159,7 @@ public class FetchPhase {
                         SequentialStoredFieldsLeafReader lf = (SequentialStoredFieldsLeafReader) currentReaderContext.reader();
                         fieldReader = lf.getSequentialStoredFieldsReader()::document;
                     } else {
-                        fieldReader = currentReaderContext.reader()::document;
+                        fieldReader = currentReaderContext.reader().storedFields()::document;
                     }
                     for (FetchSubPhaseProcessor processor : processors) {
                         processor.setNextReader(currentReaderContext);

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/highlight/HighlightUtils.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/highlight/HighlightUtils.java
@@ -72,7 +72,7 @@ public final class HighlightUtils {
     ) throws IOException {
         if (forceSource == false && fieldType.isStored()) {
             CustomFieldsVisitor fieldVisitor = new CustomFieldsVisitor(singleton(fieldType.name()), false);
-            hitContext.reader().document(hitContext.docId(), fieldVisitor);
+            hitContext.reader().storedFields().document(hitContext.docId(), fieldVisitor);
             List<Object> textsToHighlight = fieldVisitor.fields().get(fieldType.name());
             return textsToHighlight != null ? textsToHighlight : Collections.emptyList();
         }

--- a/server/src/main/java/org/opensearch/search/lookup/LeafFieldsLookup.java
+++ b/server/src/main/java/org/opensearch/search/lookup/LeafFieldsLookup.java
@@ -153,7 +153,7 @@ public class LeafFieldsLookup implements Map {
             List<Object> values = new ArrayList<>(2);
             SingleFieldsVisitor visitor = new SingleFieldsVisitor(data.fieldType(), values);
             try {
-                reader.document(docId, visitor);
+                reader.storedFields().document(docId, visitor);
             } catch (IOException e) {
                 throw new OpenSearchParseException("failed to load field [{}]", e, name);
             }

--- a/server/src/main/java/org/opensearch/search/lookup/SourceLookup.java
+++ b/server/src/main/java/org/opensearch/search/lookup/SourceLookup.java
@@ -140,7 +140,7 @@ public class SourceLookup implements Map {
                     SequentialStoredFieldsLeafReader lf = (SequentialStoredFieldsLeafReader) context.reader();
                     fieldReader = lf.getSequentialStoredFieldsReader()::document;
                 } else {
-                    fieldReader = context.reader()::document;
+                    fieldReader = context.reader().storedFields()::document;
                 }
             } catch (IOException e) {
                 throw new UncheckedIOException(e);

--- a/server/src/test/java/org/opensearch/common/lucene/LuceneTests.java
+++ b/server/src/test/java/org/opensearch/common/lucene/LuceneTests.java
@@ -35,6 +35,7 @@ import org.apache.lucene.document.LatLonPoint;
 import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.IndexFormatTooOldException;
 import org.apache.lucene.index.StandardDirectoryReader;
+import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.analysis.core.KeywordAnalyzer;
 import org.apache.lucene.document.Document;
@@ -615,12 +616,13 @@ public class LuceneTests extends OpenSearchTestCase {
         }
         try (DirectoryReader unwrapped = DirectoryReader.open(writer)) {
             DirectoryReader reader = Lucene.wrapAllDocsLive(unwrapped);
+            StoredFields storedFields = reader.storedFields();
             assertThat(reader.numDocs(), equalTo(liveDocs.size()));
             IndexSearcher searcher = new IndexSearcher(reader);
             Set<String> actualDocs = new HashSet<>();
             TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), Integer.MAX_VALUE);
             for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
-                actualDocs.add(reader.document(scoreDoc.doc).get("id"));
+                actualDocs.add(storedFields.document(scoreDoc.doc).get("id"));
             }
             assertThat(actualDocs, equalTo(liveDocs));
         }
@@ -659,13 +661,14 @@ public class LuceneTests extends OpenSearchTestCase {
         }
         try (DirectoryReader unwrapped = DirectoryReader.open(writer)) {
             DirectoryReader reader = Lucene.wrapAllDocsLive(unwrapped);
+            StoredFields storedFields = reader.storedFields();
             assertThat(reader.maxDoc(), equalTo(numDocs + abortedDocs));
             assertThat(reader.numDocs(), equalTo(liveDocs.size()));
             IndexSearcher searcher = new IndexSearcher(reader);
             List<String> actualDocs = new ArrayList<>();
             TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), Integer.MAX_VALUE);
             for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
-                actualDocs.add(reader.document(scoreDoc.doc).get("id"));
+                actualDocs.add(storedFields.document(scoreDoc.doc).get("id"));
             }
             assertThat(actualDocs, equalTo(liveDocs));
         }

--- a/server/src/test/java/org/opensearch/common/lucene/index/FreqTermsEnumTests.java
+++ b/server/src/test/java/org/opensearch/common/lucene/index/FreqTermsEnumTests.java
@@ -43,6 +43,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.TermInSetQuery;
 import org.apache.lucene.search.Query;
@@ -149,9 +150,10 @@ public class FreqTermsEnumTests extends OpenSearchTestCase {
 
         // now go over each doc, build the relevant references and filter
         reader = DirectoryReader.open(iw);
+        StoredFields storedFields = reader.storedFields();
         List<BytesRef> filterTerms = new ArrayList<>();
         for (int docId = 0; docId < reader.maxDoc(); docId++) {
-            Document doc = reader.document(docId);
+            Document doc = storedFields.document(docId);
             addFreqs(doc, referenceAll);
             if (!deletedIds.contains(doc.getField("id").stringValue())) {
                 addFreqs(doc, referenceNotDeleted);

--- a/server/src/test/java/org/opensearch/index/engine/RecoverySourcePruneMergePolicyTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/RecoverySourcePruneMergePolicyTests.java
@@ -49,6 +49,7 @@ import org.apache.lucene.index.SegmentCommitInfo;
 import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.index.ShuffleForcedMergePolicy;
 import org.apache.lucene.index.StandardDirectoryReader;
+import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.MatchAllDocsQuery;
@@ -89,8 +90,9 @@ public class RecoverySourcePruneMergePolicyTests extends OpenSearchTestCase {
                 writer.forceMerge(1);
                 writer.commit();
                 try (DirectoryReader reader = DirectoryReader.open(writer)) {
+                    StoredFields storedFields = reader.storedFields();
                     for (int i = 0; i < reader.maxDoc(); i++) {
-                        Document document = reader.document(i);
+                        Document document = storedFields.document(i);
                         assertEquals(1, document.getFields().size());
                         assertEquals("source", document.getFields().get(0).name());
                     }
@@ -157,11 +159,12 @@ public class RecoverySourcePruneMergePolicyTests extends OpenSearchTestCase {
                 writer.forceMerge(1);
                 writer.commit();
                 try (DirectoryReader reader = DirectoryReader.open(writer)) {
+                    StoredFields storedFields = reader.storedFields();
                     assertEquals(1, reader.leaves().size());
                     NumericDocValues extra_source = reader.leaves().get(0).reader().getNumericDocValues("extra_source");
                     assertNotNull(extra_source);
                     for (int i = 0; i < reader.maxDoc(); i++) {
-                        Document document = reader.document(i);
+                        Document document = storedFields.document(i);
                         Set<String> collect = document.getFields().stream().map(IndexableField::name).collect(Collectors.toSet());
                         assertTrue(collect.contains("source"));
                         assertTrue(collect.contains("even"));
@@ -197,11 +200,12 @@ public class RecoverySourcePruneMergePolicyTests extends OpenSearchTestCase {
                 writer.forceMerge(1);
                 writer.commit();
                 try (DirectoryReader reader = DirectoryReader.open(writer)) {
+                    StoredFields storedFields = reader.storedFields();
                     assertEquals(1, reader.leaves().size());
                     NumericDocValues extra_source = reader.leaves().get(0).reader().getNumericDocValues("extra_source");
                     assertNotNull(extra_source);
                     for (int i = 0; i < reader.maxDoc(); i++) {
-                        Document document = reader.document(i);
+                        Document document = storedFields.document(i);
                         Set<String> collect = document.getFields().stream().map(IndexableField::name).collect(Collectors.toSet());
                         assertTrue(collect.contains("source"));
                         assertTrue(collect.contains("extra_source"));

--- a/server/src/test/java/org/opensearch/index/query/MoreLikeThisQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/MoreLikeThisQueryBuilderTests.java
@@ -271,7 +271,7 @@ public class MoreLikeThisQueryBuilderTests extends AbstractQueryTestCase<MoreLik
         for (String fieldName : fieldNames) {
             index.addField(fieldName, text, new WhitespaceAnalyzer());
         }
-        return index.createSearcher().getIndexReader().getTermVectors(0);
+        return index.createSearcher().getIndexReader().termVectors().get(0);
     }
 
     @Override

--- a/server/src/test/java/org/opensearch/index/shard/RefreshListenersTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RefreshListenersTests.java
@@ -36,6 +36,7 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.store.Directory;
@@ -369,9 +370,8 @@ public class RefreshListenersTests extends OpenSearchTestCase {
                         try (Engine.GetResult getResult = engine.get(get, engine::acquireSearcher)) {
                             assertTrue("document not found", getResult.exists());
                             assertEquals(iteration, getResult.version());
-                            org.apache.lucene.document.Document document = getResult.docIdAndVersion().reader.document(
-                                getResult.docIdAndVersion().docId
-                            );
+                            StoredFields storedFields = getResult.docIdAndVersion().reader.storedFields();
+                            org.apache.lucene.document.Document document = storedFields.document(getResult.docIdAndVersion().docId);
                             assertThat(document.getValues("test"), arrayContaining(testFieldValue));
                         }
                     } catch (Exception t) {

--- a/server/src/test/java/org/opensearch/index/shard/ShardSplittingQueryTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/ShardSplittingQueryTests.java
@@ -326,7 +326,7 @@ public class ShardSplittingQueryTests extends OpenSearchTestCase {
                         }
                         assertEquals(shard_id.docID(), doc);
                         long shardID = shard_id.nextValue();
-                        BytesRef id = reader.document(doc).getBinaryValue("_id");
+                        BytesRef id = reader.storedFields().document(doc).getBinaryValue("_id");
                         String actualId = Uid.decodeId(id.bytes, id.offset, id.length);
                         assertNotEquals(ctx.reader() + " docID: " + doc + " actualID: " + actualId, shardID, targetShardId);
                     }

--- a/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
@@ -353,7 +353,7 @@ public class IndicesRequestCacheTests extends OpenSearchTestCase {
                 IndexSearcher searcher = new IndexSearcher(reader);
                 TopDocs topDocs = searcher.search(new TermQuery(new Term("id", Integer.toString(id))), 1);
                 assertEquals(1, topDocs.totalHits.value);
-                Document document = reader.document(topDocs.scoreDocs[0].doc);
+                Document document = reader.storedFields().document(topDocs.scoreDocs[0].doc);
                 out.writeString(document.get("value"));
                 loadedFromCache = false;
                 return out.bytes();

--- a/server/src/test/java/org/opensearch/lucene/queries/BlendedTermQueryTests.java
+++ b/server/src/test/java/org/opensearch/lucene/queries/BlendedTermQueryTests.java
@@ -112,7 +112,7 @@ public class BlendedTermQueryTests extends OpenSearchTestCase {
             query.add(BlendedTermQuery.dismaxBlendedQuery(toTerms(fields, "generator"), 0.1f), BooleanClause.Occur.SHOULD);
             TopDocs search = searcher.search(query.build(), 10);
             ScoreDoc[] scoreDocs = search.scoreDocs;
-            assertEquals(Integer.toString(0), reader.document(scoreDocs[0].doc).getField("id").stringValue());
+            assertEquals(Integer.toString(0), reader.storedFields().document(scoreDocs[0].doc).getField("id").stringValue());
         }
         {
             BooleanQuery.Builder query = new BooleanQuery.Builder();
@@ -134,7 +134,7 @@ public class BlendedTermQueryTests extends OpenSearchTestCase {
             query.add(gen, BooleanClause.Occur.SHOULD);
             TopDocs search = searcher.search(query.build(), 4);
             ScoreDoc[] scoreDocs = search.scoreDocs;
-            assertEquals(Integer.toString(1), reader.document(scoreDocs[0].doc).getField("id").stringValue());
+            assertEquals(Integer.toString(1), reader.storedFields().document(scoreDocs[0].doc).getField("id").stringValue());
 
         }
         {
@@ -269,7 +269,7 @@ public class BlendedTermQueryTests extends OpenSearchTestCase {
             Query query = BlendedTermQuery.dismaxBlendedQuery(toTerms(fields, "foo"), 0.1f);
             TopDocs search = searcher.search(query, 10);
             ScoreDoc[] scoreDocs = search.scoreDocs;
-            assertEquals(Integer.toString(0), reader.document(scoreDocs[0].doc).getField("id").stringValue());
+            assertEquals(Integer.toString(0), reader.storedFields().document(scoreDocs[0].doc).getField("id").stringValue());
         }
         reader.close();
         w.close();

--- a/server/src/test/java/org/opensearch/search/lookup/LeafFieldsLookupTests.java
+++ b/server/src/test/java/org/opensearch/search/lookup/LeafFieldsLookupTests.java
@@ -36,6 +36,7 @@ import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.StoredFieldVisitor;
+import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.opensearch.index.mapper.MappedFieldType;
@@ -43,11 +44,11 @@ import org.opensearch.index.mapper.MapperService;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.Before;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -88,12 +89,12 @@ public class LeafFieldsLookupTests extends OpenSearchTestCase {
         );
 
         LeafReader leafReader = mock(LeafReader.class);
-        doAnswer(invocation -> {
-            Object[] args = invocation.getArguments();
-            StoredFieldVisitor visitor = (StoredFieldVisitor) args[1];
-            visitor.doubleField(mockFieldInfo, 2.718);
-            return null;
-        }).when(leafReader).document(anyInt(), any(StoredFieldVisitor.class));
+        doAnswer(invocation -> new StoredFields() {
+            @Override
+            public void document(int docID, StoredFieldVisitor visitor) throws IOException {
+                visitor.doubleField(mockFieldInfo, 2.718);
+            }
+        }).when(leafReader).storedFields();
 
         fieldsLookup = new LeafFieldsLookup(mapperService, leafReader);
     }

--- a/server/src/test/java/org/opensearch/search/slice/DocValuesSliceQueryTests.java
+++ b/server/src/test/java/org/opensearch/search/slice/DocValuesSliceQueryTests.java
@@ -110,7 +110,7 @@ public class DocValuesSliceQueryTests extends OpenSearchTestCase {
 
                         @Override
                         public void collect(int doc) throws IOException {
-                            Document d = context.reader().document(doc, Collections.singleton("uuid"));
+                            Document d = context.reader().storedFields().document(doc, Collections.singleton("uuid"));
                             String uuid = d.get("uuid");
                             assertThat(keys.contains(uuid), equalTo(true));
                             keys.remove(uuid);

--- a/server/src/test/java/org/opensearch/search/slice/TermsSliceQueryTests.java
+++ b/server/src/test/java/org/opensearch/search/slice/TermsSliceQueryTests.java
@@ -120,7 +120,7 @@ public class TermsSliceQueryTests extends OpenSearchTestCase {
 
                         @Override
                         public void collect(int doc) throws IOException {
-                            Document d = context.reader().document(doc, Collections.singleton("uuid"));
+                            Document d = context.reader().storedFields().document(doc, Collections.singleton("uuid"));
                             String uuid = d.get("uuid");
                             assertThat(keys.contains(uuid), equalTo(true));
                             keys.remove(uuid);

--- a/test/framework/src/main/java/org/opensearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/engine/EngineTestCase.java
@@ -49,6 +49,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.LiveIndexWriterConfig;
 import org.apache.lucene.index.MergePolicy;
 import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
@@ -1287,6 +1288,7 @@ public abstract class EngineTestCase extends OpenSearchTestCase {
                 NumericDocValues primaryTermDocValues = reader.getNumericDocValues(SeqNoFieldMapper.PRIMARY_TERM_NAME);
                 NumericDocValues versionDocValues = reader.getNumericDocValues(VersionFieldMapper.NAME);
                 Bits liveDocs = reader.getLiveDocs();
+                StoredFields storedFields = reader.storedFields();
                 for (int i = 0; i < reader.maxDoc(); i++) {
                     if (liveDocs == null || liveDocs.get(i)) {
                         if (primaryTermDocValues.advanceExact(i) == false) {
@@ -1294,7 +1296,7 @@ public abstract class EngineTestCase extends OpenSearchTestCase {
                             continue;
                         }
                         final long primaryTerm = primaryTermDocValues.longValue();
-                        Document doc = reader.document(i, Sets.newHashSet(IdFieldMapper.NAME, SourceFieldMapper.NAME));
+                        Document doc = storedFields.document(i, Sets.newHashSet(IdFieldMapper.NAME, SourceFieldMapper.NAME));
                         BytesRef binaryID = doc.getBinaryValue(IdFieldMapper.NAME);
                         String id = Uid.decodeId(Arrays.copyOfRange(binaryID.bytes, binaryID.offset, binaryID.offset + binaryID.length));
                         final BytesRef source = doc.getBinaryValue(SourceFieldMapper.NAME);
@@ -1448,6 +1450,7 @@ public abstract class EngineTestCase extends OpenSearchTestCase {
         for (LeafReaderContext leaf : wrappedReader.leaves()) {
             NumericDocValues primaryTermDocValues = leaf.reader().getNumericDocValues(SeqNoFieldMapper.PRIMARY_TERM_NAME);
             NumericDocValues seqNoDocValues = leaf.reader().getNumericDocValues(SeqNoFieldMapper.NAME);
+            final StoredFields storedFields = leaf.reader().storedFields();
             int docId;
             while ((docId = seqNoDocValues.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
                 assertTrue(seqNoDocValues.advanceExact(docId));
@@ -1456,7 +1459,7 @@ public abstract class EngineTestCase extends OpenSearchTestCase {
                 if (primaryTermDocValues.advanceExact(docId)) {
                     if (seqNos.add(seqNo) == false) {
                         final IdOnlyFieldVisitor idFieldVisitor = new IdOnlyFieldVisitor();
-                        leaf.reader().document(docId, idFieldVisitor);
+                        storedFields.document(docId, idFieldVisitor);
                         throw new AssertionError("found multiple documents for seq=" + seqNo + " id=" + idFieldVisitor.getId());
                     }
                 }


### PR DESCRIPTION
Backport https://github.com/opensearch-project/OpenSearch/commit/4fd6877eef7c9cb0b48268a7505506aeb33278a2 from [7792](https://github.com/opensearch-project/OpenSearch/pull/7792)