### PR TITLE
Fix SegmentReplicationIT.testReplicaHasDiffFilesThanPrimary for node-node replication

### DIFF
--- a/server/src/main/java/org/opensearch/indices/replication/OngoingSegmentReplications.java
+++ b/server/src/main/java/org/opensearch/indices/replication/OngoingSegmentReplications.java
@@ -149,6 +149,8 @@ class OngoingSegmentReplications {
             request.getTargetAllocationId(),
             newHandler
         );
+        // If we are already replicating to this allocation Id, cancel the old and replace with a new execution.
+        // This will clear the old handler & referenced copy state holding an incref'd indexCommit.
         if (existingHandler != null) {
             logger.warn("Override handler for allocation id {}", request.getTargetAllocationId());
             cancelHandlers(handler -> handler.getAllocationId().equals(request.getTargetAllocationId()), "cancel due to retry");


### PR DESCRIPTION
### Description
This test is now failing for node-node replication and is a bug. On the primary shard the prepareSegmentReplication method should cancel any ongoing replication if it is running and start a new sync.  This is incorrectly using Map.compute which will cancel the existing handler but not replace its entry in the allocationIdToHandlers map. As a result this can leave the copyState map with an entry which holds an index commit while the test is cleaning up.  The copyState is only cleared when a handler is cancelled directly or from a cluster state update.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/7643

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
