### PR TITLE
[Remote Store] Add metadata prefix to Remote Translog Metadata file

### DIFF
--- a/server/src/main/java/org/opensearch/index/translog/transfer/BlobStoreTransferService.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/BlobStoreTransferService.java
@@ -213,17 +213,18 @@ public class BlobStoreTransferService implements TransferService {
         });
     }
 
-    public void listAllInSortedOrder(Iterable<String> path, int limit, ActionListener<List<BlobMetadata>> listener) {
-        blobStore.blobContainer((BlobPath) path).listBlobsByPrefixInSortedOrder("", limit, LEXICOGRAPHIC, listener);
+    public void listAllInSortedOrder(Iterable<String> path, String filenamePrefix, int limit, ActionListener<List<BlobMetadata>> listener) {
+        blobStore.blobContainer((BlobPath) path).listBlobsByPrefixInSortedOrder(filenamePrefix, limit, LEXICOGRAPHIC, listener);
     }
 
     public void listAllInSortedOrderAsync(
         String threadpoolName,
         Iterable<String> path,
+        String filenamePrefix,
         int limit,
         ActionListener<List<BlobMetadata>> listener
     ) {
-        threadPool.executor(threadpoolName).execute(() -> { listAllInSortedOrder(path, limit, listener); });
+        threadPool.executor(threadpoolName).execute(() -> { listAllInSortedOrder(path, filenamePrefix, limit, listener); });
     }
 
 }

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TransferService.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TransferService.java
@@ -125,8 +125,14 @@ public interface TransferService {
      */
     InputStream downloadBlob(Iterable<String> path, String fileName) throws IOException;
 
-    void listAllInSortedOrder(Iterable<String> path, int limit, ActionListener<List<BlobMetadata>> listener);
+    void listAllInSortedOrder(Iterable<String> path, String filenamePrefix, int limit, ActionListener<List<BlobMetadata>> listener);
 
-    void listAllInSortedOrderAsync(String threadpoolName, Iterable<String> path, int limit, ActionListener<List<BlobMetadata>> listener);
+    void listAllInSortedOrderAsync(
+        String threadpoolName,
+        Iterable<String> path,
+        String filenamePrefix,
+        int limit,
+        ActionListener<List<BlobMetadata>> listener
+    );
 
 }

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
@@ -210,7 +210,12 @@ public class TranslogTransferManager {
         );
 
         try {
-            transferService.listAllInSortedOrder(remoteMetadataTransferPath, 1, latchedActionListener);
+            transferService.listAllInSortedOrder(
+                remoteMetadataTransferPath,
+                TranslogTransferMetadata.METADATA_PREFIX,
+                1,
+                latchedActionListener
+            );
             latch.await();
         } catch (InterruptedException e) {
             throw new IOException("Exception while reading/downloading metadafile", e);
@@ -367,6 +372,7 @@ public class TranslogTransferManager {
             transferService.listAllInSortedOrderAsync(
                 ThreadPool.Names.REMOTE_PURGE,
                 remoteMetadataTransferPath,
+                TranslogTransferMetadata.METADATA_PREFIX,
                 Integer.MAX_VALUE,
                 new ActionListener<>() {
                     @Override

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
@@ -36,6 +36,8 @@ public class TranslogTransferMetadata {
 
     public static final String METADATA_SEPARATOR = "__";
 
+    public static final String METADATA_PREFIX = "metadata";
+
     static final int BUFFER_SIZE = 4096;
 
     static final int CURRENT_VERSION = 1;
@@ -83,6 +85,7 @@ public class TranslogTransferMetadata {
         return String.join(
             METADATA_SEPARATOR,
             Arrays.asList(
+                METADATA_PREFIX,
                 RemoteStoreUtils.invertLong(primaryTerm),
                 RemoteStoreUtils.invertLong(generation),
                 RemoteStoreUtils.invertLong(createdAt),

--- a/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
@@ -44,6 +44,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
@@ -205,11 +206,12 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
             null
         );
         doAnswer(invocation -> {
-            LatchedActionListener<List<BlobMetadata>> latchedActionListener = invocation.getArgument(2);
+            LatchedActionListener<List<BlobMetadata>> latchedActionListener = invocation.getArgument(3);
             List<BlobMetadata> bmList = new LinkedList<>();
             latchedActionListener.onResponse(bmList);
             return null;
-        }).when(transferService).listAllInSortedOrder(any(BlobPath.class), anyInt(), any(ActionListener.class));
+        }).when(transferService)
+            .listAllInSortedOrder(any(BlobPath.class), eq(TranslogTransferMetadata.METADATA_PREFIX), anyInt(), any(ActionListener.class));
 
         assertNull(translogTransferManager.readMetadata());
     }
@@ -225,12 +227,13 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
         TranslogTransferMetadata tm = new TranslogTransferMetadata(1, 1, 1, 2);
         String mdFilename = tm.getFileName();
         doAnswer(invocation -> {
-            LatchedActionListener<List<BlobMetadata>> latchedActionListener = invocation.getArgument(2);
+            LatchedActionListener<List<BlobMetadata>> latchedActionListener = invocation.getArgument(3);
             List<BlobMetadata> bmList = new LinkedList<>();
             bmList.add(new PlainBlobMetadata(mdFilename, 1));
             latchedActionListener.onResponse(bmList);
             return null;
-        }).when(transferService).listAllInSortedOrder(any(BlobPath.class), anyInt(), any(ActionListener.class));
+        }).when(transferService)
+            .listAllInSortedOrder(any(BlobPath.class), eq(TranslogTransferMetadata.METADATA_PREFIX), anyInt(), any(ActionListener.class));
 
         TranslogTransferMetadata metadata = createTransferSnapshot().getTranslogTransferMetadata();
         when(transferService.downloadBlob(any(BlobPath.class), eq(mdFilename))).thenReturn(
@@ -252,12 +255,13 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
         String mdFilename = tm.getFileName();
 
         doAnswer(invocation -> {
-            LatchedActionListener<List<BlobMetadata>> latchedActionListener = invocation.getArgument(2);
+            LatchedActionListener<List<BlobMetadata>> latchedActionListener = invocation.getArgument(3);
             List<BlobMetadata> bmList = new LinkedList<>();
             bmList.add(new PlainBlobMetadata(mdFilename, 1));
             latchedActionListener.onResponse(bmList);
             return null;
-        }).when(transferService).listAllInSortedOrder(any(BlobPath.class), anyInt(), any(ActionListener.class));
+        }).when(transferService)
+            .listAllInSortedOrder(any(BlobPath.class), eq(TranslogTransferMetadata.METADATA_PREFIX), anyInt(), any(ActionListener.class));
 
         when(transferService.downloadBlob(any(BlobPath.class), eq(mdFilename))).thenThrow(new IOException("Something went wrong"));
 
@@ -283,10 +287,11 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
         );
 
         doAnswer(invocation -> {
-            LatchedActionListener<List<BlobMetadata>> latchedActionListener = invocation.getArgument(2);
+            LatchedActionListener<List<BlobMetadata>> latchedActionListener = invocation.getArgument(3);
             latchedActionListener.onFailure(new IOException("Issue while listing"));
             return null;
-        }).when(transferService).listAllInSortedOrder(any(BlobPath.class), anyInt(), any(ActionListener.class));
+        }).when(transferService)
+            .listAllInSortedOrder(any(BlobPath.class), eq(TranslogTransferMetadata.METADATA_PREFIX), anyInt(), any(ActionListener.class));
 
         when(transferService.downloadBlob(any(BlobPath.class), any(String.class))).thenThrow(new IOException("Something went wrong"));
 
@@ -416,7 +421,7 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
         String tm2 = new TranslogTransferMetadata(1, 2, 1, 2).getFileName();
         String tm3 = new TranslogTransferMetadata(2, 3, 1, 2).getFileName();
         doAnswer(invocation -> {
-            ActionListener<List<BlobMetadata>> actionListener = invocation.getArgument(3);
+            ActionListener<List<BlobMetadata>> actionListener = invocation.getArgument(4);
             List<BlobMetadata> bmList = new LinkedList<>();
             bmList.add(new PlainBlobMetadata(tm1, 1));
             bmList.add(new PlainBlobMetadata(tm2, 1));
@@ -424,12 +429,19 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
             actionListener.onResponse(bmList);
             return null;
         }).when(transferService)
-            .listAllInSortedOrderAsync(eq(ThreadPool.Names.REMOTE_PURGE), any(BlobPath.class), anyInt(), any(ActionListener.class));
+            .listAllInSortedOrderAsync(
+                eq(ThreadPool.Names.REMOTE_PURGE),
+                any(BlobPath.class),
+                anyString(),
+                anyInt(),
+                any(ActionListener.class)
+            );
         List<String> files = List.of(tm2, tm3);
         translogTransferManager.deleteStaleTranslogMetadataFilesAsync(() -> {
             verify(transferService).listAllInSortedOrderAsync(
                 eq(ThreadPool.Names.REMOTE_PURGE),
                 any(BlobPath.class),
+                eq(TranslogTransferMetadata.METADATA_PREFIX),
                 eq(Integer.MAX_VALUE),
                 any()
             );

--- a/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryTests.java
+++ b/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryTests.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.repositories.blobstore;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.opensearch.Version;
 import org.opensearch.action.admin.cluster.repositories.get.GetRepositoriesResponse;
 import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
@@ -91,7 +90,6 @@ import static org.opensearch.repositories.RepositoryDataTests.generateRandomRepo
 /**
  * Tests for the {@link BlobStoreRepository} and its subclasses.
  */
-@LuceneTestCase.SuppressFileSystems("ExtrasFS")
 public class BlobStoreRepositoryTests extends OpenSearchSingleNodeTestCase {
 
     static final String REPO_TYPE = "fsLike";


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

Added `metadata` prefix to remote translog metadata files. This serves two purpose 

1. Follow convention used in Remote Segment Store metadata .
2. Ignore the extra files which can generated by different OS. 

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/8834
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
