### PR TITLE
Configure test-retry plugin filter properly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -470,7 +470,7 @@ subprojects {
         maxFailures = 10
       }
       failOnPassedAfterRetry = false
-      classRetry {
+      filter {
         includeClasses.add("org.opensearch.action.admin.cluster.node.tasks.ResourceAwareTasksTests")
         includeClasses.add("org.opensearch.action.admin.cluster.tasks.PendingTasksBlocksIT")
         includeClasses.add("org.opensearch.action.admin.indices.create.CreateIndexIT")


### PR DESCRIPTION
The intent of #8825 was to retry only specified tests. The wrong parameter was configured though: ['filter' should be set][1], not 'classRetry'.

[1]: https://github.com/gradle/test-retry-gradle-plugin/blob/main/README.adoc#filtering

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
