### PR TITLE
[Refactor] MediaTypeParserRegistry to MediaTypeRegistry

### DIFF
--- a/client/rest-high-level/src/main/java/org/opensearch/client/indices/CreateIndexRequest.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/indices/CreateIndexRequest.java
@@ -47,7 +47,7 @@ import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.core.ParseField;
 import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.MediaType;
-import org.opensearch.core.xcontent.MediaTypeParserRegistry;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -187,7 +187,7 @@ public class CreateIndexRequest extends TimedRequest implements Validatable, ToX
      */
     public CreateIndexRequest mapping(Map<String, ?> source) {
         try {
-            XContentBuilder builder = XContentFactory.contentBuilder(MediaTypeParserRegistry.getDefaultMediaType());
+            XContentBuilder builder = XContentFactory.contentBuilder(MediaTypeRegistry.getDefaultMediaType());
             builder.map(source);
             return mapping(BytesReference.bytes(builder), builder.contentType());
         } catch (IOException e) {

--- a/client/rest-high-level/src/main/java/org/opensearch/client/indices/PutMappingRequest.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/indices/PutMappingRequest.java
@@ -40,7 +40,7 @@ import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.MediaType;
-import org.opensearch.core.xcontent.MediaTypeParserRegistry;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -111,7 +111,7 @@ public class PutMappingRequest extends TimedRequest implements IndicesRequest, T
      */
     public PutMappingRequest source(Map<String, ?> mappingSource) {
         try {
-            XContentBuilder builder = XContentFactory.contentBuilder(MediaTypeParserRegistry.getDefaultMediaType());
+            XContentBuilder builder = XContentFactory.contentBuilder(MediaTypeRegistry.getDefaultMediaType());
             builder.map(mappingSource);
             return source(builder);
         } catch (IOException e) {

--- a/libs/core/src/main/java/org/opensearch/core/common/io/stream/StreamInput.java
+++ b/libs/core/src/main/java/org/opensearch/core/common/io/stream/StreamInput.java
@@ -54,7 +54,7 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException;
 import org.opensearch.core.xcontent.MediaType;
-import org.opensearch.core.xcontent.MediaTypeParserRegistry;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
 
 import java.io.ByteArrayInputStream;
 import java.io.EOFException;
@@ -347,7 +347,7 @@ public abstract class StreamInput extends InputStream {
     }
 
     public MediaType readMediaType() throws IOException {
-        return MediaTypeParserRegistry.fromMediaType(readString());
+        return MediaTypeRegistry.fromMediaType(readString());
     }
 
     @Nullable

--- a/libs/core/src/main/java/org/opensearch/core/xcontent/MediaType.java
+++ b/libs/core/src/main/java/org/opensearch/core/xcontent/MediaType.java
@@ -82,7 +82,7 @@ public interface MediaType extends Writeable {
      * This method will return {@code null} if no match is found
      */
     static MediaType fromFormat(String mediaType) {
-        return MediaTypeParserRegistry.fromFormat(mediaType);
+        return MediaTypeRegistry.fromFormat(mediaType);
     }
 
     /**
@@ -93,7 +93,7 @@ public interface MediaType extends Writeable {
      */
     static MediaType fromMediaType(String mediaTypeHeaderValue) {
         mediaTypeHeaderValue = removeVersionInMediaType(mediaTypeHeaderValue);
-        return MediaTypeParserRegistry.fromMediaType(mediaTypeHeaderValue);
+        return MediaTypeRegistry.fromMediaType(mediaTypeHeaderValue);
     }
 
     /**

--- a/libs/core/src/main/java/org/opensearch/core/xcontent/MediaTypeRegistry.java
+++ b/libs/core/src/main/java/org/opensearch/core/xcontent/MediaTypeRegistry.java
@@ -41,7 +41,7 @@ import java.util.Map;
  *
  * @opensearch.internal
  */
-public final class MediaTypeParserRegistry {
+public final class MediaTypeRegistry {
     private static Map<String, MediaType> formatToMediaType = Map.of();
     private static Map<String, MediaType> typeWithSubtypeToMediaType = Map.of();
 

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentType.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentType.java
@@ -38,7 +38,7 @@ import org.opensearch.common.xcontent.smile.SmileXContent;
 import org.opensearch.common.xcontent.yaml.YamlXContent;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.MediaType;
-import org.opensearch.core.xcontent.MediaTypeParserRegistry;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.XContent;
 
 import java.io.IOException;
@@ -133,7 +133,7 @@ public enum XContentType implements MediaType {
 
     static {
         /** a parser of media types */
-        MediaTypeParserRegistry.register(XContentType.values(), Map.of("application/*", JSON, "application/x-ndjson", JSON));
+        MediaTypeRegistry.register(XContentType.values(), Map.of("application/*", JSON, "application/x-ndjson", JSON));
     }
 
     private int index;

--- a/libs/x-content/src/test/java/org/opensearch/common/xcontent/MediaTypeParserTests.java
+++ b/libs/x-content/src/test/java/org/opensearch/common/xcontent/MediaTypeParserTests.java
@@ -32,7 +32,7 @@
 
 package org.opensearch.common.xcontent;
 
-import org.opensearch.core.xcontent.MediaTypeParserRegistry;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.Collections;
@@ -46,40 +46,37 @@ public class MediaTypeParserTests extends OpenSearchTestCase {
 
     public void testJsonWithParameters() throws Exception {
         String mediaType = "application/json";
-        assertThat(MediaTypeParserRegistry.parseMediaType(mediaType).getParameters(), equalTo(Collections.emptyMap()));
-        assertThat(MediaTypeParserRegistry.parseMediaType(mediaType + ";").getParameters(), equalTo(Collections.emptyMap()));
+        assertThat(MediaTypeRegistry.parseMediaType(mediaType).getParameters(), equalTo(Collections.emptyMap()));
+        assertThat(MediaTypeRegistry.parseMediaType(mediaType + ";").getParameters(), equalTo(Collections.emptyMap()));
+        assertThat(MediaTypeRegistry.parseMediaType(mediaType + "; charset=UTF-8").getParameters(), equalTo(Map.of("charset", "utf-8")));
         assertThat(
-            MediaTypeParserRegistry.parseMediaType(mediaType + "; charset=UTF-8").getParameters(),
-            equalTo(Map.of("charset", "utf-8"))
-        );
-        assertThat(
-            MediaTypeParserRegistry.parseMediaType(mediaType + "; custom=123;charset=UTF-8").getParameters(),
+            MediaTypeRegistry.parseMediaType(mediaType + "; custom=123;charset=UTF-8").getParameters(),
             equalTo(Map.of("charset", "utf-8", "custom", "123"))
         );
     }
 
     public void testWhiteSpaceInTypeSubtype() {
         String mediaType = " application/json ";
-        assertThat(MediaTypeParserRegistry.parseMediaType(mediaType).getMediaType(), equalTo(XContentType.JSON));
+        assertThat(MediaTypeRegistry.parseMediaType(mediaType).getMediaType(), equalTo(XContentType.JSON));
 
         assertThat(
-            MediaTypeParserRegistry.parseMediaType(mediaType + "; custom=123; charset=UTF-8").getParameters(),
+            MediaTypeRegistry.parseMediaType(mediaType + "; custom=123; charset=UTF-8").getParameters(),
             equalTo(Map.of("charset", "utf-8", "custom", "123"))
         );
         assertThat(
-            MediaTypeParserRegistry.parseMediaType(mediaType + "; custom=123;\n charset=UTF-8").getParameters(),
+            MediaTypeRegistry.parseMediaType(mediaType + "; custom=123;\n charset=UTF-8").getParameters(),
             equalTo(Map.of("charset", "utf-8", "custom", "123"))
         );
 
         mediaType = " application / json ";
-        assertThat(MediaTypeParserRegistry.parseMediaType(mediaType), is(nullValue()));
+        assertThat(MediaTypeRegistry.parseMediaType(mediaType), is(nullValue()));
     }
 
     public void testInvalidParameters() {
         String mediaType = "application/json";
-        assertThat(MediaTypeParserRegistry.parseMediaType(mediaType + "; keyvalueNoEqualsSign"), is(nullValue()));
+        assertThat(MediaTypeRegistry.parseMediaType(mediaType + "; keyvalueNoEqualsSign"), is(nullValue()));
 
-        assertThat(MediaTypeParserRegistry.parseMediaType(mediaType + "; key = value"), is(nullValue()));
-        assertThat(MediaTypeParserRegistry.parseMediaType(mediaType + "; key="), is(nullValue()));
+        assertThat(MediaTypeRegistry.parseMediaType(mediaType + "; key = value"), is(nullValue()));
+        assertThat(MediaTypeRegistry.parseMediaType(mediaType + "; key="), is(nullValue()));
     }
 }

--- a/server/src/main/java/org/opensearch/rest/AbstractRestChannel.java
+++ b/server/src/main/java/org/opensearch/rest/AbstractRestChannel.java
@@ -36,7 +36,7 @@ import org.opensearch.common.io.Streams;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.xcontent.MediaType;
-import org.opensearch.core.xcontent.MediaTypeParserRegistry;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
 
@@ -132,7 +132,7 @@ public abstract class AbstractRestChannel implements RestChannel {
                 responseContentType = requestContentType;
             } else {
                 // default to JSON output when all else fails
-                responseContentType = MediaTypeParserRegistry.getDefaultMediaType();
+                responseContentType = MediaTypeRegistry.getDefaultMediaType();
             }
         }
 

--- a/server/src/main/java/org/opensearch/transport/TransportService.java
+++ b/server/src/main/java/org/opensearch/transport/TransportService.java
@@ -62,7 +62,7 @@ import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException;
-import org.opensearch.core.xcontent.MediaTypeParserRegistry;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.node.NodeClosedException;
 import org.opensearch.node.ReportingService;
 import org.opensearch.tasks.Task;
@@ -174,7 +174,7 @@ public class TransportService extends AbstractLifecycleComponent
         /** Registers OpenSearch server specific exceptions (exceptions outside of core library) */
         OpenSearchServerException.registerExceptions();
         // set the default media type to JSON (fallback if a media type is not specified)
-        MediaTypeParserRegistry.setDefaultMediaType(XContentType.JSON);
+        MediaTypeRegistry.setDefaultMediaType(XContentType.JSON);
     }
 
     /** does nothing. easy way to ensure class is loaded so the above static block is called to register the streamables */


### PR DESCRIPTION
Coming out of https://github.com/opensearch-project/OpenSearch/pull/8826#discussion_r1273746991, this PR rote refactors `MediaTypeParserRegistry` to `MediaTypeRegistry` to make the class naming align with the intention of the logic. The `MediaTypeRegistry` is a mechanism for downstream extensions to register concrete `MediaTypes` thus having "Parser" in the name is unneeded.

relates #5910
relates #8110 