### PR TITLE
Bugfix: add replica information in remote store restore flow

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreRestoreIT.java
@@ -82,7 +82,9 @@ public class RemoteStoreRestoreIT extends RemoteStoreBaseIntegTestCase {
             TimeUnit.SECONDS
         );
         IndexResponse response = indexSingleDoc(indexName);
-        assertEquals(indexStats.get(MAX_SEQ_NO_TOTAL + "-shard-" + response.getShardId().id()) + 1, response.getSeqNo());
+        if (indexStats.containsKey(MAX_SEQ_NO_TOTAL + "-shard-" + response.getShardId().id())) {
+            assertEquals(indexStats.get(MAX_SEQ_NO_TOTAL + "-shard-" + response.getShardId().id()) + 1, response.getSeqNo());
+        }
         refresh(indexName);
         assertBusy(
             () -> assertHitCount(client().prepareSearch(indexName).setSize(0).get(), indexStats.get(TOTAL_OPERATIONS) + 1),
@@ -139,7 +141,6 @@ public class RemoteStoreRestoreIT extends RemoteStoreBaseIntegTestCase {
      * Simulates all data restored using Remote Translog Store.
      * @throws IOException IO Exception.
      */
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/7923")
     public void testRTSRestoreWithNoDataPostCommitPrimaryReplicaDown() throws Exception {
         testRestoreFlowBothPrimaryReplicasDown(1, true, randomIntBetween(1, 5));
     }
@@ -230,7 +231,7 @@ public class RemoteStoreRestoreIT extends RemoteStoreBaseIntegTestCase {
         for (String index : indices) {
             Map<String, Long> indexStats = indexData(numberOfIterations, invokeFlush, index);
             indicesStats.put(index, indexStats);
-            assertEquals(shardCount, getNumShards(index).totalNumShards);
+            assertEquals(shardCount * 2, getNumShards(index).totalNumShards);
         }
 
         for (String index : indices) {
@@ -261,7 +262,7 @@ public class RemoteStoreRestoreIT extends RemoteStoreBaseIntegTestCase {
             );
         ensureGreen(indices);
         for (String index : indices) {
-            assertEquals(shardCount, getNumShards(index).totalNumShards);
+            assertEquals(shardCount * 2, getNumShards(index).totalNumShards);
             verifyRestoredData(indicesStats.get(index), index);
         }
     }

--- a/server/src/main/java/org/opensearch/cluster/routing/RoutingTable.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RoutingTable.java
@@ -575,10 +575,11 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
         public Builder addAsRemoteStoreRestore(
             IndexMetadata indexMetadata,
             RemoteStoreRecoverySource recoverySource,
-            Map<ShardId, ShardRouting> activeInitializingShards
+            Map<ShardId, IndexShardRoutingTable> indexShardRoutingTableMap,
+            boolean restoreAllShards
         ) {
             IndexRoutingTable.Builder indexRoutingBuilder = new IndexRoutingTable.Builder(indexMetadata.getIndex())
-                .initializeAsRemoteStoreRestore(indexMetadata, recoverySource, activeInitializingShards);
+                .initializeAsRemoteStoreRestore(indexMetadata, recoverySource, indexShardRoutingTableMap, restoreAllShards);
             add(indexRoutingBuilder);
             return this;
         }

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -173,6 +173,10 @@ public final class RemoteStoreRefreshListener extends CloseableRetryableRefreshL
                 indexShard.getReplicationTracker().isPrimaryMode(),
                 indexShard.state()
             );
+            if (indexShard.state() == IndexShardState.STARTED && indexShard.getEngine() instanceof InternalEngine) {
+                // Retrying to make sure that we do not lose this refresh event
+                return false;
+            }
             return true;
         }
         ReplicationCheckpoint checkpoint = indexShard.getLatestReplicationCheckpoint();

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -173,8 +173,12 @@ public final class RemoteStoreRefreshListener extends CloseableRetryableRefreshL
                 indexShard.getReplicationTracker().isPrimaryMode(),
                 indexShard.state()
             );
+            // Following check is required to enable retry and make sure that we do not lose this refresh event
+            // When primary shard is restored from remote store, the recovery happens first followed by changing
+            // primaryMode to true. Due to this, the refresh that is triggered post replay of translog will not go through
+            // if following condition does not exist. The segments created as part of translog replay will not be present
+            // in the remote store.
             if (indexShard.state() == IndexShardState.STARTED && indexShard.getEngine() instanceof InternalEngine) {
-                // Retrying to make sure that we do not lose this refresh event
                 return false;
             }
             return true;

--- a/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
@@ -539,6 +539,8 @@ final class StoreRecovery {
 
             indexShard.syncTranslogFilesFromRemoteTranslog();
 
+            // On index creation, the only segment file that is created is segments_N. We can safely discard this file
+            // as there is no data associated with this shard as part of segments.
             if (store.directory().listAll().length <= 1) {
                 Path location = indexShard.shardPath().resolveTranslog();
                 Checkpoint checkpoint = Checkpoint.read(location.resolve(CHECKPOINT_FILE_NAME));

--- a/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
@@ -535,7 +535,7 @@ final class StoreRecovery {
         remoteStore.incRef();
         try {
             // Download segments from remote segment store
-            indexShard.syncSegmentsFromRemoteSegmentStore(true, true);
+            indexShard.syncSegmentsFromRemoteSegmentStore(true);
 
             indexShard.syncTranslogFilesFromRemoteTranslog();
 

--- a/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
@@ -539,7 +539,7 @@ final class StoreRecovery {
 
             indexShard.syncTranslogFilesFromRemoteTranslog();
 
-            if (store.directory().listAll().length == 0) {
+            if (store.directory().listAll().length <= 1) {
                 Path location = indexShard.shardPath().resolveTranslog();
                 Checkpoint checkpoint = Checkpoint.read(location.resolve(CHECKPOINT_FILE_NAME));
                 final Path translogFile = location.resolve(Translog.getFilename(checkpoint.getGeneration()));

--- a/server/src/main/java/org/opensearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/PeerRecoveryTargetService.java
@@ -245,7 +245,7 @@ public class PeerRecoveryTargetService implements IndexEventListener {
                     indexShard.prepareForIndexRecovery();
                     final boolean hasRemoteSegmentStore = indexShard.indexSettings().isRemoteStoreEnabled();
                     if (hasRemoteSegmentStore) {
-                        indexShard.syncSegmentsFromRemoteSegmentStore(false, true);
+                        indexShard.syncSegmentsFromRemoteSegmentStore(false);
                     }
                     final boolean hasRemoteTranslog = recoveryTarget.state().getPrimary() == false && indexShard.isRemoteTranslogEnabled();
                     final boolean hasNoTranslog = indexShard.indexSettings().isRemoteSnapshot();

--- a/server/src/test/java/org/opensearch/cluster/routing/RoutingTableTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/RoutingTableTests.java
@@ -50,13 +50,18 @@ import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.repositories.IndexId;
 import org.junit.Before;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static org.opensearch.cluster.routing.ShardRoutingState.INITIALIZING;
+import static org.opensearch.cluster.routing.ShardRoutingState.RELOCATING;
+import static org.opensearch.cluster.routing.ShardRoutingState.STARTED;
 import static org.opensearch.cluster.routing.ShardRoutingState.UNASSIGNED;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -64,6 +69,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class RoutingTableTests extends OpenSearchAllocationTestCase {
 
@@ -540,8 +546,47 @@ public class RoutingTableTests extends OpenSearchAllocationTestCase {
         }
     }
 
-    public void testAddAsRemoteStoreRestore() {
-        final IndexMetadata indexMetadata = createIndexMetadata(TEST_INDEX_1).state(IndexMetadata.State.OPEN).build();
+    private Map<ShardId, IndexShardRoutingTable> getIndexShardRoutingTableMap(Index index, boolean allUnassigned, int numberOfReplicas) {
+        Map<ShardId, IndexShardRoutingTable> indexShardRoutingTableMap = new HashMap<>();
+        List<ShardRoutingState> activeInitializingStates = List.of(INITIALIZING, STARTED, RELOCATING);
+        for (int i = 0; i < this.numberOfShards; i++) {
+            IndexShardRoutingTable indexShardRoutingTable = mock(IndexShardRoutingTable.class);
+            ShardRouting primaryShardRouting = mock(ShardRouting.class);
+            Boolean primaryUnassigned = allUnassigned || randomBoolean();
+            when(primaryShardRouting.unassigned()).thenReturn(primaryUnassigned);
+            if (primaryUnassigned) {
+                when(primaryShardRouting.state()).thenReturn(UNASSIGNED);
+            } else {
+                when(primaryShardRouting.state()).thenReturn(
+                    activeInitializingStates.get(randomIntBetween(0, activeInitializingStates.size() - 1))
+                );
+            }
+            when(indexShardRoutingTable.primaryShard()).thenReturn(primaryShardRouting);
+            List<ShardRouting> replicaShards = new ArrayList<>();
+            for (int j = 0; j < numberOfReplicas; j++) {
+                ShardRouting replicaShardRouting = mock(ShardRouting.class);
+                Boolean replicaUnassigned = allUnassigned || randomBoolean();
+                when(replicaShardRouting.unassigned()).thenReturn(replicaUnassigned);
+                if (replicaUnassigned) {
+                    when(replicaShardRouting.state()).thenReturn(UNASSIGNED);
+                } else {
+                    when(replicaShardRouting.state()).thenReturn(
+                        activeInitializingStates.get(randomIntBetween(0, activeInitializingStates.size() - 1))
+                    );
+                }
+                replicaShards.add(replicaShardRouting);
+            }
+            when(indexShardRoutingTable.replicaShards()).thenReturn(replicaShards);
+            indexShardRoutingTableMap.put(new ShardId(index, i), indexShardRoutingTable);
+        }
+        return indexShardRoutingTableMap;
+    }
+
+    public void testAddAsRemoteStoreRestoreAllUnassigned() {
+        int numberOfReplicas = randomIntBetween(0, 5);
+        final IndexMetadata indexMetadata = createIndexMetadata(TEST_INDEX_1).state(IndexMetadata.State.OPEN)
+            .numberOfReplicas(numberOfReplicas)
+            .build();
         final RemoteStoreRecoverySource remoteStoreRecoverySource = new RemoteStoreRecoverySource(
             "restore_uuid",
             Version.CURRENT,
@@ -550,35 +595,52 @@ public class RoutingTableTests extends OpenSearchAllocationTestCase {
         final RoutingTable routingTable = new RoutingTable.Builder().addAsRemoteStoreRestore(
             indexMetadata,
             remoteStoreRecoverySource,
-            new HashMap<>()
+            getIndexShardRoutingTableMap(indexMetadata.getIndex(), true, numberOfReplicas),
+            false
         ).build();
         assertTrue(routingTable.hasIndex(TEST_INDEX_1));
-        assertEquals(this.numberOfShards, routingTable.allShards(TEST_INDEX_1).size());
-        assertEquals(this.numberOfShards, routingTable.index(TEST_INDEX_1).shardsWithState(UNASSIGNED).size());
+        int numberOfShards = this.numberOfShards * (numberOfReplicas + 1);
+        assertEquals(numberOfShards, routingTable.allShards(TEST_INDEX_1).size());
+        assertEquals(numberOfShards, routingTable.index(TEST_INDEX_1).shardsWithState(UNASSIGNED).size());
     }
 
     public void testAddAsRemoteStoreRestoreWithActiveShards() {
-        final IndexMetadata indexMetadata = createIndexMetadata(TEST_INDEX_1).state(IndexMetadata.State.OPEN).build();
+        int numberOfReplicas = randomIntBetween(0, 5);
+        final IndexMetadata indexMetadata = createIndexMetadata(TEST_INDEX_1).state(IndexMetadata.State.OPEN)
+            .numberOfReplicas(numberOfReplicas)
+            .build();
         final RemoteStoreRecoverySource remoteStoreRecoverySource = new RemoteStoreRecoverySource(
             "restore_uuid",
             Version.CURRENT,
             new IndexId(TEST_INDEX_1, "1")
         );
-        Map<ShardId, ShardRouting> activeInitializingShards = new HashMap<>();
-        for (int i = 0; i < randomIntBetween(1, this.numberOfShards); i++) {
-            activeInitializingShards.put(new ShardId(indexMetadata.getIndex(), i), mock(ShardRouting.class));
-        }
+        Map<ShardId, IndexShardRoutingTable> indexShardRoutingTableMap = getIndexShardRoutingTableMap(
+            indexMetadata.getIndex(),
+            false,
+            numberOfReplicas
+        );
         final RoutingTable routingTable = new RoutingTable.Builder().addAsRemoteStoreRestore(
             indexMetadata,
             remoteStoreRecoverySource,
-            activeInitializingShards
+            indexShardRoutingTableMap,
+            false
         ).build();
         assertTrue(routingTable.hasIndex(TEST_INDEX_1));
-        assertEquals(this.numberOfShards, routingTable.allShards(TEST_INDEX_1).size());
-        assertEquals(
-            this.numberOfShards - activeInitializingShards.size(),
-            routingTable.index(TEST_INDEX_1).shardsWithState(UNASSIGNED).size()
-        );
+        int numberOfShards = this.numberOfShards * (numberOfReplicas + 1);
+        assertEquals(numberOfShards, routingTable.allShards(TEST_INDEX_1).size());
+        int unassignedShards = 0;
+        for (IndexShardRoutingTable indexShardRoutingTable : indexShardRoutingTableMap.values()) {
+            if (indexShardRoutingTable.primaryShard().unassigned()) {
+                unassignedShards += indexShardRoutingTable.replicaShards().size() + 1;
+            } else {
+                for (ShardRouting replicaShardRouting : indexShardRoutingTable.replicaShards()) {
+                    if (replicaShardRouting.unassigned()) {
+                        unassignedShards += 1;
+                    }
+                }
+            }
+        }
+        assertEquals(unassignedShards, routingTable.index(TEST_INDEX_1).shardsWithState(UNASSIGNED).size());
     }
 
     /** reverse engineer the in sync aid based on the given indexRoutingTable **/

--- a/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
@@ -532,10 +532,9 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
             new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
             threadPool
         );
-        RemoteStorePressureService remoteStorePressureService = new RemoteStorePressureService(clusterService, Settings.EMPTY);
+        RemoteStorePressureService remoteStorePressureService = indexShard.getRemoteStorePressureService();
         when(shard.indexSettings()).thenReturn(indexShard.indexSettings());
         when(shard.shardId()).thenReturn(indexShard.shardId());
-        remoteStorePressureService.afterIndexShardCreated(shard);
         RemoteSegmentTransferTracker tracker = remoteStorePressureService.getRemoteRefreshSegmentTracker(indexShard.shardId());
         RemoteStoreRefreshListener refreshListener = new RemoteStoreRefreshListener(shard, emptyCheckpointPublisher, tracker);
         refreshListener.afterRefresh(true);


### PR DESCRIPTION
### Description
- Currently, in remote store restore flow, we only restore primary and ignore replicas. But this creates issue with shards having replicas as mentioned in https://github.com/opensearch-project/OpenSearch/issues/8479
- In this change, we add replica information as well in the new routing table that is getting created as part of restore.
- We apply following logic:
  - If primary of the shard is unassigned, mark it for restore and mark all the replicas for peer recovery
  - If primary of the shard is active or initializing, do not mark it for restore. Check all replicas and mark replica for peer recovery only if replica is unassigned.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/8479

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
