### PR TITLE
Remove MasterServiceTests from retries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -487,7 +487,6 @@ subprojects {
         includeClasses.add("org.opensearch.cluster.metadata.IndexGraveyardTests")
         includeClasses.add("org.opensearch.cluster.routing.MovePrimaryFirstTests")
         includeClasses.add("org.opensearch.cluster.routing.allocation.decider.DiskThresholdDeciderIT")
-        includeClasses.add("org.opensearch.cluster.service.MasterServiceTests")
         includeClasses.add("org.opensearch.common.util.concurrent.QueueResizableOpenSearchThreadPoolExecutorTests")
         includeClasses.add("org.opensearch.gateway.RecoveryFromGatewayIT")
         includeClasses.add("org.opensearch.gateway.ReplicaShardAllocatorIT")


### PR DESCRIPTION
After the fix in #8901, I ran the following in a loop all day (about 1400 times) and saw no failures:

```
./gradlew ':server:test' --tests "org.opensearch.cluster.service.MasterServiceTests"
```

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
