### PR TITLE
Fix flaky ResourceAwareTasksTests.testBasicTaskResourceTracking test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 ### Fixed
+- Fix flaky ResourceAwareTasksTests.testBasicTaskResourceTracking test ([#8993](https://github.com/opensearch-project/OpenSearch/pull/8993))
 
 ### Security
 

--- a/server/src/test/java/org/opensearch/action/admin/cluster/node/tasks/ResourceAwareTasksTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/node/tasks/ResourceAwareTasksTests.java
@@ -672,8 +672,8 @@ public class ResourceAwareTasksTests extends TaskManagerTestCase {
     }
 
     private void assertMemoryUsageWithinLimits(long actual, long expected) {
-        // 5% buffer up to 200 KB to account for classloading overhead.
-        long maxOverhead = Math.min(200000, expected * 5 / 100);
+        // 5% buffer up to 500 KB to account for classloading overhead.
+        long maxOverhead = Math.min(500000, expected * 5 / 100);
         assertThat(actual, lessThanOrEqualTo(expected + maxOverhead));
     }
 


### PR DESCRIPTION
### Description
The `assertMemoryUsageWithinLimits` method checks if the memory usage is within 5% (up to 200 KB) of the expected memory usage. This additional buffer is to account for the class loading overhead when new code is encountered at runtime. Over time, addition of new code paths has resulted in greater overhead. This PR bumps up the 200 KB limit to 500 KB.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/8213

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
