### PR TITLE
[Remove] Deprecated Fractional ByteSizeValue support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Refactor] MediaTypeParser to MediaTypeParserRegistry ([#8636](https://github.com/opensearch-project/OpenSearch/pull/8636))
 - Create separate SourceLookup instance per segment slice in SignificantTextAggregatorFactory ([#8807](https://github.com/opensearch-project/OpenSearch/pull/8807))
 - Add support for aggregation profiler with concurrent aggregation ([#8801](https://github.com/opensearch-project/OpenSearch/pull/8801))
+- [Remove] Deprecated Fractional ByteSizeValue support #9005 ([#9005](https://github.com/opensearch-project/OpenSearch/pull/9005))
 
 ### Deprecated
 

--- a/modules/ingest-common/src/test/java/org/opensearch/ingest/common/BytesProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/opensearch/ingest/common/BytesProcessorTests.java
@@ -33,14 +33,13 @@
 package org.opensearch.ingest.common;
 
 import org.opensearch.OpenSearchException;
+import org.opensearch.OpenSearchParseException;
 import org.opensearch.common.unit.ByteSizeUnit;
 import org.opensearch.common.unit.ByteSizeValue;
 import org.opensearch.ingest.IngestDocument;
 import org.opensearch.ingest.Processor;
 import org.opensearch.ingest.RandomDocumentPicks;
 import org.hamcrest.CoreMatchers;
-
-import static org.hamcrest.Matchers.equalTo;
 
 public class BytesProcessorTests extends AbstractStringProcessorTestCase<Long> {
 
@@ -101,14 +100,16 @@ public class BytesProcessorTests extends AbstractStringProcessorTestCase<Long> {
         assertThat(exception.getMessage(), CoreMatchers.containsString("unit is missing or unrecognized"));
     }
 
-    public void testFractional() throws Exception {
+    public void testFractional() {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
         String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, "1.1kb");
         Processor processor = newProcessor(fieldName, randomBoolean(), fieldName);
-        processor.execute(ingestDocument);
-        assertThat(ingestDocument.getFieldValue(fieldName, expectedResultType()), equalTo(1126L));
-        assertWarnings(
-            "Fractional bytes values are deprecated. Use non-fractional bytes values instead: [1.1kb] found for setting " + "[Ingest Field]"
+        OpenSearchParseException e = expectThrows(OpenSearchParseException.class, () -> processor.execute(ingestDocument));
+        assertThat(
+            e.getMessage(),
+            CoreMatchers.containsString(
+                "Fractional bytes values have been deprecated since Legacy 6.2. " + "Use non-fractional bytes values instead:"
+            )
         );
     }
 }

--- a/server/src/test/java/org/opensearch/common/unit/ByteSizeValueTests.java
+++ b/server/src/test/java/org/opensearch/common/unit/ByteSizeValueTests.java
@@ -336,12 +336,10 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
     public void testParseFractionalNumber() throws IOException {
         ByteSizeUnit unit = randomValueOtherThan(ByteSizeUnit.BYTES, () -> randomFrom(ByteSizeUnit.values()));
         String fractionalValue = "23.5" + unit.getSuffix();
-        ByteSizeValue instance = ByteSizeValue.parseBytesSizeValue(fractionalValue, "test");
-        assertEquals(fractionalValue, instance.toString());
-        assertWarnings(
-            "Fractional bytes values are deprecated. Use non-fractional bytes values instead: ["
-                + fractionalValue
-                + "] found for setting [test]"
+        // test exception is thrown: fractional byte size values has been deprecated since Legacy 6.2
+        OpenSearchParseException e = expectThrows(
+            OpenSearchParseException.class,
+            () -> ByteSizeValue.parseBytesSizeValue(fractionalValue, "test")
         );
     }
 


### PR DESCRIPTION
This PR removes the deprecation warning for fractional bytes size values and, instead, throws an `OpenSearchParseException` if a user passes in a fraction byte value (e.g., `5.2b`). This leniency was deprecated a long time ago in Legacy 6.2 so the removal should come as no surprise to users.