### PR TITLE
Moving google.jimfs to global version properties

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -24,6 +24,7 @@ antlr4            = 4.11.1
 guava             = 32.1.1-jre
 protobuf          = 3.22.3
 jakarta_annotation = 1.3.5
+jimfs             = 1.3.0
 
 # when updating the JNA version, also update the version in buildSrc/build.gradle
 jna               = 5.5.0

--- a/distribution/tools/keystore-cli/build.gradle
+++ b/distribution/tools/keystore-cli/build.gradle
@@ -34,7 +34,7 @@ dependencies {
   compileOnly project(":server")
   compileOnly project(":libs:opensearch-cli")
   testImplementation project(":test:framework")
-  testImplementation 'com.google.jimfs:jimfs:1.3.0'
+  testImplementation "com.google.jimfs:jimfs:${versions.jimfs}"
   testRuntimeOnly("com.google.guava:guava:${versions.guava}") {
     transitive = false
   }

--- a/distribution/tools/plugin-cli/build.gradle
+++ b/distribution/tools/plugin-cli/build.gradle
@@ -40,7 +40,7 @@ dependencies {
   api "org.bouncycastle:bcpg-fips:1.0.7.1"
   api "org.bouncycastle:bc-fips:1.0.2.3"
   testImplementation project(":test:framework")
-  testImplementation 'com.google.jimfs:jimfs:1.3.0'
+  testImplementation "com.google.jimfs:jimfs:${versions.jimfs}"
   testRuntimeOnly("com.google.guava:guava:${versions.guava}") {
     transitive = false
   }

--- a/distribution/tools/upgrade-cli/build.gradle
+++ b/distribution/tools/upgrade-cli/build.gradle
@@ -20,7 +20,7 @@ dependencies {
   implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
   implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
   testImplementation project(":test:framework")
-  testImplementation 'com.google.jimfs:jimfs:1.3.0'
+  testImplementation "com.google.jimfs:jimfs:${versions.jimfs}"
   testRuntimeOnly("com.google.guava:guava:${versions.guava}") {
     transitive = false
   }

--- a/qa/evil-tests/build.gradle
+++ b/qa/evil-tests/build.gradle
@@ -40,7 +40,7 @@ apply plugin: 'opensearch.testclusters'
 apply plugin: 'opensearch.standalone-test'
 
 dependencies {
-  testImplementation 'com.google.jimfs:jimfs:1.3.0'
+  testImplementation "com.google.jimfs:jimfs:${versions.jimfs}"
 }
 
 // TODO: give each evil test its own fresh JVM for more isolation.

--- a/qa/evil-tests/build.gradle
+++ b/qa/evil-tests/build.gradle
@@ -39,10 +39,6 @@ import org.opensearch.gradle.info.BuildParams
 apply plugin: 'opensearch.testclusters'
 apply plugin: 'opensearch.standalone-test'
 
-dependencies {
-  testImplementation "com.google.jimfs:jimfs:${versions.jimfs}"
-}
-
 // TODO: give each evil test its own fresh JVM for more isolation.
 
 test {


### PR DESCRIPTION
### Description
Moving `google.jimfs` to global version properties. 
Came across this while digging into CVE: https://nvd.nist.gov/vuln/detail/CVE-2023-2976
`google.jimfs` has a transitive dependency on `com.google.guava:guava:30.1-android` which is part of the CVE. 

This PR https://github.com/opensearch-project/OpenSearch/pull/8585 was not backported to 2.x.
I'll backport this change to 2.x to keep all `google.jimfs` in sync and updated.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
