### PR TITLE
[BWC] Change BWC version check for MediaType in PercolateQueryBuilder

### DIFF
--- a/modules/percolator/src/main/java/org/opensearch/percolator/PercolateQueryBuilder.java
+++ b/modules/percolator/src/main/java/org/opensearch/percolator/PercolateQueryBuilder.java
@@ -254,7 +254,7 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
         }
         documents = in.readList(StreamInput::readBytesReference);
         if (documents.isEmpty() == false) {
-            if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+            if (in.getVersion().onOrAfter(Version.V_2_10_0)) {
                 documentXContentType = in.readMediaType();
             } else {
                 documentXContentType = in.readEnum(XContentType.class);
@@ -304,7 +304,7 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
             out.writeBytesReference(document);
         }
         if (documents.isEmpty() == false) {
-            if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+            if (out.getVersion().onOrAfter(Version.V_2_10_0)) {
                 documentXContentType.writeTo(out);
             } else {
                 out.writeEnum((XContentType) documentXContentType);


### PR DESCRIPTION
This changes the version check for `MediaType` in `PercolateQueryBuilder` for BWC.