### PR TITLE
Change to determine if concurrent segment search should be used by the request during SearchContext creation

### DIFF
--- a/server/src/main/java/org/opensearch/search/internal/FilteredSearchContext.java
+++ b/server/src/main/java/org/opensearch/search/internal/FilteredSearchContext.java
@@ -559,4 +559,9 @@ public abstract class FilteredSearchContext extends SearchContext {
     public BucketCollectorProcessor bucketCollectorProcessor() {
         return in.bucketCollectorProcessor();
     }
+
+    @Override
+    public boolean isConcurrentSegmentSearchEnabled() {
+        return in.isConcurrentSegmentSearchEnabled();
+    }
 }

--- a/server/src/test/java/org/opensearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/opensearch/search/SearchServiceTests.java
@@ -1292,6 +1292,69 @@ public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
     }
 
     /**
+     * Test that the Search Context for concurrent segment search enabled is set correctly at the time of construction.
+     * The same is used throughout the context object lifetime even if cluster setting changes before the request completion.
+     */
+    public void testConcurrentSegmentSearchIsSetOnceDuringContextCreation() throws IOException {
+        String index = randomAlphaOfLengthBetween(5, 10).toLowerCase(Locale.ROOT);
+        IndexService indexService = createIndex(index);
+        final SearchService service = getInstanceFromNode(SearchService.class);
+        ShardId shardId = new ShardId(indexService.index(), 0);
+        long nowInMillis = System.currentTimeMillis();
+        String clusterAlias = randomBoolean() ? null : randomAlphaOfLengthBetween(3, 10);
+        SearchRequest searchRequest = new SearchRequest();
+        searchRequest.allowPartialSearchResults(randomBoolean());
+        ShardSearchRequest request = new ShardSearchRequest(
+            OriginalIndices.NONE,
+            searchRequest,
+            shardId,
+            indexService.numberOfShards(),
+            AliasFilter.EMPTY,
+            1f,
+            nowInMillis,
+            clusterAlias,
+            Strings.EMPTY_ARRAY
+        );
+
+        Boolean[] concurrentSearchStates = new Boolean[] { true, false };
+        for (Boolean concurrentSearchSetting : concurrentSearchStates) {
+            // update concurrent search cluster setting and create search context
+            client().admin()
+                .cluster()
+                .prepareUpdateSettings()
+                .setTransientSettings(
+                    Settings.builder().put(SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING.getKey(), concurrentSearchSetting)
+                )
+                .get();
+            try (DefaultSearchContext searchContext = service.createSearchContext(request, new TimeValue(System.currentTimeMillis()))) {
+                // verify concurrent search state in context
+                assertEquals(concurrentSearchSetting, searchContext.isConcurrentSegmentSearchEnabled());
+                // verify executor state in searcher
+                assertEquals(concurrentSearchSetting, (searchContext.searcher().getExecutor() != null));
+
+                // update cluster setting to flip the concurrent segment search state
+                client().admin()
+                    .cluster()
+                    .prepareUpdateSettings()
+                    .setTransientSettings(
+                        Settings.builder().put(SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING.getKey(), !concurrentSearchSetting)
+                    )
+                    .get();
+
+                // verify that concurrent segment search is still set to same expected value for the context
+                assertEquals(concurrentSearchSetting, searchContext.isConcurrentSegmentSearchEnabled());
+            }
+        }
+
+        // Cleanup
+        client().admin()
+            .cluster()
+            .prepareUpdateSettings()
+            .setTransientSettings(Settings.builder().putNull(SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING.getKey()))
+            .get();
+    }
+
+    /**
      * While we have no NPE in DefaultContext constructor anymore, we still want to guard against it (or other failures) in the future to
      * avoid leaking searchers.
      */

--- a/server/src/test/java/org/opensearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/opensearch/search/SearchServiceTests.java
@@ -1275,6 +1275,12 @@ public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
                         .getSetting(index, IndexSettings.INDEX_CONCURRENT_SEGMENT_SEARCH_SETTING.getKey())
                 );
                 assertEquals(concurrentSearchEnabled, searchContext.isConcurrentSegmentSearchEnabled());
+                // verify executor nullability with concurrent search enabled/disabled
+                if (concurrentSearchEnabled) {
+                    assertNotNull(searchContext.searcher().getExecutor());
+                } else {
+                    assertNull(searchContext.searcher().getExecutor());
+                }
             }
         }
         // Cleanup


### PR DESCRIPTION
### Description
* DefaultSearchContext should evaluate if the concurrent search is enabled for a request during the construction of this object and then cache that value for all other invocations. Currently the way it is implemented it can happen that between invocations the cluster setting can change resulting in inconsistent value during the request flow.
* DefaultSearchContext should also not provide executor to the IndexSearcher if concurrent search segment is disabled for the request.

### Related Issues
Resolves #9058 

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
