### PR TITLE
[Segment Replication] Unmute testIndexingWithSegRep rolling upgrade test

### DIFF
--- a/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/IndexingIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/IndexingIT.java
@@ -168,7 +168,7 @@ public class IndexingIT extends AbstractRollingTestCase {
         }, 1, TimeUnit.MINUTES);
     }
 
-    public void testIndexing() throws IOException, ParseException {
+    public void testIndexing() throws Exception {
         switch (CLUSTER_TYPE) {
         case OLD:
             break;

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/IndexingIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/IndexingIT.java
@@ -399,12 +399,14 @@ public class IndexingIT extends AbstractRollingTestCase {
         client().performRequest(bulk);
     }
 
-    private void assertCount(String index, int count) throws IOException, ParseException {
-        Request searchTestIndexRequest = new Request("POST", "/" + index + "/_search");
-        searchTestIndexRequest.addParameter(TOTAL_HITS_AS_INT_PARAM, "true");
-        searchTestIndexRequest.addParameter("filter_path", "hits.total");
-        Response searchTestIndexResponse = client().performRequest(searchTestIndexRequest);
-        assertEquals("{\"hits\":{\"total\":" + count + "}}",
+    private void assertCount(String index, int count) throws Exception {
+        assertBusy(() -> {
+            Request searchTestIndexRequest = new Request("POST", "/" + index + "/_search");
+            searchTestIndexRequest.addParameter(TOTAL_HITS_AS_INT_PARAM, "true");
+            searchTestIndexRequest.addParameter("filter_path", "hits.total");
+            Response searchTestIndexResponse = client().performRequest(searchTestIndexRequest);
+            assertEquals("{\"hits\":{\"total\":" + count + "}}",
                 EntityUtils.toString(searchTestIndexResponse.getEntity(), StandardCharsets.UTF_8));
+        }, 30, TimeUnit.SECONDS);
     }
 }

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/IndexingIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/IndexingIT.java
@@ -108,7 +108,7 @@ public class IndexingIT extends AbstractRollingTestCase {
             Response segrepStatsResponse = client().performRequest(segrepStatsRequest);
             List<String> responseList = Streams.readAllLines(segrepStatsResponse.getEntity().getContent());
             logger.info("--> _cat/segments response\n {}", responseList.toString().replace(',', '\n'));
-
+            // Filter response for rows with zero doc count
             List<String> filteredList = new ArrayList<>();
             for(String row: responseList) {
                 String count = row.split(" +")[4];

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/IndexingIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/IndexingIT.java
@@ -250,7 +250,6 @@ public class IndexingIT extends AbstractRollingTestCase {
      *
      * @throws Exception
      */
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/8322")
     public void testIndexingWithSegRep() throws Exception {
         if (UPGRADE_FROM_VERSION.before(Version.V_2_4_0)) {
             logger.info("--> Skip test for version {} where segment replication feature is not available", UPGRADE_FROM_VERSION);


### PR DESCRIPTION
### Description
1. Unmutes `testIndexingWithSegRep` as https://github.com/opensearch-project/OpenSearch/pull/8560 (pre-requisite for segment replication bwc test) is merged to main and backported to 2.x. 
2. Fixes flakyness by first asserting row count from _cat/segments API response to enable retry without which test fails with `IndexOutOfBoundsException` as mentioned [here](https://github.com/opensearch-project/OpenSearch/issues/7679#issuecomment-1663232969). [Edit]: Needed to remove rows with `0` doc count before adding assertion of number of rows to be multiple of shard copies. 

### Related Issues
Resolves: #7679 

### Test
Ran test in a loop for ~~500~~ 100 iterations without failure on main ~~and 2.x~~

`main`
```
for in in {1..100}; do ./gradlew ':qa:rolling-upgrade:v2.10.0#upgradedClusterTest' --tests "org.opensearch.upgrades.IndexingIT.testIndexingWithSegRep"; done;
...
(base) ubuntu@ip-172-31-49-145:~/OpenSearch$ grep "BUILD" /tmp/bwc | wc -l
100
(base) ubuntu@ip-172-31-49-145:~/OpenSearch$ grep "BUILD SUCCESS" /tmp/bwc | wc -l
100
```
Will test for 2.x separately in backport PR.
~~2.x
 for in in {1..100}; do ./gradlew ':qa:rolling-upgrade:v2.8.1#upgradedClusterTest' --tests "org.opensearch.upgrades.IndexingIT.testIndexingWithSegRep" -Dtests.seed=395148148DFDD176 -Dtests.security.manager=true -Dtests.jvm.argline="-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m" -Dtests.locale=sr-BA -Dtests.timezone=America/North_Dakota/Beulah -Druntime.java=17 >> /tmp/bwc_test; done
...
(base) ubuntu@ip-172-31-49-145:~/OpenSearch$ grep "BUILD SUCCESSFUL" /tmp/bwc_test | wc -l
100~~

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
