### PR TITLE
[Backport-2.x] Add Segment download stats to remotestore stats API

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreBackpressureIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreBackpressureIT.java
@@ -17,7 +17,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.ByteSizeUnit;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException;
-import org.opensearch.index.remote.RemoteRefreshSegmentTracker;
+import org.opensearch.index.remote.RemoteSegmentTransferTracker;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.snapshots.mockstore.MockRepository;
 import org.opensearch.test.OpenSearchIntegTestCase;
@@ -92,7 +92,7 @@ public class RemoteStoreBackpressureIT extends AbstractRemoteStoreMockRepository
         assertTrue(ex.getMessage().contains("rejected execution on primary shard"));
         assertTrue(ex.getMessage().contains(breachMode));
 
-        RemoteRefreshSegmentTracker.Stats stats = stats();
+        RemoteSegmentTransferTracker.Stats stats = stats();
         assertTrue(stats.bytesLag > 0);
         assertTrue(stats.refreshTimeLagMs > 0);
         assertTrue(stats.localRefreshNumber - stats.remoteRefreshNumber > 0);
@@ -102,7 +102,7 @@ public class RemoteStoreBackpressureIT extends AbstractRemoteStoreMockRepository
             .setRandomControlIOExceptionRate(0d);
 
         assertBusy(() -> {
-            RemoteRefreshSegmentTracker.Stats finalStats = stats();
+            RemoteSegmentTransferTracker.Stats finalStats = stats();
             assertEquals(0, finalStats.bytesLag);
             assertEquals(0, finalStats.refreshTimeLagMs);
             assertEquals(0, finalStats.localRefreshNumber - finalStats.remoteRefreshNumber);
@@ -115,11 +115,11 @@ public class RemoteStoreBackpressureIT extends AbstractRemoteStoreMockRepository
         deleteRepo();
     }
 
-    private RemoteRefreshSegmentTracker.Stats stats() {
+    private RemoteSegmentTransferTracker.Stats stats() {
         String shardId = "0";
         RemoteStoreStatsResponse response = client().admin().cluster().prepareRemoteStoreStats(INDEX_NAME, shardId).get();
         final String indexShardId = String.format(Locale.ROOT, "[%s][%s]", INDEX_NAME, shardId);
-        List<RemoteStoreStats> matches = Arrays.stream(response.getShards())
+        List<RemoteStoreStats> matches = Arrays.stream(response.getRemoteStoreStats())
             .filter(stat -> indexShardId.equals(stat.getStats().shardId.toString()))
             .collect(Collectors.toList());
         assertEquals(1, matches.size());

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreStatsIT.java
@@ -15,13 +15,34 @@ import org.opensearch.action.index.IndexResponse;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.common.UUIDs;
 import org.opensearch.index.remote.RemoteRefreshSegmentTracker;
+import org.junit.Before;
+import org.opensearch.action.admin.cluster.remotestore.restore.RestoreRemoteStoreRequest;
+import org.opensearch.action.admin.cluster.remotestore.stats.RemoteStoreStats;
+import org.opensearch.action.admin.cluster.remotestore.stats.RemoteStoreStatsRequestBuilder;
+import org.opensearch.action.admin.cluster.remotestore.stats.RemoteStoreStatsResponse;
+import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.routing.ShardRouting;
+import org.opensearch.cluster.routing.ShardRoutingState;
+import org.opensearch.cluster.routing.allocation.command.MoveAllocationCommand;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.remote.RemoteSegmentTransferTracker;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
+import java.util.stream.Stream;
+
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 3)
 public class RemoteStoreStatsIT extends RemoteStoreBaseIntegTestCase {
@@ -52,14 +73,41 @@ public class RemoteStoreStatsIT extends RemoteStoreBaseIntegTestCase {
         for (String node : nodes) {
             RemoteStoreStatsResponse response = client(node).admin().cluster().prepareRemoteStoreStats(INDEX_NAME, shardId).get();
             assertTrue(response.getSuccessfulShards() > 0);
-            assertTrue(response.getShards() != null && response.getShards().length != 0);
+            assertTrue(response.getRemoteStoreStats() != null && response.getRemoteStoreStats().length != 0);
             final String indexShardId = String.format(Locale.ROOT, "[%s][%s]", INDEX_NAME, shardId);
-            List<RemoteStoreStats> matches = Arrays.stream(response.getShards())
+            List<RemoteStoreStats> matches = Arrays.stream(response.getRemoteStoreStats())
                 .filter(stat -> indexShardId.equals(stat.getStats().shardId.toString()))
                 .collect(Collectors.toList());
             assertEquals(1, matches.size());
-            RemoteRefreshSegmentTracker.Stats stats = matches.get(0).getStats();
-            assertResponseStats(stats);
+            RemoteSegmentTransferTracker.Stats stats = matches.get(0).getStats();
+            validateUploadStats(stats);
+            assertEquals(0, stats.directoryFileTransferTrackerStats.transferredBytesStarted);
+        }
+
+        // Step 3 - Enable replicas on the existing indices and ensure that download
+        // stats are being populated as well
+        changeReplicaCountAndEnsureGreen(1);
+        for (String node : nodes) {
+            RemoteStoreStatsResponse response = client(node).admin().cluster().prepareRemoteStoreStats(INDEX_NAME, shardId).get();
+            assertTrue(response.getSuccessfulShards() > 0);
+            assertTrue(response.getRemoteStoreStats() != null && response.getRemoteStoreStats().length != 0);
+            final String indexShardId = String.format(Locale.ROOT, "[%s][%s]", INDEX_NAME, shardId);
+            List<RemoteStoreStats> matches = Arrays.stream(response.getRemoteStoreStats())
+                .filter(stat -> indexShardId.equals(stat.getStats().shardId.toString()))
+                .collect(Collectors.toList());
+            assertEquals(2, matches.size());
+            for (RemoteStoreStats stat : matches) {
+                ShardRouting routing = stat.getShardRouting();
+                validateShardRouting(routing);
+                RemoteSegmentTransferTracker.Stats stats = stat.getStats();
+                if (routing.primary()) {
+                    validateUploadStats(stats);
+                    assertEquals(0, stats.directoryFileTransferTrackerStats.transferredBytesStarted);
+                } else {
+                    validateDownloadStats(stats);
+                    assertEquals(0, stats.totalUploadsStarted);
+                }
+            }
         }
     }
 
@@ -84,10 +132,31 @@ public class RemoteStoreStatsIT extends RemoteStoreBaseIntegTestCase {
             .cluster()
             .prepareRemoteStoreStats(INDEX_NAME, null);
         RemoteStoreStatsResponse response = remoteStoreStatsRequestBuilder.get();
-        assertTrue(response.getSuccessfulShards() == 3);
-        assertTrue(response.getShards() != null && response.getShards().length == 3);
-        RemoteRefreshSegmentTracker.Stats stats = response.getShards()[0].getStats();
-        assertResponseStats(stats);
+        assertEquals(3, response.getSuccessfulShards());
+        assertTrue(response.getRemoteStoreStats() != null && response.getRemoteStoreStats().length == 3);
+        RemoteSegmentTransferTracker.Stats stats = response.getRemoteStoreStats()[0].getStats();
+        validateUploadStats(stats);
+        assertEquals(0, stats.directoryFileTransferTrackerStats.transferredBytesStarted);
+
+        // Step 3 - Enable replicas on the existing indices and ensure that download
+        // stats are being populated as well
+        changeReplicaCountAndEnsureGreen(1);
+        response = client(node).admin().cluster().prepareRemoteStoreStats(INDEX_NAME, null).get();
+        assertEquals(6, response.getSuccessfulShards());
+        assertTrue(response.getRemoteStoreStats() != null && response.getRemoteStoreStats().length == 6);
+        for (RemoteStoreStats stat : response.getRemoteStoreStats()) {
+            ShardRouting routing = stat.getShardRouting();
+            validateShardRouting(routing);
+            stats = stat.getStats();
+            if (routing.primary()) {
+                validateUploadStats(stats);
+                assertEquals(0, stats.directoryFileTransferTrackerStats.transferredBytesStarted);
+            } else {
+                validateDownloadStats(stats);
+                assertEquals(0, stats.totalUploadsStarted);
+            }
+        }
+
     }
 
     public void testStatsResponseFromLocalNode() {
@@ -112,29 +181,398 @@ public class RemoteStoreStatsIT extends RemoteStoreBaseIntegTestCase {
                 .prepareRemoteStoreStats(INDEX_NAME, null);
             remoteStoreStatsRequestBuilder.setLocal(true);
             RemoteStoreStatsResponse response = remoteStoreStatsRequestBuilder.get();
-            assertTrue(response.getSuccessfulShards() == 1);
-            assertTrue(response.getShards() != null && response.getShards().length == 1);
-            RemoteRefreshSegmentTracker.Stats stats = response.getShards()[0].getStats();
-            assertResponseStats(stats);
+            assertEquals(1, response.getSuccessfulShards());
+            assertTrue(response.getRemoteStoreStats() != null && response.getRemoteStoreStats().length == 1);
+            RemoteSegmentTransferTracker.Stats stats = response.getRemoteStoreStats()[0].getStats();
+            validateUploadStats(stats);
+            assertEquals(0, stats.directoryFileTransferTrackerStats.transferredBytesStarted);
+        }
+        changeReplicaCountAndEnsureGreen(1);
+        for (String node : nodes) {
+            RemoteStoreStatsRequestBuilder remoteStoreStatsRequestBuilder = client(node).admin()
+                .cluster()
+                .prepareRemoteStoreStats(INDEX_NAME, null);
+            remoteStoreStatsRequestBuilder.setLocal(true);
+            RemoteStoreStatsResponse response = remoteStoreStatsRequestBuilder.get();
+            assertTrue(response.getSuccessfulShards() > 0);
+            assertTrue(response.getRemoteStoreStats() != null && response.getRemoteStoreStats().length != 0);
+            for (RemoteStoreStats stat : response.getRemoteStoreStats()) {
+                ShardRouting routing = stat.getShardRouting();
+                validateShardRouting(routing);
+                RemoteSegmentTransferTracker.Stats stats = stat.getStats();
+                if (routing.primary()) {
+                    validateUploadStats(stats);
+                    assertEquals(0, stats.directoryFileTransferTrackerStats.transferredBytesStarted);
+                } else {
+                    validateDownloadStats(stats);
+                    assertEquals(0, stats.totalUploadsStarted);
+                }
+            }
         }
     }
 
+    public void testDownloadStatsCorrectnessSinglePrimarySingleReplica() throws Exception {
+        // Scenario:
+        // - Create index with single primary and single replica shard
+        // - Disable Refresh Interval for the index
+        // - Index documents
+        // - Trigger refresh and flush
+        // - Assert that download stats == upload stats
+        // - Repeat this step for random times (between 5 and 10)
+
+        // Create index with 1 pri and 1 replica and refresh interval disabled
+        createIndex(
+            INDEX_NAME,
+            Settings.builder().put(remoteStoreIndexSettings(1, 1)).put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), -1).build()
+        );
+        ensureGreen(INDEX_NAME);
+
+        // Manually invoke a refresh
+        refresh(INDEX_NAME);
+
+        // Get zero state values
+        // Extract and assert zero state primary stats
+        RemoteStoreStatsResponse zeroStateResponse = client().admin().cluster().prepareRemoteStoreStats(INDEX_NAME, "0").get();
+        RemoteSegmentTransferTracker.Stats zeroStatePrimaryStats = Arrays.stream(zeroStateResponse.getRemoteStoreStats())
+            .filter(remoteStoreStats -> remoteStoreStats.getShardRouting().primary())
+            .collect(Collectors.toList())
+            .get(0)
+            .getStats();
+        assertTrue(
+            zeroStatePrimaryStats.totalUploadsStarted == zeroStatePrimaryStats.totalUploadsSucceeded
+                && zeroStatePrimaryStats.totalUploadsSucceeded == 1
+        );
+        assertTrue(
+            zeroStatePrimaryStats.uploadBytesStarted == zeroStatePrimaryStats.uploadBytesSucceeded
+                && zeroStatePrimaryStats.uploadBytesSucceeded > 0
+        );
+        assertTrue(zeroStatePrimaryStats.totalUploadsFailed == 0 && zeroStatePrimaryStats.uploadBytesFailed == 0);
+
+        // Extract and assert zero state replica stats
+        RemoteSegmentTransferTracker.Stats zeroStateReplicaStats = Arrays.stream(zeroStateResponse.getRemoteStoreStats())
+            .filter(remoteStoreStats -> !remoteStoreStats.getShardRouting().primary())
+            .collect(Collectors.toList())
+            .get(0)
+            .getStats();
+        assertTrue(
+            zeroStateReplicaStats.directoryFileTransferTrackerStats.transferredBytesStarted == 0
+                && zeroStateReplicaStats.directoryFileTransferTrackerStats.transferredBytesSucceeded == 0
+        );
+
+        // Index documents
+        for (int i = 1; i <= randomIntBetween(5, 10); i++) {
+            indexSingleDoc(INDEX_NAME);
+            // Running Flush & Refresh manually
+            flushAndRefresh(INDEX_NAME);
+            ensureGreen(INDEX_NAME);
+
+            // Poll for RemoteStore Stats
+            assertBusy(() -> {
+                RemoteStoreStatsResponse response = client().admin().cluster().prepareRemoteStoreStats(INDEX_NAME, "0").get();
+                // Iterate through the response and extract the relevant segment upload and download stats
+                List<RemoteStoreStats> primaryStatsList = Arrays.stream(response.getRemoteStoreStats())
+                    .filter(remoteStoreStats -> remoteStoreStats.getShardRouting().primary())
+                    .collect(Collectors.toList());
+                assertEquals(1, primaryStatsList.size());
+                List<RemoteStoreStats> replicaStatsList = Arrays.stream(response.getRemoteStoreStats())
+                    .filter(remoteStoreStats -> !remoteStoreStats.getShardRouting().primary())
+                    .collect(Collectors.toList());
+                assertEquals(1, replicaStatsList.size());
+                RemoteSegmentTransferTracker.Stats primaryStats = primaryStatsList.get(0).getStats();
+                RemoteSegmentTransferTracker.Stats replicaStats = replicaStatsList.get(0).getStats();
+                // Assert Upload syncs - zero state uploads == download syncs
+                assertTrue(primaryStats.totalUploadsStarted > 0);
+                assertTrue(primaryStats.totalUploadsSucceeded > 0);
+                assertTrue(
+                    replicaStats.directoryFileTransferTrackerStats.transferredBytesStarted > 0
+                        && primaryStats.uploadBytesStarted
+                            - zeroStatePrimaryStats.uploadBytesStarted == replicaStats.directoryFileTransferTrackerStats.transferredBytesStarted
+                );
+                assertTrue(
+                    replicaStats.directoryFileTransferTrackerStats.transferredBytesSucceeded > 0
+                        && primaryStats.uploadBytesSucceeded
+                            - zeroStatePrimaryStats.uploadBytesSucceeded == replicaStats.directoryFileTransferTrackerStats.transferredBytesSucceeded
+                );
+                // Assert zero failures
+                assertEquals(0, primaryStats.uploadBytesFailed);
+                assertEquals(0, replicaStats.directoryFileTransferTrackerStats.transferredBytesFailed);
+            }, 60, TimeUnit.SECONDS);
+        }
+    }
+
+    public void testDownloadStatsCorrectnessSinglePrimaryMultipleReplicaShards() throws Exception {
+        // Scenario:
+        // - Create index with single primary and N-1 replica shards (N = no of data nodes)
+        // - Disable Refresh Interval for the index
+        // - Index documents
+        // - Trigger refresh and flush
+        // - Assert that download stats == upload stats
+        // - Repeat this step for random times (between 5 and 10)
+
+        // Create index
+        int dataNodeCount = client().admin().cluster().prepareHealth().get().getNumberOfDataNodes();
+        createIndex(
+            INDEX_NAME,
+            Settings.builder()
+                .put(remoteStoreIndexSettings(dataNodeCount - 1, 1))
+                .put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), -1)
+                .build()
+        );
+        ensureGreen(INDEX_NAME);
+
+        // Manually invoke a refresh
+        refresh(INDEX_NAME);
+
+        // Get zero state values
+        // Extract and assert zero state primary stats
+        RemoteStoreStatsResponse zeroStateResponse = client().admin().cluster().prepareRemoteStoreStats(INDEX_NAME, "0").get();
+        RemoteSegmentTransferTracker.Stats zeroStatePrimaryStats = Arrays.stream(zeroStateResponse.getRemoteStoreStats())
+            .filter(remoteStoreStats -> remoteStoreStats.getShardRouting().primary())
+            .collect(Collectors.toList())
+            .get(0)
+            .getStats();
+        assertTrue(
+            zeroStatePrimaryStats.totalUploadsStarted == zeroStatePrimaryStats.totalUploadsSucceeded
+                && zeroStatePrimaryStats.totalUploadsSucceeded == 1
+        );
+        assertTrue(
+            zeroStatePrimaryStats.uploadBytesStarted == zeroStatePrimaryStats.uploadBytesSucceeded
+                && zeroStatePrimaryStats.uploadBytesSucceeded > 0
+        );
+        assertTrue(zeroStatePrimaryStats.totalUploadsFailed == 0 && zeroStatePrimaryStats.uploadBytesFailed == 0);
+
+        // Extract and assert zero state replica stats
+        List<RemoteStoreStats> zeroStateReplicaStats = Arrays.stream(zeroStateResponse.getRemoteStoreStats())
+            .filter(remoteStoreStats -> !remoteStoreStats.getShardRouting().primary())
+            .collect(Collectors.toList());
+        zeroStateReplicaStats.forEach(stats -> {
+            assertTrue(
+                stats.getStats().directoryFileTransferTrackerStats.transferredBytesStarted == 0
+                    && stats.getStats().directoryFileTransferTrackerStats.transferredBytesSucceeded == 0
+            );
+        });
+
+        int currentNodesInCluster = client().admin().cluster().prepareHealth().get().getNumberOfDataNodes();
+        for (int i = 0; i < randomIntBetween(5, 10); i++) {
+            indexSingleDoc(INDEX_NAME);
+            // Running Flush & Refresh manually
+            flushAndRefresh(INDEX_NAME);
+
+            assertBusy(() -> {
+                RemoteStoreStatsResponse response = client().admin().cluster().prepareRemoteStoreStats(INDEX_NAME, "0").get();
+                assertEquals(currentNodesInCluster, response.getSuccessfulShards());
+                long uploadsStarted = 0, uploadsSucceeded = 0, uploadsFailed = 0;
+                long uploadBytesStarted = 0, uploadBytesSucceeded = 0, uploadBytesFailed = 0;
+                List<Long> downloadBytesStarted = new ArrayList<>(), downloadBytesSucceeded = new ArrayList<>(), downloadBytesFailed =
+                    new ArrayList<>();
+
+                // Assert that stats for primary shard and replica shard set are equal
+                for (RemoteStoreStats eachStatsObject : response.getRemoteStoreStats()) {
+                    RemoteSegmentTransferTracker.Stats stats = eachStatsObject.getStats();
+                    if (eachStatsObject.getShardRouting().primary()) {
+                        uploadBytesStarted = stats.uploadBytesStarted;
+                        uploadBytesSucceeded = stats.uploadBytesSucceeded;
+                        uploadBytesFailed = stats.uploadBytesFailed;
+                    } else {
+                        downloadBytesStarted.add(stats.directoryFileTransferTrackerStats.transferredBytesStarted);
+                        downloadBytesSucceeded.add(stats.directoryFileTransferTrackerStats.transferredBytesSucceeded);
+                        downloadBytesFailed.add(stats.directoryFileTransferTrackerStats.transferredBytesFailed);
+                    }
+                }
+
+                assertEquals(0, uploadsFailed);
+                assertEquals(0, uploadBytesFailed);
+                for (int j = 0; j < response.getSuccessfulShards() - 1; j++) {
+                    assertEquals(uploadBytesStarted - zeroStatePrimaryStats.uploadBytesStarted, (long) downloadBytesStarted.get(j));
+                    assertEquals(uploadBytesSucceeded - zeroStatePrimaryStats.uploadBytesSucceeded, (long) downloadBytesSucceeded.get(j));
+                    assertEquals(0, (long) downloadBytesFailed.get(j));
+                }
+            }, 60, TimeUnit.SECONDS);
+        }
+    }
+
+    public void testStatsOnShardRelocation() {
+        // Scenario:
+        // - Create index with single primary and single replica shard
+        // - Index documents
+        // - Reroute replica shard to one of the remaining nodes
+        // - Assert that remote store stats reflects the new node ID
+
+        // Create index
+        createIndex(INDEX_NAME, remoteStoreIndexSettings(1, 1));
+        ensureGreen(INDEX_NAME);
+        // Index docs
+        indexDocs();
+
+        // Fetch current set of nodes in the cluster
+        List<String> currentNodesInCluster = getClusterState().nodes()
+            .getDataNodes()
+            .values()
+            .stream()
+            .map(DiscoveryNode::getId)
+            .collect(Collectors.toList());
+        DiscoveryNode[] discoveryNodesForIndex = client().admin().cluster().prepareSearchShards(INDEX_NAME).get().getNodes();
+
+        // Fetch nodes with shard copies of the created index
+        List<String> nodeIdsWithShardCopies = new ArrayList<>();
+        Arrays.stream(discoveryNodesForIndex).forEach(eachNode -> nodeIdsWithShardCopies.add(eachNode.getId()));
+
+        // Fetch nodes which does not have any copies of the index
+        List<String> nodeIdsWithoutShardCopy = currentNodesInCluster.stream()
+            .filter(eachNode -> !nodeIdsWithShardCopies.contains(eachNode))
+            .collect(Collectors.toList());
+        assertEquals(1, nodeIdsWithoutShardCopy.size());
+
+        // Manually reroute shard to a node which does not have any shard copy at present
+        ShardRouting replicaShardRouting = getClusterState().routingTable()
+            .index(INDEX_NAME)
+            .shard(0)
+            .assignedShards()
+            .stream()
+            .filter(shard -> !shard.primary())
+            .collect(Collectors.toList())
+            .get(0);
+        String sourceNode = replicaShardRouting.currentNodeId();
+        String destinationNode = nodeIdsWithoutShardCopy.get(0);
+        relocateShard(0, sourceNode, destinationNode);
+        RemoteStoreStats[] allShardsStats = client().admin().cluster().prepareRemoteStoreStats(INDEX_NAME, "0").get().getRemoteStoreStats();
+        RemoteStoreStats replicaShardStat = Arrays.stream(allShardsStats)
+            .filter(eachStat -> !eachStat.getShardRouting().primary())
+            .collect(Collectors.toList())
+            .get(0);
+
+        // Assert that remote store stats reflect the new shard state
+        assertEquals(ShardRoutingState.STARTED, replicaShardStat.getShardRouting().state());
+        assertEquals(destinationNode, replicaShardStat.getShardRouting().currentNodeId());
+    }
+
+    public void testStatsOnShardUnassigned() throws IOException {
+        // Scenario:
+        // - Create index with single primary and two replica shard
+        // - Index documents
+        // - Stop one data node
+        // - Assert:
+        // a. Total shard Count in the response object is equal to the previous node count
+        // b. Successful shard count in the response object is equal to the new node count
+        createIndex(INDEX_NAME, remoteStoreIndexSettings(2, 1));
+        ensureGreen(INDEX_NAME);
+        indexDocs();
+        int dataNodeCountBeforeStop = client().admin().cluster().prepareHealth().get().getNumberOfDataNodes();
+        internalCluster().stopRandomDataNode();
+        RemoteStoreStatsResponse response = client().admin().cluster().prepareRemoteStoreStats(INDEX_NAME, "0").get();
+        int dataNodeCountAfterStop = client().admin().cluster().prepareHealth().get().getNumberOfDataNodes();
+        assertEquals(dataNodeCountBeforeStop, response.getTotalShards());
+        assertEquals(dataNodeCountAfterStop, response.getSuccessfulShards());
+    }
+
+    public void testStatsOnRemoteStoreRestore() throws IOException {
+        // Creating an index with primary shard count == total nodes in cluster and 0 replicas
+        int dataNodeCount = client().admin().cluster().prepareHealth().get().getNumberOfDataNodes();
+        createIndex(INDEX_NAME, remoteStoreIndexSettings(0, dataNodeCount));
+        ensureGreen(INDEX_NAME);
+
+        // Index some docs to ensure segments being uploaded to remote store
+        indexDocs();
+        refresh(INDEX_NAME);
+
+        // Stop one data node to force the index into a red state
+        internalCluster().stopRandomDataNode();
+        ensureRed(INDEX_NAME);
+
+        // Start another data node to fulfil the previously launched capacity
+        internalCluster().startDataOnlyNode();
+
+        // Restore index from remote store
+        assertAcked(client().admin().indices().prepareClose(INDEX_NAME));
+        client().admin()
+            .cluster()
+            .restoreRemoteStore(new RestoreRemoteStoreRequest().indices(INDEX_NAME).restoreAllShards(true), PlainActionFuture.newFuture());
+
+        // Ensure that the index is green
+        ensureGreen(INDEX_NAME);
+
+        // Index some more docs to force segment uploads to remote store
+        indexDocs();
+
+        RemoteStoreStatsResponse remoteStoreStatsResponse = client().admin().cluster().prepareRemoteStoreStats(INDEX_NAME, "0").get();
+        Arrays.stream(remoteStoreStatsResponse.getRemoteStoreStats()).forEach(statObject -> {
+            RemoteSegmentTransferTracker.Stats segmentTracker = statObject.getStats();
+            // Assert that we have both upload and download stats for the index
+            assertTrue(
+                segmentTracker.totalUploadsStarted > 0 && segmentTracker.totalUploadsSucceeded > 0 && segmentTracker.totalUploadsFailed == 0
+            );
+            assertTrue(
+                segmentTracker.directoryFileTransferTrackerStats.transferredBytesStarted > 0
+                    && segmentTracker.directoryFileTransferTrackerStats.transferredBytesSucceeded > 0
+            );
+        });
+    }
+
+    public void testNonZeroPrimaryStatsOnNewlyCreatedIndexWithZeroDocs() throws Exception {
+        // Create an index with one primary and one replica shard
+        createIndex(INDEX_NAME, remoteStoreIndexSettings(1, 1));
+        ensureGreen(INDEX_NAME);
+        refresh(INDEX_NAME);
+
+        // Ensure that the index has 0 documents in it
+        assertEquals(0, client().admin().indices().prepareStats(INDEX_NAME).get().getTotal().docs.getCount());
+
+        // Assert that within 5 seconds the download and upload stats moves to a non-zero value
+        assertBusy(() -> {
+            RemoteStoreStats[] remoteStoreStats = client().admin()
+                .cluster()
+                .prepareRemoteStoreStats(INDEX_NAME, "0")
+                .get()
+                .getRemoteStoreStats();
+            Arrays.stream(remoteStoreStats).forEach(statObject -> {
+                RemoteSegmentTransferTracker.Stats segmentTracker = statObject.getStats();
+                if (statObject.getShardRouting().primary()) {
+                    assertTrue(
+                        segmentTracker.totalUploadsSucceeded == 1
+                            && segmentTracker.totalUploadsStarted == segmentTracker.totalUploadsSucceeded
+                            && segmentTracker.totalUploadsFailed == 0
+                    );
+                } else {
+                    assertTrue(
+                        segmentTracker.directoryFileTransferTrackerStats.transferredBytesStarted == 0
+                            && segmentTracker.directoryFileTransferTrackerStats.transferredBytesSucceeded == 0
+                    );
+                }
+            });
+        }, 5, TimeUnit.SECONDS);
+    }
+
     private void indexDocs() {
-        // Indexing documents along with refreshes and flushes.
         for (int i = 0; i < randomIntBetween(5, 10); i++) {
             if (randomBoolean()) {
                 flush(INDEX_NAME);
             } else {
                 refresh(INDEX_NAME);
             }
-            int numberOfOperations = randomIntBetween(20, 50);
+            int numberOfOperations = randomIntBetween(10, 30);
             for (int j = 0; j < numberOfOperations; j++) {
                 indexSingleDoc();
             }
         }
     }
 
-    private void assertResponseStats(RemoteRefreshSegmentTracker.Stats stats) {
+    private void changeReplicaCountAndEnsureGreen(int replicaCount) {
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareUpdateSettings(INDEX_NAME)
+                .setSettings(Settings.builder().put(SETTING_NUMBER_OF_REPLICAS, replicaCount))
+        );
+        ensureYellowAndNoInitializingShards(INDEX_NAME);
+        ensureGreen(INDEX_NAME);
+    }
+
+    private void relocateShard(int shardId, String sourceNode, String destNode) {
+        assertAcked(client().admin().cluster().prepareReroute().add(new MoveAllocationCommand(INDEX_NAME, shardId, sourceNode, destNode)));
+        ensureGreen(INDEX_NAME);
+    }
+
+    private void validateUploadStats(RemoteSegmentTransferTracker.Stats stats) {
         assertEquals(0, stats.refreshTimeLagMs);
         assertEquals(stats.localRefreshNumber, stats.remoteRefreshNumber);
         assertTrue(stats.uploadBytesStarted > 0);
@@ -158,4 +596,31 @@ public class RemoteStoreStatsIT extends RemoteStoreBaseIntegTestCase {
             .get();
     }
 
+    private void validateDownloadStats(RemoteSegmentTransferTracker.Stats stats) {
+        assertTrue(stats.directoryFileTransferTrackerStats.lastTransferTimestampMs > 0);
+        assertTrue(stats.directoryFileTransferTrackerStats.transferredBytesStarted > 0);
+        assertTrue(stats.directoryFileTransferTrackerStats.transferredBytesSucceeded > 0);
+        assertEquals(stats.directoryFileTransferTrackerStats.transferredBytesFailed, 0);
+        assertTrue(stats.directoryFileTransferTrackerStats.lastSuccessfulTransferInBytes > 0);
+        assertTrue(stats.directoryFileTransferTrackerStats.transferredBytesMovingAverage > 0);
+        assertTrue(stats.directoryFileTransferTrackerStats.transferredBytesPerSecMovingAverage > 0);
+    }
+
+    // Validate if the shardRouting obtained from cluster state contains the exact same routing object
+    // parameters as obtained from the remote store stats API
+    private void validateShardRouting(ShardRouting routing) {
+        Stream<ShardRouting> currentRoutingTable = getClusterState().routingTable()
+            .getIndicesRouting()
+            .get(INDEX_NAME)
+            .shard(routing.id())
+            .assignedShards()
+            .stream();
+        assertTrue(
+            currentRoutingTable.anyMatch(
+                r -> (r.currentNodeId().equals(routing.currentNodeId())
+                    && r.state().equals(routing.state())
+                    && r.primary() == routing.primary())
+            )
+        );
+    }
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/stats/RemoteStoreStats.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/stats/RemoteStoreStats.java
@@ -11,9 +11,13 @@ package org.opensearch.action.admin.cluster.remotestore.stats;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.core.xcontent.ToXContentFragment;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.index.remote.RemoteRefreshSegmentTracker;
+import org.opensearch.index.remote.RemoteSegmentTransferTracker;
 
 import java.io.IOException;
 
@@ -24,72 +28,128 @@ import java.io.IOException;
  */
 public class RemoteStoreStats implements Writeable, ToXContentFragment {
 
-    private final RemoteRefreshSegmentTracker.Stats remoteSegmentUploadShardStats;
+    private final RemoteSegmentTransferTracker.Stats remoteSegmentShardStats;
 
-    public RemoteStoreStats(RemoteRefreshSegmentTracker.Stats remoteSegmentUploadShardStats) {
-        this.remoteSegmentUploadShardStats = remoteSegmentUploadShardStats;
+    private final ShardRouting shardRouting;
+
+    public RemoteStoreStats(RemoteSegmentTransferTracker.Stats remoteSegmentUploadShardStats, ShardRouting shardRouting) {
+        this.remoteSegmentShardStats = remoteSegmentUploadShardStats;
+        this.shardRouting = shardRouting;
     }
 
     public RemoteStoreStats(StreamInput in) throws IOException {
-        remoteSegmentUploadShardStats = in.readOptionalWriteable(RemoteRefreshSegmentTracker.Stats::new);
+        this.remoteSegmentShardStats = in.readOptionalWriteable(RemoteSegmentTransferTracker.Stats::new);
+        this.shardRouting = new ShardRouting(in);
     }
 
-    public RemoteRefreshSegmentTracker.Stats getStats() {
-        return remoteSegmentUploadShardStats;
+    public RemoteSegmentTransferTracker.Stats getStats() {
+        return remoteSegmentShardStats;
+    }
+
+    public ShardRouting getShardRouting() {
+        return shardRouting;
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject()
-            .field(Fields.SHARD_ID, remoteSegmentUploadShardStats.shardId)
-            .field(Fields.LOCAL_REFRESH_TIMESTAMP, remoteSegmentUploadShardStats.localRefreshClockTimeMs)
-            .field(Fields.REMOTE_REFRESH_TIMESTAMP, remoteSegmentUploadShardStats.remoteRefreshClockTimeMs)
-            .field(Fields.REFRESH_TIME_LAG_IN_MILLIS, remoteSegmentUploadShardStats.refreshTimeLagMs)
-            .field(Fields.REFRESH_LAG, remoteSegmentUploadShardStats.localRefreshNumber - remoteSegmentUploadShardStats.remoteRefreshNumber)
-            .field(Fields.BYTES_LAG, remoteSegmentUploadShardStats.bytesLag)
-
-            .field(Fields.BACKPRESSURE_REJECTION_COUNT, remoteSegmentUploadShardStats.rejectionCount)
-            .field(Fields.CONSECUTIVE_FAILURE_COUNT, remoteSegmentUploadShardStats.consecutiveFailuresCount);
-
-        builder.startObject(Fields.TOTAL_REMOTE_REFRESH);
-        builder.field(SubFields.STARTED, remoteSegmentUploadShardStats.totalUploadsStarted)
-            .field(SubFields.SUCCEEDED, remoteSegmentUploadShardStats.totalUploadsSucceeded)
-            .field(SubFields.FAILED, remoteSegmentUploadShardStats.totalUploadsFailed);
+        builder.startObject();
+        buildShardRouting(builder);
+        builder.startObject(Fields.SEGMENT);
+        builder.startObject(SubFields.DOWNLOAD);
+        // Ensuring that we are not showing 0 metrics to the user
+        if (remoteSegmentShardStats.directoryFileTransferTrackerStats.transferredBytesStarted != 0) {
+            buildDownloadStats(builder);
+        }
         builder.endObject();
-
-        builder.startObject(Fields.TOTAL_UPLOADS_IN_BYTES);
-        builder.field(SubFields.STARTED, remoteSegmentUploadShardStats.uploadBytesStarted)
-            .field(SubFields.SUCCEEDED, remoteSegmentUploadShardStats.uploadBytesSucceeded)
-            .field(SubFields.FAILED, remoteSegmentUploadShardStats.uploadBytesFailed);
-        builder.endObject();
-
-        builder.startObject(Fields.REMOTE_REFRESH_SIZE_IN_BYTES);
-        builder.field(SubFields.LAST_SUCCESSFUL, remoteSegmentUploadShardStats.lastSuccessfulRemoteRefreshBytes);
-        builder.field(SubFields.MOVING_AVG, remoteSegmentUploadShardStats.uploadBytesMovingAverage);
-        builder.endObject();
-
-        builder.startObject(Fields.UPLOAD_LATENCY_IN_BYTES_PER_SEC);
-        builder.field(SubFields.MOVING_AVG, remoteSegmentUploadShardStats.uploadBytesPerSecMovingAverage);
-        builder.endObject();
-        builder.startObject(Fields.REMOTE_REFRESH_LATENCY_IN_MILLIS);
-        builder.field(SubFields.MOVING_AVG, remoteSegmentUploadShardStats.uploadTimeMovingAverage);
+        builder.startObject(SubFields.UPLOAD);
+        // Ensuring that we are not showing 0 metrics to the user
+        if (remoteSegmentShardStats.totalUploadsStarted != 0) {
+            buildUploadStats(builder);
+        }
         builder.endObject();
         builder.endObject();
-
-        return builder;
+        return builder.endObject();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeOptionalWriteable(remoteSegmentUploadShardStats);
+        out.writeOptionalWriteable(remoteSegmentShardStats);
+        shardRouting.writeTo(out);
+    }
+
+    private void buildUploadStats(XContentBuilder builder) throws IOException {
+        builder.field(UploadStatsFields.LOCAL_REFRESH_TIMESTAMP, remoteSegmentShardStats.localRefreshClockTimeMs)
+            .field(UploadStatsFields.REMOTE_REFRESH_TIMESTAMP, remoteSegmentShardStats.remoteRefreshClockTimeMs)
+            .field(UploadStatsFields.REFRESH_TIME_LAG_IN_MILLIS, remoteSegmentShardStats.refreshTimeLagMs)
+            .field(UploadStatsFields.REFRESH_LAG, remoteSegmentShardStats.localRefreshNumber - remoteSegmentShardStats.remoteRefreshNumber)
+            .field(UploadStatsFields.BYTES_LAG, remoteSegmentShardStats.bytesLag)
+            .field(UploadStatsFields.BACKPRESSURE_REJECTION_COUNT, remoteSegmentShardStats.rejectionCount)
+            .field(UploadStatsFields.CONSECUTIVE_FAILURE_COUNT, remoteSegmentShardStats.consecutiveFailuresCount);
+        builder.startObject(UploadStatsFields.TOTAL_SYNCS_TO_REMOTE)
+            .field(SubFields.STARTED, remoteSegmentShardStats.totalUploadsStarted)
+            .field(SubFields.SUCCEEDED, remoteSegmentShardStats.totalUploadsSucceeded)
+            .field(SubFields.FAILED, remoteSegmentShardStats.totalUploadsFailed);
+        builder.endObject();
+        builder.startObject(UploadStatsFields.TOTAL_UPLOADS_IN_BYTES)
+            .field(SubFields.STARTED, remoteSegmentShardStats.uploadBytesStarted)
+            .field(SubFields.SUCCEEDED, remoteSegmentShardStats.uploadBytesSucceeded)
+            .field(SubFields.FAILED, remoteSegmentShardStats.uploadBytesFailed);
+        builder.endObject();
+        builder.startObject(UploadStatsFields.REMOTE_REFRESH_SIZE_IN_BYTES)
+            .field(SubFields.LAST_SUCCESSFUL, remoteSegmentShardStats.lastSuccessfulRemoteRefreshBytes)
+            .field(SubFields.MOVING_AVG, remoteSegmentShardStats.uploadBytesMovingAverage);
+        builder.endObject();
+        builder.startObject(UploadStatsFields.UPLOAD_LATENCY_IN_BYTES_PER_SEC)
+            .field(SubFields.MOVING_AVG, remoteSegmentShardStats.uploadBytesPerSecMovingAverage);
+        builder.endObject();
+        builder.startObject(UploadStatsFields.REMOTE_REFRESH_LATENCY_IN_MILLIS)
+            .field(SubFields.MOVING_AVG, remoteSegmentShardStats.uploadTimeMovingAverage);
+        builder.endObject();
+    }
+
+    private void buildDownloadStats(XContentBuilder builder) throws IOException {
+        builder.field(
+            DownloadStatsFields.LAST_SYNC_TIMESTAMP,
+            remoteSegmentShardStats.directoryFileTransferTrackerStats.lastTransferTimestampMs
+        );
+        builder.startObject(DownloadStatsFields.TOTAL_DOWNLOADS_IN_BYTES)
+            .field(SubFields.STARTED, remoteSegmentShardStats.directoryFileTransferTrackerStats.transferredBytesStarted)
+            .field(SubFields.SUCCEEDED, remoteSegmentShardStats.directoryFileTransferTrackerStats.transferredBytesSucceeded)
+            .field(SubFields.FAILED, remoteSegmentShardStats.directoryFileTransferTrackerStats.transferredBytesFailed);
+        builder.endObject();
+        builder.startObject(DownloadStatsFields.DOWNLOAD_SIZE_IN_BYTES)
+            .field(SubFields.LAST_SUCCESSFUL, remoteSegmentShardStats.directoryFileTransferTrackerStats.lastSuccessfulTransferInBytes)
+            .field(SubFields.MOVING_AVG, remoteSegmentShardStats.directoryFileTransferTrackerStats.transferredBytesMovingAverage);
+        builder.endObject();
+        builder.startObject(DownloadStatsFields.DOWNLOAD_SPEED_IN_BYTES_PER_SEC)
+            .field(SubFields.MOVING_AVG, remoteSegmentShardStats.directoryFileTransferTrackerStats.transferredBytesPerSecMovingAverage);
+        builder.endObject();
+    }
+
+    private void buildShardRouting(XContentBuilder builder) throws IOException {
+        builder.startObject(Fields.ROUTING);
+        builder.field(RoutingFields.STATE, shardRouting.state());
+        builder.field(RoutingFields.PRIMARY, shardRouting.primary());
+        builder.field(RoutingFields.NODE_ID, shardRouting.currentNodeId());
+        builder.endObject();
+    }
+
+    static final class Fields {
+        static final String ROUTING = "routing";
+        static final String SEGMENT = "segment";
+        static final String TRANSLOG = "translog";
+    }
+
+    static final class RoutingFields {
+        static final String STATE = "state";
+        static final String PRIMARY = "primary";
+        static final String NODE_ID = "node";
     }
 
     /**
      * Fields for remote store stats response
      */
-    static final class Fields {
-        static final String SHARD_ID = "shard_id";
-
+    static final class UploadStatsFields {
         /**
          * Lag in terms of bytes b/w local and remote store
          */
@@ -128,7 +188,7 @@ public class RemoteStoreStats implements Writeable, ToXContentFragment {
         /**
          * Represents the number of remote refreshes
          */
-        static final String TOTAL_REMOTE_REFRESH = "total_remote_refresh";
+        static final String TOTAL_SYNCS_TO_REMOTE = "total_syncs_to_remote";
 
         /**
          * Represents the total uploads to remote store in bytes
@@ -151,21 +211,46 @@ public class RemoteStoreStats implements Writeable, ToXContentFragment {
         static final String REMOTE_REFRESH_LATENCY_IN_MILLIS = "remote_refresh_latency_in_millis";
     }
 
+    static final class DownloadStatsFields {
+        /**
+         * Last successful sync from remote in milliseconds
+         */
+        static final String LAST_SYNC_TIMESTAMP = "last_sync_timestamp";
+
+        /**
+         * Total bytes of segment files downloaded from the remote store for a specific shard
+         */
+        static final String TOTAL_DOWNLOADS_IN_BYTES = "total_downloads_in_bytes";
+
+        /**
+         * Size of each segment file downloaded from the remote store
+         */
+        static final String DOWNLOAD_SIZE_IN_BYTES = "download_size_in_bytes";
+
+        /**
+         * Speed (in bytes/sec) for segment file downloads
+         */
+        static final String DOWNLOAD_SPEED_IN_BYTES_PER_SEC = "download_speed_in_bytes_per_sec";
+    }
+
     /**
-     * Reusable sub fields for {@link Fields}
+     * Reusable sub fields for {@link UploadStatsFields} and {@link DownloadStatsFields}
      */
     static final class SubFields {
         static final String STARTED = "started";
         static final String SUCCEEDED = "succeeded";
         static final String FAILED = "failed";
 
+        static final String DOWNLOAD = "download";
+        static final String UPLOAD = "upload";
+
         /**
-         * Moving avg over last N values stat for a {@link Fields}
+         * Moving avg over last N values stat
          */
         static final String MOVING_AVG = "moving_avg";
 
         /**
-         * Most recent successful attempt stat for a {@link Fields}
+         * Most recent successful attempt stat
          */
         static final String LAST_SUCCESSFUL = "last_successful";
     }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/stats/RemoteStoreStatsResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/stats/RemoteStoreStatsResponse.java
@@ -17,7 +17,10 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Remote Store stats response
@@ -26,49 +29,71 @@ import java.util.List;
  */
 public class RemoteStoreStatsResponse extends BroadcastResponse {
 
-    private final RemoteStoreStats[] shards;
+    private final RemoteStoreStats[] remoteStoreStats;
 
     public RemoteStoreStatsResponse(StreamInput in) throws IOException {
         super(in);
-        shards = in.readArray(RemoteStoreStats::new, RemoteStoreStats[]::new);
+        remoteStoreStats = in.readArray(RemoteStoreStats::new, RemoteStoreStats[]::new);
     }
 
     public RemoteStoreStatsResponse(
-        RemoteStoreStats[] shards,
+        RemoteStoreStats[] remoteStoreStats,
         int totalShards,
         int successfulShards,
         int failedShards,
         List<DefaultShardOperationFailedException> shardFailures
     ) {
         super(totalShards, successfulShards, failedShards, shardFailures);
-        this.shards = shards;
+        this.remoteStoreStats = remoteStoreStats;
     }
 
-    public RemoteStoreStats[] getShards() {
-        return this.shards;
+    public RemoteStoreStats[] getRemoteStoreStats() {
+        return this.remoteStoreStats;
     }
 
-    public RemoteStoreStats getAt(int position) {
-        return shards[position];
+    public Map<String, Map<Integer, List<RemoteStoreStats>>> groupByIndexAndShards() {
+        Map<String, Map<Integer, List<RemoteStoreStats>>> indexWiseStats = new HashMap<>();
+        for (RemoteStoreStats shardStat : remoteStoreStats) {
+            indexWiseStats.computeIfAbsent(shardStat.getShardRouting().getIndexName(), k -> new HashMap<>())
+                .computeIfAbsent(shardStat.getShardRouting().getId(), k -> new ArrayList<>())
+                .add(shardStat);
+        }
+        return indexWiseStats;
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeArray(shards);
+        out.writeArray(remoteStoreStats);
     }
 
     @Override
     protected void addCustomXContentFields(XContentBuilder builder, Params params) throws IOException {
-        builder.startArray("stats");
-        for (RemoteStoreStats shard : shards) {
-            shard.toXContent(builder, params);
+        Map<String, Map<Integer, List<RemoteStoreStats>>> indexWiseStats = groupByIndexAndShards();
+        builder.startObject(Fields.INDICES);
+        for (String indexName : indexWiseStats.keySet()) {
+            builder.startObject(indexName);
+            builder.startObject(Fields.SHARDS);
+            for (int shardId : indexWiseStats.get(indexName).keySet()) {
+                builder.startArray(Integer.toString(shardId));
+                for (RemoteStoreStats shardStat : indexWiseStats.get(indexName).get(shardId)) {
+                    shardStat.toXContent(builder, params);
+                }
+                builder.endArray();
+            }
+            builder.endObject();
+            builder.endObject();
         }
-        builder.endArray();
+        builder.endObject();
     }
 
     @Override
     public String toString() {
         return Strings.toString(XContentType.JSON, this, true, false);
+    }
+
+    static final class Fields {
+        static final String SHARDS = "shards";
+        static final String INDICES = "indices";
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/stats/TransportRemoteStoreStatsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/stats/TransportRemoteStoreStatsAction.java
@@ -24,7 +24,7 @@ import org.opensearch.common.inject.Inject;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.remote.RemoteRefreshSegmentPressureService;
-import org.opensearch.index.remote.RemoteRefreshSegmentTracker;
+import org.opensearch.index.remote.RemoteSegmentTransferTracker;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.shard.ShardNotFoundException;
 import org.opensearch.indices.IndicesService;
@@ -49,6 +49,7 @@ public class TransportRemoteStoreStatsAction extends TransportBroadcastByNodeAct
     RemoteStoreStats> {
 
     private final IndicesService indicesService;
+
     private final RemoteRefreshSegmentPressureService remoteRefreshSegmentPressureService;
 
     @Inject
@@ -95,7 +96,6 @@ public class TransportRemoteStoreStatsAction extends TransportBroadcastByNodeAct
                         || (shardRouting.currentNodeId() == null
                             || shardRouting.currentNodeId().equals(clusterState.getNodes().getLocalNodeId()))
                 )
-                .filter(ShardRouting::primary)
                 .filter(
                     shardRouting -> Boolean.parseBoolean(
                         clusterState.getMetadata().index(shardRouting.index()).getSettings().get(IndexMetadata.SETTING_REMOTE_STORE_ENABLED)
@@ -153,11 +153,10 @@ public class TransportRemoteStoreStatsAction extends TransportBroadcastByNodeAct
             throw new ShardNotFoundException(indexShard.shardId());
         }
 
-        RemoteRefreshSegmentTracker remoteRefreshSegmentTracker = remoteRefreshSegmentPressureService.getRemoteRefreshSegmentTracker(
+        RemoteSegmentTransferTracker remoteSegmentTransferTracker = remoteRefreshSegmentPressureService.getRemoteRefreshSegmentTracker(
             indexShard.shardId()
         );
-        assert Objects.nonNull(remoteRefreshSegmentTracker);
-
-        return new RemoteStoreStats(remoteRefreshSegmentTracker.stats());
+        assert Objects.nonNull(remoteSegmentTransferTracker);
+        return new RemoteStoreStats(remoteSegmentTransferTracker.stats(), indexShard.routingEntry());
     }
 }

--- a/server/src/main/java/org/opensearch/index/remote/RemoteSegmentTransferTracker.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteSegmentTransferTracker.java
@@ -15,6 +15,8 @@ import org.opensearch.common.util.MovingAverage;
 import org.opensearch.common.util.Streak;
 import org.opensearch.common.util.concurrent.ConcurrentCollections;
 import org.opensearch.index.shard.ShardId;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.index.store.DirectoryFileTransferTracker;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -30,7 +32,7 @@ import java.util.stream.Collectors;
  *
  * @opensearch.internal
  */
-public class RemoteRefreshSegmentTracker {
+public class RemoteSegmentTransferTracker {
 
     /**
      * ShardId for which this instance tracks the remote segment upload metadata.
@@ -169,8 +171,14 @@ public class RemoteRefreshSegmentTracker {
 
     private final Object uploadTimeMsMutex = new Object();
 
-    public RemoteRefreshSegmentTracker(
+    /**
+     * {@link org.opensearch.index.store.Store.StoreDirectory} level file transfer tracker, used to show download stats
+     */
+    private final DirectoryFileTransferTracker directoryFileTransferTracker;
+
+    public RemoteSegmentTransferTracker(
         ShardId shardId,
+        DirectoryFileTransferTracker directoryFileTransferTracker,
         int uploadBytesMovingAverageWindowSize,
         int uploadBytesPerSecMovingAverageWindowSize,
         int uploadTimeMsMovingAverageWindowSize
@@ -188,6 +196,7 @@ public class RemoteRefreshSegmentTracker {
         uploadTimeMsMovingAverageReference = new AtomicReference<>(new MovingAverage(uploadTimeMsMovingAverageWindowSize));
 
         latestLocalFileNameLengthMap = new HashMap<>();
+        this.directoryFileTransferTracker = directoryFileTransferTracker;
     }
 
     ShardId getShardId() {
@@ -472,8 +481,12 @@ public class RemoteRefreshSegmentTracker {
         }
     }
 
-    public RemoteRefreshSegmentTracker.Stats stats() {
-        return new RemoteRefreshSegmentTracker.Stats(
+    public DirectoryFileTransferTracker getDirectoryFileTransferTracker() {
+        return directoryFileTransferTracker;
+    }
+
+    public RemoteSegmentTransferTracker.Stats stats() {
+        return new RemoteSegmentTransferTracker.Stats(
             shardId,
             localRefreshClockTimeMs,
             remoteRefreshClockTimeMs,
@@ -492,7 +505,8 @@ public class RemoteRefreshSegmentTracker {
             uploadBytesMovingAverageReference.get().getAverage(),
             uploadBytesPerSecMovingAverageReference.get().getAverage(),
             uploadTimeMsMovingAverageReference.get().getAverage(),
-            getBytesLag()
+            getBytesLag(),
+            directoryFileTransferTracker.stats()
         );
     }
 
@@ -522,6 +536,7 @@ public class RemoteRefreshSegmentTracker {
         public final double uploadBytesPerSecMovingAverage;
         public final double uploadTimeMovingAverage;
         public final long bytesLag;
+        public final DirectoryFileTransferTracker.Stats directoryFileTransferTrackerStats;
 
         public Stats(
             ShardId shardId,
@@ -542,7 +557,8 @@ public class RemoteRefreshSegmentTracker {
             double uploadBytesMovingAverage,
             double uploadBytesPerSecMovingAverage,
             double uploadTimeMovingAverage,
-            long bytesLag
+            long bytesLag,
+            DirectoryFileTransferTracker.Stats directoryFileTransferTrackerStats
         ) {
             this.shardId = shardId;
             this.localRefreshClockTimeMs = localRefreshClockTimeMs;
@@ -563,6 +579,7 @@ public class RemoteRefreshSegmentTracker {
             this.uploadBytesPerSecMovingAverage = uploadBytesPerSecMovingAverage;
             this.uploadTimeMovingAverage = uploadTimeMovingAverage;
             this.bytesLag = bytesLag;
+            this.directoryFileTransferTrackerStats = directoryFileTransferTrackerStats;
         }
 
         public Stats(StreamInput in) throws IOException {
@@ -586,6 +603,7 @@ public class RemoteRefreshSegmentTracker {
                 this.uploadBytesPerSecMovingAverage = in.readDouble();
                 this.uploadTimeMovingAverage = in.readDouble();
                 this.bytesLag = in.readLong();
+                this.directoryFileTransferTrackerStats = in.readOptionalWriteable(DirectoryFileTransferTracker.Stats::new);
             } catch (IOException e) {
                 throw e;
             }
@@ -612,7 +630,7 @@ public class RemoteRefreshSegmentTracker {
             out.writeDouble(uploadBytesPerSecMovingAverage);
             out.writeDouble(uploadTimeMovingAverage);
             out.writeLong(bytesLag);
+            out.writeOptionalWriteable(directoryFileTransferTrackerStats);
         }
     }
-
 }

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -30,7 +30,7 @@ import org.opensearch.common.util.UploadListener;
 import org.opensearch.common.util.concurrent.ConcurrentCollections;
 import org.opensearch.index.engine.EngineException;
 import org.opensearch.index.engine.InternalEngine;
-import org.opensearch.index.remote.RemoteRefreshSegmentTracker;
+import org.opensearch.index.remote.RemoteSegmentTransferTracker;
 import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.index.store.RemoteSegmentStoreDirectory;
 import org.opensearch.index.store.remote.metadata.RemoteSegmentMetadata;
@@ -95,7 +95,7 @@ public final class RemoteStoreRefreshListener implements ReferenceManager.Refres
     private final IndexShard indexShard;
     private final Directory storeDirectory;
     private final RemoteSegmentStoreDirectory remoteDirectory;
-    private final RemoteRefreshSegmentTracker segmentTracker;
+    private final RemoteSegmentTransferTracker segmentTracker;
     private final Map<String, String> localSegmentChecksumMap;
     private long primaryTerm;
 
@@ -120,7 +120,7 @@ public final class RemoteStoreRefreshListener implements ReferenceManager.Refres
     public RemoteStoreRefreshListener(
         IndexShard indexShard,
         SegmentReplicationCheckpointPublisher checkpointPublisher,
-        RemoteRefreshSegmentTracker segmentTracker
+        RemoteSegmentTransferTracker segmentTracker
     ) {
         logger = Loggers.getLogger(getClass(), indexShard.shardId());
         this.indexShard = indexShard;

--- a/server/src/main/java/org/opensearch/index/store/DirectoryFileTransferTracker.java
+++ b/server/src/main/java/org/opensearch/index/store/DirectoryFileTransferTracker.java
@@ -1,0 +1,195 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.store;
+
+import org.opensearch.common.util.MovingAverage;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+
+import java.io.IOException;
+
+/**
+ * Tracks the amount of bytes transferred between two {@link org.apache.lucene.store.Directory} instances
+ *
+ * @opensearch.internal
+ */
+public class DirectoryFileTransferTracker {
+    /**
+     * Cumulative size of files (in bytes) attempted to be transferred over from the source {@link org.apache.lucene.store.Directory}
+     */
+    private volatile long transferredBytesStarted;
+
+    /**
+     * Cumulative size of files (in bytes) successfully transferred over from the source {@link org.apache.lucene.store.Directory}
+     */
+    private volatile long transferredBytesFailed;
+
+    /**
+     * Cumulative size of files (in bytes) failed in transfer over from the source {@link org.apache.lucene.store.Directory}
+     */
+    private volatile long transferredBytesSucceeded;
+
+    /**
+     * Time in milliseconds for the last successful transfer from the source {@link org.apache.lucene.store.Directory}
+     */
+    private volatile long lastTransferTimestampMs;
+
+    /**
+     * Provides moving average over the last N total size in bytes of files transferred from the source {@link org.apache.lucene.store.Directory}.
+     * N is window size
+     */
+    private volatile MovingAverage transferredBytesMovingAverageReference;
+
+    private volatile long lastSuccessfulTransferInBytes;
+
+    /**
+     * Provides moving average over the last N transfer speed (in bytes/s) of segment files transferred from the source {@link org.apache.lucene.store.Directory}.
+     * N is window size
+     */
+    private volatile MovingAverage transferredBytesPerSecMovingAverageReference;
+
+    private final int DIRECTORY_FILES_TRANSFER_DEFAULT_WINDOW_SIZE = 20;
+
+    public long getTransferredBytesStarted() {
+        return transferredBytesStarted;
+    }
+
+    public void addTransferredBytesStarted(long size) {
+        transferredBytesStarted += size;
+    }
+
+    public long getTransferredBytesFailed() {
+        return transferredBytesFailed;
+    }
+
+    public void addTransferredBytesFailed(long size) {
+        transferredBytesFailed += size;
+    }
+
+    public long getTransferredBytesSucceeded() {
+        return transferredBytesSucceeded;
+    }
+
+    public void addTransferredBytesSucceeded(long size, long startTimeInMs) {
+        transferredBytesSucceeded += size;
+        updateLastSuccessfulTransferSize(size);
+        long currentTimeInMs = System.currentTimeMillis();
+        updateLastTransferTimestampMs(currentTimeInMs);
+        long timeTakenInMS = Math.max(1, currentTimeInMs - startTimeInMs);
+        addTransferredBytesPerSec((size * 1_000L) / timeTakenInMS);
+    }
+
+    public boolean isTransferredBytesPerSecAverageReady() {
+        return transferredBytesPerSecMovingAverageReference.isReady();
+    }
+
+    public double getTransferredBytesPerSecAverage() {
+        return transferredBytesPerSecMovingAverageReference.getAverage();
+    }
+
+    // Visible for testing
+    public void addTransferredBytesPerSec(long bytesPerSec) {
+        this.transferredBytesPerSecMovingAverageReference.record(bytesPerSec);
+    }
+
+    public boolean isTransferredBytesAverageReady() {
+        return transferredBytesMovingAverageReference.isReady();
+    }
+
+    public double getTransferredBytesAverage() {
+        return transferredBytesMovingAverageReference.getAverage();
+    }
+
+    // Visible for testing
+    public void updateLastSuccessfulTransferSize(long size) {
+        lastSuccessfulTransferInBytes = size;
+        this.transferredBytesMovingAverageReference.record(size);
+    }
+
+    public long getLastTransferTimestampMs() {
+        return lastTransferTimestampMs;
+    }
+
+    // Visible for testing
+    public void updateLastTransferTimestampMs(long downloadTimestampInMs) {
+        this.lastTransferTimestampMs = downloadTimestampInMs;
+    }
+
+    public DirectoryFileTransferTracker() {
+        transferredBytesMovingAverageReference = new MovingAverage(DIRECTORY_FILES_TRANSFER_DEFAULT_WINDOW_SIZE);
+        transferredBytesPerSecMovingAverageReference = new MovingAverage(DIRECTORY_FILES_TRANSFER_DEFAULT_WINDOW_SIZE);
+    }
+
+    public DirectoryFileTransferTracker.Stats stats() {
+        return new Stats(
+            transferredBytesStarted,
+            transferredBytesFailed,
+            transferredBytesSucceeded,
+            lastTransferTimestampMs,
+            transferredBytesMovingAverageReference.getAverage(),
+            lastSuccessfulTransferInBytes,
+            transferredBytesPerSecMovingAverageReference.getAverage()
+        );
+    }
+
+    /**
+     * Represents the tracker's stats presentable to an API.
+     *
+     * @opensearch.internal
+     */
+    public static class Stats implements Writeable {
+        public final long transferredBytesStarted;
+        public final long transferredBytesFailed;
+        public final long transferredBytesSucceeded;
+        public final long lastTransferTimestampMs;
+        public final double transferredBytesMovingAverage;
+        public final long lastSuccessfulTransferInBytes;
+        public final double transferredBytesPerSecMovingAverage;
+
+        public Stats(
+            long transferredBytesStarted,
+            long transferredBytesFailed,
+            long downloadBytesSucceeded,
+            long lastTransferTimestampMs,
+            double transferredBytesMovingAverage,
+            long lastSuccessfulTransferInBytes,
+            double transferredBytesPerSecMovingAverage
+        ) {
+            this.transferredBytesStarted = transferredBytesStarted;
+            this.transferredBytesFailed = transferredBytesFailed;
+            this.transferredBytesSucceeded = downloadBytesSucceeded;
+            this.lastTransferTimestampMs = lastTransferTimestampMs;
+            this.transferredBytesMovingAverage = transferredBytesMovingAverage;
+            this.lastSuccessfulTransferInBytes = lastSuccessfulTransferInBytes;
+            this.transferredBytesPerSecMovingAverage = transferredBytesPerSecMovingAverage;
+        }
+
+        public Stats(StreamInput in) throws IOException {
+            this.transferredBytesStarted = in.readLong();
+            this.transferredBytesFailed = in.readLong();
+            this.transferredBytesSucceeded = in.readLong();
+            this.lastTransferTimestampMs = in.readLong();
+            this.transferredBytesMovingAverage = in.readDouble();
+            this.lastSuccessfulTransferInBytes = in.readLong();
+            this.transferredBytesPerSecMovingAverage = in.readDouble();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeLong(transferredBytesStarted);
+            out.writeLong(transferredBytesFailed);
+            out.writeLong(transferredBytesSucceeded);
+            out.writeLong(lastTransferTimestampMs);
+            out.writeDouble(transferredBytesMovingAverage);
+            out.writeLong(lastSuccessfulTransferInBytes);
+            out.writeDouble(transferredBytesPerSecMovingAverage);
+        }
+    }
+}

--- a/server/src/test/java/org/opensearch/action/admin/cluster/remotestore/stats/RemoteStoreStatsResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/remotestore/stats/RemoteStoreStatsResponseTests.java
@@ -15,6 +15,14 @@ import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.remote.RemoteRefreshSegmentTracker;
 import org.opensearch.index.shard.ShardId;
+import org.opensearch.core.action.support.DefaultShardOperationFailedException;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.cluster.routing.ShardRouting;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.remote.RemoteSegmentTransferTracker;
+import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
@@ -23,7 +31,10 @@ import java.util.ArrayList;
 import java.util.Map;
 
 import static org.opensearch.action.admin.cluster.remotestore.stats.RemoteStoreStatsTestHelper.compareStatsResponse;
-import static org.opensearch.action.admin.cluster.remotestore.stats.RemoteStoreStatsTestHelper.createPressureTrackerStats;
+import static org.opensearch.action.admin.cluster.remotestore.stats.RemoteStoreStatsTestHelper.createShardRouting;
+import static org.opensearch.action.admin.cluster.remotestore.stats.RemoteStoreStatsTestHelper.createStatsForNewPrimary;
+import static org.opensearch.action.admin.cluster.remotestore.stats.RemoteStoreStatsTestHelper.createStatsForNewReplica;
+import static org.opensearch.action.admin.cluster.remotestore.stats.RemoteStoreStatsTestHelper.createStatsForRemoteStoreRestoredPrimary;
 import static org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS;
 
 public class RemoteStoreStatsResponseTests extends OpenSearchTestCase {
@@ -43,11 +54,12 @@ public class RemoteStoreStatsResponseTests extends OpenSearchTestCase {
         threadPool.shutdownNow();
     }
 
-    public void testSerialization() throws Exception {
-        RemoteRefreshSegmentTracker.Stats pressureTrackerStats = createPressureTrackerStats(shardId);
-        RemoteStoreStats stats = new RemoteStoreStats(pressureTrackerStats);
+    public void testSerializationForPrimary() throws Exception {
+        RemoteSegmentTransferTracker.Stats mockPrimaryTrackerStats = createStatsForNewPrimary(shardId);
+        ShardRouting primaryShardRouting = createShardRouting(shardId, true);
+        RemoteStoreStats primaryShardStats = new RemoteStoreStats(mockPrimaryTrackerStats, primaryShardRouting);
         RemoteStoreStatsResponse statsResponse = new RemoteStoreStatsResponse(
-            new RemoteStoreStats[] { stats },
+            new RemoteStoreStats[] { primaryShardStats },
             1,
             1,
             0,
@@ -58,15 +70,96 @@ public class RemoteStoreStatsResponseTests extends OpenSearchTestCase {
         statsResponse.toXContent(builder, EMPTY_PARAMS);
         Map<String, Object> jsonResponseObject = XContentHelper.convertToMap(BytesReference.bytes(builder), false, builder.contentType())
             .v2();
+        Map<String, Object> metadataShardsObject = (Map<String, Object>) jsonResponseObject.get("_shards");
+        assertEquals(metadataShardsObject.get("total"), 1);
+        assertEquals(metadataShardsObject.get("successful"), 1);
+        assertEquals(metadataShardsObject.get("failed"), 0);
+        Map<String, Object> indicesObject = (Map<String, Object>) jsonResponseObject.get("indices");
+        assertTrue(indicesObject.containsKey("index"));
+        Map<String, Object> shardsObject = (Map) ((Map) indicesObject.get("index")).get("shards");
+        ArrayList<Map<String, Object>> perShardNumberObject = (ArrayList<Map<String, Object>>) shardsObject.get("0");
+        assertEquals(perShardNumberObject.size(), 1);
+        Map<String, Object> perShardCopyObject = perShardNumberObject.get(0);
+        compareStatsResponse(perShardCopyObject, mockPrimaryTrackerStats, primaryShardRouting);
+    }
 
-        ArrayList<Map<String, Object>> statsObjectArray = (ArrayList<Map<String, Object>>) jsonResponseObject.get("stats");
-        assertEquals(statsObjectArray.size(), 1);
-        Map<String, Object> statsObject = statsObjectArray.get(0);
-        Map<String, Object> shardsObject = (Map<String, Object>) jsonResponseObject.get("_shards");
+    public void testSerializationForBothPrimaryAndReplica() throws Exception {
+        RemoteSegmentTransferTracker.Stats mockPrimaryTrackerStats = createStatsForNewPrimary(shardId);
+        RemoteSegmentTransferTracker.Stats mockReplicaTrackerStats = createStatsForNewReplica(shardId);
+        ShardRouting primaryShardRouting = createShardRouting(shardId, true);
+        ShardRouting replicaShardRouting = createShardRouting(shardId, false);
+        RemoteStoreStats primaryShardStats = new RemoteStoreStats(mockPrimaryTrackerStats, primaryShardRouting);
+        RemoteStoreStats replicaShardStats = new RemoteStoreStats(mockReplicaTrackerStats, replicaShardRouting);
+        RemoteStoreStatsResponse statsResponse = new RemoteStoreStatsResponse(
+            new RemoteStoreStats[] { primaryShardStats, replicaShardStats },
+            2,
+            2,
+            0,
+            new ArrayList<DefaultShardOperationFailedException>()
+        );
 
-        assertEquals(shardsObject.get("total"), 1);
-        assertEquals(shardsObject.get("successful"), 1);
-        assertEquals(shardsObject.get("failed"), 0);
-        compareStatsResponse(statsObject, pressureTrackerStats);
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        statsResponse.toXContent(builder, EMPTY_PARAMS);
+        Map<String, Object> jsonResponseObject = XContentHelper.convertToMap(BytesReference.bytes(builder), false, builder.contentType())
+            .v2();
+        Map<String, Object> metadataShardsObject = (Map<String, Object>) jsonResponseObject.get("_shards");
+        assertEquals(2, metadataShardsObject.get("total"));
+        assertEquals(2, metadataShardsObject.get("successful"));
+        assertEquals(0, metadataShardsObject.get("failed"));
+        Map<String, Object> indicesObject = (Map<String, Object>) jsonResponseObject.get("indices");
+        assertTrue(indicesObject.containsKey("index"));
+        Map<String, Object> shardsObject = (Map) ((Map) indicesObject.get("index")).get("shards");
+        ArrayList<Map<String, Object>> perShardNumberObject = (ArrayList<Map<String, Object>>) shardsObject.get("0");
+        assertEquals(2, perShardNumberObject.size());
+        perShardNumberObject.forEach(shardObject -> {
+            boolean isPrimary = (boolean) ((Map) shardObject.get(RemoteStoreStats.Fields.ROUTING)).get(
+                RemoteStoreStats.RoutingFields.PRIMARY
+            );
+            if (isPrimary) {
+                compareStatsResponse(shardObject, mockPrimaryTrackerStats, primaryShardRouting);
+            } else {
+                compareStatsResponse(shardObject, mockReplicaTrackerStats, replicaShardRouting);
+            }
+        });
+    }
+
+    public void testSerializationForBothRemoteStoreRestoredPrimaryAndReplica() throws Exception {
+        RemoteSegmentTransferTracker.Stats mockPrimaryTrackerStats = createStatsForRemoteStoreRestoredPrimary(shardId);
+        RemoteSegmentTransferTracker.Stats mockReplicaTrackerStats = createStatsForNewReplica(shardId);
+        ShardRouting primaryShardRouting = createShardRouting(shardId, true);
+        ShardRouting replicaShardRouting = createShardRouting(shardId, false);
+        RemoteStoreStats primaryShardStats = new RemoteStoreStats(mockPrimaryTrackerStats, primaryShardRouting);
+        RemoteStoreStats replicaShardStats = new RemoteStoreStats(mockReplicaTrackerStats, replicaShardRouting);
+        RemoteStoreStatsResponse statsResponse = new RemoteStoreStatsResponse(
+            new RemoteStoreStats[] { primaryShardStats, replicaShardStats },
+            2,
+            2,
+            0,
+            new ArrayList<DefaultShardOperationFailedException>()
+        );
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        statsResponse.toXContent(builder, EMPTY_PARAMS);
+        Map<String, Object> jsonResponseObject = XContentHelper.convertToMap(BytesReference.bytes(builder), false, builder.contentType())
+            .v2();
+        Map<String, Object> metadataShardsObject = (Map<String, Object>) jsonResponseObject.get("_shards");
+        assertEquals(2, metadataShardsObject.get("total"));
+        assertEquals(2, metadataShardsObject.get("successful"));
+        assertEquals(0, metadataShardsObject.get("failed"));
+        Map<String, Object> indicesObject = (Map<String, Object>) jsonResponseObject.get("indices");
+        assertTrue(indicesObject.containsKey("index"));
+        Map<String, Object> shardsObject = (Map) ((Map) indicesObject.get("index")).get("shards");
+        ArrayList<Map<String, Object>> perShardNumberObject = (ArrayList<Map<String, Object>>) shardsObject.get("0");
+        assertEquals(2, perShardNumberObject.size());
+        perShardNumberObject.forEach(shardObject -> {
+            boolean isPrimary = (boolean) ((Map) shardObject.get(RemoteStoreStats.Fields.ROUTING)).get(
+                RemoteStoreStats.RoutingFields.PRIMARY
+            );
+            if (isPrimary) {
+                compareStatsResponse(shardObject, mockPrimaryTrackerStats, primaryShardRouting);
+            } else {
+                compareStatsResponse(shardObject, mockReplicaTrackerStats, replicaShardRouting);
+            }
+        });
     }
 }

--- a/server/src/test/java/org/opensearch/action/admin/cluster/remotestore/stats/RemoteStoreStatsTestHelper.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/remotestore/stats/RemoteStoreStatsTestHelper.java
@@ -10,78 +10,264 @@ package org.opensearch.action.admin.cluster.remotestore.stats;
 
 import org.opensearch.index.remote.RemoteRefreshSegmentTracker;
 import org.opensearch.index.shard.ShardId;
+import org.opensearch.cluster.routing.ShardRouting;
+import org.opensearch.cluster.routing.ShardRoutingState;
+import org.opensearch.cluster.routing.TestShardRouting;
+import org.opensearch.index.remote.RemoteSegmentTransferTracker;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.index.store.DirectoryFileTransferTracker;
 
 import java.util.Map;
 
+import static org.junit.Assert.assertTrue;
 import static org.opensearch.test.OpenSearchTestCase.assertEquals;
+import static org.opensearch.test.OpenSearchTestCase.randomAlphaOfLength;
 
 /**
  * Helper utilities for Remote Store stats tests
  */
 public class RemoteStoreStatsTestHelper {
-    static RemoteRefreshSegmentTracker.Stats createPressureTrackerStats(ShardId shardId) {
-        return new RemoteRefreshSegmentTracker.Stats(shardId, 101, 102, 100, 3, 2, 10, 5, 5, 10, 5, 5, 3, 2, 5, 2, 3, 4, 9);
+    static RemoteSegmentTransferTracker.Stats createStatsForNewPrimary(ShardId shardId) {
+        return new RemoteSegmentTransferTracker.Stats(
+            shardId,
+            101,
+            102,
+            100,
+            0,
+            10,
+            2,
+            10,
+            5,
+            5,
+            0,
+            0,
+            0,
+            5,
+            5,
+            5,
+            0,
+            0,
+            0,
+            createZeroDirectoryFileTransferStats()
+        );
     }
 
-    static void compareStatsResponse(Map<String, Object> statsObject, RemoteRefreshSegmentTracker.Stats pressureTrackerStats) {
-        assertEquals(statsObject.get(RemoteStoreStats.Fields.SHARD_ID), pressureTrackerStats.shardId.toString());
-        assertEquals(statsObject.get(RemoteStoreStats.Fields.LOCAL_REFRESH_TIMESTAMP), (int) pressureTrackerStats.localRefreshClockTimeMs);
-        assertEquals(
-            statsObject.get(RemoteStoreStats.Fields.REMOTE_REFRESH_TIMESTAMP),
-            (int) pressureTrackerStats.remoteRefreshClockTimeMs
+    static RemoteSegmentTransferTracker.Stats createStatsForNewReplica(ShardId shardId) {
+        return new RemoteSegmentTransferTracker.Stats(
+            shardId,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            createSampleDirectoryFileTransferStats()
         );
-        assertEquals(statsObject.get(RemoteStoreStats.Fields.REFRESH_TIME_LAG_IN_MILLIS), (int) pressureTrackerStats.refreshTimeLagMs);
-        assertEquals(
-            statsObject.get(RemoteStoreStats.Fields.REFRESH_LAG),
-            (int) (pressureTrackerStats.localRefreshNumber - pressureTrackerStats.remoteRefreshNumber)
-        );
-        assertEquals(statsObject.get(RemoteStoreStats.Fields.BYTES_LAG), (int) pressureTrackerStats.bytesLag);
+    }
 
-        assertEquals(statsObject.get(RemoteStoreStats.Fields.BACKPRESSURE_REJECTION_COUNT), (int) pressureTrackerStats.rejectionCount);
+    static RemoteSegmentTransferTracker.Stats createStatsForRemoteStoreRestoredPrimary(ShardId shardId) {
+        return new RemoteSegmentTransferTracker.Stats(
+            shardId,
+            50,
+            50,
+            0,
+            50,
+            11,
+            11,
+            10,
+            10,
+            0,
+            10,
+            10,
+            0,
+            10,
+            10,
+            0,
+            0,
+            0,
+            100,
+            createSampleDirectoryFileTransferStats()
+        );
+    }
+
+    static DirectoryFileTransferTracker.Stats createSampleDirectoryFileTransferStats() {
+        return new DirectoryFileTransferTracker.Stats(10, 0, 10, 12345, 5, 5, 5);
+    }
+
+    static DirectoryFileTransferTracker.Stats createZeroDirectoryFileTransferStats() {
+        return new DirectoryFileTransferTracker.Stats(0, 0, 0, 0, 0, 0, 0);
+    }
+
+    static ShardRouting createShardRouting(ShardId shardId, boolean isPrimary) {
+        return TestShardRouting.newShardRouting(shardId, randomAlphaOfLength(4), isPrimary, ShardRoutingState.STARTED);
+    }
+
+    static void compareStatsResponse(
+        Map<String, Object> statsObject,
+        RemoteSegmentTransferTracker.Stats statsTracker,
+        ShardRouting routing
+    ) {
         assertEquals(
-            statsObject.get(RemoteStoreStats.Fields.CONSECUTIVE_FAILURE_COUNT),
-            (int) pressureTrackerStats.consecutiveFailuresCount
+            ((Map) statsObject.get(RemoteStoreStats.Fields.ROUTING)).get(RemoteStoreStats.RoutingFields.NODE_ID),
+            routing.currentNodeId()
+        );
+        assertEquals(
+            ((Map) statsObject.get(RemoteStoreStats.Fields.ROUTING)).get(RemoteStoreStats.RoutingFields.STATE),
+            routing.state().toString()
+        );
+        assertEquals(
+            ((Map) statsObject.get(RemoteStoreStats.Fields.ROUTING)).get(RemoteStoreStats.RoutingFields.PRIMARY),
+            routing.primary()
         );
 
-        assertEquals(
-            ((Map) statsObject.get(RemoteStoreStats.Fields.TOTAL_UPLOADS_IN_BYTES)).get(RemoteStoreStats.SubFields.STARTED),
-            (int) pressureTrackerStats.uploadBytesStarted
-        );
-        assertEquals(
-            ((Map) statsObject.get(RemoteStoreStats.Fields.TOTAL_UPLOADS_IN_BYTES)).get(RemoteStoreStats.SubFields.SUCCEEDED),
-            (int) pressureTrackerStats.uploadBytesSucceeded
-        );
-        assertEquals(
-            ((Map) statsObject.get(RemoteStoreStats.Fields.TOTAL_UPLOADS_IN_BYTES)).get(RemoteStoreStats.SubFields.FAILED),
-            (int) pressureTrackerStats.uploadBytesFailed
-        );
-        assertEquals(
-            ((Map) statsObject.get(RemoteStoreStats.Fields.REMOTE_REFRESH_SIZE_IN_BYTES)).get(RemoteStoreStats.SubFields.MOVING_AVG),
-            pressureTrackerStats.uploadBytesMovingAverage
-        );
-        assertEquals(
-            ((Map) statsObject.get(RemoteStoreStats.Fields.REMOTE_REFRESH_SIZE_IN_BYTES)).get(RemoteStoreStats.SubFields.LAST_SUCCESSFUL),
-            (int) pressureTrackerStats.lastSuccessfulRemoteRefreshBytes
-        );
-        assertEquals(
-            ((Map) statsObject.get(RemoteStoreStats.Fields.UPLOAD_LATENCY_IN_BYTES_PER_SEC)).get(RemoteStoreStats.SubFields.MOVING_AVG),
-            pressureTrackerStats.uploadBytesPerSecMovingAverage
-        );
-        assertEquals(
-            ((Map) statsObject.get(RemoteStoreStats.Fields.TOTAL_REMOTE_REFRESH)).get(RemoteStoreStats.SubFields.STARTED),
-            (int) pressureTrackerStats.totalUploadsStarted
-        );
-        assertEquals(
-            ((Map) statsObject.get(RemoteStoreStats.Fields.TOTAL_REMOTE_REFRESH)).get(RemoteStoreStats.SubFields.SUCCEEDED),
-            (int) pressureTrackerStats.totalUploadsSucceeded
-        );
-        assertEquals(
-            ((Map) statsObject.get(RemoteStoreStats.Fields.TOTAL_REMOTE_REFRESH)).get(RemoteStoreStats.SubFields.FAILED),
-            (int) pressureTrackerStats.totalUploadsFailed
-        );
-        assertEquals(
-            ((Map) statsObject.get(RemoteStoreStats.Fields.REMOTE_REFRESH_LATENCY_IN_MILLIS)).get(RemoteStoreStats.SubFields.MOVING_AVG),
-            pressureTrackerStats.uploadTimeMovingAverage
-        );
+        Map<String, Object> segment = ((Map) statsObject.get(RemoteStoreStats.Fields.SEGMENT));
+        Map<String, Object> segmentDownloads = ((Map) segment.get(RemoteStoreStats.SubFields.DOWNLOAD));
+        Map<String, Object> segmentUploads = ((Map) segment.get(RemoteStoreStats.SubFields.UPLOAD));
+
+        if (statsTracker.directoryFileTransferTrackerStats.transferredBytesStarted != 0) {
+            assertEquals(
+                segmentDownloads.get(RemoteStoreStats.DownloadStatsFields.LAST_SYNC_TIMESTAMP),
+                (int) statsTracker.directoryFileTransferTrackerStats.lastTransferTimestampMs
+            );
+            assertEquals(
+                ((Map) segmentDownloads.get(RemoteStoreStats.DownloadStatsFields.TOTAL_DOWNLOADS_IN_BYTES)).get(
+                    RemoteStoreStats.SubFields.STARTED
+                ),
+                (int) statsTracker.directoryFileTransferTrackerStats.transferredBytesStarted
+            );
+            assertEquals(
+                ((Map) segmentDownloads.get(RemoteStoreStats.DownloadStatsFields.TOTAL_DOWNLOADS_IN_BYTES)).get(
+                    RemoteStoreStats.SubFields.SUCCEEDED
+                ),
+                (int) statsTracker.directoryFileTransferTrackerStats.transferredBytesSucceeded
+            );
+            assertEquals(
+                ((Map) segmentDownloads.get(RemoteStoreStats.DownloadStatsFields.TOTAL_DOWNLOADS_IN_BYTES)).get(
+                    RemoteStoreStats.SubFields.FAILED
+                ),
+                (int) statsTracker.directoryFileTransferTrackerStats.transferredBytesFailed
+            );
+            assertEquals(
+                ((Map) segmentDownloads.get(RemoteStoreStats.DownloadStatsFields.DOWNLOAD_SIZE_IN_BYTES)).get(
+                    RemoteStoreStats.SubFields.LAST_SUCCESSFUL
+                ),
+                (int) statsTracker.directoryFileTransferTrackerStats.lastSuccessfulTransferInBytes
+            );
+            assertEquals(
+                ((Map) segmentDownloads.get(RemoteStoreStats.DownloadStatsFields.DOWNLOAD_SIZE_IN_BYTES)).get(
+                    RemoteStoreStats.SubFields.MOVING_AVG
+                ),
+                statsTracker.directoryFileTransferTrackerStats.transferredBytesMovingAverage
+            );
+            assertEquals(
+                ((Map) segmentDownloads.get(RemoteStoreStats.DownloadStatsFields.DOWNLOAD_SPEED_IN_BYTES_PER_SEC)).get(
+                    RemoteStoreStats.SubFields.MOVING_AVG
+                ),
+                statsTracker.directoryFileTransferTrackerStats.transferredBytesPerSecMovingAverage
+            );
+        } else {
+            assertTrue(segmentDownloads.isEmpty());
+        }
+
+        if (statsTracker.totalUploadsStarted != 0) {
+            assertEquals(
+                segmentUploads.get(RemoteStoreStats.UploadStatsFields.LOCAL_REFRESH_TIMESTAMP),
+                (int) statsTracker.localRefreshClockTimeMs
+            );
+            assertEquals(
+                segmentUploads.get(RemoteStoreStats.UploadStatsFields.REMOTE_REFRESH_TIMESTAMP),
+                (int) statsTracker.remoteRefreshClockTimeMs
+            );
+            assertEquals(
+                segmentUploads.get(RemoteStoreStats.UploadStatsFields.REFRESH_TIME_LAG_IN_MILLIS),
+                (int) statsTracker.refreshTimeLagMs
+            );
+            assertEquals(
+                segmentUploads.get(RemoteStoreStats.UploadStatsFields.REFRESH_LAG),
+                (int) (statsTracker.localRefreshNumber - statsTracker.remoteRefreshNumber)
+            );
+            assertEquals(segmentUploads.get(RemoteStoreStats.UploadStatsFields.BYTES_LAG), (int) statsTracker.bytesLag);
+
+            assertEquals(
+                segmentUploads.get(RemoteStoreStats.UploadStatsFields.BACKPRESSURE_REJECTION_COUNT),
+                (int) statsTracker.rejectionCount
+            );
+            assertEquals(
+                segmentUploads.get(RemoteStoreStats.UploadStatsFields.CONSECUTIVE_FAILURE_COUNT),
+                (int) statsTracker.consecutiveFailuresCount
+            );
+            assertEquals(
+                ((Map) segmentUploads.get(RemoteStoreStats.UploadStatsFields.TOTAL_UPLOADS_IN_BYTES)).get(
+                    RemoteStoreStats.SubFields.STARTED
+                ),
+                (int) statsTracker.uploadBytesStarted
+            );
+            assertEquals(
+                ((Map) segmentUploads.get(RemoteStoreStats.UploadStatsFields.TOTAL_UPLOADS_IN_BYTES)).get(
+                    RemoteStoreStats.SubFields.SUCCEEDED
+                ),
+                (int) statsTracker.uploadBytesSucceeded
+            );
+            assertEquals(
+                ((Map) segmentUploads.get(RemoteStoreStats.UploadStatsFields.TOTAL_UPLOADS_IN_BYTES)).get(
+                    RemoteStoreStats.SubFields.FAILED
+                ),
+                (int) statsTracker.uploadBytesFailed
+            );
+            assertEquals(
+                ((Map) segmentUploads.get(RemoteStoreStats.UploadStatsFields.REMOTE_REFRESH_SIZE_IN_BYTES)).get(
+                    RemoteStoreStats.SubFields.MOVING_AVG
+                ),
+                statsTracker.uploadBytesMovingAverage
+            );
+            assertEquals(
+                ((Map) segmentUploads.get(RemoteStoreStats.UploadStatsFields.REMOTE_REFRESH_SIZE_IN_BYTES)).get(
+                    RemoteStoreStats.SubFields.LAST_SUCCESSFUL
+                ),
+                (int) statsTracker.lastSuccessfulRemoteRefreshBytes
+            );
+            assertEquals(
+                ((Map) segmentUploads.get(RemoteStoreStats.UploadStatsFields.UPLOAD_LATENCY_IN_BYTES_PER_SEC)).get(
+                    RemoteStoreStats.SubFields.MOVING_AVG
+                ),
+                statsTracker.uploadBytesPerSecMovingAverage
+            );
+            assertEquals(
+                ((Map) segmentUploads.get(RemoteStoreStats.UploadStatsFields.TOTAL_SYNCS_TO_REMOTE)).get(
+                    RemoteStoreStats.SubFields.STARTED
+                ),
+                (int) statsTracker.totalUploadsStarted
+            );
+            assertEquals(
+                ((Map) segmentUploads.get(RemoteStoreStats.UploadStatsFields.TOTAL_SYNCS_TO_REMOTE)).get(
+                    RemoteStoreStats.SubFields.SUCCEEDED
+                ),
+                (int) statsTracker.totalUploadsSucceeded
+            );
+            assertEquals(
+                ((Map) segmentUploads.get(RemoteStoreStats.UploadStatsFields.TOTAL_SYNCS_TO_REMOTE)).get(RemoteStoreStats.SubFields.FAILED),
+                (int) statsTracker.totalUploadsFailed
+            );
+            assertEquals(
+                ((Map) segmentUploads.get(RemoteStoreStats.UploadStatsFields.REMOTE_REFRESH_LATENCY_IN_MILLIS)).get(
+                    RemoteStoreStats.SubFields.MOVING_AVG
+                ),
+                statsTracker.uploadTimeMovingAverage
+            );
+        } else {
+            assertTrue(segmentUploads.isEmpty());
+        }
     }
 }

--- a/server/src/test/java/org/opensearch/action/admin/cluster/remotestore/stats/RemoteStoreStatsTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/remotestore/stats/RemoteStoreStatsTests.java
@@ -9,6 +9,8 @@
 package org.opensearch.action.admin.cluster.remotestore.stats;
 
 import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.xcontent.XContentFactory;
@@ -16,6 +18,8 @@ import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.remote.RemoteRefreshSegmentTracker;
 import org.opensearch.index.shard.ShardId;
+import org.opensearch.index.remote.RemoteSegmentTransferTracker;
+import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
@@ -24,7 +28,10 @@ import java.io.IOException;
 import java.util.Map;
 
 import static org.opensearch.action.admin.cluster.remotestore.stats.RemoteStoreStatsTestHelper.compareStatsResponse;
-import static org.opensearch.action.admin.cluster.remotestore.stats.RemoteStoreStatsTestHelper.createPressureTrackerStats;
+import static org.opensearch.action.admin.cluster.remotestore.stats.RemoteStoreStatsTestHelper.createStatsForNewReplica;
+import static org.opensearch.action.admin.cluster.remotestore.stats.RemoteStoreStatsTestHelper.createShardRouting;
+import static org.opensearch.action.admin.cluster.remotestore.stats.RemoteStoreStatsTestHelper.createStatsForNewPrimary;
+import static org.opensearch.action.admin.cluster.remotestore.stats.RemoteStoreStatsTestHelper.createStatsForRemoteStoreRestoredPrimary;
 import static org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS;
 
 public class RemoteStoreStatsTests extends OpenSearchTestCase {
@@ -44,43 +51,175 @@ public class RemoteStoreStatsTests extends OpenSearchTestCase {
         threadPool.shutdownNow();
     }
 
-    public void testXContentBuilder() throws IOException {
-        RemoteRefreshSegmentTracker.Stats pressureTrackerStats = createPressureTrackerStats(shardId);
-        RemoteStoreStats stats = new RemoteStoreStats(pressureTrackerStats);
+    public void testXContentBuilderWithPrimaryShard() throws IOException {
+        RemoteSegmentTransferTracker.Stats uploadStats = createStatsForNewPrimary(shardId);
+        ShardRouting routing = createShardRouting(shardId, true);
+        RemoteStoreStats stats = new RemoteStoreStats(uploadStats, routing);
 
         XContentBuilder builder = XContentFactory.jsonBuilder();
         stats.toXContent(builder, EMPTY_PARAMS);
         Map<String, Object> jsonObject = XContentHelper.convertToMap(BytesReference.bytes(builder), false, builder.contentType()).v2();
-        compareStatsResponse(jsonObject, pressureTrackerStats);
+        compareStatsResponse(jsonObject, uploadStats, routing);
     }
 
-    public void testSerialization() throws Exception {
-        RemoteRefreshSegmentTracker.Stats pressureTrackerStats = createPressureTrackerStats(shardId);
-        RemoteStoreStats stats = new RemoteStoreStats(pressureTrackerStats);
+    public void testXContentBuilderWithReplicaShard() throws IOException {
+        RemoteSegmentTransferTracker.Stats downloadStats = createStatsForNewReplica(shardId);
+        ShardRouting routing = createShardRouting(shardId, false);
+        RemoteStoreStats stats = new RemoteStoreStats(downloadStats, routing);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        stats.toXContent(builder, EMPTY_PARAMS);
+        Map<String, Object> jsonObject = XContentHelper.convertToMap(BytesReference.bytes(builder), false, builder.contentType()).v2();
+        compareStatsResponse(jsonObject, downloadStats, routing);
+    }
+
+    public void testXContentBuilderWithRemoteStoreRestoredShard() throws IOException {
+        RemoteSegmentTransferTracker.Stats remotestoreRestoredShardStats = createStatsForRemoteStoreRestoredPrimary(shardId);
+        ShardRouting routing = createShardRouting(shardId, true);
+        RemoteStoreStats stats = new RemoteStoreStats(remotestoreRestoredShardStats, routing);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        stats.toXContent(builder, EMPTY_PARAMS);
+        Map<String, Object> jsonObject = XContentHelper.convertToMap(BytesReference.bytes(builder), false, builder.contentType()).v2();
+        compareStatsResponse(jsonObject, remotestoreRestoredShardStats, routing);
+    }
+
+    public void testSerializationForPrimaryShard() throws Exception {
+        RemoteSegmentTransferTracker.Stats primaryShardStats = createStatsForNewPrimary(shardId);
+        RemoteStoreStats stats = new RemoteStoreStats(primaryShardStats, createShardRouting(shardId, true));
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             stats.writeTo(out);
             try (StreamInput in = out.bytes().streamInput()) {
-                RemoteStoreStats deserializedStats = new RemoteStoreStats(in);
-                assertEquals(deserializedStats.getStats().shardId.toString(), stats.getStats().shardId.toString());
-                assertEquals(deserializedStats.getStats().refreshTimeLagMs, stats.getStats().refreshTimeLagMs);
-                assertEquals(deserializedStats.getStats().localRefreshNumber, stats.getStats().localRefreshNumber);
-                assertEquals(deserializedStats.getStats().remoteRefreshNumber, stats.getStats().remoteRefreshNumber);
-                assertEquals(deserializedStats.getStats().uploadBytesStarted, stats.getStats().uploadBytesStarted);
-                assertEquals(deserializedStats.getStats().uploadBytesSucceeded, stats.getStats().uploadBytesSucceeded);
-                assertEquals(deserializedStats.getStats().uploadBytesFailed, stats.getStats().uploadBytesFailed);
-                assertEquals(deserializedStats.getStats().totalUploadsStarted, stats.getStats().totalUploadsStarted);
-                assertEquals(deserializedStats.getStats().totalUploadsFailed, stats.getStats().totalUploadsFailed);
-                assertEquals(deserializedStats.getStats().totalUploadsSucceeded, stats.getStats().totalUploadsSucceeded);
-                assertEquals(deserializedStats.getStats().rejectionCount, stats.getStats().rejectionCount);
-                assertEquals(deserializedStats.getStats().consecutiveFailuresCount, stats.getStats().consecutiveFailuresCount);
-                assertEquals(deserializedStats.getStats().uploadBytesMovingAverage, stats.getStats().uploadBytesMovingAverage, 0);
+                RemoteSegmentTransferTracker.Stats deserializedStats = new RemoteStoreStats(in).getStats();
+                assertEquals(stats.getStats().refreshTimeLagMs, deserializedStats.refreshTimeLagMs);
+                assertEquals(stats.getStats().localRefreshNumber, deserializedStats.localRefreshNumber);
+                assertEquals(stats.getStats().remoteRefreshNumber, deserializedStats.remoteRefreshNumber);
+                assertEquals(stats.getStats().uploadBytesStarted, deserializedStats.uploadBytesStarted);
+                assertEquals(stats.getStats().uploadBytesSucceeded, deserializedStats.uploadBytesSucceeded);
+                assertEquals(stats.getStats().uploadBytesFailed, deserializedStats.uploadBytesFailed);
+                assertEquals(stats.getStats().totalUploadsStarted, deserializedStats.totalUploadsStarted);
+                assertEquals(stats.getStats().totalUploadsFailed, deserializedStats.totalUploadsFailed);
+                assertEquals(stats.getStats().totalUploadsSucceeded, deserializedStats.totalUploadsSucceeded);
+                assertEquals(stats.getStats().rejectionCount, deserializedStats.rejectionCount);
+                assertEquals(stats.getStats().consecutiveFailuresCount, deserializedStats.consecutiveFailuresCount);
+                assertEquals(stats.getStats().uploadBytesMovingAverage, deserializedStats.uploadBytesMovingAverage, 0);
+                assertEquals(stats.getStats().uploadBytesPerSecMovingAverage, deserializedStats.uploadBytesPerSecMovingAverage, 0);
+                assertEquals(stats.getStats().uploadTimeMovingAverage, deserializedStats.uploadTimeMovingAverage, 0);
+                assertEquals(stats.getStats().bytesLag, deserializedStats.bytesLag);
+                assertEquals(0, deserializedStats.directoryFileTransferTrackerStats.transferredBytesStarted);
+                assertEquals(0, deserializedStats.directoryFileTransferTrackerStats.transferredBytesFailed);
+                assertEquals(0, deserializedStats.directoryFileTransferTrackerStats.transferredBytesSucceeded);
+                assertEquals(0, deserializedStats.directoryFileTransferTrackerStats.lastSuccessfulTransferInBytes);
+                assertEquals(0, deserializedStats.directoryFileTransferTrackerStats.lastTransferTimestampMs);
+            }
+        }
+    }
+
+    public void testSerializationForReplicaShard() throws Exception {
+        RemoteSegmentTransferTracker.Stats replicaShardStats = createStatsForNewReplica(shardId);
+        RemoteStoreStats stats = new RemoteStoreStats(replicaShardStats, createShardRouting(shardId, false));
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            stats.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                RemoteSegmentTransferTracker.Stats deserializedStats = new RemoteStoreStats(in).getStats();
+                assertEquals(0, deserializedStats.refreshTimeLagMs);
+                assertEquals(0, deserializedStats.localRefreshNumber);
+                assertEquals(0, deserializedStats.remoteRefreshNumber);
+                assertEquals(0, deserializedStats.uploadBytesStarted);
+                assertEquals(0, deserializedStats.uploadBytesSucceeded);
+                assertEquals(0, deserializedStats.uploadBytesFailed);
+                assertEquals(0, deserializedStats.totalUploadsStarted);
+                assertEquals(0, deserializedStats.totalUploadsFailed);
+                assertEquals(0, deserializedStats.totalUploadsSucceeded);
+                assertEquals(0, deserializedStats.rejectionCount);
+                assertEquals(0, deserializedStats.consecutiveFailuresCount);
+                assertEquals(0, deserializedStats.bytesLag);
                 assertEquals(
-                    deserializedStats.getStats().uploadBytesPerSecMovingAverage,
-                    stats.getStats().uploadBytesPerSecMovingAverage,
+                    stats.getStats().directoryFileTransferTrackerStats.transferredBytesStarted,
+                    deserializedStats.directoryFileTransferTrackerStats.transferredBytesStarted
+                );
+                assertEquals(
+                    stats.getStats().directoryFileTransferTrackerStats.transferredBytesFailed,
+                    deserializedStats.directoryFileTransferTrackerStats.transferredBytesFailed
+                );
+                assertEquals(
+                    stats.getStats().directoryFileTransferTrackerStats.transferredBytesSucceeded,
+                    deserializedStats.directoryFileTransferTrackerStats.transferredBytesSucceeded
+                );
+                assertEquals(
+                    stats.getStats().directoryFileTransferTrackerStats.lastSuccessfulTransferInBytes,
+                    deserializedStats.directoryFileTransferTrackerStats.lastSuccessfulTransferInBytes
+                );
+                assertEquals(
+                    stats.getStats().directoryFileTransferTrackerStats.lastTransferTimestampMs,
+                    deserializedStats.directoryFileTransferTrackerStats.lastTransferTimestampMs
+                );
+                assertEquals(
+                    stats.getStats().directoryFileTransferTrackerStats.transferredBytesPerSecMovingAverage,
+                    deserializedStats.directoryFileTransferTrackerStats.transferredBytesPerSecMovingAverage,
                     0
                 );
-                assertEquals(deserializedStats.getStats().uploadTimeMovingAverage, stats.getStats().uploadTimeMovingAverage, 0);
-                assertEquals(deserializedStats.getStats().bytesLag, stats.getStats().bytesLag);
+                assertEquals(
+                    stats.getStats().directoryFileTransferTrackerStats.transferredBytesMovingAverage,
+                    deserializedStats.directoryFileTransferTrackerStats.transferredBytesMovingAverage,
+                    0
+                );
+            }
+        }
+    }
+
+    public void testSerializationForRemoteStoreRestoredPrimaryShard() throws Exception {
+        RemoteSegmentTransferTracker.Stats primaryShardStats = createStatsForRemoteStoreRestoredPrimary(shardId);
+        RemoteStoreStats stats = new RemoteStoreStats(primaryShardStats, createShardRouting(shardId, true));
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            stats.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                RemoteSegmentTransferTracker.Stats deserializedStats = new RemoteStoreStats(in).getStats();
+                assertEquals(stats.getStats().refreshTimeLagMs, deserializedStats.refreshTimeLagMs);
+                assertEquals(stats.getStats().localRefreshNumber, deserializedStats.localRefreshNumber);
+                assertEquals(stats.getStats().remoteRefreshNumber, deserializedStats.remoteRefreshNumber);
+                assertEquals(stats.getStats().uploadBytesStarted, deserializedStats.uploadBytesStarted);
+                assertEquals(stats.getStats().uploadBytesSucceeded, deserializedStats.uploadBytesSucceeded);
+                assertEquals(stats.getStats().uploadBytesFailed, deserializedStats.uploadBytesFailed);
+                assertEquals(stats.getStats().totalUploadsStarted, deserializedStats.totalUploadsStarted);
+                assertEquals(stats.getStats().totalUploadsFailed, deserializedStats.totalUploadsFailed);
+                assertEquals(stats.getStats().totalUploadsSucceeded, deserializedStats.totalUploadsSucceeded);
+                assertEquals(stats.getStats().rejectionCount, deserializedStats.rejectionCount);
+                assertEquals(stats.getStats().consecutiveFailuresCount, deserializedStats.consecutiveFailuresCount);
+                assertEquals(stats.getStats().uploadBytesMovingAverage, deserializedStats.uploadBytesMovingAverage, 0);
+                assertEquals(stats.getStats().uploadBytesPerSecMovingAverage, deserializedStats.uploadBytesPerSecMovingAverage, 0);
+                assertEquals(stats.getStats().uploadTimeMovingAverage, deserializedStats.uploadTimeMovingAverage, 0);
+                assertEquals(stats.getStats().bytesLag, deserializedStats.bytesLag);
+                assertEquals(
+                    stats.getStats().directoryFileTransferTrackerStats.transferredBytesStarted,
+                    deserializedStats.directoryFileTransferTrackerStats.transferredBytesStarted
+                );
+                assertEquals(
+                    stats.getStats().directoryFileTransferTrackerStats.transferredBytesFailed,
+                    deserializedStats.directoryFileTransferTrackerStats.transferredBytesFailed
+                );
+                assertEquals(
+                    stats.getStats().directoryFileTransferTrackerStats.transferredBytesSucceeded,
+                    deserializedStats.directoryFileTransferTrackerStats.transferredBytesSucceeded
+                );
+                assertEquals(
+                    stats.getStats().directoryFileTransferTrackerStats.lastSuccessfulTransferInBytes,
+                    deserializedStats.directoryFileTransferTrackerStats.lastSuccessfulTransferInBytes
+                );
+                assertEquals(
+                    stats.getStats().directoryFileTransferTrackerStats.lastTransferTimestampMs,
+                    deserializedStats.directoryFileTransferTrackerStats.lastTransferTimestampMs
+                );
+                assertEquals(
+                    stats.getStats().directoryFileTransferTrackerStats.transferredBytesPerSecMovingAverage,
+                    deserializedStats.directoryFileTransferTrackerStats.transferredBytesPerSecMovingAverage,
+                    0
+                );
+                assertEquals(
+                    stats.getStats().directoryFileTransferTrackerStats.transferredBytesMovingAverage,
+                    deserializedStats.directoryFileTransferTrackerStats.transferredBytesMovingAverage,
+                    0
+                );
             }
         }
     }

--- a/server/src/test/java/org/opensearch/action/admin/cluster/remotestore/stats/TransportRemoteStoreStatsActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/remotestore/stats/TransportRemoteStoreStatsActionTests.java
@@ -29,7 +29,7 @@ import org.opensearch.index.Index;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.remote.RemoteRefreshSegmentPressureService;
-import org.opensearch.index.remote.RemoteRefreshSegmentTracker;
+import org.opensearch.index.remote.RemoteSegmentTransferTracker;
 import org.opensearch.index.shard.IndexShardTestCase;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.test.FeatureFlagSetter;
@@ -86,7 +86,7 @@ public class TransportRemoteStoreStatsActionTests extends IndexShardTestCase {
             Collections.emptySet()
         );
 
-        when(pressureService.getRemoteRefreshSegmentTracker(any())).thenReturn(mock(RemoteRefreshSegmentTracker.class));
+        when(pressureService.getRemoteRefreshSegmentTracker(any())).thenReturn(mock(RemoteSegmentTransferTracker.class));
         when(indicesService.indexService(INDEX)).thenReturn(indexService);
         when(indexService.getIndexSettings()).thenReturn(new IndexSettings(remoteStoreIndexMetadata, Settings.EMPTY));
         statsAction = new TransportRemoteStoreStatsAction(
@@ -108,7 +108,7 @@ public class TransportRemoteStoreStatsActionTests extends IndexShardTestCase {
         clusterService.close();
     }
 
-    public void testOnlyPrimaryShards() throws Exception {
+    public void testAllShardCopies() throws Exception {
         FeatureFlagSetter.set(FeatureFlags.REMOTE_STORE);
         RoutingTable routingTable = RoutingTable.builder().addAsNew(remoteStoreIndexMetadata).build();
         Metadata metadata = Metadata.builder().put(remoteStoreIndexMetadata, false).build();
@@ -125,7 +125,7 @@ public class TransportRemoteStoreStatsActionTests extends IndexShardTestCase {
             new String[] { INDEX.getName() }
         );
 
-        assertEquals(shardsIterator.size(), 2);
+        assertEquals(shardsIterator.size(), 4);
     }
 
     public void testOnlyLocalShards() throws Exception {
@@ -153,10 +153,10 @@ public class TransportRemoteStoreStatsActionTests extends IndexShardTestCase {
         remoteStoreStatsRequest.local(true);
         ShardsIterator shardsIterator = statsAction.shards(clusterService.state(), remoteStoreStatsRequest, concreteIndices);
 
-        assertEquals(shardsIterator.size(), 1);
+        assertEquals(shardsIterator.size(), 2);
     }
 
-    public void testOnlyRemoteStoreEnabledShards() throws Exception {
+    public void testOnlyRemoteStoreEnabledShardCopies() throws Exception {
         FeatureFlagSetter.set(FeatureFlags.REMOTE_STORE);
         Index NEW_INDEX = new Index("newIndex", "newUUID");
         IndexMetadata indexMetadataWithoutRemoteStore = IndexMetadata.builder(NEW_INDEX.getName())
@@ -189,6 +189,6 @@ public class TransportRemoteStoreStatsActionTests extends IndexShardTestCase {
             new String[] { INDEX.getName() }
         );
 
-        assertEquals(shardsIterator.size(), 2);
+        assertEquals(shardsIterator.size(), 4);
     }
 }

--- a/server/src/test/java/org/opensearch/index/remote/RemoteRefreshSegmentPressureServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteRefreshSegmentPressureServiceTests.java
@@ -16,6 +16,8 @@ import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.shard.ShardId;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.index.store.Store;
 import org.opensearch.test.IndexSettingsModule;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
@@ -99,7 +101,7 @@ public class RemoteRefreshSegmentPressureServiceTests extends OpenSearchTestCase
         pressureService = new RemoteRefreshSegmentPressureService(clusterService, Settings.EMPTY);
         pressureService.afterIndexShardCreated(indexShard);
 
-        RemoteRefreshSegmentTracker pressureTracker = pressureService.getRemoteRefreshSegmentTracker(shardId);
+        RemoteSegmentTransferTracker pressureTracker = pressureService.getRemoteRefreshSegmentTracker(shardId);
         pressureTracker.updateLocalRefreshSeqNo(6);
 
         // 1. time lag more than dynamic threshold
@@ -152,10 +154,11 @@ public class RemoteRefreshSegmentPressureServiceTests extends OpenSearchTestCase
     private static IndexShard createIndexShard(ShardId shardId, boolean remoteStoreEnabled) {
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_REMOTE_STORE_ENABLED, String.valueOf(remoteStoreEnabled)).build();
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test_index", settings);
+        Store store = mock(Store.class);
         IndexShard indexShard = mock(IndexShard.class);
         when(indexShard.indexSettings()).thenReturn(indexSettings);
         when(indexShard.shardId()).thenReturn(shardId);
+        when(indexShard.store()).thenReturn(store);
         return indexShard;
     }
-
 }

--- a/server/src/test/java/org/opensearch/index/remote/RemoteSegmentTransferTrackerTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteSegmentTransferTrackerTests.java
@@ -14,6 +14,8 @@ import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.shard.ShardId;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.index.store.DirectoryFileTransferTracker;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
@@ -24,7 +26,7 @@ import java.util.Map;
 
 import static org.mockito.Mockito.mock;
 
-public class RemoteRefreshSegmentTrackerTests extends OpenSearchTestCase {
+public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
 
     private RemoteRefreshSegmentPressureSettings pressureSettings;
 
@@ -34,7 +36,9 @@ public class RemoteRefreshSegmentTrackerTests extends OpenSearchTestCase {
 
     private ShardId shardId;
 
-    private RemoteRefreshSegmentTracker pressureTracker;
+    private RemoteSegmentTransferTracker pressureTracker;
+
+    private DirectoryFileTransferTracker directoryFileTransferTracker;
 
     @Override
     public void setUp() throws Exception {
@@ -51,6 +55,7 @@ public class RemoteRefreshSegmentTrackerTests extends OpenSearchTestCase {
             mock(RemoteRefreshSegmentPressureService.class)
         );
         shardId = new ShardId("index", "uuid", 0);
+        directoryFileTransferTracker = new DirectoryFileTransferTracker();
     }
 
     @Override
@@ -60,8 +65,9 @@ public class RemoteRefreshSegmentTrackerTests extends OpenSearchTestCase {
     }
 
     public void testGetShardId() {
-        pressureTracker = new RemoteRefreshSegmentTracker(
+        pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
+            directoryFileTransferTracker,
             pressureSettings.getUploadBytesMovingAverageWindowSize(),
             pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
             pressureSettings.getUploadTimeMovingAverageWindowSize()
@@ -70,8 +76,9 @@ public class RemoteRefreshSegmentTrackerTests extends OpenSearchTestCase {
     }
 
     public void testUpdateLocalRefreshSeqNo() {
-        pressureTracker = new RemoteRefreshSegmentTracker(
+        pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
+            directoryFileTransferTracker,
             pressureSettings.getUploadBytesMovingAverageWindowSize(),
             pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
             pressureSettings.getUploadTimeMovingAverageWindowSize()
@@ -82,8 +89,9 @@ public class RemoteRefreshSegmentTrackerTests extends OpenSearchTestCase {
     }
 
     public void testUpdateRemoteRefreshSeqNo() {
-        pressureTracker = new RemoteRefreshSegmentTracker(
+        pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
+            directoryFileTransferTracker,
             pressureSettings.getUploadBytesMovingAverageWindowSize(),
             pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
             pressureSettings.getUploadTimeMovingAverageWindowSize()
@@ -94,8 +102,9 @@ public class RemoteRefreshSegmentTrackerTests extends OpenSearchTestCase {
     }
 
     public void testUpdateLocalRefreshTimeMs() {
-        pressureTracker = new RemoteRefreshSegmentTracker(
+        pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
+            directoryFileTransferTracker,
             pressureSettings.getUploadBytesMovingAverageWindowSize(),
             pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
             pressureSettings.getUploadTimeMovingAverageWindowSize()
@@ -106,8 +115,9 @@ public class RemoteRefreshSegmentTrackerTests extends OpenSearchTestCase {
     }
 
     public void testUpdateRemoteRefreshTimeMs() {
-        pressureTracker = new RemoteRefreshSegmentTracker(
+        pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
+            directoryFileTransferTracker,
             pressureSettings.getUploadBytesMovingAverageWindowSize(),
             pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
             pressureSettings.getUploadTimeMovingAverageWindowSize()
@@ -117,9 +127,23 @@ public class RemoteRefreshSegmentTrackerTests extends OpenSearchTestCase {
         assertEquals(refreshTimeMs, pressureTracker.getRemoteRefreshTimeMs());
     }
 
-    public void testComputeSeqNoLagOnUpdate() {
-        pressureTracker = new RemoteRefreshSegmentTracker(
+    public void testLastDownloadTimestampMs() {
+        pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
+            directoryFileTransferTracker,
+            pressureSettings.getUploadBytesMovingAverageWindowSize(),
+            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
+            pressureSettings.getUploadTimeMovingAverageWindowSize()
+        );
+        long currentTimeInMs = System.currentTimeMillis();
+        pressureTracker.getDirectoryFileTransferTracker().updateLastTransferTimestampMs(currentTimeInMs);
+        assertEquals(currentTimeInMs, pressureTracker.getDirectoryFileTransferTracker().getLastTransferTimestampMs());
+    }
+
+    public void testComputeSeqNoLagOnUpdate() {
+        pressureTracker = new RemoteSegmentTransferTracker(
+            shardId,
+            directoryFileTransferTracker,
             pressureSettings.getUploadBytesMovingAverageWindowSize(),
             pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
             pressureSettings.getUploadTimeMovingAverageWindowSize()
@@ -133,8 +157,9 @@ public class RemoteRefreshSegmentTrackerTests extends OpenSearchTestCase {
     }
 
     public void testComputeTimeLagOnUpdate() {
-        pressureTracker = new RemoteRefreshSegmentTracker(
+        pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
+            directoryFileTransferTracker,
             pressureSettings.getUploadBytesMovingAverageWindowSize(),
             pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
             pressureSettings.getUploadTimeMovingAverageWindowSize()
@@ -150,8 +175,9 @@ public class RemoteRefreshSegmentTrackerTests extends OpenSearchTestCase {
     }
 
     public void testAddUploadBytesStarted() {
-        pressureTracker = new RemoteRefreshSegmentTracker(
+        pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
+            directoryFileTransferTracker,
             pressureSettings.getUploadBytesMovingAverageWindowSize(),
             pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
             pressureSettings.getUploadTimeMovingAverageWindowSize()
@@ -165,8 +191,9 @@ public class RemoteRefreshSegmentTrackerTests extends OpenSearchTestCase {
     }
 
     public void testAddUploadBytesFailed() {
-        pressureTracker = new RemoteRefreshSegmentTracker(
+        pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
+            directoryFileTransferTracker,
             pressureSettings.getUploadBytesMovingAverageWindowSize(),
             pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
             pressureSettings.getUploadTimeMovingAverageWindowSize()
@@ -180,8 +207,9 @@ public class RemoteRefreshSegmentTrackerTests extends OpenSearchTestCase {
     }
 
     public void testAddUploadBytesSucceeded() {
-        pressureTracker = new RemoteRefreshSegmentTracker(
+        pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
+            directoryFileTransferTracker,
             pressureSettings.getUploadBytesMovingAverageWindowSize(),
             pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
             pressureSettings.getUploadTimeMovingAverageWindowSize()
@@ -194,9 +222,58 @@ public class RemoteRefreshSegmentTrackerTests extends OpenSearchTestCase {
         assertEquals(bytesToAdd + moreBytesToAdd, pressureTracker.getUploadBytesSucceeded());
     }
 
-    public void testGetInflightUploadBytes() {
-        pressureTracker = new RemoteRefreshSegmentTracker(
+    public void testAddDownloadBytesStarted() {
+        pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
+            directoryFileTransferTracker,
+            pressureSettings.getUploadBytesMovingAverageWindowSize(),
+            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
+            pressureSettings.getUploadTimeMovingAverageWindowSize()
+        );
+        long bytesToAdd = randomLongBetween(1000, 1000000);
+        pressureTracker.getDirectoryFileTransferTracker().addTransferredBytesStarted(bytesToAdd);
+        assertEquals(bytesToAdd, pressureTracker.getDirectoryFileTransferTracker().getTransferredBytesStarted());
+        long moreBytesToAdd = randomLongBetween(1000, 10000);
+        pressureTracker.getDirectoryFileTransferTracker().addTransferredBytesStarted(moreBytesToAdd);
+        assertEquals(bytesToAdd + moreBytesToAdd, pressureTracker.getDirectoryFileTransferTracker().getTransferredBytesStarted());
+    }
+
+    public void testAddDownloadBytesFailed() {
+        pressureTracker = new RemoteSegmentTransferTracker(
+            shardId,
+            directoryFileTransferTracker,
+            pressureSettings.getUploadBytesMovingAverageWindowSize(),
+            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
+            pressureSettings.getUploadTimeMovingAverageWindowSize()
+        );
+        long bytesToAdd = randomLongBetween(1000, 1000000);
+        pressureTracker.getDirectoryFileTransferTracker().addTransferredBytesFailed(bytesToAdd);
+        assertEquals(bytesToAdd, pressureTracker.getDirectoryFileTransferTracker().getTransferredBytesFailed());
+        long moreBytesToAdd = randomLongBetween(1000, 10000);
+        pressureTracker.getDirectoryFileTransferTracker().addTransferredBytesFailed(moreBytesToAdd);
+        assertEquals(bytesToAdd + moreBytesToAdd, pressureTracker.getDirectoryFileTransferTracker().getTransferredBytesFailed());
+    }
+
+    public void testAddDownloadBytesSucceeded() {
+        pressureTracker = new RemoteSegmentTransferTracker(
+            shardId,
+            directoryFileTransferTracker,
+            pressureSettings.getUploadBytesMovingAverageWindowSize(),
+            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
+            pressureSettings.getUploadTimeMovingAverageWindowSize()
+        );
+        long bytesToAdd = randomLongBetween(1000, 1000000);
+        pressureTracker.getDirectoryFileTransferTracker().addTransferredBytesSucceeded(bytesToAdd, System.currentTimeMillis());
+        assertEquals(bytesToAdd, pressureTracker.getDirectoryFileTransferTracker().getTransferredBytesSucceeded());
+        long moreBytesToAdd = randomLongBetween(1000, 10000);
+        pressureTracker.getDirectoryFileTransferTracker().addTransferredBytesSucceeded(moreBytesToAdd, System.currentTimeMillis());
+        assertEquals(bytesToAdd + moreBytesToAdd, pressureTracker.getDirectoryFileTransferTracker().getTransferredBytesSucceeded());
+    }
+
+    public void testGetInflightUploadBytes() {
+        pressureTracker = new RemoteSegmentTransferTracker(
+            shardId,
+            directoryFileTransferTracker,
             pressureSettings.getUploadBytesMovingAverageWindowSize(),
             pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
             pressureSettings.getUploadTimeMovingAverageWindowSize()
@@ -211,8 +288,9 @@ public class RemoteRefreshSegmentTrackerTests extends OpenSearchTestCase {
     }
 
     public void testIncrementTotalUploadsStarted() {
-        pressureTracker = new RemoteRefreshSegmentTracker(
+        pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
+            directoryFileTransferTracker,
             pressureSettings.getUploadBytesMovingAverageWindowSize(),
             pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
             pressureSettings.getUploadTimeMovingAverageWindowSize()
@@ -224,8 +302,9 @@ public class RemoteRefreshSegmentTrackerTests extends OpenSearchTestCase {
     }
 
     public void testIncrementTotalUploadsFailed() {
-        pressureTracker = new RemoteRefreshSegmentTracker(
+        pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
+            directoryFileTransferTracker,
             pressureSettings.getUploadBytesMovingAverageWindowSize(),
             pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
             pressureSettings.getUploadTimeMovingAverageWindowSize()
@@ -237,8 +316,9 @@ public class RemoteRefreshSegmentTrackerTests extends OpenSearchTestCase {
     }
 
     public void testIncrementTotalUploadSucceeded() {
-        pressureTracker = new RemoteRefreshSegmentTracker(
+        pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
+            directoryFileTransferTracker,
             pressureSettings.getUploadBytesMovingAverageWindowSize(),
             pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
             pressureSettings.getUploadTimeMovingAverageWindowSize()
@@ -250,8 +330,9 @@ public class RemoteRefreshSegmentTrackerTests extends OpenSearchTestCase {
     }
 
     public void testGetInflightUploads() {
-        pressureTracker = new RemoteRefreshSegmentTracker(
+        pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
+            directoryFileTransferTracker,
             pressureSettings.getUploadBytesMovingAverageWindowSize(),
             pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
             pressureSettings.getUploadTimeMovingAverageWindowSize()
@@ -267,8 +348,9 @@ public class RemoteRefreshSegmentTrackerTests extends OpenSearchTestCase {
     }
 
     public void testIncrementRejectionCount() {
-        pressureTracker = new RemoteRefreshSegmentTracker(
+        pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
+            directoryFileTransferTracker,
             pressureSettings.getUploadBytesMovingAverageWindowSize(),
             pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
             pressureSettings.getUploadTimeMovingAverageWindowSize()
@@ -280,8 +362,9 @@ public class RemoteRefreshSegmentTrackerTests extends OpenSearchTestCase {
     }
 
     public void testGetConsecutiveFailureCount() {
-        pressureTracker = new RemoteRefreshSegmentTracker(
+        pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
+            directoryFileTransferTracker,
             pressureSettings.getUploadBytesMovingAverageWindowSize(),
             pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
             pressureSettings.getUploadTimeMovingAverageWindowSize()
@@ -295,8 +378,9 @@ public class RemoteRefreshSegmentTrackerTests extends OpenSearchTestCase {
     }
 
     public void testComputeBytesLag() {
-        pressureTracker = new RemoteRefreshSegmentTracker(
+        pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
+            directoryFileTransferTracker,
             pressureSettings.getUploadBytesMovingAverageWindowSize(),
             pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
             pressureSettings.getUploadTimeMovingAverageWindowSize()
@@ -324,8 +408,9 @@ public class RemoteRefreshSegmentTrackerTests extends OpenSearchTestCase {
     }
 
     public void testIsUploadBytesAverageReady() {
-        pressureTracker = new RemoteRefreshSegmentTracker(
+        pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
+            directoryFileTransferTracker,
             pressureSettings.getUploadBytesMovingAverageWindowSize(),
             pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
             pressureSettings.getUploadTimeMovingAverageWindowSize()
@@ -351,8 +436,9 @@ public class RemoteRefreshSegmentTrackerTests extends OpenSearchTestCase {
     }
 
     public void testIsUploadBytesPerSecAverageReady() {
-        pressureTracker = new RemoteRefreshSegmentTracker(
+        pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
+            directoryFileTransferTracker,
             pressureSettings.getUploadBytesMovingAverageWindowSize(),
             pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
             pressureSettings.getUploadTimeMovingAverageWindowSize()
@@ -378,8 +464,9 @@ public class RemoteRefreshSegmentTrackerTests extends OpenSearchTestCase {
     }
 
     public void testIsUploadTimeMsAverageReady() {
-        pressureTracker = new RemoteRefreshSegmentTracker(
+        pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
+            directoryFileTransferTracker,
             pressureSettings.getUploadBytesMovingAverageWindowSize(),
             pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
             pressureSettings.getUploadTimeMovingAverageWindowSize()
@@ -404,12 +491,68 @@ public class RemoteRefreshSegmentTrackerTests extends OpenSearchTestCase {
         assertEquals((double) sum / 20, pressureTracker.getUploadTimeMsAverage(), 0.0d);
     }
 
+    public void testIsDownloadBytesAverageReady() {
+        pressureTracker = new RemoteSegmentTransferTracker(
+            shardId,
+            directoryFileTransferTracker,
+            pressureSettings.getUploadBytesMovingAverageWindowSize(),
+            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
+            pressureSettings.getUploadTimeMovingAverageWindowSize()
+        );
+        assertFalse(pressureTracker.getDirectoryFileTransferTracker().isTransferredBytesAverageReady());
+
+        long sum = 0;
+        for (int i = 1; i < 20; i++) {
+            pressureTracker.getDirectoryFileTransferTracker().updateLastSuccessfulTransferSize(i);
+            sum += i;
+            assertFalse(pressureTracker.getDirectoryFileTransferTracker().isTransferredBytesAverageReady());
+            assertEquals((double) sum / i, pressureTracker.getDirectoryFileTransferTracker().getTransferredBytesAverage(), 0.0d);
+        }
+
+        pressureTracker.getDirectoryFileTransferTracker().updateLastSuccessfulTransferSize(20);
+        sum += 20;
+        assertTrue(pressureTracker.getDirectoryFileTransferTracker().isTransferredBytesAverageReady());
+        assertEquals((double) sum / 20, pressureTracker.getDirectoryFileTransferTracker().getTransferredBytesAverage(), 0.0d);
+
+        pressureTracker.getDirectoryFileTransferTracker().updateLastSuccessfulTransferSize(100);
+        sum = sum + 100 - 1;
+        assertEquals((double) sum / 20, pressureTracker.getDirectoryFileTransferTracker().getTransferredBytesAverage(), 0.0d);
+    }
+
+    public void testIsDownloadBytesPerSecAverageReady() {
+        pressureTracker = new RemoteSegmentTransferTracker(
+            shardId,
+            directoryFileTransferTracker,
+            pressureSettings.getUploadBytesMovingAverageWindowSize(),
+            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
+            pressureSettings.getUploadTimeMovingAverageWindowSize()
+        );
+        assertFalse(pressureTracker.getDirectoryFileTransferTracker().isTransferredBytesPerSecAverageReady());
+
+        long sum = 0;
+        for (int i = 1; i < 20; i++) {
+            pressureTracker.getDirectoryFileTransferTracker().addTransferredBytesPerSec(i);
+            sum += i;
+            assertFalse(pressureTracker.getDirectoryFileTransferTracker().isTransferredBytesPerSecAverageReady());
+            assertEquals((double) sum / i, pressureTracker.getDirectoryFileTransferTracker().getTransferredBytesPerSecAverage(), 0.0d);
+        }
+
+        pressureTracker.getDirectoryFileTransferTracker().addTransferredBytesPerSec(20);
+        sum += 20;
+        assertTrue(pressureTracker.getDirectoryFileTransferTracker().isTransferredBytesPerSecAverageReady());
+        assertEquals((double) sum / 20, pressureTracker.getDirectoryFileTransferTracker().getTransferredBytesPerSecAverage(), 0.0d);
+
+        pressureTracker.getDirectoryFileTransferTracker().addTransferredBytesPerSec(100);
+        sum = sum + 100 - 1;
+        assertEquals((double) sum / 20, pressureTracker.getDirectoryFileTransferTracker().getTransferredBytesPerSecAverage(), 0.0d);
+    }
+
     /**
-     * Tests whether RemoteRefreshSegmentTracker.Stats object generated correctly from RemoteRefreshSegmentTracker.
+     * Tests whether RemoteSegmentTransferTracker.Stats object generated correctly from RemoteSegmentTransferTracker.
      * */
     public void testStatsObjectCreation() {
         pressureTracker = constructTracker();
-        RemoteRefreshSegmentTracker.Stats pressureTrackerStats = pressureTracker.stats();
+        RemoteSegmentTransferTracker.Stats pressureTrackerStats = pressureTracker.stats();
         assertEquals(pressureTracker.getShardId(), pressureTrackerStats.shardId);
         assertEquals(pressureTracker.getTimeMsLag(), (int) pressureTrackerStats.refreshTimeLagMs);
         assertEquals(pressureTracker.getLocalRefreshSeqNo(), (int) pressureTrackerStats.localRefreshNumber);
@@ -429,16 +572,16 @@ public class RemoteRefreshSegmentTrackerTests extends OpenSearchTestCase {
     }
 
     /**
-     * Tests whether RemoteRefreshSegmentTracker.Stats object serialize and deserialize is working fine.
+     * Tests whether RemoteSegmentTransferTracker.Stats object serialize and deserialize is working fine.
      * This comes into play during internode data transfer.
      * */
     public void testStatsObjectCreationViaStream() throws IOException {
         pressureTracker = constructTracker();
-        RemoteRefreshSegmentTracker.Stats pressureTrackerStats = pressureTracker.stats();
+        RemoteSegmentTransferTracker.Stats pressureTrackerStats = pressureTracker.stats();
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             pressureTrackerStats.writeTo(out);
             try (StreamInput in = out.bytes().streamInput()) {
-                RemoteRefreshSegmentTracker.Stats deserializedStats = new RemoteRefreshSegmentTracker.Stats(in);
+                RemoteSegmentTransferTracker.Stats deserializedStats = new RemoteSegmentTransferTracker.Stats(in);
                 assertEquals(deserializedStats.shardId, pressureTrackerStats.shardId);
                 assertEquals((int) deserializedStats.refreshTimeLagMs, (int) pressureTrackerStats.refreshTimeLagMs);
                 assertEquals((int) deserializedStats.localRefreshNumber, (int) pressureTrackerStats.localRefreshNumber);
@@ -459,13 +602,26 @@ public class RemoteRefreshSegmentTrackerTests extends OpenSearchTestCase {
                 assertEquals((int) deserializedStats.totalUploadsStarted, (int) pressureTrackerStats.totalUploadsStarted);
                 assertEquals((int) deserializedStats.totalUploadsSucceeded, (int) pressureTrackerStats.totalUploadsSucceeded);
                 assertEquals((int) deserializedStats.totalUploadsFailed, (int) pressureTrackerStats.totalUploadsFailed);
+                assertEquals(
+                    (int) deserializedStats.directoryFileTransferTrackerStats.transferredBytesStarted,
+                    (int) pressureTrackerStats.directoryFileTransferTrackerStats.transferredBytesStarted
+                );
+                assertEquals(
+                    (int) deserializedStats.directoryFileTransferTrackerStats.transferredBytesSucceeded,
+                    (int) pressureTrackerStats.directoryFileTransferTrackerStats.transferredBytesSucceeded
+                );
+                assertEquals(
+                    (int) deserializedStats.directoryFileTransferTrackerStats.transferredBytesPerSecMovingAverage,
+                    (int) pressureTrackerStats.directoryFileTransferTrackerStats.transferredBytesPerSecMovingAverage
+                );
             }
         }
     }
 
-    private RemoteRefreshSegmentTracker constructTracker() {
-        RemoteRefreshSegmentTracker segmentPressureTracker = new RemoteRefreshSegmentTracker(
+    private RemoteSegmentTransferTracker constructTracker() {
+        RemoteSegmentTransferTracker segmentPressureTracker = new RemoteSegmentTransferTracker(
             shardId,
+            new DirectoryFileTransferTracker(),
             pressureSettings.getUploadBytesMovingAverageWindowSize(),
             pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
             pressureSettings.getUploadTimeMovingAverageWindowSize()
@@ -475,6 +631,9 @@ public class RemoteRefreshSegmentTrackerTests extends OpenSearchTestCase {
         segmentPressureTracker.addUploadBytes(99);
         segmentPressureTracker.updateRemoteRefreshTimeMs(System.nanoTime() / 1_000_000L + randomIntBetween(10, 100));
         segmentPressureTracker.incrementRejectionCount();
+        segmentPressureTracker.getDirectoryFileTransferTracker().addTransferredBytesStarted(10);
+        segmentPressureTracker.getDirectoryFileTransferTracker().addTransferredBytesSucceeded(10, System.currentTimeMillis());
+        segmentPressureTracker.getDirectoryFileTransferTracker().addTransferredBytesPerSec(5);
         return segmentPressureTracker;
     }
 }

--- a/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
@@ -26,7 +26,7 @@ import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.engine.InternalEngineFactory;
 import org.opensearch.index.remote.RemoteRefreshSegmentPressureService;
-import org.opensearch.index.remote.RemoteRefreshSegmentTracker;
+import org.opensearch.index.remote.RemoteSegmentTransferTracker;
 import org.opensearch.index.store.RemoteSegmentStoreDirectory;
 import org.opensearch.index.store.Store;
 import org.opensearch.indices.replication.checkpoint.SegmentReplicationCheckpointPublisher;
@@ -248,7 +248,7 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
         assertBusy(() -> assertEquals(0, refreshCountLatch.getCount()));
         assertBusy(() -> assertEquals(0, successLatch.getCount()));
         RemoteRefreshSegmentPressureService pressureService = tuple.v2();
-        RemoteRefreshSegmentTracker segmentTracker = pressureService.getRemoteRefreshSegmentTracker(indexShard.shardId());
+        RemoteSegmentTransferTracker segmentTracker = pressureService.getRemoteRefreshSegmentTracker(indexShard.shardId());
         assertNoLagAndTotalUploadsFailed(segmentTracker, 0);
     }
 
@@ -269,7 +269,7 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
         assertBusy(() -> assertEquals(0, refreshCountLatch.getCount()));
         assertBusy(() -> assertEquals(0, successLatch.getCount()));
         RemoteRefreshSegmentPressureService pressureService = tuple.v2();
-        RemoteRefreshSegmentTracker segmentTracker = pressureService.getRemoteRefreshSegmentTracker(indexShard.shardId());
+        RemoteSegmentTransferTracker segmentTracker = pressureService.getRemoteRefreshSegmentTracker(indexShard.shardId());
         assertNoLagAndTotalUploadsFailed(segmentTracker, 1);
     }
 
@@ -315,11 +315,11 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
         assertBusy(() -> assertEquals(0, refreshCountLatch.getCount()));
         assertBusy(() -> assertEquals(0, successLatch.getCount()));
         RemoteRefreshSegmentPressureService pressureService = tuple.v2();
-        RemoteRefreshSegmentTracker segmentTracker = pressureService.getRemoteRefreshSegmentTracker(indexShard.shardId());
+        RemoteSegmentTransferTracker segmentTracker = pressureService.getRemoteRefreshSegmentTracker(indexShard.shardId());
         assertNoLagAndTotalUploadsFailed(segmentTracker, 2);
     }
 
-    private void assertNoLagAndTotalUploadsFailed(RemoteRefreshSegmentTracker segmentTracker, long totalUploadsFailed) throws Exception {
+    private void assertNoLagAndTotalUploadsFailed(RemoteSegmentTransferTracker segmentTracker, long totalUploadsFailed) throws Exception {
         assertBusy(() -> {
             assertEquals(0, segmentTracker.getBytesLag());
             assertEquals(0, segmentTracker.getRefreshSeqNoLag());
@@ -332,7 +332,7 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
         Tuple<RemoteStoreRefreshListener, RemoteRefreshSegmentPressureService> tuple = mockIndexShardWithRetryAndScheduleRefresh(1);
         RemoteStoreRefreshListener listener = tuple.v1();
         RemoteRefreshSegmentPressureService pressureService = tuple.v2();
-        RemoteRefreshSegmentTracker tracker = pressureService.getRemoteRefreshSegmentTracker(indexShard.shardId());
+        RemoteSegmentTransferTracker tracker = pressureService.getRemoteRefreshSegmentTracker(indexShard.shardId());
         assertNoLag(tracker);
         indexDocs(100, randomIntBetween(100, 200));
         indexShard.refresh("test");
@@ -340,7 +340,7 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
         assertBusy(() -> assertNoLag(tracker));
     }
 
-    private void assertNoLag(RemoteRefreshSegmentTracker tracker) {
+    private void assertNoLag(RemoteSegmentTransferTracker tracker) {
         assertEquals(0, tracker.getRefreshSeqNoLag());
         assertEquals(0, tracker.getBytesLag());
         assertEquals(0, tracker.getTimeMsLag());


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Backport https://github.com/opensearch-project/OpenSearch/pull/8718

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
