### PR TITLE
Fix testUploadMetadataMissingSegment unit test on 2.x

### DIFF
--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -766,7 +766,8 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         IndexOutput indexOutput = mock(IndexOutput.class);
 
         String generation = RemoteStoreUtils.invertLong(segmentInfos.getGeneration());
-        String primaryTerm = RemoteStoreUtils.invertLong(12);
+        long primaryTermLong = indexShard.getLatestReplicationCheckpoint().getPrimaryTerm();
+        String primaryTerm = RemoteStoreUtils.invertLong(primaryTermLong);
         when(storeDirectory.createOutput(startsWith("metadata__" + primaryTerm + "__" + generation), eq(IOContext.DEFAULT))).thenReturn(
             indexOutput
         );


### PR DESCRIPTION
### Description
Fixes unit test `testUploadMetadataMissingSegment` by fetching primary term from ReplicationCheckpoint vs using hard-coded value. 

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/9096

### Test
Ran this test 1k times successfully without failure

<img width="1003" alt="Screenshot 2023-08-03 at 12 35 35 PM" src="https://github.com/opensearch-project/OpenSearch/assets/79435743/e8998c9e-754e-4d28-8326-49c19a51509c">

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
