### PR TITLE
Update search.concurrent.max_slice setting to dynamic cluster setting for main with lucene-9.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add getter for path field in NestedQueryBuilder ([#4636](https://github.com/opensearch-project/OpenSearch/pull/4636))
 - Allow mmap to use new JDK-19 preview APIs in Apache Lucene 9.4+ ([#5151](https://github.com/opensearch-project/OpenSearch/pull/5151))
 - Add events correlation engine plugin ([#6854](https://github.com/opensearch-project/OpenSearch/issues/6854))
+- Introduce new dynamic cluster setting to control slice computation for concurrent segment search ([#9107](https://github.com/opensearch-project/OpenSearch/pull/9107))
 
 ### Dependencies
 - Bump `log4j-core` from 2.18.0 to 2.19.0

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -678,7 +678,10 @@ public final class ClusterSettings extends AbstractScopedSettings {
             IndicesService.CLUSTER_REMOTE_TRANSLOG_REPOSITORY_SETTING
         ),
         List.of(FeatureFlags.CONCURRENT_SEGMENT_SEARCH),
-        List.of(SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING),
+        List.of(
+            SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING,
+            SearchService.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING
+        ),
         List.of(FeatureFlags.TELEMETRY),
         List.of(TelemetrySettings.TRACER_ENABLED_SETTING)
     );

--- a/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
@@ -943,4 +943,12 @@ final class DefaultSearchContext extends SearchContext {
             return false;
         }
     }
+
+    @Override
+    public int getTargetMaxSliceCount() {
+        if (!isConcurrentSegmentSearchEnabled()) {
+            throw new IllegalStateException("Target slice count should not be used when concurrent search is disabled");
+        }
+        return clusterService.getClusterSettings().get(SearchService.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING);
+    }
 }

--- a/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
@@ -946,7 +946,7 @@ final class DefaultSearchContext extends SearchContext {
 
     @Override
     public int getTargetMaxSliceCount() {
-        if (!isConcurrentSegmentSearchEnabled()) {
+        if (isConcurrentSegmentSearchEnabled() == false) {
             throw new IllegalStateException("Target slice count should not be used when concurrent search is disabled");
         }
         return clusterService.getClusterSettings().get(SearchService.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING);

--- a/server/src/main/java/org/opensearch/search/SearchService.java
+++ b/server/src/main/java/org/opensearch/search/SearchService.java
@@ -254,6 +254,20 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         Property.NodeScope
     );
 
+    // settings to configure maximum slice created per search request using OS custom slice computation mechanism. Default lucene
+    // mechanism will not be used if this setting is set with value > 0
+    public static final String CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_KEY = "search.concurrent.max_slice";
+    public static final int CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_DEFAULT_VALUE = 0;
+
+    // value == 0 means lucene slice computation will be used
+    public static final Setting<Integer> CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING = Setting.intSetting(
+        CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_KEY,
+        CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_DEFAULT_VALUE,
+        CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_DEFAULT_VALUE,
+        Property.Dynamic,
+        Property.NodeScope
+    );
+
     public static final int DEFAULT_SIZE = 10;
     public static final int DEFAULT_FROM = 0;
 

--- a/server/src/main/java/org/opensearch/search/SearchService.java
+++ b/server/src/main/java/org/opensearch/search/SearchService.java
@@ -256,7 +256,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
 
     // settings to configure maximum slice created per search request using OS custom slice computation mechanism. Default lucene
     // mechanism will not be used if this setting is set with value > 0
-    public static final String CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_KEY = "search.concurrent.max_slice";
+    public static final String CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_KEY = "search.concurrent.max_slice_count";
     public static final int CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_DEFAULT_VALUE = 0;
 
     // value == 0 means lucene slice computation will be used

--- a/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
@@ -32,6 +32,8 @@
 
 package org.opensearch.search.internal;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
@@ -93,11 +95,13 @@ import java.util.concurrent.Executor;
  * @opensearch.internal
  */
 public class ContextIndexSearcher extends IndexSearcher implements Releasable {
+
+    private static final Logger logger = LogManager.getLogger(ContextIndexSearcher.class);
     /**
      * The interval at which we check for search cancellation when we cannot use
      * a {@link CancellableBulkScorer}. See {@link #intersectScorerAndBitSet}.
      */
-    private static int CHECK_CANCELLED_SCORER_INTERVAL = 1 << 11;
+    private static final int CHECK_CANCELLED_SCORER_INTERVAL = 1 << 11;
 
     private AggregatedDfs aggregatedDfs;
     private QueryProfiler profiler;
@@ -443,6 +447,16 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
         return collectionStatistics;
     }
 
+    /**
+     * Compute the leaf slices that will be used by concurrent segment search to spread work across threads
+     * @param leaves all the segments
+     * @return leafSlice group to be executed by different threads
+     */
+    @Override
+    public LeafSlice[] slices(List<LeafReaderContext> leaves) {
+        return slicesInternal(leaves, searchContext.getTargetMaxSliceCount());
+    }
+
     public DirectoryReader getDirectoryReader() {
         final IndexReader reader = getIndexReader();
         assert reader instanceof DirectoryReader : "expected an instance of DirectoryReader, got " + reader.getClass();
@@ -521,5 +535,20 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
             }
         }
         return false;
+    }
+
+    // package-private for testing
+    LeafSlice[] slicesInternal(List<LeafReaderContext> leaves, int targetMaxSlice) {
+        LeafSlice[] leafSlices;
+        if (targetMaxSlice == 0) {
+            // use the default lucene slice calculation
+            leafSlices = super.slices(leaves);
+            logger.debug("Slice count using lucene default [{}]", leafSlices.length);
+        } else {
+            // use the custom slice calculation based on targetMaxSlice
+            leafSlices = MaxTargetSliceSupplier.getSlices(leaves, targetMaxSlice);
+            logger.debug("Slice count using max target slice supplier [{}]", leafSlices.length);
+        }
+        return leafSlices;
     }
 }

--- a/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
@@ -453,7 +453,7 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
      * @return leafSlice group to be executed by different threads
      */
     @Override
-    public LeafSlice[] slices(List<LeafReaderContext> leaves) {
+    protected LeafSlice[] slices(List<LeafReaderContext> leaves) {
         return slicesInternal(leaves, searchContext.getTargetMaxSliceCount());
     }
 

--- a/server/src/main/java/org/opensearch/search/internal/FilteredSearchContext.java
+++ b/server/src/main/java/org/opensearch/search/internal/FilteredSearchContext.java
@@ -564,4 +564,9 @@ public abstract class FilteredSearchContext extends SearchContext {
     public boolean isConcurrentSegmentSearchEnabled() {
         return in.isConcurrentSegmentSearchEnabled();
     }
+
+    @Override
+    public int getTargetMaxSliceCount() {
+        return in.getTargetMaxSliceCount();
+    }
 }

--- a/server/src/main/java/org/opensearch/search/internal/MaxTargetSliceSupplier.java
+++ b/server/src/main/java/org/opensearch/search/internal/MaxTargetSliceSupplier.java
@@ -40,7 +40,7 @@ final class MaxTargetSliceSupplier {
         // Sort by maxDoc, descending:
         sortedLeaves.sort(Collections.reverseOrder(Comparator.comparingInt(l -> l.reader().maxDoc())));
 
-        final List<List<LeafReaderContext>> groupedLeaves = new ArrayList<>();
+        final List<List<LeafReaderContext>> groupedLeaves = new ArrayList<>(targetSliceCount);
         for (int i = 0; i < targetSliceCount; ++i) {
             groupedLeaves.add(new ArrayList<>());
         }

--- a/server/src/main/java/org/opensearch/search/internal/MaxTargetSliceSupplier.java
+++ b/server/src/main/java/org/opensearch/search/internal/MaxTargetSliceSupplier.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.internal;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.IndexSearcher;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Supplier to compute leaf slices based on passed in leaves and max target slice count to limit the number of computed slices. It sorts
+ * all the leaves based on document count and then assign each leaf in round-robin fashion to the target slice count slices. Based on
+ * experiment results as shared in <a href=https://github.com/opensearch-project/OpenSearch/issues/7358>issue-7358</a>
+ * we can see this mechanism helps to achieve better tail/median latency over default lucene slice computation.
+ *
+ * @opensearch.internal
+ */
+final class MaxTargetSliceSupplier {
+
+    static IndexSearcher.LeafSlice[] getSlices(List<LeafReaderContext> leaves, int targetMaxSlice) {
+        if (targetMaxSlice <= 0) {
+            throw new IllegalArgumentException("MaxTargetSliceSupplier called with unexpected slice count of " + targetMaxSlice);
+        }
+
+        // slice count should not exceed the segment count
+        int targetSliceCount = Math.min(targetMaxSlice, leaves.size());
+
+        // Make a copy so we can sort:
+        List<LeafReaderContext> sortedLeaves = new ArrayList<>(leaves);
+
+        // Sort by maxDoc, descending:
+        sortedLeaves.sort(Collections.reverseOrder(Comparator.comparingInt(l -> l.reader().maxDoc())));
+
+        final List<List<LeafReaderContext>> groupedLeaves = new ArrayList<>();
+        for (int i = 0; i < targetSliceCount; ++i) {
+            groupedLeaves.add(new ArrayList<>());
+        }
+        // distribute the slices in round-robin fashion
+        for (int idx = 0; idx < sortedLeaves.size(); ++idx) {
+            int currentGroup = idx % targetSliceCount;
+            groupedLeaves.get(currentGroup).add(sortedLeaves.get(idx));
+        }
+
+        return groupedLeaves.stream().map(IndexSearcher.LeafSlice::new).toArray(IndexSearcher.LeafSlice[]::new);
+    }
+}

--- a/server/src/main/java/org/opensearch/search/internal/SearchContext.java
+++ b/server/src/main/java/org/opensearch/search/internal/SearchContext.java
@@ -471,4 +471,6 @@ public abstract class SearchContext implements Releasable {
     public abstract void setBucketCollectorProcessor(BucketCollectorProcessor bucketCollectorProcessor);
 
     public abstract BucketCollectorProcessor bucketCollectorProcessor();
+
+    public abstract int getTargetMaxSliceCount();
 }

--- a/server/src/test/java/org/opensearch/common/settings/SettingsModuleTests.java
+++ b/server/src/test/java/org/opensearch/common/settings/SettingsModuleTests.java
@@ -335,4 +335,36 @@ public class SettingsModuleTests extends ModuleTestCase {
             "node"
         );
     }
+
+    public void testMaxSliceCountClusterSettingsForConcurrentSearch() {
+        // Test that we throw an exception without the feature flag
+        Settings settings = Settings.builder()
+            .put(SearchService.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING.getKey(), 2)
+            .build();
+        SettingsException ex = expectThrows(SettingsException.class, () -> new SettingsModule(settings));
+        assertTrue(
+            ex.getMessage()
+                .contains("unknown setting [" + SearchService.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING.getKey() + "]")
+        );
+
+        // Test that the settings updates correctly with the feature flag
+        FeatureFlagSetter.set(FeatureFlags.CONCURRENT_SEGMENT_SEARCH);
+        int settingValue = randomIntBetween(0, 10);
+        Settings settingsWithFeatureFlag = Settings.builder()
+            .put(SearchService.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING.getKey(), settingValue)
+            .build();
+        SettingsModule settingsModule = new SettingsModule(settingsWithFeatureFlag);
+        assertEquals(
+            settingValue,
+            (int) SearchService.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING.get(settingsModule.getSettings())
+        );
+
+        // Test that negative value is not allowed
+        settingValue = -1;
+        final Settings settingsWithFeatureFlag_2 = Settings.builder()
+            .put(SearchService.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING.getKey(), settingValue)
+            .build();
+        IllegalArgumentException iae = expectThrows(IllegalArgumentException.class, () -> new SettingsModule(settingsWithFeatureFlag_2));
+        assertTrue(iae.getMessage().contains(SearchService.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING.getKey()));
+    }
 }

--- a/server/src/test/java/org/opensearch/search/internal/ContextIndexSearcherTests.java
+++ b/server/src/test/java/org/opensearch/search/internal/ContextIndexSearcherTests.java
@@ -81,6 +81,7 @@ import org.opensearch.index.IndexSettings;
 import org.opensearch.index.cache.bitset.BitsetFilterCache;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.shard.IndexShard;
+import org.opensearch.search.SearchService;
 import org.opensearch.search.aggregations.LeafBucketCollector;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.IndexSettingsModule;
@@ -89,7 +90,9 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Collections;
 import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -99,6 +102,7 @@ import static org.opensearch.search.internal.ExitableDirectoryReader.ExitablePoi
 import static org.opensearch.search.internal.ExitableDirectoryReader.ExitableTerms;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.opensearch.search.internal.IndexReaderUtils.getLeaves;
 
 public class ContextIndexSearcherTests extends OpenSearchTestCase {
     public void testIntersectScorerAndRoleBits() throws Exception {
@@ -301,6 +305,115 @@ public class ContextIndexSearcherTests extends OpenSearchTestCase {
         assertEquals(3f, topDocs.scoreDocs[0].score, 0);
 
         IOUtils.close(reader, w, dir);
+    }
+
+    public void testSlicesInternal() throws Exception {
+        final List<LeafReaderContext> leaves = getLeaves(10);
+
+        final Directory directory = newDirectory();
+        IndexWriter iw = new IndexWriter(directory, new IndexWriterConfig(new StandardAnalyzer()).setMergePolicy(NoMergePolicy.INSTANCE));
+        Document document = new Document();
+        document.add(new StringField("field1", "value1", Field.Store.NO));
+        document.add(new StringField("field2", "value1", Field.Store.NO));
+        iw.addDocument(document);
+        iw.commit();
+        DirectoryReader directoryReader = DirectoryReader.open(directory);
+
+        SearchContext searchContext = mock(SearchContext.class);
+        IndexShard indexShard = mock(IndexShard.class);
+        when(searchContext.indexShard()).thenReturn(indexShard);
+        when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
+        ContextIndexSearcher searcher = new ContextIndexSearcher(
+            directoryReader,
+            IndexSearcher.getDefaultSimilarity(),
+            IndexSearcher.getDefaultQueryCache(),
+            IndexSearcher.getDefaultQueryCachingPolicy(),
+            true,
+            null,
+            searchContext
+        );
+        // Case 1: Verify the slice count when lucene default slice computation is used
+        IndexSearcher.LeafSlice[] slices = searcher.slicesInternal(
+            leaves,
+            SearchService.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_DEFAULT_VALUE
+        );
+        int expectedSliceCount = 2;
+        // 2 slices will be created since max segment per slice of 5 will be reached
+        assertEquals(expectedSliceCount, slices.length);
+        for (int i = 0; i < expectedSliceCount; ++i) {
+            assertEquals(5, slices[i].leaves.length);
+        }
+
+        // Case 2: Verify the slice count when custom max slice computation is used
+        expectedSliceCount = 4;
+        slices = searcher.slicesInternal(leaves, expectedSliceCount);
+
+        // 4 slices will be created with 3 leaves in first 2 slices and 2 leaves in other slices
+        assertEquals(expectedSliceCount, slices.length);
+        for (int i = 0; i < expectedSliceCount; ++i) {
+            if (i < 2) {
+                assertEquals(3, slices[i].leaves.length);
+            } else {
+                assertEquals(2, slices[i].leaves.length);
+            }
+        }
+        IOUtils.close(directoryReader, iw, directory);
+    }
+
+    public void testGetSlicesWithNonNullExecutorButCSDisabled() throws Exception {
+        final List<LeafReaderContext> leaves = getLeaves(10);
+
+        final Directory directory = newDirectory();
+        IndexWriter iw = new IndexWriter(directory, new IndexWriterConfig(new StandardAnalyzer()).setMergePolicy(NoMergePolicy.INSTANCE));
+        Document document = new Document();
+        document.add(new StringField("field1", "value1", Field.Store.NO));
+        document.add(new StringField("field2", "value1", Field.Store.NO));
+        iw.addDocument(document);
+        iw.commit();
+        DirectoryReader directoryReader = DirectoryReader.open(directory);
+
+        SearchContext searchContext = mock(SearchContext.class);
+        IndexShard indexShard = mock(IndexShard.class);
+        when(searchContext.indexShard()).thenReturn(indexShard);
+        when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
+        when(searchContext.isConcurrentSegmentSearchEnabled()).thenReturn(false);
+        ContextIndexSearcher searcher = new ContextIndexSearcher(
+            directoryReader,
+            IndexSearcher.getDefaultSimilarity(),
+            IndexSearcher.getDefaultQueryCache(),
+            IndexSearcher.getDefaultQueryCachingPolicy(),
+            true,
+            null,
+            searchContext
+        );
+        // Case 1: Verify getSlices return null when concurrent segment search is disabled
+        assertNull(searcher.getSlices());
+
+        // Case 2: Verify the slice count when custom max slice computation is used
+        searcher = new ContextIndexSearcher(
+            directoryReader,
+            IndexSearcher.getDefaultSimilarity(),
+            IndexSearcher.getDefaultQueryCache(),
+            IndexSearcher.getDefaultQueryCachingPolicy(),
+            true,
+            mock(ExecutorService.class),
+            searchContext
+        );
+        when(searchContext.isConcurrentSegmentSearchEnabled()).thenReturn(true);
+        when(searchContext.getTargetMaxSliceCount()).thenReturn(4);
+        int expectedSliceCount = 4;
+        IndexSearcher.LeafSlice[] slices = searcher.slices(leaves);
+
+        // 4 slices will be created with 3 leaves in first 2 slices and 2 leaves in other slices
+        assertEquals(expectedSliceCount, slices.length);
+        for (int i = 0; i < expectedSliceCount; ++i) {
+            if (i < 2) {
+                assertEquals(3, slices[i].leaves.length);
+            } else {
+                assertEquals(2, slices[i].leaves.length);
+            }
+        }
+        IOUtils.close(directoryReader, iw, directory);
     }
 
     private SparseFixedBitSet query(LeafReaderContext leaf, String field, String value) throws IOException {

--- a/server/src/test/java/org/opensearch/search/internal/ContextIndexSearcherTests.java
+++ b/server/src/test/java/org/opensearch/search/internal/ContextIndexSearcherTests.java
@@ -309,111 +309,119 @@ public class ContextIndexSearcherTests extends OpenSearchTestCase {
 
     public void testSlicesInternal() throws Exception {
         final List<LeafReaderContext> leaves = getLeaves(10);
+        try (
+            final Directory directory = newDirectory();
+            IndexWriter iw = new IndexWriter(
+                directory,
+                new IndexWriterConfig(new StandardAnalyzer()).setMergePolicy(NoMergePolicy.INSTANCE)
+            )
+        ) {
+            Document document = new Document();
+            document.add(new StringField("field1", "value1", Field.Store.NO));
+            document.add(new StringField("field2", "value1", Field.Store.NO));
+            iw.addDocument(document);
+            iw.commit();
+            try (DirectoryReader directoryReader = DirectoryReader.open(directory)) {
+                SearchContext searchContext = mock(SearchContext.class);
+                IndexShard indexShard = mock(IndexShard.class);
+                when(searchContext.indexShard()).thenReturn(indexShard);
+                when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
+                ContextIndexSearcher searcher = new ContextIndexSearcher(
+                    directoryReader,
+                    IndexSearcher.getDefaultSimilarity(),
+                    IndexSearcher.getDefaultQueryCache(),
+                    IndexSearcher.getDefaultQueryCachingPolicy(),
+                    true,
+                    null,
+                    searchContext
+                );
+                // Case 1: Verify the slice count when lucene default slice computation is used
+                IndexSearcher.LeafSlice[] slices = searcher.slicesInternal(
+                    leaves,
+                    SearchService.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_DEFAULT_VALUE
+                );
+                int expectedSliceCount = 2;
+                // 2 slices will be created since max segment per slice of 5 will be reached
+                assertEquals(expectedSliceCount, slices.length);
+                for (int i = 0; i < expectedSliceCount; ++i) {
+                    assertEquals(5, slices[i].leaves.length);
+                }
 
-        final Directory directory = newDirectory();
-        IndexWriter iw = new IndexWriter(directory, new IndexWriterConfig(new StandardAnalyzer()).setMergePolicy(NoMergePolicy.INSTANCE));
-        Document document = new Document();
-        document.add(new StringField("field1", "value1", Field.Store.NO));
-        document.add(new StringField("field2", "value1", Field.Store.NO));
-        iw.addDocument(document);
-        iw.commit();
-        DirectoryReader directoryReader = DirectoryReader.open(directory);
+                // Case 2: Verify the slice count when custom max slice computation is used
+                expectedSliceCount = 4;
+                slices = searcher.slicesInternal(leaves, expectedSliceCount);
 
-        SearchContext searchContext = mock(SearchContext.class);
-        IndexShard indexShard = mock(IndexShard.class);
-        when(searchContext.indexShard()).thenReturn(indexShard);
-        when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
-        ContextIndexSearcher searcher = new ContextIndexSearcher(
-            directoryReader,
-            IndexSearcher.getDefaultSimilarity(),
-            IndexSearcher.getDefaultQueryCache(),
-            IndexSearcher.getDefaultQueryCachingPolicy(),
-            true,
-            null,
-            searchContext
-        );
-        // Case 1: Verify the slice count when lucene default slice computation is used
-        IndexSearcher.LeafSlice[] slices = searcher.slicesInternal(
-            leaves,
-            SearchService.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_DEFAULT_VALUE
-        );
-        int expectedSliceCount = 2;
-        // 2 slices will be created since max segment per slice of 5 will be reached
-        assertEquals(expectedSliceCount, slices.length);
-        for (int i = 0; i < expectedSliceCount; ++i) {
-            assertEquals(5, slices[i].leaves.length);
-        }
-
-        // Case 2: Verify the slice count when custom max slice computation is used
-        expectedSliceCount = 4;
-        slices = searcher.slicesInternal(leaves, expectedSliceCount);
-
-        // 4 slices will be created with 3 leaves in first 2 slices and 2 leaves in other slices
-        assertEquals(expectedSliceCount, slices.length);
-        for (int i = 0; i < expectedSliceCount; ++i) {
-            if (i < 2) {
-                assertEquals(3, slices[i].leaves.length);
-            } else {
-                assertEquals(2, slices[i].leaves.length);
+                // 4 slices will be created with 3 leaves in first 2 slices and 2 leaves in other slices
+                assertEquals(expectedSliceCount, slices.length);
+                for (int i = 0; i < expectedSliceCount; ++i) {
+                    if (i < 2) {
+                        assertEquals(3, slices[i].leaves.length);
+                    } else {
+                        assertEquals(2, slices[i].leaves.length);
+                    }
+                }
             }
         }
-        IOUtils.close(directoryReader, iw, directory);
     }
 
     public void testGetSlicesWithNonNullExecutorButCSDisabled() throws Exception {
         final List<LeafReaderContext> leaves = getLeaves(10);
+        try (
+            final Directory directory = newDirectory();
+            IndexWriter iw = new IndexWriter(
+                directory,
+                new IndexWriterConfig(new StandardAnalyzer()).setMergePolicy(NoMergePolicy.INSTANCE)
+            )
+        ) {
+            Document document = new Document();
+            document.add(new StringField("field1", "value1", Field.Store.NO));
+            document.add(new StringField("field2", "value1", Field.Store.NO));
+            iw.addDocument(document);
+            iw.commit();
+            try (DirectoryReader directoryReader = DirectoryReader.open(directory);) {
+                SearchContext searchContext = mock(SearchContext.class);
+                IndexShard indexShard = mock(IndexShard.class);
+                when(searchContext.indexShard()).thenReturn(indexShard);
+                when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
+                when(searchContext.isConcurrentSegmentSearchEnabled()).thenReturn(false);
+                ContextIndexSearcher searcher = new ContextIndexSearcher(
+                    directoryReader,
+                    IndexSearcher.getDefaultSimilarity(),
+                    IndexSearcher.getDefaultQueryCache(),
+                    IndexSearcher.getDefaultQueryCachingPolicy(),
+                    true,
+                    null,
+                    searchContext
+                );
+                // Case 1: Verify getSlices return null when concurrent segment search is disabled
+                assertNull(searcher.getSlices());
 
-        final Directory directory = newDirectory();
-        IndexWriter iw = new IndexWriter(directory, new IndexWriterConfig(new StandardAnalyzer()).setMergePolicy(NoMergePolicy.INSTANCE));
-        Document document = new Document();
-        document.add(new StringField("field1", "value1", Field.Store.NO));
-        document.add(new StringField("field2", "value1", Field.Store.NO));
-        iw.addDocument(document);
-        iw.commit();
-        DirectoryReader directoryReader = DirectoryReader.open(directory);
+                // Case 2: Verify the slice count when custom max slice computation is used
+                searcher = new ContextIndexSearcher(
+                    directoryReader,
+                    IndexSearcher.getDefaultSimilarity(),
+                    IndexSearcher.getDefaultQueryCache(),
+                    IndexSearcher.getDefaultQueryCachingPolicy(),
+                    true,
+                    mock(ExecutorService.class),
+                    searchContext
+                );
+                when(searchContext.isConcurrentSegmentSearchEnabled()).thenReturn(true);
+                when(searchContext.getTargetMaxSliceCount()).thenReturn(4);
+                int expectedSliceCount = 4;
+                IndexSearcher.LeafSlice[] slices = searcher.slices(leaves);
 
-        SearchContext searchContext = mock(SearchContext.class);
-        IndexShard indexShard = mock(IndexShard.class);
-        when(searchContext.indexShard()).thenReturn(indexShard);
-        when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
-        when(searchContext.isConcurrentSegmentSearchEnabled()).thenReturn(false);
-        ContextIndexSearcher searcher = new ContextIndexSearcher(
-            directoryReader,
-            IndexSearcher.getDefaultSimilarity(),
-            IndexSearcher.getDefaultQueryCache(),
-            IndexSearcher.getDefaultQueryCachingPolicy(),
-            true,
-            null,
-            searchContext
-        );
-        // Case 1: Verify getSlices return null when concurrent segment search is disabled
-        assertNull(searcher.getSlices());
-
-        // Case 2: Verify the slice count when custom max slice computation is used
-        searcher = new ContextIndexSearcher(
-            directoryReader,
-            IndexSearcher.getDefaultSimilarity(),
-            IndexSearcher.getDefaultQueryCache(),
-            IndexSearcher.getDefaultQueryCachingPolicy(),
-            true,
-            mock(ExecutorService.class),
-            searchContext
-        );
-        when(searchContext.isConcurrentSegmentSearchEnabled()).thenReturn(true);
-        when(searchContext.getTargetMaxSliceCount()).thenReturn(4);
-        int expectedSliceCount = 4;
-        IndexSearcher.LeafSlice[] slices = searcher.slices(leaves);
-
-        // 4 slices will be created with 3 leaves in first 2 slices and 2 leaves in other slices
-        assertEquals(expectedSliceCount, slices.length);
-        for (int i = 0; i < expectedSliceCount; ++i) {
-            if (i < 2) {
-                assertEquals(3, slices[i].leaves.length);
-            } else {
-                assertEquals(2, slices[i].leaves.length);
+                // 4 slices will be created with 3 leaves in first 2 slices and 2 leaves in other slices
+                assertEquals(expectedSliceCount, slices.length);
+                for (int i = 0; i < expectedSliceCount; ++i) {
+                    if (i < 2) {
+                        assertEquals(3, slices[i].leaves.length);
+                    } else {
+                        assertEquals(2, slices[i].leaves.length);
+                    }
+                }
             }
         }
-        IOUtils.close(directoryReader, iw, directory);
     }
 
     private SparseFixedBitSet query(LeafReaderContext leaf, String field, String value) throws IOException {

--- a/server/src/test/java/org/opensearch/search/internal/IndexReaderUtils.java
+++ b/server/src/test/java/org/opensearch/search/internal/IndexReaderUtils.java
@@ -31,21 +31,25 @@ public class IndexReaderUtils {
      * @return created leaves
      */
     public static List<LeafReaderContext> getLeaves(int leafCount) throws Exception {
-        final Directory directory = newDirectory();
-        IndexWriter iw = new IndexWriter(directory, new IndexWriterConfig(new StandardAnalyzer()).setMergePolicy(NoMergePolicy.INSTANCE));
-        for (int i = 0; i < leafCount; ++i) {
-            Document document = new Document();
-            final String fieldValue = "value" + i;
-            document.add(new StringField("field1", fieldValue, Field.Store.NO));
-            document.add(new StringField("field2", fieldValue, Field.Store.NO));
-            iw.addDocument(document);
-            iw.commit();
+        try (
+            final Directory directory = newDirectory();
+            final IndexWriter iw = new IndexWriter(
+                directory,
+                new IndexWriterConfig(new StandardAnalyzer()).setMergePolicy(NoMergePolicy.INSTANCE)
+            )
+        ) {
+            for (int i = 0; i < leafCount; ++i) {
+                Document document = new Document();
+                final String fieldValue = "value" + i;
+                document.add(new StringField("field1", fieldValue, Field.Store.NO));
+                document.add(new StringField("field2", fieldValue, Field.Store.NO));
+                iw.addDocument(document);
+                iw.commit();
+            }
+            try (DirectoryReader directoryReader = DirectoryReader.open(directory)) {
+                List<LeafReaderContext> leaves = directoryReader.leaves();
+                return leaves;
+            }
         }
-        iw.close();
-        DirectoryReader directoryReader = DirectoryReader.open(directory);
-        List<LeafReaderContext> leaves = directoryReader.leaves();
-        directoryReader.close();
-        directory.close();
-        return leaves;
     }
 }

--- a/server/src/test/java/org/opensearch/search/internal/IndexReaderUtils.java
+++ b/server/src/test/java/org/opensearch/search/internal/IndexReaderUtils.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.internal;
+
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.store.Directory;
+
+import java.util.List;
+
+import static org.apache.lucene.tests.util.LuceneTestCase.newDirectory;
+
+public class IndexReaderUtils {
+
+    /**
+     * Utility to create leafCount number of {@link LeafReaderContext}
+     * @param leafCount count of leaves to create
+     * @return created leaves
+     */
+    public static List<LeafReaderContext> getLeaves(int leafCount) throws Exception {
+        final Directory directory = newDirectory();
+        IndexWriter iw = new IndexWriter(directory, new IndexWriterConfig(new StandardAnalyzer()).setMergePolicy(NoMergePolicy.INSTANCE));
+        for (int i = 0; i < leafCount; ++i) {
+            Document document = new Document();
+            final String fieldValue = "value" + i;
+            document.add(new StringField("field1", fieldValue, Field.Store.NO));
+            document.add(new StringField("field2", fieldValue, Field.Store.NO));
+            iw.addDocument(document);
+            iw.commit();
+        }
+        iw.close();
+        DirectoryReader directoryReader = DirectoryReader.open(directory);
+        List<LeafReaderContext> leaves = directoryReader.leaves();
+        directoryReader.close();
+        directory.close();
+        return leaves;
+    }
+}

--- a/server/src/test/java/org/opensearch/search/internal/MaxTargetSliceSupplierTests.java
+++ b/server/src/test/java/org/opensearch/search/internal/MaxTargetSliceSupplierTests.java
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.internal;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.IndexSearcher;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.opensearch.search.internal.IndexReaderUtils.getLeaves;
+
+public class MaxTargetSliceSupplierTests extends OpenSearchTestCase {
+
+    public void testSliceCountGreaterThanLeafCount() throws Exception {
+        int expectedSliceCount = 2;
+        IndexSearcher.LeafSlice[] slices = MaxTargetSliceSupplier.getSlices(getLeaves(expectedSliceCount), 5);
+        // verify slice count is same as leaf count
+        assertEquals(expectedSliceCount, slices.length);
+        for (int i = 0; i < expectedSliceCount; ++i) {
+            assertEquals(1, slices[i].leaves.length);
+        }
+    }
+
+    public void testNegativeSliceCount() {
+        assertThrows(IllegalArgumentException.class, () -> MaxTargetSliceSupplier.getSlices(new ArrayList<>(), randomIntBetween(-3, 0)));
+    }
+
+    public void testSingleSliceWithMultipleLeaves() throws Exception {
+        int leafCount = randomIntBetween(1, 10);
+        IndexSearcher.LeafSlice[] slices = MaxTargetSliceSupplier.getSlices(getLeaves(leafCount), 1);
+        assertEquals(1, slices.length);
+        assertEquals(leafCount, slices[0].leaves.length);
+    }
+
+    public void testSliceCountLessThanLeafCount() throws Exception {
+        int leafCount = 12;
+        List<LeafReaderContext> leaves = getLeaves(leafCount);
+
+        // Case 1: test with equal number of leaves per slice
+        int expectedSliceCount = 3;
+        IndexSearcher.LeafSlice[] slices = MaxTargetSliceSupplier.getSlices(leaves, expectedSliceCount);
+        int expectedLeavesPerSlice = leafCount / expectedSliceCount;
+
+        assertEquals(expectedSliceCount, slices.length);
+        for (int i = 0; i < expectedSliceCount; ++i) {
+            assertEquals(expectedLeavesPerSlice, slices[i].leaves.length);
+        }
+
+        // Case 2: test with first 2 slice more leaves than others
+        expectedSliceCount = 5;
+        slices = MaxTargetSliceSupplier.getSlices(leaves, expectedSliceCount);
+        int expectedLeavesInFirst2Slice = 3;
+        int expectedLeavesInOtherSlice = 2;
+
+        assertEquals(expectedSliceCount, slices.length);
+        for (int i = 0; i < expectedSliceCount; ++i) {
+            if (i < 2) {
+                assertEquals(expectedLeavesInFirst2Slice, slices[i].leaves.length);
+            } else {
+                assertEquals(expectedLeavesInOtherSlice, slices[i].leaves.length);
+            }
+        }
+    }
+
+    public void testEmptyLeaves() {
+        IndexSearcher.LeafSlice[] slices = MaxTargetSliceSupplier.getSlices(new ArrayList<>(), 2);
+        assertEquals(0, slices.length);
+    }
+}

--- a/server/src/test/java/org/opensearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/opensearch/search/query/QueryPhaseTests.java
@@ -1208,6 +1208,12 @@ public class QueryPhaseTests extends IndexShardTestCase {
         IndexShard indexShard = mock(IndexShard.class);
         when(searchContext.indexShard()).thenReturn(indexShard);
         when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
+        when(searchContext.isConcurrentSegmentSearchEnabled()).thenReturn(executor != null);
+        if (executor != null) {
+            when(searchContext.getTargetMaxSliceCount()).thenReturn(randomIntBetween(0, 2));
+        } else {
+            when(searchContext.getTargetMaxSliceCount()).thenThrow(IllegalStateException.class);
+        }
         return new ContextIndexSearcher(
             reader,
             IndexSearcher.getDefaultSimilarity(),
@@ -1225,6 +1231,12 @@ public class QueryPhaseTests extends IndexShardTestCase {
         IndexShard indexShard = mock(IndexShard.class);
         when(searchContext.indexShard()).thenReturn(indexShard);
         when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
+        when(searchContext.isConcurrentSegmentSearchEnabled()).thenReturn(executor != null);
+        if (executor != null) {
+            when(searchContext.getTargetMaxSliceCount()).thenReturn(randomIntBetween(0, 2));
+        } else {
+            when(searchContext.getTargetMaxSliceCount()).thenThrow(IllegalStateException.class);
+        }
         return new ContextIndexSearcher(
             reader,
             IndexSearcher.getDefaultSimilarity(),

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
@@ -1893,6 +1893,7 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
      * In other words subclasses must ensure this method is idempotent.
      */
     protected Settings nodeSettings(int nodeOrdinal) {
+        final Settings featureFlagSettings = featureFlagSettings();
         Settings.Builder builder = Settings.builder()
             // Default the watermarks to absurdly low to prevent the tests
             // from failing on nodes without enough disk space
@@ -1914,6 +1915,11 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
         // Enable tracer only when Telemetry Setting is enabled
         if (featureFlagSettings().getAsBoolean(FeatureFlags.TELEMETRY_SETTING.getKey(), false)) {
             builder.put(TelemetrySettings.TRACER_ENABLED_SETTING.getKey(), true);
+        }
+        if (FeatureFlags.CONCURRENT_SEGMENT_SEARCH_SETTING.get(featureFlagSettings)) {
+            // By default, for tests we will put the target slice count of 2. This will increase the probability of having multiple slices
+            // when tests are run with concurrent segment search enabled
+            builder.put(SearchService.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_KEY, 2);
         }
         return builder.build();
     }

--- a/test/framework/src/main/java/org/opensearch/test/TestSearchContext.java
+++ b/test/framework/src/main/java/org/opensearch/test/TestSearchContext.java
@@ -83,6 +83,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.opensearch.test.OpenSearchTestCase.randomIntBetween;
+
 public class TestSearchContext extends SearchContext {
     public static final SearchShardTarget SHARD_TARGET = new SearchShardTarget(
         "test",
@@ -118,12 +120,21 @@ public class TestSearchContext extends SearchContext {
     private CollapseContext collapse;
     protected boolean concurrentSegmentSearchEnabled;
     private BucketCollectorProcessor bucketCollectorProcessor = NO_OP_BUCKET_COLLECTOR_PROCESSOR;
+    private int maxSliceCount;
 
     /**
      * Sets the concurrent segment search enabled field
      */
     public void setConcurrentSegmentSearchEnabled(boolean concurrentSegmentSearchEnabled) {
         this.concurrentSegmentSearchEnabled = concurrentSegmentSearchEnabled;
+    }
+
+    /**
+     * Sets the maxSliceCount for concurrent search
+     * @param sliceCount maxSliceCount
+     */
+    public void setMaxSliceCount(int sliceCount) {
+        this.maxSliceCount = sliceCount;
     }
 
     private final Map<String, SearchExtBuilder> searchExtBuilders = new HashMap<>();
@@ -161,6 +172,7 @@ public class TestSearchContext extends SearchContext {
         this.queryShardContext = queryShardContext;
         this.searcher = searcher;
         this.concurrentSegmentSearchEnabled = searcher != null && (searcher.getExecutor() != null);
+        this.maxSliceCount = randomIntBetween(0, 2);
         this.scrollContext = scrollContext;
     }
 
@@ -672,6 +684,12 @@ public class TestSearchContext extends SearchContext {
     @Override
     public BucketCollectorProcessor bucketCollectorProcessor() {
         return bucketCollectorProcessor;
+    }
+
+    @Override
+    public int getTargetMaxSliceCount() {
+        assert concurrentSegmentSearchEnabled == true : "Please use concurrent search before fetching maxSliceCount";
+        return maxSliceCount;
     }
 
     /**


### PR DESCRIPTION
### Description
This is a follow-up to https://github.com/opensearch-project/OpenSearch/issues/7358 to make the setting `search.concurrent.max_slice` dynamic in main (with lucene 9.8 version).  This PR will not be backported to 2.x unless lucene 9.8 is released and available in 2.x branch. Until then we will use the static setting mechanism for 2.x branch supported by previous PR.

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/8870

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
