### PR TITLE
Soft deletes support in BlobStoreRepository and using it for Remote Store

### DIFF
--- a/server/src/main/java/org/opensearch/common/blobstore/BlobContainer.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/BlobContainer.java
@@ -157,6 +157,10 @@ public interface BlobContainer {
      */
     DeleteResult delete() throws IOException;
 
+    default DeleteResult softDelete() throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
     /**
      * Deletes the blobs with given names. This method will not throw an exception
      * when one or multiple of the given blobs don't exist and simply ignore this case.
@@ -165,6 +169,10 @@ public interface BlobContainer {
      * @throws  IOException if a subset of blob exists but could not be deleted.
      */
     void deleteBlobsIgnoringIfNotExists(List<String> blobNames) throws IOException;
+
+    default void softDeleteBlobsIgnoringIfNotExists(List<String> blobNames) throws IOException {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * Lists all blobs in the container.
@@ -238,4 +246,9 @@ public interface BlobContainer {
             listener.onFailure(e);
         }
     }
+
+    default boolean softDeleteable() {
+        return false;
+    }
+
 }

--- a/server/src/main/java/org/opensearch/index/store/RemoteDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteDirectory.java
@@ -119,7 +119,11 @@ public class RemoteDirectory extends Directory {
     @Override
     public void deleteFile(String name) throws IOException {
         // ToDo: Add a check for file existence
-        blobContainer.deleteBlobsIgnoringIfNotExists(Collections.singletonList(name));
+        if (blobContainer.softDeleteable()) {
+            blobContainer.softDeleteBlobsIgnoringIfNotExists(Collections.singletonList(name));
+        } else {
+            blobContainer.deleteBlobsIgnoringIfNotExists(Collections.singletonList(name));
+        }
     }
 
     /**
@@ -257,6 +261,10 @@ public class RemoteDirectory extends Directory {
     }
 
     public void delete() throws IOException {
-        blobContainer.delete();
+        if (blobContainer.softDeleteable()) {
+            blobContainer.softDelete();
+        } else {
+            blobContainer.delete();
+        }
     }
 }

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -51,7 +51,6 @@ import java.util.function.LongSupplier;
 public class RemoteFsTranslog extends Translog {
 
     private final Logger logger;
-    private final BlobStoreRepository blobStoreRepository;
     private final TranslogTransferManager translogTransferManager;
     private final FileTransferTracker fileTransferTracker;
     private final BooleanSupplier primaryModeSupplier;
@@ -84,7 +83,6 @@ public class RemoteFsTranslog extends Translog {
     ) throws IOException {
         super(config, translogUUID, deletionPolicy, globalCheckpointSupplier, primaryTermSupplier, persistedSequenceNumberConsumer);
         logger = Loggers.getLogger(getClass(), shardId);
-        this.blobStoreRepository = blobStoreRepository;
         this.primaryModeSupplier = primaryModeSupplier;
         fileTransferTracker = new FileTransferTracker(shardId);
         this.translogTransferManager = buildTranslogTransferManager(blobStoreRepository, threadPool, shardId, fileTransferTracker);

--- a/server/src/main/java/org/opensearch/index/translog/transfer/BlobStoreTransferService.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/BlobStoreTransferService.java
@@ -160,7 +160,11 @@ public class BlobStoreTransferService implements TransferService {
 
     @Override
     public void deleteBlobs(Iterable<String> path, List<String> fileNames) throws IOException {
-        blobStore.blobContainer((BlobPath) path).deleteBlobsIgnoringIfNotExists(fileNames);
+        if (blobStore.blobContainer((BlobPath) path).softDeleteable()) {
+            blobStore.blobContainer((BlobPath) path).softDeleteBlobsIgnoringIfNotExists(fileNames);
+        } else {
+            blobStore.blobContainer((BlobPath) path).deleteBlobsIgnoringIfNotExists(fileNames);
+        }
     }
 
     @Override
@@ -177,7 +181,11 @@ public class BlobStoreTransferService implements TransferService {
 
     @Override
     public void delete(Iterable<String> path) throws IOException {
-        blobStore.blobContainer((BlobPath) path).delete();
+        if (blobStore.blobContainer((BlobPath) path).softDeleteable()) {
+            blobStore.blobContainer((BlobPath) path).softDelete();
+        } else {
+            blobStore.blobContainer((BlobPath) path).delete();
+        }
     }
 
     @Override


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
1. Introduces Soft Delete Support on Repository Interface and corresponding S3 Repository changes to support it 

1. Using Soft Deletes in Remote Store 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Pending 
1. Performance tests
2. Failing UT fix 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
