### PR TITLE
Referencing default and best compressions codecs as their algo name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add configuration for file cache size to max remote data ratio to prevent oversubscription of file cache ([#8606](https://github.com/opensearch-project/OpenSearch/pull/8606))
 - Disallow compression level to be set for default and best_compression index codecs ([#8737]()https://github.com/opensearch-project/OpenSearch/pull/8737)
 - Prioritize replica shard movement during shard relocation ([#8875](https://github.com/opensearch-project/OpenSearch/pull/8875))
+- Introducing Default and Best Compression codecs as their algorithm name ([#9123]()https://github.com/opensearch-project/OpenSearch/pull/9123)
 
 ### Dependencies
 - Bump `org.apache.logging.log4j:log4j-core` from 2.17.1 to 2.20.0 ([#8307](https://github.com/opensearch-project/OpenSearch/pull/8307))

--- a/modules/reindex/src/internalClusterTest/java/org/opensearch/index/codec/MultiCodecReindexIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/opensearch/index/codec/MultiCodecReindexIT.java
@@ -45,11 +45,15 @@ public class MultiCodecReindexIT extends ReindexTestCase {
         Map<String, String> codecMap = Map.of(
             "best_compression",
             "BEST_COMPRESSION",
+            "zlib",
+            "BEST_COMPRESSION",
             "zstd_no_dict",
             "ZSTD_NO_DICT",
             "zstd",
             "ZSTD",
             "default",
+            "BEST_SPEED",
+            "lz4",
             "BEST_SPEED"
         );
 

--- a/server/src/internalClusterTest/java/org/opensearch/index/codec/MultiCodecMergeIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/codec/MultiCodecMergeIT.java
@@ -45,11 +45,15 @@ public class MultiCodecMergeIT extends OpenSearchIntegTestCase {
         Map<String, String> codecMap = Map.of(
             "best_compression",
             "BEST_COMPRESSION",
+            "zlib",
+            "BEST_COMPRESSION",
             "zstd_no_dict",
             "ZSTD_NO_DICT",
             "zstd",
             "ZSTD",
             "default",
+            "BEST_SPEED",
+            "lz4",
             "BEST_SPEED"
         );
 

--- a/server/src/main/java/org/opensearch/index/codec/CodecService.java
+++ b/server/src/main/java/org/opensearch/index/codec/CodecService.java
@@ -60,7 +60,9 @@ public class CodecService {
     private final Map<String, Codec> codecs;
 
     public static final String DEFAULT_CODEC = "default";
+    public static final String LZ4 = "lz4";
     public static final String BEST_COMPRESSION_CODEC = "best_compression";
+    public static final String ZLIB = "zlib";
     /**
      * the raw unfiltered lucene default. useful for testing
      */
@@ -74,12 +76,16 @@ public class CodecService {
         int compressionLevel = indexSettings.getValue(INDEX_CODEC_COMPRESSION_LEVEL_SETTING);
         if (mapperService == null) {
             codecs.put(DEFAULT_CODEC, new Lucene95Codec());
+            codecs.put(LZ4, new Lucene95Codec());
             codecs.put(BEST_COMPRESSION_CODEC, new Lucene95Codec(Mode.BEST_COMPRESSION));
+            codecs.put(ZLIB, new Lucene95Codec(Mode.BEST_COMPRESSION));
             codecs.put(ZSTD_CODEC, new ZstdCodec(compressionLevel));
             codecs.put(ZSTD_NO_DICT_CODEC, new ZstdNoDictCodec(compressionLevel));
         } else {
             codecs.put(DEFAULT_CODEC, new PerFieldMappingPostingFormatCodec(Mode.BEST_SPEED, mapperService, logger));
+            codecs.put(LZ4, new PerFieldMappingPostingFormatCodec(Mode.BEST_SPEED, mapperService, logger));
             codecs.put(BEST_COMPRESSION_CODEC, new PerFieldMappingPostingFormatCodec(Mode.BEST_COMPRESSION, mapperService, logger));
+            codecs.put(ZLIB, new PerFieldMappingPostingFormatCodec(Mode.BEST_COMPRESSION, mapperService, logger));
             codecs.put(ZSTD_CODEC, new ZstdCodec(mapperService, logger, compressionLevel));
             codecs.put(ZSTD_NO_DICT_CODEC, new ZstdNoDictCodec(mapperService, logger, compressionLevel));
         }

--- a/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
+++ b/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
@@ -130,7 +130,9 @@ public final class EngineConfig {
     public static final Setting<String> INDEX_CODEC_SETTING = new Setting<>("index.codec", "default", s -> {
         switch (s) {
             case "default":
+            case "lz4":
             case "best_compression":
+            case "zlib":
             case "zstd":
             case "zstd_no_dict":
             case "lucene_default":
@@ -138,7 +140,8 @@ public final class EngineConfig {
             default:
                 if (Codec.availableCodecs().contains(s) == false) { // we don't error message the not officially supported ones
                     throw new IllegalArgumentException(
-                        "unknown value for [index.codec] must be one of [default, best_compression, zstd, zstd_no_dict] but was: " + s
+                        "unknown value for [index.codec] must be one of [default, lz4, best_compression, zlib, zstd, zstd_no_dict] but was: "
+                            + s
                     );
                 }
                 return s;
@@ -182,8 +185,10 @@ public final class EngineConfig {
             case "zstd_no_dict":
                 return;
             case "best_compression":
+            case "zlib":
             case "lucene_default":
             case "default":
+            case "lz4":
                 break;
             default:
                 if (Codec.availableCodecs().contains(codec)) {

--- a/server/src/test/java/org/opensearch/index/codec/CodecTests.java
+++ b/server/src/test/java/org/opensearch/index/codec/CodecTests.java
@@ -83,6 +83,18 @@ public class CodecTests extends OpenSearchTestCase {
         assertStoredFieldsCompressionEquals(Lucene95Codec.Mode.BEST_COMPRESSION, codec);
     }
 
+    public void testLZ4() throws Exception {
+        Codec codec = createCodecService(false).codec("lz4");
+        assertStoredFieldsCompressionEquals(Lucene95Codec.Mode.BEST_SPEED, codec);
+        assert codec instanceof PerFieldMappingPostingFormatCodec;
+    }
+
+    public void testZlib() throws Exception {
+        Codec codec = createCodecService(false).codec("zlib");
+        assertStoredFieldsCompressionEquals(Lucene95Codec.Mode.BEST_COMPRESSION, codec);
+        assert codec instanceof PerFieldMappingPostingFormatCodec;
+    }
+
     public void testZstd() throws Exception {
         Codec codec = createCodecService(false).codec("zstd");
         assertStoredFieldsCompressionEquals(Lucene95CustomCodec.Mode.ZSTD, codec);

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
@@ -279,7 +279,9 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
      */
     public static final List<String> CODECS = List.of(
         CodecService.DEFAULT_CODEC,
+        CodecService.LZ4,
         CodecService.BEST_COMPRESSION_CODEC,
+        CodecService.ZLIB,
         CodecService.ZSTD_CODEC,
         CodecService.ZSTD_NO_DICT_CODEC
     );


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description 
The users will be able to set the codecs in the index settings using their algorithm names. This will help the user get visibility on the algorithm being used in the background for compression 

### Related Issues
Resolves #8695

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
