### PR TITLE
Fix flaky testCorruptedTranslog test

### DIFF
--- a/server/src/test/java/org/opensearch/index/shard/RemoveCorruptedShardDataCommandTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoveCorruptedShardDataCommandTests.java
@@ -295,8 +295,8 @@ public class RemoveCorruptedShardDataCommandTests extends IndexShardTestCase {
         final Exception exception = expectThrows(Exception.class, () -> newStartedShard(p -> corruptedShard, true));
         // if corruption is in engine UUID in header, the TranslogCorruptedException is caught and rethrown as
         // EngineCreationFailureException rather than TranslogException
-        final Throwable cause = (exception.getCause() instanceof TranslogException
-            || exception.getCause() instanceof EngineCreationFailureException) ? exception.getCause().getCause() : exception.getCause();
+        final Throwable cause = exception.getCause() instanceof TranslogException
+            || exception.getCause() instanceof EngineCreationFailureException ? exception.getCause().getCause() : exception.getCause();
         assertThat(cause, instanceOf(TranslogCorruptedException.class));
 
         closeShard(corruptedShard, false); // translog is corrupted already - do not check consistency


### PR DESCRIPTION
### Description

The `RemoveCorruptedShardDataCommandTests` tests for appropriate exceptions on corrupted translogs.  In the rare edge case where the corruption occurs in the header where the UUID tracks the engine, the expected `TranslogCorruptedException` is caught and rethrown as an `EngineCreationFailureException` rather than the `TranslogException` expected by the test.

This change relaxes the test to allow either wrapped exception while testing the same cause.

### Related Issues

Fixes #6179 

Command reproducing this failure at linked issue; this test passes after this fix.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
