### PR TITLE
Fix compilation warning in CollectionUtils affecting maven snapshot publication

### DIFF
--- a/libs/core/src/main/java/org/opensearch/core/common/util/CollectionUtils.java
+++ b/libs/core/src/main/java/org/opensearch/core/common/util/CollectionUtils.java
@@ -140,7 +140,10 @@ public class CollectionUtils {
         }
         if (value instanceof Map) {
             Map<?, ?> map = (Map<?, ?>) value;
-            return () -> Iterators.concat(map.keySet().iterator(), map.values().iterator());
+            Iterator<?>[] iterators = new Iterator<?>[2];
+            iterators[0] = map.keySet().iterator();
+            iterators[1] = map.values().iterator();
+            return () -> Iterators.concat(iterators);
         } else if ((value instanceof Iterable) && (value instanceof Path == false)) {
             return (Iterable<?>) value;
         } else if (value instanceof Object[]) {

--- a/libs/core/src/main/java/org/opensearch/core/common/util/CollectionUtils.java
+++ b/libs/core/src/main/java/org/opensearch/core/common/util/CollectionUtils.java
@@ -134,16 +134,14 @@ public class CollectionUtils {
         }
     }
 
+    @SuppressWarnings("unchecked")
     private static Iterable<?> convert(Object value) {
         if (value == null) {
             return null;
         }
         if (value instanceof Map) {
             Map<?, ?> map = (Map<?, ?>) value;
-            Iterator<?>[] iterators = new Iterator<?>[2];
-            iterators[0] = map.keySet().iterator();
-            iterators[1] = map.values().iterator();
-            return () -> Iterators.concat(iterators);
+            return () -> Iterators.concat(map.keySet().iterator(), map.values().iterator());
         } else if ((value instanceof Iterable) && (value instanceof Path == false)) {
             return (Iterable<?>) value;
         } else if (value instanceof Object[]) {


### PR DESCRIPTION
### Description

Maven snapshot publication started failing after: https://github.com/opensearch-project/OpenSearch/pull/9120

The error stemmed from a compilation warning:

> /home/runner/work/OpenSearch/OpenSearch/libs/core/src/main/java/org/opensearch/core/common/util/CollectionUtils.java:143: warning: [unchecked] unchecked generic array creation for varargs parameter of type Iterator<? extends Object>[]
            return () -> Iterators.concat(map.keySet().iterator(), map.values().iterator());
                                         ^
error: warnings found and -Werror specified

See: https://github.com/opensearch-project/OpenSearch/actions/runs/5767554873/job/15637408847

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
