### PR TITLE
Add Gradle's 'assemble' check to catch the distribution generation issues (#8924)

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -1,16 +1,29 @@
-name: Gradle Precommit
+name: Gradle Precommit and Asssemble
 on: [pull_request]
 
 jobs:
   precommit:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 11
-          distribution: adopt
-      - name: Run Gradle
+          distribution: temurin
+          cache: gradle
+      - name: Run Gradle (precommit)
         run: |
-          ./gradlew precommit --parallel
+          ./gradlew javadoc precommit --parallel
+      - name: Setup docker (missing on MacOS)
+        if: runner.os == 'macos'
+        run: |
+          brew install docker
+          colima start
+          sudo ln -sf $HOME/.colima/default/docker.sock /var/run/docker.sock
+      - name: Run Gradle (assemble)
+        run: |
+          ./gradlew assemble --parallel

--- a/buildSrc/src/main/java/org/opensearch/gradle/docker/DockerSupportService.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/docker/DockerSupportService.java
@@ -68,7 +68,9 @@ public abstract class DockerSupportService implements BuildService<DockerSupport
     // Defines the possible locations of the Docker CLI. These will be searched in order.
     private static String[] DOCKER_BINARIES_UNIX = { "/usr/bin/docker", "/usr/local/bin/docker" };
 
-    private static String[] DOCKER_BINARIES_WINDOWS = { System.getenv("PROGRAMFILES") + "\\Docker\\Docker\\resources\\bin\\docker.exe" };
+    private static String[] DOCKER_BINARIES_WINDOWS = {
+        System.getenv("PROGRAMFILES") + "\\Docker\\Docker\\resources\\bin\\docker.exe",
+        System.getenv("SystemRoot") + "\\System32\\docker.exe" /* Github Actions */ };
 
     private static String[] DOCKER_BINARIES = Os.isFamily(Os.FAMILY_WINDOWS) ? DOCKER_BINARIES_WINDOWS : DOCKER_BINARIES_UNIX;
 


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/8924 to `2.x`