### PR TITLE
Reinstate maintainers from emeritus to active

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,6 +6,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 | Maintainer               | GitHub ID                                               | Affiliation |
 |--------------------------| ------------------------------------------------------- | ----------- |
+| Abbas Hussain           | [abbashus](https://github.com/abbashus)     | Meta        |
 | Anas Alkouz              | [anasalkouz](https://github.com/anasalkouz)             | Amazon      |
 | Andrew Ross              | [andrross](https://github.com/andrross)                 | Amazon      |
 | Andriy Redko             | [reta](https://github.com/reta)                         | Aiven       |
@@ -20,6 +21,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Marc Handalian           | [mch2](https://github.com/mch2)                         | Amazon      |
 | Nick Knize               | [nknize](https://github.com/nknize)                     | Amazon      |
 | Owais Kazi               | [owaiskazi19](https://github.com/owaiskazi19)           | Amazon      |
+| Rabi Panda              | [adnapibar](https://github.com/adnapibar)   | Independent |
 | Rishikesh Pasham         | [Rishikesh1159](https://github.com/Rishikesh1159)       | Amazon      |
 | Ryan Bogan               | [ryanbogan](https://github.com/ryanbogan)               | Amazon      |
 | Sachin Kale              | [sachinpkale](https://github.com/sachinpkale)           | Amazon      |
@@ -33,8 +35,6 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 ## Emeritus
 
 | Maintainer              | GitHub ID                                   | Affiliation |
-|-------------------------|---------------------------------------------| ----------- |
-| Abbas Hussain           | [abbashus](https://github.com/abbashus)     | Amazon      |
+|-------------------------|---------------------------------------------|-------------|
 | Megha Sai Kavikondala   | [meghasaik](https://github.com/meghasaik)   | Amazon      |
-| Rabi Panda              | [adnapibar](https://github.com/adnapibar)   | Amazon      |
 | Xue Zhou                | [xuezhou25](https://github.com/xuezhou25)   | Amazon      |


### PR DESCRIPTION
This PR reinstates Rabi Panda, and Abbas Hussain as maintainers of the opensearch repository after inadvertant removal in https://github.com/opensearch-project/OpenSearch/commit/0f651b8664ea80c993e93d47170b33fcef0d8d73 and  https://github.com/opensearch-project/OpenSearch/commit/62157b93d297f30a922c462a74310c7578ee4537, respectively. The [removing maintainers](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#moving-on) process specifies maintainers are removed as follows: 

```
Existing maintainers can choose to leave the project at any time, with or without reason, by making a pull request to move themselves to the "Emeritus" section of MAINTAINERS.md, and asking an [members of the admin team](https://github.com/opensearch-project/.github/blob/main/ADMINS.md) to remove their permissions.
```


