### PR TITLE
[Backport] [2.x] Bump org.apache.maven:maven-model from 3.9.3 to 3.9.4 in /buildSrc (#9148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `netty` from 4.1.94.Final to 4.1.96.Final ([#9030](https://github.com/opensearch-project/OpenSearch/pull/9030))
 - Bump `com.google.jimfs:jimfs` from 1.2 to 1.3.0 ([#9080](https://github.com/opensearch-project/OpenSearch/pull/9080))
 - Bump `io.projectreactor.netty:reactor-netty-http` from 1.1.8 to 1.1.9 ([#9147](https://github.com/opensearch-project/OpenSearch/pull/9147))
+- Bump `org.apache.maven:maven-model` from 3.9.3 to 3.9.4 ([#9148](https://github.com/opensearch-project/OpenSearch/pull/9148))
 
 ### Changed
 - Perform aggregation postCollection in ContextIndexSearcher after searching leaves ([#8303](https://github.com/opensearch-project/OpenSearch/pull/8303))
@@ -63,9 +64,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Security
 
-<<<<<<< HEAD
-[Unreleased 2.x]: https://github.com/opensearch-project/OpenSearch/compare/2.9...2.x
-=======
-[Unreleased 3.0]: https://github.com/opensearch-project/OpenSearch/compare/2.x...HEAD
 [Unreleased 2.x]: https://github.com/opensearch-project/OpenSearch/compare/2.10...2.x
->>>>>>> e1eade10174 (Bump io.projectreactor.netty:reactor-netty-http from 1.1.8 to 1.1.9 in /plugins/repository-azure (#9147))

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -117,7 +117,7 @@ dependencies {
   api 'de.thetaphi:forbiddenapis:3.5.1'
   api 'com.avast.gradle:gradle-docker-compose-plugin:0.16.11'
   api "org.yaml:snakeyaml:${props.getProperty('snakeyaml')}"
-  api 'org.apache.maven:maven-model:3.9.3'
+  api 'org.apache.maven:maven-model:3.9.4'
   api 'com.networknt:json-schema-validator:1.0.86'
   api 'org.jruby.jcodings:jcodings:1.0.58'
   api 'org.jruby.joni:joni:2.2.1'


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/9148 to `2.x`