### PR TITLE
Mute flaky test ShardMovementStrategyTests.testClusterGreenAfterParti…

### DIFF
--- a/server/src/test/java/org/opensearch/cluster/routing/ShardMovementStrategyTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/ShardMovementStrategyTests.java
@@ -70,6 +70,7 @@ public class ShardMovementStrategyTests extends OpenSearchIntegTestCase {
         testClusterGreenAfterPartialRelocation(ShardMovementStrategy.REPLICA_FIRST, false);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/9178")
     public void testClusterGreenAfterPartialRelocationNoPreferenceShardMovementPrimaryFirstEnabled() throws InterruptedException {
         testClusterGreenAfterPartialRelocation(ShardMovementStrategy.NO_PREFERENCE, true);
     }


### PR DESCRIPTION
…alRelocationNoPreferenceShardMovementPrimaryFirstEnabled

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Mutes flaky test org.opensearch.cluster.routing.ShardMovementStrategyTests.testClusterGreenAfterPartialRelocationNoPreferenceShardMovementPrimaryFirstEnabled until fix is merged in. 

### Related Issues
Issue is being tracked here: https://github.com/opensearch-project/OpenSearch/issues/9178 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
