### PR TITLE
Fix flaky test by preventing duplicate keys in random mapping fields

### DIFF
--- a/client/rest-high-level/src/test/java/org/opensearch/client/indices/GetIndexTemplatesResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/indices/GetIndexTemplatesResponseTests.java
@@ -34,18 +34,18 @@ package org.opensearch.client.indices;
 
 import org.opensearch.cluster.metadata.AliasMetadata;
 import org.opensearch.cluster.metadata.MappingMetadata;
-import org.opensearch.core.common.bytes.BytesArray;
-import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.common.compress.CompressedXContent;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.core.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -53,18 +53,21 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
 import static org.opensearch.index.RandomCreateIndexGenerator.randomIndexSettings;
 import static org.opensearch.index.RandomCreateIndexGenerator.randomMappingFields;
 import static org.opensearch.test.AbstractXContentTestCase.xContentTester;
-import static org.hamcrest.Matchers.equalTo;
 
 public class GetIndexTemplatesResponseTests extends OpenSearchTestCase {
 
@@ -99,8 +102,12 @@ public class GetIndexTemplatesResponseTests extends OpenSearchTestCase {
                 esIMD.settings(randomIndexSettings());
                 esIMD.putMapping("_doc", new CompressedXContent(BytesReference.bytes(randomMapping("_doc", xContentType))));
                 int numAliases = randomIntBetween(0, 8);
+                Set<String> uniqueAliases = new HashSet<>();
                 for (int j = 0; j < numAliases; j++) {
-                    esIMD.putAlias(randomAliasMetadata(String.format(Locale.ROOT, "%02d ", j) + randomAlphaOfLength(4)));
+                    uniqueAliases.add(String.format(Locale.ROOT, "%02d ", j) + randomAlphaOfLength(4));
+                }
+                for (String uniqueAlias : uniqueAliases) {
+                    esIMD.putAlias(randomAliasMetadata(uniqueAlias));
                 }
                 esIMD.order(randomIntBetween(0, Integer.MAX_VALUE));
                 esIMD.version(randomIntBetween(0, Integer.MAX_VALUE));

--- a/client/rest-high-level/src/test/java/org/opensearch/client/indices/GetIndexTemplatesResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/indices/GetIndexTemplatesResponseTests.java
@@ -34,18 +34,18 @@ package org.opensearch.client.indices;
 
 import org.opensearch.cluster.metadata.AliasMetadata;
 import org.opensearch.cluster.metadata.MappingMetadata;
-import org.opensearch.common.compress.CompressedXContent;
-import org.opensearch.common.settings.Settings;
-import org.opensearch.common.xcontent.XContentHelper;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.common.compress.CompressedXContent;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -53,21 +53,18 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
 import static org.opensearch.index.RandomCreateIndexGenerator.randomIndexSettings;
 import static org.opensearch.index.RandomCreateIndexGenerator.randomMappingFields;
 import static org.opensearch.test.AbstractXContentTestCase.xContentTester;
+import static org.hamcrest.Matchers.equalTo;
 
 public class GetIndexTemplatesResponseTests extends OpenSearchTestCase {
 
@@ -102,12 +99,8 @@ public class GetIndexTemplatesResponseTests extends OpenSearchTestCase {
                 esIMD.settings(randomIndexSettings());
                 esIMD.putMapping("_doc", new CompressedXContent(BytesReference.bytes(randomMapping("_doc", xContentType))));
                 int numAliases = randomIntBetween(0, 8);
-                Set<String> uniqueAliases = new HashSet<>();
                 for (int j = 0; j < numAliases; j++) {
-                    uniqueAliases.add(String.format(Locale.ROOT, "%02d ", j) + randomAlphaOfLength(4));
-                }
-                for (String uniqueAlias : uniqueAliases) {
-                    esIMD.putAlias(randomAliasMetadata(uniqueAlias));
+                    esIMD.putAlias(randomAliasMetadata(String.format(Locale.ROOT, "%02d ", j) + randomAlphaOfLength(4)));
                 }
                 esIMD.order(randomIntBetween(0, Integer.MAX_VALUE));
                 esIMD.version(randomIntBetween(0, Integer.MAX_VALUE));

--- a/test/framework/src/main/java/org/opensearch/index/RandomCreateIndexGenerator.java
+++ b/test/framework/src/main/java/org/opensearch/index/RandomCreateIndexGenerator.java
@@ -115,7 +115,7 @@ public final class RandomCreateIndexGenerator {
 
         int fieldsNo = randomIntBetween(0, 5);
         Set<String> uniqueFields = new HashSet<>();
-        for (int i = 0; i < fieldsNo; i++) {
+        while (uniqueFields.size() < fieldsNo) {
             uniqueFields.add(randomAlphaOfLength(5));
         }
         for (String uniqueField : uniqueFields) {

--- a/test/framework/src/main/java/org/opensearch/index/RandomCreateIndexGenerator.java
+++ b/test/framework/src/main/java/org/opensearch/index/RandomCreateIndexGenerator.java
@@ -35,11 +35,13 @@ package org.opensearch.index;
 import org.opensearch.action.admin.indices.alias.Alias;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
@@ -112,8 +114,12 @@ public final class RandomCreateIndexGenerator {
         builder.startObject("properties");
 
         int fieldsNo = randomIntBetween(0, 5);
+        Set<String> uniqueFields = new HashSet<>();
         for (int i = 0; i < fieldsNo; i++) {
-            builder.startObject(randomAlphaOfLength(5));
+            uniqueFields.add(randomAlphaOfLength(5));
+        }
+        for (String uniqueField : uniqueFields) {
+            builder.startObject(uniqueField);
 
             if (allowObjectField && randomBoolean()) {
                 randomMappingFields(builder, false);


### PR DESCRIPTION
### Description

Although rare, [if you throw random alpha strings together often enough](https://en.wikipedia.org/wiki/Infinite_monkey_theorem), you'll get a collision.

### Related Issues

Fixes #6739

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
