### PR TITLE
[BUG] org.opensearch.client.RestClientSingleHostIntegTests.testRequestResetAndAbort is flaky

### DIFF
--- a/client/rest/src/test/java/org/opensearch/client/RestClientSingleHostIntegTests.java
+++ b/client/rest/src/test/java/org/opensearch/client/RestClientSingleHostIntegTests.java
@@ -48,6 +48,7 @@ import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.message.BasicHeader;
@@ -73,6 +74,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
+import java.util.concurrent.Phaser;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -298,37 +300,70 @@ public class RestClientSingleHostIntegTests extends RestClientTestCase {
                 httpGet.reset();
                 assertFalse(httpGet.isAborted());
 
-                Future<ClassicHttpResponse> future = client.execute(getRequestProducer(httpGet, httpHost), getResponseConsumer(), null);
-                httpGet.setDependency((org.apache.hc.core5.concurrent.Cancellable) future);
-                httpGet.abort();
+                final Phaser phaser = new Phaser(2);
+                phaser.register();
 
                 try {
-                    future.get();
-                    fail("expected cancellation exception");
-                } catch (CancellationException e) {
-                    // expected
-                }
-                assertTrue(future.isCancelled());
-            }
-            {
-                httpGet.reset();
-                Future<ClassicHttpResponse> future = client.execute(getRequestProducer(httpGet, httpHost), getResponseConsumer(), null);
-                assertFalse(httpGet.isAborted());
-                httpGet.setDependency((org.apache.hc.core5.concurrent.Cancellable) future);
-                httpGet.abort();
-                assertTrue(httpGet.isAborted());
-                try {
+                    Future<ClassicHttpResponse> future = client.execute(
+                        getRequestProducer(httpGet, httpHost),
+                        getResponseConsumer(phaser),
+                        null
+                    );
+                    httpGet.setDependency((org.apache.hc.core5.concurrent.Cancellable) future);
+                    httpGet.abort();
+
+                    try {
+                        phaser.arriveAndDeregister();
+                        future.get();
+                        fail("expected cancellation exception");
+                    } catch (CancellationException e) {
+                        // expected
+                    }
                     assertTrue(future.isCancelled());
-                    future.get();
-                    throw new AssertionError("exception should have been thrown");
-                } catch (CancellationException e) {
-                    // expected
+                } finally {
+                    // Forcing termination since the AsyncResponseConsumer may not be reached,
+                    // the request is aborted right before
+                    phaser.forceTermination();
+                }
+            }
+            {
+                final Phaser phaser = new Phaser(2);
+                phaser.register();
+
+                try {
+                    httpGet.reset();
+                    Future<ClassicHttpResponse> future = client.execute(
+                        getRequestProducer(httpGet, httpHost),
+                        getResponseConsumer(phaser),
+                        null
+                    );
+                    assertFalse(httpGet.isAborted());
+                    httpGet.setDependency((org.apache.hc.core5.concurrent.Cancellable) future);
+                    httpGet.abort();
+                    assertTrue(httpGet.isAborted());
+                    try {
+                        phaser.arriveAndDeregister();
+                        assertTrue(future.isCancelled());
+                        future.get();
+                        throw new AssertionError("exception should have been thrown");
+                    } catch (CancellationException e) {
+                        // expected
+                    }
+                } finally {
+                    // Forcing termination since the AsyncResponseConsumer may not be reached,
+                    // the request is aborted right before
+                    phaser.forceTermination();
                 }
             }
             {
                 httpGet.reset();
                 assertFalse(httpGet.isAborted());
-                Future<ClassicHttpResponse> future = client.execute(getRequestProducer(httpGet, httpHost), getResponseConsumer(), null);
+                final Phaser phaser = new Phaser(0);
+                Future<ClassicHttpResponse> future = client.execute(
+                    getRequestProducer(httpGet, httpHost),
+                    getResponseConsumer(phaser),
+                    null
+                );
                 assertFalse(httpGet.isAborted());
                 assertEquals(200, future.get().getCode());
                 assertFalse(future.isCancelled());
@@ -554,8 +589,15 @@ public class RestClientSingleHostIntegTests extends RestClientTestCase {
         return esResponse;
     }
 
-    private AsyncResponseConsumer<ClassicHttpResponse> getResponseConsumer() {
-        return new HeapBufferedAsyncResponseConsumer(1024);
+    private AsyncResponseConsumer<ClassicHttpResponse> getResponseConsumer(Phaser phaser) {
+        phaser.register();
+        return new HeapBufferedAsyncResponseConsumer(1024) {
+            @Override
+            protected ClassicHttpResponse buildResult(HttpResponse response, byte[] entity, ContentType contentType) {
+                phaser.arriveAndAwaitAdvance();
+                return super.buildResult(response, entity, contentType);
+            }
+        };
     }
 
     private HttpUriRequestProducer getRequestProducer(HttpUriRequestBase request, HttpHost host) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The issue was caused by race between aborting the HTTP request and completing the resulting future. Added `Phaser` to predictably control the cancellation race.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/9034
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
