### PR TITLE
[Backport 2.x] Do not evaluate shard_size and shard_min_doc_count at segment slice level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Make MultiBucketConsumerService thread safe to use across slices during search ([#9047](https://github.com/opensearch-project/OpenSearch/pull/9047))
 - Removed blocking wait in TransportGetSnapshotsAction which was exhausting generic threadpool ([#8377](https://github.com/opensearch-project/OpenSearch/pull/8377))
 - Adds support for tracing runnable scenarios ([#8831](https://github.com/opensearch-project/OpenSearch/pull/8831))
+- Change shard_size and shard_min_doc_count evaluation to happen in shard level reduce phase ([#9085](https://github.com/opensearch-project/OpenSearch/pull/9085))
 
 ### Deprecated
 

--- a/benchmarks/src/main/java/org/opensearch/benchmark/search/aggregations/TermsReduceBenchmark.java
+++ b/benchmarks/src/main/java/org/opensearch/benchmark/search/aggregations/TermsReduceBenchmark.java
@@ -57,6 +57,7 @@ import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.InternalAggregations;
 import org.opensearch.search.aggregations.MultiBucketConsumerService;
 import org.opensearch.search.aggregations.bucket.terms.StringTerms;
+import org.opensearch.search.aggregations.bucket.terms.TermsAggregator;
 import org.opensearch.search.aggregations.pipeline.PipelineAggregator;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.query.QuerySearchResult;
@@ -170,15 +171,14 @@ public class TermsReduceBenchmark {
                 "terms",
                 BucketOrder.key(true),
                 BucketOrder.count(false),
-                topNSize,
-                1,
                 Collections.emptyMap(),
                 DocValueFormat.RAW,
                 numShards,
                 true,
                 0,
                 buckets,
-                0
+                0,
+                new TermsAggregator.BucketCountThresholds(1, 0, topNSize, numShards)
             );
         }
 

--- a/benchmarks/src/main/java/org/opensearch/benchmark/search/aggregations/bucket/terms/StringTermsSerializationBenchmark.java
+++ b/benchmarks/src/main/java/org/opensearch/benchmark/search/aggregations/bucket/terms/StringTermsSerializationBenchmark.java
@@ -51,6 +51,7 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
+import org.opensearch.search.aggregations.bucket.terms.TermsAggregator;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -86,15 +87,14 @@ public class StringTermsSerializationBenchmark {
             "test",
             BucketOrder.key(true),
             BucketOrder.key(true),
-            buckets,
-            1,
             null,
             DocValueFormat.RAW,
             buckets,
             false,
             100000,
             resultBuckets,
-            0
+            0,
+            new TermsAggregator.BucketCountThresholds(1, 0, buckets, buckets)
         );
     }
 

--- a/server/src/main/java/org/opensearch/search/aggregations/AggregationCollectorManager.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/AggregationCollectorManager.java
@@ -26,7 +26,7 @@ import java.util.List;
  * aggregation operators
  */
 class AggregationCollectorManager implements CollectorManager<Collector, ReduceableSearchResult> {
-    private final SearchContext context;
+    protected final SearchContext context;
     private final CheckedFunction<SearchContext, List<Aggregator>, IOException> aggProvider;
     private final String collectorReason;
 
@@ -68,18 +68,11 @@ class AggregationCollectorManager implements CollectorManager<Collector, Reducea
             internals,
             context.request().source().aggregations()::buildPipelineTree
         );
-        // Reduce the aggregations across slices before sending to the coordinator. We will perform shard level reduce iff multiple slices
-        // were created to execute this request and it used concurrent segment search path
-        // TODO: Add the check for flag that the request was executed using concurrent search
-        if (collectors.size() > 1) {
-            // using topLevelReduce here as PipelineTreeSource needs to be sent to coordinator in older release of OpenSearch. The actual
-            // evaluation of pipeline aggregation though happens on the coordinator during final reduction phase
-            return new AggregationReduceableSearchResult(
-                InternalAggregations.topLevelReduce(Collections.singletonList(internalAggregations), context.partialOnShard())
-            );
-        } else {
-            return new AggregationReduceableSearchResult(internalAggregations);
-        }
+        return buildAggregationResult(internalAggregations);
+    }
+
+    protected AggregationReduceableSearchResult buildAggregationResult(InternalAggregations internalAggregations) {
+        return new AggregationReduceableSearchResult(internalAggregations);
     }
 
     static Collector createCollector(SearchContext context, List<Aggregator> collectors, String reason) throws IOException {

--- a/server/src/main/java/org/opensearch/search/aggregations/GlobalAggCollectorManager.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/GlobalAggCollectorManager.java
@@ -14,6 +14,7 @@ import org.opensearch.search.internal.SearchContext;
 import org.opensearch.search.profile.query.CollectorResult;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Objects;
 
 /**
@@ -37,5 +38,16 @@ public class GlobalAggCollectorManager extends AggregationCollectorManager {
         } else {
             return super.newCollector();
         }
+    }
+
+    @Override
+    protected AggregationReduceableSearchResult buildAggregationResult(InternalAggregations internalAggregations) {
+        // Reduce the aggregations across slices before sending to the coordinator. We will perform shard level reduce as long as any slices
+        // were created so that we can apply shard level bucket count thresholds in the reduce phase.
+        return new AggregationReduceableSearchResult(
+            // using topLevelReduce here as PipelineTreeSource needs to be sent to coordinator in older release of OpenSearch. The actual
+            // evaluation of pipeline aggregation though happens on the coordinator during final reduction phase
+            InternalAggregations.topLevelReduce(Collections.singletonList(internalAggregations), context.partialOnShard())
+        );
     }
 }

--- a/server/src/main/java/org/opensearch/search/aggregations/InternalAggregation.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/InternalAggregation.java
@@ -41,6 +41,8 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.rest.action.search.RestSearchAction;
 import org.opensearch.script.ScriptService;
+import org.opensearch.search.aggregations.bucket.LocalBucketCountThresholds;
+import org.opensearch.search.aggregations.bucket.terms.TermsAggregator;
 import org.opensearch.search.aggregations.pipeline.PipelineAggregator;
 import org.opensearch.search.aggregations.pipeline.PipelineAggregator.PipelineTree;
 import org.opensearch.search.aggregations.support.AggregationPath;
@@ -159,6 +161,18 @@ public abstract class InternalAggregation implements Aggregation, NamedWriteable
 
         public boolean isSliceLevel() {
             return this.isSliceLevel;
+        }
+
+        /**
+         * For slice level partial reduce we will apply shard level `shard_size` and `shard_min_doc_count` limits
+         * whereas for coordinator level partial reduce it will use top level `size` and `min_doc_count`
+         */
+        public LocalBucketCountThresholds asLocalBucketCountThresholds(TermsAggregator.BucketCountThresholds bucketCountThresholds) {
+            if (isSliceLevel()) {
+                return new LocalBucketCountThresholds(bucketCountThresholds.getShardMinDocCount(), bucketCountThresholds.getShardSize());
+            } else {
+                return new LocalBucketCountThresholds(bucketCountThresholds.getMinDocCount(), bucketCountThresholds.getRequiredSize());
+            }
         }
 
         public BigArrays bigArrays() {

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/LocalBucketCountThresholds.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/LocalBucketCountThresholds.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.aggregations.bucket;
+
+import org.opensearch.search.aggregations.bucket.terms.TermsAggregator;
+
+/**
+ * BucketCountThresholds type that holds the local (either shard level or request level) bucket count thresholds in minDocCount and requireSize fields.
+ * Similar to {@link TermsAggregator.BucketCountThresholds} however only provides getters for the local members and no setters.
+ *
+ * @opensearch.internal
+ */
+public class LocalBucketCountThresholds {
+
+    private final long minDocCount;
+    private final int requiredSize;
+
+    public LocalBucketCountThresholds(long localminDocCount, int localRequiredSize) {
+        this.minDocCount = localminDocCount;
+        this.requiredSize = localRequiredSize;
+    }
+
+    public int getRequiredSize() {
+        return requiredSize;
+    }
+
+    public long getMinDocCount() {
+        return minDocCount;
+    }
+}

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/AbstractStringTermsAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/AbstractStringTermsAggregator.java
@@ -76,15 +76,14 @@ abstract class AbstractStringTermsAggregator extends TermsAggregator {
             name,
             order,
             order,
-            bucketCountThresholds.getRequiredSize(),
-            bucketCountThresholds.getMinDocCount(),
             metadata(),
             format,
             bucketCountThresholds.getShardSize(),
             showTermDocCountError,
             0,
             emptyList(),
-            0
+            0,
+            bucketCountThresholds
         );
     }
 
@@ -95,14 +94,13 @@ abstract class AbstractStringTermsAggregator extends TermsAggregator {
         int supersetSize = topReader.numDocs();
         return new SignificantStringTerms(
             name,
-            bucketCountThresholds.getRequiredSize(),
-            bucketCountThresholds.getMinDocCount(),
             metadata(),
             format,
             subsetSize,
             supersetSize,
             significanceHeuristic,
-            emptyList()
+            emptyList(),
+            bucketCountThresholds
         );
     }
 }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/DoubleTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/DoubleTerms.java
@@ -130,29 +130,27 @@ public class DoubleTerms extends InternalMappedTerms<DoubleTerms, DoubleTerms.Bu
         String name,
         BucketOrder reduceOrder,
         BucketOrder order,
-        int requiredSize,
-        long minDocCount,
         Map<String, Object> metadata,
         DocValueFormat format,
         int shardSize,
         boolean showTermDocCountError,
         long otherDocCount,
         List<Bucket> buckets,
-        long docCountError
+        long docCountError,
+        TermsAggregator.BucketCountThresholds bucketCountThresholds
     ) {
         super(
             name,
             reduceOrder,
             order,
-            requiredSize,
-            minDocCount,
             metadata,
             format,
             shardSize,
             showTermDocCountError,
             otherDocCount,
             buckets,
-            docCountError
+            docCountError,
+            bucketCountThresholds
         );
     }
 
@@ -174,15 +172,14 @@ public class DoubleTerms extends InternalMappedTerms<DoubleTerms, DoubleTerms.Bu
             name,
             reduceOrder,
             order,
-            requiredSize,
-            minDocCount,
             metadata,
             format,
             shardSize,
             showTermDocCountError,
             otherDocCount,
             buckets,
-            docCountError
+            docCountError,
+            bucketCountThresholds
         );
     }
 
@@ -204,15 +201,14 @@ public class DoubleTerms extends InternalMappedTerms<DoubleTerms, DoubleTerms.Bu
             name,
             reduceOrder,
             order,
-            requiredSize,
-            minDocCount,
             getMetadata(),
             format,
             shardSize,
             showTermDocCountError,
             otherDocCount,
             buckets,
-            docCountError
+            docCountError,
+            bucketCountThresholds
         );
     }
 

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/InternalMappedSignificantTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/InternalMappedSignificantTerms.java
@@ -64,16 +64,15 @@ public abstract class InternalMappedSignificantTerms<
 
     protected InternalMappedSignificantTerms(
         String name,
-        int requiredSize,
-        long minDocCount,
         Map<String, Object> metadata,
         DocValueFormat format,
         long subsetSize,
         long supersetSize,
         SignificanceHeuristic significanceHeuristic,
-        List<B> buckets
+        List<B> buckets,
+        TermsAggregator.BucketCountThresholds bucketCountThresholds
     ) {
-        super(name, requiredSize, minDocCount, metadata);
+        super(name, bucketCountThresholds, metadata);
         this.format = format;
         this.buckets = buckets;
         this.subsetSize = subsetSize;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/InternalMappedTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/InternalMappedTerms.java
@@ -64,17 +64,16 @@ public abstract class InternalMappedTerms<A extends InternalTerms<A, B>, B exten
         String name,
         BucketOrder reduceOrder,
         BucketOrder order,
-        int requiredSize,
-        long minDocCount,
         Map<String, Object> metadata,
         DocValueFormat format,
         int shardSize,
         boolean showTermDocCountError,
         long otherDocCount,
         List<B> buckets,
-        long docCountError
+        long docCountError,
+        TermsAggregator.BucketCountThresholds bucketCountThresholds
     ) {
-        super(name, reduceOrder, order, requiredSize, minDocCount, metadata);
+        super(name, reduceOrder, order, bucketCountThresholds, metadata);
         this.format = format;
         this.shardSize = shardSize;
         this.showTermDocCountError = showTermDocCountError;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/InternalMultiTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/InternalMultiTerms.java
@@ -233,17 +233,16 @@ public class InternalMultiTerms extends InternalTerms<InternalMultiTerms, Intern
         String name,
         BucketOrder reduceOrder,
         BucketOrder order,
-        int requiredSize,
-        long minDocCount,
         Map<String, Object> metadata,
         int shardSize,
         boolean showTermDocCountError,
         long otherDocCount,
         long docCountError,
         List<DocValueFormat> formats,
-        List<Bucket> buckets
+        List<Bucket> buckets,
+        TermsAggregator.BucketCountThresholds bucketCountThresholds
     ) {
-        super(name, reduceOrder, order, requiredSize, minDocCount, metadata);
+        super(name, reduceOrder, order, bucketCountThresholds, metadata);
         this.shardSize = shardSize;
         this.showTermDocCountError = showTermDocCountError;
         this.otherDocCount = otherDocCount;
@@ -278,15 +277,14 @@ public class InternalMultiTerms extends InternalTerms<InternalMultiTerms, Intern
             name,
             reduceOrder,
             order,
-            requiredSize,
-            minDocCount,
             metadata,
             shardSize,
             showTermDocCountError,
             otherDocCount,
             docCountError,
             termFormats,
-            buckets
+            buckets,
+            bucketCountThresholds
         );
     }
 
@@ -357,15 +355,14 @@ public class InternalMultiTerms extends InternalTerms<InternalMultiTerms, Intern
             name,
             reduceOrder,
             order,
-            requiredSize,
-            minDocCount,
             metadata,
             shardSize,
             showTermDocCountError,
             otherDocCount,
             docCountError,
             termFormats,
-            buckets
+            buckets,
+            bucketCountThresholds
         );
     }
 

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/InternalTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/InternalTerms.java
@@ -47,6 +47,7 @@ import org.opensearch.search.aggregations.InternalMultiBucketAggregation;
 import org.opensearch.search.aggregations.InternalOrder;
 import org.opensearch.search.aggregations.KeyComparable;
 import org.opensearch.search.aggregations.bucket.IteratorAndCurrent;
+import org.opensearch.search.aggregations.bucket.LocalBucketCountThresholds;
 import org.opensearch.search.aggregations.bucket.MultiBucketsAggregation;
 
 import java.io.IOException;
@@ -224,29 +225,29 @@ public abstract class InternalTerms<A extends InternalTerms<A, B>, B extends Int
     protected final BucketOrder order;
     protected final int requiredSize;
     protected final long minDocCount;
+    protected final TermsAggregator.BucketCountThresholds bucketCountThresholds;
 
     /**
      * Creates a new {@link InternalTerms}
      * @param name The name of the aggregation
      * @param reduceOrder The {@link BucketOrder} that should be used to merge shard results.
      * @param order The {@link BucketOrder} that should be used to sort the final reduce.
-     * @param requiredSize The number of top buckets.
-     * @param minDocCount The minimum number of documents allowed per bucket.
+     * @param bucketCountThresholds Object containing values for minDocCount, shardMinDocCount, size, shardSize.
      * @param metadata The metadata associated with the aggregation.
      */
     protected InternalTerms(
         String name,
         BucketOrder reduceOrder,
         BucketOrder order,
-        int requiredSize,
-        long minDocCount,
+        TermsAggregator.BucketCountThresholds bucketCountThresholds,
         Map<String, Object> metadata
     ) {
         super(name, metadata);
         this.reduceOrder = reduceOrder;
         this.order = order;
-        this.requiredSize = requiredSize;
-        this.minDocCount = minDocCount;
+        this.bucketCountThresholds = bucketCountThresholds;
+        this.requiredSize = bucketCountThresholds.getRequiredSize();
+        this.minDocCount = bucketCountThresholds.getMinDocCount();
     }
 
     /**
@@ -262,6 +263,9 @@ public abstract class InternalTerms<A extends InternalTerms<A, B>, B extends Int
         }
         requiredSize = readSize(in);
         minDocCount = in.readVLong();
+        // shardMinDocCount and shardSize are not used on the coordinator, so they are not deserialized. We use
+        // CoordinatorBucketCountThresholds which will throw an exception if they are accessed.
+        bucketCountThresholds = new TermsAggregator.CoordinatorBucketCountThresholds(minDocCount, -1, requiredSize, getShardSize());
     }
 
     @Override
@@ -392,6 +396,7 @@ public abstract class InternalTerms<A extends InternalTerms<A, B>, B extends Int
     }
 
     public InternalAggregation reduce(List<InternalAggregation> aggregations, ReduceContext reduceContext) {
+        LocalBucketCountThresholds localBucketCountThresholds = reduceContext.asLocalBucketCountThresholds(bucketCountThresholds);
         long sumDocCountError = 0;
         long otherDocCount = 0;
         InternalTerms<A, B> referenceTerms = null;
@@ -451,8 +456,8 @@ public abstract class InternalTerms<A extends InternalTerms<A, B>, B extends Int
             reducedBuckets = reduceLegacy(aggregations, reduceContext);
         }
         final B[] list;
-        if (reduceContext.isFinalReduce()) {
-            final int size = Math.min(requiredSize, reducedBuckets.size());
+        if (reduceContext.isFinalReduce() || reduceContext.isSliceLevel()) {
+            final int size = Math.min(localBucketCountThresholds.getRequiredSize(), reducedBuckets.size());
             // final comparator
             final BucketPriorityQueue<B> ordered = new BucketPriorityQueue<>(size, order.comparator());
             for (B bucket : reducedBuckets) {
@@ -462,7 +467,7 @@ public abstract class InternalTerms<A extends InternalTerms<A, B>, B extends Int
                     final long finalSumDocCountError = sumDocCountError;
                     bucket.setDocCountError(docCountError -> docCountError + finalSumDocCountError);
                 }
-                if (bucket.getDocCount() >= minDocCount) {
+                if (bucket.getDocCount() >= localBucketCountThresholds.getMinDocCount()) {
                     B removed = ordered.insertWithOverflow(bucket);
                     if (removed != null) {
                         otherDocCount += removed.getDocCount();
@@ -481,7 +486,9 @@ public abstract class InternalTerms<A extends InternalTerms<A, B>, B extends Int
         } else {
             // we can prune the list on partial reduce if the aggregation is ordered by key
             // and not filtered (minDocCount == 0)
-            int size = isKeyOrder(order) && minDocCount == 0 ? Math.min(requiredSize, reducedBuckets.size()) : reducedBuckets.size();
+            int size = isKeyOrder(order) && localBucketCountThresholds.getMinDocCount() == 0
+                ? Math.min(localBucketCountThresholds.getRequiredSize(), reducedBuckets.size())
+                : reducedBuckets.size();
             list = createBucketsArray(size);
             for (int i = 0; i < size; i++) {
                 reduceContext.consumeBucketsAndMaybeBreak(1);
@@ -499,6 +506,11 @@ public abstract class InternalTerms<A extends InternalTerms<A, B>, B extends Int
             docCountError = -1;
         } else {
             docCountError = aggregations.size() == 1 ? 0 : sumDocCountError;
+        }
+
+        // Shards must return buckets sorted by key, so we apply the sort here in shard level reduce
+        if (reduceContext.isSliceLevel()) {
+            Arrays.sort(list, thisReduceOrder.comparator());
         }
         return create(name, Arrays.asList(list), reduceContext.isFinalReduce() ? order : thisReduceOrder, docCountError, otherDocCount);
     }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/LongTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/LongTerms.java
@@ -142,29 +142,27 @@ public class LongTerms extends InternalMappedTerms<LongTerms, LongTerms.Bucket> 
         String name,
         BucketOrder reduceOrder,
         BucketOrder order,
-        int requiredSize,
-        long minDocCount,
         Map<String, Object> metadata,
         DocValueFormat format,
         int shardSize,
         boolean showTermDocCountError,
         long otherDocCount,
         List<Bucket> buckets,
-        long docCountError
+        long docCountError,
+        TermsAggregator.BucketCountThresholds bucketCountThresholds
     ) {
         super(
             name,
             reduceOrder,
             order,
-            requiredSize,
-            minDocCount,
             metadata,
             format,
             shardSize,
             showTermDocCountError,
             otherDocCount,
             buckets,
-            docCountError
+            docCountError,
+            bucketCountThresholds
         );
     }
 
@@ -186,15 +184,14 @@ public class LongTerms extends InternalMappedTerms<LongTerms, LongTerms.Bucket> 
             name,
             reduceOrder,
             order,
-            requiredSize,
-            minDocCount,
             metadata,
             format,
             shardSize,
             showTermDocCountError,
             otherDocCount,
             buckets,
-            docCountError
+            docCountError,
+            bucketCountThresholds
         );
     }
 
@@ -216,15 +213,14 @@ public class LongTerms extends InternalMappedTerms<LongTerms, LongTerms.Bucket> 
             name,
             reduceOrder,
             order,
-            requiredSize,
-            minDocCount,
             getMetadata(),
             format,
             shardSize,
             showTermDocCountError,
             otherDocCount,
             buckets,
-            docCountError
+            docCountError,
+            bucketCountThresholds
         );
     }
 
@@ -293,15 +289,14 @@ public class LongTerms extends InternalMappedTerms<LongTerms, LongTerms.Bucket> 
             longTerms.getName(),
             longTerms.reduceOrder,
             longTerms.order,
-            longTerms.requiredSize,
-            longTerms.minDocCount,
             longTerms.metadata,
             longTerms.format,
             longTerms.shardSize,
             longTerms.showTermDocCountError,
             longTerms.otherDocCount,
             newBuckets,
-            longTerms.docCountError
+            longTerms.docCountError,
+            longTerms.bucketCountThresholds
         );
     }
 }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MapStringTermsAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MapStringTermsAggregator.java
@@ -50,6 +50,7 @@ import org.opensearch.search.aggregations.InternalMultiBucketAggregation;
 import org.opensearch.search.aggregations.InternalOrder;
 import org.opensearch.search.aggregations.LeafBucketCollector;
 import org.opensearch.search.aggregations.LeafBucketCollectorBase;
+import org.opensearch.search.aggregations.bucket.LocalBucketCountThresholds;
 import org.opensearch.search.aggregations.bucket.terms.SignificanceLookup.BackgroundFrequencyForBytes;
 import org.opensearch.search.aggregations.bucket.terms.heuristic.SignificanceHeuristic;
 import org.opensearch.search.aggregations.support.ValuesSource;
@@ -244,11 +245,12 @@ public class MapStringTermsAggregator extends AbstractStringTermsAggregator {
             Releasable {
 
         private InternalAggregation[] buildAggregations(long[] owningBucketOrds) throws IOException {
+            LocalBucketCountThresholds localBucketCountThresholds = context.asLocalBucketCountThresholds(bucketCountThresholds);
             B[][] topBucketsPerOrd = buildTopBucketsPerOrd(owningBucketOrds.length);
             long[] otherDocCounts = new long[owningBucketOrds.length];
             for (int ordIdx = 0; ordIdx < owningBucketOrds.length; ordIdx++) {
                 collectZeroDocEntriesIfNeeded(owningBucketOrds[ordIdx]);
-                int size = (int) Math.min(bucketOrds.size(), bucketCountThresholds.getShardSize());
+                int size = (int) Math.min(bucketOrds.size(), localBucketCountThresholds.getRequiredSize());
 
                 PriorityQueue<B> ordered = buildPriorityQueue(size);
                 B spare = null;
@@ -257,7 +259,7 @@ public class MapStringTermsAggregator extends AbstractStringTermsAggregator {
                 while (ordsEnum.next()) {
                     long docCount = bucketDocCount(ordsEnum.ord());
                     otherDocCounts[ordIdx] += docCount;
-                    if (docCount < bucketCountThresholds.getShardMinDocCount()) {
+                    if (docCount < localBucketCountThresholds.getMinDocCount()) {
                         continue;
                     }
                     if (spare == null) {
@@ -454,15 +456,14 @@ public class MapStringTermsAggregator extends AbstractStringTermsAggregator {
                 name,
                 reduceOrder,
                 order,
-                bucketCountThresholds.getRequiredSize(),
-                bucketCountThresholds.getMinDocCount(),
                 metadata(),
                 format,
                 bucketCountThresholds.getShardSize(),
                 showTermDocCountError,
                 otherDocCount,
                 Arrays.asList(topBuckets),
-                0
+                0,
+                bucketCountThresholds
             );
         }
 
@@ -572,14 +573,13 @@ public class MapStringTermsAggregator extends AbstractStringTermsAggregator {
         SignificantStringTerms buildResult(long owningBucketOrd, long otherDocCount, SignificantStringTerms.Bucket[] topBuckets) {
             return new SignificantStringTerms(
                 name,
-                bucketCountThresholds.getRequiredSize(),
-                bucketCountThresholds.getMinDocCount(),
                 metadata(),
                 format,
                 subsetSizes.get(owningBucketOrd),
                 supersetSize,
                 significanceHeuristic,
-                Arrays.asList(topBuckets)
+                Arrays.asList(topBuckets),
+                bucketCountThresholds
             );
         }
 

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregator.java
@@ -33,6 +33,7 @@ import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.InternalOrder;
 import org.opensearch.search.aggregations.LeafBucketCollector;
 import org.opensearch.search.aggregations.bucket.DeferableBucketAggregator;
+import org.opensearch.search.aggregations.bucket.LocalBucketCountThresholds;
 import org.opensearch.search.aggregations.support.AggregationPath;
 import org.opensearch.search.aggregations.support.ValuesSource;
 import org.opensearch.search.internal.SearchContext;
@@ -118,13 +119,14 @@ public class MultiTermsAggregator extends DeferableBucketAggregator {
 
     @Override
     public InternalAggregation[] buildAggregations(long[] owningBucketOrds) throws IOException {
+        LocalBucketCountThresholds localBucketCountThresholds = context.asLocalBucketCountThresholds(bucketCountThresholds);
         InternalMultiTerms.Bucket[][] topBucketsPerOrd = new InternalMultiTerms.Bucket[owningBucketOrds.length][];
         long[] otherDocCounts = new long[owningBucketOrds.length];
         for (int ordIdx = 0; ordIdx < owningBucketOrds.length; ordIdx++) {
             collectZeroDocEntriesIfNeeded(owningBucketOrds[ordIdx]);
             long bucketsInOrd = bucketOrds.bucketsInOrd(owningBucketOrds[ordIdx]);
 
-            int size = (int) Math.min(bucketsInOrd, bucketCountThresholds.getShardSize());
+            int size = (int) Math.min(bucketsInOrd, localBucketCountThresholds.getRequiredSize());
             PriorityQueue<InternalMultiTerms.Bucket> ordered = new BucketPriorityQueue<>(size, partiallyBuiltBucketComparator);
             InternalMultiTerms.Bucket spare = null;
             BytesRef dest = null;
@@ -136,7 +138,7 @@ public class MultiTermsAggregator extends DeferableBucketAggregator {
             while (ordsEnum.next()) {
                 long docCount = bucketDocCount(ordsEnum.ord());
                 otherDocCounts[ordIdx] += docCount;
-                if (docCount < bucketCountThresholds.getShardMinDocCount()) {
+                if (docCount < localBucketCountThresholds.getMinDocCount()) {
                     continue;
                 }
                 if (spare == null) {
@@ -182,15 +184,14 @@ public class MultiTermsAggregator extends DeferableBucketAggregator {
             name,
             reduceOrder,
             order,
-            bucketCountThresholds.getRequiredSize(),
-            bucketCountThresholds.getMinDocCount(),
             metadata(),
             bucketCountThresholds.getShardSize(),
             showTermDocCountError,
             otherDocCount,
             0,
             formats,
-            List.of(topBuckets)
+            List.of(topBuckets),
+            bucketCountThresholds
         );
     }
 
@@ -200,15 +201,14 @@ public class MultiTermsAggregator extends DeferableBucketAggregator {
             name,
             order,
             order,
-            bucketCountThresholds.getRequiredSize(),
-            bucketCountThresholds.getMinDocCount(),
             metadata(),
             bucketCountThresholds.getShardSize(),
             showTermDocCountError,
             0,
             0,
             formats,
-            Collections.emptyList()
+            Collections.emptyList(),
+            bucketCountThresholds
         );
     }
 

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/NumericTermsAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/NumericTermsAggregator.java
@@ -52,6 +52,7 @@ import org.opensearch.search.aggregations.InternalMultiBucketAggregation;
 import org.opensearch.search.aggregations.InternalOrder;
 import org.opensearch.search.aggregations.LeafBucketCollector;
 import org.opensearch.search.aggregations.LeafBucketCollectorBase;
+import org.opensearch.search.aggregations.bucket.LocalBucketCountThresholds;
 import org.opensearch.search.aggregations.bucket.terms.IncludeExclude.LongFilter;
 import org.opensearch.search.aggregations.bucket.terms.LongKeyedBucketOrds.BucketOrdsEnum;
 import org.opensearch.search.aggregations.bucket.terms.SignificanceLookup.BackgroundFrequencyForLong;
@@ -173,13 +174,14 @@ public class NumericTermsAggregator extends TermsAggregator {
         implements
             Releasable {
         private InternalAggregation[] buildAggregations(long[] owningBucketOrds) throws IOException {
+            LocalBucketCountThresholds localBucketCountThresholds = context.asLocalBucketCountThresholds(bucketCountThresholds);
             B[][] topBucketsPerOrd = buildTopBucketsPerOrd(owningBucketOrds.length);
             long[] otherDocCounts = new long[owningBucketOrds.length];
             for (int ordIdx = 0; ordIdx < owningBucketOrds.length; ordIdx++) {
                 collectZeroDocEntriesIfNeeded(owningBucketOrds[ordIdx]);
                 long bucketsInOrd = bucketOrds.bucketsInOrd(owningBucketOrds[ordIdx]);
 
-                int size = (int) Math.min(bucketsInOrd, bucketCountThresholds.getShardSize());
+                int size = (int) Math.min(bucketsInOrd, localBucketCountThresholds.getRequiredSize());
                 PriorityQueue<B> ordered = buildPriorityQueue(size);
                 B spare = null;
                 BucketOrdsEnum ordsEnum = bucketOrds.ordsEnum(owningBucketOrds[ordIdx]);
@@ -187,7 +189,7 @@ public class NumericTermsAggregator extends TermsAggregator {
                 while (ordsEnum.next()) {
                     long docCount = bucketDocCount(ordsEnum.ord());
                     otherDocCounts[ordIdx] += docCount;
-                    if (docCount < bucketCountThresholds.getShardMinDocCount()) {
+                    if (docCount < localBucketCountThresholds.getMinDocCount()) {
                         continue;
                     }
                     if (spare == null) {
@@ -395,15 +397,14 @@ public class NumericTermsAggregator extends TermsAggregator {
                 name,
                 reduceOrder,
                 order,
-                bucketCountThresholds.getRequiredSize(),
-                bucketCountThresholds.getMinDocCount(),
                 metadata(),
                 format,
                 bucketCountThresholds.getShardSize(),
                 showTermDocCountError,
                 otherDocCount,
                 List.of(topBuckets),
-                0
+                0,
+                bucketCountThresholds
             );
         }
 
@@ -413,15 +414,14 @@ public class NumericTermsAggregator extends TermsAggregator {
                 name,
                 order,
                 order,
-                bucketCountThresholds.getRequiredSize(),
-                bucketCountThresholds.getMinDocCount(),
                 metadata(),
                 format,
                 bucketCountThresholds.getShardSize(),
                 showTermDocCountError,
                 0,
                 emptyList(),
-                0
+                0,
+                bucketCountThresholds
             );
         }
     }
@@ -477,15 +477,14 @@ public class NumericTermsAggregator extends TermsAggregator {
                 name,
                 reduceOrder,
                 order,
-                bucketCountThresholds.getRequiredSize(),
-                bucketCountThresholds.getMinDocCount(),
                 metadata(),
                 format,
                 bucketCountThresholds.getShardSize(),
                 showTermDocCountError,
                 otherDocCount,
                 List.of(topBuckets),
-                0
+                0,
+                bucketCountThresholds
             );
         }
 
@@ -495,15 +494,14 @@ public class NumericTermsAggregator extends TermsAggregator {
                 name,
                 order,
                 order,
-                bucketCountThresholds.getRequiredSize(),
-                bucketCountThresholds.getMinDocCount(),
                 metadata(),
                 format,
                 bucketCountThresholds.getShardSize(),
                 showTermDocCountError,
                 0,
                 emptyList(),
-                0
+                0,
+                bucketCountThresholds
             );
         }
     }
@@ -558,15 +556,14 @@ public class NumericTermsAggregator extends TermsAggregator {
                 name,
                 reduceOrder,
                 order,
-                bucketCountThresholds.getRequiredSize(),
-                bucketCountThresholds.getMinDocCount(),
                 metadata(),
                 format,
                 bucketCountThresholds.getShardSize(),
                 showTermDocCountError,
                 otherDocCount,
                 List.of(topBuckets),
-                0
+                0,
+                bucketCountThresholds
             );
         }
 
@@ -576,15 +573,14 @@ public class NumericTermsAggregator extends TermsAggregator {
                 name,
                 order,
                 order,
-                bucketCountThresholds.getRequiredSize(),
-                bucketCountThresholds.getMinDocCount(),
                 metadata(),
                 format,
                 bucketCountThresholds.getShardSize(),
                 showTermDocCountError,
                 0,
                 emptyList(),
-                0
+                0,
+                bucketCountThresholds
             );
         }
     }
@@ -670,17 +666,17 @@ public class NumericTermsAggregator extends TermsAggregator {
 
         @Override
         SignificantLongTerms buildResult(long owningBucketOrd, long otherDocCoun, SignificantLongTerms.Bucket[] topBuckets) {
-            return new SignificantLongTerms(
+            SignificantLongTerms significantLongTerms = new SignificantLongTerms(
                 name,
-                bucketCountThresholds.getRequiredSize(),
-                bucketCountThresholds.getMinDocCount(),
                 metadata(),
                 format,
                 subsetSizes.get(owningBucketOrd),
                 supersetSize,
                 significanceHeuristic,
-                List.of(topBuckets)
+                List.of(topBuckets),
+                bucketCountThresholds
             );
+            return significantLongTerms;
         }
 
         @Override
@@ -691,14 +687,13 @@ public class NumericTermsAggregator extends TermsAggregator {
             int supersetSize = topReader.numDocs();
             return new SignificantLongTerms(
                 name,
-                bucketCountThresholds.getRequiredSize(),
-                bucketCountThresholds.getMinDocCount(),
                 metadata(),
                 format,
                 0,
                 supersetSize,
                 significanceHeuristic,
-                emptyList()
+                emptyList(),
+                bucketCountThresholds
             );
         }
 

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/SignificantLongTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/SignificantLongTerms.java
@@ -130,16 +130,15 @@ public class SignificantLongTerms extends InternalMappedSignificantTerms<Signifi
 
     public SignificantLongTerms(
         String name,
-        int requiredSize,
-        long minDocCount,
         Map<String, Object> metadata,
         DocValueFormat format,
         long subsetSize,
         long supersetSize,
         SignificanceHeuristic significanceHeuristic,
-        List<Bucket> buckets
+        List<Bucket> buckets,
+        TermsAggregator.BucketCountThresholds bucketCountThresholds
     ) {
-        super(name, requiredSize, minDocCount, metadata, format, subsetSize, supersetSize, significanceHeuristic, buckets);
+        super(name, metadata, format, subsetSize, supersetSize, significanceHeuristic, buckets, bucketCountThresholds);
     }
 
     /**
@@ -158,14 +157,13 @@ public class SignificantLongTerms extends InternalMappedSignificantTerms<Signifi
     public SignificantLongTerms create(List<SignificantLongTerms.Bucket> buckets) {
         return new SignificantLongTerms(
             name,
-            requiredSize,
-            minDocCount,
             metadata,
             format,
             subsetSize,
             supersetSize,
             significanceHeuristic,
-            buckets
+            buckets,
+            bucketCountThresholds
         );
     }
 
@@ -187,14 +185,13 @@ public class SignificantLongTerms extends InternalMappedSignificantTerms<Signifi
     protected SignificantLongTerms create(long subsetSize, long supersetSize, List<Bucket> buckets) {
         return new SignificantLongTerms(
             getName(),
-            requiredSize,
-            minDocCount,
             getMetadata(),
             format,
             subsetSize,
             supersetSize,
             significanceHeuristic,
-            buckets
+            buckets,
+            bucketCountThresholds
         );
     }
 

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/SignificantStringTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/SignificantStringTerms.java
@@ -135,16 +135,15 @@ public class SignificantStringTerms extends InternalMappedSignificantTerms<Signi
 
     public SignificantStringTerms(
         String name,
-        int requiredSize,
-        long minDocCount,
         Map<String, Object> metadata,
         DocValueFormat format,
         long subsetSize,
         long supersetSize,
         SignificanceHeuristic significanceHeuristic,
-        List<Bucket> buckets
+        List<Bucket> buckets,
+        TermsAggregator.BucketCountThresholds bucketCountThresholds
     ) {
-        super(name, requiredSize, minDocCount, metadata, format, subsetSize, supersetSize, significanceHeuristic, buckets);
+        super(name, metadata, format, subsetSize, supersetSize, significanceHeuristic, buckets, bucketCountThresholds);
     }
 
     /**
@@ -163,14 +162,13 @@ public class SignificantStringTerms extends InternalMappedSignificantTerms<Signi
     public SignificantStringTerms create(List<SignificantStringTerms.Bucket> buckets) {
         return new SignificantStringTerms(
             name,
-            requiredSize,
-            minDocCount,
             metadata,
             format,
             subsetSize,
             supersetSize,
             significanceHeuristic,
-            buckets
+            buckets,
+            bucketCountThresholds
         );
     }
 
@@ -192,14 +190,13 @@ public class SignificantStringTerms extends InternalMappedSignificantTerms<Signi
     protected SignificantStringTerms create(long subsetSize, long supersetSize, List<Bucket> buckets) {
         return new SignificantStringTerms(
             getName(),
-            requiredSize,
-            minDocCount,
             getMetadata(),
             format,
             subsetSize,
             supersetSize,
             significanceHeuristic,
-            buckets
+            buckets,
+            bucketCountThresholds
         );
     }
 

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/SignificantTermsAggregatorFactory.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/SignificantTermsAggregatorFactory.java
@@ -246,12 +246,7 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
 
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext, Aggregator parent, Map<String, Object> metadata) throws IOException {
-        final InternalAggregation aggregation = new UnmappedSignificantTerms(
-            name,
-            bucketCountThresholds.getRequiredSize(),
-            bucketCountThresholds.getMinDocCount(),
-            metadata
-        );
+        final InternalAggregation aggregation = new UnmappedSignificantTerms(name, bucketCountThresholds, metadata);
         return new NonCollectingAggregator(name, searchContext, parent, factories, metadata) {
             @Override
             public InternalAggregation buildEmptyAggregation() {

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/StringTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/StringTerms.java
@@ -134,29 +134,27 @@ public class StringTerms extends InternalMappedTerms<StringTerms, StringTerms.Bu
         String name,
         BucketOrder reduceOrder,
         BucketOrder order,
-        int requiredSize,
-        long minDocCount,
         Map<String, Object> metadata,
         DocValueFormat format,
         int shardSize,
         boolean showTermDocCountError,
         long otherDocCount,
         List<Bucket> buckets,
-        long docCountError
+        long docCountError,
+        TermsAggregator.BucketCountThresholds bucketCountThresholds
     ) {
         super(
             name,
             reduceOrder,
             order,
-            requiredSize,
-            minDocCount,
             metadata,
             format,
             shardSize,
             showTermDocCountError,
             otherDocCount,
             buckets,
-            docCountError
+            docCountError,
+            bucketCountThresholds
         );
     }
 
@@ -178,15 +176,14 @@ public class StringTerms extends InternalMappedTerms<StringTerms, StringTerms.Bu
             name,
             reduceOrder,
             order,
-            requiredSize,
-            minDocCount,
             metadata,
             format,
             shardSize,
             showTermDocCountError,
             otherDocCount,
             buckets,
-            docCountError
+            docCountError,
+            bucketCountThresholds
         );
     }
 
@@ -213,15 +210,14 @@ public class StringTerms extends InternalMappedTerms<StringTerms, StringTerms.Bu
             name,
             reduceOrder,
             order,
-            requiredSize,
-            minDocCount,
             getMetadata(),
             format,
             shardSize,
             showTermDocCountError,
             otherDocCount,
             buckets,
-            docCountError
+            docCountError,
+            bucketCountThresholds
         );
     }
 

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
@@ -265,13 +265,7 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
 
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext, Aggregator parent, Map<String, Object> metadata) throws IOException {
-        final InternalAggregation aggregation = new UnmappedTerms(
-            name,
-            order,
-            bucketCountThresholds.getRequiredSize(),
-            bucketCountThresholds.getMinDocCount(),
-            metadata
-        );
+        final InternalAggregation aggregation = new UnmappedTerms(name, order, bucketCountThresholds, metadata);
         Aggregator agg = new NonCollectingAggregator(name, searchContext, parent, factories, metadata) {
             @Override
             public InternalAggregation buildEmptyAggregation() {

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/UnmappedSignificantTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/UnmappedSignificantTerms.java
@@ -77,8 +77,12 @@ public class UnmappedSignificantTerms extends InternalSignificantTerms<UnmappedS
         }
     }
 
-    public UnmappedSignificantTerms(String name, int requiredSize, long minDocCount, Map<String, Object> metadata) {
-        super(name, requiredSize, minDocCount, metadata);
+    public UnmappedSignificantTerms(
+        String name,
+        TermsAggregator.BucketCountThresholds bucketCountThresholds,
+        Map<String, Object> metadata
+    ) {
+        super(name, bucketCountThresholds, metadata);
     }
 
     /**
@@ -105,7 +109,7 @@ public class UnmappedSignificantTerms extends InternalSignificantTerms<UnmappedS
 
     @Override
     public UnmappedSignificantTerms create(List<Bucket> buckets) {
-        return new UnmappedSignificantTerms(name, requiredSize, minDocCount, metadata);
+        return new UnmappedSignificantTerms(name, bucketCountThresholds, metadata);
     }
 
     @Override
@@ -132,7 +136,7 @@ public class UnmappedSignificantTerms extends InternalSignificantTerms<UnmappedS
 
     @Override
     public InternalAggregation reduce(List<InternalAggregation> aggregations, ReduceContext reduceContext) {
-        return new UnmappedSignificantTerms(name, requiredSize, minDocCount, metadata);
+        return new UnmappedSignificantTerms(name, bucketCountThresholds, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/UnmappedTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/UnmappedTerms.java
@@ -72,8 +72,13 @@ public class UnmappedTerms extends InternalTerms<UnmappedTerms, UnmappedTerms.Bu
         }
     }
 
-    public UnmappedTerms(String name, BucketOrder order, int requiredSize, long minDocCount, Map<String, Object> metadata) {
-        super(name, order, order, requiredSize, minDocCount, metadata);
+    public UnmappedTerms(
+        String name,
+        BucketOrder order,
+        TermsAggregator.BucketCountThresholds bucketCountThresholds,
+        Map<String, Object> metadata
+    ) {
+        super(name, order, order, bucketCountThresholds, metadata);
     }
 
     /**
@@ -100,7 +105,7 @@ public class UnmappedTerms extends InternalTerms<UnmappedTerms, UnmappedTerms.Bu
 
     @Override
     public UnmappedTerms create(List<Bucket> buckets) {
-        return new UnmappedTerms(name, order, requiredSize, minDocCount, metadata);
+        return new UnmappedTerms(name, order, bucketCountThresholds, metadata);
     }
 
     @Override
@@ -120,7 +125,7 @@ public class UnmappedTerms extends InternalTerms<UnmappedTerms, UnmappedTerms.Bu
 
     @Override
     public InternalAggregation reduce(List<InternalAggregation> aggregations, ReduceContext reduceContext) {
-        return new UnmappedTerms(name, order, requiredSize, minDocCount, metadata);
+        return new UnmappedTerms(name, order, bucketCountThresholds, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/UnsignedLongTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/UnsignedLongTerms.java
@@ -121,29 +121,27 @@ public class UnsignedLongTerms extends InternalMappedTerms<UnsignedLongTerms, Un
         String name,
         BucketOrder reduceOrder,
         BucketOrder order,
-        int requiredSize,
-        long minDocCount,
         Map<String, Object> metadata,
         DocValueFormat format,
         int shardSize,
         boolean showTermDocCountError,
         long otherDocCount,
         List<Bucket> buckets,
-        long docCountError
+        long docCountError,
+        TermsAggregator.BucketCountThresholds bucketCountThresholds
     ) {
         super(
             name,
             reduceOrder,
             order,
-            requiredSize,
-            minDocCount,
             metadata,
             format,
             shardSize,
             showTermDocCountError,
             otherDocCount,
             buckets,
-            docCountError
+            docCountError,
+            bucketCountThresholds
         );
     }
 
@@ -165,15 +163,14 @@ public class UnsignedLongTerms extends InternalMappedTerms<UnsignedLongTerms, Un
             name,
             reduceOrder,
             order,
-            requiredSize,
-            minDocCount,
             metadata,
             format,
             shardSize,
             showTermDocCountError,
             otherDocCount,
             buckets,
-            docCountError
+            docCountError,
+            bucketCountThresholds
         );
     }
 
@@ -195,15 +192,14 @@ public class UnsignedLongTerms extends InternalMappedTerms<UnsignedLongTerms, Un
             name,
             reduceOrder,
             order,
-            requiredSize,
-            minDocCount,
             getMetadata(),
             format,
             shardSize,
             showTermDocCountError,
             otherDocCount,
             buckets,
-            docCountError
+            docCountError,
+            bucketCountThresholds
         );
     }
 
@@ -272,15 +268,14 @@ public class UnsignedLongTerms extends InternalMappedTerms<UnsignedLongTerms, Un
             unsignedLongTerms.getName(),
             unsignedLongTerms.reduceOrder,
             unsignedLongTerms.order,
-            unsignedLongTerms.requiredSize,
-            unsignedLongTerms.minDocCount,
             unsignedLongTerms.metadata,
             unsignedLongTerms.format,
             unsignedLongTerms.shardSize,
             unsignedLongTerms.showTermDocCountError,
             unsignedLongTerms.otherDocCount,
             newBuckets,
-            unsignedLongTerms.docCountError
+            unsignedLongTerms.docCountError,
+            unsignedLongTerms.bucketCountThresholds
         );
     }
 }

--- a/server/src/main/java/org/opensearch/search/internal/SearchContext.java
+++ b/server/src/main/java/org/opensearch/search/internal/SearchContext.java
@@ -35,6 +35,7 @@ import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.util.ArrayUtil;
 import org.opensearch.action.search.SearchShardTask;
 import org.opensearch.action.search.SearchType;
 import org.opensearch.common.Nullable;
@@ -57,6 +58,8 @@ import org.opensearch.search.aggregations.Aggregator;
 import org.opensearch.search.aggregations.BucketCollectorProcessor;
 import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.SearchContextAggregations;
+import org.opensearch.search.aggregations.bucket.LocalBucketCountThresholds;
+import org.opensearch.search.aggregations.bucket.terms.TermsAggregator;
 import org.opensearch.search.collapse.CollapseContext;
 import org.opensearch.search.dfs.DfsSearchResult;
 import org.opensearch.search.fetch.FetchPhase;
@@ -398,6 +401,17 @@ public abstract class SearchContext implements Releasable {
      */
     public boolean isConcurrentSegmentSearchEnabled() {
         return false;
+    }
+
+    /**
+     * Returns local bucket count thresholds based on concurrent segment search status
+     */
+    public LocalBucketCountThresholds asLocalBucketCountThresholds(TermsAggregator.BucketCountThresholds bucketCountThresholds) {
+        if (isConcurrentSegmentSearchEnabled()) {
+            return new LocalBucketCountThresholds(0, ArrayUtil.MAX_ARRAY_LENGTH - 1);
+        } else {
+            return new LocalBucketCountThresholds(bucketCountThresholds.getShardMinDocCount(), bucketCountThresholds.getShardSize());
+        }
     }
 
     /**

--- a/server/src/test/java/org/opensearch/search/aggregations/InternalAggregationsTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/InternalAggregationsTests.java
@@ -44,6 +44,7 @@ import org.opensearch.search.aggregations.bucket.histogram.InternalDateHistogram
 import org.opensearch.search.aggregations.bucket.terms.StringTerms;
 import org.opensearch.search.aggregations.bucket.terms.StringTermsTests;
 import org.opensearch.search.aggregations.pipeline.AvgBucketPipelineAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.terms.TermsAggregator;
 import org.opensearch.search.aggregations.pipeline.InternalSimpleValueTests;
 import org.opensearch.search.aggregations.pipeline.MaxBucketPipelineAggregationBuilder;
 import org.opensearch.search.aggregations.pipeline.PipelineAggregator;
@@ -79,15 +80,14 @@ public class InternalAggregationsTests extends OpenSearchTestCase {
             "name",
             BucketOrder.key(true),
             BucketOrder.key(true),
-            10,
-            1,
             Collections.emptyMap(),
             DocValueFormat.RAW,
             25,
             false,
             10,
             Collections.emptyList(),
-            0
+            0,
+            new TermsAggregator.BucketCountThresholds(1, 0, 10, 25)
         );
         List<InternalAggregations> aggs = singletonList(InternalAggregations.from(Collections.singletonList(terms)));
         InternalAggregations reducedAggs = InternalAggregations.topLevelReduce(aggs, maxBucketReduceContext().forPartialReduction());
@@ -100,15 +100,14 @@ public class InternalAggregationsTests extends OpenSearchTestCase {
             "name",
             BucketOrder.key(true),
             BucketOrder.key(true),
-            10,
-            1,
             Collections.emptyMap(),
             DocValueFormat.RAW,
             25,
             false,
             10,
             Collections.emptyList(),
-            0
+            0,
+            new TermsAggregator.BucketCountThresholds(1, 0, 10, 25)
         );
 
         InternalAggregations aggs = InternalAggregations.from(Collections.singletonList(terms));

--- a/server/src/test/java/org/opensearch/search/aggregations/InternalMultiBucketAggregationTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/InternalMultiBucketAggregationTests.java
@@ -37,6 +37,7 @@ import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.bucket.terms.InternalTerms;
 import org.opensearch.search.aggregations.bucket.terms.LongTerms;
 import org.opensearch.search.aggregations.bucket.terms.StringTerms;
+import org.opensearch.search.aggregations.bucket.terms.TermsAggregator;
 import org.opensearch.search.aggregations.metrics.InternalAvg;
 import org.opensearch.search.aggregations.support.AggregationPath;
 import org.opensearch.test.OpenSearchTestCase;
@@ -164,20 +165,18 @@ public class InternalMultiBucketAggregationTests extends OpenSearchTestCase {
                 DocValueFormat.RAW
             )
         );
-
         InternalTerms termsAgg = new StringTerms(
             "string_terms",
             BucketOrder.count(false),
             BucketOrder.count(false),
-            1,
-            0,
             Collections.emptyMap(),
             DocValueFormat.RAW,
             1,
             false,
             0,
             stringBuckets,
-            0
+            0,
+            new TermsAggregator.BucketCountThresholds(0, 0, 1, 1)
         );
         InternalAggregations internalAggregations = InternalAggregations.from(Collections.singletonList(termsAgg));
         LongTerms.Bucket bucket = new LongTerms.Bucket(19, 1, internalAggregations, false, 0, DocValueFormat.RAW);
@@ -208,15 +207,14 @@ public class InternalMultiBucketAggregationTests extends OpenSearchTestCase {
             "string_terms",
             BucketOrder.count(false),
             BucketOrder.count(false),
-            1,
-            0,
             Collections.emptyMap(),
             DocValueFormat.RAW,
             1,
             false,
             0,
             stringBuckets,
-            0
+            0,
+            new TermsAggregator.BucketCountThresholds(0, 0, 1, 1)
         );
         InternalAggregations internalAggregations = InternalAggregations.from(Collections.singletonList(termsAgg));
         LongTerms.Bucket bucket = new LongTerms.Bucket(19, 1, internalAggregations, false, 0, DocValueFormat.RAW);

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/DoubleTermsTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/DoubleTermsTests.java
@@ -59,6 +59,12 @@ public class DoubleTermsTests extends InternalTermsTestCase {
         long minDocCount = 1;
         int requiredSize = 3;
         int shardSize = requiredSize + 2;
+        TermsAggregator.BucketCountThresholds bucketCountThresholds = new TermsAggregator.BucketCountThresholds(
+            minDocCount,
+            0,
+            requiredSize,
+            shardSize
+        );
         DocValueFormat format = randomNumericDocValueFormat();
         long otherDocCount = 0;
         List<DoubleTerms.Bucket> buckets = new ArrayList<>();
@@ -75,15 +81,14 @@ public class DoubleTermsTests extends InternalTermsTestCase {
             name,
             reduceOrder,
             order,
-            requiredSize,
-            minDocCount,
             metadata,
             format,
             shardSize,
             showTermDocCountError,
             otherDocCount,
             buckets,
-            docCountError
+            docCountError,
+            bucketCountThresholds
         );
     }
 
@@ -158,15 +163,14 @@ public class DoubleTermsTests extends InternalTermsTestCase {
                 name,
                 doubleTerms.reduceOrder,
                 order,
-                requiredSize,
-                minDocCount,
                 metadata,
                 format,
                 shardSize,
                 showTermDocCountError,
                 otherDocCount,
                 buckets,
-                docCountError
+                docCountError,
+                new TermsAggregator.BucketCountThresholds(minDocCount, 0, requiredSize, shardSize)
             );
         } else {
             String name = instance.getName();
@@ -195,7 +199,7 @@ public class DoubleTermsTests extends InternalTermsTestCase {
                 default:
                     throw new AssertionError("Illegal randomisation branch");
             }
-            return new UnmappedTerms(name, order, requiredSize, minDocCount, metadata);
+            return new UnmappedTerms(name, order, new TermsAggregator.BucketCountThresholds(minDocCount, 0, requiredSize, 0), metadata);
         }
     }
 

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/InternalMultiTermsTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/InternalMultiTermsTests.java
@@ -45,6 +45,12 @@ public class InternalMultiTermsTests extends InternalTermsTestCase {
         int requiredSize = 3;
         int shardSize = requiredSize + 2;
         long otherDocCount = 0;
+        TermsAggregator.BucketCountThresholds bucketCountThresholds = new TermsAggregator.BucketCountThresholds(
+            minDocCount,
+            0,
+            requiredSize,
+            shardSize
+        );
 
         final int numBuckets = randomNumberOfBuckets();
 
@@ -70,15 +76,14 @@ public class InternalMultiTermsTests extends InternalTermsTestCase {
             name,
             reduceOrder,
             order,
-            requiredSize,
-            minDocCount,
             metadata,
             shardSize,
             showTermDocCountError,
             otherDocCount,
             docCountError,
             formats,
-            buckets
+            buckets,
+            bucketCountThresholds
         );
     }
 

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/InternalSignificantTermsTestCase.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/InternalSignificantTermsTestCase.java
@@ -114,7 +114,7 @@ public abstract class InternalSignificantTermsTestCase extends InternalMultiBuck
     @Override
     protected InternalSignificantTerms createUnmappedInstance(String name, Map<String, Object> metadata) {
         InternalSignificantTerms<?, ?> testInstance = createTestInstance(name, metadata);
-        return new UnmappedSignificantTerms(name, testInstance.requiredSize, testInstance.minDocCount, metadata);
+        return new UnmappedSignificantTerms(name, testInstance.bucketCountThresholds, metadata);
     }
 
     @Override

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/InternalTermsTestCase.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/InternalTermsTestCase.java
@@ -73,7 +73,7 @@ public abstract class InternalTermsTestCase extends InternalMultiBucketAggregati
     @Override
     protected InternalTerms<?, ?> createUnmappedInstance(String name, Map<String, Object> metadata) {
         InternalTerms<?, ?> testInstance = createTestInstance(name, metadata);
-        return new UnmappedTerms(name, testInstance.order, testInstance.requiredSize, testInstance.minDocCount, metadata);
+        return new UnmappedTerms(name, testInstance.order, testInstance.bucketCountThresholds, metadata);
     }
 
     @Override

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/LongTermsTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/LongTermsTests.java
@@ -59,6 +59,12 @@ public class LongTermsTests extends InternalTermsTestCase {
         long minDocCount = 1;
         int requiredSize = 3;
         int shardSize = requiredSize + 2;
+        TermsAggregator.BucketCountThresholds bucketCountThresholds = new TermsAggregator.BucketCountThresholds(
+            minDocCount,
+            0,
+            requiredSize,
+            shardSize
+        );
         DocValueFormat format = randomNumericDocValueFormat();
         long otherDocCount = 0;
         List<LongTerms.Bucket> buckets = new ArrayList<>();
@@ -75,15 +81,14 @@ public class LongTermsTests extends InternalTermsTestCase {
             name,
             reduceOrder,
             order,
-            requiredSize,
-            minDocCount,
             metadata,
             format,
             shardSize,
             showTermDocCountError,
             otherDocCount,
             buckets,
-            docCountError
+            docCountError,
+            bucketCountThresholds
         );
     }
 
@@ -158,15 +163,14 @@ public class LongTermsTests extends InternalTermsTestCase {
                 name,
                 longTerms.reduceOrder,
                 order,
-                requiredSize,
-                minDocCount,
                 metadata,
                 format,
                 shardSize,
                 showTermDocCountError,
                 otherDocCount,
                 buckets,
-                docCountError
+                docCountError,
+                new TermsAggregator.BucketCountThresholds(minDocCount, 0, requiredSize, shardSize)
             );
         } else {
             String name = instance.getName();
@@ -195,7 +199,7 @@ public class LongTermsTests extends InternalTermsTestCase {
                 default:
                     throw new AssertionError("Illegal randomisation branch");
             }
-            return new UnmappedTerms(name, order, requiredSize, minDocCount, metadata);
+            return new UnmappedTerms(name, order, new TermsAggregator.BucketCountThresholds(minDocCount, 0, requiredSize, 0), metadata);
         }
     }
 }

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/SignificanceHeuristicTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/SignificanceHeuristicTests.java
@@ -130,7 +130,16 @@ public class SignificanceHeuristicTests extends OpenSearchTestCase {
                 DocValueFormat.RAW,
                 randomDoubleBetween(0, 100, true)
             );
-            return new SignificantLongTerms("some_name", 1, 1, null, DocValueFormat.RAW, 10, 20, heuristic, singletonList(bucket));
+            return new SignificantLongTerms(
+                "some_name",
+                null,
+                DocValueFormat.RAW,
+                10,
+                20,
+                heuristic,
+                singletonList(bucket),
+                new TermsAggregator.BucketCountThresholds(1, 0, 1, 0)
+            );
         } else {
             SignificantStringTerms.Bucket bucket = new SignificantStringTerms.Bucket(
                 new BytesRef("someterm"),
@@ -142,7 +151,16 @@ public class SignificanceHeuristicTests extends OpenSearchTestCase {
                 DocValueFormat.RAW,
                 randomDoubleBetween(0, 100, true)
             );
-            return new SignificantStringTerms("some_name", 1, 1, null, DocValueFormat.RAW, 10, 20, heuristic, singletonList(bucket));
+            return new SignificantStringTerms(
+                "some_name",
+                null,
+                DocValueFormat.RAW,
+                10,
+                20,
+                heuristic,
+                singletonList(bucket),
+                new TermsAggregator.BucketCountThresholds(1, 0, 1, 0)
+            );
         }
     }
 
@@ -209,14 +227,13 @@ public class SignificanceHeuristicTests extends OpenSearchTestCase {
         ) {
             return new SignificantStringTerms(
                 "sig_terms",
-                2,
-                -1,
                 emptyMap(),
                 DocValueFormat.RAW,
                 subsetSize,
                 supersetSize,
                 significanceHeuristic,
-                buckets
+                buckets,
+                new TermsAggregator.BucketCountThresholds(-1, 0, 2, 0)
             );
         }
 
@@ -245,14 +262,13 @@ public class SignificanceHeuristicTests extends OpenSearchTestCase {
         ) {
             return new SignificantLongTerms(
                 "sig_terms",
-                2,
-                -1,
                 emptyMap(),
                 DocValueFormat.RAW,
                 subsetSize,
                 supersetSize,
                 significanceHeuristic,
-                buckets
+                buckets,
+                new TermsAggregator.BucketCountThresholds(-1, 0, 2, 0)
             );
         }
 

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/SignificantLongTermsTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/SignificantLongTermsTests.java
@@ -85,7 +85,17 @@ public class SignificantLongTermsTests extends InternalSignificantTermsTestCase 
             bucket.updateScore(significanceHeuristic);
             buckets.add(bucket);
         }
-        return new SignificantLongTerms(name, requiredSize, 1L, metadata, format, subsetSize, supersetSize, significanceHeuristic, buckets);
+
+        return new SignificantLongTerms(
+            name,
+            metadata,
+            format,
+            subsetSize,
+            supersetSize,
+            significanceHeuristic,
+            buckets,
+            new TermsAggregator.BucketCountThresholds(1L, 0, requiredSize, 0)
+        );
     }
 
     @Override
@@ -150,14 +160,13 @@ public class SignificantLongTermsTests extends InternalSignificantTermsTestCase 
             }
             return new SignificantLongTerms(
                 name,
-                requiredSize,
-                minDocCount,
                 metadata,
                 format,
                 subsetSize,
                 supersetSize,
                 significanceHeuristic,
-                buckets
+                buckets,
+                new TermsAggregator.BucketCountThresholds(minDocCount, 0, requiredSize, 0)
             );
         } else {
             String name = instance.getName();
@@ -185,7 +194,7 @@ public class SignificantLongTermsTests extends InternalSignificantTermsTestCase 
                 default:
                     throw new AssertionError("Illegal randomisation branch");
             }
-            return new UnmappedSignificantTerms(name, requiredSize, minDocCount, metadata);
+            return new UnmappedSignificantTerms(name, new TermsAggregator.BucketCountThresholds(minDocCount, 0, requiredSize, 0), metadata);
         }
     }
 }

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/SignificantStringTermsTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/SignificantStringTermsTests.java
@@ -80,14 +80,13 @@ public class SignificantStringTermsTests extends InternalSignificantTermsTestCas
         }
         return new SignificantStringTerms(
             name,
-            requiredSize,
-            1L,
             metadata,
             format,
             subsetSize,
             supersetSize,
             significanceHeuristic,
-            buckets
+            buckets,
+            new TermsAggregator.BucketCountThresholds(1L, 0, requiredSize, 0)
         );
     }
 
@@ -153,14 +152,13 @@ public class SignificantStringTermsTests extends InternalSignificantTermsTestCas
             }
             return new SignificantStringTerms(
                 name,
-                requiredSize,
-                minDocCount,
                 metadata,
                 format,
                 subsetSize,
                 supersetSize,
                 significanceHeuristic,
-                buckets
+                buckets,
+                new TermsAggregator.BucketCountThresholds(minDocCount, 0, requiredSize, 0)
             );
         } else {
             String name = instance.getName();
@@ -188,7 +186,7 @@ public class SignificantStringTermsTests extends InternalSignificantTermsTestCas
                 default:
                     throw new AssertionError("Illegal randomisation branch");
             }
-            return new UnmappedSignificantTerms(name, requiredSize, minDocCount, metadata);
+            return new UnmappedSignificantTerms(name, new TermsAggregator.BucketCountThresholds(minDocCount, 0, requiredSize, 0), metadata);
         }
     }
 }

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/StringTermsTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/StringTermsTests.java
@@ -140,15 +140,14 @@ public class StringTermsTests extends InternalTermsTestCase {
                 name,
                 stringTerms.reduceOrder,
                 order,
-                requiredSize,
-                minDocCount,
                 metadata,
                 format,
                 shardSize,
                 showTermDocCountError,
                 otherDocCount,
                 buckets,
-                docCountError
+                docCountError,
+                new TermsAggregator.BucketCountThresholds(minDocCount, 0, requiredSize, shardSize)
             );
         } else {
             String name = instance.getName();
@@ -177,7 +176,7 @@ public class StringTermsTests extends InternalTermsTestCase {
                 default:
                     throw new AssertionError("Illegal randomisation branch");
             }
-            return new UnmappedTerms(name, order, requiredSize, minDocCount, metadata);
+            return new UnmappedTerms(name, order, new TermsAggregator.BucketCountThresholds(minDocCount, 0, requiredSize, 0), metadata);
         }
     }
 
@@ -206,6 +205,12 @@ public class StringTermsTests extends InternalTermsTestCase {
         long minDocCount = 1;
         int requiredSize = 3;
         int shardSize = requiredSize + 2;
+        TermsAggregator.BucketCountThresholds bucketCountThresholds = new TermsAggregator.BucketCountThresholds(
+            minDocCount,
+            0,
+            requiredSize,
+            shardSize
+        );
         DocValueFormat format = DocValueFormat.RAW;
         long otherDocCount = 0;
         List<StringTerms.Bucket> buckets = new ArrayList<>();
@@ -226,15 +231,14 @@ public class StringTermsTests extends InternalTermsTestCase {
             name,
             reduceOrder,
             order,
-            requiredSize,
-            minDocCount,
             metadata,
             format,
             shardSize,
             showTermDocCountError,
             otherDocCount,
             buckets,
-            docCountError
+            docCountError,
+            bucketCountThresholds
         );
     }
 }

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/UnsignedLongTermsTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/UnsignedLongTermsTests.java
@@ -36,6 +36,12 @@ public class UnsignedLongTermsTests extends InternalTermsTestCase {
         long minDocCount = 1;
         int requiredSize = 3;
         int shardSize = requiredSize + 2;
+        TermsAggregator.BucketCountThresholds bucketCountThresholds = new TermsAggregator.BucketCountThresholds(
+            minDocCount,
+            0,
+            requiredSize,
+            shardSize
+        );
         DocValueFormat format = randomNumericDocValueFormat();
         long otherDocCount = 0;
         List<UnsignedLongTerms.Bucket> buckets = new ArrayList<>();
@@ -52,15 +58,14 @@ public class UnsignedLongTermsTests extends InternalTermsTestCase {
             name,
             reduceOrder,
             order,
-            requiredSize,
-            minDocCount,
             metadata,
             format,
             shardSize,
             showTermDocCountError,
             otherDocCount,
             buckets,
-            docCountError
+            docCountError,
+            bucketCountThresholds
         );
     }
 
@@ -135,15 +140,14 @@ public class UnsignedLongTermsTests extends InternalTermsTestCase {
                 name,
                 longTerms.reduceOrder,
                 order,
-                requiredSize,
-                minDocCount,
                 metadata,
                 format,
                 shardSize,
                 showTermDocCountError,
                 otherDocCount,
                 buckets,
-                docCountError
+                docCountError,
+                new TermsAggregator.BucketCountThresholds(minDocCount, 0, requiredSize, shardSize)
             );
         } else {
             String name = instance.getName();
@@ -172,7 +176,7 @@ public class UnsignedLongTermsTests extends InternalTermsTestCase {
                 default:
                     throw new AssertionError("Illegal randomisation branch");
             }
-            return new UnmappedTerms(name, order, requiredSize, minDocCount, metadata);
+            return new UnmappedTerms(name, order, new TermsAggregator.BucketCountThresholds(minDocCount, 0, requiredSize, 0), metadata);
         }
     }
 }

--- a/test/framework/src/main/java/org/opensearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/search/aggregations/AggregatorTestCase.java
@@ -350,6 +350,7 @@ public abstract class AggregatorTestCase extends OpenSearchTestCase {
         when(searchContext.aggregations()).thenReturn(new SearchContextAggregations(AggregatorFactories.EMPTY, bucketConsumer));
         when(searchContext.query()).thenReturn(query);
         when(searchContext.bucketCollectorProcessor()).thenReturn(new BucketCollectorProcessor());
+        when(searchContext.asLocalBucketCountThresholds(any())).thenCallRealMethod();
         /*
          * Always use the circuit breaking big arrays instance so that the CircuitBreakerService
          * we're passed gets a chance to break.


### PR DESCRIPTION
### Description
Backport for #8860

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
