### PR TITLE
[Segment Replication] Support realtime reads for GET requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Introducing Default and Best Compression codecs as their algorithm name ([#9123]()https://github.com/opensearch-project/OpenSearch/pull/9123)
 - Make SearchTemplateRequest implement IndicesRequest.Replaceable ([#9122]()https://github.com/opensearch-project/OpenSearch/pull/9122)
 - [BWC and API enforcement] Define the initial set of annotations, their meaning and relations between them ([#9223](https://github.com/opensearch-project/OpenSearch/pull/9223))
+- [Segment Replication] Support realtime reads for GET requests ([#9212](https://github.com/opensearch-project/OpenSearch/pull/9212))
 
 ### Dependencies
 - Bump `org.apache.logging.log4j:log4j-core` from 2.17.1 to 2.20.0 ([#8307](https://github.com/opensearch-project/OpenSearch/pull/8307))

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -118,7 +118,7 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
         internalCluster().startClusterManagerOnlyNode();
     }
 
-    static String indexOrAlias() {
+    private static String indexOrAlias() {
         return randomBoolean() ? INDEX_NAME : "alias";
     }
 
@@ -1458,15 +1458,14 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
      */
     public void testRealtimeGetRequestsSuccessful() {
         final String primary = internalCluster().startDataOnlyNode();
-        final String replica = internalCluster().startDataOnlyNode();
-
         assertAcked(
             prepareCreate(INDEX_NAME).setSettings(Settings.builder().put("index.refresh_interval", -1).put(indexSettings()))
                 .addAlias(new Alias("alias"))
         );
+        final String replica = internalCluster().startDataOnlyNode();
         ensureGreen(INDEX_NAME);
 
-        GetResponse response = client().prepareGet(indexOrAlias(), "1").get();
+        GetResponse response = client(replica).prepareGet(indexOrAlias(), "1").get();
         assertFalse(response.isExists());
 
         // index doc 1
@@ -1476,12 +1475,8 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
         response = client().prepareGet(indexOrAlias(), "1").setRealtime(false).get();
         assertFalse(response.isExists());
 
-        // non realtime get 1 (on replica shard only)
-        response = client(replica).prepareGet(indexOrAlias(), "1").setPreference("_only_local").setRealtime(false).get();
-        assertFalse(response.isExists());
-
-        // realtime get 1
-        response = client().prepareGet(indexOrAlias(), "1").get();
+        // realtime get 1 (on replica shard only)
+        response = client(replica).prepareGet(indexOrAlias(), "1").get();
         assertTrue(response.isExists());
         assertThat(response.getIndex(), equalTo(INDEX_NAME));
         assertThat(response.getSourceAsMap().get("foo").toString(), equalTo("bar"));
@@ -1489,13 +1484,12 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
 
     public void testRealtimeGetRequestsUnsuccessful() {
         final String primary = internalCluster().startDataOnlyNode();
-        final String replica = internalCluster().startDataOnlyNode();
-
         assertAcked(
             prepareCreate(INDEX_NAME).setSettings(
                 Settings.builder().put("index.refresh_interval", -1).put(indexSettings()).put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 2)
             ).addAlias(new Alias("alias"))
         );
+        final String replica = internalCluster().startDataOnlyNode();
         ensureGreen(INDEX_NAME);
 
         final String id = routingKeyForShard(INDEX_NAME, 0);
@@ -1509,12 +1503,12 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
         assertFalse(response.isExists());
 
         // realtime get 1 (preference = _replica)
-        response = client().prepareGet(indexOrAlias(), "1").setPreference(Preference.REPLICA.type()).get();
+        response = client(replica).prepareGet(indexOrAlias(), "1").setPreference(Preference.REPLICA.type()).get();
         assertFalse(response.isExists());
         assertThat(response.getIndex(), equalTo(INDEX_NAME));
 
         // realtime get 1 (with routing set)
-        response = client().prepareGet(INDEX_NAME, "1").setRouting(routingOtherShard).get();
+        response = client(replica).prepareGet(INDEX_NAME, "1").setRouting(routingOtherShard).get();
         assertFalse(response.isExists());
         assertThat(response.getIndex(), equalTo(INDEX_NAME));
     }
@@ -1524,12 +1518,11 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
      */
     public void testRealtimeMultiGetRequestsSuccessful() {
         final String primary = internalCluster().startDataOnlyNode();
-        final String replica = internalCluster().startDataOnlyNode();
-
         assertAcked(
             prepareCreate(INDEX_NAME).setSettings(Settings.builder().put("index.refresh_interval", -1).put(indexSettings()))
                 .addAlias(new Alias("alias"))
         );
+        final String replica = internalCluster().startDataOnlyNode();
         ensureGreen(INDEX_NAME);
 
         // index doc 1
@@ -1548,7 +1541,7 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
         assertFalse(mgetResponse.getResponses()[0].getResponse().isExists());
 
         // multi get realtime 1
-        mgetResponse = client().prepareMultiGet()
+        mgetResponse = client(replica).prepareMultiGet()
             .add(new MultiGetRequest.Item(INDEX_NAME, "1"))
             .add(new MultiGetRequest.Item("nonExistingIndex", "1"))
             .get();
@@ -1569,13 +1562,12 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
 
     public void testRealtimeMultiGetRequestsUnsuccessful() {
         final String primary = internalCluster().startDataOnlyNode();
-        final String replica = internalCluster().startDataOnlyNode();
-
         assertAcked(
             prepareCreate(INDEX_NAME).setSettings(
                 Settings.builder().put("index.refresh_interval", -1).put(indexSettings()).put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 2)
             ).addAlias(new Alias("alias"))
         );
+        final String replica = internalCluster().startDataOnlyNode();
         ensureGreen(INDEX_NAME);
 
         final String id = routingKeyForShard(INDEX_NAME, 0);
@@ -1585,7 +1577,7 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
         client().prepareIndex(indexOrAlias()).setId("1").setSource("foo", "bar").setRouting(id).get();
 
         // realtime multi get 1 (preference = _replica)
-        MultiGetResponse mgetResponse = client().prepareMultiGet()
+        MultiGetResponse mgetResponse = client(replica).prepareMultiGet()
             .add(new MultiGetRequest.Item(INDEX_NAME, "1"))
             .setPreference(Preference.REPLICA.type())
             .add(new MultiGetRequest.Item("nonExistingIndex", "1"))
@@ -1598,7 +1590,7 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
         assertTrue(mgetResponse.getResponses()[1].isFailed());
 
         // realtime multi get 1 (routing set)
-        mgetResponse = client().prepareMultiGet()
+        mgetResponse = client(replica).prepareMultiGet()
             .add(new MultiGetRequest.Item(INDEX_NAME, "1").routing(routingOtherShard))
             .add(new MultiGetRequest.Item("nonExistingIndex", "1"))
             .get();

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -21,9 +21,13 @@ import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.index.StandardDirectoryReader;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
+import org.junit.Before;
+import org.opensearch.common.action.ActionFuture;
+import org.opensearch.action.admin.indices.alias.Alias;
 import org.opensearch.action.admin.indices.flush.FlushRequest;
 import org.opensearch.action.admin.indices.stats.IndicesStatsRequest;
 import org.opensearch.action.admin.indices.stats.IndicesStatsResponse;
+import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.CreatePitAction;
 import org.opensearch.action.search.CreatePitRequest;
@@ -43,7 +47,6 @@ import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.ShardRoutingState;
 import org.opensearch.cluster.routing.allocation.command.CancelAllocationCommand;
-import org.opensearch.common.action.ActionFuture;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.concurrent.GatedCloseable;
 import org.opensearch.common.lease.Releasable;
@@ -74,7 +77,6 @@ import org.opensearch.test.InternalTestCluster;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.transport.MockTransportService;
 import org.opensearch.transport.TransportService;
-import org.junit.Before;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -87,6 +89,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.equalTo;
 import static org.opensearch.action.search.PitTestsUtil.assertSegments;
 import static org.opensearch.action.search.SearchContextId.decode;
 import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
@@ -108,6 +111,10 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
     @Before
     private void setup() {
         internalCluster().startClusterManagerOnlyNode();
+    }
+
+    static String indexOrAlias() {
+        return randomBoolean() ? INDEX_NAME : "alias";
     }
 
     public void testPrimaryStopped_ReplicaPromoted() throws Exception {
@@ -1439,5 +1446,35 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
         internalCluster().restartNode(primary);
         ensureYellow(INDEX_NAME);
         assertDocCounts(1, primary);
+    }
+
+    /**
+     * Tests whether segment replication supports realtime get requests and reads and parses source from the translog to serve strong reads.
+     */
+    public void testRealtimeGetRequests() {
+        final String primary = internalCluster().startDataOnlyNode();
+        final String replica = internalCluster().startDataOnlyNode();
+
+        assertAcked(
+            prepareCreate(INDEX_NAME).setSettings(Settings.builder().put("index.refresh_interval", -1).put(indexSettings()))
+                .addAlias(new Alias("alias"))
+        );
+        ensureGreen(INDEX_NAME);
+
+        GetResponse response = client().prepareGet(indexOrAlias(), "1").get();
+        assertThat(response.isExists(), equalTo(false));
+
+        logger.info("--> index doc 1");
+        client().prepareIndex(indexOrAlias()).setId("1").setSource("foo", "bar").get();
+
+        logger.info("--> non realtime get 1");
+        response = client().prepareGet(indexOrAlias(), "1").setRealtime(false).get();
+        assertThat(response.isExists(), equalTo(false));
+
+        logger.info("--> realtime get 1");
+        response = client().prepareGet(indexOrAlias(), "1").get();
+        assertThat(response.isExists(), equalTo(true));
+        assertThat(response.getIndex(), equalTo(INDEX_NAME));
+        assertThat(response.getSourceAsMap().get("foo").toString(), equalTo("bar"));
     }
 }

--- a/server/src/main/java/org/opensearch/action/get/TransportGetAction.java
+++ b/server/src/main/java/org/opensearch/action/get/TransportGetAction.java
@@ -95,21 +95,12 @@ public class TransportGetAction extends TransportSingleShardAction<GetRequest, G
      * Returns true if GET request should be routed to primary shards, else false.
      */
     protected boolean isPrimaryBasedRouting(ClusterState state, InternalRequest request) {
-        try {
-            if (state.getMetadata()
-                .index(request.concreteIndex())
-                .getSettings()
-                .get(IndexMetadata.SETTING_REPLICATION_TYPE)
-                .equals(ReplicationType.SEGMENT.toString())
-                && request.request().realtime()
-                && request.request().routing() == null
-                && request.request().preference() == null) {
-                return true;
-            }
-        } catch (NullPointerException e) {
-            return false;
-        }
-        return false;
+        IndexMetadata indexMetadata = state.getMetadata().index(request.concreteIndex());
+        return indexMetadata != null
+            && indexMetadata.getSettings().get(IndexMetadata.SETTING_REPLICATION_TYPE).equals(ReplicationType.SEGMENT.toString())
+            && request.request().realtime()
+            && request.request().routing() == null
+            && request.request().preference() == null;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/get/TransportMultiGetAction.java
+++ b/server/src/main/java/org/opensearch/action/get/TransportMultiGetAction.java
@@ -82,22 +82,12 @@ public class TransportMultiGetAction extends HandledTransportAction<MultiGetRequ
      * Returns true if MultiGet request should be routed to primary shards, else false.
      */
     boolean isPrimaryBasedRouting(MultiGetRequest request, MultiGetRequest.Item item) {
-        try {
-            if (request.preference == null
-                && item.routing() == null
-                && request.realtime
-                && clusterService.state()
-                    .getMetadata()
-                    .index(item.index())
-                    .getSettings()
-                    .get(IndexMetadata.SETTING_REPLICATION_TYPE)
-                    .equals(ReplicationType.SEGMENT.toString())) {
-                return true;
-            }
-        } catch (NullPointerException e) {
-            return false;
-        }
-        return false;
+        IndexMetadata indexMetadata = clusterService.state().getMetadata().index(item.index());
+        return indexMetadata != null
+            && indexMetadata.getSettings().get(IndexMetadata.SETTING_REPLICATION_TYPE).equals(ReplicationType.SEGMENT.toString())
+            && request.preference == null
+            && item.routing() == null
+            && request.realtime;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/get/TransportMultiGetAction.java
+++ b/server/src/main/java/org/opensearch/action/get/TransportMultiGetAction.java
@@ -51,7 +51,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.opensearch.action.get.TransportGetAction.isPrimaryBasedRouting;
+import static org.opensearch.action.get.TransportGetAction.shouldForcePrimaryRouting;
 
 /**
  * Perform the multi get action.
@@ -112,7 +112,7 @@ public class TransportMultiGetAction extends HandledTransportAction<MultiGetRequ
 
             MultiGetShardRequest shardRequest = shardRequests.get(shardId);
             if (shardRequest == null) {
-                if (isPrimaryBasedRouting(clusterState, request.realtime, request.preference, concreteSingleIndex)) {
+                if (shouldForcePrimaryRouting(clusterState, request.realtime, request.preference, concreteSingleIndex)) {
                     request.preference(Preference.PRIMARY.type());
                 }
                 shardRequest = new MultiGetShardRequest(request, shardId.getIndexName(), shardId.getId());

--- a/server/src/test/java/org/opensearch/action/get/TransportGetActionTests.java
+++ b/server/src/test/java/org/opensearch/action/get/TransportGetActionTests.java
@@ -1,0 +1,108 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.action.get;
+
+import org.opensearch.Version;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.routing.Preference;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.index.Index;
+import org.opensearch.indices.replication.common.ReplicationType;
+import org.opensearch.test.OpenSearchTestCase;
+import org.junit.BeforeClass;
+
+import static org.opensearch.common.UUIDs.randomBase64UUID;
+
+public class TransportGetActionTests extends OpenSearchTestCase {
+
+    private static ClusterState clusterState;
+    private static ClusterState clusterState2;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+
+        final Index index1 = new Index("index1", randomBase64UUID());
+        final Index index2 = new Index("index2", randomBase64UUID());
+        clusterState = ClusterState.builder(new ClusterName(TransportGetActionTests.class.getSimpleName()))
+            .metadata(
+                new Metadata.Builder().put(
+                    new IndexMetadata.Builder(index1.getName()).settings(
+                        Settings.builder()
+                            .put("index.version.created", Version.CURRENT)
+                            .put("index.number_of_shards", 1)
+                            .put("index.number_of_replicas", 1)
+                            .put(IndexMetadata.SETTING_INDEX_UUID, index1.getUUID())
+                            .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+                    )
+                )
+            )
+            .build();
+
+        clusterState2 = ClusterState.builder(new ClusterName(TransportGetActionTests.class.getSimpleName()))
+            .metadata(
+                new Metadata.Builder().put(
+                    new IndexMetadata.Builder(index2.getName()).settings(
+                        Settings.builder()
+                            .put("index.version.created", Version.CURRENT)
+                            .put("index.number_of_shards", 1)
+                            .put("index.number_of_replicas", 1)
+                            .put(IndexMetadata.SETTING_INDEX_UUID, index2.getUUID())
+                    )
+                )
+            )
+            .build();
+    }
+
+    public void testIsPrimaryBasedRouting() {
+
+        // should return false since preference is set for request
+        assertFalse(TransportGetAction.isPrimaryBasedRouting(clusterState, true, Preference.REPLICA.type(), "index1"));
+
+        // should return false since request is not realtime
+        assertFalse(TransportGetAction.isPrimaryBasedRouting(clusterState, false, null, "index1"));
+
+        // should return true since segment replication is enabled
+        assertTrue(TransportGetAction.isPrimaryBasedRouting(clusterState, true, null, "index1"));
+
+        // should return false since index doesn't exist
+        assertFalse(TransportGetAction.isPrimaryBasedRouting(clusterState, true, null, "index3"));
+
+        // should fail since document replication enabled
+        assertFalse(TransportGetAction.isPrimaryBasedRouting(clusterState2, true, null, "index2"));
+
+    }
+
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This change supports realtime reads for GET requests when segment replication is enabled. 
If there are no preferences mentioned for the incoming GET request then we route it to primary shards which serve strong reads by parsing source from the translog. 

### Related Issues
Resolves #8536 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
