### PR TITLE
Fix flaky test SegmentReplicationIndexShardTests.testPrimaryRestart

### DIFF
--- a/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
@@ -62,7 +62,6 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -771,33 +770,6 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
             if (shard != null) {
                 closeShard(shard, false);
             }
-        }
-    }
-
-    public void testPrimaryRestart() throws Exception {
-        final Path remotePath = createTempDir();
-        try (ReplicationGroup shards = createGroup(0, getIndexSettings(), indexMapping, new NRTReplicationEngineFactory(), remotePath)) {
-            shards.startAll();
-            // ensure primary has uploaded something
-            shards.indexDocs(10);
-            IndexShard primary = shards.getPrimary();
-            if (randomBoolean()) {
-                flushShard(primary);
-            } else {
-                primary.refresh("test");
-            }
-            assertDocCount(primary, 10);
-            // get a metadata map - we'll use segrep diff to ensure segments on reader are identical after restart.
-            final Map<String, StoreFileMetadata> metadataBeforeRestart = primary.getSegmentMetadataMap();
-            // restart the primary
-            shards.reinitPrimaryShard(remotePath);
-            // the store is open at this point but the shard has not yet run through recovery
-            primary = shards.getPrimary();
-            shards.startPrimary();
-            assertDocCount(primary, 10);
-            final Store.RecoveryDiff diff = Store.segmentReplicationDiff(metadataBeforeRestart, primary.getSegmentMetadataMap());
-            assertTrue(diff.missing.isEmpty());
-            assertTrue(diff.different.isEmpty());
         }
     }
 


### PR DESCRIPTION
### Description
This test is specific to remote store and should not be run for node-node replication.

### Related Issues
NA

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
