### PR TITLE
Add support for query profiler with concurrent aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Use non-concurrent path for sort request on timeseries index and field([#9562](https://github.com/opensearch-project/OpenSearch/pull/9562))
 - Added sampler based on `Blanket Probabilistic Sampling rate` and `Override for on demand` ([#9621](https://github.com/opensearch-project/OpenSearch/issues/9621))
 - [Remote Store] Add support for Remote Translog Store stats in `_remotestore/stats/` API ([#9263](https://github.com/opensearch-project/OpenSearch/pull/9263))
+- Add support for query profiler with concurrent aggregation ([#9248](https://github.com/opensearch-project/OpenSearch/pull/9248))
 
 ### Deprecated
 

--- a/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
@@ -299,6 +299,10 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
         final LeafCollector leafCollector;
         try {
             cancellable.checkCancelled();
+            if (weight instanceof ProfileWeight) {
+                ((ProfileWeight) weight).associateLeafToCollector(ctx, collector);
+                ((ProfileWeight) weight).buildCollectorList(collector);
+            }
             weight = wrapWeight(weight);
             // See please https://github.com/apache/lucene/pull/964
             collector.setWeight(weight);

--- a/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
@@ -300,8 +300,7 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
         try {
             cancellable.checkCancelled();
             if (weight instanceof ProfileWeight) {
-                ((ProfileWeight) weight).associateLeafToCollector(ctx, collector);
-                ((ProfileWeight) weight).buildCollectorList(collector);
+                ((ProfileWeight) weight).associateCollectorToLeaves(ctx, collector);
             }
             weight = wrapWeight(weight);
             // See please https://github.com/apache/lucene/pull/964

--- a/server/src/main/java/org/opensearch/search/profile/AbstractInternalProfileTree.java
+++ b/server/src/main/java/org/opensearch/search/profile/AbstractInternalProfileTree.java
@@ -186,7 +186,10 @@ public abstract class AbstractInternalProfileTree<PB extends AbstractProfileBrea
             breakdown.toBreakdownMap(),
             breakdown.toDebugMap(),
             breakdown.toNodeTime(),
-            childrenProfileResults
+            childrenProfileResults,
+            breakdown.getMaxSliceNodeTime(),
+            breakdown.getMinSliceNodeTime(),
+            breakdown.getAvgSliceNodeTime()
         );
     }
 

--- a/server/src/main/java/org/opensearch/search/profile/AbstractInternalProfileTree.java
+++ b/server/src/main/java/org/opensearch/search/profile/AbstractInternalProfileTree.java
@@ -180,16 +180,17 @@ public abstract class AbstractInternalProfileTree<PB extends AbstractProfileBrea
         // calculating the same times over and over...but worth the effort?
         String type = getTypeFromElement(element);
         String description = getDescriptionFromElement(element);
+        return createProfileResult(type, description, breakdown, childrenProfileResults);
+    }
+
+    protected ProfileResult createProfileResult(String type, String description, PB breakdown, List<ProfileResult> childrenProfileResults) {
         return new ProfileResult(
             type,
             description,
             breakdown.toBreakdownMap(),
             breakdown.toDebugMap(),
             breakdown.toNodeTime(),
-            childrenProfileResults,
-            breakdown.getMaxSliceNodeTime(),
-            breakdown.getMinSliceNodeTime(),
-            breakdown.getAvgSliceNodeTime()
+            childrenProfileResults
         );
     }
 

--- a/server/src/main/java/org/opensearch/search/profile/AbstractProfileBreakdown.java
+++ b/server/src/main/java/org/opensearch/search/profile/AbstractProfileBreakdown.java
@@ -80,6 +80,7 @@ public abstract class AbstractProfileBreakdown<T extends Enum<T>> {
         for (T timingType : this.timingTypes) {
             map.put(timingType.toString(), this.timings[timingType.ordinal()].getApproximateTiming());
             map.put(timingType + TIMING_TYPE_COUNT_SUFFIX, this.timings[timingType.ordinal()].getCount());
+            map.put(timingType + TIMING_TYPE_START_TIME_SUFFIX, this.timings[timingType.ordinal()].getEarliestTimerStartTime());
         }
         return Collections.unmodifiableMap(map);
     }
@@ -91,11 +92,23 @@ public abstract class AbstractProfileBreakdown<T extends Enum<T>> {
         return emptyMap();
     }
 
-    public final long toNodeTime() {
+    public long toNodeTime() {
         long total = 0;
         for (T timingType : timingTypes) {
             total += timings[timingType.ordinal()].getApproximateTiming();
         }
         return total;
+    }
+
+    public Long getMaxSliceNodeTime() {
+        return null;
+    }
+
+    public Long getMinSliceNodeTime() {
+        return null;
+    }
+
+    public Long getAvgSliceNodeTime() {
+        return null;
     }
 }

--- a/server/src/main/java/org/opensearch/search/profile/AbstractProfileBreakdown.java
+++ b/server/src/main/java/org/opensearch/search/profile/AbstractProfileBreakdown.java
@@ -88,7 +88,7 @@ public abstract class AbstractProfileBreakdown<T extends Enum<T>> {
     /**
      * Fetch extra debugging information.
      */
-    protected Map<String, Object> toDebugMap() {
+    public Map<String, Object> toDebugMap() {
         return emptyMap();
     }
 
@@ -98,17 +98,5 @@ public abstract class AbstractProfileBreakdown<T extends Enum<T>> {
             total += timings[timingType.ordinal()].getApproximateTiming();
         }
         return total;
-    }
-
-    public Long getMaxSliceNodeTime() {
-        return null;
-    }
-
-    public Long getMinSliceNodeTime() {
-        return null;
-    }
-
-    public Long getAvgSliceNodeTime() {
-        return null;
     }
 }

--- a/server/src/main/java/org/opensearch/search/profile/ContextualProfileBreakdown.java
+++ b/server/src/main/java/org/opensearch/search/profile/ContextualProfileBreakdown.java
@@ -8,6 +8,9 @@
 
 package org.opensearch.search.profile;
 
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.Collector;
+
 /**
  * Provide contextual profile breakdowns which are associated with freestyle context. Used when concurrent
  * search over segments is activated and each collector needs own non-shareable profile breakdown instance.
@@ -15,6 +18,7 @@ package org.opensearch.search.profile;
  * @opensearch.internal
  */
 public abstract class ContextualProfileBreakdown<T extends Enum<T>> extends AbstractProfileBreakdown<T> {
+
     public ContextualProfileBreakdown(Class<T> clazz) {
         super(clazz);
     }
@@ -25,4 +29,8 @@ public abstract class ContextualProfileBreakdown<T extends Enum<T>> extends Abst
      * @return contextual profile breakdown instance
      */
     public abstract AbstractProfileBreakdown<T> context(Object context);
+
+    public void associateLeafToCollector(LeafReaderContext leaf, Collector collector) {}
+
+    public void buildCollectorList(Collector collector) {}
 }

--- a/server/src/main/java/org/opensearch/search/profile/ContextualProfileBreakdown.java
+++ b/server/src/main/java/org/opensearch/search/profile/ContextualProfileBreakdown.java
@@ -11,6 +11,9 @@ package org.opensearch.search.profile;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Collector;
 
+import java.util.List;
+import java.util.Map;
+
 /**
  * Provide contextual profile breakdowns which are associated with freestyle context. Used when concurrent
  * search over segments is activated and each collector needs own non-shareable profile breakdown instance.
@@ -30,4 +33,6 @@ public abstract class ContextualProfileBreakdown<T extends Enum<T>> extends Abst
     public abstract AbstractProfileBreakdown<T> context(Object context);
 
     public void associateCollectorToLeaves(LeafReaderContext leaf, Collector collector) {}
+
+    public void associateCollectorToLeaves(Map<String, List<LeafReaderContext>> collectorToLeaves) {}
 }

--- a/server/src/main/java/org/opensearch/search/profile/ContextualProfileBreakdown.java
+++ b/server/src/main/java/org/opensearch/search/profile/ContextualProfileBreakdown.java
@@ -18,7 +18,6 @@ import org.apache.lucene.search.Collector;
  * @opensearch.internal
  */
 public abstract class ContextualProfileBreakdown<T extends Enum<T>> extends AbstractProfileBreakdown<T> {
-
     public ContextualProfileBreakdown(Class<T> clazz) {
         super(clazz);
     }
@@ -30,7 +29,5 @@ public abstract class ContextualProfileBreakdown<T extends Enum<T>> extends Abst
      */
     public abstract AbstractProfileBreakdown<T> context(Object context);
 
-    public void associateLeafToCollector(LeafReaderContext leaf, Collector collector) {}
-
-    public void buildCollectorList(Collector collector) {}
+    public void associateCollectorToLeaves(LeafReaderContext leaf, Collector collector) {}
 }

--- a/server/src/main/java/org/opensearch/search/profile/ContextualProfileBreakdown.java
+++ b/server/src/main/java/org/opensearch/search/profile/ContextualProfileBreakdown.java
@@ -32,7 +32,7 @@ public abstract class ContextualProfileBreakdown<T extends Enum<T>> extends Abst
      */
     public abstract AbstractProfileBreakdown<T> context(Object context);
 
-    public void associateCollectorToLeaves(LeafReaderContext leaf, Collector collector) {}
+    public void associateCollectorToLeaves(Collector collector, LeafReaderContext leaf) {}
 
-    public void associateCollectorToLeaves(Map<String, List<LeafReaderContext>> collectorToLeaves) {}
+    public void associateCollectorToLeaves(Map<Collector, List<LeafReaderContext>> collectorToLeaves) {}
 }

--- a/server/src/main/java/org/opensearch/search/profile/ContextualProfileBreakdown.java
+++ b/server/src/main/java/org/opensearch/search/profile/ContextualProfileBreakdown.java
@@ -34,5 +34,5 @@ public abstract class ContextualProfileBreakdown<T extends Enum<T>> extends Abst
 
     public void associateCollectorToLeaves(Collector collector, LeafReaderContext leaf) {}
 
-    public void associateCollectorToLeaves(Map<Collector, List<LeafReaderContext>> collectorToLeaves) {}
+    public void associateCollectorsToLeaves(Map<Collector, List<LeafReaderContext>> collectorToLeaves) {}
 }

--- a/server/src/main/java/org/opensearch/search/profile/aggregation/AggregationProfileBreakdown.java
+++ b/server/src/main/java/org/opensearch/search/profile/aggregation/AggregationProfileBreakdown.java
@@ -34,7 +34,6 @@ package org.opensearch.search.profile.aggregation;
 
 import org.opensearch.search.profile.AbstractProfileBreakdown;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -60,21 +59,7 @@ public class AggregationProfileBreakdown extends AbstractProfileBreakdown<Aggreg
     }
 
     @Override
-    protected Map<String, Object> toDebugMap() {
+    public Map<String, Object> toDebugMap() {
         return unmodifiableMap(extra);
-    }
-
-    /**
-     * Build a timing count startTime breakdown for aggregation timing types
-     */
-    @Override
-    public Map<String, Long> toBreakdownMap() {
-        Map<String, Long> map = new HashMap<>(timings.length * 3);
-        for (AggregationTimingType timingType : timingTypes) {
-            map.put(timingType.toString(), timings[timingType.ordinal()].getApproximateTiming());
-            map.put(timingType + TIMING_TYPE_COUNT_SUFFIX, timings[timingType.ordinal()].getCount());
-            map.put(timingType + TIMING_TYPE_START_TIME_SUFFIX, timings[timingType.ordinal()].getEarliestTimerStartTime());
-        }
-        return Collections.unmodifiableMap(map);
     }
 }

--- a/server/src/main/java/org/opensearch/search/profile/query/AbstractQueryProfileTree.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/AbstractQueryProfileTree.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.profile.query;
+
+import org.apache.lucene.search.Query;
+import org.opensearch.search.profile.AbstractInternalProfileTree;
+import org.opensearch.search.profile.ContextualProfileBreakdown;
+import org.opensearch.search.profile.ProfileResult;
+
+/**
+ * This class tracks the dependency tree for queries (scoring and rewriting) and
+ * generates {@link QueryProfileBreakdown} for each node in the tree.  It also finalizes the tree
+ * and returns a list of {@link ProfileResult} that can be serialized back to the client
+ *
+ * @opensearch.internal
+ */
+public abstract class AbstractQueryProfileTree extends AbstractInternalProfileTree<ContextualProfileBreakdown<QueryTimingType>, Query> {
+
+    /** Rewrite time */
+    private long rewriteTime;
+    private long rewriteScratch;
+
+    @Override
+    protected String getTypeFromElement(Query query) {
+        // Anonymous classes won't have a name,
+        // we need to get the super class
+        if (query.getClass().getSimpleName().isEmpty()) {
+            return query.getClass().getSuperclass().getSimpleName();
+        }
+        return query.getClass().getSimpleName();
+    }
+
+    @Override
+    protected String getDescriptionFromElement(Query query) {
+        return query.toString();
+    }
+
+    /**
+     * Begin timing a query for a specific Timing context
+     */
+    public void startRewriteTime() {
+        assert rewriteScratch == 0;
+        rewriteScratch = System.nanoTime();
+    }
+
+    /**
+     * Halt the timing process and add the elapsed rewriting time.
+     * startRewriteTime() must be called for a particular context prior to calling
+     * stopAndAddRewriteTime(), otherwise the elapsed time will be negative and
+     * nonsensical
+     *
+     * @return          The elapsed time
+     */
+    public long stopAndAddRewriteTime() {
+        long time = Math.max(1, System.nanoTime() - rewriteScratch);
+        rewriteTime += time;
+        rewriteScratch = 0;
+        return time;
+    }
+
+    public long getRewriteTime() {
+        return rewriteTime;
+    }
+}

--- a/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdown.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdown.java
@@ -28,18 +28,18 @@ import java.util.concurrent.ConcurrentHashMap;
  * @opensearch.internal
  */
 public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBreakdown<QueryTimingType> {
-    private static final String SLICE_END_TIME_SUFFIX = "_slice_end_time";
-    private static final String SLICE_START_TIME_SUFFIX = "_slice_start_time";
-    private static final String MAX_PREFIX = "max_";
-    private static final String MIN_PREFIX = "min_";
-    private static final String AVG_PREFIX = "avg_";
+    static final String SLICE_END_TIME_SUFFIX = "_slice_end_time";
+    static final String SLICE_START_TIME_SUFFIX = "_slice_start_time";
+    static final String MAX_PREFIX = "max_";
+    static final String MIN_PREFIX = "min_";
+    static final String AVG_PREFIX = "avg_";
     private long queryNodeTime = Long.MIN_VALUE;
     private long maxSliceNodeTime = Long.MIN_VALUE;
     private long minSliceNodeTime = Long.MAX_VALUE;
     private long avgSliceNodeTime = 0L;
 
-    // keep track of all breakdown timings per segment
-    private final Map<Object, AbstractProfileBreakdown<QueryTimingType>> contexts = new ConcurrentHashMap<>();
+    // keep track of all breakdown timings per segment. package-private for testing
+    final Map<Object, AbstractProfileBreakdown<QueryTimingType>> contexts = new ConcurrentHashMap<>();
 
     // represents slice to leaves mapping as for each slice a unique collector instance is created
     private final Map<Collector, List<LeafReaderContext>> sliceCollectorToLeaves = new HashMap<>();
@@ -127,7 +127,7 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
      * @param createWeightStartTime start time when createWeight is called
      * @return map of collector (or slice) to breakdown map
      */
-    private Map<Collector, Map<String, Long>> buildSliceLevelBreakdown(long createWeightStartTime) {
+    Map<Collector, Map<String, Long>> buildSliceLevelBreakdown(long createWeightStartTime) {
         final Map<Collector, Map<String, Long>> sliceLevelBreakdowns = new HashMap<>();
         long totalSliceNodeTime = 0;
         for (Map.Entry<Collector, List<LeafReaderContext>> slice : sliceCollectorToLeaves.entrySet()) {
@@ -215,8 +215,8 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
     public Map<String, Long> buildQueryBreakdownMap(
         Map<Collector, Map<String, Long>> sliceLevelBreakdowns,
         long createWeightTime,
-        long createWeightStartTime)
-    {
+        long createWeightStartTime
+    ) {
         final Map<String, Long> queryBreakdownMap = new HashMap<>();
         long queryEndTime = Long.MIN_VALUE;
         for (QueryTimingType queryTimingType : QueryTimingType.values()) {

--- a/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdown.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdown.java
@@ -8,10 +8,14 @@
 
 package org.opensearch.search.profile.query;
 
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.Collector;
 import org.opensearch.search.profile.AbstractProfileBreakdown;
 import org.opensearch.search.profile.ContextualProfileBreakdown;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -23,7 +27,22 @@ import java.util.concurrent.ConcurrentHashMap;
  * @opensearch.internal
  */
 public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBreakdown<QueryTimingType> {
+    public static final String MAX_END_TIME_SUFFIX = "_max_end_time";
+    public static final String MIN_START_TIME_SUFFIX = "_min_start_time";
+    private static final String AT = "@";
+    private static final String LATEST_LEAF_END_TIME = "latest_leaf_end_time";
+    private static final String MAX_PREFIX = "max_";
+    private static final String MIN_PREFIX = "min_";
+    private static final String AVG_PREFIX = "avg_";
+    private static long breakdownMaxEndTime = 0;
+    private static long breakdownMinStartTime = Long.MAX_VALUE;
+    private static long maxSliceNodeTime = Long.MIN_VALUE;
+    private static long minSliceNodeTime = Long.MAX_VALUE;
+    private static long avgSliceNodeTime = 0L;
+    private static long nodeTimeSum = 0L;
     private final Map<Object, AbstractProfileBreakdown<QueryTimingType>> contexts = new ConcurrentHashMap<>();
+    private List<String> collectorList = new ArrayList<>();
+    private Map<LeafReaderContext, String> leafToCollector = new HashMap<>();
 
     /** Sole constructor. */
     public ConcurrentQueryProfileBreakdown() {
@@ -46,12 +65,177 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
     public Map<String, Long> toBreakdownMap() {
         final Map<String, Long> map = new HashMap<>(super.toBreakdownMap());
 
-        for (final AbstractProfileBreakdown<QueryTimingType> context : contexts.values()) {
-            for (final Map.Entry<String, Long> entry : context.toBreakdownMap().entrySet()) {
-                map.merge(entry.getKey(), entry.getValue(), Long::sum);
+        for (final Map.Entry<Object, AbstractProfileBreakdown<QueryTimingType>> context : contexts.entrySet()) {
+            Map<String, Long> breakdown = context.getValue().toBreakdownMap();
+            String collector = leafToCollector.get(context.getKey());
+            for (final Map.Entry<String, Long> entry : breakdown.entrySet()) {
+                String breakdownType = entry.getKey();
+                Long breakdownValue = entry.getValue();
+                // Adding breakdown type count
+                if (breakdownType.contains(TIMING_TYPE_COUNT_SUFFIX)) {
+                    map.merge(breakdownType, breakdownValue, Long::sum);
+                }
+                // Adding slice level breakdown
+                if (!breakdownType.contains(TIMING_TYPE_START_TIME_SUFFIX)) {
+                    String sliceLevelBreakdownType = breakdownType + AT + collector;
+                    map.put(sliceLevelBreakdownType, map.getOrDefault(sliceLevelBreakdownType, 0L) + breakdownValue);
+                }
+            }
+            addMaxEndTimeAndMinStartTime(map, breakdown);
+            // Adding slice level latest leaf end time
+            long currentLeafEndTime = 0L;
+            for (QueryTimingType queryTimingType : QueryTimingType.values()) {
+                String timingType = queryTimingType.toString();
+                String timingTypeStartTime = timingType + AbstractProfileBreakdown.TIMING_TYPE_START_TIME_SUFFIX;
+                currentLeafEndTime = Math.max(currentLeafEndTime, breakdown.get(timingTypeStartTime) + breakdown.get(timingType));
+            }
+            String latestLeafEndTime = LATEST_LEAF_END_TIME + AT + collector;
+            map.put(latestLeafEndTime, Math.max(map.getOrDefault(latestLeafEndTime, 0L), currentLeafEndTime));
+        }
+        return buildQueryProfileBreakdownMap(map);
+    }
+
+    /**
+     * This method is used to bring the max end time and min start time fields to the query profile breakdown.
+     *
+     * @param  map  the query level timing count breakdown for current instance
+     * @param  breakdown the segment level timing count breakdown for current instance
+     */
+    void addMaxEndTimeAndMinStartTime(Map<String, Long> map, Map<String, Long> breakdown) {
+        for (QueryTimingType queryTimingType : QueryTimingType.values()) {
+            String timingType = queryTimingType.toString();
+            String timingTypeStartTime = timingType + AbstractProfileBreakdown.TIMING_TYPE_START_TIME_SUFFIX;
+            long currentMaxEndTime = map.getOrDefault(timingType + MAX_END_TIME_SUFFIX, 0L);
+            long currentMinStartTime = map.getOrDefault(timingType + MIN_START_TIME_SUFFIX, Long.MAX_VALUE);
+            // Only "create_weight" is performed at the query level
+            Map<String, Long> source = timingType.equals(QueryTimingType.CREATE_WEIGHT.toString()) ? map : breakdown;
+            long maxEndTime = Math.max(currentMaxEndTime, source.get(timingTypeStartTime) + source.get(timingType));
+            long minStartTime = Math.min(currentMinStartTime, source.get(timingTypeStartTime));
+            map.put(timingType + MAX_END_TIME_SUFFIX, maxEndTime);
+            map.put(timingType + MIN_START_TIME_SUFFIX, minStartTime);
+        }
+    }
+
+    /**
+     * This method is used to construct the final query profile breakdown map for return.
+     *
+     * @param  map  a timing count breakdown map with the max end time and min start time information
+     */
+    Map<String, Long> buildQueryProfileBreakdownMap(Map<String, Long> map) {
+        final Map<String, Long> breakdownMap = new HashMap<>();
+        int collectorListSize = collectorList.size();
+        // Calculating the total time stats for the query
+        if (collectorList != null && !collectorList.isEmpty()) {
+            for (String collector : collectorList) {
+                Long latestLeafEndTime = map.get(LATEST_LEAF_END_TIME + AT + collector);
+                if (latestLeafEndTime != null) {
+                    Long currentSliceNodeTime = latestLeafEndTime - map.get(
+                        QueryTimingType.CREATE_WEIGHT + AbstractProfileBreakdown.TIMING_TYPE_START_TIME_SUFFIX
+                    );
+                    maxSliceNodeTime = Math.max(maxSliceNodeTime, currentSliceNodeTime);
+                    minSliceNodeTime = Math.min(minSliceNodeTime, currentSliceNodeTime);
+                    nodeTimeSum += currentSliceNodeTime;
+                }
+            }
+            avgSliceNodeTime = nodeTimeSum / collectorListSize;
+        }
+        for (QueryTimingType timingType : QueryTimingType.values()) {
+            // Computing the total time for each breakdown including any wait time
+            String type = timingType.toString();
+            String timingTypeStartTime = type + AbstractProfileBreakdown.TIMING_TYPE_START_TIME_SUFFIX;
+            Long timingTypeMaxEndTime = map.getOrDefault(type + MAX_END_TIME_SUFFIX, map.get(timingTypeStartTime) + map.get(type));
+            Long timingTypeMinStartTime = map.getOrDefault(type + MIN_START_TIME_SUFFIX, map.get(timingTypeStartTime));
+            breakdownMap.put(type, timingTypeMaxEndTime - timingTypeMinStartTime);
+            breakdownMap.put(type + TIMING_TYPE_COUNT_SUFFIX, map.get(type + TIMING_TYPE_COUNT_SUFFIX));
+            // Computing the max end time and min start time for the query
+            breakdownMaxEndTime = Math.max(breakdownMaxEndTime, timingTypeMaxEndTime);
+            if (timingTypeMaxEndTime != 0L && timingTypeMinStartTime != 0L) {
+                breakdownMinStartTime = Math.min(breakdownMinStartTime, timingTypeMinStartTime);
+            }
+            // Computing the time/count stats for each breakdown across all slices
+            if (collectorList != null && !collectorList.isEmpty() && !type.contains(QueryTimingType.CREATE_WEIGHT.toString())) {
+                String maxSliceTypeTime = MAX_PREFIX + type;
+                String minSliceTypeTime = MIN_PREFIX + type;
+                String avgSliceTypeTime = AVG_PREFIX + type;
+                String maxSliceTypeCount = maxSliceTypeTime + TIMING_TYPE_COUNT_SUFFIX;
+                String minSliceTypeCount = minSliceTypeTime + TIMING_TYPE_COUNT_SUFFIX;
+                String avgSliceTypeCount = avgSliceTypeTime + TIMING_TYPE_COUNT_SUFFIX;
+                Long totalBreakdownTime = 0L;
+                Long totalBreakdownCount = 0L;
+                for (String collector : collectorList) {
+                    Long breakdownTime = map.get(type + AT + collector);
+                    Long breakdownCount = map.get(type + TIMING_TYPE_COUNT_SUFFIX + AT + collector);
+                    totalBreakdownTime = constructStatResults(
+                        breakdownMap,
+                        maxSliceTypeTime,
+                        minSliceTypeTime,
+                        totalBreakdownTime,
+                        breakdownTime
+                    );
+                    totalBreakdownCount = constructStatResults(
+                        breakdownMap,
+                        maxSliceTypeCount,
+                        minSliceTypeCount,
+                        totalBreakdownCount,
+                        breakdownCount
+                    );
+                }
+                breakdownMap.put(avgSliceTypeTime, totalBreakdownTime / collectorListSize);
+                breakdownMap.put(avgSliceTypeCount, totalBreakdownCount / collectorListSize);
             }
         }
+        return breakdownMap;
+    }
 
-        return map;
+    private Long constructStatResults(
+        Map<String, Long> breakdownMap,
+        String maxSliceTypeName,
+        String minSliceTypeName,
+        Long totalBreakdown,
+        Long breakdown
+    ) {
+        if (breakdown == null) {
+            breakdownMap.put(maxSliceTypeName, null);
+            breakdownMap.put(minSliceTypeName, null);
+        } else {
+            breakdownMap.put(maxSliceTypeName, Math.max(breakdownMap.getOrDefault(maxSliceTypeName, Long.MIN_VALUE), breakdown));
+            breakdownMap.put(minSliceTypeName, Math.min(breakdownMap.getOrDefault(minSliceTypeName, Long.MAX_VALUE), breakdown));
+            totalBreakdown += breakdown;
+        }
+        return totalBreakdown;
+    }
+
+    @Override
+    public long toNodeTime() {
+        return breakdownMaxEndTime - breakdownMinStartTime;
+    }
+
+    @Override
+    public Long getMaxSliceNodeTime() {
+        return maxSliceNodeTime;
+    }
+
+    @Override
+    public Long getMinSliceNodeTime() {
+        return minSliceNodeTime;
+    }
+
+    @Override
+    public Long getAvgSliceNodeTime() {
+        return avgSliceNodeTime;
+    }
+
+    @Override
+    public void associateLeafToCollector(LeafReaderContext leaf, Collector collector) {
+        if (collector != null) {
+            leafToCollector.put(leaf, collector.toString());
+        }
+    }
+
+    @Override
+    public void buildCollectorList(Collector collector) {
+        if (collector != null) {
+            collectorList.add(collector.toString());
+        }
     }
 }

--- a/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdown.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdown.java
@@ -14,6 +14,7 @@ import org.opensearch.search.profile.AbstractProfileBreakdown;
 import org.opensearch.search.profile.ContextualProfileBreakdown;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -227,5 +228,14 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
             leaves.add(leaf);
             collectorToLeaves.put(collectorManager, leaves);
         }
+    }
+
+    @Override
+    public void associateCollectorToLeaves(Map<String, List<LeafReaderContext>> collectorToLeaves) {
+        this.collectorToLeaves.putAll(collectorToLeaves);
+    }
+
+    Map<String, List<LeafReaderContext>> getCollectorToLeaves() {
+        return Collections.unmodifiableMap(collectorToLeaves);
     }
 }

--- a/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdown.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdown.java
@@ -29,20 +29,17 @@ import java.util.concurrent.ConcurrentHashMap;
 public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBreakdown<QueryTimingType> {
     public static final String MAX_END_TIME_SUFFIX = "_max_end_time";
     public static final String MIN_START_TIME_SUFFIX = "_min_start_time";
-    private static final String AT = "@";
-    private static final String LATEST_LEAF_END_TIME = "latest_leaf_end_time";
     private static final String MAX_PREFIX = "max_";
     private static final String MIN_PREFIX = "min_";
     private static final String AVG_PREFIX = "avg_";
-    private static long breakdownMaxEndTime = 0;
-    private static long breakdownMinStartTime = Long.MAX_VALUE;
-    private static long maxSliceNodeTime = Long.MIN_VALUE;
-    private static long minSliceNodeTime = Long.MAX_VALUE;
-    private static long avgSliceNodeTime = 0L;
-    private static long nodeTimeSum = 0L;
+    private long breakdownMaxEndTime = Long.MIN_VALUE;
+    private long breakdownMinStartTime = Long.MAX_VALUE;
+    private long maxSliceNodeTime = Long.MIN_VALUE;
+    private long minSliceNodeTime = Long.MAX_VALUE;
+    private long avgSliceNodeTime = 0L;
+    private long nodeTimeSum = 0L;
     private final Map<Object, AbstractProfileBreakdown<QueryTimingType>> contexts = new ConcurrentHashMap<>();
-    private List<String> collectorList = new ArrayList<>();
-    private Map<LeafReaderContext, String> leafToCollector = new HashMap<>();
+    private Map<String, List<LeafReaderContext>> collectorToLeaves = new HashMap<>();
 
     /** Sole constructor. */
     public ConcurrentQueryProfileBreakdown() {
@@ -63,146 +60,146 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
 
     @Override
     public Map<String, Long> toBreakdownMap() {
-        final Map<String, Long> map = new HashMap<>(super.toBreakdownMap());
-
-        for (final Map.Entry<Object, AbstractProfileBreakdown<QueryTimingType>> context : contexts.entrySet()) {
-            Map<String, Long> breakdown = context.getValue().toBreakdownMap();
-            String collector = leafToCollector.get(context.getKey());
-            for (final Map.Entry<String, Long> entry : breakdown.entrySet()) {
-                String breakdownType = entry.getKey();
-                Long breakdownValue = entry.getValue();
-                // Adding breakdown type count
-                if (breakdownType.contains(TIMING_TYPE_COUNT_SUFFIX)) {
-                    map.merge(breakdownType, breakdownValue, Long::sum);
+        Map<String, Map<String, Long>> sliceLevelBreakdown = new HashMap<>();
+        if (collectorToLeaves == null || collectorToLeaves.isEmpty() || contexts.isEmpty()) {
+            return new HashMap<>(super.toBreakdownMap());
+        }
+        for (Map.Entry<String, List<LeafReaderContext>> slice : collectorToLeaves.entrySet()) {
+            String sliceCollector = slice.getKey();
+            List<LeafReaderContext> leaves = slice.getValue();
+            long lastLeafEndTime = 0L;
+            for (LeafReaderContext leaf : leaves) {
+                long currentLeafEndTime = 0L;
+                Map<String, Long> currentLeafBreakdownMap = contexts.get(leaf).toBreakdownMap();
+                for (Map.Entry<String, Long> breakDownEntry : currentLeafBreakdownMap.entrySet()) {
+                    Map<String, Long> currentSliceBreakdown = sliceLevelBreakdown.getOrDefault(
+                        sliceCollector,
+                        new HashMap<>(super.toBreakdownMap())
+                    );
+                    String breakdownType = breakDownEntry.getKey();
+                    Long breakdownValue = breakDownEntry.getValue();
+                    // Adding breakdown type count
+                    if (breakdownType.contains(TIMING_TYPE_COUNT_SUFFIX)) {
+                        currentSliceBreakdown.merge(breakdownType, breakdownValue, Long::sum);
+                    }
+                    if (breakdownType.contains(TIMING_TYPE_START_TIME_SUFFIX)) {
+                        // Finding the earliest start time and the last end time for each breakdown types within the current slice to
+                        // compute the total breakdown time
+                        String method = breakdownType.split(TIMING_TYPE_START_TIME_SUFFIX)[0];
+                        String maxEndTimeKey = method + MAX_END_TIME_SUFFIX;
+                        String minStartTimeKey = method + MIN_START_TIME_SUFFIX;
+                        long maxEndTime = Math.max(
+                            currentSliceBreakdown.getOrDefault(maxEndTimeKey, Long.MIN_VALUE),
+                            breakdownValue + currentLeafBreakdownMap.get(method)
+                        );
+                        long minStartTime = Math.min(currentSliceBreakdown.getOrDefault(minStartTimeKey, Long.MAX_VALUE), breakdownValue);
+                        currentSliceBreakdown.put(maxEndTimeKey, maxEndTime);
+                        currentSliceBreakdown.put(minStartTimeKey, minStartTime);
+                        // Finding the current leaf end time to compute the last leaf end time
+                        currentLeafEndTime = Math.max(currentLeafEndTime, maxEndTime);
+                    }
+                    sliceLevelBreakdown.put(sliceCollector, currentSliceBreakdown);
                 }
-                // Adding slice level breakdown
-                if (!breakdownType.contains(TIMING_TYPE_START_TIME_SUFFIX)) {
-                    String sliceLevelBreakdownType = breakdownType + AT + collector;
-                    map.put(sliceLevelBreakdownType, map.getOrDefault(sliceLevelBreakdownType, 0L) + breakdownValue);
-                }
+                lastLeafEndTime = Math.max(lastLeafEndTime, currentLeafEndTime);
             }
-            addMaxEndTimeAndMinStartTime(map, breakdown);
-            // Adding slice level latest leaf end time
-            long currentLeafEndTime = 0L;
+            // Computing breakdown type total time
             for (QueryTimingType queryTimingType : QueryTimingType.values()) {
                 String timingType = queryTimingType.toString();
-                String timingTypeStartTime = timingType + AbstractProfileBreakdown.TIMING_TYPE_START_TIME_SUFFIX;
-                currentLeafEndTime = Math.max(currentLeafEndTime, breakdown.get(timingTypeStartTime) + breakdown.get(timingType));
+                if (queryTimingType != QueryTimingType.CREATE_WEIGHT) {
+                    long currentSliceMaxEndTime = sliceLevelBreakdown.get(sliceCollector).get(timingType + MAX_END_TIME_SUFFIX);
+                    long currentSliceMinStartTime = sliceLevelBreakdown.get(sliceCollector).get(timingType + MIN_START_TIME_SUFFIX);
+                    sliceLevelBreakdown.get(sliceCollector).put(timingType, currentSliceMaxEndTime - currentSliceMinStartTime);
+                }
             }
-            String latestLeafEndTime = LATEST_LEAF_END_TIME + AT + collector;
-            map.put(latestLeafEndTime, Math.max(map.getOrDefault(latestLeafEndTime, 0L), currentLeafEndTime));
+            // Computing slice level node time and stats
+            long createWeightStartTime = sliceLevelBreakdown.get(sliceCollector)
+                .get(QueryTimingType.CREATE_WEIGHT + AbstractProfileBreakdown.TIMING_TYPE_START_TIME_SUFFIX);
+            breakdownMaxEndTime = Math.max(breakdownMaxEndTime, lastLeafEndTime);
+            breakdownMinStartTime = createWeightStartTime;
+            long currentSliceNodeTime = lastLeafEndTime - createWeightStartTime;
+            maxSliceNodeTime = Math.max(maxSliceNodeTime, currentSliceNodeTime);
+            minSliceNodeTime = Math.min(minSliceNodeTime, currentSliceNodeTime);
+            nodeTimeSum += currentSliceNodeTime;
         }
-        return buildQueryProfileBreakdownMap(map);
-    }
-
-    /**
-     * This method is used to bring the max end time and min start time fields to the query profile breakdown.
-     *
-     * @param  map  the query level timing count breakdown for current instance
-     * @param  breakdown the segment level timing count breakdown for current instance
-     */
-    void addMaxEndTimeAndMinStartTime(Map<String, Long> map, Map<String, Long> breakdown) {
-        for (QueryTimingType queryTimingType : QueryTimingType.values()) {
-            String timingType = queryTimingType.toString();
-            String timingTypeStartTime = timingType + AbstractProfileBreakdown.TIMING_TYPE_START_TIME_SUFFIX;
-            long currentMaxEndTime = map.getOrDefault(timingType + MAX_END_TIME_SUFFIX, 0L);
-            long currentMinStartTime = map.getOrDefault(timingType + MIN_START_TIME_SUFFIX, Long.MAX_VALUE);
-            // Only "create_weight" is performed at the query level
-            Map<String, Long> source = timingType.equals(QueryTimingType.CREATE_WEIGHT.toString()) ? map : breakdown;
-            long maxEndTime = Math.max(currentMaxEndTime, source.get(timingTypeStartTime) + source.get(timingType));
-            long minStartTime = Math.min(currentMinStartTime, source.get(timingTypeStartTime));
-            map.put(timingType + MAX_END_TIME_SUFFIX, maxEndTime);
-            map.put(timingType + MIN_START_TIME_SUFFIX, minStartTime);
-        }
+        // Computing avg slice node time
+        avgSliceNodeTime = nodeTimeSum / collectorToLeaves.size();
+        return buildFinalBreakdownMap(sliceLevelBreakdown);
     }
 
     /**
      * This method is used to construct the final query profile breakdown map for return.
      *
-     * @param  map  a timing count breakdown map with the max end time and min start time information
+     * @param  sliceLevelBreakdown a timing count breakdown map with the max end time and min start time information
      */
-    Map<String, Long> buildQueryProfileBreakdownMap(Map<String, Long> map) {
+    Map<String, Long> buildFinalBreakdownMap(Map<String, Map<String, Long>> sliceLevelBreakdown) {
         final Map<String, Long> breakdownMap = new HashMap<>();
-        int collectorListSize = collectorList.size();
-        // Calculating the total time stats for the query
-        if (collectorList != null && !collectorList.isEmpty()) {
-            for (String collector : collectorList) {
-                Long latestLeafEndTime = map.get(LATEST_LEAF_END_TIME + AT + collector);
-                if (latestLeafEndTime != null) {
-                    Long currentSliceNodeTime = latestLeafEndTime - map.get(
-                        QueryTimingType.CREATE_WEIGHT + AbstractProfileBreakdown.TIMING_TYPE_START_TIME_SUFFIX
+        final Map<String, Long> totalTimeMap = new HashMap<>();
+        int sliceCount = sliceLevelBreakdown.size();
+        for (Map.Entry<String, Map<String, Long>> slice : sliceLevelBreakdown.entrySet()) {
+            for (QueryTimingType queryTimingType : QueryTimingType.values()) {
+                String timingType = queryTimingType.toString();
+                // Computing the time/count stats for each breakdown across all slices
+                if (queryTimingType != QueryTimingType.CREATE_WEIGHT) {
+                    String maxBreakdownTypeTime = MAX_PREFIX + timingType;
+                    String minBreakdownTypeTime = MIN_PREFIX + timingType;
+                    String avgBreakdownTypeTime = AVG_PREFIX + timingType;
+                    String maxBreakdownTypeCount = maxBreakdownTypeTime + TIMING_TYPE_COUNT_SUFFIX;
+                    String minBreakdownTypeCount = minBreakdownTypeTime + TIMING_TYPE_COUNT_SUFFIX;
+                    String avgBreakdownTypeCount = avgBreakdownTypeTime + TIMING_TYPE_COUNT_SUFFIX;
+                    Long breakdownTime = slice.getValue().get(timingType);
+                    Long breakdownCount = slice.getValue().get(timingType + TIMING_TYPE_COUNT_SUFFIX);
+                    breakdownMap.put(
+                        maxBreakdownTypeTime,
+                        Math.max(breakdownMap.getOrDefault(maxBreakdownTypeTime, Long.MIN_VALUE), breakdownTime)
                     );
-                    maxSliceNodeTime = Math.max(maxSliceNodeTime, currentSliceNodeTime);
-                    minSliceNodeTime = Math.min(minSliceNodeTime, currentSliceNodeTime);
-                    nodeTimeSum += currentSliceNodeTime;
+                    breakdownMap.put(
+                        minBreakdownTypeTime,
+                        Math.min(breakdownMap.getOrDefault(minBreakdownTypeTime, Long.MAX_VALUE), breakdownTime)
+                    );
+                    breakdownMap.put(avgBreakdownTypeTime, breakdownMap.getOrDefault(avgBreakdownTypeTime, 0L) + breakdownTime);
+                    breakdownMap.put(
+                        maxBreakdownTypeCount,
+                        Math.max(breakdownMap.getOrDefault(maxBreakdownTypeCount, Long.MIN_VALUE), breakdownCount)
+                    );
+                    breakdownMap.put(
+                        minBreakdownTypeCount,
+                        Math.min(breakdownMap.getOrDefault(minBreakdownTypeCount, Long.MAX_VALUE), breakdownCount)
+                    );
+                    breakdownMap.put(avgBreakdownTypeCount, breakdownMap.getOrDefault(avgBreakdownTypeCount, 0L) + breakdownCount);
+                }
+                // Finding the max slice end time and min slice start time to compute total time
+                String maxEndTime = timingType + MAX_END_TIME_SUFFIX;
+                String minStartTime = timingType + MIN_START_TIME_SUFFIX;
+                Long maxEndTimeValue = slice.getValue().get(timingType + MAX_END_TIME_SUFFIX);
+                Long minStartTimeValue = slice.getValue().get(timingType + MIN_START_TIME_SUFFIX);
+                totalTimeMap.put(maxEndTime, Math.max(totalTimeMap.getOrDefault(maxEndTime, Long.MIN_VALUE), maxEndTimeValue));
+                totalTimeMap.put(minStartTime, Math.min(totalTimeMap.getOrDefault(minStartTime, Long.MAX_VALUE), minStartTimeValue));
+                // Computing the total count for each breakdown across all slices
+                String breakdownCount = timingType + TIMING_TYPE_COUNT_SUFFIX;
+                Long breakdownCountValue = slice.getValue().get(breakdownCount);
+                if (queryTimingType != QueryTimingType.CREATE_WEIGHT) {
+                    breakdownMap.put(breakdownCount, breakdownMap.getOrDefault(breakdownCount, 0L) + breakdownCountValue);
+                } else {
+                    breakdownMap.put(breakdownCount, 1L);
+                    breakdownMap.put(timingType, slice.getValue().get(timingType));
                 }
             }
-            avgSliceNodeTime = nodeTimeSum / collectorListSize;
         }
-        for (QueryTimingType timingType : QueryTimingType.values()) {
-            // Computing the total time for each breakdown including any wait time
-            String type = timingType.toString();
-            String timingTypeStartTime = type + AbstractProfileBreakdown.TIMING_TYPE_START_TIME_SUFFIX;
-            Long timingTypeMaxEndTime = map.getOrDefault(type + MAX_END_TIME_SUFFIX, map.get(timingTypeStartTime) + map.get(type));
-            Long timingTypeMinStartTime = map.getOrDefault(type + MIN_START_TIME_SUFFIX, map.get(timingTypeStartTime));
-            breakdownMap.put(type, timingTypeMaxEndTime - timingTypeMinStartTime);
-            breakdownMap.put(type + TIMING_TYPE_COUNT_SUFFIX, map.get(type + TIMING_TYPE_COUNT_SUFFIX));
-            // Computing the max end time and min start time for the query
-            breakdownMaxEndTime = Math.max(breakdownMaxEndTime, timingTypeMaxEndTime);
-            if (timingTypeMaxEndTime != 0L && timingTypeMinStartTime != 0L) {
-                breakdownMinStartTime = Math.min(breakdownMinStartTime, timingTypeMinStartTime);
-            }
-            // Computing the time/count stats for each breakdown across all slices
-            if (collectorList != null && !collectorList.isEmpty() && !type.contains(QueryTimingType.CREATE_WEIGHT.toString())) {
-                String maxSliceTypeTime = MAX_PREFIX + type;
-                String minSliceTypeTime = MIN_PREFIX + type;
-                String avgSliceTypeTime = AVG_PREFIX + type;
-                String maxSliceTypeCount = maxSliceTypeTime + TIMING_TYPE_COUNT_SUFFIX;
-                String minSliceTypeCount = minSliceTypeTime + TIMING_TYPE_COUNT_SUFFIX;
-                String avgSliceTypeCount = avgSliceTypeTime + TIMING_TYPE_COUNT_SUFFIX;
-                Long totalBreakdownTime = 0L;
-                Long totalBreakdownCount = 0L;
-                for (String collector : collectorList) {
-                    Long breakdownTime = map.get(type + AT + collector);
-                    Long breakdownCount = map.get(type + TIMING_TYPE_COUNT_SUFFIX + AT + collector);
-                    totalBreakdownTime = constructStatResults(
-                        breakdownMap,
-                        maxSliceTypeTime,
-                        minSliceTypeTime,
-                        totalBreakdownTime,
-                        breakdownTime
-                    );
-                    totalBreakdownCount = constructStatResults(
-                        breakdownMap,
-                        maxSliceTypeCount,
-                        minSliceTypeCount,
-                        totalBreakdownCount,
-                        breakdownCount
-                    );
-                }
-                breakdownMap.put(avgSliceTypeTime, totalBreakdownTime / collectorListSize);
-                breakdownMap.put(avgSliceTypeCount, totalBreakdownCount / collectorListSize);
+        for (QueryTimingType queryTimingType : QueryTimingType.values()) {
+            String timingType = queryTimingType.toString();
+            if (queryTimingType != QueryTimingType.CREATE_WEIGHT) {
+                // Computing avg time/count stats
+                String avgBreakdownTypeTime = AVG_PREFIX + timingType;
+                String avgBreakdownTypeCount = avgBreakdownTypeTime + TIMING_TYPE_COUNT_SUFFIX;
+                breakdownMap.put(avgBreakdownTypeTime, breakdownMap.get(avgBreakdownTypeTime) / sliceCount);
+                breakdownMap.put(avgBreakdownTypeCount, breakdownMap.get(avgBreakdownTypeCount) / sliceCount);
+                // Computing total time for each breakdown including any wait time
+                Long maxSliceEndTime = totalTimeMap.get(timingType + MAX_END_TIME_SUFFIX);
+                Long mingSliceStartTime = totalTimeMap.get(timingType + MIN_START_TIME_SUFFIX);
+                breakdownMap.put(timingType, maxSliceEndTime - mingSliceStartTime);
             }
         }
         return breakdownMap;
-    }
-
-    private Long constructStatResults(
-        Map<String, Long> breakdownMap,
-        String maxSliceTypeName,
-        String minSliceTypeName,
-        Long totalBreakdown,
-        Long breakdown
-    ) {
-        if (breakdown == null) {
-            breakdownMap.put(maxSliceTypeName, null);
-            breakdownMap.put(minSliceTypeName, null);
-        } else {
-            breakdownMap.put(maxSliceTypeName, Math.max(breakdownMap.getOrDefault(maxSliceTypeName, Long.MIN_VALUE), breakdown));
-            breakdownMap.put(minSliceTypeName, Math.min(breakdownMap.getOrDefault(minSliceTypeName, Long.MAX_VALUE), breakdown));
-            totalBreakdown += breakdown;
-        }
-        return totalBreakdown;
     }
 
     @Override
@@ -210,32 +207,25 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
         return breakdownMaxEndTime - breakdownMinStartTime;
     }
 
-    @Override
     public Long getMaxSliceNodeTime() {
         return maxSliceNodeTime;
     }
 
-    @Override
     public Long getMinSliceNodeTime() {
         return minSliceNodeTime;
     }
 
-    @Override
     public Long getAvgSliceNodeTime() {
         return avgSliceNodeTime;
     }
 
     @Override
-    public void associateLeafToCollector(LeafReaderContext leaf, Collector collector) {
+    public void associateCollectorToLeaves(LeafReaderContext leaf, Collector collector) {
         if (collector != null) {
-            leafToCollector.put(leaf, collector.toString());
-        }
-    }
-
-    @Override
-    public void buildCollectorList(Collector collector) {
-        if (collector != null) {
-            collectorList.add(collector.toString());
+            String collectorManager = collector.toString();
+            List<LeafReaderContext> leaves = collectorToLeaves.getOrDefault(collectorManager, new ArrayList<>());
+            leaves.add(leaf);
+            collectorToLeaves.put(collectorManager, leaves);
         }
     }
 }

--- a/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileTree.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileTree.java
@@ -8,10 +8,12 @@
 
 package org.opensearch.search.profile.query;
 
+import org.apache.lucene.index.LeafReaderContext;
 import org.opensearch.search.profile.ContextualProfileBreakdown;
 import org.opensearch.search.profile.ProfileResult;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * This class returns a list of {@link ProfileResult} that can be serialized back to the client in the concurrent execution.
@@ -45,5 +47,44 @@ public class ConcurrentQueryProfileTree extends AbstractQueryProfileTree {
             concurrentBreakdown.getMinSliceNodeTime(),
             concurrentBreakdown.getAvgSliceNodeTime()
         );
+    }
+
+    /**
+     * For concurrent query case, when there are nested queries (with children), then the {@link ConcurrentQueryProfileBreakdown} created
+     * for the child queries weight doesn't have the association of collector to leaves. This is because child query weights are not
+     * exposed by the {@link org.apache.lucene.search.Weight} interface. So after all the collection is happened and before the result
+     * tree is created we need to pass the association from parent to the child breakdowns. This will be then used to create the
+     * breakdown map at slice level for the child queries as well
+     *
+     * @return a hierarchical representation of the profiled query tree
+     */
+    @Override
+    public List<ProfileResult> getTree() {
+        for (Integer root : roots) {
+            final ContextualProfileBreakdown<QueryTimingType> parentBreakdown = breakdowns.get(root);
+            assert parentBreakdown instanceof ConcurrentQueryProfileBreakdown;
+            final Map<String, List<LeafReaderContext>> parentCollectorToLeaves = ((ConcurrentQueryProfileBreakdown) parentBreakdown)
+                .getCollectorToLeaves();
+            // update all the children with the parent collectorToLeaves association
+            updateCollectorToLeavesForChildBreakdowns(root, parentCollectorToLeaves);
+        }
+        // once the collector to leaves mapping is updated, get the result
+        return super.getTree();
+    }
+
+    /**
+     * Updates the children with collector to leaves mapping as recorded by parent breakdown
+     * @param parentToken parent token number in the tree
+     * @param collectorToLeaves collector to leaves mapping recorded by parent
+     */
+    private void updateCollectorToLeavesForChildBreakdowns(Integer parentToken, Map<String, List<LeafReaderContext>> collectorToLeaves) {
+        final List<Integer> children = tree.get(parentToken);
+        if (children != null) {
+            for (Integer currentChild : children) {
+                final ContextualProfileBreakdown<QueryTimingType> currentChildBreakdown = breakdowns.get(currentChild);
+                currentChildBreakdown.associateCollectorToLeaves(collectorToLeaves);
+                updateCollectorToLeavesForChildBreakdowns(currentChild, collectorToLeaves);
+            }
+        }
     }
 }

--- a/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileTree.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileTree.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.profile.query;
+
+import org.opensearch.search.profile.ContextualProfileBreakdown;
+import org.opensearch.search.profile.ProfileResult;
+
+import java.util.List;
+
+/**
+ * This class returns a list of {@link ProfileResult} that can be serialized back to the client in the concurrent execution.
+ *
+ * @opensearch.internal
+ */
+public class ConcurrentQueryProfileTree extends AbstractQueryProfileTree {
+
+    @Override
+    protected ContextualProfileBreakdown<QueryTimingType> createProfileBreakdown() {
+        return new ConcurrentQueryProfileBreakdown();
+    }
+
+    @Override
+    protected ProfileResult createProfileResult(
+        String type,
+        String description,
+        ContextualProfileBreakdown<QueryTimingType> breakdown,
+        List<ProfileResult> childrenProfileResults
+    ) {
+        assert breakdown instanceof ConcurrentQueryProfileBreakdown;
+        final ConcurrentQueryProfileBreakdown concurrentBreakdown = (ConcurrentQueryProfileBreakdown) breakdown;
+        return new ProfileResult(
+            type,
+            description,
+            concurrentBreakdown.toBreakdownMap(),
+            concurrentBreakdown.toDebugMap(),
+            concurrentBreakdown.toNodeTime(),
+            childrenProfileResults,
+            concurrentBreakdown.getMaxSliceNodeTime(),
+            concurrentBreakdown.getMinSliceNodeTime(),
+            concurrentBreakdown.getAvgSliceNodeTime()
+        );
+    }
+}

--- a/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileTree.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileTree.java
@@ -9,6 +9,7 @@
 package org.opensearch.search.profile.query;
 
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.Collector;
 import org.opensearch.search.profile.ContextualProfileBreakdown;
 import org.opensearch.search.profile.ProfileResult;
 
@@ -63,8 +64,8 @@ public class ConcurrentQueryProfileTree extends AbstractQueryProfileTree {
         for (Integer root : roots) {
             final ContextualProfileBreakdown<QueryTimingType> parentBreakdown = breakdowns.get(root);
             assert parentBreakdown instanceof ConcurrentQueryProfileBreakdown;
-            final Map<String, List<LeafReaderContext>> parentCollectorToLeaves = ((ConcurrentQueryProfileBreakdown) parentBreakdown)
-                .getCollectorToLeaves();
+            final Map<Collector, List<LeafReaderContext>> parentCollectorToLeaves = ((ConcurrentQueryProfileBreakdown) parentBreakdown)
+                .getSliceCollectorToLeaves();
             // update all the children with the parent collectorToLeaves association
             updateCollectorToLeavesForChildBreakdowns(root, parentCollectorToLeaves);
         }
@@ -77,7 +78,7 @@ public class ConcurrentQueryProfileTree extends AbstractQueryProfileTree {
      * @param parentToken parent token number in the tree
      * @param collectorToLeaves collector to leaves mapping recorded by parent
      */
-    private void updateCollectorToLeavesForChildBreakdowns(Integer parentToken, Map<String, List<LeafReaderContext>> collectorToLeaves) {
+    private void updateCollectorToLeavesForChildBreakdowns(Integer parentToken, Map<Collector, List<LeafReaderContext>> collectorToLeaves) {
         final List<Integer> children = tree.get(parentToken);
         if (children != null) {
             for (Integer currentChild : children) {

--- a/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileTree.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileTree.java
@@ -65,7 +65,7 @@ public class ConcurrentQueryProfileTree extends AbstractQueryProfileTree {
             final ContextualProfileBreakdown<QueryTimingType> parentBreakdown = breakdowns.get(root);
             assert parentBreakdown instanceof ConcurrentQueryProfileBreakdown;
             final Map<Collector, List<LeafReaderContext>> parentCollectorToLeaves = ((ConcurrentQueryProfileBreakdown) parentBreakdown)
-                .getSliceCollectorToLeaves();
+                .getSliceCollectorsToLeaves();
             // update all the children with the parent collectorToLeaves association
             updateCollectorToLeavesForChildBreakdowns(root, parentCollectorToLeaves);
         }
@@ -83,7 +83,7 @@ public class ConcurrentQueryProfileTree extends AbstractQueryProfileTree {
         if (children != null) {
             for (Integer currentChild : children) {
                 final ContextualProfileBreakdown<QueryTimingType> currentChildBreakdown = breakdowns.get(currentChild);
-                currentChildBreakdown.associateCollectorToLeaves(collectorToLeaves);
+                currentChildBreakdown.associateCollectorsToLeaves(collectorToLeaves);
                 updateCollectorToLeavesForChildBreakdowns(currentChild, collectorToLeaves);
             }
         }

--- a/server/src/main/java/org/opensearch/search/profile/query/InternalQueryProfileTree.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/InternalQueryProfileTree.java
@@ -32,73 +32,18 @@
 
 package org.opensearch.search.profile.query;
 
-import org.apache.lucene.search.Query;
-import org.opensearch.search.profile.AbstractInternalProfileTree;
 import org.opensearch.search.profile.ContextualProfileBreakdown;
 import org.opensearch.search.profile.ProfileResult;
 
 /**
- * This class tracks the dependency tree for queries (scoring and rewriting) and
- * generates {@link QueryProfileBreakdown} for each node in the tree.  It also finalizes the tree
- * and returns a list of {@link ProfileResult} that can be serialized back to the client
+ * This class returns a list of {@link ProfileResult} that can be serialized back to the client in the non-concurrent execution.
  *
  * @opensearch.internal
  */
-final class InternalQueryProfileTree extends AbstractInternalProfileTree<ContextualProfileBreakdown<QueryTimingType>, Query> {
-
-    /** Rewrite time */
-    private long rewriteTime;
-    private long rewriteScratch;
-    private final boolean concurrent;
-
-    InternalQueryProfileTree(boolean concurrent) {
-        this.concurrent = concurrent;
-    }
+public class InternalQueryProfileTree extends AbstractQueryProfileTree {
 
     @Override
     protected ContextualProfileBreakdown<QueryTimingType> createProfileBreakdown() {
-        return (concurrent) ? new ConcurrentQueryProfileBreakdown() : new QueryProfileBreakdown();
-    }
-
-    @Override
-    protected String getTypeFromElement(Query query) {
-        // Anonymous classes won't have a name,
-        // we need to get the super class
-        if (query.getClass().getSimpleName().isEmpty()) {
-            return query.getClass().getSuperclass().getSimpleName();
-        }
-        return query.getClass().getSimpleName();
-    }
-
-    @Override
-    protected String getDescriptionFromElement(Query query) {
-        return query.toString();
-    }
-
-    /**
-     * Begin timing a query for a specific Timing context
-     */
-    public void startRewriteTime() {
-        assert rewriteScratch == 0;
-        rewriteScratch = System.nanoTime();
-    }
-
-    /**
-     * Halt the timing process and add the elapsed rewriting time.
-     * startRewriteTime() must be called for a particular context prior to calling
-     * stopAndAddRewriteTime(), otherwise the elapsed time will be negative and
-     * nonsensical
-     *
-     * @return          The elapsed time
-     */
-    public long stopAndAddRewriteTime() {
-        long time = Math.max(1, System.nanoTime() - rewriteScratch);
-        rewriteTime += time;
-        rewriteScratch = 0;
-        return time;
-    }
-
-    public long getRewriteTime() {
-        return rewriteTime;
+        return new QueryProfileBreakdown();
     }
 }

--- a/server/src/main/java/org/opensearch/search/profile/query/ProfileWeight.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/ProfileWeight.java
@@ -34,6 +34,7 @@ package org.opensearch.search.profile.query;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.BulkScorer;
+import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Scorer;
@@ -137,4 +138,11 @@ public final class ProfileWeight extends Weight {
         return false;
     }
 
+    public void associateLeafToCollector(LeafReaderContext leaf, Collector collector) {
+        profile.associateLeafToCollector(leaf, collector);
+    }
+
+    public void buildCollectorList(Collector collector) {
+        profile.buildCollectorList(collector);
+    }
 }

--- a/server/src/main/java/org/opensearch/search/profile/query/ProfileWeight.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/ProfileWeight.java
@@ -139,6 +139,6 @@ public final class ProfileWeight extends Weight {
     }
 
     public void associateCollectorToLeaves(LeafReaderContext leaf, Collector collector) {
-        profile.associateCollectorToLeaves(leaf, collector);
+        profile.associateCollectorToLeaves(collector, leaf);
     }
 }

--- a/server/src/main/java/org/opensearch/search/profile/query/ProfileWeight.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/ProfileWeight.java
@@ -138,11 +138,7 @@ public final class ProfileWeight extends Weight {
         return false;
     }
 
-    public void associateLeafToCollector(LeafReaderContext leaf, Collector collector) {
-        profile.associateLeafToCollector(leaf, collector);
-    }
-
-    public void buildCollectorList(Collector collector) {
-        profile.buildCollectorList(collector);
+    public void associateCollectorToLeaves(LeafReaderContext leaf, Collector collector) {
+        profile.associateCollectorToLeaves(leaf, collector);
     }
 }

--- a/server/src/main/java/org/opensearch/search/profile/query/QueryProfiler.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/QueryProfiler.java
@@ -59,7 +59,7 @@ public final class QueryProfiler extends AbstractProfiler<ContextualProfileBreak
     private InternalProfileComponent collector;
 
     public QueryProfiler(boolean concurrent) {
-        super(new InternalQueryProfileTree(concurrent));
+        super(concurrent ? new ConcurrentQueryProfileTree() : new InternalQueryProfileTree());
     }
 
     /** Set the collector that is associated with this profiler. */
@@ -75,7 +75,7 @@ public final class QueryProfiler extends AbstractProfiler<ContextualProfileBreak
      * single metric
      */
     public void startRewriteTime() {
-        ((InternalQueryProfileTree) profileTree).startRewriteTime();
+        ((AbstractQueryProfileTree) profileTree).startRewriteTime();
     }
 
     /**
@@ -85,14 +85,14 @@ public final class QueryProfiler extends AbstractProfiler<ContextualProfileBreak
      * @return cumulative rewrite time
      */
     public long stopAndAddRewriteTime() {
-        return ((InternalQueryProfileTree) profileTree).stopAndAddRewriteTime();
+        return ((AbstractQueryProfileTree) profileTree).stopAndAddRewriteTime();
     }
 
     /**
      * @return total time taken to rewrite all queries in this profile
      */
     public long getRewriteTime() {
-        return ((InternalQueryProfileTree) profileTree).getRewriteTime();
+        return ((AbstractQueryProfileTree) profileTree).getRewriteTime();
     }
 
     /**

--- a/server/src/test/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdownTests.java
+++ b/server/src/test/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdownTests.java
@@ -33,7 +33,7 @@ public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
     private static final String MAX_END_TIME_SUFFIX = "_max_end_time";
     private static final String MIN_START_TIME_SUFFIX = "_min_start_time";
 
-    public void testBuildQueryProfileBreakdownMap() {
+    public void testBuildFinalBreakdownMap() {
         Map<String, Long> testMap = new HashMap<>();
         testMap.put(CREATE_WEIGHT, 370343L);
         testMap.put(CREATE_WEIGHT + COUNT_SUFFIX, 1L);
@@ -81,78 +81,13 @@ public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
         testMap.put(SET_MIN_COMPETITIVE_SCORE + MAX_END_TIME_SUFFIX, 0L);
         testMap.put(SET_MIN_COMPETITIVE_SCORE + MIN_START_TIME_SUFFIX, 0L);
         ConcurrentQueryProfileBreakdown profileBreakdown = new ConcurrentQueryProfileBreakdown();
-        Map<String, Long> breakdownMap = profileBreakdown.buildQueryProfileBreakdownMap(testMap);
-        assertEquals(18, breakdownMap.size());
+        Map<String, Map<String, Long>> sliceLevelBreakdown = new HashMap<>();
+        sliceLevelBreakdown.put("testCollector", testMap);
+        Map<String, Long> breakdownMap = profileBreakdown.buildFinalBreakdownMap(sliceLevelBreakdown);
+        assertEquals(66, breakdownMap.size());
         assertEquals(
-            "{set_min_competitive_score_count=0, match_count=0, shallow_advance_count=0, set_min_competitive_score=0, next_doc=188383, match=0, next_doc_count=5, score_count=5, compute_max_score_count=0, compute_max_score=0, advance=288755, advance_count=3, score=264243, build_scorer_count=6, create_weight=370343, shallow_advance=0, create_weight_count=1, build_scorer=1821422}",
+            "{max_match=0, set_min_competitive_score_count=0, match_count=0, avg_score_count=5, shallow_advance_count=0, next_doc=188383, min_build_scorer=0, score_count=5, compute_max_score_count=0, advance=288755, min_advance=0, min_set_min_competitive_score=0, score=264243, avg_set_min_competitive_score_count=0, min_match_count=0, avg_score=0, max_next_doc_count=5, avg_shallow_advance=0, max_compute_max_score_count=0, max_shallow_advance_count=0, set_min_competitive_score=0, min_build_scorer_count=6, next_doc_count=5, avg_next_doc=0, min_match=0, compute_max_score=0, max_build_scorer=0, min_set_min_competitive_score_count=0, avg_match_count=0, avg_advance=0, build_scorer_count=6, avg_build_scorer_count=6, min_next_doc_count=5, avg_match=0, max_score_count=5, min_shallow_advance_count=0, avg_compute_max_score=0, max_advance=0, avg_shallow_advance_count=0, avg_set_min_competitive_score=0, avg_compute_max_score_count=0, avg_build_scorer=0, max_set_min_competitive_score_count=0, advance_count=3, max_build_scorer_count=6, shallow_advance=0, max_match_count=0, min_compute_max_score=0, create_weight_count=1, build_scorer=1821422, max_compute_max_score=0, max_set_min_competitive_score=0, min_shallow_advance=0, match=0, min_next_doc=0, avg_advance_count=3, max_shallow_advance=0, max_advance_count=3, min_score=0, max_next_doc=0, create_weight=370343, avg_next_doc_count=5, max_score=0, min_compute_max_score_count=0, min_score_count=5, min_advance_count=3}",
             breakdownMap.toString()
-        );
-    }
-
-    public void testAddMaxEndTimeAndMinStartTime() {
-        Map<String, Long> map = new HashMap<>();
-        map.put(CREATE_WEIGHT, 201692L);
-        map.put(CREATE_WEIGHT + COUNT_SUFFIX, 1L);
-        map.put(CREATE_WEIGHT + START_TIME_SUFFIX, 1629732014278990L);
-        map.put(BUILD_SCORER, 0L);
-        map.put(BUILD_SCORER + COUNT_SUFFIX, 2L);
-        map.put(BUILD_SCORER + START_TIME_SUFFIX, 0L);
-        map.put(NEXT_DOC, 0L);
-        map.put(NEXT_DOC + COUNT_SUFFIX, 2L);
-        map.put(NEXT_DOC + START_TIME_SUFFIX, 0L);
-        map.put(ADVANCE, 0L);
-        map.put(ADVANCE + COUNT_SUFFIX, 1L);
-        map.put(ADVANCE + START_TIME_SUFFIX, 0L);
-        map.put(MATCH, 0L);
-        map.put(MATCH + COUNT_SUFFIX, 0L);
-        map.put(MATCH + START_TIME_SUFFIX, 0L);
-        map.put(SCORE, 0L);
-        map.put(SCORE + COUNT_SUFFIX, 2L);
-        map.put(SCORE + START_TIME_SUFFIX, 0L);
-        map.put(SHALLOW_ADVANCE, 0L);
-        map.put(SHALLOW_ADVANCE + COUNT_SUFFIX, 0L);
-        map.put(SHALLOW_ADVANCE + START_TIME_SUFFIX, 0L);
-        map.put(COMPUTE_MAX_SCORE, 0L);
-        map.put(COMPUTE_MAX_SCORE + COUNT_SUFFIX, 0L);
-        map.put(COMPUTE_MAX_SCORE + START_TIME_SUFFIX, 0L);
-        map.put(SET_MIN_COMPETITIVE_SCORE, 0L);
-        map.put(SET_MIN_COMPETITIVE_SCORE + COUNT_SUFFIX, 0L);
-        map.put(SET_MIN_COMPETITIVE_SCORE + START_TIME_SUFFIX, 0L);
-
-        Map<String, Long> breakdown = new HashMap<>();
-        breakdown.put(CREATE_WEIGHT, 0L);
-        breakdown.put(CREATE_WEIGHT + COUNT_SUFFIX, 0L);
-        breakdown.put(CREATE_WEIGHT + START_TIME_SUFFIX, 0L);
-        breakdown.put(BUILD_SCORER, 9649L);
-        breakdown.put(BUILD_SCORER + COUNT_SUFFIX, 2L);
-        breakdown.put(BUILD_SCORER + START_TIME_SUFFIX, 1629732030749745L);
-        breakdown.put(NEXT_DOC, 1150L);
-        breakdown.put(NEXT_DOC + COUNT_SUFFIX, 2L);
-        breakdown.put(NEXT_DOC + START_TIME_SUFFIX, 1629732030806446L);
-        breakdown.put(ADVANCE, 920L);
-        breakdown.put(ADVANCE + COUNT_SUFFIX, 1L);
-        breakdown.put(ADVANCE + START_TIME_SUFFIX, 1629732030776129L);
-        breakdown.put(MATCH, 0L);
-        breakdown.put(MATCH + COUNT_SUFFIX, 0L);
-        breakdown.put(MATCH + START_TIME_SUFFIX, 0L);
-        breakdown.put(SCORE, 1050L);
-        breakdown.put(SCORE + COUNT_SUFFIX, 2L);
-        breakdown.put(SCORE + START_TIME_SUFFIX, 1629732030778977L);
-        breakdown.put(SHALLOW_ADVANCE, 0L);
-        breakdown.put(SHALLOW_ADVANCE + COUNT_SUFFIX, 0L);
-        breakdown.put(SHALLOW_ADVANCE + START_TIME_SUFFIX, 0L);
-        breakdown.put(COMPUTE_MAX_SCORE, 0L);
-        breakdown.put(COMPUTE_MAX_SCORE + COUNT_SUFFIX, 0L);
-        breakdown.put(COMPUTE_MAX_SCORE + START_TIME_SUFFIX, 0L);
-        breakdown.put(SET_MIN_COMPETITIVE_SCORE, 0L);
-        breakdown.put(SET_MIN_COMPETITIVE_SCORE + COUNT_SUFFIX, 0L);
-        breakdown.put(SET_MIN_COMPETITIVE_SCORE + START_TIME_SUFFIX, 0L);
-        ConcurrentQueryProfileBreakdown profileBreakdown = new ConcurrentQueryProfileBreakdown();
-        profileBreakdown.addMaxEndTimeAndMinStartTime(map, breakdown);
-        assertEquals(45, map.size());
-        assertEquals(
-            "{set_min_competitive_score_count=0, match_count=0, score_start_time=0, shallow_advance_count=0, create_weight_start_time=1629732014278990, next_doc=0, compute_max_score_start_time=0, shallow_advance_min_start_time=0, score_count=2, compute_max_score_count=0, advance_start_time=0, advance=0, advance_count=1, compute_max_score_min_start_time=0, score=0, next_doc_max_end_time=1629732030807596, advance_max_end_time=1629732030777049, next_doc_start_time=0, shallow_advance=0, build_scorer_max_end_time=1629732030759394, create_weight_count=1, create_weight_max_end_time=1629732014480682, match_min_start_time=0, build_scorer=0, compute_max_score_max_end_time=0, next_doc_min_start_time=1629732030806446, set_min_competitive_score=0, set_min_competitive_score_start_time=0, match=0, set_min_competitive_score_max_end_time=0, match_start_time=0, shallow_advance_max_end_time=0, build_scorer_start_time=0, next_doc_count=2, shallow_advance_start_time=0, set_min_competitive_score_min_start_time=0, compute_max_score=0, create_weight_min_start_time=1629732014278990, build_scorer_count=2, create_weight=201692, score_min_start_time=1629732030778977, match_max_end_time=0, advance_min_start_time=1629732030776129, score_max_end_time=1629732030780027, build_scorer_min_start_time=1629732030749745}",
-            map.toString()
         );
     }
 }

--- a/server/src/test/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdownTests.java
+++ b/server/src/test/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdownTests.java
@@ -13,81 +13,311 @@
 
 package org.opensearch.search.profile.query;
 
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.store.Directory;
+import org.opensearch.search.profile.AbstractProfileBreakdown;
+import org.opensearch.search.profile.Timer;
 import org.opensearch.test.OpenSearchTestCase;
+import org.junit.Before;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
-    private static final String CREATE_WEIGHT = QueryTimingType.CREATE_WEIGHT.toString();
-    private static final String BUILD_SCORER = QueryTimingType.BUILD_SCORER.toString();
-    private static final String NEXT_DOC = QueryTimingType.NEXT_DOC.toString();
-    private static final String ADVANCE = QueryTimingType.ADVANCE.toString();
-    private static final String MATCH = QueryTimingType.MATCH.toString();
-    private static final String SCORE = QueryTimingType.SCORE.toString();
-    private static final String SHALLOW_ADVANCE = QueryTimingType.SHALLOW_ADVANCE.toString();
-    private static final String COMPUTE_MAX_SCORE = QueryTimingType.COMPUTE_MAX_SCORE.toString();
-    private static final String SET_MIN_COMPETITIVE_SCORE = QueryTimingType.SET_MIN_COMPETITIVE_SCORE.toString();
-    private static final String COUNT_SUFFIX = "_count";
-    private static final String START_TIME_SUFFIX = "_start_time";
-    private static final String MAX_END_TIME_SUFFIX = "_max_end_time";
-    private static final String MIN_START_TIME_SUFFIX = "_min_start_time";
+import static org.opensearch.search.profile.AbstractProfileBreakdown.TIMING_TYPE_COUNT_SUFFIX;
+import static org.opensearch.search.profile.AbstractProfileBreakdown.TIMING_TYPE_START_TIME_SUFFIX;
+import static org.opensearch.search.profile.query.ConcurrentQueryProfileBreakdown.MIN_PREFIX;
+import static org.opensearch.search.profile.query.ConcurrentQueryProfileBreakdown.SLICE_END_TIME_SUFFIX;
+import static org.opensearch.search.profile.query.ConcurrentQueryProfileBreakdown.SLICE_START_TIME_SUFFIX;
+import static org.mockito.Mockito.mock;
 
-    public void testBuildFinalBreakdownMap() {
-//        Map<String, Long> testMap = new HashMap<>();
-//        testMap.put(CREATE_WEIGHT, 370343L);
-//        testMap.put(CREATE_WEIGHT + COUNT_SUFFIX, 1L);
-//        testMap.put(CREATE_WEIGHT + START_TIME_SUFFIX, 1598347679188617L);
-//        testMap.put(CREATE_WEIGHT + MAX_END_TIME_SUFFIX, 1598347679558960L);
-//        testMap.put(CREATE_WEIGHT + MIN_START_TIME_SUFFIX, 1598347679188617L);
-//        testMap.put(BUILD_SCORER, 0L);
-//        testMap.put(BUILD_SCORER + COUNT_SUFFIX, 6L);
-//        testMap.put(BUILD_SCORER + START_TIME_SUFFIX, 0L);
-//        testMap.put(BUILD_SCORER + MAX_END_TIME_SUFFIX, 1598347688270123L);
-//        testMap.put(BUILD_SCORER + MIN_START_TIME_SUFFIX, 1598347686448701L);
-//        testMap.put(NEXT_DOC, 0L);
-//        testMap.put(NEXT_DOC + COUNT_SUFFIX, 5L);
-//        testMap.put(NEXT_DOC + START_TIME_SUFFIX, 0L);
-//        testMap.put(NEXT_DOC + MAX_END_TIME_SUFFIX, 1598347688298671L);
-//        testMap.put(NEXT_DOC + MIN_START_TIME_SUFFIX, 1598347688110288L);
-//        testMap.put(ADVANCE, 0L);
-//        testMap.put(ADVANCE + COUNT_SUFFIX, 3L);
-//        testMap.put(ADVANCE + START_TIME_SUFFIX, 0L);
-//        testMap.put(ADVANCE + MAX_END_TIME_SUFFIX, 1598347688280739L);
-//        testMap.put(ADVANCE + MIN_START_TIME_SUFFIX, 1598347687991984L);
-//        testMap.put(MATCH, 0L);
-//        testMap.put(MATCH + COUNT_SUFFIX, 0L);
-//        testMap.put(MATCH + START_TIME_SUFFIX, 0L);
-//        testMap.put(MATCH + MAX_END_TIME_SUFFIX, 0L);
-//        testMap.put(MATCH + MIN_START_TIME_SUFFIX, 0L);
-//        testMap.put(SCORE, 0L);
-//        testMap.put(SCORE + COUNT_SUFFIX, 5L);
-//        testMap.put(SCORE + START_TIME_SUFFIX, 0L);
-//        testMap.put(SCORE + MAX_END_TIME_SUFFIX, 1598347688282743L);
-//        testMap.put(SCORE + MIN_START_TIME_SUFFIX, 1598347688018500L);
-//        testMap.put(SHALLOW_ADVANCE, 0L);
-//        testMap.put(SHALLOW_ADVANCE + COUNT_SUFFIX, 0L);
-//        testMap.put(SHALLOW_ADVANCE + START_TIME_SUFFIX, 0L);
-//        testMap.put(SHALLOW_ADVANCE + MAX_END_TIME_SUFFIX, 0L);
-//        testMap.put(SHALLOW_ADVANCE + MIN_START_TIME_SUFFIX, 0L);
-//        testMap.put(COMPUTE_MAX_SCORE, 0L);
-//        testMap.put(COMPUTE_MAX_SCORE + COUNT_SUFFIX, 0L);
-//        testMap.put(COMPUTE_MAX_SCORE + START_TIME_SUFFIX, 0L);
-//        testMap.put(COMPUTE_MAX_SCORE + MAX_END_TIME_SUFFIX, 0L);
-//        testMap.put(COMPUTE_MAX_SCORE + MIN_START_TIME_SUFFIX, 0L);
-//        testMap.put(SET_MIN_COMPETITIVE_SCORE, 0L);
-//        testMap.put(SET_MIN_COMPETITIVE_SCORE + COUNT_SUFFIX, 0L);
-//        testMap.put(SET_MIN_COMPETITIVE_SCORE + START_TIME_SUFFIX, 0L);
-//        testMap.put(SET_MIN_COMPETITIVE_SCORE + MAX_END_TIME_SUFFIX, 0L);
-//        testMap.put(SET_MIN_COMPETITIVE_SCORE + MIN_START_TIME_SUFFIX, 0L);
-//        ConcurrentQueryProfileBreakdown profileBreakdown = new ConcurrentQueryProfileBreakdown();
-//        Map<String, Map<String, Long>> sliceLevelBreakdown = new HashMap<>();
-//        sliceLevelBreakdown.put("testCollector", testMap);
-//        Map<String, Long> breakdownMap = profileBreakdown.buildQueryBreakdownMap(sliceLevelBreakdown, 1598347679188617L);
-//        assertEquals(66, breakdownMap.size());
-//        assertEquals(
-//            "{max_match=0, set_min_competitive_score_count=0, match_count=0, avg_score_count=5, shallow_advance_count=0, next_doc=188383, min_build_scorer=0, score_count=5, compute_max_score_count=0, advance=288755, min_advance=0, min_set_min_competitive_score=0, score=264243, avg_set_min_competitive_score_count=0, min_match_count=0, avg_score=0, max_next_doc_count=5, avg_shallow_advance=0, max_compute_max_score_count=0, max_shallow_advance_count=0, set_min_competitive_score=0, min_build_scorer_count=6, next_doc_count=5, avg_next_doc=0, min_match=0, compute_max_score=0, max_build_scorer=0, min_set_min_competitive_score_count=0, avg_match_count=0, avg_advance=0, build_scorer_count=6, avg_build_scorer_count=6, min_next_doc_count=5, avg_match=0, max_score_count=5, min_shallow_advance_count=0, avg_compute_max_score=0, max_advance=0, avg_shallow_advance_count=0, avg_set_min_competitive_score=0, avg_compute_max_score_count=0, avg_build_scorer=0, max_set_min_competitive_score_count=0, advance_count=3, max_build_scorer_count=6, shallow_advance=0, max_match_count=0, min_compute_max_score=0, create_weight_count=1, build_scorer=1821422, max_compute_max_score=0, max_set_min_competitive_score=0, min_shallow_advance=0, match=0, min_next_doc=0, avg_advance_count=3, max_shallow_advance=0, max_advance_count=3, min_score=0, max_next_doc=0, create_weight=370343, avg_next_doc_count=5, max_score=0, min_compute_max_score_count=0, min_score_count=5, min_advance_count=3}",
-//            breakdownMap.toString()
-//        );
+public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
+    private ConcurrentQueryProfileBreakdown testQueryProfileBreakdown;
+    private Timer createWeightTimer;
+
+    @Before
+    public void setup() {
+        testQueryProfileBreakdown = new ConcurrentQueryProfileBreakdown();
+        createWeightTimer = testQueryProfileBreakdown.getTimer(QueryTimingType.CREATE_WEIGHT);
+        try {
+            createWeightTimer.start();
+            Thread.sleep(10);
+        } catch (InterruptedException ex) {
+            // ignore
+        } finally {
+            createWeightTimer.stop();
+        }
+    }
+
+    public void testBreakdownMapWithNoLeafContext() throws Exception {
+        final Map<String, Long> queryBreakDownMap = testQueryProfileBreakdown.toBreakdownMap();
+        assertFalse(queryBreakDownMap == null || queryBreakDownMap.isEmpty());
+        assertEquals(66, queryBreakDownMap.size());
+        for (QueryTimingType queryTimingType : QueryTimingType.values()) {
+            String timingTypeKey = queryTimingType.toString();
+            String timingTypeCountKey = queryTimingType + TIMING_TYPE_COUNT_SUFFIX;
+
+            if (queryTimingType.equals(QueryTimingType.CREATE_WEIGHT)) {
+                final long createWeightTime = queryBreakDownMap.get(timingTypeKey);
+                assertTrue(createWeightTime > 0);
+                assertEquals(1, (long) queryBreakDownMap.get(timingTypeCountKey));
+                // verify there is no min/max/avg for weight type stats
+                assertFalse(
+                    queryBreakDownMap.containsKey(ConcurrentQueryProfileBreakdown.MAX_PREFIX + timingTypeKey)
+                        || queryBreakDownMap.containsKey(MIN_PREFIX + timingTypeKey)
+                        || queryBreakDownMap.containsKey(ConcurrentQueryProfileBreakdown.AVG_PREFIX + timingTypeKey)
+                        || queryBreakDownMap.containsKey(ConcurrentQueryProfileBreakdown.MAX_PREFIX + timingTypeCountKey)
+                        || queryBreakDownMap.containsKey(MIN_PREFIX + timingTypeCountKey)
+                        || queryBreakDownMap.containsKey(ConcurrentQueryProfileBreakdown.AVG_PREFIX + timingTypeCountKey)
+                );
+                // verify total/min/max/avg node time is same as weight time
+                assertEquals(createWeightTime, testQueryProfileBreakdown.toNodeTime());
+                assertEquals(createWeightTime, (long) testQueryProfileBreakdown.getMaxSliceNodeTime());
+                assertEquals(createWeightTime, (long) testQueryProfileBreakdown.getMinSliceNodeTime());
+                assertEquals(createWeightTime, (long) testQueryProfileBreakdown.getAvgSliceNodeTime());
+                continue;
+            }
+            assertEquals(0, (long) queryBreakDownMap.get(timingTypeKey));
+            assertEquals(0, (long) queryBreakDownMap.get(ConcurrentQueryProfileBreakdown.MAX_PREFIX + timingTypeKey));
+            assertEquals(0, (long) queryBreakDownMap.get(ConcurrentQueryProfileBreakdown.AVG_PREFIX + timingTypeKey));
+            assertEquals(0, (long) queryBreakDownMap.get(MIN_PREFIX + timingTypeKey));
+            assertEquals(0, (long) queryBreakDownMap.get(timingTypeCountKey));
+            assertEquals(0, (long) queryBreakDownMap.get(ConcurrentQueryProfileBreakdown.MAX_PREFIX + timingTypeCountKey));
+            assertEquals(0, (long) queryBreakDownMap.get(MIN_PREFIX + timingTypeCountKey));
+            assertEquals(0, (long) queryBreakDownMap.get(ConcurrentQueryProfileBreakdown.AVG_PREFIX + timingTypeCountKey));
+        }
+    }
+
+    public void testBuildSliceLevelBreakdownWithSingleSlice() throws Exception {
+        final DirectoryReader directoryReader = getDirectoryReader(1);
+        final Directory directory = directoryReader.directory();
+        final LeafReaderContext sliceLeaf = directoryReader.leaves().get(0);
+        final Collector sliceCollector = mock(Collector.class);
+        final long createWeightEarliestStartTime = createWeightTimer.getEarliestTimerStartTime();
+        final Map<String, Long> leafProfileBreakdownMap = getLeafBreakdownMap(createWeightEarliestStartTime + 10, 10, 1);
+        final AbstractProfileBreakdown<QueryTimingType> leafProfileBreakdown = new TestQueryProfileBreakdown(
+            QueryTimingType.class,
+            leafProfileBreakdownMap
+        );
+        testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector, sliceLeaf);
+        testQueryProfileBreakdown.contexts.put(sliceLeaf, leafProfileBreakdown);
+        final Map<Collector, Map<String, Long>> sliceBreakdownMap = testQueryProfileBreakdown.buildSliceLevelBreakdown(
+            createWeightEarliestStartTime
+        );
+        assertFalse(sliceBreakdownMap == null || sliceBreakdownMap.isEmpty());
+        assertEquals(1, sliceBreakdownMap.size());
+        assertTrue(sliceBreakdownMap.containsKey(sliceCollector));
+
+        final Map<String, Long> sliceBreakdown = sliceBreakdownMap.entrySet().iterator().next().getValue();
+        for (QueryTimingType timingType : QueryTimingType.values()) {
+            String timingTypeKey = timingType.toString();
+            String timingTypeCountKey = timingTypeKey + TIMING_TYPE_COUNT_SUFFIX;
+
+            if (timingType.equals(QueryTimingType.CREATE_WEIGHT)) {
+                // there should be no entry for create weight at slice level breakdown map
+                assertNull(sliceBreakdown.get(timingTypeKey));
+                assertNull(sliceBreakdown.get(timingTypeCountKey));
+                continue;
+            }
+
+            // for other timing type we will have all the value and will be same as leaf breakdown as there is single slice and single leaf
+            assertEquals(leafProfileBreakdownMap.get(timingTypeKey), sliceBreakdown.get(timingTypeKey));
+            assertEquals(leafProfileBreakdownMap.get(timingTypeCountKey), sliceBreakdown.get(timingTypeCountKey));
+            assertEquals(
+                leafProfileBreakdownMap.get(timingTypeKey + TIMING_TYPE_START_TIME_SUFFIX),
+                sliceBreakdown.get(timingTypeKey + SLICE_START_TIME_SUFFIX)
+            );
+            assertEquals(
+                leafProfileBreakdownMap.get(timingTypeKey + TIMING_TYPE_START_TIME_SUFFIX) + leafProfileBreakdownMap.get(timingTypeKey),
+                (long) sliceBreakdown.get(timingTypeKey + SLICE_END_TIME_SUFFIX)
+            );
+        }
+        assertEquals(20, (long) testQueryProfileBreakdown.getMaxSliceNodeTime());
+        assertEquals(20, (long) testQueryProfileBreakdown.getMinSliceNodeTime());
+        assertEquals(20, (long) testQueryProfileBreakdown.getAvgSliceNodeTime());
+        directoryReader.close();
+        directory.close();
+    }
+
+    public void testBuildSliceLevelBreakdownWithMultipleSlices() throws Exception {
+        final DirectoryReader directoryReader = getDirectoryReader(2);
+        final Directory directory = directoryReader.directory();
+        final Collector sliceCollector_1 = mock(Collector.class);
+        final Collector sliceCollector_2 = mock(Collector.class);
+        final long createWeightEarliestStartTime = createWeightTimer.getEarliestTimerStartTime();
+        final Map<String, Long> leafProfileBreakdownMap_1 = getLeafBreakdownMap(createWeightEarliestStartTime + 10, 10, 1);
+        final Map<String, Long> leafProfileBreakdownMap_2 = getLeafBreakdownMap(createWeightEarliestStartTime + 40, 10, 1);
+        final AbstractProfileBreakdown<QueryTimingType> leafProfileBreakdown_1 = new TestQueryProfileBreakdown(
+            QueryTimingType.class,
+            leafProfileBreakdownMap_1
+        );
+        final AbstractProfileBreakdown<QueryTimingType> leafProfileBreakdown_2 = new TestQueryProfileBreakdown(
+            QueryTimingType.class,
+            leafProfileBreakdownMap_2
+        );
+        testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector_1, directoryReader.leaves().get(0));
+        testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector_2, directoryReader.leaves().get(1));
+        testQueryProfileBreakdown.contexts.put(directoryReader.leaves().get(0), leafProfileBreakdown_1);
+        testQueryProfileBreakdown.contexts.put(directoryReader.leaves().get(1), leafProfileBreakdown_2);
+        final Map<Collector, Map<String, Long>> sliceBreakdownMap = testQueryProfileBreakdown.buildSliceLevelBreakdown(
+            createWeightEarliestStartTime
+        );
+        assertFalse(sliceBreakdownMap == null || sliceBreakdownMap.isEmpty());
+        assertEquals(2, sliceBreakdownMap.size());
+
+        for (Map.Entry<Collector, Map<String, Long>> sliceBreakdowns : sliceBreakdownMap.entrySet()) {
+            Map<String, Long> sliceBreakdown = sliceBreakdowns.getValue();
+            Map<String, Long> leafProfileBreakdownMap;
+            if (sliceBreakdowns.getKey().equals(sliceCollector_1)) {
+                leafProfileBreakdownMap = leafProfileBreakdownMap_1;
+            } else {
+                leafProfileBreakdownMap = leafProfileBreakdownMap_2;
+            }
+            for (QueryTimingType timingType : QueryTimingType.values()) {
+                String timingTypeKey = timingType.toString();
+                String timingTypeCountKey = timingTypeKey + TIMING_TYPE_COUNT_SUFFIX;
+
+                if (timingType.equals(QueryTimingType.CREATE_WEIGHT)) {
+                    // there should be no entry for create weight at slice level breakdown map
+                    assertNull(sliceBreakdown.get(timingTypeKey));
+                    assertNull(sliceBreakdown.get(timingTypeCountKey));
+                    continue;
+                }
+
+                // for other timing type we will have all the value and will be same as leaf breakdown as there is single slice and single
+                // leaf
+                assertEquals(leafProfileBreakdownMap.get(timingTypeKey), sliceBreakdown.get(timingTypeKey));
+                assertEquals(leafProfileBreakdownMap.get(timingTypeCountKey), sliceBreakdown.get(timingTypeCountKey));
+                assertEquals(
+                    leafProfileBreakdownMap.get(timingTypeKey + TIMING_TYPE_START_TIME_SUFFIX),
+                    sliceBreakdown.get(timingTypeKey + SLICE_START_TIME_SUFFIX)
+                );
+                assertEquals(
+                    leafProfileBreakdownMap.get(timingTypeKey + TIMING_TYPE_START_TIME_SUFFIX) + leafProfileBreakdownMap.get(timingTypeKey),
+                    (long) sliceBreakdown.get(timingTypeKey + SLICE_END_TIME_SUFFIX)
+                );
+            }
+        }
+
+        assertEquals(50, (long) testQueryProfileBreakdown.getMaxSliceNodeTime());
+        assertEquals(20, (long) testQueryProfileBreakdown.getMinSliceNodeTime());
+        assertEquals(35, (long) testQueryProfileBreakdown.getAvgSliceNodeTime());
+        directoryReader.close();
+        directory.close();
+    }
+
+    public void testBreakDownMapWithMultipleSlices() throws Exception {
+        final DirectoryReader directoryReader = getDirectoryReader(2);
+        final Directory directory = directoryReader.directory();
+        final Collector sliceCollector_1 = mock(Collector.class);
+        final Collector sliceCollector_2 = mock(Collector.class);
+        final long createWeightEarliestStartTime = createWeightTimer.getEarliestTimerStartTime();
+        final Map<String, Long> leafProfileBreakdownMap_1 = getLeafBreakdownMap(createWeightEarliestStartTime + 10, 10, 1);
+        final Map<String, Long> leafProfileBreakdownMap_2 = getLeafBreakdownMap(createWeightEarliestStartTime + 40, 20, 1);
+        final AbstractProfileBreakdown<QueryTimingType> leafProfileBreakdown_1 = new TestQueryProfileBreakdown(
+            QueryTimingType.class,
+            leafProfileBreakdownMap_1
+        );
+        final AbstractProfileBreakdown<QueryTimingType> leafProfileBreakdown_2 = new TestQueryProfileBreakdown(
+            QueryTimingType.class,
+            leafProfileBreakdownMap_2
+        );
+        testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector_1, directoryReader.leaves().get(0));
+        testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector_2, directoryReader.leaves().get(1));
+        testQueryProfileBreakdown.contexts.put(directoryReader.leaves().get(0), leafProfileBreakdown_1);
+        testQueryProfileBreakdown.contexts.put(directoryReader.leaves().get(1), leafProfileBreakdown_2);
+
+        Map<String, Long> queryBreakDownMap = testQueryProfileBreakdown.toBreakdownMap();
+        assertFalse(queryBreakDownMap == null || queryBreakDownMap.isEmpty());
+        assertEquals(66, queryBreakDownMap.size());
+
+        for (QueryTimingType queryTimingType : QueryTimingType.values()) {
+            String timingTypeKey = queryTimingType.toString();
+            String timingTypeCountKey = queryTimingType + TIMING_TYPE_COUNT_SUFFIX;
+
+            if (queryTimingType.equals(QueryTimingType.CREATE_WEIGHT)) {
+                final long createWeightTime = queryBreakDownMap.get(timingTypeKey);
+                assertEquals(createWeightTimer.getApproximateTiming(), createWeightTime);
+                assertEquals(1, (long) queryBreakDownMap.get(timingTypeCountKey));
+                // verify there is no min/max/avg for weight type stats
+                assertFalse(
+                    queryBreakDownMap.containsKey(ConcurrentQueryProfileBreakdown.MAX_PREFIX + timingTypeKey)
+                        || queryBreakDownMap.containsKey(MIN_PREFIX + timingTypeKey)
+                        || queryBreakDownMap.containsKey(ConcurrentQueryProfileBreakdown.AVG_PREFIX + timingTypeKey)
+                        || queryBreakDownMap.containsKey(ConcurrentQueryProfileBreakdown.MAX_PREFIX + timingTypeCountKey)
+                        || queryBreakDownMap.containsKey(MIN_PREFIX + timingTypeCountKey)
+                        || queryBreakDownMap.containsKey(ConcurrentQueryProfileBreakdown.AVG_PREFIX + timingTypeCountKey)
+                );
+                continue;
+            }
+            assertEquals(50, (long) queryBreakDownMap.get(timingTypeKey));
+            assertEquals(20, (long) queryBreakDownMap.get(ConcurrentQueryProfileBreakdown.MAX_PREFIX + timingTypeKey));
+            assertEquals(15, (long) queryBreakDownMap.get(ConcurrentQueryProfileBreakdown.AVG_PREFIX + timingTypeKey));
+            assertEquals(10, (long) queryBreakDownMap.get(MIN_PREFIX + timingTypeKey));
+            assertEquals(2, (long) queryBreakDownMap.get(timingTypeCountKey));
+            assertEquals(1, (long) queryBreakDownMap.get(ConcurrentQueryProfileBreakdown.MAX_PREFIX + timingTypeCountKey));
+            assertEquals(1, (long) queryBreakDownMap.get(MIN_PREFIX + timingTypeCountKey));
+            assertEquals(1, (long) queryBreakDownMap.get(ConcurrentQueryProfileBreakdown.AVG_PREFIX + timingTypeCountKey));
+        }
+
+        assertEquals(60, (long) testQueryProfileBreakdown.getMaxSliceNodeTime());
+        assertEquals(20, (long) testQueryProfileBreakdown.getMinSliceNodeTime());
+        assertEquals(40, (long) testQueryProfileBreakdown.getAvgSliceNodeTime());
+        directoryReader.close();
+        directory.close();
+    }
+
+    private Map<String, Long> getLeafBreakdownMap(long startTime, long timeTaken, long count) {
+        Map<String, Long> leafBreakDownMap = new HashMap<>();
+        for (QueryTimingType timingType : QueryTimingType.values()) {
+            if (timingType.equals(QueryTimingType.CREATE_WEIGHT)) {
+                // don't add anything
+                continue;
+            }
+            String timingTypeKey = timingType.toString();
+            leafBreakDownMap.put(timingTypeKey, timeTaken);
+            leafBreakDownMap.put(timingTypeKey + TIMING_TYPE_COUNT_SUFFIX, count);
+            leafBreakDownMap.put(timingTypeKey + TIMING_TYPE_START_TIME_SUFFIX, startTime);
+        }
+        return leafBreakDownMap;
+    }
+
+    private DirectoryReader getDirectoryReader(int numLeaves) throws Exception {
+        final Directory directory = newDirectory();
+        IndexWriter iw = new IndexWriter(directory, new IndexWriterConfig(new StandardAnalyzer()).setMergePolicy(NoMergePolicy.INSTANCE));
+
+        for (int i = 0; i < numLeaves; ++i) {
+            Document document = new Document();
+            document.add(new StringField("field1", "value" + i, Field.Store.NO));
+            document.add(new StringField("field2", "value" + i, Field.Store.NO));
+            iw.addDocument(document);
+            iw.commit();
+        }
+        iw.deleteDocuments(new Term("field1", "value3"));
+        iw.close();
+        return DirectoryReader.open(directory);
+    }
+
+    private static class TestQueryProfileBreakdown extends AbstractProfileBreakdown<QueryTimingType> {
+        private Map<String, Long> breakdownMap;
+
+        public TestQueryProfileBreakdown(Class<QueryTimingType> clazz, Map<String, Long> breakdownMap) {
+            super(clazz);
+            this.breakdownMap = breakdownMap;
+        }
+
+        @Override
+        public Map<String, Long> toBreakdownMap() {
+            return breakdownMap;
+        }
     }
 }

--- a/server/src/test/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdownTests.java
+++ b/server/src/test/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdownTests.java
@@ -34,60 +34,60 @@ public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
     private static final String MIN_START_TIME_SUFFIX = "_min_start_time";
 
     public void testBuildFinalBreakdownMap() {
-        Map<String, Long> testMap = new HashMap<>();
-        testMap.put(CREATE_WEIGHT, 370343L);
-        testMap.put(CREATE_WEIGHT + COUNT_SUFFIX, 1L);
-        testMap.put(CREATE_WEIGHT + START_TIME_SUFFIX, 1598347679188617L);
-        testMap.put(CREATE_WEIGHT + MAX_END_TIME_SUFFIX, 1598347679558960L);
-        testMap.put(CREATE_WEIGHT + MIN_START_TIME_SUFFIX, 1598347679188617L);
-        testMap.put(BUILD_SCORER, 0L);
-        testMap.put(BUILD_SCORER + COUNT_SUFFIX, 6L);
-        testMap.put(BUILD_SCORER + START_TIME_SUFFIX, 0L);
-        testMap.put(BUILD_SCORER + MAX_END_TIME_SUFFIX, 1598347688270123L);
-        testMap.put(BUILD_SCORER + MIN_START_TIME_SUFFIX, 1598347686448701L);
-        testMap.put(NEXT_DOC, 0L);
-        testMap.put(NEXT_DOC + COUNT_SUFFIX, 5L);
-        testMap.put(NEXT_DOC + START_TIME_SUFFIX, 0L);
-        testMap.put(NEXT_DOC + MAX_END_TIME_SUFFIX, 1598347688298671L);
-        testMap.put(NEXT_DOC + MIN_START_TIME_SUFFIX, 1598347688110288L);
-        testMap.put(ADVANCE, 0L);
-        testMap.put(ADVANCE + COUNT_SUFFIX, 3L);
-        testMap.put(ADVANCE + START_TIME_SUFFIX, 0L);
-        testMap.put(ADVANCE + MAX_END_TIME_SUFFIX, 1598347688280739L);
-        testMap.put(ADVANCE + MIN_START_TIME_SUFFIX, 1598347687991984L);
-        testMap.put(MATCH, 0L);
-        testMap.put(MATCH + COUNT_SUFFIX, 0L);
-        testMap.put(MATCH + START_TIME_SUFFIX, 0L);
-        testMap.put(MATCH + MAX_END_TIME_SUFFIX, 0L);
-        testMap.put(MATCH + MIN_START_TIME_SUFFIX, 0L);
-        testMap.put(SCORE, 0L);
-        testMap.put(SCORE + COUNT_SUFFIX, 5L);
-        testMap.put(SCORE + START_TIME_SUFFIX, 0L);
-        testMap.put(SCORE + MAX_END_TIME_SUFFIX, 1598347688282743L);
-        testMap.put(SCORE + MIN_START_TIME_SUFFIX, 1598347688018500L);
-        testMap.put(SHALLOW_ADVANCE, 0L);
-        testMap.put(SHALLOW_ADVANCE + COUNT_SUFFIX, 0L);
-        testMap.put(SHALLOW_ADVANCE + START_TIME_SUFFIX, 0L);
-        testMap.put(SHALLOW_ADVANCE + MAX_END_TIME_SUFFIX, 0L);
-        testMap.put(SHALLOW_ADVANCE + MIN_START_TIME_SUFFIX, 0L);
-        testMap.put(COMPUTE_MAX_SCORE, 0L);
-        testMap.put(COMPUTE_MAX_SCORE + COUNT_SUFFIX, 0L);
-        testMap.put(COMPUTE_MAX_SCORE + START_TIME_SUFFIX, 0L);
-        testMap.put(COMPUTE_MAX_SCORE + MAX_END_TIME_SUFFIX, 0L);
-        testMap.put(COMPUTE_MAX_SCORE + MIN_START_TIME_SUFFIX, 0L);
-        testMap.put(SET_MIN_COMPETITIVE_SCORE, 0L);
-        testMap.put(SET_MIN_COMPETITIVE_SCORE + COUNT_SUFFIX, 0L);
-        testMap.put(SET_MIN_COMPETITIVE_SCORE + START_TIME_SUFFIX, 0L);
-        testMap.put(SET_MIN_COMPETITIVE_SCORE + MAX_END_TIME_SUFFIX, 0L);
-        testMap.put(SET_MIN_COMPETITIVE_SCORE + MIN_START_TIME_SUFFIX, 0L);
-        ConcurrentQueryProfileBreakdown profileBreakdown = new ConcurrentQueryProfileBreakdown();
-        Map<String, Map<String, Long>> sliceLevelBreakdown = new HashMap<>();
-        sliceLevelBreakdown.put("testCollector", testMap);
-        Map<String, Long> breakdownMap = profileBreakdown.buildFinalBreakdownMap(sliceLevelBreakdown);
-        assertEquals(66, breakdownMap.size());
-        assertEquals(
-            "{max_match=0, set_min_competitive_score_count=0, match_count=0, avg_score_count=5, shallow_advance_count=0, next_doc=188383, min_build_scorer=0, score_count=5, compute_max_score_count=0, advance=288755, min_advance=0, min_set_min_competitive_score=0, score=264243, avg_set_min_competitive_score_count=0, min_match_count=0, avg_score=0, max_next_doc_count=5, avg_shallow_advance=0, max_compute_max_score_count=0, max_shallow_advance_count=0, set_min_competitive_score=0, min_build_scorer_count=6, next_doc_count=5, avg_next_doc=0, min_match=0, compute_max_score=0, max_build_scorer=0, min_set_min_competitive_score_count=0, avg_match_count=0, avg_advance=0, build_scorer_count=6, avg_build_scorer_count=6, min_next_doc_count=5, avg_match=0, max_score_count=5, min_shallow_advance_count=0, avg_compute_max_score=0, max_advance=0, avg_shallow_advance_count=0, avg_set_min_competitive_score=0, avg_compute_max_score_count=0, avg_build_scorer=0, max_set_min_competitive_score_count=0, advance_count=3, max_build_scorer_count=6, shallow_advance=0, max_match_count=0, min_compute_max_score=0, create_weight_count=1, build_scorer=1821422, max_compute_max_score=0, max_set_min_competitive_score=0, min_shallow_advance=0, match=0, min_next_doc=0, avg_advance_count=3, max_shallow_advance=0, max_advance_count=3, min_score=0, max_next_doc=0, create_weight=370343, avg_next_doc_count=5, max_score=0, min_compute_max_score_count=0, min_score_count=5, min_advance_count=3}",
-            breakdownMap.toString()
-        );
+//        Map<String, Long> testMap = new HashMap<>();
+//        testMap.put(CREATE_WEIGHT, 370343L);
+//        testMap.put(CREATE_WEIGHT + COUNT_SUFFIX, 1L);
+//        testMap.put(CREATE_WEIGHT + START_TIME_SUFFIX, 1598347679188617L);
+//        testMap.put(CREATE_WEIGHT + MAX_END_TIME_SUFFIX, 1598347679558960L);
+//        testMap.put(CREATE_WEIGHT + MIN_START_TIME_SUFFIX, 1598347679188617L);
+//        testMap.put(BUILD_SCORER, 0L);
+//        testMap.put(BUILD_SCORER + COUNT_SUFFIX, 6L);
+//        testMap.put(BUILD_SCORER + START_TIME_SUFFIX, 0L);
+//        testMap.put(BUILD_SCORER + MAX_END_TIME_SUFFIX, 1598347688270123L);
+//        testMap.put(BUILD_SCORER + MIN_START_TIME_SUFFIX, 1598347686448701L);
+//        testMap.put(NEXT_DOC, 0L);
+//        testMap.put(NEXT_DOC + COUNT_SUFFIX, 5L);
+//        testMap.put(NEXT_DOC + START_TIME_SUFFIX, 0L);
+//        testMap.put(NEXT_DOC + MAX_END_TIME_SUFFIX, 1598347688298671L);
+//        testMap.put(NEXT_DOC + MIN_START_TIME_SUFFIX, 1598347688110288L);
+//        testMap.put(ADVANCE, 0L);
+//        testMap.put(ADVANCE + COUNT_SUFFIX, 3L);
+//        testMap.put(ADVANCE + START_TIME_SUFFIX, 0L);
+//        testMap.put(ADVANCE + MAX_END_TIME_SUFFIX, 1598347688280739L);
+//        testMap.put(ADVANCE + MIN_START_TIME_SUFFIX, 1598347687991984L);
+//        testMap.put(MATCH, 0L);
+//        testMap.put(MATCH + COUNT_SUFFIX, 0L);
+//        testMap.put(MATCH + START_TIME_SUFFIX, 0L);
+//        testMap.put(MATCH + MAX_END_TIME_SUFFIX, 0L);
+//        testMap.put(MATCH + MIN_START_TIME_SUFFIX, 0L);
+//        testMap.put(SCORE, 0L);
+//        testMap.put(SCORE + COUNT_SUFFIX, 5L);
+//        testMap.put(SCORE + START_TIME_SUFFIX, 0L);
+//        testMap.put(SCORE + MAX_END_TIME_SUFFIX, 1598347688282743L);
+//        testMap.put(SCORE + MIN_START_TIME_SUFFIX, 1598347688018500L);
+//        testMap.put(SHALLOW_ADVANCE, 0L);
+//        testMap.put(SHALLOW_ADVANCE + COUNT_SUFFIX, 0L);
+//        testMap.put(SHALLOW_ADVANCE + START_TIME_SUFFIX, 0L);
+//        testMap.put(SHALLOW_ADVANCE + MAX_END_TIME_SUFFIX, 0L);
+//        testMap.put(SHALLOW_ADVANCE + MIN_START_TIME_SUFFIX, 0L);
+//        testMap.put(COMPUTE_MAX_SCORE, 0L);
+//        testMap.put(COMPUTE_MAX_SCORE + COUNT_SUFFIX, 0L);
+//        testMap.put(COMPUTE_MAX_SCORE + START_TIME_SUFFIX, 0L);
+//        testMap.put(COMPUTE_MAX_SCORE + MAX_END_TIME_SUFFIX, 0L);
+//        testMap.put(COMPUTE_MAX_SCORE + MIN_START_TIME_SUFFIX, 0L);
+//        testMap.put(SET_MIN_COMPETITIVE_SCORE, 0L);
+//        testMap.put(SET_MIN_COMPETITIVE_SCORE + COUNT_SUFFIX, 0L);
+//        testMap.put(SET_MIN_COMPETITIVE_SCORE + START_TIME_SUFFIX, 0L);
+//        testMap.put(SET_MIN_COMPETITIVE_SCORE + MAX_END_TIME_SUFFIX, 0L);
+//        testMap.put(SET_MIN_COMPETITIVE_SCORE + MIN_START_TIME_SUFFIX, 0L);
+//        ConcurrentQueryProfileBreakdown profileBreakdown = new ConcurrentQueryProfileBreakdown();
+//        Map<String, Map<String, Long>> sliceLevelBreakdown = new HashMap<>();
+//        sliceLevelBreakdown.put("testCollector", testMap);
+//        Map<String, Long> breakdownMap = profileBreakdown.buildQueryBreakdownMap(sliceLevelBreakdown, 1598347679188617L);
+//        assertEquals(66, breakdownMap.size());
+//        assertEquals(
+//            "{max_match=0, set_min_competitive_score_count=0, match_count=0, avg_score_count=5, shallow_advance_count=0, next_doc=188383, min_build_scorer=0, score_count=5, compute_max_score_count=0, advance=288755, min_advance=0, min_set_min_competitive_score=0, score=264243, avg_set_min_competitive_score_count=0, min_match_count=0, avg_score=0, max_next_doc_count=5, avg_shallow_advance=0, max_compute_max_score_count=0, max_shallow_advance_count=0, set_min_competitive_score=0, min_build_scorer_count=6, next_doc_count=5, avg_next_doc=0, min_match=0, compute_max_score=0, max_build_scorer=0, min_set_min_competitive_score_count=0, avg_match_count=0, avg_advance=0, build_scorer_count=6, avg_build_scorer_count=6, min_next_doc_count=5, avg_match=0, max_score_count=5, min_shallow_advance_count=0, avg_compute_max_score=0, max_advance=0, avg_shallow_advance_count=0, avg_set_min_competitive_score=0, avg_compute_max_score_count=0, avg_build_scorer=0, max_set_min_competitive_score_count=0, advance_count=3, max_build_scorer_count=6, shallow_advance=0, max_match_count=0, min_compute_max_score=0, create_weight_count=1, build_scorer=1821422, max_compute_max_score=0, max_set_min_competitive_score=0, min_shallow_advance=0, match=0, min_next_doc=0, avg_advance_count=3, max_shallow_advance=0, max_advance_count=3, min_score=0, max_next_doc=0, create_weight=370343, avg_next_doc_count=5, max_score=0, min_compute_max_score_count=0, min_score_count=5, min_advance_count=3}",
+//            breakdownMap.toString()
+//        );
     }
 }

--- a/server/src/test/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdownTests.java
+++ b/server/src/test/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdownTests.java
@@ -1,0 +1,158 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.search.profile.query;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
+    private static final String CREATE_WEIGHT = QueryTimingType.CREATE_WEIGHT.toString();
+    private static final String BUILD_SCORER = QueryTimingType.BUILD_SCORER.toString();
+    private static final String NEXT_DOC = QueryTimingType.NEXT_DOC.toString();
+    private static final String ADVANCE = QueryTimingType.ADVANCE.toString();
+    private static final String MATCH = QueryTimingType.MATCH.toString();
+    private static final String SCORE = QueryTimingType.SCORE.toString();
+    private static final String SHALLOW_ADVANCE = QueryTimingType.SHALLOW_ADVANCE.toString();
+    private static final String COMPUTE_MAX_SCORE = QueryTimingType.COMPUTE_MAX_SCORE.toString();
+    private static final String SET_MIN_COMPETITIVE_SCORE = QueryTimingType.SET_MIN_COMPETITIVE_SCORE.toString();
+    private static final String COUNT_SUFFIX = "_count";
+    private static final String START_TIME_SUFFIX = "_start_time";
+    private static final String MAX_END_TIME_SUFFIX = "_max_end_time";
+    private static final String MIN_START_TIME_SUFFIX = "_min_start_time";
+
+    public void testBuildQueryProfileBreakdownMap() {
+        Map<String, Long> testMap = new HashMap<>();
+        testMap.put(CREATE_WEIGHT, 370343L);
+        testMap.put(CREATE_WEIGHT + COUNT_SUFFIX, 1L);
+        testMap.put(CREATE_WEIGHT + START_TIME_SUFFIX, 1598347679188617L);
+        testMap.put(CREATE_WEIGHT + MAX_END_TIME_SUFFIX, 1598347679558960L);
+        testMap.put(CREATE_WEIGHT + MIN_START_TIME_SUFFIX, 1598347679188617L);
+        testMap.put(BUILD_SCORER, 0L);
+        testMap.put(BUILD_SCORER + COUNT_SUFFIX, 6L);
+        testMap.put(BUILD_SCORER + START_TIME_SUFFIX, 0L);
+        testMap.put(BUILD_SCORER + MAX_END_TIME_SUFFIX, 1598347688270123L);
+        testMap.put(BUILD_SCORER + MIN_START_TIME_SUFFIX, 1598347686448701L);
+        testMap.put(NEXT_DOC, 0L);
+        testMap.put(NEXT_DOC + COUNT_SUFFIX, 5L);
+        testMap.put(NEXT_DOC + START_TIME_SUFFIX, 0L);
+        testMap.put(NEXT_DOC + MAX_END_TIME_SUFFIX, 1598347688298671L);
+        testMap.put(NEXT_DOC + MIN_START_TIME_SUFFIX, 1598347688110288L);
+        testMap.put(ADVANCE, 0L);
+        testMap.put(ADVANCE + COUNT_SUFFIX, 3L);
+        testMap.put(ADVANCE + START_TIME_SUFFIX, 0L);
+        testMap.put(ADVANCE + MAX_END_TIME_SUFFIX, 1598347688280739L);
+        testMap.put(ADVANCE + MIN_START_TIME_SUFFIX, 1598347687991984L);
+        testMap.put(MATCH, 0L);
+        testMap.put(MATCH + COUNT_SUFFIX, 0L);
+        testMap.put(MATCH + START_TIME_SUFFIX, 0L);
+        testMap.put(MATCH + MAX_END_TIME_SUFFIX, 0L);
+        testMap.put(MATCH + MIN_START_TIME_SUFFIX, 0L);
+        testMap.put(SCORE, 0L);
+        testMap.put(SCORE + COUNT_SUFFIX, 5L);
+        testMap.put(SCORE + START_TIME_SUFFIX, 0L);
+        testMap.put(SCORE + MAX_END_TIME_SUFFIX, 1598347688282743L);
+        testMap.put(SCORE + MIN_START_TIME_SUFFIX, 1598347688018500L);
+        testMap.put(SHALLOW_ADVANCE, 0L);
+        testMap.put(SHALLOW_ADVANCE + COUNT_SUFFIX, 0L);
+        testMap.put(SHALLOW_ADVANCE + START_TIME_SUFFIX, 0L);
+        testMap.put(SHALLOW_ADVANCE + MAX_END_TIME_SUFFIX, 0L);
+        testMap.put(SHALLOW_ADVANCE + MIN_START_TIME_SUFFIX, 0L);
+        testMap.put(COMPUTE_MAX_SCORE, 0L);
+        testMap.put(COMPUTE_MAX_SCORE + COUNT_SUFFIX, 0L);
+        testMap.put(COMPUTE_MAX_SCORE + START_TIME_SUFFIX, 0L);
+        testMap.put(COMPUTE_MAX_SCORE + MAX_END_TIME_SUFFIX, 0L);
+        testMap.put(COMPUTE_MAX_SCORE + MIN_START_TIME_SUFFIX, 0L);
+        testMap.put(SET_MIN_COMPETITIVE_SCORE, 0L);
+        testMap.put(SET_MIN_COMPETITIVE_SCORE + COUNT_SUFFIX, 0L);
+        testMap.put(SET_MIN_COMPETITIVE_SCORE + START_TIME_SUFFIX, 0L);
+        testMap.put(SET_MIN_COMPETITIVE_SCORE + MAX_END_TIME_SUFFIX, 0L);
+        testMap.put(SET_MIN_COMPETITIVE_SCORE + MIN_START_TIME_SUFFIX, 0L);
+        ConcurrentQueryProfileBreakdown profileBreakdown = new ConcurrentQueryProfileBreakdown();
+        Map<String, Long> breakdownMap = profileBreakdown.buildQueryProfileBreakdownMap(testMap);
+        assertEquals(18, breakdownMap.size());
+        assertEquals(
+            "{set_min_competitive_score_count=0, match_count=0, shallow_advance_count=0, set_min_competitive_score=0, next_doc=188383, match=0, next_doc_count=5, score_count=5, compute_max_score_count=0, compute_max_score=0, advance=288755, advance_count=3, score=264243, build_scorer_count=6, create_weight=370343, shallow_advance=0, create_weight_count=1, build_scorer=1821422}",
+            breakdownMap.toString()
+        );
+    }
+
+    public void testAddMaxEndTimeAndMinStartTime() {
+        Map<String, Long> map = new HashMap<>();
+        map.put(CREATE_WEIGHT, 201692L);
+        map.put(CREATE_WEIGHT + COUNT_SUFFIX, 1L);
+        map.put(CREATE_WEIGHT + START_TIME_SUFFIX, 1629732014278990L);
+        map.put(BUILD_SCORER, 0L);
+        map.put(BUILD_SCORER + COUNT_SUFFIX, 2L);
+        map.put(BUILD_SCORER + START_TIME_SUFFIX, 0L);
+        map.put(NEXT_DOC, 0L);
+        map.put(NEXT_DOC + COUNT_SUFFIX, 2L);
+        map.put(NEXT_DOC + START_TIME_SUFFIX, 0L);
+        map.put(ADVANCE, 0L);
+        map.put(ADVANCE + COUNT_SUFFIX, 1L);
+        map.put(ADVANCE + START_TIME_SUFFIX, 0L);
+        map.put(MATCH, 0L);
+        map.put(MATCH + COUNT_SUFFIX, 0L);
+        map.put(MATCH + START_TIME_SUFFIX, 0L);
+        map.put(SCORE, 0L);
+        map.put(SCORE + COUNT_SUFFIX, 2L);
+        map.put(SCORE + START_TIME_SUFFIX, 0L);
+        map.put(SHALLOW_ADVANCE, 0L);
+        map.put(SHALLOW_ADVANCE + COUNT_SUFFIX, 0L);
+        map.put(SHALLOW_ADVANCE + START_TIME_SUFFIX, 0L);
+        map.put(COMPUTE_MAX_SCORE, 0L);
+        map.put(COMPUTE_MAX_SCORE + COUNT_SUFFIX, 0L);
+        map.put(COMPUTE_MAX_SCORE + START_TIME_SUFFIX, 0L);
+        map.put(SET_MIN_COMPETITIVE_SCORE, 0L);
+        map.put(SET_MIN_COMPETITIVE_SCORE + COUNT_SUFFIX, 0L);
+        map.put(SET_MIN_COMPETITIVE_SCORE + START_TIME_SUFFIX, 0L);
+
+        Map<String, Long> breakdown = new HashMap<>();
+        breakdown.put(CREATE_WEIGHT, 0L);
+        breakdown.put(CREATE_WEIGHT + COUNT_SUFFIX, 0L);
+        breakdown.put(CREATE_WEIGHT + START_TIME_SUFFIX, 0L);
+        breakdown.put(BUILD_SCORER, 9649L);
+        breakdown.put(BUILD_SCORER + COUNT_SUFFIX, 2L);
+        breakdown.put(BUILD_SCORER + START_TIME_SUFFIX, 1629732030749745L);
+        breakdown.put(NEXT_DOC, 1150L);
+        breakdown.put(NEXT_DOC + COUNT_SUFFIX, 2L);
+        breakdown.put(NEXT_DOC + START_TIME_SUFFIX, 1629732030806446L);
+        breakdown.put(ADVANCE, 920L);
+        breakdown.put(ADVANCE + COUNT_SUFFIX, 1L);
+        breakdown.put(ADVANCE + START_TIME_SUFFIX, 1629732030776129L);
+        breakdown.put(MATCH, 0L);
+        breakdown.put(MATCH + COUNT_SUFFIX, 0L);
+        breakdown.put(MATCH + START_TIME_SUFFIX, 0L);
+        breakdown.put(SCORE, 1050L);
+        breakdown.put(SCORE + COUNT_SUFFIX, 2L);
+        breakdown.put(SCORE + START_TIME_SUFFIX, 1629732030778977L);
+        breakdown.put(SHALLOW_ADVANCE, 0L);
+        breakdown.put(SHALLOW_ADVANCE + COUNT_SUFFIX, 0L);
+        breakdown.put(SHALLOW_ADVANCE + START_TIME_SUFFIX, 0L);
+        breakdown.put(COMPUTE_MAX_SCORE, 0L);
+        breakdown.put(COMPUTE_MAX_SCORE + COUNT_SUFFIX, 0L);
+        breakdown.put(COMPUTE_MAX_SCORE + START_TIME_SUFFIX, 0L);
+        breakdown.put(SET_MIN_COMPETITIVE_SCORE, 0L);
+        breakdown.put(SET_MIN_COMPETITIVE_SCORE + COUNT_SUFFIX, 0L);
+        breakdown.put(SET_MIN_COMPETITIVE_SCORE + START_TIME_SUFFIX, 0L);
+        ConcurrentQueryProfileBreakdown profileBreakdown = new ConcurrentQueryProfileBreakdown();
+        profileBreakdown.addMaxEndTimeAndMinStartTime(map, breakdown);
+        assertEquals(45, map.size());
+        assertEquals(
+            "{set_min_competitive_score_count=0, match_count=0, score_start_time=0, shallow_advance_count=0, create_weight_start_time=1629732014278990, next_doc=0, compute_max_score_start_time=0, shallow_advance_min_start_time=0, score_count=2, compute_max_score_count=0, advance_start_time=0, advance=0, advance_count=1, compute_max_score_min_start_time=0, score=0, next_doc_max_end_time=1629732030807596, advance_max_end_time=1629732030777049, next_doc_start_time=0, shallow_advance=0, build_scorer_max_end_time=1629732030759394, create_weight_count=1, create_weight_max_end_time=1629732014480682, match_min_start_time=0, build_scorer=0, compute_max_score_max_end_time=0, next_doc_min_start_time=1629732030806446, set_min_competitive_score=0, set_min_competitive_score_start_time=0, match=0, set_min_competitive_score_max_end_time=0, match_start_time=0, shallow_advance_max_end_time=0, build_scorer_start_time=0, next_doc_count=2, shallow_advance_start_time=0, set_min_competitive_score_min_start_time=0, compute_max_score=0, create_weight_min_start_time=1629732014278990, build_scorer_count=2, create_weight=201692, score_min_start_time=1629732030778977, match_max_end_time=0, advance_min_start_time=1629732030776129, score_max_end_time=1629732030780027, build_scorer_min_start_time=1629732030749745}",
+            map.toString()
+        );
+    }
+}

--- a/server/src/test/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdownTests.java
+++ b/server/src/test/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdownTests.java
@@ -81,9 +81,9 @@ public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
                 );
                 // verify total/min/max/avg node time is same as weight time
                 assertEquals(createWeightTime, testQueryProfileBreakdown.toNodeTime());
-                assertEquals(createWeightTime, (long) testQueryProfileBreakdown.getMaxSliceNodeTime());
-                assertEquals(createWeightTime, (long) testQueryProfileBreakdown.getMinSliceNodeTime());
-                assertEquals(createWeightTime, (long) testQueryProfileBreakdown.getAvgSliceNodeTime());
+                assertEquals(createWeightTime, testQueryProfileBreakdown.getMaxSliceNodeTime());
+                assertEquals(createWeightTime, testQueryProfileBreakdown.getMinSliceNodeTime());
+                assertEquals(createWeightTime, testQueryProfileBreakdown.getAvgSliceNodeTime());
                 continue;
             }
             assertEquals(0, (long) queryBreakDownMap.get(timingTypeKey));
@@ -109,7 +109,7 @@ public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
             leafProfileBreakdownMap
         );
         testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector, sliceLeaf);
-        testQueryProfileBreakdown.contexts.put(sliceLeaf, leafProfileBreakdown);
+        testQueryProfileBreakdown.getContexts().put(sliceLeaf, leafProfileBreakdown);
         final Map<Collector, Map<String, Long>> sliceBreakdownMap = testQueryProfileBreakdown.buildSliceLevelBreakdown(
             createWeightEarliestStartTime
         );
@@ -141,9 +141,9 @@ public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
                 (long) sliceBreakdown.get(timingTypeKey + SLICE_END_TIME_SUFFIX)
             );
         }
-        assertEquals(20, (long) testQueryProfileBreakdown.getMaxSliceNodeTime());
-        assertEquals(20, (long) testQueryProfileBreakdown.getMinSliceNodeTime());
-        assertEquals(20, (long) testQueryProfileBreakdown.getAvgSliceNodeTime());
+        assertEquals(20, testQueryProfileBreakdown.getMaxSliceNodeTime());
+        assertEquals(20, testQueryProfileBreakdown.getMinSliceNodeTime());
+        assertEquals(20, testQueryProfileBreakdown.getAvgSliceNodeTime());
         directoryReader.close();
         directory.close();
     }
@@ -166,8 +166,8 @@ public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
         );
         testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector_1, directoryReader.leaves().get(0));
         testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector_2, directoryReader.leaves().get(1));
-        testQueryProfileBreakdown.contexts.put(directoryReader.leaves().get(0), leafProfileBreakdown_1);
-        testQueryProfileBreakdown.contexts.put(directoryReader.leaves().get(1), leafProfileBreakdown_2);
+        testQueryProfileBreakdown.getContexts().put(directoryReader.leaves().get(0), leafProfileBreakdown_1);
+        testQueryProfileBreakdown.getContexts().put(directoryReader.leaves().get(1), leafProfileBreakdown_2);
         final Map<Collector, Map<String, Long>> sliceBreakdownMap = testQueryProfileBreakdown.buildSliceLevelBreakdown(
             createWeightEarliestStartTime
         );
@@ -208,9 +208,9 @@ public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
             }
         }
 
-        assertEquals(50, (long) testQueryProfileBreakdown.getMaxSliceNodeTime());
-        assertEquals(20, (long) testQueryProfileBreakdown.getMinSliceNodeTime());
-        assertEquals(35, (long) testQueryProfileBreakdown.getAvgSliceNodeTime());
+        assertEquals(50, testQueryProfileBreakdown.getMaxSliceNodeTime());
+        assertEquals(20, testQueryProfileBreakdown.getMinSliceNodeTime());
+        assertEquals(35, testQueryProfileBreakdown.getAvgSliceNodeTime());
         directoryReader.close();
         directory.close();
     }
@@ -233,8 +233,8 @@ public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
         );
         testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector_1, directoryReader.leaves().get(0));
         testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector_2, directoryReader.leaves().get(1));
-        testQueryProfileBreakdown.contexts.put(directoryReader.leaves().get(0), leafProfileBreakdown_1);
-        testQueryProfileBreakdown.contexts.put(directoryReader.leaves().get(1), leafProfileBreakdown_2);
+        testQueryProfileBreakdown.getContexts().put(directoryReader.leaves().get(0), leafProfileBreakdown_1);
+        testQueryProfileBreakdown.getContexts().put(directoryReader.leaves().get(1), leafProfileBreakdown_2);
 
         Map<String, Long> queryBreakDownMap = testQueryProfileBreakdown.toBreakdownMap();
         assertFalse(queryBreakDownMap == null || queryBreakDownMap.isEmpty());
@@ -269,9 +269,9 @@ public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
             assertEquals(1, (long) queryBreakDownMap.get(ConcurrentQueryProfileBreakdown.AVG_PREFIX + timingTypeCountKey));
         }
 
-        assertEquals(60, (long) testQueryProfileBreakdown.getMaxSliceNodeTime());
-        assertEquals(20, (long) testQueryProfileBreakdown.getMinSliceNodeTime());
-        assertEquals(40, (long) testQueryProfileBreakdown.getAvgSliceNodeTime());
+        assertEquals(60, testQueryProfileBreakdown.getMaxSliceNodeTime());
+        assertEquals(20, testQueryProfileBreakdown.getMinSliceNodeTime());
+        assertEquals(40, testQueryProfileBreakdown.getAvgSliceNodeTime());
         directoryReader.close();
         directory.close();
     }

--- a/server/src/test/java/org/opensearch/search/profile/query/QueryProfilerTests.java
+++ b/server/src/test/java/org/opensearch/search/profile/query/QueryProfilerTests.java
@@ -89,6 +89,10 @@ public class QueryProfilerTests extends OpenSearchTestCase {
     private IndexReader reader;
     private ContextIndexSearcher searcher;
     private ExecutorService executor;
+    private static final String MAX_PREFIX = "max_";
+    private static final String MIN_PREFIX = "min_";
+    private static final String AVG_PREFIX = "avg_";
+    private static final String TIMING_TYPE_COUNT_SUFFIX = "_count";
 
     @ParametersFactory
     public static Collection<Object[]> concurrency() {
@@ -168,12 +172,45 @@ public class QueryProfilerTests extends OpenSearchTestCase {
         assertThat(breakdown.get(QueryTimingType.SCORE.toString()), greaterThan(0L));
         assertThat(breakdown.get(QueryTimingType.MATCH.toString()), equalTo(0L));
 
-        assertThat(breakdown.get(QueryTimingType.CREATE_WEIGHT.toString() + "_count"), greaterThan(0L));
-        assertThat(breakdown.get(QueryTimingType.BUILD_SCORER.toString() + "_count"), greaterThan(0L));
-        assertThat(breakdown.get(QueryTimingType.NEXT_DOC.toString() + "_count"), greaterThan(0L));
-        assertThat(breakdown.get(QueryTimingType.ADVANCE.toString() + "_count"), equalTo(0L));
-        assertThat(breakdown.get(QueryTimingType.SCORE.toString() + "_count"), greaterThan(0L));
-        assertThat(breakdown.get(QueryTimingType.MATCH.toString() + "_count"), equalTo(0L));
+        assertThat(breakdown.get(QueryTimingType.CREATE_WEIGHT + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+        assertThat(breakdown.get(QueryTimingType.BUILD_SCORER + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+        assertThat(breakdown.get(QueryTimingType.NEXT_DOC + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+        assertThat(breakdown.get(QueryTimingType.ADVANCE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+        assertThat(breakdown.get(QueryTimingType.SCORE + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+        assertThat(breakdown.get(QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+
+        if (results.get(0).getMaxSliceTime() != null) {
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.BUILD_SCORER), greaterThan(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.BUILD_SCORER), greaterThan(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.BUILD_SCORER), greaterThan(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.NEXT_DOC), greaterThan(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.NEXT_DOC), greaterThan(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.NEXT_DOC), greaterThan(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.ADVANCE), equalTo(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.ADVANCE), equalTo(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.ADVANCE), equalTo(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.SCORE), greaterThan(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.SCORE), greaterThan(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.SCORE), greaterThan(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.MATCH), equalTo(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.MATCH), equalTo(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.MATCH), equalTo(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.BUILD_SCORER + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.BUILD_SCORER + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.BUILD_SCORER + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.NEXT_DOC + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.NEXT_DOC + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.NEXT_DOC + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.ADVANCE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.ADVANCE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.ADVANCE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.SCORE + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.SCORE + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.SCORE + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+        }
 
         long rewriteTime = profiler.getRewriteTime();
         assertThat(rewriteTime, greaterThan(0L));
@@ -194,12 +231,45 @@ public class QueryProfilerTests extends OpenSearchTestCase {
         assertThat(breakdown.get(QueryTimingType.SCORE.toString()), equalTo(0L));
         assertThat(breakdown.get(QueryTimingType.MATCH.toString()), equalTo(0L));
 
-        assertThat(breakdown.get(QueryTimingType.CREATE_WEIGHT.toString() + "_count"), greaterThan(0L));
-        assertThat(breakdown.get(QueryTimingType.BUILD_SCORER.toString() + "_count"), greaterThan(0L));
-        assertThat(breakdown.get(QueryTimingType.NEXT_DOC.toString() + "_count"), greaterThan(0L));
-        assertThat(breakdown.get(QueryTimingType.ADVANCE.toString() + "_count"), equalTo(0L));
-        assertThat(breakdown.get(QueryTimingType.SCORE.toString() + "_count"), equalTo(0L));
-        assertThat(breakdown.get(QueryTimingType.MATCH.toString() + "_count"), equalTo(0L));
+        assertThat(breakdown.get(QueryTimingType.CREATE_WEIGHT + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+        assertThat(breakdown.get(QueryTimingType.BUILD_SCORER + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+        assertThat(breakdown.get(QueryTimingType.NEXT_DOC + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+        assertThat(breakdown.get(QueryTimingType.ADVANCE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+        assertThat(breakdown.get(QueryTimingType.SCORE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+        assertThat(breakdown.get(QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+
+        if (results.get(0).getMaxSliceTime() != null) {
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.BUILD_SCORER), greaterThan(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.BUILD_SCORER), greaterThan(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.BUILD_SCORER), greaterThan(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.NEXT_DOC), greaterThan(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.NEXT_DOC), greaterThan(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.NEXT_DOC), greaterThan(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.ADVANCE), equalTo(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.ADVANCE), equalTo(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.ADVANCE), equalTo(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.SCORE), equalTo(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.SCORE), equalTo(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.SCORE), equalTo(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.MATCH), equalTo(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.MATCH), equalTo(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.MATCH), equalTo(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.BUILD_SCORER + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.BUILD_SCORER + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.BUILD_SCORER + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.NEXT_DOC + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.NEXT_DOC + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.NEXT_DOC + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.ADVANCE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.ADVANCE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.ADVANCE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.SCORE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.SCORE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.SCORE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+        }
 
         long rewriteTime = profiler.getRewriteTime();
         assertThat(rewriteTime, greaterThan(0L));
@@ -234,12 +304,45 @@ public class QueryProfilerTests extends OpenSearchTestCase {
         assertThat(breakdown.get(QueryTimingType.SCORE.toString()), equalTo(0L));
         assertThat(breakdown.get(QueryTimingType.MATCH.toString()), greaterThan(0L));
 
-        assertThat(breakdown.get(QueryTimingType.CREATE_WEIGHT.toString() + "_count"), greaterThan(0L));
-        assertThat(breakdown.get(QueryTimingType.BUILD_SCORER.toString() + "_count"), greaterThan(0L));
-        assertThat(breakdown.get(QueryTimingType.NEXT_DOC.toString() + "_count"), greaterThan(0L));
-        assertThat(breakdown.get(QueryTimingType.ADVANCE.toString() + "_count"), equalTo(0L));
-        assertThat(breakdown.get(QueryTimingType.SCORE.toString() + "_count"), equalTo(0L));
-        assertThat(breakdown.get(QueryTimingType.MATCH.toString() + "_count"), greaterThan(0L));
+        assertThat(breakdown.get(QueryTimingType.CREATE_WEIGHT + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+        assertThat(breakdown.get(QueryTimingType.BUILD_SCORER + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+        assertThat(breakdown.get(QueryTimingType.NEXT_DOC + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+        assertThat(breakdown.get(QueryTimingType.ADVANCE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+        assertThat(breakdown.get(QueryTimingType.SCORE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+        assertThat(breakdown.get(QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+
+        if (results.get(0).getMaxSliceTime() != null) {
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.BUILD_SCORER), greaterThan(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.BUILD_SCORER), greaterThan(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.BUILD_SCORER), greaterThan(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.NEXT_DOC), greaterThan(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.NEXT_DOC), greaterThan(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.NEXT_DOC), greaterThan(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.ADVANCE), equalTo(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.ADVANCE), equalTo(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.ADVANCE), equalTo(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.SCORE), equalTo(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.SCORE), equalTo(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.SCORE), equalTo(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.MATCH), greaterThan(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.MATCH), greaterThan(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.MATCH), greaterThan(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.BUILD_SCORER + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.BUILD_SCORER + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.BUILD_SCORER + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.NEXT_DOC + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.NEXT_DOC + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.NEXT_DOC + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.ADVANCE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.ADVANCE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.ADVANCE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.SCORE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.SCORE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.SCORE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+        }
 
         long rewriteTime = profiler.getRewriteTime();
         assertThat(rewriteTime, greaterThan(0L));

--- a/server/src/test/java/org/opensearch/search/profile/query/QueryProfilerTests.java
+++ b/server/src/test/java/org/opensearch/search/profile/query/QueryProfilerTests.java
@@ -81,10 +81,14 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class QueryProfilerTests extends OpenSearchTestCase {
+    private final int concurrency;
     private Directory dir;
     private IndexReader reader;
     private ContextIndexSearcher searcher;
@@ -101,6 +105,7 @@ public class QueryProfilerTests extends OpenSearchTestCase {
 
     public QueryProfilerTests(int concurrency) {
         this.executor = (concurrency > 0) ? Executors.newFixedThreadPool(concurrency) : null;
+        this.concurrency = concurrency;
     }
 
     @Before
@@ -164,7 +169,8 @@ public class QueryProfilerTests extends OpenSearchTestCase {
         searcher.search(query, 1);
         List<ProfileResult> results = profiler.getTree();
         assertEquals(1, results.size());
-        Map<String, Long> breakdown = results.get(0).getTimeBreakdown();
+        ProfileResult profileResult = results.get(0);
+        Map<String, Long> breakdown = profileResult.getTimeBreakdown();
         assertThat(breakdown.get(QueryTimingType.CREATE_WEIGHT.toString()), greaterThan(0L));
         assertThat(breakdown.get(QueryTimingType.BUILD_SCORER.toString()), greaterThan(0L));
         assertThat(breakdown.get(QueryTimingType.NEXT_DOC.toString()), greaterThan(0L));
@@ -179,7 +185,10 @@ public class QueryProfilerTests extends OpenSearchTestCase {
         assertThat(breakdown.get(QueryTimingType.SCORE + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
         assertThat(breakdown.get(QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
 
-        if (results.get(0).getMaxSliceTime() != null) {
+        if (concurrency > 0) {
+            assertThat(profileResult.getMaxSliceTime(), is(not(nullValue())));
+            assertThat(profileResult.getMinSliceTime(), is(not(nullValue())));
+            assertThat(profileResult.getAvgSliceTime(), is(not(nullValue())));
             assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.BUILD_SCORER), greaterThan(0L));
             assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.BUILD_SCORER), greaterThan(0L));
             assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.BUILD_SCORER), greaterThan(0L));
@@ -210,6 +219,10 @@ public class QueryProfilerTests extends OpenSearchTestCase {
             assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
             assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
             assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+        } else {
+            assertThat(profileResult.getMaxSliceTime(), is(nullValue()));
+            assertThat(profileResult.getMinSliceTime(), is(nullValue()));
+            assertThat(profileResult.getAvgSliceTime(), is(nullValue()));
         }
 
         long rewriteTime = profiler.getRewriteTime();
@@ -223,7 +236,8 @@ public class QueryProfilerTests extends OpenSearchTestCase {
         searcher.search(query, 1, Sort.INDEXORDER); // scores are not needed
         List<ProfileResult> results = profiler.getTree();
         assertEquals(1, results.size());
-        Map<String, Long> breakdown = results.get(0).getTimeBreakdown();
+        ProfileResult profileResult = results.get(0);
+        Map<String, Long> breakdown = profileResult.getTimeBreakdown();
         assertThat(breakdown.get(QueryTimingType.CREATE_WEIGHT.toString()), greaterThan(0L));
         assertThat(breakdown.get(QueryTimingType.BUILD_SCORER.toString()), greaterThan(0L));
         assertThat(breakdown.get(QueryTimingType.NEXT_DOC.toString()), greaterThan(0L));
@@ -238,7 +252,10 @@ public class QueryProfilerTests extends OpenSearchTestCase {
         assertThat(breakdown.get(QueryTimingType.SCORE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
         assertThat(breakdown.get(QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
 
-        if (results.get(0).getMaxSliceTime() != null) {
+        if (concurrency > 0) {
+            assertThat(profileResult.getMaxSliceTime(), is(not(nullValue())));
+            assertThat(profileResult.getMinSliceTime(), is(not(nullValue())));
+            assertThat(profileResult.getAvgSliceTime(), is(not(nullValue())));
             assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.BUILD_SCORER), greaterThan(0L));
             assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.BUILD_SCORER), greaterThan(0L));
             assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.BUILD_SCORER), greaterThan(0L));
@@ -269,6 +286,10 @@ public class QueryProfilerTests extends OpenSearchTestCase {
             assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
             assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
             assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+        } else {
+            assertThat(profileResult.getMaxSliceTime(), is(nullValue()));
+            assertThat(profileResult.getMinSliceTime(), is(nullValue()));
+            assertThat(profileResult.getAvgSliceTime(), is(nullValue()));
         }
 
         long rewriteTime = profiler.getRewriteTime();
@@ -296,7 +317,8 @@ public class QueryProfilerTests extends OpenSearchTestCase {
         searcher.count(query);
         List<ProfileResult> results = profiler.getTree();
         assertEquals(1, results.size());
-        Map<String, Long> breakdown = results.get(0).getTimeBreakdown();
+        ProfileResult profileResult = results.get(0);
+        Map<String, Long> breakdown = profileResult.getTimeBreakdown();
         assertThat(breakdown.get(QueryTimingType.CREATE_WEIGHT.toString()), greaterThan(0L));
         assertThat(breakdown.get(QueryTimingType.BUILD_SCORER.toString()), greaterThan(0L));
         assertThat(breakdown.get(QueryTimingType.NEXT_DOC.toString()), greaterThan(0L));
@@ -311,7 +333,10 @@ public class QueryProfilerTests extends OpenSearchTestCase {
         assertThat(breakdown.get(QueryTimingType.SCORE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
         assertThat(breakdown.get(QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
 
-        if (results.get(0).getMaxSliceTime() != null) {
+        if (concurrency > 0) {
+            assertThat(profileResult.getMaxSliceTime(), is(not(nullValue())));
+            assertThat(profileResult.getMinSliceTime(), is(not(nullValue())));
+            assertThat(profileResult.getAvgSliceTime(), is(not(nullValue())));
             assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.BUILD_SCORER), greaterThan(0L));
             assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.BUILD_SCORER), greaterThan(0L));
             assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.BUILD_SCORER), greaterThan(0L));
@@ -342,6 +367,10 @@ public class QueryProfilerTests extends OpenSearchTestCase {
             assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
             assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
             assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+        } else {
+            assertThat(profileResult.getMaxSliceTime(), is(nullValue()));
+            assertThat(profileResult.getMinSliceTime(), is(nullValue()));
+            assertThat(profileResult.getAvgSliceTime(), is(nullValue()));
         }
 
         long rewriteTime = profiler.getRewriteTime();

--- a/server/src/test/java/org/opensearch/search/profile/query/QueryProfilerTests.java
+++ b/server/src/test/java/org/opensearch/search/profile/query/QueryProfilerTests.java
@@ -88,7 +88,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class QueryProfilerTests extends OpenSearchTestCase {
-    private final int concurrency;
     private Directory dir;
     private IndexReader reader;
     private ContextIndexSearcher searcher;
@@ -105,7 +104,6 @@ public class QueryProfilerTests extends OpenSearchTestCase {
 
     public QueryProfilerTests(int concurrency) {
         this.executor = (concurrency > 0) ? Executors.newFixedThreadPool(concurrency) : null;
-        this.concurrency = concurrency;
     }
 
     @Before
@@ -185,7 +183,7 @@ public class QueryProfilerTests extends OpenSearchTestCase {
         assertThat(breakdown.get(QueryTimingType.SCORE + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
         assertThat(breakdown.get(QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
 
-        if (concurrency > 0) {
+        if (executor != null) {
             assertThat(profileResult.getMaxSliceTime(), is(not(nullValue())));
             assertThat(profileResult.getMinSliceTime(), is(not(nullValue())));
             assertThat(profileResult.getAvgSliceTime(), is(not(nullValue())));
@@ -252,7 +250,7 @@ public class QueryProfilerTests extends OpenSearchTestCase {
         assertThat(breakdown.get(QueryTimingType.SCORE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
         assertThat(breakdown.get(QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
 
-        if (concurrency > 0) {
+        if (executor != null) {
             assertThat(profileResult.getMaxSliceTime(), is(not(nullValue())));
             assertThat(profileResult.getMinSliceTime(), is(not(nullValue())));
             assertThat(profileResult.getAvgSliceTime(), is(not(nullValue())));
@@ -333,7 +331,7 @@ public class QueryProfilerTests extends OpenSearchTestCase {
         assertThat(breakdown.get(QueryTimingType.SCORE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
         assertThat(breakdown.get(QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
 
-        if (concurrency > 0) {
+        if (executor != null) {
             assertThat(profileResult.getMaxSliceTime(), is(not(nullValue())));
             assertThat(profileResult.getMinSliceTime(), is(not(nullValue())));
             assertThat(profileResult.getAvgSliceTime(), is(not(nullValue())));

--- a/server/src/test/java/org/opensearch/search/query/QueryProfilePhaseTests.java
+++ b/server/src/test/java/org/opensearch/search/query/QueryProfilePhaseTests.java
@@ -338,6 +338,14 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
             assertThat(query.getTimeBreakdown().keySet(), not(empty()));
             assertThat(query.getTimeBreakdown().get("score"), greaterThanOrEqualTo(100L));
             assertThat(query.getTimeBreakdown().get("score_count"), equalTo(1L));
+            if (query.getMaxSliceTime() != null) {
+                assertThat(query.getTimeBreakdown().get("max_score"), greaterThanOrEqualTo(100L));
+                assertThat(query.getTimeBreakdown().get("min_score"), greaterThanOrEqualTo(100L));
+                assertThat(query.getTimeBreakdown().get("avg_score"), greaterThanOrEqualTo(100L));
+                assertThat(query.getTimeBreakdown().get("max_score_count"), equalTo(1L));
+                assertThat(query.getTimeBreakdown().get("min_score_count"), equalTo(1L));
+                assertThat(query.getTimeBreakdown().get("avg_score_count"), equalTo(1L));
+            }
             assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
         }, collector -> {
@@ -477,6 +485,14 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
                 assertThat(query.getTimeBreakdown().keySet(), not(empty()));
                 assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("score_count"), greaterThan(0L));
+                if (query.getMaxSliceTime() != null) {
+                    assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
+                    assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
+                    assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
+                    assertThat(query.getTimeBreakdown().get("max_score_count"), greaterThan(0L));
+                    assertThat(query.getTimeBreakdown().get("min_score_count"), greaterThan(0L));
+                    assertThat(query.getTimeBreakdown().get("avg_score_count"), greaterThan(0L));
+                }
                 assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
             }, collector -> {
@@ -547,6 +563,14 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
                 assertThat(query.getTimeBreakdown().keySet(), not(empty()));
                 assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("score_count"), greaterThan(0L));
+                if (query.getMaxSliceTime() != null) {
+                    assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
+                    assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
+                    assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
+                    assertThat(query.getTimeBreakdown().get("max_score_count"), greaterThan(0L));
+                    assertThat(query.getTimeBreakdown().get("min_score_count"), greaterThan(0L));
+                    assertThat(query.getTimeBreakdown().get("avg_score_count"), greaterThan(0L));
+                }
                 assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
             }, collector -> {
@@ -585,6 +609,14 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
                 assertThat(query.getTimeBreakdown().keySet(), not(empty()));
                 assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("score_count"), greaterThan(0L));
+                if (query.getMaxSliceTime() != null) {
+                    assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
+                    assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
+                    assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
+                    assertThat(query.getTimeBreakdown().get("max_score_count"), greaterThan(0L));
+                    assertThat(query.getTimeBreakdown().get("min_score_count"), greaterThan(0L));
+                    assertThat(query.getTimeBreakdown().get("avg_score_count"), greaterThan(0L));
+                }
                 assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
 
@@ -709,6 +741,14 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
                 assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
                 assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("score"), greaterThan(0L));
                 assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("score_count"), greaterThan(0L));
+                if (query.getMaxSliceTime() != null) {
+                    assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("max_score"), greaterThan(0L));
+                    assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("min_score"), greaterThan(0L));
+                    assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("avg_score"), greaterThan(0L));
+                    assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("max_score_count"), greaterThan(0L));
+                    assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("min_score_count"), greaterThan(0L));
+                    assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("avg_score_count"), greaterThan(0L));
+                }
 
                 assertThat(query.getProfiledChildren().get(1).getQueryName(), equalTo("TermQuery"));
                 assertThat(query.getProfiledChildren().get(1).getTime(), greaterThan(0L));
@@ -716,6 +756,14 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
                 assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
                 assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("score"), greaterThan(0L));
                 assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("score_count"), greaterThan(0L));
+                if (query.getMaxSliceTime() != null) {
+                    assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("max_score"), greaterThan(0L));
+                    assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("min_score"), greaterThan(0L));
+                    assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("avg_score"), greaterThan(0L));
+                    assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("max_score_count"), greaterThan(0L));
+                    assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("min_score_count"), greaterThan(0L));
+                    assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("avg_score_count"), greaterThan(0L));
+                }
             }, collector -> {
                 assertThat(collector.getReason(), equalTo("search_terminate_after_count"));
                 assertThat(collector.getTime(), greaterThan(0L));
@@ -1054,6 +1102,14 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
             assertThat(query.getTimeBreakdown().keySet(), not(empty()));
             assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("score_count"), greaterThan(0L));
+            if (query.getMaxSliceTime() != null) {
+                assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("max_score_count"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("min_score_count"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("avg_score_count"), greaterThan(0L));
+            }
             assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
         }, collector -> {
@@ -1133,6 +1189,14 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
             assertThat(query.getTimeBreakdown().keySet(), not(empty()));
             assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("score_count"), equalTo(10L));
+            if (query.getMaxSliceTime() != null) {
+                assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("max_score_count"), equalTo(10L));
+                assertThat(query.getTimeBreakdown().get("min_score_count"), equalTo(10L));
+                assertThat(query.getTimeBreakdown().get("avg_score_count"), equalTo(10L));
+            }
             assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
 
@@ -1210,6 +1274,14 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
             assertThat(query.getTimeBreakdown().keySet(), not(empty()));
             assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("score_count"), greaterThanOrEqualTo(6L));
+            if (query.getMaxSliceTime() != null) {
+                assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("min_score"), greaterThanOrEqualTo(0L));
+                assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("max_score_count"), greaterThanOrEqualTo(6L));
+                assertThat(query.getTimeBreakdown().get("min_score_count"), greaterThanOrEqualTo(0L));
+                assertThat(query.getTimeBreakdown().get("avg_score_count"), greaterThanOrEqualTo(1L));
+            }
             assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
 
@@ -1245,6 +1317,14 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
             assertThat(query.getTimeBreakdown().keySet(), not(empty()));
             assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("score_count"), greaterThanOrEqualTo(6L));
+            if (query.getMaxSliceTime() != null) {
+                assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("max_score_count"), greaterThanOrEqualTo(6L));
+                assertThat(query.getTimeBreakdown().get("min_score_count"), greaterThanOrEqualTo(0L));
+                assertThat(query.getTimeBreakdown().get("avg_score_count"), greaterThanOrEqualTo(1L));
+            }
             assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
 
@@ -1315,6 +1395,14 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
             assertThat(query.getTimeBreakdown().keySet(), not(empty()));
             assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("score_count"), greaterThanOrEqualTo(6L));
+            if (query.getMaxSliceTime() != null) {
+                assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("max_score_count"), greaterThanOrEqualTo(6L));
+                assertThat(query.getTimeBreakdown().get("min_score_count"), greaterThanOrEqualTo(6L));
+                assertThat(query.getTimeBreakdown().get("avg_score_count"), greaterThanOrEqualTo(6L));
+            }
             assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
             assertThat(query.getProfiledChildren(), empty());
@@ -1342,6 +1430,14 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
             assertThat(query.getTimeBreakdown().keySet(), not(empty()));
             assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("score_count"), greaterThanOrEqualTo(6L));
+            if (query.getMaxSliceTime() != null) {
+                assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("max_score_count"), greaterThanOrEqualTo(6L));
+                assertThat(query.getTimeBreakdown().get("min_score_count"), greaterThanOrEqualTo(6L));
+                assertThat(query.getTimeBreakdown().get("avg_score_count"), greaterThanOrEqualTo(6L));
+            }
             assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
             assertThat(query.getProfiledChildren(), empty());

--- a/server/src/test/java/org/opensearch/search/query/QueryProfilePhaseTests.java
+++ b/server/src/test/java/org/opensearch/search/query/QueryProfilePhaseTests.java
@@ -97,6 +97,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class QueryProfilePhaseTests extends IndexShardTestCase {
+    private final int concurrency;
     private IndexShard indexShard;
     private final ExecutorService executor;
     private final QueryPhaseSearcher queryPhaseSearcher;
@@ -112,6 +113,7 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
     public QueryProfilePhaseTests(int concurrency, QueryPhaseSearcher queryPhaseSearcher) {
         this.executor = (concurrency > 0) ? Executors.newFixedThreadPool(concurrency) : null;
         this.queryPhaseSearcher = queryPhaseSearcher;
+        this.concurrency = concurrency;
     }
 
     @Override
@@ -338,7 +340,7 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
             assertThat(query.getTimeBreakdown().keySet(), not(empty()));
             assertThat(query.getTimeBreakdown().get("score"), greaterThanOrEqualTo(100L));
             assertThat(query.getTimeBreakdown().get("score_count"), equalTo(1L));
-            if (query.getMaxSliceTime() != null) {
+            if (concurrency > 0) {
                 assertThat(query.getTimeBreakdown().get("max_score"), greaterThanOrEqualTo(100L));
                 assertThat(query.getTimeBreakdown().get("min_score"), greaterThanOrEqualTo(100L));
                 assertThat(query.getTimeBreakdown().get("avg_score"), greaterThanOrEqualTo(100L));
@@ -485,7 +487,7 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
                 assertThat(query.getTimeBreakdown().keySet(), not(empty()));
                 assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("score_count"), greaterThan(0L));
-                if (query.getMaxSliceTime() != null) {
+                if (concurrency > 0) {
                     assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
                     assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
                     assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
@@ -563,7 +565,7 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
                 assertThat(query.getTimeBreakdown().keySet(), not(empty()));
                 assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("score_count"), greaterThan(0L));
-                if (query.getMaxSliceTime() != null) {
+                if (concurrency > 0) {
                     assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
                     assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
                     assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
@@ -609,7 +611,7 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
                 assertThat(query.getTimeBreakdown().keySet(), not(empty()));
                 assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("score_count"), greaterThan(0L));
-                if (query.getMaxSliceTime() != null) {
+                if (concurrency > 0) {
                     assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
                     assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
                     assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
@@ -741,7 +743,7 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
                 assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
                 assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("score"), greaterThan(0L));
                 assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("score_count"), greaterThan(0L));
-                if (query.getMaxSliceTime() != null) {
+                if (concurrency > 0) {
                     assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("max_score"), greaterThan(0L));
                     assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("min_score"), greaterThan(0L));
                     assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("avg_score"), greaterThan(0L));
@@ -756,7 +758,7 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
                 assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
                 assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("score"), greaterThan(0L));
                 assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("score_count"), greaterThan(0L));
-                if (query.getMaxSliceTime() != null) {
+                if (concurrency > 0) {
                     assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("max_score"), greaterThan(0L));
                     assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("min_score"), greaterThan(0L));
                     assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("avg_score"), greaterThan(0L));
@@ -1102,7 +1104,7 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
             assertThat(query.getTimeBreakdown().keySet(), not(empty()));
             assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("score_count"), greaterThan(0L));
-            if (query.getMaxSliceTime() != null) {
+            if (concurrency > 0) {
                 assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
@@ -1189,7 +1191,7 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
             assertThat(query.getTimeBreakdown().keySet(), not(empty()));
             assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("score_count"), equalTo(10L));
-            if (query.getMaxSliceTime() != null) {
+            if (concurrency > 0) {
                 assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
@@ -1274,7 +1276,7 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
             assertThat(query.getTimeBreakdown().keySet(), not(empty()));
             assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("score_count"), greaterThanOrEqualTo(6L));
-            if (query.getMaxSliceTime() != null) {
+            if (concurrency > 0) {
                 assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("min_score"), greaterThanOrEqualTo(0L));
                 assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
@@ -1317,7 +1319,7 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
             assertThat(query.getTimeBreakdown().keySet(), not(empty()));
             assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("score_count"), greaterThanOrEqualTo(6L));
-            if (query.getMaxSliceTime() != null) {
+            if (concurrency > 0) {
                 assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
@@ -1395,7 +1397,7 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
             assertThat(query.getTimeBreakdown().keySet(), not(empty()));
             assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("score_count"), greaterThanOrEqualTo(6L));
-            if (query.getMaxSliceTime() != null) {
+            if (concurrency > 0) {
                 assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
@@ -1430,7 +1432,7 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
             assertThat(query.getTimeBreakdown().keySet(), not(empty()));
             assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("score_count"), greaterThanOrEqualTo(6L));
-            if (query.getMaxSliceTime() != null) {
+            if (concurrency > 0) {
                 assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));

--- a/server/src/test/java/org/opensearch/search/query/QueryProfilePhaseTests.java
+++ b/server/src/test/java/org/opensearch/search/query/QueryProfilePhaseTests.java
@@ -97,7 +97,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class QueryProfilePhaseTests extends IndexShardTestCase {
-    private final int concurrency;
     private IndexShard indexShard;
     private final ExecutorService executor;
     private final QueryPhaseSearcher queryPhaseSearcher;
@@ -113,7 +112,6 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
     public QueryProfilePhaseTests(int concurrency, QueryPhaseSearcher queryPhaseSearcher) {
         this.executor = (concurrency > 0) ? Executors.newFixedThreadPool(concurrency) : null;
         this.queryPhaseSearcher = queryPhaseSearcher;
-        this.concurrency = concurrency;
     }
 
     @Override
@@ -340,7 +338,7 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
             assertThat(query.getTimeBreakdown().keySet(), not(empty()));
             assertThat(query.getTimeBreakdown().get("score"), greaterThanOrEqualTo(100L));
             assertThat(query.getTimeBreakdown().get("score_count"), equalTo(1L));
-            if (concurrency > 0) {
+            if (executor != null) {
                 assertThat(query.getTimeBreakdown().get("max_score"), greaterThanOrEqualTo(100L));
                 assertThat(query.getTimeBreakdown().get("min_score"), greaterThanOrEqualTo(100L));
                 assertThat(query.getTimeBreakdown().get("avg_score"), greaterThanOrEqualTo(100L));
@@ -487,7 +485,7 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
                 assertThat(query.getTimeBreakdown().keySet(), not(empty()));
                 assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("score_count"), greaterThan(0L));
-                if (concurrency > 0) {
+                if (executor != null) {
                     assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
                     assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
                     assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
@@ -565,7 +563,7 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
                 assertThat(query.getTimeBreakdown().keySet(), not(empty()));
                 assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("score_count"), greaterThan(0L));
-                if (concurrency > 0) {
+                if (executor != null) {
                     assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
                     assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
                     assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
@@ -611,7 +609,7 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
                 assertThat(query.getTimeBreakdown().keySet(), not(empty()));
                 assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("score_count"), greaterThan(0L));
-                if (concurrency > 0) {
+                if (executor != null) {
                     assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
                     assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
                     assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
@@ -743,7 +741,7 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
                 assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
                 assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("score"), greaterThan(0L));
                 assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("score_count"), greaterThan(0L));
-                if (concurrency > 0) {
+                if (executor != null) {
                     assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("max_score"), greaterThan(0L));
                     assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("min_score"), greaterThan(0L));
                     assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("avg_score"), greaterThan(0L));
@@ -758,7 +756,7 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
                 assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
                 assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("score"), greaterThan(0L));
                 assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("score_count"), greaterThan(0L));
-                if (concurrency > 0) {
+                if (executor != null) {
                     assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("max_score"), greaterThan(0L));
                     assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("min_score"), greaterThan(0L));
                     assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("avg_score"), greaterThan(0L));
@@ -1104,7 +1102,7 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
             assertThat(query.getTimeBreakdown().keySet(), not(empty()));
             assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("score_count"), greaterThan(0L));
-            if (concurrency > 0) {
+            if (executor != null) {
                 assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
@@ -1191,7 +1189,7 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
             assertThat(query.getTimeBreakdown().keySet(), not(empty()));
             assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("score_count"), equalTo(10L));
-            if (concurrency > 0) {
+            if (executor != null) {
                 assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
@@ -1276,7 +1274,7 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
             assertThat(query.getTimeBreakdown().keySet(), not(empty()));
             assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("score_count"), greaterThanOrEqualTo(6L));
-            if (concurrency > 0) {
+            if (executor != null) {
                 assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("min_score"), greaterThanOrEqualTo(0L));
                 assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
@@ -1319,7 +1317,7 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
             assertThat(query.getTimeBreakdown().keySet(), not(empty()));
             assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("score_count"), greaterThanOrEqualTo(6L));
-            if (concurrency > 0) {
+            if (executor != null) {
                 assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
@@ -1397,7 +1395,7 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
             assertThat(query.getTimeBreakdown().keySet(), not(empty()));
             assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("score_count"), greaterThanOrEqualTo(6L));
-            if (concurrency > 0) {
+            if (executor != null) {
                 assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
@@ -1432,7 +1430,7 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
             assertThat(query.getTimeBreakdown().keySet(), not(empty()));
             assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("score_count"), greaterThanOrEqualTo(6L));
-            if (concurrency > 0) {
+            if (executor != null) {
                 assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
At present, the query profiler is the total timing obtained by summing all segments. However, this does not accurately represent the detailed timing of the query, including queue time and gap time, during concurrent execution. This PR will address the problem.

#### A sample query response for a concurrent search with 2 segment slices:
``` json
{
    "took": 61,
    "timed_out": false,
    "num_reduce_phases": 2,
    "_shards": {...},
    "hits": {...},
    "profile":
    {
        "shards":
        [
            {
                "id": "[FFjuubYPTGSYwNLsL2ccbA][test][0]",
                "inbound_network_time_in_millis": 6,
                "outbound_network_time_in_millis": 1,
                "searches":
                [
                    {
                        "query":
                        [
                            {
                                "type": "TermQuery",
                                "description": "field1:one",
                                "time_in_nanos": 3944209,
                                "max_slice_time_in_nanos": 3944209,
                                "min_slice_time_in_nanos": 3892625,
                                "avg_slice_time_in_nanos": 3918417,
                                "breakdown":
                                {
                                    "max_match": 0,
                                    "set_min_competitive_score_count": 0,
                                    "match_count": 0,
                                    "avg_score_count": 4,
                                    "shallow_advance_count": 0,
                                    "next_doc": 50625,
                                    "min_build_scorer": 1327791,
                                    "score_count": 8,
                                    "compute_max_score_count": 0,
                                    "advance": 96583,
                                    "min_set_min_competitive_score": 0,
                                    "min_advance": 4042,
                                    "score": 96751,
                                    "avg_set_min_competitive_score_count": 0,
                                    "min_match_count": 0,
                                    "avg_score": 65438,
                                    "max_next_doc_count": 7,
                                    "max_compute_max_score_count": 0,
                                    "avg_shallow_advance": 0,
                                    "max_shallow_advance_count": 0,
                                    "set_min_competitive_score": 0,
                                    "min_build_scorer_count": 2,
                                    "next_doc_count": 8,
                                    "min_match": 0,
                                    "avg_next_doc": 26250,
                                    "compute_max_score": 0,
                                    "min_set_min_competitive_score_count": 0,
                                    "max_build_scorer": 1722750,
                                    "avg_match_count": 0,
                                    "avg_advance": 50125,
                                    "build_scorer_count": 6,
                                    "avg_build_scorer_count": 3,
                                    "min_next_doc_count": 1,
                                    "min_shallow_advance_count": 0,
                                    "max_score_count": 7,
                                    "avg_match": 0,
                                    "avg_compute_max_score": 0,
                                    "max_advance": 96208,
                                    "avg_shallow_advance_count": 0,
                                    "avg_set_min_competitive_score": 0,
                                    "avg_compute_max_score_count": 0,
                                    "avg_build_scorer": 1525270,
                                    "max_set_min_competitive_score_count": 0,
                                    "advance_count": 3,
                                    "max_build_scorer_count": 4,
                                    "shallow_advance": 0,
                                    "min_compute_max_score": 0,
                                    "max_match_count": 0,
                                    "create_weight_count": 1,
                                    "build_scorer": 1830250,
                                    "max_set_min_competitive_score": 0,
                                    "max_compute_max_score": 0,
                                    "min_shallow_advance": 0,
                                    "match": 0,
                                    "max_shallow_advance": 0,
                                    "avg_advance_count": 1,
                                    "min_next_doc": 1875,
                                    "max_advance_count": 2,
                                    "min_score": 34209,
                                    "max_next_doc": 50625,
                                    "create_weight": 472375,
                                    "avg_next_doc_count": 4,
                                    "max_score": 96667,
                                    "min_compute_max_score_count": 0,
                                    "min_score_count": 1,
                                    "min_advance_count": 1
                                }
                            }
                        ],
                        "rewrite_time": 175791,
                        "collector": [...]
                    }
                ],
                "aggregations": []
            },
            {...},
            {...}
        ]
    }
}
```

### Related Issues
Resolves #8330 #7354
<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
