### PR TITLE
[Remote Store][Refactor] Introduce RemoteStoreRestoreService to handle restore from remote store

### DIFF
--- a/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/restore/TransportRestoreRemoteStoreAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/restore/TransportRestoreRemoteStoreAction.java
@@ -19,7 +19,7 @@ import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.common.io.stream.StreamInput;
-import org.opensearch.snapshots.RestoreService;
+import org.opensearch.index.recovery.RemoteStoreRestoreService;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
@@ -33,14 +33,14 @@ import java.io.IOException;
 public final class TransportRestoreRemoteStoreAction extends TransportClusterManagerNodeAction<
     RestoreRemoteStoreRequest,
     RestoreRemoteStoreResponse> {
-    private final RestoreService restoreService;
+    private final RemoteStoreRestoreService restoreService;
 
     @Inject
     public TransportRestoreRemoteStoreAction(
         TransportService transportService,
         ClusterService clusterService,
         ThreadPool threadPool,
-        RestoreService restoreService,
+        RemoteStoreRestoreService restoreService,
         ActionFilters actionFilters,
         IndexNameExpressionResolver indexNameExpressionResolver
     ) {
@@ -84,7 +84,7 @@ public final class TransportRestoreRemoteStoreAction extends TransportClusterMan
         final ClusterState state,
         final ActionListener<RestoreRemoteStoreResponse> listener
     ) {
-        restoreService.restoreFromRemoteStore(
+        restoreService.restore(
             request,
             ActionListener.delegateFailure(listener, (delegatedListener, restoreCompletionResponse) -> {
                 if (restoreCompletionResponse.getRestoreInfo() == null && request.waitForCompletion()) {

--- a/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/restore/TransportRestoreRemoteStoreAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/restore/TransportRestoreRemoteStoreAction.java
@@ -84,20 +84,17 @@ public final class TransportRestoreRemoteStoreAction extends TransportClusterMan
         final ClusterState state,
         final ActionListener<RestoreRemoteStoreResponse> listener
     ) {
-        restoreService.restore(
-            request,
-            ActionListener.delegateFailure(listener, (delegatedListener, restoreCompletionResponse) -> {
-                if (restoreCompletionResponse.getRestoreInfo() == null && request.waitForCompletion()) {
-                    RestoreClusterStateListener.createAndRegisterListener(
-                        clusterService,
-                        restoreCompletionResponse,
-                        delegatedListener,
-                        RestoreRemoteStoreResponse::new
-                    );
-                } else {
-                    delegatedListener.onResponse(new RestoreRemoteStoreResponse(restoreCompletionResponse.getRestoreInfo()));
-                }
-            })
-        );
+        restoreService.restore(request, ActionListener.delegateFailure(listener, (delegatedListener, restoreCompletionResponse) -> {
+            if (restoreCompletionResponse.getRestoreInfo() == null && request.waitForCompletion()) {
+                RestoreClusterStateListener.createAndRegisterListener(
+                    clusterService,
+                    restoreCompletionResponse,
+                    delegatedListener,
+                    RestoreRemoteStoreResponse::new
+                );
+            } else {
+                delegatedListener.onResponse(new RestoreRemoteStoreResponse(restoreCompletionResponse.getRestoreInfo()));
+            }
+        }));
     }
 }

--- a/server/src/main/java/org/opensearch/index/recovery/RemoteStoreRestoreService.java
+++ b/server/src/main/java/org/opensearch/index/recovery/RemoteStoreRestoreService.java
@@ -41,6 +41,8 @@ import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REMOTE_STORE
 
 /**
  * Service responsible for restoring index data from remote store
+ *
+ * @opensearch.internal
  */
 public class RemoteStoreRestoreService {
     private static final Logger logger = LogManager.getLogger(RemoteStoreRestoreService.class);

--- a/server/src/main/java/org/opensearch/index/recovery/RemoteStoreRestoreService.java
+++ b/server/src/main/java/org/opensearch/index/recovery/RemoteStoreRestoreService.java
@@ -47,13 +47,9 @@ public class RemoteStoreRestoreService {
 
     private final ClusterService clusterService;
 
-
     private final AllocationService allocationService;
 
-    public RemoteStoreRestoreService(
-        ClusterService clusterService,
-        AllocationService allocationService
-    ) {
+    public RemoteStoreRestoreService(ClusterService clusterService, AllocationService allocationService) {
         this.clusterService = clusterService;
         this.allocationService = allocationService;
     }

--- a/server/src/main/java/org/opensearch/index/recovery/RemoteStoreRestoreService.java
+++ b/server/src/main/java/org/opensearch/index/recovery/RemoteStoreRestoreService.java
@@ -10,7 +10,6 @@ package org.opensearch.index.recovery;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.action.ActionListener;
 import org.opensearch.action.admin.cluster.remotestore.restore.RestoreRemoteStoreRequest;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.ClusterStateUpdateTask;
@@ -25,6 +24,7 @@ import org.opensearch.cluster.routing.allocation.AllocationService;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.repositories.IndexId;
 import org.opensearch.snapshots.RestoreInfo;

--- a/server/src/main/java/org/opensearch/index/recovery/RemoteStoreRestoreService.java
+++ b/server/src/main/java/org/opensearch/index/recovery/RemoteStoreRestoreService.java
@@ -1,0 +1,155 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.recovery;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.admin.cluster.remotestore.restore.RestoreRemoteStoreRequest;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.ClusterStateUpdateTask;
+import org.opensearch.cluster.block.ClusterBlocks;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.routing.IndexShardRoutingTable;
+import org.opensearch.cluster.routing.RecoverySource;
+import org.opensearch.cluster.routing.RoutingTable;
+import org.opensearch.cluster.routing.ShardRouting;
+import org.opensearch.cluster.routing.allocation.AllocationService;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.UUIDs;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.repositories.IndexId;
+import org.opensearch.snapshots.RestoreInfo;
+import org.opensearch.snapshots.RestoreService;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REMOTE_STORE_ENABLED;
+
+/**
+ * Service responsible for restoring index data from remote store
+ */
+public class RemoteStoreRestoreService {
+    private static final Logger logger = LogManager.getLogger(RemoteStoreRestoreService.class);
+
+    private final ClusterService clusterService;
+
+
+    private final AllocationService allocationService;
+
+    public RemoteStoreRestoreService(
+        ClusterService clusterService,
+        AllocationService allocationService
+    ) {
+        this.clusterService = clusterService;
+        this.allocationService = allocationService;
+    }
+
+    public void restore(RestoreRemoteStoreRequest request, final ActionListener<RestoreService.RestoreCompletionResponse> listener) {
+        clusterService.submitStateUpdateTask("restore[remote_store]", new ClusterStateUpdateTask() {
+            final String restoreUUID = UUIDs.randomBase64UUID();
+            RestoreInfo restoreInfo = null;
+
+            @Override
+            public ClusterState execute(ClusterState currentState) {
+                // Updating cluster state
+                ClusterState.Builder builder = ClusterState.builder(currentState);
+                Metadata.Builder mdBuilder = Metadata.builder(currentState.metadata());
+                ClusterBlocks.Builder blocks = ClusterBlocks.builder().blocks(currentState.blocks());
+                RoutingTable.Builder rtBuilder = RoutingTable.builder(currentState.routingTable());
+
+                List<String> indicesToBeRestored = new ArrayList<>();
+                int totalShards = 0;
+                for (String index : request.indices()) {
+                    IndexMetadata currentIndexMetadata = currentState.metadata().index(index);
+                    if (currentIndexMetadata == null) {
+                        // ToDo: Handle index metadata does not exist case. (GitHub #3457)
+                        logger.warn("Remote store restore is not supported for non-existent index. Skipping: {}", index);
+                        continue;
+                    }
+                    if (currentIndexMetadata.getSettings().getAsBoolean(SETTING_REMOTE_STORE_ENABLED, false)) {
+                        IndexMetadata updatedIndexMetadata = currentIndexMetadata;
+                        Map<ShardId, ShardRouting> activeInitializingShards = new HashMap<>();
+                        if (request.restoreAllShards()) {
+                            if (currentIndexMetadata.getState() != IndexMetadata.State.CLOSE) {
+                                throw new IllegalStateException(
+                                    "cannot restore index ["
+                                        + index
+                                        + "] because an open index "
+                                        + "with same name already exists in the cluster. Close the existing index"
+                                );
+                            }
+                            updatedIndexMetadata = IndexMetadata.builder(currentIndexMetadata)
+                                .state(IndexMetadata.State.OPEN)
+                                .version(1 + currentIndexMetadata.getVersion())
+                                .mappingVersion(1 + currentIndexMetadata.getMappingVersion())
+                                .settingsVersion(1 + currentIndexMetadata.getSettingsVersion())
+                                .aliasesVersion(1 + currentIndexMetadata.getAliasesVersion())
+                                .build();
+                        } else {
+                            activeInitializingShards = currentState.routingTable()
+                                .index(index)
+                                .shards()
+                                .values()
+                                .stream()
+                                .map(IndexShardRoutingTable::primaryShard)
+                                .filter(shardRouting -> shardRouting.unassigned() == false)
+                                .collect(Collectors.toMap(ShardRouting::shardId, Function.identity()));
+                        }
+
+                        IndexId indexId = new IndexId(index, updatedIndexMetadata.getIndexUUID());
+
+                        RecoverySource.RemoteStoreRecoverySource recoverySource = new RecoverySource.RemoteStoreRecoverySource(
+                            restoreUUID,
+                            updatedIndexMetadata.getCreationVersion(),
+                            indexId
+                        );
+                        rtBuilder.addAsRemoteStoreRestore(updatedIndexMetadata, recoverySource, activeInitializingShards);
+                        blocks.updateBlocks(updatedIndexMetadata);
+                        mdBuilder.put(updatedIndexMetadata, true);
+                        indicesToBeRestored.add(index);
+                        totalShards += updatedIndexMetadata.getNumberOfShards();
+                    } else {
+                        logger.warn("Remote store is not enabled for index: {}", index);
+                    }
+                }
+
+                restoreInfo = new RestoreInfo("remote_store", indicesToBeRestored, totalShards, totalShards);
+
+                RoutingTable rt = rtBuilder.build();
+                ClusterState updatedState = builder.metadata(mdBuilder).blocks(blocks).routingTable(rt).build();
+                return allocationService.reroute(updatedState, "restored from remote store");
+            }
+
+            @Override
+            public void onFailure(String source, Exception e) {
+                logger.warn("failed to restore from remote store", e);
+                listener.onFailure(e);
+            }
+
+            @Override
+            public TimeValue timeout() {
+                return request.masterNodeTimeout();
+            }
+
+            @Override
+            public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                listener.onResponse(new RestoreService.RestoreCompletionResponse(restoreUUID, null, restoreInfo));
+            }
+        });
+
+    }
+}

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -44,6 +44,7 @@ import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.cluster.routing.allocation.AwarenessReplicaBalance;
 import org.opensearch.index.IndexModule;
 import org.opensearch.index.IndexingPressureService;
+import org.opensearch.index.recovery.RemoteStoreRestoreService;
 import org.opensearch.index.store.remote.filecache.FileCache;
 import org.opensearch.index.store.remote.filecache.FileCacheCleaner;
 import org.opensearch.index.store.remote.filecache.FileCacheFactory;
@@ -945,6 +946,16 @@ public class Node implements Closeable {
                 indicesService,
                 clusterInfoService::getClusterInfo
             );
+            RemoteStoreRestoreService remoteStoreRestoreService = new RemoteStoreRestoreService(
+                clusterService,
+                clusterModule.getAllocationService()
+//                repositoryService,
+//                metadataCreateIndexService,
+//                metadataIndexUpgradeService,
+//                shardLimitValidator,
+//                indicesService,
+//                clusterInfoService::getClusterInfo
+            );
 
             final DiskThresholdMonitor diskThresholdMonitor = new DiskThresholdMonitor(
                 settings,
@@ -1141,6 +1152,7 @@ public class Node implements Closeable {
                 b.bind(SnapshotShardsService.class).toInstance(snapshotShardsService);
                 b.bind(TransportNodesSnapshotsStatus.class).toInstance(nodesSnapshotsStatus);
                 b.bind(RestoreService.class).toInstance(restoreService);
+                b.bind(RemoteStoreRestoreService.class).toInstance(remoteStoreRestoreService);
                 b.bind(RerouteService.class).toInstance(rerouteService);
                 b.bind(ShardLimitValidator.class).toInstance(shardLimitValidator);
                 b.bind(FsHealthService.class).toInstance(fsHealthService);

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -949,12 +949,6 @@ public class Node implements Closeable {
             RemoteStoreRestoreService remoteStoreRestoreService = new RemoteStoreRestoreService(
                 clusterService,
                 clusterModule.getAllocationService()
-//                repositoryService,
-//                metadataCreateIndexService,
-//                metadataIndexUpgradeService,
-//                shardLimitValidator,
-//                indicesService,
-//                clusterInfoService::getClusterInfo
             );
 
             final DiskThresholdMonitor diskThresholdMonitor = new DiskThresholdMonitor(

--- a/server/src/main/java/org/opensearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/opensearch/snapshots/RestoreService.java
@@ -986,7 +986,7 @@ public class RestoreService implements ClusterStateApplier {
         private final Snapshot snapshot;
         private final RestoreInfo restoreInfo;
 
-        private RestoreCompletionResponse(final String uuid, final Snapshot snapshot, final RestoreInfo restoreInfo) {
+        public RestoreCompletionResponse(final String uuid, final Snapshot snapshot, final RestoreInfo restoreInfo) {
             this.uuid = uuid;
             this.snapshot = snapshot;
             this.restoreInfo = restoreInfo;


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
- Currently remote store backed index restore logic resides in RestoreService along with snapshot restore logic.
- We introduce a new RemoteStoreRestoreService which will host the logic for remote store restore.
- RestoreService will keep on existing and will only contain logic around snapshot restore.

### Related Issues
NA

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
