### PR TITLE
[Remote Store] Add support for Remote Translog Store stats in `_remotestore/stats/` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Redefine telemetry context restoration and propagation ([#9617](https://github.com/opensearch-project/OpenSearch/pull/9617))
 - Use non-concurrent path for sort request on timeseries index and field([#9562](https://github.com/opensearch-project/OpenSearch/pull/9562))
 - Added sampler based on `Blanket Probabilistic Sampling rate` and `Override for on demand` ([#9621](https://github.com/opensearch-project/OpenSearch/issues/9621))
+- [Remote Store] Add support for Remote Translog Store stats in `_remotestore/stats/` API ([#9263](https://github.com/opensearch-project/OpenSearch/pull/9263))
 
 ### Deprecated
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/stats/RemoteStoreStats.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/stats/RemoteStoreStats.java
@@ -36,7 +36,7 @@ public class RemoteStoreStats implements Writeable, ToXContentFragment {
     private final RemoteTranslogTransferTracker.Stats remoteTranslogShardStats;
     private final ShardRouting shardRouting;
 
-    public RemoteStoreStats(
+    RemoteStoreStats(
         RemoteSegmentTransferTracker.Stats remoteSegmentUploadShardStats,
         RemoteTranslogTransferTracker.Stats remoteTranslogShardStats,
         ShardRouting shardRouting
@@ -46,7 +46,7 @@ public class RemoteStoreStats implements Writeable, ToXContentFragment {
         this.shardRouting = shardRouting;
     }
 
-    public RemoteStoreStats(StreamInput in) throws IOException {
+    RemoteStoreStats(StreamInput in) throws IOException {
         remoteSegmentShardStats = in.readOptionalWriteable(RemoteSegmentTransferTracker.Stats::new);
         remoteTranslogShardStats = in.readOptionalWriteable(RemoteTranslogTransferTracker.Stats::new);
         this.shardRouting = new ShardRouting(in);
@@ -60,7 +60,7 @@ public class RemoteStoreStats implements Writeable, ToXContentFragment {
         return shardRouting;
     }
 
-    RemoteTranslogTransferTracker.Stats getTranslogStats() {
+    public RemoteTranslogTransferTracker.Stats getTranslogStats() {
         return remoteTranslogShardStats;
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/stats/TransportRemoteStoreStatsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/stats/TransportRemoteStoreStatsAction.java
@@ -25,6 +25,7 @@ import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.remote.RemoteSegmentTransferTracker;
 import org.opensearch.index.remote.RemoteStoreStatsTrackerFactory;
+import org.opensearch.index.remote.RemoteTranslogTransferTracker;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.shard.ShardNotFoundException;
 import org.opensearch.indices.IndicesService;
@@ -157,6 +158,11 @@ public class TransportRemoteStoreStatsAction extends TransportBroadcastByNodeAct
             indexShard.shardId()
         );
         assert Objects.nonNull(remoteSegmentTransferTracker);
-        return new RemoteStoreStats(remoteSegmentTransferTracker.stats(), indexShard.routingEntry());
+        RemoteTranslogTransferTracker remoteTranslogTransferTracker = remoteStoreStatsTrackerFactory.getRemoteTranslogTransferTracker(
+            indexShard.shardId()
+        );
+        assert Objects.nonNull(remoteTranslogTransferTracker);
+
+        return new RemoteStoreStats(remoteSegmentTransferTracker.stats(), remoteTranslogTransferTracker.stats(), indexShard.routingEntry());
     }
 }

--- a/server/src/main/java/org/opensearch/index/remote/RemoteStorePressureService.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStorePressureService.java
@@ -133,18 +133,18 @@ public class RemoteStorePressureService {
             if (pressureTracker.getRefreshSeqNoLag() <= 1) {
                 return true;
             }
-            if (pressureTracker.isUploadBytesAverageReady() == false) {
+            if (pressureTracker.isUploadBytesMovingAverageReady() == false) {
                 logger.trace("upload bytes moving average is not ready");
                 return true;
             }
-            double dynamicBytesLagThreshold = pressureTracker.getUploadBytesAverage() * pressureSettings.getBytesLagVarianceFactor();
+            double dynamicBytesLagThreshold = pressureTracker.getUploadBytesMovingAverage() * pressureSettings.getBytesLagVarianceFactor();
             long bytesLag = pressureTracker.getBytesLag();
             return bytesLag <= dynamicBytesLagThreshold;
         }
 
         @Override
         public String rejectionMessage(RemoteSegmentTransferTracker pressureTracker, ShardId shardId) {
-            double dynamicBytesLagThreshold = pressureTracker.getUploadBytesAverage() * pressureSettings.getBytesLagVarianceFactor();
+            double dynamicBytesLagThreshold = pressureTracker.getUploadBytesMovingAverage() * pressureSettings.getBytesLagVarianceFactor();
             return String.format(
                 Locale.ROOT,
                 "rejected execution on primary shard:%s due to remote segments lagging behind local segments."
@@ -179,18 +179,20 @@ public class RemoteStorePressureService {
             if (pressureTracker.getRefreshSeqNoLag() <= 1) {
                 return true;
             }
-            if (pressureTracker.isUploadTimeMsAverageReady() == false) {
+            if (pressureTracker.isUploadTimeMovingAverageReady() == false) {
                 logger.trace("upload time moving average is not ready");
                 return true;
             }
             long timeLag = pressureTracker.getTimeMsLag();
-            double dynamicTimeLagThreshold = pressureTracker.getUploadTimeMsAverage() * pressureSettings.getUploadTimeLagVarianceFactor();
+            double dynamicTimeLagThreshold = pressureTracker.getUploadTimeMovingAverage() * pressureSettings
+                .getUploadTimeLagVarianceFactor();
             return timeLag <= dynamicTimeLagThreshold;
         }
 
         @Override
         public String rejectionMessage(RemoteSegmentTransferTracker pressureTracker, ShardId shardId) {
-            double dynamicTimeLagThreshold = pressureTracker.getUploadTimeMsAverage() * pressureSettings.getUploadTimeLagVarianceFactor();
+            double dynamicTimeLagThreshold = pressureTracker.getUploadTimeMovingAverage() * pressureSettings
+                .getUploadTimeLagVarianceFactor();
             return String.format(
                 Locale.ROOT,
                 "rejected execution on primary shard:%s due to remote segments lagging behind local segments."

--- a/server/src/main/java/org/opensearch/index/remote/RemoteStorePressureSettings.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStorePressureSettings.java
@@ -89,43 +89,43 @@ public class RemoteStorePressureSettings {
         clusterSettings.addSettingsUpdateConsumer(MIN_CONSECUTIVE_FAILURES_LIMIT, this::setMinConsecutiveFailuresLimit);
     }
 
-    public boolean isRemoteRefreshSegmentPressureEnabled() {
+    boolean isRemoteRefreshSegmentPressureEnabled() {
         return remoteRefreshSegmentPressureEnabled;
     }
 
-    public void setRemoteRefreshSegmentPressureEnabled(boolean remoteRefreshSegmentPressureEnabled) {
+    private void setRemoteRefreshSegmentPressureEnabled(boolean remoteRefreshSegmentPressureEnabled) {
         this.remoteRefreshSegmentPressureEnabled = remoteRefreshSegmentPressureEnabled;
     }
 
-    public long getMinRefreshSeqNoLagLimit() {
+    long getMinRefreshSeqNoLagLimit() {
         return minRefreshSeqNoLagLimit;
     }
 
-    public void setMinRefreshSeqNoLagLimit(long minRefreshSeqNoLagLimit) {
+    private void setMinRefreshSeqNoLagLimit(long minRefreshSeqNoLagLimit) {
         this.minRefreshSeqNoLagLimit = minRefreshSeqNoLagLimit;
     }
 
-    public double getBytesLagVarianceFactor() {
+    double getBytesLagVarianceFactor() {
         return bytesLagVarianceFactor;
     }
 
-    public void setBytesLagVarianceFactor(double bytesLagVarianceFactor) {
+    private void setBytesLagVarianceFactor(double bytesLagVarianceFactor) {
         this.bytesLagVarianceFactor = bytesLagVarianceFactor;
     }
 
-    public double getUploadTimeLagVarianceFactor() {
+    double getUploadTimeLagVarianceFactor() {
         return uploadTimeLagVarianceFactor;
     }
 
-    public void setUploadTimeLagVarianceFactor(double uploadTimeLagVarianceFactor) {
+    private void setUploadTimeLagVarianceFactor(double uploadTimeLagVarianceFactor) {
         this.uploadTimeLagVarianceFactor = uploadTimeLagVarianceFactor;
     }
 
-    public int getMinConsecutiveFailuresLimit() {
+    int getMinConsecutiveFailuresLimit() {
         return minConsecutiveFailuresLimit;
     }
 
-    public void setMinConsecutiveFailuresLimit(int minConsecutiveFailuresLimit) {
+    private void setMinConsecutiveFailuresLimit(int minConsecutiveFailuresLimit) {
         this.minConsecutiveFailuresLimit = minConsecutiveFailuresLimit;
     }
 }

--- a/server/src/main/java/org/opensearch/index/remote/RemoteTransferTracker.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteTransferTracker.java
@@ -14,6 +14,11 @@ import org.opensearch.core.index.shard.ShardId;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
+/**
+ * Base class for remote store stats trackers
+ *
+ * @opensearch.internal
+ */
 public abstract class RemoteTransferTracker {
     /**
      * The shard that this tracker is associated with

--- a/server/src/main/java/org/opensearch/index/remote/RemoteTransferTracker.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteTransferTracker.java
@@ -1,0 +1,264 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.remote;
+
+import org.opensearch.common.util.MovingAverage;
+import org.opensearch.core.index.shard.ShardId;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+public abstract class RemoteTransferTracker {
+    /**
+     * The shard that this tracker is associated with
+     */
+    protected final ShardId shardId;
+
+    /**
+     * Total time spent on Remote Store uploads.
+     */
+    protected final AtomicLong totalUploadTimeInMillis;
+
+    /**
+     * Total number of Remote Store uploads that have been started.
+     */
+    protected final AtomicLong totalUploadsStarted;
+
+    /**
+     * Total number of Remote Store uploads that have failed.
+     */
+    protected final AtomicLong totalUploadsFailed;
+
+    /**
+     * Total number of Remote Store that have been successful.
+     */
+    protected final AtomicLong totalUploadsSucceeded;
+
+    /**
+     * Total number of byte uploads to Remote Store that have been started.
+     */
+    protected final AtomicLong uploadBytesStarted;
+
+    /**
+     * Total number of byte uploads to Remote Store that have failed.
+     */
+    protected final AtomicLong uploadBytesFailed;
+
+    /**
+     * Total number of byte uploads to Remote Store that have been successful.
+     */
+    protected final AtomicLong uploadBytesSucceeded;
+
+    /**
+     * Provides moving average over the last N total size in bytes of files uploaded as part of Remote Store upload.
+     * N is window size. Wrapped with {@code AtomicReference} for dynamic changes in window size.
+     */
+    protected final AtomicReference<MovingAverage> uploadBytesMovingAverageReference;
+
+    /**
+     * This lock object is used for making sure we do not miss any data.
+     */
+    protected final Object uploadBytesMutex;
+
+    /**
+     * Provides moving average over the last N upload speed (in bytes/s) of files uploaded as part of Remote Store upload.
+     * N is window size. Wrapped with {@code AtomicReference} for dynamic changes in window size.
+     */
+    protected final AtomicReference<MovingAverage> uploadBytesPerSecMovingAverageReference;
+
+    /**
+     * This lock object is used for making sure we do not miss any data.
+     */
+    protected final Object uploadBytesPerSecMutex;
+
+    /**
+     * Provides moving average over the last N overall upload time (in nanos) as part of Remote Store upload. N is window size.
+     * Wrapped with {@code AtomicReference} for dynamic changes in window size.
+     */
+    protected final AtomicReference<MovingAverage> uploadTimeMsMovingAverageReference;
+
+    /**
+     * This lock object is used for making sure we do not miss any data.
+     */
+    protected final Object uploadTimeMsMutex;
+
+    public RemoteTransferTracker(ShardId shardId, int movingAverageWindowSize) {
+        this.shardId = shardId;
+        totalUploadTimeInMillis = new AtomicLong(0);
+        totalUploadsStarted = new AtomicLong(0);
+        totalUploadsFailed = new AtomicLong(0);
+        totalUploadsSucceeded = new AtomicLong(0);
+        uploadBytesStarted = new AtomicLong(0);
+        uploadBytesFailed = new AtomicLong(0);
+        uploadBytesSucceeded = new AtomicLong(0);
+        uploadBytesMutex = new Object();
+        uploadBytesMovingAverageReference = new AtomicReference<>(new MovingAverage(movingAverageWindowSize));
+        uploadBytesPerSecMutex = new Object();
+        uploadBytesPerSecMovingAverageReference = new AtomicReference<>(new MovingAverage(movingAverageWindowSize));
+        uploadTimeMsMutex = new Object();
+        uploadTimeMsMovingAverageReference = new AtomicReference<>(new MovingAverage(movingAverageWindowSize));
+    }
+
+    ShardId getShardId() {
+        return shardId;
+    }
+
+    public long getTotalUploadTimeInMillis() {
+        return totalUploadTimeInMillis.get();
+    }
+
+    public void addUploadTimeInMillis(long duration) {
+        totalUploadTimeInMillis.addAndGet(duration);
+    }
+
+    public long getTotalUploadsStarted() {
+        return totalUploadsStarted.get();
+    }
+
+    public long getTotalUploadsFailed() {
+        return totalUploadsFailed.get();
+    }
+
+    public long getTotalUploadsSucceeded() {
+        return totalUploadsSucceeded.get();
+    }
+
+    public void incrementTotalUploadsStarted() {
+        totalUploadsStarted.addAndGet(1);
+    }
+
+    public void incrementTotalUploadsFailed() {
+        checkTotal(totalUploadsStarted.get(), totalUploadsFailed.get(), totalUploadsSucceeded.get(), 1);
+        totalUploadsFailed.addAndGet(1);
+    }
+
+    public void incrementTotalUploadsSucceeded() {
+        checkTotal(totalUploadsStarted.get(), totalUploadsFailed.get(), totalUploadsSucceeded.get(), 1);
+        totalUploadsSucceeded.addAndGet(1);
+    }
+
+    public long getUploadBytesStarted() {
+        return uploadBytesStarted.get();
+    }
+
+    public long getUploadBytesFailed() {
+        return uploadBytesFailed.get();
+    }
+
+    public long getUploadBytesSucceeded() {
+        return uploadBytesSucceeded.get();
+    }
+
+    public void addUploadBytesStarted(long count) {
+        uploadBytesStarted.addAndGet(count);
+    }
+
+    public void addUploadBytesFailed(long count) {
+        checkTotal(uploadBytesStarted.get(), uploadBytesFailed.get(), uploadBytesSucceeded.get(), count);
+        uploadBytesFailed.addAndGet(count);
+    }
+
+    public void addUploadBytesSucceeded(long count) {
+        checkTotal(uploadBytesStarted.get(), uploadBytesFailed.get(), uploadBytesSucceeded.get(), count);
+        uploadBytesSucceeded.addAndGet(count);
+    }
+
+    boolean isUploadBytesMovingAverageReady() {
+        return uploadBytesMovingAverageReference.get().isReady();
+    }
+
+    double getUploadBytesMovingAverage() {
+        return uploadBytesMovingAverageReference.get().getAverage();
+    }
+
+    public void updateUploadBytesMovingAverage(long count) {
+        updateMovingAverage(count, uploadBytesMutex, uploadBytesMovingAverageReference);
+    }
+
+    boolean isUploadBytesPerSecMovingAverageReady() {
+        return uploadBytesPerSecMovingAverageReference.get().isReady();
+    }
+
+    double getUploadBytesPerSecMovingAverage() {
+        return uploadBytesPerSecMovingAverageReference.get().getAverage();
+    }
+
+    public void updateUploadBytesPerSecMovingAverage(long speed) {
+        updateMovingAverage(speed, uploadBytesPerSecMutex, uploadBytesPerSecMovingAverageReference);
+    }
+
+    boolean isUploadTimeMovingAverageReady() {
+        return uploadTimeMsMovingAverageReference.get().isReady();
+    }
+
+    double getUploadTimeMovingAverage() {
+        return uploadTimeMsMovingAverageReference.get().getAverage();
+    }
+
+    public void updateUploadTimeMovingAverage(long duration) {
+        updateMovingAverage(duration, uploadTimeMsMutex, uploadTimeMsMovingAverageReference);
+    }
+
+    /**
+     * Records a new data point for a moving average stat
+     *
+     * @param value The new data point to be added
+     * @param mutex The mutex to use for the update
+     * @param movingAverageReference The atomic reference to be updated
+     */
+    protected void updateMovingAverage(long value, Object mutex, AtomicReference<MovingAverage> movingAverageReference) {
+        synchronized (mutex) {
+            movingAverageReference.get().record(value);
+        }
+    }
+
+    /**
+     * Updates the window size for data collection. This also resets any data collected so far.
+     *
+     * @param updatedSize The updated size
+     */
+    void updateMovingAverageWindowSize(int updatedSize) {
+        updateMovingAverageWindowSize(updatedSize, uploadBytesMutex, uploadBytesMovingAverageReference);
+        updateMovingAverageWindowSize(updatedSize, uploadBytesPerSecMutex, uploadBytesPerSecMovingAverageReference);
+        updateMovingAverageWindowSize(updatedSize, uploadTimeMsMutex, uploadTimeMsMovingAverageReference);
+    }
+
+    /**
+     * Updates the window size for data collection. This also resets any data collected so far.
+     *
+     * @param updatedSize The updated size
+     * @param mutex The mutex to use for the update
+     * @param movingAverageReference The atomic reference to be updated
+     */
+    protected void updateMovingAverageWindowSize(int updatedSize, Object mutex, AtomicReference<MovingAverage> movingAverageReference) {
+        synchronized (mutex) {
+            movingAverageReference.set(movingAverageReference.get().copyWithSize(updatedSize));
+        }
+    }
+
+    /**
+     * Validates that the sum of successful operations, failed operations, and the number of operations to add (irrespective of failed/successful) does not exceed the number of operations originally started
+     * @param startedCount Number of operations started
+     * @param failedCount Number of operations failed
+     * @param succeededCount Number of operations successful
+     * @param countToAdd Number of operations to add
+     */
+    private void checkTotal(long startedCount, long failedCount, long succeededCount, long countToAdd) {
+        long delta = startedCount - (failedCount + succeededCount + countToAdd);
+        assert delta >= 0 : "Sum of failure count ("
+            + failedCount
+            + "), success count ("
+            + succeededCount
+            + "), and count to add ("
+            + countToAdd
+            + ") cannot exceed started count ("
+            + startedCount
+            + ")";
+    }
+}

--- a/server/src/main/java/org/opensearch/index/remote/RemoteTranslogTransferTracker.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteTranslogTransferTracker.java
@@ -1,0 +1,732 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.remote;
+
+import org.opensearch.common.util.MovingAverage;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.index.shard.ShardId;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Stores Remote Translog Store-related stats for a given IndexShard.
+ *
+ * @opensearch.internal
+ */
+public class RemoteTranslogTransferTracker {
+    /**
+     * The shard that this tracker is associated with
+     */
+    public final ShardId shardId;
+
+    /**
+     * Epoch timestamp of the last successful Remote Translog Store upload.
+     */
+    private final AtomicLong lastSuccessfulUploadTimestamp;
+
+    /**
+     * Total number of Remote Translog Store uploads that have been started.
+     */
+    private final AtomicLong totalUploadsStarted;
+
+    /**
+     * Total number of Remote Translog Store uploads that have failed.
+     */
+    private final AtomicLong totalUploadsFailed;
+
+    /**
+     * Total number of Remote Translog Store that have been successful.
+     */
+    private final AtomicLong totalUploadsSucceeded;
+
+    /**
+     * Total number of byte uploads to Remote Translog Store that have been started.
+     */
+    private final AtomicLong uploadBytesStarted;
+
+    /**
+     * Total number of byte uploads to Remote Translog Store that have failed.
+     */
+    private final AtomicLong uploadBytesFailed;
+
+    /**
+     * Total number of byte uploads to Remote Translog Store that have been successful.
+     */
+    private final AtomicLong uploadBytesSucceeded;
+
+    /**
+     * Total time spent on Remote Translog Store uploads.
+     */
+    private final AtomicLong totalUploadTimeInMillis;
+
+    /**
+     * Provides moving average over the last N total size in bytes of translog files uploaded as part of Remote Translog Store upload.
+     * N is window size. Wrapped with {@code AtomicReference} for dynamic changes in window size.
+     */
+    private final AtomicReference<MovingAverage> uploadBytesMovingAverageReference;
+
+    /**
+     * This lock object is used for making sure we do not miss any data.
+     */
+    private final Object uploadBytesMutex;
+
+    /**
+     * Provides moving average over the last N upload speed (in bytes/s) of translog files uploaded as part of Remote Translog Store upload.
+     * N is window size. Wrapped with {@code AtomicReference} for dynamic changes in window size.
+     */
+    private final AtomicReference<MovingAverage> uploadBytesPerSecMovingAverageReference;
+
+    /**
+     * This lock object is used for making sure we do not miss any data.
+     */
+    private final Object uploadBytesPerSecMutex;
+
+    /**
+     * Provides moving average over the last N overall upload time (in nanos) as part of Remote Translog Store upload. N is window size.
+     * Wrapped with {@code AtomicReference} for dynamic changes in window size.
+     */
+    private final AtomicReference<MovingAverage> uploadTimeMsMovingAverageReference;
+
+    /**
+     * This lock object is used for making sure we do not miss any data.
+     */
+    private final Object uploadTimeMsMutex;
+
+    /**
+     * Epoch timestamp of the last successful Remote Translog Store download.
+     */
+    private final AtomicLong lastSuccessfulDownloadTimestamp;
+
+    /**
+     * Total number of Remote Translog Store downloads that have been successful.
+     */
+    private final AtomicLong totalDownloadsSucceeded;
+
+    /**
+     * Total number of byte downloads to Remote Translog Store that have been successful.
+     */
+    private final AtomicLong downloadBytesSucceeded;
+
+    /**
+     * Total time spent on Remote Translog Store downloads.
+     */
+    private final AtomicLong totalDownloadTimeInMillis;
+
+    /**
+     * Provides moving average over the last N total size in bytes of translog files downloaded as part of Remote Translog Store download.
+     * N is window size. Wrapped with {@code AtomicReference} for dynamic changes in window size.
+     */
+    private final AtomicReference<MovingAverage> downloadBytesMovingAverageReference;
+
+    /**
+     * This lock object is used for making sure we do not miss any data.
+     */
+    private final Object downloadBytesMutex;
+
+    /**
+     * Provides moving average over the last N download speed (in bytes/s) of translog files downloaded as part of Remote Translog Store download.
+     * N is window size. Wrapped with {@code AtomicReference} for dynamic changes in window size.
+     */
+    private final AtomicReference<MovingAverage> downloadBytesPerSecMovingAverageReference;
+
+    /**
+     * This lock object is used for making sure we do not miss any data.
+     */
+    private final Object downloadBytesPerSecMutex;
+
+    /**
+     * Provides moving average over the last N overall download time (in nanos) as part of Remote Translog Store download. N is window size.
+     * Wrapped with {@code AtomicReference} for dynamic changes in window size.
+     */
+    private final AtomicReference<MovingAverage> downloadTimeMsMovingAverageReference;
+
+    /**
+     * This lock object is used for making sure we do not miss any data.
+     */
+    private final Object downloadTimeMsMutex;
+
+    public RemoteTranslogTransferTracker(ShardId shardId, int movingAverageWindowSize) {
+        this.shardId = shardId;
+
+        this.lastSuccessfulUploadTimestamp = new AtomicLong(0);
+        this.totalUploadsStarted = new AtomicLong(0);
+        this.totalUploadsFailed = new AtomicLong(0);
+        this.totalUploadsSucceeded = new AtomicLong(0);
+        this.uploadBytesStarted = new AtomicLong(0);
+        this.uploadBytesFailed = new AtomicLong(0);
+        this.uploadBytesSucceeded = new AtomicLong(0);
+        this.totalUploadTimeInMillis = new AtomicLong(0);
+        uploadBytesMutex = new Object();
+        uploadBytesMovingAverageReference = new AtomicReference<>(new MovingAverage(movingAverageWindowSize));
+        uploadBytesPerSecMutex = new Object();
+        uploadBytesPerSecMovingAverageReference = new AtomicReference<>(new MovingAverage(movingAverageWindowSize));
+        uploadTimeMsMutex = new Object();
+        uploadTimeMsMovingAverageReference = new AtomicReference<>(new MovingAverage(movingAverageWindowSize));
+
+        this.lastSuccessfulDownloadTimestamp = new AtomicLong(0);
+        this.totalDownloadsSucceeded = new AtomicLong(0);
+        this.downloadBytesSucceeded = new AtomicLong(0);
+        this.totalDownloadTimeInMillis = new AtomicLong(0);
+        downloadBytesMutex = new Object();
+        downloadBytesMovingAverageReference = new AtomicReference<>(new MovingAverage(movingAverageWindowSize));
+        downloadBytesPerSecMutex = new Object();
+        downloadBytesPerSecMovingAverageReference = new AtomicReference<>(new MovingAverage(movingAverageWindowSize));
+        downloadTimeMsMutex = new Object();
+        downloadTimeMsMovingAverageReference = new AtomicReference<>(new MovingAverage(movingAverageWindowSize));
+    }
+
+    public long getTotalUploadsStarted() {
+        return totalUploadsStarted.get();
+    }
+
+    public long getTotalUploadsFailed() {
+        return totalUploadsFailed.get();
+    }
+
+    public long getTotalUploadsSucceeded() {
+        return totalUploadsSucceeded.get();
+    }
+
+    public long getUploadBytesStarted() {
+        return uploadBytesStarted.get();
+    }
+
+    public long getUploadBytesFailed() {
+        return uploadBytesFailed.get();
+    }
+
+    public long getUploadBytesSucceeded() {
+        return uploadBytesSucceeded.get();
+    }
+
+    public long getTotalUploadTimeInMillis() {
+        return totalUploadTimeInMillis.get();
+    }
+
+    ShardId getShardId() {
+        return shardId;
+    }
+
+    public void incrementUploadsStarted() {
+        totalUploadsStarted.addAndGet(1);
+    }
+
+    public void incrementUploadsFailed() {
+        checkTotal(totalUploadsStarted.get(), totalUploadsFailed.get(), totalUploadsSucceeded.get(), 1);
+        totalUploadsFailed.addAndGet(1);
+    }
+
+    public void incrementUploadsSucceeded() {
+        checkTotal(totalUploadsStarted.get(), totalUploadsFailed.get(), totalUploadsSucceeded.get(), 1);
+        totalUploadsSucceeded.addAndGet(1);
+    }
+
+    public void addUploadBytesStarted(long count) {
+        uploadBytesStarted.addAndGet(count);
+    }
+
+    public void addUploadBytesFailed(long count) {
+        checkTotal(uploadBytesStarted.get(), uploadBytesFailed.get(), uploadBytesSucceeded.get(), count);
+        uploadBytesFailed.addAndGet(count);
+    }
+
+    public void addUploadBytesSucceeded(long count) {
+        checkTotal(uploadBytesStarted.get(), uploadBytesFailed.get(), uploadBytesSucceeded.get(), count);
+        uploadBytesSucceeded.addAndGet(count);
+    }
+
+    public void addUploadTimeInMillis(long duration) {
+        totalUploadTimeInMillis.addAndGet(duration);
+    }
+
+    public long getLastSuccessfulUploadTimestamp() {
+        return lastSuccessfulUploadTimestamp.get();
+    }
+
+    public void setLastSuccessfulUploadTimestamp(long lastSuccessfulUploadTimestamp) {
+        this.lastSuccessfulUploadTimestamp.set(lastSuccessfulUploadTimestamp);
+    }
+
+    boolean isUploadBytesMovingAverageReady() {
+        return uploadBytesMovingAverageReference.get().isReady();
+    }
+
+    public double getUploadBytesMovingAverage() {
+        return uploadBytesMovingAverageReference.get().getAverage();
+    }
+
+    public void updateUploadBytesMovingAverage(long count) {
+        synchronized (uploadBytesMutex) {
+            this.uploadBytesMovingAverageReference.get().record(count);
+        }
+    }
+
+    boolean isUploadBytesPerSecMovingAverageReady() {
+        return uploadBytesPerSecMovingAverageReference.get().isReady();
+    }
+
+    double getUploadBytesPerSecMovingAverage() {
+        return uploadBytesPerSecMovingAverageReference.get().getAverage();
+    }
+
+    public void updateUploadBytesPerSecMovingAverage(long speed) {
+        synchronized (uploadBytesPerSecMutex) {
+            this.uploadBytesPerSecMovingAverageReference.get().record(speed);
+        }
+    }
+
+    boolean isUploadTimeMovingAverageReady() {
+        return uploadTimeMsMovingAverageReference.get().isReady();
+    }
+
+    double getUploadTimeMovingAverage() {
+        return uploadTimeMsMovingAverageReference.get().getAverage();
+    }
+
+    public void updateUploadTimeMovingAverage(long duration) {
+        synchronized (uploadTimeMsMutex) {
+            this.uploadTimeMsMovingAverageReference.get().record(duration);
+        }
+    }
+
+    /**
+     * Updates the window size for data collection. This also resets any data collected so far.
+     *
+     * @param updatedSize the updated size
+     */
+    void updateMovingAverageWindowSize(int updatedSize) {
+        synchronized (uploadBytesMutex) {
+            this.uploadBytesMovingAverageReference.set(this.uploadBytesMovingAverageReference.get().copyWithSize(updatedSize));
+        }
+
+        synchronized (uploadBytesPerSecMutex) {
+            this.uploadBytesPerSecMovingAverageReference.set(this.uploadBytesPerSecMovingAverageReference.get().copyWithSize(updatedSize));
+        }
+
+        synchronized (uploadTimeMsMutex) {
+            this.uploadTimeMsMovingAverageReference.set(this.uploadTimeMsMovingAverageReference.get().copyWithSize(updatedSize));
+        }
+
+        synchronized (downloadBytesMutex) {
+            this.downloadBytesMovingAverageReference.set(this.downloadBytesMovingAverageReference.get().copyWithSize(updatedSize));
+        }
+
+        synchronized (downloadBytesPerSecMutex) {
+            this.downloadBytesPerSecMovingAverageReference.set(
+                this.downloadBytesPerSecMovingAverageReference.get().copyWithSize(updatedSize)
+            );
+        }
+
+        synchronized (downloadTimeMsMutex) {
+            this.downloadTimeMsMovingAverageReference.set(this.downloadTimeMsMovingAverageReference.get().copyWithSize(updatedSize));
+        }
+    }
+
+    public long getTotalDownloadsSucceeded() {
+        return totalDownloadsSucceeded.get();
+    }
+
+    public void incrementDownloadsSucceeded() {
+        totalDownloadsSucceeded.addAndGet(1);
+    }
+
+    public long getDownloadBytesSucceeded() {
+        return downloadBytesSucceeded.get();
+    }
+
+    public void addDownloadBytesSucceeded(long count) {
+        downloadBytesSucceeded.addAndGet(count);
+    }
+
+    public long getTotalDownloadTimeInMillis() {
+        return totalDownloadTimeInMillis.get();
+    }
+
+    public void addDownloadTimeInMillis(long duration) {
+        totalDownloadTimeInMillis.addAndGet(duration);
+    }
+
+    public long getLastSuccessfulDownloadTimestamp() {
+        return lastSuccessfulDownloadTimestamp.get();
+    }
+
+    void setLastSuccessfulDownloadTimestamp(long lastSuccessfulDownloadTimestamp) {
+        this.lastSuccessfulDownloadTimestamp.set(lastSuccessfulDownloadTimestamp);
+    }
+
+    boolean isDownloadBytesMovingAverageReady() {
+        return downloadBytesMovingAverageReference.get().isReady();
+    }
+
+    double getDownloadBytesMovingAverage() {
+        return downloadBytesMovingAverageReference.get().getAverage();
+    }
+
+    void updateDownloadBytesMovingAverage(long count) {
+        synchronized (downloadBytesMutex) {
+            this.downloadBytesMovingAverageReference.get().record(count);
+        }
+    }
+
+    boolean isDownloadBytesPerSecMovingAverageReady() {
+        return downloadBytesPerSecMovingAverageReference.get().isReady();
+    }
+
+    double getDownloadBytesPerSecMovingAverage() {
+        return downloadBytesPerSecMovingAverageReference.get().getAverage();
+    }
+
+    void updateDownloadBytesPerSecMovingAverage(long speed) {
+        synchronized (downloadBytesPerSecMutex) {
+            this.downloadBytesPerSecMovingAverageReference.get().record(speed);
+        }
+    }
+
+    boolean isDownloadTimeMovingAverageReady() {
+        return downloadTimeMsMovingAverageReference.get().isReady();
+    }
+
+    double getDownloadTimeMovingAverage() {
+        return downloadTimeMsMovingAverageReference.get().getAverage();
+    }
+
+    void updateDownloadTimeMovingAverage(long duration) {
+        synchronized (downloadTimeMsMutex) {
+            this.downloadTimeMsMovingAverageReference.get().record(duration);
+        }
+    }
+
+    /**
+     * Record stats related to a download from Remote Translog Store
+     * @param bytesBefore Number of downloadBytesSucceeded in this tracker before the download was started
+     * @param downloadStartTime System nano time when the download was started
+     */
+    public void recordDownloadStats(long bytesBefore, long downloadStartTime) {
+        long downloadEndTime = System.nanoTime();
+        long downloadEndTimeMs = System.currentTimeMillis();
+        long durationInMillis = (downloadEndTime - downloadStartTime) / 1_000_000L;
+        long bytesDownloaded = getDownloadBytesSucceeded() - bytesBefore;
+
+        setLastSuccessfulDownloadTimestamp(downloadEndTimeMs);
+        incrementDownloadsSucceeded();
+
+        updateDownloadBytesMovingAverage(bytesDownloaded);
+        updateDownloadTimeMovingAverage(durationInMillis);
+        if (durationInMillis > 0) {
+            updateDownloadBytesPerSecMovingAverage(bytesDownloaded * 1_000L / durationInMillis);
+        }
+    }
+
+    /**
+     * Gets the tracker's state as seen in the stats API
+     * @return Stats object with the tracker's stats
+     */
+    public RemoteTranslogTransferTracker.Stats stats() {
+        return new RemoteTranslogTransferTracker.Stats(
+            shardId,
+            lastSuccessfulUploadTimestamp.get(),
+            totalUploadsStarted.get(),
+            totalUploadsSucceeded.get(),
+            totalUploadsFailed.get(),
+            uploadBytesStarted.get(),
+            uploadBytesSucceeded.get(),
+            uploadBytesFailed.get(),
+            totalUploadTimeInMillis.get(),
+            uploadBytesMovingAverageReference.get().getAverage(),
+            uploadBytesPerSecMovingAverageReference.get().getAverage(),
+            uploadTimeMsMovingAverageReference.get().getAverage(),
+            lastSuccessfulDownloadTimestamp.get(),
+            totalDownloadsSucceeded.get(),
+            downloadBytesSucceeded.get(),
+            totalDownloadTimeInMillis.get(),
+            downloadBytesMovingAverageReference.get().getAverage(),
+            downloadBytesPerSecMovingAverageReference.get().getAverage(),
+            downloadTimeMsMovingAverageReference.get().getAverage()
+        );
+    }
+
+    /**
+     * Validates that the sum of successful operations, failed operations, and the number of operations to add (irrespective of failed/successful) does not exceed the number of operations originally started
+     * @param startedCount Number of operations started
+     * @param failedCount Number of operations failed
+     * @param succeededCount Number of operations successful
+     * @param countToAdd Number of operations to add
+     */
+    private void checkTotal(long startedCount, long failedCount, long succeededCount, long countToAdd) {
+        long delta = startedCount - (failedCount + succeededCount + countToAdd);
+        assert delta >= 0 : "Sum of failure count ("
+            + failedCount
+            + "), success count ("
+            + succeededCount
+            + "), and count to add ("
+            + countToAdd
+            + ") cannot exceed started count ("
+            + startedCount
+            + ")";
+    }
+
+    /**
+     * Represents the tracker's state as seen in the stats API.
+     *
+     * @opensearch.internal
+     */
+    public static class Stats implements Writeable {
+
+        public final ShardId shardId;
+
+        /**
+         * Epoch timestamp of the last successful Remote Translog Store upload.
+         */
+        public final long lastSuccessfulUploadTimestamp;
+
+        /**
+         * Total number of Remote Translog Store uploads that have been started.
+         */
+        public final long totalUploadsStarted;
+
+        /**
+         * Total number of Remote Translog Store uploads that have failed.
+         */
+        public final long totalUploadsFailed;
+
+        /**
+         * Total number of Remote Translog Store that have been successful.
+         */
+        public final long totalUploadsSucceeded;
+
+        /**
+         * Total number of byte uploads to Remote Translog Store that have been started.
+         */
+        public final long uploadBytesStarted;
+
+        /**
+         * Total number of byte uploads to Remote Translog Store that have failed.
+         */
+        public final long uploadBytesFailed;
+
+        /**
+         * Total number of byte uploads to Remote Translog Store that have been successful.
+         */
+        public final long uploadBytesSucceeded;
+
+        /**
+         * Total time spent on Remote Translog Store uploads.
+         */
+        public final long totalUploadTimeInMillis;
+
+        /**
+         * Size of a Remote Translog Store upload in bytes.
+         */
+        public final double uploadBytesMovingAverage;
+
+        /**
+         * Speed of a Remote Translog Store upload in bytes-per-second.
+         */
+        public final double uploadBytesPerSecMovingAverage;
+
+        /**
+         *  Time taken by a Remote Translog Store upload.
+         */
+        public final double uploadTimeMovingAverage;
+
+        /**
+         * Epoch timestamp of the last successful Remote Translog Store download.
+         */
+        public final long lastSuccessfulDownloadTimestamp;
+
+        /**
+         * Total number of Remote Translog Store downloads that have been successful.
+         */
+        public final long totalDownloadsSucceeded;
+
+        /**
+         * Total number of byte downloads from Remote Translog Store that have been successful.
+         */
+        public final long downloadBytesSucceeded;
+
+        /**
+         * Total time spent on Remote Translog Store downloads.
+         */
+        public final long totalDownloadTimeInMillis;
+
+        /**
+         * Size of a Remote Translog Store download in bytes.
+         */
+        public final double downloadBytesMovingAverage;
+
+        /**
+         * Speed of a Remote Translog Store download in bytes-per-second.
+         */
+        public final double downloadBytesPerSecMovingAverage;
+
+        /**
+         *  Time taken by a Remote Translog Store download.
+         */
+        public final double downloadTimeMovingAverage;
+
+        public Stats(
+            ShardId shardId,
+            long lastSuccessfulUploadTimestamp,
+            long totalUploadsStarted,
+            long totalUploadsSucceeded,
+            long totalUploadsFailed,
+            long uploadBytesStarted,
+            long uploadBytesSucceeded,
+            long uploadBytesFailed,
+            long totalUploadTimeInMillis,
+            double uploadBytesMovingAverage,
+            double uploadBytesPerSecMovingAverage,
+            double uploadTimeMovingAverage,
+            long lastSuccessfulDownloadTimestamp,
+            long totalDownloadsSucceeded,
+            long downloadBytesSucceeded,
+            long totalDownloadTimeInMillis,
+            double downloadBytesMovingAverage,
+            double downloadBytesPerSecMovingAverage,
+            double downloadTimeMovingAverage
+        ) {
+            this.shardId = shardId;
+
+            this.lastSuccessfulUploadTimestamp = lastSuccessfulUploadTimestamp;
+            this.totalUploadsStarted = totalUploadsStarted;
+            this.totalUploadsFailed = totalUploadsFailed;
+            this.totalUploadsSucceeded = totalUploadsSucceeded;
+            this.uploadBytesStarted = uploadBytesStarted;
+            this.uploadBytesFailed = uploadBytesFailed;
+            this.uploadBytesSucceeded = uploadBytesSucceeded;
+            this.totalUploadTimeInMillis = totalUploadTimeInMillis;
+            this.uploadBytesMovingAverage = uploadBytesMovingAverage;
+            this.uploadBytesPerSecMovingAverage = uploadBytesPerSecMovingAverage;
+            this.uploadTimeMovingAverage = uploadTimeMovingAverage;
+
+            this.lastSuccessfulDownloadTimestamp = lastSuccessfulDownloadTimestamp;
+            this.totalDownloadsSucceeded = totalDownloadsSucceeded;
+            this.downloadBytesSucceeded = downloadBytesSucceeded;
+            this.totalDownloadTimeInMillis = totalDownloadTimeInMillis;
+            this.downloadBytesMovingAverage = downloadBytesMovingAverage;
+            this.downloadBytesPerSecMovingAverage = downloadBytesPerSecMovingAverage;
+            this.downloadTimeMovingAverage = downloadTimeMovingAverage;
+        }
+
+        public Stats(StreamInput in) throws IOException {
+            this.shardId = new ShardId(in);
+
+            this.lastSuccessfulUploadTimestamp = in.readVLong();
+            this.totalUploadsStarted = in.readVLong();
+            this.totalUploadsFailed = in.readVLong();
+            this.totalUploadsSucceeded = in.readVLong();
+            this.uploadBytesStarted = in.readVLong();
+            this.uploadBytesFailed = in.readVLong();
+            this.uploadBytesSucceeded = in.readVLong();
+            this.totalUploadTimeInMillis = in.readVLong();
+            this.uploadBytesMovingAverage = in.readDouble();
+            this.uploadBytesPerSecMovingAverage = in.readDouble();
+            this.uploadTimeMovingAverage = in.readDouble();
+
+            this.lastSuccessfulDownloadTimestamp = in.readVLong();
+            this.totalDownloadsSucceeded = in.readVLong();
+            this.downloadBytesSucceeded = in.readVLong();
+            this.totalDownloadTimeInMillis = in.readVLong();
+            this.downloadBytesMovingAverage = in.readDouble();
+            this.downloadBytesPerSecMovingAverage = in.readDouble();
+            this.downloadTimeMovingAverage = in.readDouble();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            shardId.writeTo(out);
+
+            out.writeVLong(lastSuccessfulUploadTimestamp);
+            out.writeVLong(totalUploadsStarted);
+            out.writeVLong(totalUploadsFailed);
+            out.writeVLong(totalUploadsSucceeded);
+            out.writeVLong(uploadBytesStarted);
+            out.writeVLong(uploadBytesFailed);
+            out.writeVLong(uploadBytesSucceeded);
+            out.writeVLong(totalUploadTimeInMillis);
+            out.writeDouble(uploadBytesMovingAverage);
+            out.writeDouble(uploadBytesPerSecMovingAverage);
+            out.writeDouble(uploadTimeMovingAverage);
+
+            out.writeVLong(lastSuccessfulDownloadTimestamp);
+            out.writeVLong(totalDownloadsSucceeded);
+            out.writeVLong(downloadBytesSucceeded);
+            out.writeVLong(totalDownloadTimeInMillis);
+            out.writeDouble(downloadBytesMovingAverage);
+            out.writeDouble(downloadBytesPerSecMovingAverage);
+            out.writeDouble(downloadTimeMovingAverage);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) return true;
+            if (obj == null || getClass() != obj.getClass()) return false;
+            RemoteTranslogTransferTracker.Stats other = (RemoteTranslogTransferTracker.Stats) obj;
+
+            return this.shardId.equals(other.shardId)
+                && this.lastSuccessfulUploadTimestamp == other.lastSuccessfulUploadTimestamp
+                && this.totalUploadsStarted == other.totalUploadsStarted
+                && this.totalUploadsFailed == other.totalUploadsFailed
+                && this.totalUploadsSucceeded == other.totalUploadsSucceeded
+                && this.uploadBytesStarted == other.uploadBytesStarted
+                && this.uploadBytesFailed == other.uploadBytesFailed
+                && this.uploadBytesSucceeded == other.uploadBytesSucceeded
+                && this.totalUploadTimeInMillis == other.totalUploadTimeInMillis
+                && Double.compare(this.uploadBytesMovingAverage, other.uploadBytesMovingAverage) == 0
+                && Double.compare(this.uploadBytesPerSecMovingAverage, other.uploadBytesPerSecMovingAverage) == 0
+                && Double.compare(this.uploadTimeMovingAverage, other.uploadTimeMovingAverage) == 0
+                && this.lastSuccessfulDownloadTimestamp == other.lastSuccessfulDownloadTimestamp
+                && this.totalDownloadsSucceeded == other.totalDownloadsSucceeded
+                && this.downloadBytesSucceeded == other.downloadBytesSucceeded
+                && this.totalDownloadTimeInMillis == other.totalDownloadTimeInMillis
+                && Double.compare(this.downloadBytesMovingAverage, other.downloadBytesMovingAverage) == 0
+                && Double.compare(this.downloadBytesPerSecMovingAverage, other.downloadBytesPerSecMovingAverage) == 0
+                && Double.compare(this.downloadTimeMovingAverage, other.downloadTimeMovingAverage) == 0;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(
+                shardId.toString(),
+                lastSuccessfulUploadTimestamp,
+                totalUploadsStarted,
+                totalUploadsFailed,
+                totalUploadsSucceeded,
+                uploadBytesStarted,
+                uploadBytesFailed,
+                uploadBytesSucceeded,
+                totalUploadTimeInMillis,
+                uploadBytesMovingAverage,
+                uploadBytesPerSecMovingAverage,
+                uploadTimeMovingAverage,
+                lastSuccessfulDownloadTimestamp,
+                totalDownloadsSucceeded,
+                downloadBytesSucceeded,
+                totalDownloadTimeInMillis,
+                downloadBytesMovingAverage,
+                downloadBytesPerSecMovingAverage,
+                downloadTimeMovingAverage
+            );
+        }
+    }
+
+    /**
+     * Validates if the stats in this tracker and the stats contained in the given stats object are same or not
+     * @param other Stats object to compare this tracker against
+     * @return true if stats are same and false otherwise
+     */
+    boolean hasSameStatsAs(RemoteTranslogTransferTracker.Stats other) {
+        return this.stats().equals(other);
+    }
+}

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -430,9 +430,9 @@ public final class RemoteStoreRefreshListener extends CloseableRetryableRefreshL
             long bytesUploaded = segmentTracker.getUploadBytesSucceeded() - bytesBeforeUpload;
             long timeTakenInMS = TimeValue.nsecToMSec(System.nanoTime() - startTimeInNS);
             segmentTracker.incrementTotalUploadsSucceeded();
-            segmentTracker.addUploadBytes(bytesUploaded);
-            segmentTracker.addUploadBytesPerSec((bytesUploaded * 1_000L) / Math.max(1, timeTakenInMS));
-            segmentTracker.addTimeForCompletedUploadSync(timeTakenInMS);
+            segmentTracker.updateUploadBytesMovingAverage(bytesUploaded);
+            segmentTracker.updateUploadBytesPerSecMovingAverage((bytesUploaded * 1_000L) / Math.max(1, timeTakenInMS));
+            segmentTracker.updateUploadTimeMovingAverage(timeTakenInMS);
         } else {
             segmentTracker.incrementTotalUploadsFailed();
         }
@@ -457,14 +457,14 @@ public final class RemoteStoreRefreshListener extends CloseableRetryableRefreshL
                 // Track upload success
                 segmentTracker.addUploadBytesSucceeded(segmentTracker.getLatestLocalFileNameLengthMap().get(file));
                 segmentTracker.addToLatestUploadedFiles(file);
-                segmentTracker.addTotalUploadTimeInMs(Math.max(1, System.currentTimeMillis() - uploadStartTime));
+                segmentTracker.addUploadTimeInMillis(Math.max(1, System.currentTimeMillis() - uploadStartTime));
             }
 
             @Override
             public void onFailure(String file) {
                 // Track upload failure
                 segmentTracker.addUploadBytesFailed(segmentTracker.getLatestLocalFileNameLengthMap().get(file));
-                segmentTracker.addTotalUploadTimeInMs(Math.max(1, System.currentTimeMillis() - uploadStartTime));
+                segmentTracker.addUploadTimeInMillis(Math.max(1, System.currentTimeMillis() - uploadStartTime));
             }
         };
     }

--- a/server/src/main/java/org/opensearch/index/translog/RemoteBlobStoreInternalTranslogFactory.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteBlobStoreInternalTranslogFactory.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.index.translog;
 
+import org.opensearch.index.remote.RemoteTranslogTransferTracker;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.repositories.Repository;
 import org.opensearch.repositories.RepositoryMissingException;
@@ -31,10 +32,13 @@ public class RemoteBlobStoreInternalTranslogFactory implements TranslogFactory {
 
     private final ThreadPool threadPool;
 
+    private final RemoteTranslogTransferTracker remoteTranslogTransferTracker;
+
     public RemoteBlobStoreInternalTranslogFactory(
         Supplier<RepositoriesService> repositoriesServiceSupplier,
         ThreadPool threadPool,
-        String repositoryName
+        String repositoryName,
+        RemoteTranslogTransferTracker remoteTranslogTransferTracker
     ) {
         Repository repository;
         try {
@@ -44,6 +48,7 @@ public class RemoteBlobStoreInternalTranslogFactory implements TranslogFactory {
         }
         this.repository = repository;
         this.threadPool = threadPool;
+        this.remoteTranslogTransferTracker = remoteTranslogTransferTracker;
     }
 
     @Override
@@ -68,7 +73,8 @@ public class RemoteBlobStoreInternalTranslogFactory implements TranslogFactory {
             persistedSequenceNumberConsumer,
             blobStoreRepository,
             threadPool,
-            primaryModeSupplier
+            primaryModeSupplier,
+            remoteTranslogTransferTracker
         );
     }
 

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -134,10 +134,6 @@ public class RemoteFsTranslog extends Translog {
         }
     }
 
-    RemoteTranslogTransferTracker getRemoteTranslogTracker() {
-        return remoteTranslogTransferTracker;
-    }
-
     public static void download(Repository repository, ShardId shardId, ThreadPool threadPool, Path location, Logger logger)
         throws IOException {
         assert repository instanceof BlobStoreRepository : String.format(

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -134,6 +134,11 @@ public class RemoteFsTranslog extends Translog {
         }
     }
 
+    // visible for testing
+    RemoteTranslogTransferTracker getRemoteTranslogTracker() {
+        return remoteTranslogTransferTracker;
+    }
+
     public static void download(Repository repository, ShardId shardId, ThreadPool threadPool, Path location, Logger logger)
         throws IOException {
         assert repository instanceof BlobStoreRepository : String.format(

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -17,7 +17,9 @@ import org.opensearch.common.util.concurrent.ReleasableLock;
 import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.util.FileSystemUtils;
+import org.opensearch.index.remote.RemoteTranslogTransferTracker;
 import org.opensearch.index.translog.transfer.BlobStoreTransferService;
+import org.opensearch.index.translog.transfer.FileSnapshot;
 import org.opensearch.index.translog.transfer.FileTransferTracker;
 import org.opensearch.index.translog.transfer.TransferSnapshot;
 import org.opensearch.index.translog.transfer.TranslogCheckpointTransferSnapshot;
@@ -31,6 +33,7 @@ import org.opensearch.threadpool.ThreadPool;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
@@ -55,6 +58,7 @@ public class RemoteFsTranslog extends Translog {
     private final TranslogTransferManager translogTransferManager;
     private final FileTransferTracker fileTransferTracker;
     private final BooleanSupplier primaryModeSupplier;
+    private final RemoteTranslogTransferTracker remoteTranslogTransferTracker;
     private volatile long maxRemoteTranslogGenerationUploaded;
 
     private volatile long minSeqNoToKeep;
@@ -80,14 +84,22 @@ public class RemoteFsTranslog extends Translog {
         LongConsumer persistedSequenceNumberConsumer,
         BlobStoreRepository blobStoreRepository,
         ThreadPool threadPool,
-        BooleanSupplier primaryModeSupplier
+        BooleanSupplier primaryModeSupplier,
+        RemoteTranslogTransferTracker remoteTranslogTransferTracker
     ) throws IOException {
         super(config, translogUUID, deletionPolicy, globalCheckpointSupplier, primaryTermSupplier, persistedSequenceNumberConsumer);
         logger = Loggers.getLogger(getClass(), shardId);
         this.blobStoreRepository = blobStoreRepository;
         this.primaryModeSupplier = primaryModeSupplier;
-        fileTransferTracker = new FileTransferTracker(shardId);
-        this.translogTransferManager = buildTranslogTransferManager(blobStoreRepository, threadPool, shardId, fileTransferTracker);
+        this.remoteTranslogTransferTracker = remoteTranslogTransferTracker;
+        fileTransferTracker = new FileTransferTracker(shardId, remoteTranslogTransferTracker);
+        this.translogTransferManager = buildTranslogTransferManager(
+            blobStoreRepository,
+            threadPool,
+            shardId,
+            fileTransferTracker,
+            remoteTranslogTransferTracker
+        );
         try {
             download(translogTransferManager, location, logger);
             Checkpoint checkpoint = readCheckpoint(location);
@@ -124,6 +136,11 @@ public class RemoteFsTranslog extends Translog {
         }
     }
 
+    // visible for testing
+    public RemoteTranslogTransferTracker getRemoteTranslogTracker() {
+        return remoteTranslogTransferTracker;
+    }
+
     public static void download(Repository repository, ShardId shardId, ThreadPool threadPool, Path location, Logger logger)
         throws IOException {
         assert repository instanceof BlobStoreRepository : String.format(
@@ -132,32 +149,48 @@ public class RemoteFsTranslog extends Translog {
             shardId
         );
         BlobStoreRepository blobStoreRepository = (BlobStoreRepository) repository;
-        FileTransferTracker fileTransferTracker = new FileTransferTracker(shardId);
+        // We use a dummy stats tracker to ensure the flow doesn't break.
+        // TODO: To be revisited as part of https://github.com/opensearch-project/OpenSearch/issues/7567
+        RemoteTranslogTransferTracker remoteTranslogTransferTracker = new RemoteTranslogTransferTracker(shardId, 1000);
+        FileTransferTracker fileTransferTracker = new FileTransferTracker(shardId, remoteTranslogTransferTracker);
         TranslogTransferManager translogTransferManager = buildTranslogTransferManager(
             blobStoreRepository,
             threadPool,
             shardId,
-            fileTransferTracker
+            fileTransferTracker,
+            remoteTranslogTransferTracker
         );
         RemoteFsTranslog.download(translogTransferManager, location, logger);
     }
 
     public static void download(TranslogTransferManager translogTransferManager, Path location, Logger logger) throws IOException {
         logger.trace("Downloading translog files from remote");
+        RemoteTranslogTransferTracker statsTracker = translogTransferManager.getRemoteTranslogTransferTracker();
+        long bytesBefore = statsTracker.getDownloadBytesSucceeded();
+        long downloadStartTime = System.nanoTime();
         TranslogTransferMetadata translogMetadata = translogTransferManager.readMetadata();
         if (translogMetadata != null) {
+            long durationInMillis = (System.nanoTime() - downloadStartTime) / 1_000_000L;
+            statsTracker.addDownloadTimeInMillis(durationInMillis);
             if (Files.notExists(location)) {
                 Files.createDirectories(location);
             }
+
             // Delete translog files on local before downloading from remote
             for (Path file : FileSystemUtils.files(location)) {
                 Files.delete(file);
             }
+
             Map<String, String> generationToPrimaryTermMapper = translogMetadata.getGenerationToPrimaryTermMapper();
             for (long i = translogMetadata.getGeneration(); i >= translogMetadata.getMinTranslogGeneration(); i--) {
                 String generation = Long.toString(i);
                 translogTransferManager.downloadTranslog(generationToPrimaryTermMapper.get(generation), generation, location);
+                durationInMillis = (System.nanoTime() - downloadStartTime) / 1_000_000L;
+                statsTracker.addDownloadTimeInMillis(durationInMillis);
             }
+
+            statsTracker.recordDownloadStats(bytesBefore, downloadStartTime);
+
             // We copy the latest generation .ckp file to translog.ckp so that flows that depend on
             // existence of translog.ckp file work in the same way
             Files.copy(
@@ -172,13 +205,15 @@ public class RemoteFsTranslog extends Translog {
         BlobStoreRepository blobStoreRepository,
         ThreadPool threadPool,
         ShardId shardId,
-        FileTransferTracker fileTransferTracker
+        FileTransferTracker fileTransferTracker,
+        RemoteTranslogTransferTracker remoteTranslogTransferTracker
     ) {
         return new TranslogTransferManager(
             shardId,
             new BlobStoreTransferService(blobStoreRepository.blobStore(), threadPool),
             blobStoreRepository.basePath().add(shardId.getIndex().getUUID()).add(String.valueOf(shardId.id())).add(TRANSLOG),
-            fileTransferTracker
+            fileTransferTracker,
+            remoteTranslogTransferTracker
         );
     }
 
@@ -265,28 +300,10 @@ public class RemoteFsTranslog extends Translog {
             ).build()
         ) {
             Releasable transferReleasable = Releasables.wrap(deletionPolicy.acquireTranslogGen(getMinFileGeneration()));
-            return translogTransferManager.transferSnapshot(transferSnapshotProvider, new TranslogTransferListener() {
-                @Override
-
-                public void onUploadComplete(TransferSnapshot transferSnapshot) throws IOException {
-                    transferReleasable.close();
-                    closeFilesIfNoPendingRetentionLocks();
-                    maxRemoteTranslogGenerationUploaded = generation;
-                    minRemoteGenReferenced = getMinFileGeneration();
-                    logger.trace("uploaded translog for {} {} ", primaryTerm, generation);
-                }
-
-                @Override
-                public void onUploadFailed(TransferSnapshot transferSnapshot, Exception ex) throws IOException {
-                    transferReleasable.close();
-                    closeFilesIfNoPendingRetentionLocks();
-                    if (ex instanceof IOException) {
-                        throw (IOException) ex;
-                    } else {
-                        throw (RuntimeException) ex;
-                    }
-                }
-            });
+            return translogTransferManager.transferSnapshot(
+                transferSnapshotProvider,
+                new RemoteFsTranslogTransferListener(transferReleasable, generation, primaryTerm)
+            );
         }
 
     }
@@ -439,12 +456,16 @@ public class RemoteFsTranslog extends Translog {
     public static void cleanup(Repository repository, ShardId shardId, ThreadPool threadPool) throws IOException {
         assert repository instanceof BlobStoreRepository : "repository should be instance of BlobStoreRepository";
         BlobStoreRepository blobStoreRepository = (BlobStoreRepository) repository;
-        FileTransferTracker fileTransferTracker = new FileTransferTracker(shardId);
+        // We use a dummy stats tracker to ensure the flow doesn't break.
+        // TODO: To be revisited as part of https://github.com/opensearch-project/OpenSearch/issues/7567
+        RemoteTranslogTransferTracker remoteTranslogTransferTracker = new RemoteTranslogTransferTracker(shardId, 1000);
+        FileTransferTracker fileTransferTracker = new FileTransferTracker(shardId, remoteTranslogTransferTracker);
         TranslogTransferManager translogTransferManager = buildTranslogTransferManager(
             blobStoreRepository,
             threadPool,
             shardId,
-            fileTransferTracker
+            fileTransferTracker,
+            remoteTranslogTransferTracker
         );
         // clean up all remote translog files
         translogTransferManager.deleteTranslogFiles();
@@ -458,5 +479,157 @@ public class RemoteFsTranslog extends Translog {
         }
         // clean up all remote translog files
         translogTransferManager.delete();
+    }
+
+    /**
+     * TranslogTransferListener implementation for RemoteFsTranslog
+     *
+     * @opensearch.internal
+     */
+    private class RemoteFsTranslogTransferListener implements TranslogTransferListener {
+        /**
+         * Releasable instance for the translog
+         */
+        Releasable transferReleasable;
+
+        /**
+         * Generation for the translog
+         */
+        Long generation;
+
+        /**
+         * Primary Term for the translog
+         */
+        Long primaryTerm;
+
+        /**
+         * Tracker holding stats related to Remote Translog Store operations
+         */
+        final RemoteTranslogTransferTracker remoteTranslogTransferTracker = RemoteFsTranslog.this.remoteTranslogTransferTracker;
+
+        /**
+         * Files (.tlog, .ckp, metadata) to upload to Remote Translog Store
+         */
+        Set<FileSnapshot.TransferFileSnapshot> toUpload;
+
+        /**
+         * Total bytes to be uploaded to Remote Translog Store
+         */
+        long uploadBytes;
+
+        /**
+         * Size of each file to be uploaded to Remote Translog Store in bytes
+         */
+        Map<String, Long> bytesForFile;
+
+        /**
+         * System nano time when the Remote Translog Store upload is started
+         */
+        long uploadStartTime;
+
+        /**
+         * System nano time when the Remote Translog Store upload is completed
+         */
+        long uploadEndTime;
+
+        /**
+         * System current time when the Remote Translog Store upload is completed
+         */
+        long uploadEndTimeMs;
+
+        public RemoteFsTranslogTransferListener(Releasable transferReleasable, Long generation, Long primaryTerm) {
+            this.transferReleasable = transferReleasable;
+            this.generation = generation;
+            this.primaryTerm = primaryTerm;
+        }
+
+        @Override
+        public void beforeUpload(TransferSnapshot transferSnapshot) throws IOException {
+            toUpload = new HashSet<>(transferSnapshot.getTranslogTransferMetadata().getCount());
+            toUpload.addAll(fileTransferTracker.exclusionFilter(transferSnapshot.getTranslogFileSnapshots()));
+            toUpload.addAll(fileTransferTracker.exclusionFilter((transferSnapshot.getCheckpointFileSnapshots())));
+            if (toUpload.size() > 0) {
+                bytesForFile = new HashMap<>();
+                toUpload.forEach(file -> {
+                    try {
+                        bytesForFile.put(file.getName(), file.getContentLength());
+                    } catch (IOException ignored) {}
+                });
+                uploadBytes = bytesForFile.values().stream().reduce(0L, Long::sum);
+                captureStatsBeforeUpload();
+                uploadStartTime = System.nanoTime();
+            }
+        }
+
+        @Override
+        public void onUploadComplete(TransferSnapshot transferSnapshot) throws IOException {
+            if (toUpload != null && toUpload.size() > 0) {
+                uploadEndTime = System.nanoTime();
+                uploadEndTimeMs = System.currentTimeMillis();
+                captureStatsOnUploadSuccess();
+            }
+
+            transferReleasable.close();
+            closeFilesIfNoPendingRetentionLocks();
+            maxRemoteTranslogGenerationUploaded = generation;
+            minRemoteGenReferenced = getMinFileGeneration();
+            logger.trace("uploaded translog for {} {} ", primaryTerm, generation);
+        }
+
+        @Override
+        public void onUploadFailed(TransferSnapshot transferSnapshot, Exception ex) throws IOException {
+            if (toUpload != null && toUpload.size() > 0) {
+                captureStatsOnUploadFailure();
+            }
+
+            transferReleasable.close();
+            closeFilesIfNoPendingRetentionLocks();
+            if (ex instanceof IOException) {
+                throw (IOException) ex;
+            } else {
+                throw (RuntimeException) ex;
+            }
+        }
+
+        /**
+         * Adds relevant stats to the tracker when an upload is started
+         */
+        private void captureStatsBeforeUpload() {
+            remoteTranslogTransferTracker.incrementUploadsStarted();
+            remoteTranslogTransferTracker.addUploadBytesStarted(uploadBytes);
+        }
+
+        /**
+         * Adds relevant stats to the tracker when an upload is successfully completed
+         */
+        private void captureStatsOnUploadSuccess() {
+            remoteTranslogTransferTracker.incrementUploadsSucceeded();
+            remoteTranslogTransferTracker.addUploadBytesSucceeded(uploadBytes);
+            remoteTranslogTransferTracker.setLastSuccessfulUploadTimestamp(uploadEndTimeMs);
+
+            remoteTranslogTransferTracker.updateUploadBytesMovingAverage(uploadBytes);
+            long uploadDurationInMillis = (uploadEndTime - uploadStartTime) / 1_000_000L;
+            remoteTranslogTransferTracker.updateUploadTimeMovingAverage(uploadDurationInMillis);
+            if (uploadDurationInMillis > 0) {
+                remoteTranslogTransferTracker.updateUploadBytesPerSecMovingAverage((uploadBytes * 1_000L) / uploadDurationInMillis);
+            }
+        }
+
+        /**
+         * Adds relevant stats to the tracker when an upload has failed
+         */
+        private void captureStatsOnUploadFailure() {
+            remoteTranslogTransferTracker.incrementUploadsFailed();
+
+            Set<String> uploadedFiles = fileTransferTracker.allUploaded();
+            for (FileSnapshot.TransferFileSnapshot file : toUpload) {
+                String fileName = file.getName();
+                if (uploadedFiles.contains(fileName)) {
+                    remoteTranslogTransferTracker.addUploadBytesSucceeded(bytesForFile.get(fileName));
+                } else {
+                    remoteTranslogTransferTracker.addUploadBytesFailed(bytesForFile.get(fileName));
+                }
+            }
+        }
     }
 }

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
@@ -147,6 +147,7 @@ public class TranslogTransferManager {
 
             uploadStartTime = System.nanoTime();
             // TODO: Ideally each file's upload start time should be when it is actually picked for upload
+            // https://github.com/opensearch-project/OpenSearch/issues/9729
             fileTransferTracker.recordFileTransferStartTime(uploadStartTime);
             transferService.uploadBlobs(toUpload, blobPathMap, latchedActionListener, WritePriority.HIGH);
 
@@ -199,6 +200,7 @@ public class TranslogTransferManager {
     private void captureStatsBeforeUpload() {
         remoteTranslogTransferTracker.incrementTotalUploadsStarted();
         // TODO: Ideally each file's byte uploads started should be when it is actually picked for upload
+        // https://github.com/opensearch-project/OpenSearch/issues/9729
         remoteTranslogTransferTracker.addUploadBytesStarted(fileTransferTracker.getTotalBytesToUpload());
     }
 

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
@@ -103,6 +103,11 @@ public class TranslogTransferManager {
         throws IOException {
         List<Exception> exceptionList = new ArrayList<>(transferSnapshot.getTranslogTransferMetadata().getCount());
         Set<TransferFileSnapshot> toUpload = new HashSet<>(transferSnapshot.getTranslogTransferMetadata().getCount());
+        long metadataBytesToUpload;
+        long metadataUploadStartTime;
+        long uploadStartTime;
+        long prevUploadBytesSucceeded = remoteTranslogTransferTracker.getUploadBytesSucceeded();
+        long prevUploadTimeInMillis = remoteTranslogTransferTracker.getTotalUploadTimeInMillis();
 
         try {
             toUpload.addAll(fileTransferTracker.exclusionFilter(transferSnapshot.getTranslogFileSnapshots()));
@@ -112,8 +117,8 @@ public class TranslogTransferManager {
                 return true;
             }
 
-            translogTransferListener.beforeUpload(transferSnapshot);
-            fileTransferTracker.recordFileTransferStartTime();
+            fileTransferTracker.recordBytesForFiles(toUpload);
+            captureStatsBeforeUpload();
             final CountDownLatch latch = new CountDownLatch(toUpload.size());
             LatchedActionListener<TransferFileSnapshot> latchedActionListener = new LatchedActionListener<>(
                 ActionListener.wrap(fileTransferTracker::onSuccess, ex -> {
@@ -126,7 +131,8 @@ public class TranslogTransferManager {
                         ex
                     );
                     FileTransferException e = (FileTransferException) ex;
-                    fileTransferTracker.onFailure(e.getFileSnapshot(), ex);
+                    TransferFileSnapshot file = e.getFileSnapshot();
+                    fileTransferTracker.onFailure(file, ex);
                     exceptionList.add(ex);
                 }),
                 latch
@@ -139,6 +145,9 @@ public class TranslogTransferManager {
                 )
             );
 
+            uploadStartTime = System.nanoTime();
+            // TODO: Ideally each file's upload start time should be when it is actually picked for upload
+            fileTransferTracker.recordFileTransferStartTime(uploadStartTime);
             transferService.uploadBlobs(toUpload, blobPathMap, latchedActionListener, WritePriority.HIGH);
 
             try {
@@ -153,7 +162,22 @@ public class TranslogTransferManager {
                 throw ex;
             }
             if (exceptionList.isEmpty()) {
-                transferService.uploadBlob(prepareMetadata(transferSnapshot), remoteMetadataTransferPath, WritePriority.HIGH);
+                TransferFileSnapshot tlogMetadata = prepareMetadata(transferSnapshot);
+                metadataBytesToUpload = tlogMetadata.getContentLength();
+                remoteTranslogTransferTracker.addUploadBytesStarted(metadataBytesToUpload);
+                metadataUploadStartTime = System.nanoTime();
+                try {
+                    transferService.uploadBlob(tlogMetadata, remoteMetadataTransferPath, WritePriority.HIGH);
+                } catch (Exception exception) {
+                    remoteTranslogTransferTracker.addUploadTimeInMillis((System.nanoTime() - metadataUploadStartTime) / 1_000_000L);
+                    remoteTranslogTransferTracker.addUploadBytesFailed(metadataBytesToUpload);
+                    // outer catch handles capturing stats on upload failure
+                    throw exception;
+                }
+
+                remoteTranslogTransferTracker.addUploadTimeInMillis((System.nanoTime() - metadataUploadStartTime) / 1_000_000L);
+                remoteTranslogTransferTracker.addUploadBytesSucceeded(metadataBytesToUpload);
+                captureStatsOnUploadSuccess(prevUploadBytesSucceeded, prevUploadTimeInMillis);
                 translogTransferListener.onUploadComplete(transferSnapshot);
                 return true;
             } else {
@@ -163,9 +187,41 @@ public class TranslogTransferManager {
             }
         } catch (Exception ex) {
             logger.error(() -> new ParameterizedMessage("Transfer failed for snapshot {}", transferSnapshot), ex);
+            captureStatsOnUploadFailure();
             translogTransferListener.onUploadFailed(transferSnapshot, ex);
             return false;
         }
+    }
+
+    /**
+     * Adds relevant stats to the tracker when an upload is started
+     */
+    private void captureStatsBeforeUpload() {
+        remoteTranslogTransferTracker.incrementTotalUploadsStarted();
+        // TODO: Ideally each file's byte uploads started should be when it is actually picked for upload
+        remoteTranslogTransferTracker.addUploadBytesStarted(fileTransferTracker.getTotalBytesToUpload());
+    }
+
+    /**
+     * Adds relevant stats to the tracker when an upload is successfully completed
+     */
+    private void captureStatsOnUploadSuccess(long prevUploadBytesSucceeded, long prevUploadTimeInMillis) {
+        remoteTranslogTransferTracker.setLastSuccessfulUploadTimestamp(System.currentTimeMillis());
+        remoteTranslogTransferTracker.incrementTotalUploadsSucceeded();
+        long totalUploadedBytes = remoteTranslogTransferTracker.getUploadBytesSucceeded() - prevUploadBytesSucceeded;
+        remoteTranslogTransferTracker.updateUploadBytesMovingAverage(totalUploadedBytes);
+        long uploadDurationInMillis = remoteTranslogTransferTracker.getTotalUploadTimeInMillis() - prevUploadTimeInMillis;
+        remoteTranslogTransferTracker.updateUploadTimeMovingAverage(uploadDurationInMillis);
+        if (uploadDurationInMillis > 0) {
+            remoteTranslogTransferTracker.updateUploadBytesPerSecMovingAverage((totalUploadedBytes * 1_000L) / uploadDurationInMillis);
+        }
+    }
+
+    /**
+     * Adds relevant stats to the tracker when an upload has failed
+     */
+    private void captureStatsOnUploadFailure() {
+        remoteTranslogTransferTracker.incrementTotalUploadsFailed();
     }
 
     public boolean downloadTranslog(String primaryTerm, String generation, Path location) throws IOException {
@@ -192,16 +248,20 @@ public class TranslogTransferManager {
             Files.delete(filePath);
         }
 
-        long bytesToRead;
+        long downloadStartTime = System.nanoTime();
         try (InputStream inputStream = transferService.downloadBlob(remoteDataTransferPath.add(primaryTerm), fileName)) {
             // Capture number of bytes for stats before reading
-            bytesToRead = inputStream.available();
+            long bytesToRead = inputStream.available();
             Files.copy(inputStream, filePath);
+            remoteTranslogTransferTracker.addDownloadTimeInMillis((System.nanoTime() - downloadStartTime) / 1_000_000L);
+            remoteTranslogTransferTracker.addDownloadBytesSucceeded(bytesToRead);
+        } catch (IOException e) {
+            remoteTranslogTransferTracker.addDownloadTimeInMillis((System.nanoTime() - downloadStartTime) / 1_000_000L);
+            logger.error(() -> new ParameterizedMessage("Exception while reading file: {}", fileName), e);
         }
 
         // Mark in FileTransferTracker so that the same files are not uploaded at the time of translog sync
         fileTransferTracker.add(fileName, true);
-        remoteTranslogTransferTracker.addDownloadBytesSucceeded(bytesToRead);
     }
 
     public TranslogTransferMetadata readMetadata() throws IOException {
@@ -212,13 +272,16 @@ public class TranslogTransferManager {
             ActionListener.wrap(blobMetadataList -> {
                 if (blobMetadataList.isEmpty()) return;
                 String filename = blobMetadataList.get(0).name();
+                long downloadStartTime = System.nanoTime();
                 try (InputStream inputStream = transferService.downloadBlob(remoteMetadataTransferPath, filename)) {
                     // Capture number of bytes for stats before reading
                     long bytesToRead = inputStream.available();
                     IndexInput indexInput = new ByteArrayIndexInput("metadata file", inputStream.readAllBytes());
                     metadataSetOnce.set(metadataStreamWrapper.readStream(indexInput));
+                    remoteTranslogTransferTracker.addDownloadTimeInMillis((System.nanoTime() - downloadStartTime) / 1_000_000L);
                     remoteTranslogTransferTracker.addDownloadBytesSucceeded(bytesToRead);
                 } catch (IOException e) {
+                    remoteTranslogTransferTracker.addDownloadTimeInMillis((System.nanoTime() - downloadStartTime) / 1_000_000L);
                     logger.error(() -> new ParameterizedMessage("Exception while reading metadata file: {}", filename), e);
                     exceptionSetOnce.set(e);
                 }

--- a/server/src/main/java/org/opensearch/index/translog/transfer/listener/TranslogTransferListener.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/listener/TranslogTransferListener.java
@@ -19,12 +19,6 @@ import java.io.IOException;
  */
 public interface TranslogTransferListener {
     /**
-     * Invoked before the transfer of {@link TransferSnapshot}
-     * @param transferSnapshot the transfer snapshot
-     */
-    void beforeUpload(TransferSnapshot transferSnapshot) throws IOException;
-
-    /**
      * Invoked when the transfer of {@link TransferSnapshot} succeeds
      * @param transferSnapshot the transfer snapshot
      * @throws IOException the exception during the transfer of data

--- a/server/src/main/java/org/opensearch/index/translog/transfer/listener/TranslogTransferListener.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/listener/TranslogTransferListener.java
@@ -18,6 +18,11 @@ import java.io.IOException;
  * @opensearch.internal
  */
 public interface TranslogTransferListener {
+    /**
+     * Invoked before the transfer of {@link TransferSnapshot}
+     * @param transferSnapshot the transfer snapshot
+     */
+    void beforeUpload(TransferSnapshot transferSnapshot) throws IOException;
 
     /**
      * Invoked when the transfer of {@link TransferSnapshot} succeeds

--- a/server/src/main/java/org/opensearch/indices/IndicesModule.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesModule.java
@@ -71,7 +71,6 @@ import org.opensearch.index.mapper.SourceFieldMapper;
 import org.opensearch.index.mapper.TextFieldMapper;
 import org.opensearch.index.mapper.VersionFieldMapper;
 import org.opensearch.index.remote.RemoteStorePressureService;
-import org.opensearch.index.remote.RemoteStoreStatsTrackerFactory;
 import org.opensearch.index.seqno.GlobalCheckpointSyncAction;
 import org.opensearch.index.seqno.RetentionLeaseBackgroundSyncAction;
 import org.opensearch.index.seqno.RetentionLeaseSyncAction;
@@ -290,7 +289,6 @@ public class IndicesModule extends AbstractModule {
         bind(SegmentReplicationCheckpointPublisher.class).asEagerSingleton();
         bind(SegmentReplicationPressureService.class).asEagerSingleton();
         if (FeatureFlags.isEnabled(FeatureFlags.REMOTE_STORE)) {
-            bind(RemoteStoreStatsTrackerFactory.class).asEagerSingleton();
             bind(RemoteStorePressureService.class).asEagerSingleton();
         }
     }

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -740,7 +740,6 @@ public class Node implements Closeable {
             );
 
             remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(clusterService, settings);
-
             final IndicesService indicesService = new IndicesService(
                 settings,
                 pluginsService,

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -137,6 +137,7 @@ import org.opensearch.index.IndexingPressureService;
 import org.opensearch.index.analysis.AnalysisRegistry;
 import org.opensearch.index.engine.EngineFactory;
 import org.opensearch.index.recovery.RemoteStoreRestoreService;
+import org.opensearch.index.remote.RemoteStoreStatsTrackerFactory;
 import org.opensearch.index.store.RemoteSegmentStoreDirectoryFactory;
 import org.opensearch.index.store.remote.filecache.FileCache;
 import org.opensearch.index.store.remote.filecache.FileCacheCleaner;
@@ -387,6 +388,7 @@ public class Node implements Closeable {
     final NamedWriteableRegistry namedWriteableRegistry;
     private final AtomicReference<RunnableTaskExecutionListener> runnableTaskListener;
     private FileCache fileCache;
+    private final RemoteStoreStatsTrackerFactory remoteStoreStatsTrackerFactory;
 
     public Node(Environment environment) {
         this(environment, Collections.emptyList(), true);
@@ -737,6 +739,8 @@ public class Node implements Closeable {
                 threadPool
             );
 
+            remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(clusterService, settings);
+
             final IndicesService indicesService = new IndicesService(
                 settings,
                 pluginsService,
@@ -760,7 +764,8 @@ public class Node implements Closeable {
                 recoveryStateFactories,
                 remoteDirectoryFactory,
                 repositoriesServiceReference::get,
-                fileCacheCleaner
+                fileCacheCleaner,
+                remoteStoreStatsTrackerFactory
             );
 
             final AliasValidator aliasValidator = new AliasValidator();
@@ -1117,6 +1122,7 @@ public class Node implements Closeable {
                 b.bind(MetaStateService.class).toInstance(metaStateService);
                 b.bind(PersistedClusterStateService.class).toInstance(lucenePersistedStateFactory);
                 b.bind(IndicesService.class).toInstance(indicesService);
+                b.bind(RemoteStoreStatsTrackerFactory.class).toInstance(remoteStoreStatsTrackerFactory);
                 b.bind(AliasValidator.class).toInstance(aliasValidator);
                 b.bind(MetadataCreateIndexService.class).toInstance(metadataCreateIndexService);
                 b.bind(AwarenessReplicaBalance.class).toInstance(awarenessReplicaBalance);

--- a/server/src/test/java/org/opensearch/action/admin/cluster/remotestore/stats/RemoteStoreStatsResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/remotestore/stats/RemoteStoreStatsResponseTests.java
@@ -16,6 +16,7 @@ import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.remote.RemoteSegmentTransferTracker;
+import org.opensearch.index.remote.RemoteTranslogTransferTracker;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
@@ -24,10 +25,12 @@ import java.util.ArrayList;
 import java.util.Map;
 
 import static org.opensearch.action.admin.cluster.remotestore.stats.RemoteStoreStatsTestHelper.compareStatsResponse;
+import static org.opensearch.action.admin.cluster.remotestore.stats.RemoteStoreStatsTestHelper.createEmptyTranslogStats;
 import static org.opensearch.action.admin.cluster.remotestore.stats.RemoteStoreStatsTestHelper.createShardRouting;
 import static org.opensearch.action.admin.cluster.remotestore.stats.RemoteStoreStatsTestHelper.createStatsForNewPrimary;
 import static org.opensearch.action.admin.cluster.remotestore.stats.RemoteStoreStatsTestHelper.createStatsForNewReplica;
 import static org.opensearch.action.admin.cluster.remotestore.stats.RemoteStoreStatsTestHelper.createStatsForRemoteStoreRestoredPrimary;
+import static org.opensearch.action.admin.cluster.remotestore.stats.RemoteStoreStatsTestHelper.createTranslogStats;
 import static org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS;
 
 public class RemoteStoreStatsResponseTests extends OpenSearchTestCase {
@@ -48,9 +51,10 @@ public class RemoteStoreStatsResponseTests extends OpenSearchTestCase {
     }
 
     public void testSerializationForPrimary() throws Exception {
-        RemoteSegmentTransferTracker.Stats mockPrimaryTrackerStats = createStatsForNewPrimary(shardId);
+        RemoteSegmentTransferTracker.Stats mockSegmentTrackerStats = createStatsForNewPrimary(shardId);
+        RemoteTranslogTransferTracker.Stats mockTranslogTrackerStats = createTranslogStats(shardId);
         ShardRouting primaryShardRouting = createShardRouting(shardId, true);
-        RemoteStoreStats primaryShardStats = new RemoteStoreStats(mockPrimaryTrackerStats, primaryShardRouting);
+        RemoteStoreStats primaryShardStats = new RemoteStoreStats(mockSegmentTrackerStats, mockTranslogTrackerStats, primaryShardRouting);
         RemoteStoreStatsResponse statsResponse = new RemoteStoreStatsResponse(
             new RemoteStoreStats[] { primaryShardStats },
             1,
@@ -73,16 +77,26 @@ public class RemoteStoreStatsResponseTests extends OpenSearchTestCase {
         ArrayList<Map<String, Object>> perShardNumberObject = (ArrayList<Map<String, Object>>) shardsObject.get("0");
         assertEquals(perShardNumberObject.size(), 1);
         Map<String, Object> perShardCopyObject = perShardNumberObject.get(0);
-        compareStatsResponse(perShardCopyObject, mockPrimaryTrackerStats, primaryShardRouting);
+        compareStatsResponse(perShardCopyObject, mockSegmentTrackerStats, mockTranslogTrackerStats, primaryShardRouting);
     }
 
     public void testSerializationForBothPrimaryAndReplica() throws Exception {
-        RemoteSegmentTransferTracker.Stats mockPrimaryTrackerStats = createStatsForNewPrimary(shardId);
-        RemoteSegmentTransferTracker.Stats mockReplicaTrackerStats = createStatsForNewReplica(shardId);
+        RemoteSegmentTransferTracker.Stats mockPrimarySegmentTrackerStats = createStatsForNewPrimary(shardId);
+        RemoteSegmentTransferTracker.Stats mockReplicaSegmentTrackerStats = createStatsForNewReplica(shardId);
+        RemoteTranslogTransferTracker.Stats mockPrimaryTranslogTrackerStats = createTranslogStats(shardId);
+        RemoteTranslogTransferTracker.Stats mockReplicaTranslogTrackerStats = createEmptyTranslogStats(shardId);
         ShardRouting primaryShardRouting = createShardRouting(shardId, true);
         ShardRouting replicaShardRouting = createShardRouting(shardId, false);
-        RemoteStoreStats primaryShardStats = new RemoteStoreStats(mockPrimaryTrackerStats, primaryShardRouting);
-        RemoteStoreStats replicaShardStats = new RemoteStoreStats(mockReplicaTrackerStats, replicaShardRouting);
+        RemoteStoreStats primaryShardStats = new RemoteStoreStats(
+            mockPrimarySegmentTrackerStats,
+            mockPrimaryTranslogTrackerStats,
+            primaryShardRouting
+        );
+        RemoteStoreStats replicaShardStats = new RemoteStoreStats(
+            mockReplicaSegmentTrackerStats,
+            mockReplicaTranslogTrackerStats,
+            replicaShardRouting
+        );
         RemoteStoreStatsResponse statsResponse = new RemoteStoreStatsResponse(
             new RemoteStoreStats[] { primaryShardStats, replicaShardStats },
             2,
@@ -109,20 +123,30 @@ public class RemoteStoreStatsResponseTests extends OpenSearchTestCase {
                 RemoteStoreStats.RoutingFields.PRIMARY
             );
             if (isPrimary) {
-                compareStatsResponse(shardObject, mockPrimaryTrackerStats, primaryShardRouting);
+                compareStatsResponse(shardObject, mockPrimarySegmentTrackerStats, mockPrimaryTranslogTrackerStats, primaryShardRouting);
             } else {
-                compareStatsResponse(shardObject, mockReplicaTrackerStats, replicaShardRouting);
+                compareStatsResponse(shardObject, mockReplicaSegmentTrackerStats, mockReplicaTranslogTrackerStats, replicaShardRouting);
             }
         });
     }
 
     public void testSerializationForBothRemoteStoreRestoredPrimaryAndReplica() throws Exception {
-        RemoteSegmentTransferTracker.Stats mockPrimaryTrackerStats = createStatsForRemoteStoreRestoredPrimary(shardId);
-        RemoteSegmentTransferTracker.Stats mockReplicaTrackerStats = createStatsForNewReplica(shardId);
+        RemoteSegmentTransferTracker.Stats mockPrimarySegmentTrackerStats = createStatsForRemoteStoreRestoredPrimary(shardId);
+        RemoteSegmentTransferTracker.Stats mockReplicaSegmentTrackerStats = createStatsForNewReplica(shardId);
+        RemoteTranslogTransferTracker.Stats mockPrimaryTranslogTrackerStats = createTranslogStats(shardId);
+        RemoteTranslogTransferTracker.Stats mockReplicaTranslogTrackerStats = createEmptyTranslogStats(shardId);
         ShardRouting primaryShardRouting = createShardRouting(shardId, true);
         ShardRouting replicaShardRouting = createShardRouting(shardId, false);
-        RemoteStoreStats primaryShardStats = new RemoteStoreStats(mockPrimaryTrackerStats, primaryShardRouting);
-        RemoteStoreStats replicaShardStats = new RemoteStoreStats(mockReplicaTrackerStats, replicaShardRouting);
+        RemoteStoreStats primaryShardStats = new RemoteStoreStats(
+            mockPrimarySegmentTrackerStats,
+            mockPrimaryTranslogTrackerStats,
+            primaryShardRouting
+        );
+        RemoteStoreStats replicaShardStats = new RemoteStoreStats(
+            mockReplicaSegmentTrackerStats,
+            mockReplicaTranslogTrackerStats,
+            replicaShardRouting
+        );
         RemoteStoreStatsResponse statsResponse = new RemoteStoreStatsResponse(
             new RemoteStoreStats[] { primaryShardStats, replicaShardStats },
             2,
@@ -149,9 +173,9 @@ public class RemoteStoreStatsResponseTests extends OpenSearchTestCase {
                 RemoteStoreStats.RoutingFields.PRIMARY
             );
             if (isPrimary) {
-                compareStatsResponse(shardObject, mockPrimaryTrackerStats, primaryShardRouting);
+                compareStatsResponse(shardObject, mockPrimarySegmentTrackerStats, mockPrimaryTranslogTrackerStats, primaryShardRouting);
             } else {
-                compareStatsResponse(shardObject, mockReplicaTrackerStats, replicaShardRouting);
+                compareStatsResponse(shardObject, mockReplicaSegmentTrackerStats, mockReplicaTranslogTrackerStats, replicaShardRouting);
             }
         });
     }

--- a/server/src/test/java/org/opensearch/action/admin/cluster/remotestore/stats/RemoteStoreStatsTestHelper.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/remotestore/stats/RemoteStoreStatsTestHelper.java
@@ -13,12 +13,14 @@ import org.opensearch.cluster.routing.ShardRoutingState;
 import org.opensearch.cluster.routing.TestShardRouting;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.remote.RemoteSegmentTransferTracker;
+import org.opensearch.index.remote.RemoteTranslogTransferTracker;
 import org.opensearch.index.store.DirectoryFileTransferTracker;
 
 import java.util.Map;
 
 import static org.opensearch.test.OpenSearchTestCase.assertEquals;
 import static org.opensearch.test.OpenSearchTestCase.randomAlphaOfLength;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -115,11 +117,21 @@ public class RemoteStoreStatsTestHelper {
         return TestShardRouting.newShardRouting(shardId, randomAlphaOfLength(4), isPrimary, ShardRoutingState.STARTED);
     }
 
+    static RemoteTranslogTransferTracker.Stats createTranslogStats(ShardId shardId) {
+        return new RemoteTranslogTransferTracker.Stats(shardId, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9D, 10D, 11D, 1L, 2L, 3L, 4L, 9D, 10D, 11D);
+    }
+
+    static RemoteTranslogTransferTracker.Stats createEmptyTranslogStats(ShardId shardId) {
+        return new RemoteTranslogTransferTracker.Stats(shardId, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0D, 0D, 0D, 0L, 0L, 0L, 0L, 0D, 0D, 0D);
+    }
+
     static void compareStatsResponse(
         Map<String, Object> statsObject,
-        RemoteSegmentTransferTracker.Stats segmentStatsTracker,
+        RemoteSegmentTransferTracker.Stats segmentTransferStats,
+        RemoteTranslogTransferTracker.Stats translogTransferStats,
         ShardRouting routing
     ) {
+        // Compare Remote Segment Store stats
         assertEquals(
             ((Map) statsObject.get(RemoteStoreStats.Fields.ROUTING)).get(RemoteStoreStats.RoutingFields.NODE_ID),
             routing.currentNodeId()
@@ -137,138 +149,273 @@ public class RemoteStoreStatsTestHelper {
         Map<String, Object> segmentDownloads = ((Map) segment.get(RemoteStoreStats.SubFields.DOWNLOAD));
         Map<String, Object> segmentUploads = ((Map) segment.get(RemoteStoreStats.SubFields.UPLOAD));
 
-        if (segmentStatsTracker.directoryFileTransferTrackerStats.transferredBytesStarted != 0) {
+        if (segmentTransferStats.directoryFileTransferTrackerStats.transferredBytesStarted != 0) {
             assertEquals(
                 segmentDownloads.get(RemoteStoreStats.DownloadStatsFields.LAST_SYNC_TIMESTAMP),
-                (int) segmentStatsTracker.directoryFileTransferTrackerStats.lastTransferTimestampMs
+                (int) segmentTransferStats.directoryFileTransferTrackerStats.lastTransferTimestampMs
             );
             assertEquals(
                 ((Map) segmentDownloads.get(RemoteStoreStats.DownloadStatsFields.TOTAL_DOWNLOADS_IN_BYTES)).get(
                     RemoteStoreStats.SubFields.STARTED
                 ),
-                (int) segmentStatsTracker.directoryFileTransferTrackerStats.transferredBytesStarted
+                (int) segmentTransferStats.directoryFileTransferTrackerStats.transferredBytesStarted
             );
             assertEquals(
                 ((Map) segmentDownloads.get(RemoteStoreStats.DownloadStatsFields.TOTAL_DOWNLOADS_IN_BYTES)).get(
                     RemoteStoreStats.SubFields.SUCCEEDED
                 ),
-                (int) segmentStatsTracker.directoryFileTransferTrackerStats.transferredBytesSucceeded
+                (int) segmentTransferStats.directoryFileTransferTrackerStats.transferredBytesSucceeded
             );
             assertEquals(
                 ((Map) segmentDownloads.get(RemoteStoreStats.DownloadStatsFields.TOTAL_DOWNLOADS_IN_BYTES)).get(
                     RemoteStoreStats.SubFields.FAILED
                 ),
-                (int) segmentStatsTracker.directoryFileTransferTrackerStats.transferredBytesFailed
+                (int) segmentTransferStats.directoryFileTransferTrackerStats.transferredBytesFailed
             );
             assertEquals(
                 ((Map) segmentDownloads.get(RemoteStoreStats.DownloadStatsFields.DOWNLOAD_SIZE_IN_BYTES)).get(
                     RemoteStoreStats.SubFields.LAST_SUCCESSFUL
                 ),
-                (int) segmentStatsTracker.directoryFileTransferTrackerStats.lastSuccessfulTransferInBytes
+                (int) segmentTransferStats.directoryFileTransferTrackerStats.lastSuccessfulTransferInBytes
             );
             assertEquals(
                 ((Map) segmentDownloads.get(RemoteStoreStats.DownloadStatsFields.DOWNLOAD_SIZE_IN_BYTES)).get(
                     RemoteStoreStats.SubFields.MOVING_AVG
                 ),
-                segmentStatsTracker.directoryFileTransferTrackerStats.transferredBytesMovingAverage
+                segmentTransferStats.directoryFileTransferTrackerStats.transferredBytesMovingAverage
             );
             assertEquals(
                 ((Map) segmentDownloads.get(RemoteStoreStats.DownloadStatsFields.DOWNLOAD_SPEED_IN_BYTES_PER_SEC)).get(
                     RemoteStoreStats.SubFields.MOVING_AVG
                 ),
-                segmentStatsTracker.directoryFileTransferTrackerStats.transferredBytesPerSecMovingAverage
+                segmentTransferStats.directoryFileTransferTrackerStats.transferredBytesPerSecMovingAverage
             );
         } else {
             assertTrue(segmentDownloads.isEmpty());
         }
 
-        if (segmentStatsTracker.totalUploadsStarted != 0) {
+        if (segmentTransferStats.totalUploadsStarted != 0) {
             assertEquals(
                 segmentUploads.get(RemoteStoreStats.UploadStatsFields.LOCAL_REFRESH_TIMESTAMP),
-                (int) segmentStatsTracker.localRefreshClockTimeMs
+                (int) segmentTransferStats.localRefreshClockTimeMs
             );
             assertEquals(
                 segmentUploads.get(RemoteStoreStats.UploadStatsFields.REMOTE_REFRESH_TIMESTAMP),
-                (int) segmentStatsTracker.remoteRefreshClockTimeMs
+                (int) segmentTransferStats.remoteRefreshClockTimeMs
             );
             assertEquals(
                 segmentUploads.get(RemoteStoreStats.UploadStatsFields.REFRESH_TIME_LAG_IN_MILLIS),
-                (int) segmentStatsTracker.refreshTimeLagMs
+                (int) segmentTransferStats.refreshTimeLagMs
             );
             assertEquals(
                 segmentUploads.get(RemoteStoreStats.UploadStatsFields.REFRESH_LAG),
-                (int) (segmentStatsTracker.localRefreshNumber - segmentStatsTracker.remoteRefreshNumber)
+                (int) (segmentTransferStats.localRefreshNumber - segmentTransferStats.remoteRefreshNumber)
             );
-            assertEquals(segmentUploads.get(RemoteStoreStats.UploadStatsFields.BYTES_LAG), (int) segmentStatsTracker.bytesLag);
+            assertEquals(segmentUploads.get(RemoteStoreStats.UploadStatsFields.BYTES_LAG), (int) segmentTransferStats.bytesLag);
 
             assertEquals(
                 segmentUploads.get(RemoteStoreStats.UploadStatsFields.BACKPRESSURE_REJECTION_COUNT),
-                (int) segmentStatsTracker.rejectionCount
+                (int) segmentTransferStats.rejectionCount
             );
             assertEquals(
                 segmentUploads.get(RemoteStoreStats.UploadStatsFields.CONSECUTIVE_FAILURE_COUNT),
-                (int) segmentStatsTracker.consecutiveFailuresCount
+                (int) segmentTransferStats.consecutiveFailuresCount
             );
             assertEquals(
                 ((Map) segmentUploads.get(RemoteStoreStats.UploadStatsFields.TOTAL_UPLOADS_IN_BYTES)).get(
                     RemoteStoreStats.SubFields.STARTED
                 ),
-                (int) segmentStatsTracker.uploadBytesStarted
+                (int) segmentTransferStats.uploadBytesStarted
             );
             assertEquals(
                 ((Map) segmentUploads.get(RemoteStoreStats.UploadStatsFields.TOTAL_UPLOADS_IN_BYTES)).get(
                     RemoteStoreStats.SubFields.SUCCEEDED
                 ),
-                (int) segmentStatsTracker.uploadBytesSucceeded
+                (int) segmentTransferStats.uploadBytesSucceeded
             );
             assertEquals(
                 ((Map) segmentUploads.get(RemoteStoreStats.UploadStatsFields.TOTAL_UPLOADS_IN_BYTES)).get(
                     RemoteStoreStats.SubFields.FAILED
                 ),
-                (int) segmentStatsTracker.uploadBytesFailed
+                (int) segmentTransferStats.uploadBytesFailed
             );
             assertEquals(
                 ((Map) segmentUploads.get(RemoteStoreStats.UploadStatsFields.REMOTE_REFRESH_SIZE_IN_BYTES)).get(
                     RemoteStoreStats.SubFields.MOVING_AVG
                 ),
-                segmentStatsTracker.uploadBytesMovingAverage
+                segmentTransferStats.uploadBytesMovingAverage
             );
             assertEquals(
                 ((Map) segmentUploads.get(RemoteStoreStats.UploadStatsFields.REMOTE_REFRESH_SIZE_IN_BYTES)).get(
                     RemoteStoreStats.SubFields.LAST_SUCCESSFUL
                 ),
-                (int) segmentStatsTracker.lastSuccessfulRemoteRefreshBytes
+                (int) segmentTransferStats.lastSuccessfulRemoteRefreshBytes
             );
             assertEquals(
-                ((Map) segmentUploads.get(RemoteStoreStats.UploadStatsFields.UPLOAD_LATENCY_IN_BYTES_PER_SEC)).get(
+                ((Map) segmentUploads.get(RemoteStoreStats.UploadStatsFields.UPLOAD_SPEED_IN_BYTES_PER_SEC)).get(
                     RemoteStoreStats.SubFields.MOVING_AVG
                 ),
-                segmentStatsTracker.uploadBytesPerSecMovingAverage
+                segmentTransferStats.uploadBytesPerSecMovingAverage
             );
             assertEquals(
                 ((Map) segmentUploads.get(RemoteStoreStats.UploadStatsFields.TOTAL_SYNCS_TO_REMOTE)).get(
                     RemoteStoreStats.SubFields.STARTED
                 ),
-                (int) segmentStatsTracker.totalUploadsStarted
+                (int) segmentTransferStats.totalUploadsStarted
             );
             assertEquals(
                 ((Map) segmentUploads.get(RemoteStoreStats.UploadStatsFields.TOTAL_SYNCS_TO_REMOTE)).get(
                     RemoteStoreStats.SubFields.SUCCEEDED
                 ),
-                (int) segmentStatsTracker.totalUploadsSucceeded
+                (int) segmentTransferStats.totalUploadsSucceeded
             );
             assertEquals(
                 ((Map) segmentUploads.get(RemoteStoreStats.UploadStatsFields.TOTAL_SYNCS_TO_REMOTE)).get(RemoteStoreStats.SubFields.FAILED),
-                (int) segmentStatsTracker.totalUploadsFailed
+                (int) segmentTransferStats.totalUploadsFailed
             );
             assertEquals(
                 ((Map) segmentUploads.get(RemoteStoreStats.UploadStatsFields.REMOTE_REFRESH_LATENCY_IN_MILLIS)).get(
                     RemoteStoreStats.SubFields.MOVING_AVG
                 ),
-                segmentStatsTracker.uploadTimeMovingAverage
+                segmentTransferStats.uploadTimeMovingAverage
             );
         } else {
             assertTrue(segmentUploads.isEmpty());
+        }
+
+        // Compare Remote Translog Store stats
+        Map<?, ?> tlogStatsObj = (Map<?, ?>) statsObject.get(RemoteStoreStats.Fields.TRANSLOG);
+        Map<?, ?> tlogUploadStatsObj = (Map<?, ?>) tlogStatsObj.get(RemoteStoreStats.SubFields.UPLOAD);
+        if (translogTransferStats.totalUploadsStarted > 0) {
+            assertEquals(
+                translogTransferStats.lastSuccessfulUploadTimestamp,
+                Long.parseLong(tlogUploadStatsObj.get(RemoteStoreStats.UploadStatsFields.LAST_SUCCESSFUL_UPLOAD_TIMESTAMP).toString())
+            );
+
+            assertEquals(
+                translogTransferStats.totalUploadsStarted,
+                Long.parseLong(
+                    ((Map<?, ?>) tlogUploadStatsObj.get(RemoteStoreStats.UploadStatsFields.TOTAL_UPLOADS)).get(
+                        RemoteStoreStats.SubFields.STARTED
+                    ).toString()
+                )
+            );
+            assertEquals(
+                translogTransferStats.totalUploadsSucceeded,
+                Long.parseLong(
+                    ((Map<?, ?>) tlogUploadStatsObj.get(RemoteStoreStats.UploadStatsFields.TOTAL_UPLOADS)).get(
+                        RemoteStoreStats.SubFields.SUCCEEDED
+                    ).toString()
+                )
+            );
+            assertEquals(
+                translogTransferStats.totalUploadsFailed,
+                Long.parseLong(
+                    ((Map<?, ?>) tlogUploadStatsObj.get(RemoteStoreStats.UploadStatsFields.TOTAL_UPLOADS)).get(
+                        RemoteStoreStats.SubFields.FAILED
+                    ).toString()
+                )
+            );
+
+            assertEquals(
+                translogTransferStats.uploadBytesStarted,
+                Long.parseLong(
+                    ((Map<?, ?>) tlogUploadStatsObj.get(RemoteStoreStats.UploadStatsFields.TOTAL_UPLOADS_IN_BYTES)).get(
+                        RemoteStoreStats.SubFields.STARTED
+                    ).toString()
+                )
+            );
+            assertEquals(
+                translogTransferStats.uploadBytesSucceeded,
+                Long.parseLong(
+                    ((Map<?, ?>) tlogUploadStatsObj.get(RemoteStoreStats.UploadStatsFields.TOTAL_UPLOADS_IN_BYTES)).get(
+                        RemoteStoreStats.SubFields.SUCCEEDED
+                    ).toString()
+                )
+            );
+            assertEquals(
+                translogTransferStats.uploadBytesFailed,
+                Long.parseLong(
+                    ((Map<?, ?>) tlogUploadStatsObj.get(RemoteStoreStats.UploadStatsFields.TOTAL_UPLOADS_IN_BYTES)).get(
+                        RemoteStoreStats.SubFields.FAILED
+                    ).toString()
+                )
+            );
+
+            assertEquals(
+                translogTransferStats.totalUploadTimeInMillis,
+                Long.parseLong(tlogUploadStatsObj.get(RemoteStoreStats.UploadStatsFields.TOTAL_UPLOAD_TIME_IN_MILLIS).toString())
+            );
+
+            assertEquals(
+                translogTransferStats.uploadBytesMovingAverage,
+                ((Map<?, ?>) tlogUploadStatsObj.get(RemoteStoreStats.UploadStatsFields.UPLOAD_SIZE_IN_BYTES)).get(
+                    RemoteStoreStats.SubFields.MOVING_AVG
+                )
+            );
+            assertEquals(
+                translogTransferStats.uploadBytesPerSecMovingAverage,
+                ((Map<?, ?>) tlogUploadStatsObj.get(RemoteStoreStats.UploadStatsFields.UPLOAD_SPEED_IN_BYTES_PER_SEC)).get(
+                    RemoteStoreStats.SubFields.MOVING_AVG
+                )
+            );
+            assertEquals(
+                translogTransferStats.uploadTimeMovingAverage,
+                ((Map<?, ?>) tlogUploadStatsObj.get(RemoteStoreStats.UploadStatsFields.UPLOAD_TIME_IN_MILLIS)).get(
+                    RemoteStoreStats.SubFields.MOVING_AVG
+                )
+            );
+        } else {
+            assertNull(tlogUploadStatsObj.get(RemoteStoreStats.UploadStatsFields.TOTAL_UPLOADS));
+        }
+
+        Map<?, ?> tlogDownloadStatsObj = (Map<?, ?>) tlogStatsObj.get(RemoteStoreStats.SubFields.DOWNLOAD);
+        if (translogTransferStats.totalDownloadsSucceeded > 0) {
+            assertEquals(
+                translogTransferStats.lastSuccessfulDownloadTimestamp,
+                Long.parseLong(tlogDownloadStatsObj.get(RemoteStoreStats.DownloadStatsFields.LAST_SUCCESSFUL_DOWNLOAD_TIMESTAMP).toString())
+            );
+            assertEquals(
+                translogTransferStats.totalDownloadsSucceeded,
+                Long.parseLong(
+                    ((Map<?, ?>) tlogDownloadStatsObj.get(RemoteStoreStats.DownloadStatsFields.TOTAL_DOWNLOADS)).get(
+                        RemoteStoreStats.SubFields.SUCCEEDED
+                    ).toString()
+                )
+            );
+            assertEquals(
+                translogTransferStats.downloadBytesSucceeded,
+                Long.parseLong(
+                    ((Map<?, ?>) tlogDownloadStatsObj.get(RemoteStoreStats.DownloadStatsFields.TOTAL_DOWNLOADS_IN_BYTES)).get(
+                        RemoteStoreStats.SubFields.SUCCEEDED
+                    ).toString()
+                )
+            );
+            assertEquals(
+                translogTransferStats.totalDownloadTimeInMillis,
+                Long.parseLong(tlogDownloadStatsObj.get(RemoteStoreStats.DownloadStatsFields.TOTAL_DOWNLOAD_TIME_IN_MILLIS).toString())
+            );
+
+            assertEquals(
+                translogTransferStats.downloadBytesMovingAverage,
+                ((Map<?, ?>) tlogDownloadStatsObj.get(RemoteStoreStats.DownloadStatsFields.DOWNLOAD_SIZE_IN_BYTES)).get(
+                    RemoteStoreStats.SubFields.MOVING_AVG
+                )
+            );
+            assertEquals(
+                translogTransferStats.downloadBytesPerSecMovingAverage,
+                ((Map<?, ?>) tlogDownloadStatsObj.get(RemoteStoreStats.DownloadStatsFields.DOWNLOAD_SPEED_IN_BYTES_PER_SEC)).get(
+                    RemoteStoreStats.SubFields.MOVING_AVG
+                )
+            );
+            assertEquals(
+                translogTransferStats.downloadTimeMovingAverage,
+                ((Map<?, ?>) tlogDownloadStatsObj.get(RemoteStoreStats.DownloadStatsFields.DOWNLOAD_TIME_IN_MILLIS)).get(
+                    RemoteStoreStats.SubFields.MOVING_AVG
+                )
+            );
+        } else {
+            assertNull(tlogDownloadStatsObj.get(RemoteStoreStats.DownloadStatsFields.TOTAL_DOWNLOADS_IN_BYTES));
         }
     }
 }

--- a/server/src/test/java/org/opensearch/index/IndexModuleTests.java
+++ b/server/src/test/java/org/opensearch/index/IndexModuleTests.java
@@ -87,6 +87,7 @@ import org.opensearch.index.engine.InternalEngineTests;
 import org.opensearch.index.fielddata.IndexFieldDataCache;
 import org.opensearch.index.mapper.ParsedDocument;
 import org.opensearch.index.mapper.Uid;
+import org.opensearch.index.remote.RemoteTranslogTransferTracker;
 import org.opensearch.index.shard.IndexEventListener;
 import org.opensearch.index.shard.IndexingOperationListener;
 import org.opensearch.index.shard.SearchOperationListener;
@@ -231,7 +232,8 @@ public class IndexModuleTests extends OpenSearchTestCase {
                 return new RemoteBlobStoreInternalTranslogFactory(
                     repositoriesServiceReference::get,
                     threadPool,
-                    indexSettings.getRemoteStoreTranslogRepository()
+                    indexSettings.getRemoteStoreTranslogRepository(),
+                    new RemoteTranslogTransferTracker(shardRouting.shardId(), 10)
                 );
             }
             return new InternalTranslogFactory();

--- a/server/src/test/java/org/opensearch/index/remote/RemoteTranslogTransferTrackerTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteTranslogTransferTrackerTests.java
@@ -1,0 +1,383 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.remote;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.test.OpenSearchTestCase;
+import org.junit.Before;
+
+import java.io.IOException;
+
+public class RemoteTranslogTransferTrackerTests extends OpenSearchTestCase {
+    private ShardId shardId;
+    private RemoteTranslogTransferTracker tracker;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        shardId = new ShardId("index", "uuid", 0);
+    }
+
+    @Before
+    public void initTracker() {
+        tracker = new RemoteTranslogTransferTracker(shardId, RemoteStoreStatsTrackerFactory.Defaults.MOVING_AVERAGE_WINDOW_SIZE_MIN_VALUE);
+    }
+
+    public void testGetShardId() {
+        assertEquals(shardId, tracker.getShardId());
+    }
+
+    public void testAddUploadsStarted() {
+        populateUploadsStarted();
+    }
+
+    public void testAddUploadsFailed() {
+        populateUploadsStarted();
+        assertEquals(0L, tracker.getTotalUploadsFailed());
+        tracker.incrementUploadsFailed();
+        assertEquals(1L, tracker.getTotalUploadsFailed());
+        tracker.incrementUploadsFailed();
+        assertEquals(2L, tracker.getTotalUploadsFailed());
+    }
+
+    public void testInvalidAddUploadsFailed() {
+        populateUploadsStarted();
+        for (int i = 0; i < tracker.getTotalUploadsStarted(); i++) {
+            tracker.incrementUploadsSucceeded();
+        }
+
+        AssertionError error = assertThrows(AssertionError.class, () -> tracker.incrementUploadsFailed());
+        assertTrue(error.getMessage().contains("Sum of failure count ("));
+    }
+
+    public void testAddUploadsSucceeded() {
+        populateUploadsStarted();
+        assertEquals(0L, tracker.getTotalUploadsSucceeded());
+        tracker.incrementUploadsSucceeded();
+        assertEquals(1L, tracker.getTotalUploadsSucceeded());
+        tracker.incrementUploadsSucceeded();
+        assertEquals(2L, tracker.getTotalUploadsSucceeded());
+    }
+
+    public void testInvalidAddUploadsSucceeded() {
+        populateUploadsStarted();
+        for (int i = 0; i < tracker.getTotalUploadsStarted(); i++) {
+            tracker.incrementUploadsFailed();
+        }
+
+        AssertionError error = assertThrows(AssertionError.class, () -> tracker.incrementUploadsSucceeded());
+        assertTrue(error.getMessage().contains("Sum of failure count ("));
+    }
+
+    public void testAddUploadBytesStarted() {
+        populateUploadBytesStarted();
+    }
+
+    public void testAddUploadBytesFailed() {
+        populateUploadBytesStarted();
+        assertEquals(0L, tracker.getUploadBytesFailed());
+        long count1 = randomIntBetween(1, (int) tracker.getUploadBytesStarted() / 4);
+        tracker.addUploadBytesFailed(count1);
+        assertEquals(count1, tracker.getUploadBytesFailed());
+        long count2 = randomIntBetween(1, (int) tracker.getUploadBytesStarted() / 4);
+        tracker.addUploadBytesFailed(count2);
+        assertEquals(count1 + count2, tracker.getUploadBytesFailed());
+    }
+
+    public void testInvalidAddUploadBytesFailed() {
+        populateUploadBytesStarted();
+        tracker.addUploadBytesSucceeded(tracker.getUploadBytesStarted());
+        AssertionError error = assertThrows(AssertionError.class, () -> tracker.addUploadBytesFailed(1L));
+        assertTrue(error.getMessage().contains("Sum of failure count ("));
+    }
+
+    public void testAddUploadBytesSucceeded() {
+        populateUploadBytesStarted();
+        assertEquals(0L, tracker.getUploadBytesSucceeded());
+        long count1 = randomIntBetween(1, (int) tracker.getUploadBytesStarted() / 4);
+        tracker.addUploadBytesSucceeded(count1);
+        assertEquals(count1, tracker.getUploadBytesSucceeded());
+        long count2 = randomIntBetween(1, (int) tracker.getUploadBytesStarted() / 4);
+        tracker.addUploadBytesSucceeded(count2);
+        assertEquals(count1 + count2, tracker.getUploadBytesSucceeded());
+    }
+
+    public void testInvalidAddUploadBytesSucceeded() {
+        populateUploadBytesStarted();
+        tracker.addUploadBytesFailed(tracker.getUploadBytesStarted());
+        AssertionError error = assertThrows(AssertionError.class, () -> tracker.addUploadBytesSucceeded(1L));
+        assertTrue(error.getMessage().contains("Sum of failure count ("));
+    }
+
+    public void testAddUploadTimeInMillis() {
+        assertEquals(0L, tracker.getTotalUploadTimeInMillis());
+        int duration1 = randomIntBetween(10, 50);
+        tracker.addUploadTimeInMillis(duration1);
+        assertEquals(duration1, tracker.getTotalUploadTimeInMillis());
+        int duration2 = randomIntBetween(10, 50);
+        tracker.addUploadTimeInMillis(duration2);
+        assertEquals(duration1 + duration2, tracker.getTotalUploadTimeInMillis());
+    }
+
+    public void testSetLastSuccessfulUploadTimestamp() {
+        assertEquals(0, tracker.getLastSuccessfulUploadTimestamp());
+        long lastUploadTimestamp = System.currentTimeMillis() + randomIntBetween(10, 100);
+        tracker.setLastSuccessfulUploadTimestamp(lastUploadTimestamp);
+        assertEquals(lastUploadTimestamp, tracker.getLastSuccessfulUploadTimestamp());
+    }
+
+    public void testUpdateUploadBytesMovingAverage() {
+        int movingAverageWindowSize = randomIntBetween(
+            RemoteStoreStatsTrackerFactory.Defaults.MOVING_AVERAGE_WINDOW_SIZE_MIN_VALUE,
+            RemoteStoreStatsTrackerFactory.Defaults.MOVING_AVERAGE_WINDOW_SIZE + 5
+        );
+        tracker = new RemoteTranslogTransferTracker(shardId, movingAverageWindowSize);
+        assertFalse(tracker.isUploadBytesMovingAverageReady());
+
+        long sum = 0;
+        for (int i = 1; i < movingAverageWindowSize; i++) {
+            tracker.updateUploadBytesMovingAverage(i);
+            sum += i;
+            assertFalse(tracker.isUploadBytesMovingAverageReady());
+            assertEquals((double) sum / i, tracker.getUploadBytesMovingAverage(), 0.0d);
+        }
+
+        tracker.updateUploadBytesMovingAverage(movingAverageWindowSize);
+        sum += movingAverageWindowSize;
+        assertTrue(tracker.isUploadBytesMovingAverageReady());
+        assertEquals((double) sum / movingAverageWindowSize, tracker.getUploadBytesMovingAverage(), 0.0d);
+
+        tracker.updateUploadBytesMovingAverage(100);
+        sum = sum + 100 - 1;
+        assertEquals((double) sum / movingAverageWindowSize, tracker.getUploadBytesMovingAverage(), 0.0d);
+    }
+
+    public void testUpdateUploadBytesPerSecMovingAverage() {
+        int movingAverageWindowSize = randomIntBetween(
+            RemoteStoreStatsTrackerFactory.Defaults.MOVING_AVERAGE_WINDOW_SIZE_MIN_VALUE,
+            RemoteStoreStatsTrackerFactory.Defaults.MOVING_AVERAGE_WINDOW_SIZE + 5
+        );
+        tracker = new RemoteTranslogTransferTracker(shardId, movingAverageWindowSize);
+        assertFalse(tracker.isUploadBytesPerSecMovingAverageReady());
+
+        long sum = 0;
+        for (int i = 1; i < movingAverageWindowSize; i++) {
+            tracker.updateUploadBytesPerSecMovingAverage(i);
+            sum += i;
+            assertFalse(tracker.isUploadBytesPerSecMovingAverageReady());
+            assertEquals((double) sum / i, tracker.getUploadBytesPerSecMovingAverage(), 0.0d);
+        }
+
+        tracker.updateUploadBytesPerSecMovingAverage(movingAverageWindowSize);
+        sum += movingAverageWindowSize;
+        assertTrue(tracker.isUploadBytesPerSecMovingAverageReady());
+        assertEquals((double) sum / movingAverageWindowSize, tracker.getUploadBytesPerSecMovingAverage(), 0.0d);
+
+        tracker.updateUploadBytesPerSecMovingAverage(100);
+        sum = sum + 100 - 1;
+        assertEquals((double) sum / movingAverageWindowSize, tracker.getUploadBytesPerSecMovingAverage(), 0.0d);
+    }
+
+    public void testUpdateUploadTimeMovingAverage() {
+        int movingAverageWindowSize = randomIntBetween(
+            RemoteStoreStatsTrackerFactory.Defaults.MOVING_AVERAGE_WINDOW_SIZE_MIN_VALUE,
+            RemoteStoreStatsTrackerFactory.Defaults.MOVING_AVERAGE_WINDOW_SIZE + 5
+        );
+        tracker = new RemoteTranslogTransferTracker(shardId, movingAverageWindowSize);
+        assertFalse(tracker.isUploadTimeMovingAverageReady());
+
+        long sum = 0;
+        for (int i = 1; i < movingAverageWindowSize; i++) {
+            tracker.updateUploadTimeMovingAverage(i);
+            sum += i;
+            assertFalse(tracker.isUploadTimeMovingAverageReady());
+            assertEquals((double) sum / i, tracker.getUploadTimeMovingAverage(), 0.0d);
+        }
+
+        tracker.updateUploadTimeMovingAverage(movingAverageWindowSize);
+        sum += movingAverageWindowSize;
+        assertTrue(tracker.isUploadTimeMovingAverageReady());
+        assertEquals((double) sum / movingAverageWindowSize, tracker.getUploadTimeMovingAverage(), 0.0d);
+
+        tracker.updateUploadTimeMovingAverage(100);
+        sum = sum + 100 - 1;
+        assertEquals((double) sum / movingAverageWindowSize, tracker.getUploadTimeMovingAverage(), 0.0d);
+    }
+
+    public void testAddDownloadsSucceeded() {
+        assertEquals(0L, tracker.getTotalDownloadsSucceeded());
+        tracker.incrementDownloadsSucceeded();
+        assertEquals(1L, tracker.getTotalDownloadsSucceeded());
+        tracker.incrementDownloadsSucceeded();
+        assertEquals(2L, tracker.getTotalDownloadsSucceeded());
+    }
+
+    public void testAddDownloadBytesSucceeded() {
+        assertEquals(0L, tracker.getDownloadBytesSucceeded());
+        long count1 = randomIntBetween(1, 500);
+        tracker.addDownloadBytesSucceeded(count1);
+        assertEquals(count1, tracker.getDownloadBytesSucceeded());
+        long count2 = randomIntBetween(1, 500);
+        tracker.addDownloadBytesSucceeded(count2);
+        assertEquals(count1 + count2, tracker.getDownloadBytesSucceeded());
+    }
+
+    public void testAddDownloadTimeInMillis() {
+        assertEquals(0L, tracker.getTotalDownloadTimeInMillis());
+        int duration1 = randomIntBetween(10, 50);
+        tracker.addDownloadTimeInMillis(duration1);
+        assertEquals(duration1, tracker.getTotalDownloadTimeInMillis());
+        int duration2 = randomIntBetween(10, 50);
+        tracker.addDownloadTimeInMillis(duration2);
+        assertEquals(duration1 + duration2, tracker.getTotalDownloadTimeInMillis());
+    }
+
+    public void testSetLastSuccessfulDownloadTimestamp() {
+        assertEquals(0, tracker.getLastSuccessfulDownloadTimestamp());
+        long lastSuccessfulDownloadTimestamp = System.currentTimeMillis() + randomIntBetween(10, 100);
+        tracker.setLastSuccessfulDownloadTimestamp(lastSuccessfulDownloadTimestamp);
+        assertEquals(lastSuccessfulDownloadTimestamp, tracker.getLastSuccessfulDownloadTimestamp());
+    }
+
+    public void testUpdateDowmloadBytesMovingAverage() {
+        int movingAverageWindowSize = randomIntBetween(
+            RemoteStoreStatsTrackerFactory.Defaults.MOVING_AVERAGE_WINDOW_SIZE_MIN_VALUE,
+            RemoteStoreStatsTrackerFactory.Defaults.MOVING_AVERAGE_WINDOW_SIZE + 5
+        );
+        tracker = new RemoteTranslogTransferTracker(shardId, movingAverageWindowSize);
+        assertFalse(tracker.isDownloadBytesMovingAverageReady());
+
+        long sum = 0;
+        for (int i = 1; i < movingAverageWindowSize; i++) {
+            tracker.updateDownloadBytesMovingAverage(i);
+            sum += i;
+            assertFalse(tracker.isDownloadBytesMovingAverageReady());
+            assertEquals((double) sum / i, tracker.getDownloadBytesMovingAverage(), 0.0d);
+        }
+
+        tracker.updateDownloadBytesMovingAverage(movingAverageWindowSize);
+        sum += movingAverageWindowSize;
+        assertTrue(tracker.isDownloadBytesMovingAverageReady());
+        assertEquals((double) sum / movingAverageWindowSize, tracker.getDownloadBytesMovingAverage(), 0.0d);
+
+        tracker.updateDownloadBytesMovingAverage(100);
+        sum = sum + 100 - 1;
+        assertEquals((double) sum / movingAverageWindowSize, tracker.getDownloadBytesMovingAverage(), 0.0d);
+    }
+
+    public void testUpdateDownloadBytesPerSecMovingAverage() {
+        int movingAverageWindowSize = randomIntBetween(
+            RemoteStoreStatsTrackerFactory.Defaults.MOVING_AVERAGE_WINDOW_SIZE_MIN_VALUE,
+            RemoteStoreStatsTrackerFactory.Defaults.MOVING_AVERAGE_WINDOW_SIZE + 5
+        );
+        tracker = new RemoteTranslogTransferTracker(shardId, movingAverageWindowSize);
+        assertFalse(tracker.isDownloadBytesPerSecMovingAverageReady());
+
+        long sum = 0;
+        for (int i = 1; i < movingAverageWindowSize; i++) {
+            tracker.updateDownloadBytesPerSecMovingAverage(i);
+            sum += i;
+            assertFalse(tracker.isDownloadBytesPerSecMovingAverageReady());
+            assertEquals((double) sum / i, tracker.getDownloadBytesPerSecMovingAverage(), 0.0d);
+        }
+
+        tracker.updateDownloadBytesPerSecMovingAverage(movingAverageWindowSize);
+        sum += movingAverageWindowSize;
+        assertTrue(tracker.isDownloadBytesPerSecMovingAverageReady());
+        assertEquals((double) sum / movingAverageWindowSize, tracker.getDownloadBytesPerSecMovingAverage(), 0.0d);
+
+        tracker.updateDownloadBytesPerSecMovingAverage(100);
+        sum = sum + 100 - 1;
+        assertEquals((double) sum / movingAverageWindowSize, tracker.getDownloadBytesPerSecMovingAverage(), 0.0d);
+    }
+
+    public void testUpdateDownloadTimeMovingAverage() {
+        int movingAverageWindowSize = randomIntBetween(
+            RemoteStoreStatsTrackerFactory.Defaults.MOVING_AVERAGE_WINDOW_SIZE_MIN_VALUE,
+            RemoteStoreStatsTrackerFactory.Defaults.MOVING_AVERAGE_WINDOW_SIZE + 5
+        );
+        tracker = new RemoteTranslogTransferTracker(shardId, movingAverageWindowSize);
+        assertFalse(tracker.isDownloadTimeMovingAverageReady());
+
+        long sum = 0;
+        for (int i = 1; i < movingAverageWindowSize; i++) {
+            tracker.updateDownloadTimeMovingAverage(i);
+            sum += i;
+            assertFalse(tracker.isDownloadTimeMovingAverageReady());
+            assertEquals((double) sum / i, tracker.getDownloadTimeMovingAverage(), 0.0d);
+        }
+
+        tracker.updateDownloadTimeMovingAverage(movingAverageWindowSize);
+        sum += movingAverageWindowSize;
+        assertTrue(tracker.isDownloadTimeMovingAverageReady());
+        assertEquals((double) sum / movingAverageWindowSize, tracker.getDownloadTimeMovingAverage(), 0.0d);
+
+        tracker.updateDownloadTimeMovingAverage(100);
+        sum = sum + 100 - 1;
+        assertEquals((double) sum / movingAverageWindowSize, tracker.getDownloadTimeMovingAverage(), 0.0d);
+    }
+
+    public void testStatsObjectCreation() {
+        populateDummyStats();
+        RemoteTranslogTransferTracker.Stats actualStats = tracker.stats();
+        assertTrue(tracker.hasSameStatsAs(actualStats));
+    }
+
+    public void testStatsObjectCreationViaStream() throws IOException {
+        populateDummyStats();
+        RemoteTranslogTransferTracker.Stats expectedStats = tracker.stats();
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            expectedStats.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                RemoteTranslogTransferTracker.Stats deserializedStats = new RemoteTranslogTransferTracker.Stats(in);
+                assertTrue(tracker.hasSameStatsAs(deserializedStats));
+            }
+        }
+    }
+
+    private void populateUploadsStarted() {
+        assertEquals(0L, tracker.getTotalUploadsStarted());
+        tracker.incrementUploadsStarted();
+        assertEquals(1L, tracker.getTotalUploadsStarted());
+        tracker.incrementUploadsStarted();
+        assertEquals(2L, tracker.getTotalUploadsStarted());
+    }
+
+    private void populateUploadBytesStarted() {
+        assertEquals(0L, tracker.getUploadBytesStarted());
+        long count1 = randomIntBetween(500, 1000);
+        tracker.addUploadBytesStarted(count1);
+        assertEquals(count1, tracker.getUploadBytesStarted());
+        long count2 = randomIntBetween(500, 1000);
+        tracker.addUploadBytesStarted(count2);
+        assertEquals(count1 + count2, tracker.getUploadBytesStarted());
+    }
+
+    private void populateDummyStats() {
+        int startedBytesUpload = randomIntBetween(10, 100);
+        tracker.addUploadBytesStarted(startedBytesUpload);
+        tracker.addUploadBytesFailed(randomIntBetween(1, startedBytesUpload / 2));
+        tracker.addUploadBytesSucceeded(randomIntBetween(1, startedBytesUpload / 2));
+
+        tracker.addUploadTimeInMillis(randomIntBetween(10, 100));
+        tracker.setLastSuccessfulUploadTimestamp(System.currentTimeMillis() + randomIntBetween(10, 100));
+
+        tracker.incrementUploadsStarted();
+        tracker.incrementUploadsStarted();
+        tracker.incrementUploadsFailed();
+        tracker.incrementUploadsSucceeded();
+
+        tracker.addDownloadBytesSucceeded(randomIntBetween(10, 100));
+        tracker.addDownloadTimeInMillis(randomIntBetween(10, 100));
+        tracker.setLastSuccessfulDownloadTimestamp(System.currentTimeMillis() + randomIntBetween(10, 100));
+        tracker.incrementDownloadsSucceeded();
+    }
+}

--- a/server/src/test/java/org/opensearch/index/remote/RemoteTranslogTransferTrackerTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteTranslogTransferTrackerTests.java
@@ -42,38 +42,38 @@ public class RemoteTranslogTransferTrackerTests extends OpenSearchTestCase {
     public void testAddUploadsFailed() {
         populateUploadsStarted();
         assertEquals(0L, tracker.getTotalUploadsFailed());
-        tracker.incrementUploadsFailed();
+        tracker.incrementTotalUploadsFailed();
         assertEquals(1L, tracker.getTotalUploadsFailed());
-        tracker.incrementUploadsFailed();
+        tracker.incrementTotalUploadsFailed();
         assertEquals(2L, tracker.getTotalUploadsFailed());
     }
 
     public void testInvalidAddUploadsFailed() {
         populateUploadsStarted();
         for (int i = 0; i < tracker.getTotalUploadsStarted(); i++) {
-            tracker.incrementUploadsSucceeded();
+            tracker.incrementTotalUploadsSucceeded();
         }
 
-        AssertionError error = assertThrows(AssertionError.class, () -> tracker.incrementUploadsFailed());
+        AssertionError error = assertThrows(AssertionError.class, () -> tracker.incrementTotalUploadsFailed());
         assertTrue(error.getMessage().contains("Sum of failure count ("));
     }
 
     public void testAddUploadsSucceeded() {
         populateUploadsStarted();
         assertEquals(0L, tracker.getTotalUploadsSucceeded());
-        tracker.incrementUploadsSucceeded();
+        tracker.incrementTotalUploadsSucceeded();
         assertEquals(1L, tracker.getTotalUploadsSucceeded());
-        tracker.incrementUploadsSucceeded();
+        tracker.incrementTotalUploadsSucceeded();
         assertEquals(2L, tracker.getTotalUploadsSucceeded());
     }
 
     public void testInvalidAddUploadsSucceeded() {
         populateUploadsStarted();
         for (int i = 0; i < tracker.getTotalUploadsStarted(); i++) {
-            tracker.incrementUploadsFailed();
+            tracker.incrementTotalUploadsFailed();
         }
 
-        AssertionError error = assertThrows(AssertionError.class, () -> tracker.incrementUploadsSucceeded());
+        AssertionError error = assertThrows(AssertionError.class, () -> tracker.incrementTotalUploadsSucceeded());
         assertTrue(error.getMessage().contains("Sum of failure count ("));
     }
 
@@ -345,9 +345,9 @@ public class RemoteTranslogTransferTrackerTests extends OpenSearchTestCase {
 
     private void populateUploadsStarted() {
         assertEquals(0L, tracker.getTotalUploadsStarted());
-        tracker.incrementUploadsStarted();
+        tracker.incrementTotalUploadsStarted();
         assertEquals(1L, tracker.getTotalUploadsStarted());
-        tracker.incrementUploadsStarted();
+        tracker.incrementTotalUploadsStarted();
         assertEquals(2L, tracker.getTotalUploadsStarted());
     }
 
@@ -370,10 +370,10 @@ public class RemoteTranslogTransferTrackerTests extends OpenSearchTestCase {
         tracker.addUploadTimeInMillis(randomIntBetween(10, 100));
         tracker.setLastSuccessfulUploadTimestamp(System.currentTimeMillis() + randomIntBetween(10, 100));
 
-        tracker.incrementUploadsStarted();
-        tracker.incrementUploadsStarted();
-        tracker.incrementUploadsFailed();
-        tracker.incrementUploadsSucceeded();
+        tracker.incrementTotalUploadsStarted();
+        tracker.incrementTotalUploadsStarted();
+        tracker.incrementTotalUploadsFailed();
+        tracker.incrementTotalUploadsSucceeded();
 
         tracker.addDownloadBytesSucceeded(randomIntBetween(10, 100));
         tracker.addDownloadTimeInMillis(randomIntBetween(10, 100));

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -4903,6 +4903,7 @@ public class IndexShardTests extends IndexShardTestCase {
 
     private void populateSampleRemoteStoreStats(RemoteSegmentTransferTracker tracker) {
         tracker.addUploadBytesStarted(10L);
+        tracker.addUploadBytesStarted(10L);
         tracker.addUploadBytesSucceeded(10L);
         tracker.addUploadBytesFailed(10L);
     }

--- a/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
@@ -248,7 +248,7 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
             .listAllInSortedOrder(any(BlobPath.class), eq(TranslogTransferMetadata.METADATA_PREFIX), anyInt(), any(ActionListener.class));
 
         assertNull(translogTransferManager.readMetadata());
-        assertNoDownloadStats();
+        assertNoDownloadStats(false);
     }
 
     // This should happen most of the time - Just a single metadata file
@@ -307,7 +307,7 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
         when(transferService.downloadBlob(any(BlobPath.class), eq(mdFilename))).thenThrow(new IOException("Something went wrong"));
 
         assertThrows(IOException.class, translogTransferManager::readMetadata);
-        assertNoDownloadStats();
+        assertNoDownloadStats(true);
     }
 
     public void testMetadataFileNameOrder() throws IOException {
@@ -339,7 +339,7 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
         when(transferService.downloadBlob(any(BlobPath.class), any(String.class))).thenThrow(new IOException("Something went wrong"));
 
         assertThrows(IOException.class, translogTransferManager::readMetadata);
-        assertNoDownloadStats();
+        assertNoDownloadStats(false);
     }
 
     public void testDownloadTranslog() throws IOException {
@@ -480,11 +480,15 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
         assertEquals(2, tracker.allUploaded().size());
     }
 
-    private void assertNoDownloadStats() {
+    private void assertNoDownloadStats(boolean nonZeroUploadTime) {
         assertEquals(0, remoteTranslogTransferTracker.getDownloadBytesSucceeded());
         assertEquals(0, remoteTranslogTransferTracker.getTotalDownloadsSucceeded());
-        assertEquals(0, remoteTranslogTransferTracker.getTotalDownloadTimeInMillis());
         assertEquals(0, remoteTranslogTransferTracker.getLastSuccessfulDownloadTimestamp());
+        if (nonZeroUploadTime) {
+            assertNotEquals(0, remoteTranslogTransferTracker.getTotalDownloadTimeInMillis());
+        } else {
+            assertEquals(0, remoteTranslogTransferTracker.getTotalDownloadTimeInMillis());
+        }        
     }
 
     private void assertTlogCkpDownloadStats() {

--- a/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
@@ -488,7 +488,7 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
             assertNotEquals(0, remoteTranslogTransferTracker.getTotalDownloadTimeInMillis());
         } else {
             assertEquals(0, remoteTranslogTransferTracker.getTotalDownloadTimeInMillis());
-        }        
+        }
     }
 
     private void assertTlogCkpDownloadStats() {

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -2064,7 +2064,8 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                     emptyMap(),
                     new RemoteSegmentStoreDirectoryFactory(() -> repositoriesService, threadPool),
                     repositoriesServiceReference::get,
-                    fileCacheCleaner
+                    fileCacheCleaner,
+                    new RemoteStoreStatsTrackerFactory(clusterService, settings)
                 );
                 final RecoverySettings recoverySettings = new RecoverySettings(settings, clusterSettings);
                 snapshotShardsService = new SnapshotShardsService(

--- a/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
@@ -98,6 +98,7 @@ import org.opensearch.index.engine.NRTReplicationEngineFactory;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.SourceToParse;
 import org.opensearch.index.remote.RemoteStoreStatsTrackerFactory;
+import org.opensearch.index.remote.RemoteTranslogTransferTracker;
 import org.opensearch.index.replication.TestReplicationSource;
 import org.opensearch.index.seqno.ReplicationTracker;
 import org.opensearch.index.seqno.RetentionLeaseSyncer;
@@ -662,11 +663,11 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
 
             final BiFunction<IndexSettings, ShardRouting, TranslogFactory> translogFactorySupplier = (settings, shardRouting) -> {
                 if (settings.isRemoteTranslogStoreEnabled() && shardRouting.primary()) {
-
                     return new RemoteBlobStoreInternalTranslogFactory(
                         () -> mockRepoSvc,
                         threadPool,
-                        settings.getRemoteStoreTranslogRepository()
+                        settings.getRemoteStoreTranslogRepository(),
+                        new RemoteTranslogTransferTracker(shardRouting.shardId(), 20)
                     );
                 }
                 return new InternalTranslogFactory();


### PR DESCRIPTION
### Description
This is an incremental PR for PR #8908. This PR adds the logic to surface stats related to Remote Translog Store upload and download flows, when queried via the `_remotestore/stats/` API. 

A sample response would look like:

```json
"4": [ // shard number
  {
    "routing" : {
      "state" : "STARTED",
      "primary" : true, // note that this is the primary copy
      "node" : "9GGM_5tWSIGjx9gd4-P4cg"
    },
    "segment" : { // segment stats
      "download" : { }, // segment stats for download flow
      "upload" : { } // segment stats for upload flow
    },
    "translog" : { // translog stats
      "upload" : { // translog stats for upload flow
        "last_successful_upload_timestamp" : 1692192354058, // System time in millis when the last successful upload completed
        "total_uploads" : { // Number of syncs to Remote Translog Store
          "started" : 24,
          "failed" : 0,
          "succeeded" : 24
        },
        "total_uploads_in_bytes" : { // Number of bytes based on files (.tlog, .ckp, metadata) uploaded
          "started" : 2556,
          "failed" : 0,
          "succeeded" : 2556
        },
        "total_upload_time_in_millis" : 125, // Total time duration in millis spent on remote store uploads
        "upload_size_in_bytes" : { // Moving avg of bytes uploaded in a successful sync to remote (i.e. all files successfully uploaded for that sync to remote)
          "moving_avg" : 255.6
        },
        "upload_speed_in_bytes_per_sec" : { // Moving avg of bytes per sec speed for a successful sync to remote (i.e. all files successfully uploaded for that sync to remote)
          "moving_avg" : 21575.3
        },
        "upload_time_in_millis" : { // Moving avg of time duration in millis spent on a successful sync to remote (i.e. all files successfully uploaded for that sync to remote)
          "moving_avg" : 12.5
        }
      },
      "download" : { // translog stats for download flow
        "last_successful_download_timestamp" : 1692192296107, // System time in millis when the last successful download completed
        "total_downloads" : { // Number of syncs to Remote Translog Store
          "succeeded" : 7
        },
        "total_downloads_in_bytes" : { // Number of bytes based on files (.tlog, .ckp, metadata) successfully downloaded
          "succeeded" : 664
        },
        "total_download_time_in_millis" : 53, // Total time duration in millis spent on successful remote store downloads
        "download_size_in_bytes" : { // Moving avg of bytes downloaded in a successful sync from remote (i.e. all files successfully downloaded for that sync from remote)
          "moving_avg" : 664.0
        },
        "download_speed_in_bytes_per_sec" : { // Moving avg of bytes per sec speed for a successful sync from remote (i.e. all files successfully downloaded for that sync from remote)
          "moving_avg" : 12528.0
        },
        "download_time_in_millis" : { // Moving avg of time duration in millis spent on a successful sync from remote (i.e. all files successfully downloaded for that sync from remote)
          "moving_avg" : 53.0
        }
      }
    }
  },
  {
    "routing" : {
      "state" : "STARTED",
      "primary" : false, // note that this is the replica copy
      "node" : "zXMfpae7RBW9pIloLbxQiw"
    },
    "segment" : { // segment stats
      "download" : { }, // segment stats for download flow
      "upload" : { } // segment stats for upload flow
    },
    "translog" : { // translog stats
      "upload" : { }, // translog stats for upload flow
      "download" : { } // translog stats for download flow
    }
  }
]
```

Testing: [gist](https://gist.github.com/BhumikaSaini-Amazon/6ed79aee84193e2ff1cc7f1babcbc745)


### Related Issues
#8311

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
