### PR TITLE
[CheckCompatibility] Prevent interleaving of log output

### DIFF
--- a/.github/workflows/check-compatibility.yml
+++ b/.github/workflows/check-compatibility.yml
@@ -11,12 +11,12 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Run compatibility task
-        run: ./gradlew checkCompatibility | tee $HOME/gradlew-check.out
+        run: ./gradlew checkCompatibility -i | tee $HOME/gradlew-check.out
 
       - name: Get results
         run: |
           echo 'Compatibility status:' > ${{ github.workspace }}/results.txt && echo '```' >> ${{ github.workspace }}/results.txt
-          grep -e 'Compatible components' -e 'Incompatible components' -e 'Components skipped' -A 2 -B 3 $HOME/gradlew-check.out >> "${{ github.workspace }}/results.txt"
+          grep -e 'Compatible components' -e 'Incompatible components' -e 'Components skipped' $HOME/gradlew-check.out >> "${{ github.workspace }}/results.txt"
           echo '```' >> ${{ github.workspace }}/results.txt
 
       - name: GitHub App token


### PR DESCRIPTION
### Description
Prevent interleaving of log output and add more detail logging 

<details>
<summary>Example output at standard log level</summary>


```
> Task :checkCompatibility
Checking compatibility for: https://github.com/opensearch-project/sql.git with ref: main
Checking compatibility for: https://github.com/opensearch-project/security.git with ref: main
Finished compatibility check for https://github.com/opensearch-project/security.git
Error output for https://github.com/opensearch-project/security.git build:

Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

Finished compatibility check for https://github.com/opensearch-project/sql.git
Error output for https://github.com/opensearch-project/sql.git build:

Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
/tmp/groovy-generated-tmpdir-6721287947875417197/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/core/ExpressionScript.java:64: warning: [removal] AccessController in java.security has been deprecated and marked for removal
    this.fields = AccessController.doPrivileged((PrivilegedAction<Set<ReferenceExpression>>) () ->
                  ^
...
```

</details>

### Related Issues
- Related https://github.com/opensearch-project/OpenSearch/issues/9235

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
