### PR TITLE
[Segment Replication] Mute flaky testIndexingWithSegRep test

### DIFF
--- a/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/IndexingIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/IndexingIT.java
@@ -261,6 +261,7 @@ public class IndexingIT extends AbstractRollingTestCase {
      *
      * @throws Exception
      */
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/7679")
     public void testIndexingWithSegRep() throws Exception {
         if (UPGRADE_FROM_VERSION.before(Version.V_2_4_0)) {
             logger.info("--> Skip test for version {} where segment replication feature is not available", UPGRADE_FROM_VERSION);


### PR DESCRIPTION
### Description
Mute `testIndexingWithSegRep` test after it is still found to be flaky post [last fix](https://github.com/opensearch-project/OpenSearch/issues/9079). The test today fails because replica shard is remains lagging primary shard on `checkpoints_behind` metric which is verified [here](https://github.com/opensearch-project/OpenSearch/blob/8e57a660d20b257d30d05288432733595713d464/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/IndexingIT.java#L159). This assertion is important to ensure replica eventually catches up with primary but it is found replica is still not able to catch up with primary after 1 minute of wait.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
Related #7679 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
