### PR TITLE
Enforce up-to-date Guava in buildSrc

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -135,6 +135,12 @@ dependencies {
   }
 }
 
+configurations.all {
+  resolutionStrategy {
+    force "com.google.guava:guava:${props.getProperty('guava')}"
+  }
+}
+
 /*****************************************************************************
  *                         Bootstrap repositories                            *
  *****************************************************************************/


### PR DESCRIPTION
### Description
Enforces up-to-date Guava in buildSrc.
Guava is a transitive dependency of spotless via google-java-format, the version that was being pulled in has CVE-2023-2976. While this would not affect end users it causes excess alerts.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
