### PR TITLE
Fix flaky test InternalEngineTests.testLastRefreshCheckpoint

### DIFF
--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -2784,7 +2784,7 @@ public class InternalEngine extends Engine {
      * Returns the current local checkpoint getting refreshed internally.
      */
     public final long currentOngoingRefreshCheckpoint() {
-        return lastRefreshedCheckpointListener.pendingCheckpoint;
+        return lastRefreshedCheckpointListener.pendingCheckpoint.get();
     }
 
     private final Object refreshIfNeededMutex = new Object();
@@ -2804,29 +2804,33 @@ public class InternalEngine extends Engine {
 
     private final class LastRefreshedCheckpointListener implements ReferenceManager.RefreshListener {
         final AtomicLong refreshedCheckpoint;
-        volatile long pendingCheckpoint;
+        volatile AtomicLong pendingCheckpoint;
 
         LastRefreshedCheckpointListener(long initialLocalCheckpoint) {
             this.refreshedCheckpoint = new AtomicLong(initialLocalCheckpoint);
-            this.pendingCheckpoint = initialLocalCheckpoint;
+            this.pendingCheckpoint = new AtomicLong(initialLocalCheckpoint);
         }
 
         @Override
         public void beforeRefresh() {
             // all changes until this point should be visible after refresh
-            pendingCheckpoint = localCheckpointTracker.getProcessedCheckpoint();
+            pendingCheckpoint.updateAndGet(curr -> Math.max(curr, localCheckpointTracker.getProcessedCheckpoint()));
         }
 
         @Override
         public void afterRefresh(boolean didRefresh) {
             if (didRefresh) {
-                updateRefreshedCheckpoint(pendingCheckpoint);
+                updateRefreshedCheckpoint(pendingCheckpoint.get());
             }
         }
 
         void updateRefreshedCheckpoint(long checkpoint) {
             refreshedCheckpoint.updateAndGet(curr -> Math.max(curr, checkpoint));
             assert refreshedCheckpoint.get() >= checkpoint : refreshedCheckpoint.get() + " < " + checkpoint;
+            // This shouldn't be required ideally, but we're also invoking this method from refresh as of now.
+            // This change is added as safety check to ensure that our checkpoint values are consistent at all times.
+            pendingCheckpoint.updateAndGet(curr -> Math.max(curr, checkpoint));
+
         }
     }
 


### PR DESCRIPTION
### Description
We saw an assertion failure [here](https://github.com/opensearch-project/OpenSearch/blob/c1505f1cfed580ef43df3ceb3fe1c660b4bc5178/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java#L6644) where `currentOngoingRefreshCheckpoint` was `-1` and  `lastRefreshedCheckpoint` was `0`. This was not reproducible after 50K test iterations. 
```
com.carrotsearch.randomizedtesting.UncaughtExceptionError: Captured an uncaught exception in thread: Thread[id=649, name=Thread-197, state=RUNNABLE, group=TGRP-InternalEngineTests]
	at __randomizedtesting.SeedInfo.seed([B448FCE4648CA4EB:7A3CB282E14976E1]:0)
Caused by: java.lang.AssertionError: 
Expected: a value equal to or greater than <0L>
     but: <-1L> was less than <0L>
	at __randomizedtesting.SeedInfo.seed([B448FCE4648CA4EB]:0)
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:18)
	at org.junit.Assert.assertThat(Assert.java:964)
	at org.junit.Assert.assertThat(Assert.java:930)
	at org.opensearch.index.engine.InternalEngineTests.lambda$testLastRefreshCheckpoint$84(InternalEngineTests.java:6643)
```

Within the `LastRefreshedCheckpointListener`([here](https://github.com/opensearch-project/OpenSearch/blob/a352a4282448d39b4e75460476dc852ae6d65214/server/src/main/java/org/opensearch/index/engine/InternalEngine.java#L2805)) we always update `lastRefreshedCheckpoint` based on `currentOngoingRefreshCheckpoint` so this above failure condition can never occur. Except we're also invoking the `updateRefreshedCheckpoint` from [refresh](https://github.com/opensearch-project/OpenSearch/blob/a352a4282448d39b4e75460476dc852ae6d65214/server/src/main/java/org/opensearch/index/engine/InternalEngine.java#L1778) which isn't required IMO. Ideal fix would be to remove that but that is more intrusive and there isn't enough context on why it was added in the first place. 
Thus the easier fix in this PR is to ensure that we also update `pendingCheckpoint` whenever we're updating `refreshedCheckpoint` to ensure consistency.



### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/9029

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
