### PR TITLE
Fix flaky test NRTReplicationEngineTests.testPreserveLatestCommit

### DIFF
--- a/server/src/test/java/org/opensearch/index/engine/NRTReplicationEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/NRTReplicationEngineTests.java
@@ -426,12 +426,8 @@ public class NRTReplicationEngineTests extends EngineTestCase {
             for (String file : extraSegments) {
                 assertTrue(replicaFiles.contains(file));
             }
-            assertTrue(storeContainsAll(nrtEngineStore, extraSegments));
             try (NRTReplicationEngine nrtEngine = buildNrtReplicaEngine(globalCheckpoint, nrtEngineStore, INDEX_SETTINGS)) {
-                replicaFiles = List.of(nrtEngineStore.directory().listAll());
-                for (String file : extraSegments) {
-                    assertFalse(replicaFiles.contains(file));
-                }
+                assertUnreferenced(nrtEngine, extraSegments);
             }
         }
     }
@@ -452,21 +448,12 @@ public class NRTReplicationEngineTests extends EngineTestCase {
 
             final SegmentInfos lastCommittedSegmentInfos = nrtEngine.getLastCommittedSegmentInfos();
             final Collection<String> lastCommittedFiles = lastCommittedSegmentInfos.files(true);
-            assertTrue(storeContainsAll(nrtEngineStore, lastCommittedFiles));
-
-            // ensure segments and commit file are incref'd:
-            assertEquals(
-                "Segments_N is incref'd once",
-                1,
-                nrtEngine.replicaFileTracker.refCount(lastCommittedSegmentInfos.getSegmentsFileName())
-            );
-            // segments are incref'd twice because they are loaded on the reader.
-            assertRefCount(nrtEngine, lastCommittedSegmentInfos.files(false), 2);
+            assertRefCounted(nrtEngine, lastCommittedFiles);
 
             // get and close a snapshot - this will decref files when closed.
             final GatedCloseable<SegmentInfos> segmentInfosSnapshot = nrtEngine.getSegmentInfosSnapshot();
             segmentInfosSnapshot.close();
-            assertTrue(storeContainsAll(nrtEngineStore, lastCommittedFiles));
+            assertRefCounted(nrtEngine, lastCommittedFiles);
 
             // index more docs and refresh the reader - this will incref/decref files again
             indexOperations(nrtEngine, operations.subList(2, 4));
@@ -477,44 +464,44 @@ public class NRTReplicationEngineTests extends EngineTestCase {
             // get the additional segments that are only on the reader - not part of a commit.
             final Collection<String> readerOnlySegments = primaryInfos.files(false);
             readerOnlySegments.removeAll(lastCommittedFiles);
-            assertRefCount(nrtEngine, readerOnlySegments, 1);
-
-            assertTrue(storeContainsAll(nrtEngineStore, lastCommittedFiles));
-            assertEquals(
-                "Segments_N is incref'd once",
-                1,
-                nrtEngine.replicaFileTracker.refCount(lastCommittedSegmentInfos.getSegmentsFileName())
-            );
-            assertRefCount(nrtEngine, lastCommittedSegmentInfos.files(false), 2);
+            assertRefCounted(nrtEngine, readerOnlySegments);
+            // re-read the last commit from disk here in case the primary engine has flushed.
+            assertRefCounted(nrtEngine, nrtEngine.getLastCommittedSegmentInfos().files(true));
 
             // flush the primary
             engine.flush(true, true);
-            copySegments(engine.getLatestSegmentInfos().files(false), nrtEngine);
+            final Collection<String> latestPrimaryInfos = engine.getLatestSegmentInfos().files(false);
+            final Collection<String> mergedAwayFiles = nrtEngine.getLastCommittedSegmentInfos().files(false);
+            // remove files still part of latest commit.
+            mergedAwayFiles.removeAll(latestPrimaryInfos);
+            copySegments(latestPrimaryInfos, nrtEngine);
             nrtEngine.updateSegments(engine.getLatestSegmentInfos());
-            // after flush our segment_n is removed.
-            assertEquals(
-                "Segments_N is removed",
-                0,
-                nrtEngine.replicaFileTracker.refCount(lastCommittedSegmentInfos.getSegmentsFileName())
-            );
-            assertFalse(storeContainsAll(nrtEngineStore, lastCommittedFiles));
+            // after flush our original segment_n is removed but some segments may remain.
+            assertUnreferenced(nrtEngine, List.of(lastCommittedSegmentInfos.getSegmentsFileName()));
+            assertUnreferenced(nrtEngine, mergedAwayFiles);
             // close the engine - ensure we preserved the last commit
             final SegmentInfos infosBeforeClose = nrtEngine.getLatestSegmentInfos();
             nrtEngine.close();
-            assertTrue(storeContainsAll(nrtEngineStore, infosBeforeClose.files(false)));
-            assertEquals(store.readLastCommittedSegmentsInfo().files(false), infosBeforeClose.files(false));
+            assertRefCounted(nrtEngine, infosBeforeClose.files(false));
         }
     }
 
-    private void assertRefCount(NRTReplicationEngine nrtEngine, Collection<String> files, int count) {
+    private void assertRefCounted(NRTReplicationEngine nrtEngine, Collection<String> files) throws IOException {
+        List<String> storeFiles = List.of(nrtEngine.store.directory().listAll());
         for (String file : files) {
             // refCount for our segments is 2 because they are still active on the reader
-            assertEquals(count, nrtEngine.replicaFileTracker.refCount(file));
+            assertTrue("Expected: " + file + " to be referenced", nrtEngine.replicaFileTracker.refCount(file) >= 1);
+            assertTrue(storeFiles.contains(file));
         }
     }
 
-    private boolean storeContainsAll(Store nrtEngineStore, Collection<String> lastCommittedFiles) throws IOException {
-        return List.of(nrtEngineStore.directory().listAll()).containsAll(lastCommittedFiles);
+    private void assertUnreferenced(NRTReplicationEngine nrtEngine, Collection<String> files) throws IOException {
+        List<String> storeFiles = List.of(nrtEngine.store.directory().listAll());
+        for (String file : files) {
+            // refCount for our segments is 2 because they are still active on the reader
+            assertEquals("Expected: " + file + " to be unreferenced", 0, nrtEngine.replicaFileTracker.refCount(file));
+            assertFalse(storeFiles.contains(file));
+        }
     }
 
     private void cleanAndCopySegmentsFromPrimary(NRTReplicationEngine nrtEngine) throws IOException {


### PR DESCRIPTION
### Description
Fix flaky test NRTReplicationEngineTests.testPreserveLatestCommit.
This test occasionally failed when the primary's engine performed a flush and merge behind the scenes.  The test would assert against a specific refCount on committed files with a value of 2 - one for being part of the replica's latest commit and one for being active on the reader.  With the unexpected merge, the files will not be part of the latest infos on the reader but still be part of the replica's latest commit point, leaving the files referenced once.  I've changed this to instead assert referenced vs unreferenced instead of the specific refCount so that the test can handle the random merges.  Further cleaned this up so assertions include a refCount check and to validate the files exist in the directory.

I've run this ~5k times now without failure, was able to repro before this every 100-200 runs.

### Related Issues
Resolves #9356

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
