### PR TITLE
[Backport 2.x] Restrict GitHub Actions to run only on OpenSearch repo (#9284)

### DIFF
--- a/.github/workflows/changelog_verifier.yml
+++ b/.github/workflows/changelog_verifier.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   # Enforces the update of a changelog file on every pull request
   verify-changelog:
+    if: github.repository == 'opensearch-project/OpenSearch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/check-compatibility.yml
+++ b/.github/workflows/check-compatibility.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'opensearch-project/OpenSearch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/gradle-check.yml
+++ b/.github/workflows/gradle-check.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   gradle-check:
+    if: github.repository == 'opensearch-project/OpenSearch'
     permissions:
       contents: read # to fetch code (actions/checkout)
       pull-requests: write # to create or update comment (peter-evans/create-or-update-comment)

--- a/.github/workflows/lucene-snapshots.yml
+++ b/.github/workflows/lucene-snapshots.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   publish-snapshots:
+    if: github.repository == 'opensearch-project/OpenSearch'
     runs-on: ubuntu-latest
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -3,6 +3,7 @@ on: [pull_request]
 
 jobs:
   precommit:
+    if: github.repository == 'opensearch-project/OpenSearch'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/publish-maven-snapshots.yml
+++ b/.github/workflows/publish-maven-snapshots.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build-and-publish-snapshots:
+    if: github.repository == 'opensearch-project/OpenSearch'
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -8,6 +8,7 @@ on:
 permissions: {}
 jobs:
   build:
+    if: github.repository == 'opensearch-project/OpenSearch'
     runs-on: ubuntu-latest
     steps:
       - name: GitHub App token

--- a/.github/workflows/wrapper.yml
+++ b/.github/workflows/wrapper.yml
@@ -4,6 +4,7 @@ on: [pull_request]
 jobs:
   validate:
     name: Validate
+    if: github.repository == 'opensearch-project/OpenSearch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Backport 0d5dbde4d34462e0ee5178363bbd0037cb47dd28 from #9284.