### PR TITLE
[Remote Store] Add cumulative bytes lag to NodesStats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Change http code on create index API with bad input raising NotXContentException from 500 to 400 ([#4773](https://github.com/opensearch-project/OpenSearch/pull/4773))
 - Improve summary error message for invalid setting updates ([#4792](https://github.com/opensearch-project/OpenSearch/pull/4792))
 - [Remote Store] Add Segment download stats to remotestore stats API ([#8718](https://github.com/opensearch-project/OpenSearch/pull/8718))
-- [Remote Store] Add remote segment transfer stats on NodesStats API ([#9168](https://github.com/opensearch-project/OpenSearch/pull/9168))
+- [Remote Store] Add remote segment transfer stats on NodesStats API ([#9168](https://github.com/opensearch-project/OpenSearch/pull/9168) [#9393](https://github.com/opensearch-project/OpenSearch/pull/9393))
 - Return 409 Conflict HTTP status instead of 503 on failure to concurrently execute snapshots ([#8986](https://github.com/opensearch-project/OpenSearch/pull/5855))
 
 ### Deprecated

--- a/server/src/internalClusterTest/java/org/opensearch/indices/stats/IndexStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/stats/IndexStatsIT.java
@@ -1455,6 +1455,7 @@ public class IndexStatsIT extends OpenSearchIntegTestCase {
         assertEquals(0, remoteSegmentStats.getDownloadBytesSucceeded());
         assertEquals(0, remoteSegmentStats.getDownloadBytesFailed());
         assertEquals(0, remoteSegmentStats.getTotalRefreshBytesLag());
+        assertEquals(0, remoteSegmentStats.getMaxRefreshBytesLag());
         assertEquals(0, remoteSegmentStats.getMaxRefreshTimeLag());
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/indices/stats/IndexStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/stats/IndexStatsIT.java
@@ -1454,7 +1454,7 @@ public class IndexStatsIT extends OpenSearchIntegTestCase {
         assertEquals(0, remoteSegmentStats.getDownloadBytesStarted());
         assertEquals(0, remoteSegmentStats.getDownloadBytesSucceeded());
         assertEquals(0, remoteSegmentStats.getDownloadBytesFailed());
-        assertEquals(0, remoteSegmentStats.getMaxRefreshBytesLag());
+        assertEquals(0, remoteSegmentStats.getTotalRefreshBytesLag());
         assertEquals(0, remoteSegmentStats.getMaxRefreshTimeLag());
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteSegmentStatsFromNodesStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteSegmentStatsFromNodesStatsIT.java
@@ -67,7 +67,7 @@ public class RemoteSegmentStatsFromNodesStatsIT extends RemoteStoreBaseIntegTest
         indexSingleDoc(secondIndex, true);
 
         long cumulativeUploadsSucceeded = 0, cumulativeUploadsStarted = 0, cumulativeUploadsFailed = 0;
-        long total_bytes_lag = 0, max_time_lag = 0;
+        long total_bytes_lag = 0, max_bytes_lag = 0, max_time_lag = 0;
         // Fetch upload stats
         RemoteStoreStatsResponse remoteStoreStatsFirstIndex = client(randomDataNode).admin()
             .cluster()
@@ -78,6 +78,7 @@ public class RemoteSegmentStatsFromNodesStatsIT extends RemoteStoreBaseIntegTest
         cumulativeUploadsStarted += remoteStoreStatsFirstIndex.getRemoteStoreStats()[0].getSegmentStats().uploadBytesStarted;
         cumulativeUploadsFailed += remoteStoreStatsFirstIndex.getRemoteStoreStats()[0].getSegmentStats().uploadBytesFailed;
         total_bytes_lag += remoteStoreStatsFirstIndex.getRemoteStoreStats()[0].getSegmentStats().bytesLag;
+        max_bytes_lag = Math.max(max_bytes_lag, remoteStoreStatsFirstIndex.getRemoteStoreStats()[0].getSegmentStats().bytesLag);
         max_time_lag = Math.max(max_time_lag, remoteStoreStatsFirstIndex.getRemoteStoreStats()[0].getSegmentStats().refreshTimeLagMs);
 
         RemoteStoreStatsResponse remoteStoreStatsSecondIndex = client(randomDataNode).admin()
@@ -90,6 +91,7 @@ public class RemoteSegmentStatsFromNodesStatsIT extends RemoteStoreBaseIntegTest
         cumulativeUploadsStarted += remoteStoreStatsSecondIndex.getRemoteStoreStats()[0].getSegmentStats().uploadBytesStarted;
         cumulativeUploadsFailed += remoteStoreStatsSecondIndex.getRemoteStoreStats()[0].getSegmentStats().uploadBytesFailed;
         total_bytes_lag += remoteStoreStatsSecondIndex.getRemoteStoreStats()[0].getSegmentStats().bytesLag;
+        max_bytes_lag = Math.max(max_bytes_lag, remoteStoreStatsSecondIndex.getRemoteStoreStats()[0].getSegmentStats().bytesLag);
         max_time_lag = Math.max(max_time_lag, remoteStoreStatsSecondIndex.getRemoteStoreStats()[0].getSegmentStats().refreshTimeLagMs);
 
         // Fetch nodes stats
@@ -103,6 +105,7 @@ public class RemoteSegmentStatsFromNodesStatsIT extends RemoteStoreBaseIntegTest
         assertEquals(cumulativeUploadsStarted, remoteSegmentStats.getUploadBytesStarted());
         assertEquals(cumulativeUploadsFailed, remoteSegmentStats.getUploadBytesFailed());
         assertEquals(total_bytes_lag, remoteSegmentStats.getTotalRefreshBytesLag());
+        assertEquals(max_bytes_lag, remoteSegmentStats.getMaxRefreshBytesLag());
         assertEquals(max_time_lag, remoteSegmentStats.getMaxRefreshTimeLag());
     }
 
@@ -182,7 +185,7 @@ public class RemoteSegmentStatsFromNodesStatsIT extends RemoteStoreBaseIntegTest
         for (String dataNode : internalCluster().getDataNodeNames()) {
             long cumulativeUploadsSucceeded = 0, cumulativeUploadsStarted = 0, cumulativeUploadsFailed = 0;
             long cumulativeDownloadsSucceeded = 0, cumulativeDownloadsStarted = 0, cumulativeDownloadsFailed = 0;
-            long total_bytes_lag = 0, max_time_lag = 0;
+            long total_bytes_lag = 0, max_bytes_lag = 0, max_time_lag = 0;
             // Fetch upload stats
             RemoteStoreStatsResponse remoteStoreStatsFirstIndex = client(dataNode).admin()
                 .cluster()
@@ -199,6 +202,7 @@ public class RemoteSegmentStatsFromNodesStatsIT extends RemoteStoreBaseIntegTest
             cumulativeDownloadsFailed += remoteStoreStatsFirstIndex.getRemoteStoreStats()[0]
                 .getSegmentStats().directoryFileTransferTrackerStats.transferredBytesFailed;
             total_bytes_lag += remoteStoreStatsFirstIndex.getRemoteStoreStats()[0].getSegmentStats().bytesLag;
+            max_bytes_lag = Math.max(max_bytes_lag, remoteStoreStatsFirstIndex.getRemoteStoreStats()[0].getSegmentStats().bytesLag);
             max_time_lag = Math.max(max_time_lag, remoteStoreStatsFirstIndex.getRemoteStoreStats()[0].getSegmentStats().refreshTimeLagMs);
 
             RemoteStoreStatsResponse remoteStoreStatsSecondIndex = client(dataNode).admin()
@@ -216,6 +220,7 @@ public class RemoteSegmentStatsFromNodesStatsIT extends RemoteStoreBaseIntegTest
             cumulativeDownloadsFailed += remoteStoreStatsSecondIndex.getRemoteStoreStats()[0]
                 .getSegmentStats().directoryFileTransferTrackerStats.transferredBytesFailed;
             total_bytes_lag += remoteStoreStatsSecondIndex.getRemoteStoreStats()[0].getSegmentStats().bytesLag;
+            max_bytes_lag = Math.max(max_bytes_lag, remoteStoreStatsSecondIndex.getRemoteStoreStats()[0].getSegmentStats().bytesLag);
             max_time_lag = Math.max(max_time_lag, remoteStoreStatsSecondIndex.getRemoteStoreStats()[0].getSegmentStats().refreshTimeLagMs);
 
             // Fetch nodes stats
@@ -232,6 +237,7 @@ public class RemoteSegmentStatsFromNodesStatsIT extends RemoteStoreBaseIntegTest
             assertEquals(cumulativeDownloadsStarted, remoteSegmentStats.getDownloadBytesStarted());
             assertEquals(cumulativeDownloadsFailed, remoteSegmentStats.getDownloadBytesFailed());
             assertEquals(total_bytes_lag, remoteSegmentStats.getTotalRefreshBytesLag());
+            assertEquals(max_bytes_lag, remoteSegmentStats.getMaxRefreshBytesLag());
             assertEquals(max_time_lag, remoteSegmentStats.getMaxRefreshTimeLag());
         }
     }

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteSegmentStatsFromNodesStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteSegmentStatsFromNodesStatsIT.java
@@ -178,6 +178,7 @@ public class RemoteSegmentStatsFromNodesStatsIT extends RemoteStoreBaseIntegTest
         assertEquals(0, remoteSegmentStats.getDownloadBytesSucceeded());
         assertEquals(0, remoteSegmentStats.getDownloadBytesFailed());
         assertEquals(0, remoteSegmentStats.getTotalRefreshBytesLag());
+        assertEquals(0, remoteSegmentStats.getMaxRefreshBytesLag());
         assertEquals(0, remoteSegmentStats.getMaxRefreshTimeLag());
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteSegmentStatsFromNodesStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteSegmentStatsFromNodesStatsIT.java
@@ -67,7 +67,7 @@ public class RemoteSegmentStatsFromNodesStatsIT extends RemoteStoreBaseIntegTest
         indexSingleDoc(secondIndex, true);
 
         long cumulativeUploadsSucceeded = 0, cumulativeUploadsStarted = 0, cumulativeUploadsFailed = 0;
-        long max_bytes_lag = 0, max_time_lag = 0;
+        long total_bytes_lag = 0, max_time_lag = 0;
         // Fetch upload stats
         RemoteStoreStatsResponse remoteStoreStatsFirstIndex = client(randomDataNode).admin()
             .cluster()
@@ -77,7 +77,7 @@ public class RemoteSegmentStatsFromNodesStatsIT extends RemoteStoreBaseIntegTest
         cumulativeUploadsSucceeded += remoteStoreStatsFirstIndex.getRemoteStoreStats()[0].getSegmentStats().uploadBytesSucceeded;
         cumulativeUploadsStarted += remoteStoreStatsFirstIndex.getRemoteStoreStats()[0].getSegmentStats().uploadBytesStarted;
         cumulativeUploadsFailed += remoteStoreStatsFirstIndex.getRemoteStoreStats()[0].getSegmentStats().uploadBytesFailed;
-        max_bytes_lag = Math.max(max_bytes_lag, remoteStoreStatsFirstIndex.getRemoteStoreStats()[0].getSegmentStats().bytesLag);
+        total_bytes_lag += remoteStoreStatsFirstIndex.getRemoteStoreStats()[0].getSegmentStats().bytesLag;
         max_time_lag = Math.max(max_time_lag, remoteStoreStatsFirstIndex.getRemoteStoreStats()[0].getSegmentStats().refreshTimeLagMs);
 
         RemoteStoreStatsResponse remoteStoreStatsSecondIndex = client(randomDataNode).admin()
@@ -85,10 +85,11 @@ public class RemoteSegmentStatsFromNodesStatsIT extends RemoteStoreBaseIntegTest
             .prepareRemoteStoreStats(secondIndex, "0")
             .setLocal(true)
             .get();
+
         cumulativeUploadsSucceeded += remoteStoreStatsSecondIndex.getRemoteStoreStats()[0].getSegmentStats().uploadBytesSucceeded;
         cumulativeUploadsStarted += remoteStoreStatsSecondIndex.getRemoteStoreStats()[0].getSegmentStats().uploadBytesStarted;
         cumulativeUploadsFailed += remoteStoreStatsSecondIndex.getRemoteStoreStats()[0].getSegmentStats().uploadBytesFailed;
-        max_bytes_lag = Math.max(max_bytes_lag, remoteStoreStatsSecondIndex.getRemoteStoreStats()[0].getSegmentStats().bytesLag);
+        total_bytes_lag += remoteStoreStatsSecondIndex.getRemoteStoreStats()[0].getSegmentStats().bytesLag;
         max_time_lag = Math.max(max_time_lag, remoteStoreStatsSecondIndex.getRemoteStoreStats()[0].getSegmentStats().refreshTimeLagMs);
 
         // Fetch nodes stats
@@ -101,7 +102,7 @@ public class RemoteSegmentStatsFromNodesStatsIT extends RemoteStoreBaseIntegTest
         assertEquals(cumulativeUploadsSucceeded, remoteSegmentStats.getUploadBytesSucceeded());
         assertEquals(cumulativeUploadsStarted, remoteSegmentStats.getUploadBytesStarted());
         assertEquals(cumulativeUploadsFailed, remoteSegmentStats.getUploadBytesFailed());
-        assertEquals(max_bytes_lag, remoteSegmentStats.getMaxRefreshBytesLag());
+        assertEquals(total_bytes_lag, remoteSegmentStats.getTotalRefreshBytesLag());
         assertEquals(max_time_lag, remoteSegmentStats.getMaxRefreshTimeLag());
     }
 
@@ -173,7 +174,7 @@ public class RemoteSegmentStatsFromNodesStatsIT extends RemoteStoreBaseIntegTest
         assertEquals(0, remoteSegmentStats.getDownloadBytesStarted());
         assertEquals(0, remoteSegmentStats.getDownloadBytesSucceeded());
         assertEquals(0, remoteSegmentStats.getDownloadBytesFailed());
-        assertEquals(0, remoteSegmentStats.getMaxRefreshBytesLag());
+        assertEquals(0, remoteSegmentStats.getTotalRefreshBytesLag());
         assertEquals(0, remoteSegmentStats.getMaxRefreshTimeLag());
     }
 
@@ -181,7 +182,7 @@ public class RemoteSegmentStatsFromNodesStatsIT extends RemoteStoreBaseIntegTest
         for (String dataNode : internalCluster().getDataNodeNames()) {
             long cumulativeUploadsSucceeded = 0, cumulativeUploadsStarted = 0, cumulativeUploadsFailed = 0;
             long cumulativeDownloadsSucceeded = 0, cumulativeDownloadsStarted = 0, cumulativeDownloadsFailed = 0;
-            long max_bytes_lag = 0, max_time_lag = 0;
+            long total_bytes_lag = 0, max_time_lag = 0;
             // Fetch upload stats
             RemoteStoreStatsResponse remoteStoreStatsFirstIndex = client(dataNode).admin()
                 .cluster()
@@ -197,7 +198,7 @@ public class RemoteSegmentStatsFromNodesStatsIT extends RemoteStoreBaseIntegTest
                 .getSegmentStats().directoryFileTransferTrackerStats.transferredBytesStarted;
             cumulativeDownloadsFailed += remoteStoreStatsFirstIndex.getRemoteStoreStats()[0]
                 .getSegmentStats().directoryFileTransferTrackerStats.transferredBytesFailed;
-            max_bytes_lag = Math.max(max_bytes_lag, remoteStoreStatsFirstIndex.getRemoteStoreStats()[0].getSegmentStats().bytesLag);
+            total_bytes_lag += remoteStoreStatsFirstIndex.getRemoteStoreStats()[0].getSegmentStats().bytesLag;
             max_time_lag = Math.max(max_time_lag, remoteStoreStatsFirstIndex.getRemoteStoreStats()[0].getSegmentStats().refreshTimeLagMs);
 
             RemoteStoreStatsResponse remoteStoreStatsSecondIndex = client(dataNode).admin()
@@ -214,7 +215,7 @@ public class RemoteSegmentStatsFromNodesStatsIT extends RemoteStoreBaseIntegTest
                 .getSegmentStats().directoryFileTransferTrackerStats.transferredBytesStarted;
             cumulativeDownloadsFailed += remoteStoreStatsSecondIndex.getRemoteStoreStats()[0]
                 .getSegmentStats().directoryFileTransferTrackerStats.transferredBytesFailed;
-            max_bytes_lag = Math.max(max_bytes_lag, remoteStoreStatsSecondIndex.getRemoteStoreStats()[0].getSegmentStats().bytesLag);
+            total_bytes_lag += remoteStoreStatsSecondIndex.getRemoteStoreStats()[0].getSegmentStats().bytesLag;
             max_time_lag = Math.max(max_time_lag, remoteStoreStatsSecondIndex.getRemoteStoreStats()[0].getSegmentStats().refreshTimeLagMs);
 
             // Fetch nodes stats
@@ -230,7 +231,7 @@ public class RemoteSegmentStatsFromNodesStatsIT extends RemoteStoreBaseIntegTest
             assertEquals(cumulativeDownloadsSucceeded, remoteSegmentStats.getDownloadBytesSucceeded());
             assertEquals(cumulativeDownloadsStarted, remoteSegmentStats.getDownloadBytesStarted());
             assertEquals(cumulativeDownloadsFailed, remoteSegmentStats.getDownloadBytesFailed());
-            assertEquals(max_bytes_lag, remoteSegmentStats.getMaxRefreshBytesLag());
+            assertEquals(total_bytes_lag, remoteSegmentStats.getTotalRefreshBytesLag());
             assertEquals(max_time_lag, remoteSegmentStats.getMaxRefreshTimeLag());
         }
     }

--- a/server/src/main/java/org/opensearch/index/remote/RemoteSegmentStats.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteSegmentStats.java
@@ -57,10 +57,10 @@ public class RemoteSegmentStats implements Writeable, ToXContentFragment {
      */
     private long maxRefreshTimeLag;
     /**
-     * Maximum refresh lag (in bytes) between local and the remote store
+     * Total refresh lag (in bytes) between local and the remote store
      * Used to check for data freshness in the remote store
      */
-    private long maxRefreshBytesLag;
+    private long totalRefreshBytesLag;
 
     public RemoteSegmentStats() {}
 
@@ -72,7 +72,7 @@ public class RemoteSegmentStats implements Writeable, ToXContentFragment {
         downloadBytesFailed = in.readLong();
         downloadBytesSucceeded = in.readLong();
         maxRefreshTimeLag = in.readLong();
-        maxRefreshBytesLag = in.readLong();
+        totalRefreshBytesLag = in.readLong();
     }
 
     /**
@@ -91,7 +91,7 @@ public class RemoteSegmentStats implements Writeable, ToXContentFragment {
         this.downloadBytesStarted = trackerStats.directoryFileTransferTrackerStats.transferredBytesStarted;
         this.downloadBytesFailed = trackerStats.directoryFileTransferTrackerStats.transferredBytesFailed;
         this.maxRefreshTimeLag = trackerStats.refreshTimeLagMs;
-        this.maxRefreshBytesLag = trackerStats.bytesLag;
+        this.totalRefreshBytesLag = trackerStats.bytesLag;
     }
 
     // Getter and setters. All are visible for testing
@@ -151,12 +151,12 @@ public class RemoteSegmentStats implements Writeable, ToXContentFragment {
         this.maxRefreshTimeLag = Math.max(this.maxRefreshTimeLag, maxRefreshTimeLag);
     }
 
-    public long getMaxRefreshBytesLag() {
-        return maxRefreshBytesLag;
+    public long getTotalRefreshBytesLag() {
+        return totalRefreshBytesLag;
     }
 
-    public void setMaxRefreshBytesLag(long maxRefreshBytesLag) {
-        this.maxRefreshBytesLag = maxRefreshBytesLag;
+    public void setTotalRefreshBytesLag(long totalRefreshBytesLag) {
+        this.totalRefreshBytesLag = totalRefreshBytesLag;
     }
 
     /**
@@ -173,7 +173,7 @@ public class RemoteSegmentStats implements Writeable, ToXContentFragment {
             this.downloadBytesFailed += existingStats.getDownloadBytesFailed();
             this.downloadBytesSucceeded += existingStats.getDownloadBytesSucceeded();
             this.maxRefreshTimeLag = Math.max(this.maxRefreshTimeLag, existingStats.getMaxRefreshTimeLag());
-            this.maxRefreshBytesLag = Math.max(this.maxRefreshBytesLag, existingStats.getMaxRefreshBytesLag());
+            this.totalRefreshBytesLag += existingStats.getTotalRefreshBytesLag();
         }
     }
 
@@ -186,7 +186,7 @@ public class RemoteSegmentStats implements Writeable, ToXContentFragment {
         out.writeLong(downloadBytesFailed);
         out.writeLong(downloadBytesSucceeded);
         out.writeLong(maxRefreshTimeLag);
-        out.writeLong(maxRefreshBytesLag);
+        out.writeLong(totalRefreshBytesLag);
     }
 
     @Override
@@ -200,9 +200,9 @@ public class RemoteSegmentStats implements Writeable, ToXContentFragment {
         builder.endObject();
         builder.humanReadableField(Fields.MAX_REFRESH_TIME_LAG_IN_MILLIS, Fields.MAX_REFRESH_TIME_LAG, new TimeValue(maxRefreshTimeLag));
         builder.humanReadableField(
-            Fields.MAX_REFRESH_SIZE_LAG_IN_MILLIS,
-            Fields.MAX_REFRESH_SIZE_LAG,
-            new ByteSizeValue(maxRefreshBytesLag)
+            Fields.TOTAL_REFRESH_SIZE_LAG_IN_MILLIS,
+            Fields.TOTAL_REFRESH_SIZE_LAG,
+            new ByteSizeValue(totalRefreshBytesLag)
         );
         builder.endObject();
         builder.startObject(Fields.DOWNLOAD);
@@ -230,7 +230,7 @@ public class RemoteSegmentStats implements Writeable, ToXContentFragment {
         static final String SUCCEEDED_BYTES = "succeeded_bytes";
         static final String MAX_REFRESH_TIME_LAG = "max_refresh_time_lag";
         static final String MAX_REFRESH_TIME_LAG_IN_MILLIS = "max_refresh_time_lag_in_millis";
-        static final String MAX_REFRESH_SIZE_LAG = "max_refresh_size_lag";
-        static final String MAX_REFRESH_SIZE_LAG_IN_MILLIS = "max_refresh_size_lag_in_bytes";
+        static final String TOTAL_REFRESH_SIZE_LAG = "total_refresh_size_lag";
+        static final String TOTAL_REFRESH_SIZE_LAG_IN_MILLIS = "total_refresh_size_lag_in_bytes";
     }
 }

--- a/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -458,6 +458,7 @@ public class NodeStatsTests extends OpenSearchTestCase {
                     assertEquals(remoteSegmentStats.getUploadBytesSucceeded(), deserializedRemoteSegmentStats.getUploadBytesSucceeded());
                     assertEquals(remoteSegmentStats.getUploadBytesFailed(), deserializedRemoteSegmentStats.getUploadBytesFailed());
                     assertEquals(remoteSegmentStats.getMaxRefreshTimeLag(), deserializedRemoteSegmentStats.getMaxRefreshTimeLag());
+                    assertEquals(remoteSegmentStats.getMaxRefreshBytesLag(), deserializedRemoteSegmentStats.getMaxRefreshBytesLag());
                     assertEquals(remoteSegmentStats.getTotalRefreshBytesLag(), deserializedRemoteSegmentStats.getTotalRefreshBytesLag());
                 }
             }
@@ -789,7 +790,8 @@ public class NodeStatsTests extends OpenSearchTestCase {
             remoteSegmentStats.addDownloadBytesStarted(10L);
             remoteSegmentStats.addDownloadBytesSucceeded(10L);
             remoteSegmentStats.addDownloadBytesFailed(1L);
-            remoteSegmentStats.setTotalRefreshBytesLag(5L);
+            remoteSegmentStats.addTotalRefreshBytesLag(5L);
+            remoteSegmentStats.addMaxRefreshBytesLag(2L);
             remoteSegmentStats.setMaxRefreshTimeLag(2L);
         }
         return indicesStats;

--- a/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -458,7 +458,7 @@ public class NodeStatsTests extends OpenSearchTestCase {
                     assertEquals(remoteSegmentStats.getUploadBytesSucceeded(), deserializedRemoteSegmentStats.getUploadBytesSucceeded());
                     assertEquals(remoteSegmentStats.getUploadBytesFailed(), deserializedRemoteSegmentStats.getUploadBytesFailed());
                     assertEquals(remoteSegmentStats.getMaxRefreshTimeLag(), deserializedRemoteSegmentStats.getMaxRefreshTimeLag());
-                    assertEquals(remoteSegmentStats.getMaxRefreshBytesLag(), deserializedRemoteSegmentStats.getMaxRefreshBytesLag());
+                    assertEquals(remoteSegmentStats.getTotalRefreshBytesLag(), deserializedRemoteSegmentStats.getTotalRefreshBytesLag());
                 }
             }
         }
@@ -789,7 +789,7 @@ public class NodeStatsTests extends OpenSearchTestCase {
             remoteSegmentStats.addDownloadBytesStarted(10L);
             remoteSegmentStats.addDownloadBytesSucceeded(10L);
             remoteSegmentStats.addDownloadBytesFailed(1L);
-            remoteSegmentStats.setMaxRefreshBytesLag(5L);
+            remoteSegmentStats.setTotalRefreshBytesLag(5L);
             remoteSegmentStats.setMaxRefreshTimeLag(2L);
         }
         return indicesStats;


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Adding cumulative bytes lag to the `remote_store` section of NodesStats. The new API output looks like the following:

```
"remote_store": {
    "upload": {
        "total_uploads": {
            "started": "4.4mb",
            "started_bytes": 4708635,
            "succeeded": "4.4mb",
            "succeeded_bytes": 4708635,
            "failed": "0b",
            "failed_bytes": 0
        },
        "refresh_size_lag": {
            "total": "0b",
            "total_bytes": 0,
            "max": "0b",
            "max_bytes": 0
        },
        "max_refresh_time_lag": "0s",
        "max_refresh_time_lag_in_millis": 0
    }
```

### Related Issues
N/A
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
