### PR TITLE
[Search Pipelines] Add request-scoped state shared between processors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Admission control] Add Resource usage collector service and resource usage tracker  ([#9890](https://github.com/opensearch-project/OpenSearch/pull/9890))
 - [Admission control] Add enhancements to FS stats to include read/write time, queue size and IO time ([#10541](https://github.com/opensearch-project/OpenSearch/pull/10541))
 - [Remote cluster state] Change file names for remote cluster state ([#10557](https://github.com/opensearch-project/OpenSearch/pull/10557))
+- [Search Pipelines] Add request-scoped state shared between processors (and three new processors) ([#9405](https://github.com/opensearch-project/OpenSearch/pull/9405))
+- Per request phase latency ([#10351](https://github.com/opensearch-project/OpenSearch/issues/10351))
 - [Remote Store] Add repository stats for remote store([#10567](https://github.com/opensearch-project/OpenSearch/pull/10567))
 - [Remote cluster state] Upload global metadata in cluster state to remote store([#10404](https://github.com/opensearch-project/OpenSearch/pull/10404))
 - [Remote cluster state] Download functionality of global metadata from remote store ([#10535](https://github.com/opensearch-project/OpenSearch/pull/10535))

--- a/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/BasicMap.java
+++ b/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/BasicMap.java
@@ -6,7 +6,7 @@
  * compatible open source license.
  */
 
-package org.opensearch.search.pipeline.common.helpers;
+package org.opensearch.search.pipeline.common;
 
 import java.util.Collection;
 import java.util.Map;
@@ -19,7 +19,7 @@ import java.util.function.Function;
  * Helper for map abstractions passed to scripting processors. Throws {@link UnsupportedOperationException} for almost
  * all methods. Subclasses just need to implement get and put.
  */
-public abstract class BasicMap implements Map<String, Object> {
+abstract class BasicMap implements Map<String, Object> {
 
     /**
      * No-args constructor.

--- a/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/CollapseResponseProcessor.java
+++ b/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/CollapseResponseProcessor.java
@@ -1,0 +1,109 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.pipeline.common;
+
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.common.document.DocumentField;
+import org.opensearch.ingest.ConfigurationUtils;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.search.pipeline.AbstractProcessor;
+import org.opensearch.search.pipeline.Processor;
+import org.opensearch.search.pipeline.SearchResponseProcessor;
+import org.opensearch.search.pipeline.common.helpers.SearchResponseUtil;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A simple implementation of field collapsing on search responses. Note that this is not going to work as well as
+ * field collapsing at the shard level, as implemented with the "collapse" parameter in a search request. Mostly
+ * just using this to demo the oversample / truncate_hits processors.
+ */
+public class CollapseResponseProcessor extends AbstractProcessor implements SearchResponseProcessor {
+    /**
+     * Key to reference this processor type from a search pipeline.
+     */
+    public static final String TYPE = "collapse";
+    private static final String COLLAPSE_FIELD = "field";
+    private final String collapseField;
+
+    private CollapseResponseProcessor(String tag, String description, boolean ignoreFailure, String collapseField) {
+        super(tag, description, ignoreFailure);
+        this.collapseField = collapseField;
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    @Override
+    public SearchResponse processResponse(SearchRequest request, SearchResponse response) throws Exception {
+
+        if (response.getHits() != null) {
+            Map<String, SearchHit> collapsedHits = new HashMap<>();
+            for (SearchHit hit : response.getHits()) {
+                String fieldValue = "<missing>";
+                DocumentField docField = hit.getFields().get(collapseField);
+                if (docField != null) {
+                    if (docField.getValues().size() > 1) {
+                        throw new IllegalStateException("Document " + hit.getId() + " has multiple values for field " + collapseField);
+                    }
+                    fieldValue = docField.getValues().get(0).toString();
+                } else if (hit.hasSource()) {
+                    Object val = hit.getSourceAsMap().get(collapseField);
+                    if (val != null) {
+                        fieldValue = val.toString();
+                    }
+                }
+                SearchHit previousHit = collapsedHits.get(fieldValue);
+                // TODO - Support the sort used in the request, rather than just score
+                if (previousHit == null || hit.getScore() > previousHit.getScore()) {
+                    collapsedHits.put(fieldValue, hit);
+                }
+            }
+            List<SearchHit> hitsToReturn = new ArrayList<>(collapsedHits.values());
+            hitsToReturn.sort(Comparator.comparingDouble(SearchHit::getScore).reversed());
+            SearchHit[] newHits = hitsToReturn.toArray(new SearchHit[0]);
+            List<String> collapseValues = new ArrayList<>(collapsedHits.keySet());
+            SearchHits searchHits = new SearchHits(
+                newHits,
+                response.getHits().getTotalHits(),
+                response.getHits().getMaxScore(),
+                response.getHits().getSortFields(),
+                collapseField,
+                collapseValues.toArray()
+            );
+            return SearchResponseUtil.replaceHits(searchHits, response);
+        }
+        return response;
+    }
+
+    static class Factory implements Processor.Factory<SearchResponseProcessor> {
+
+        @Override
+        public CollapseResponseProcessor create(
+            Map<String, Processor.Factory<SearchResponseProcessor>> processorFactories,
+            String tag,
+            String description,
+            boolean ignoreFailure,
+            Map<String, Object> config,
+            PipelineContext pipelineContext
+        ) {
+            String collapseField = ConfigurationUtils.readStringProperty(TYPE, tag, config, COLLAPSE_FIELD);
+            return new CollapseResponseProcessor(tag, description, ignoreFailure, collapseField);
+        }
+    }
+
+}

--- a/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/OversampleRequestProcessor.java
+++ b/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/OversampleRequestProcessor.java
@@ -10,7 +10,9 @@ package org.opensearch.search.pipeline.common;
 
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.ingest.ConfigurationUtils;
+import org.opensearch.search.SearchService;
 import org.opensearch.search.pipeline.AbstractProcessor;
+import org.opensearch.search.pipeline.PipelinedRequestContext;
 import org.opensearch.search.pipeline.Processor;
 import org.opensearch.search.pipeline.SearchRequestProcessor;
 import org.opensearch.search.pipeline.StatefulSearchRequestProcessor;
@@ -42,10 +44,13 @@ public class OversampleRequestProcessor extends AbstractProcessor implements Sta
     }
 
     @Override
-    public SearchRequest processRequest(SearchRequest request, Map<String, Object> requestContext) {
+    public SearchRequest processRequest(SearchRequest request, PipelinedRequestContext requestContext) {
         if (request.source() != null) {
             int originalSize = request.source().size();
-            requestContext.put(applyContextPrefix(contextPrefix, ORIGINAL_SIZE), originalSize);
+            if (originalSize == -1) {
+                originalSize = SearchService.DEFAULT_SIZE;
+            }
+            requestContext.getGenericRequestContext().put(applyContextPrefix(contextPrefix, ORIGINAL_SIZE), originalSize);
             int newSize = (int) Math.ceil(originalSize * sampleFactor);
             request.source().size(newSize);
         }

--- a/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/OversampleRequestProcessor.java
+++ b/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/OversampleRequestProcessor.java
@@ -12,7 +12,7 @@ import org.opensearch.action.search.SearchRequest;
 import org.opensearch.ingest.ConfigurationUtils;
 import org.opensearch.search.SearchService;
 import org.opensearch.search.pipeline.AbstractProcessor;
-import org.opensearch.search.pipeline.PipelinedRequestContext;
+import org.opensearch.search.pipeline.PipelineProcessingContext;
 import org.opensearch.search.pipeline.Processor;
 import org.opensearch.search.pipeline.SearchRequestProcessor;
 import org.opensearch.search.pipeline.StatefulSearchRequestProcessor;
@@ -44,7 +44,7 @@ public class OversampleRequestProcessor extends AbstractProcessor implements Sta
     }
 
     @Override
-    public SearchRequest processRequest(SearchRequest request, PipelinedRequestContext requestContext) {
+    public SearchRequest processRequest(SearchRequest request, PipelineProcessingContext requestContext) {
         if (request.source() != null) {
             int originalSize = request.source().size();
             if (originalSize == -1) {

--- a/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/OversampleRequestProcessor.java
+++ b/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/OversampleRequestProcessor.java
@@ -1,0 +1,73 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.pipeline.common;
+
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.ingest.ConfigurationUtils;
+import org.opensearch.search.pipeline.AbstractProcessor;
+import org.opensearch.search.pipeline.Processor;
+import org.opensearch.search.pipeline.SearchRequestProcessor;
+import org.opensearch.search.pipeline.StatefulSearchRequestProcessor;
+
+import java.util.Map;
+
+/**
+ * Multiplies the "size" parameter on the {@link SearchRequest} by the given scaling factor, storing the original value
+ * in the request context as "original_size".
+ */
+public class OversampleRequestProcessor extends AbstractProcessor implements StatefulSearchRequestProcessor {
+
+    /**
+     * Key to reference this processor type from a search pipeline.
+     */
+    public static final String TYPE = "oversample";
+    private static final String SAMPLE_FACTOR = "sample_factor";
+    static final String ORIGINAL_SIZE = "original_size";
+    private final double sampleFactor;
+
+    private OversampleRequestProcessor(String tag, String description, boolean ignoreFailure, double sampleFactor) {
+        super(tag, description, ignoreFailure);
+        this.sampleFactor = sampleFactor;
+    }
+
+    @Override
+    public SearchRequest processRequest(SearchRequest request, Map<String, Object> requestContext) {
+        if (request.source() != null) {
+            int originalSize = request.source().size();
+            requestContext.put(ORIGINAL_SIZE, originalSize);
+            int newSize = (int) Math.ceil(originalSize * sampleFactor);
+            request.source().size(newSize);
+        }
+        return request;
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    static class Factory implements Processor.Factory<SearchRequestProcessor> {
+
+        @Override
+        public OversampleRequestProcessor create(
+            Map<String, Processor.Factory<SearchRequestProcessor>> processorFactories,
+            String tag,
+            String description,
+            boolean ignoreFailure,
+            Map<String, Object> config,
+            PipelineContext pipelineContext
+        ) {
+            double sampleFactor = ConfigurationUtils.readDoubleProperty(TYPE, tag, config, SAMPLE_FACTOR);
+            if (sampleFactor < 1.0) {
+                throw ConfigurationUtils.newConfigurationException(TYPE, tag, SAMPLE_FACTOR, "Value must be >= 1.0");
+            }
+            return new OversampleRequestProcessor(tag, description, ignoreFailure, sampleFactor);
+        }
+    }
+}

--- a/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/OversampleRequestProcessor.java
+++ b/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/OversampleRequestProcessor.java
@@ -50,7 +50,7 @@ public class OversampleRequestProcessor extends AbstractProcessor implements Sta
             if (originalSize == -1) {
                 originalSize = SearchService.DEFAULT_SIZE;
             }
-            requestContext.getGenericRequestContext().put(applyContextPrefix(contextPrefix, ORIGINAL_SIZE), originalSize);
+            requestContext.setAttribute(applyContextPrefix(contextPrefix, ORIGINAL_SIZE), originalSize);
             int newSize = (int) Math.ceil(originalSize * sampleFactor);
             request.source().size(newSize);
         }

--- a/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/ScriptRequestProcessor.java
+++ b/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/ScriptRequestProcessor.java
@@ -23,7 +23,7 @@ import org.opensearch.script.ScriptService;
 import org.opensearch.script.ScriptType;
 import org.opensearch.script.SearchScript;
 import org.opensearch.search.pipeline.AbstractProcessor;
-import org.opensearch.search.pipeline.PipelinedRequestContext;
+import org.opensearch.search.pipeline.PipelineProcessingContext;
 import org.opensearch.search.pipeline.Processor;
 import org.opensearch.search.pipeline.SearchRequestProcessor;
 import org.opensearch.search.pipeline.StatefulSearchRequestProcessor;
@@ -76,7 +76,7 @@ public final class ScriptRequestProcessor extends AbstractProcessor implements S
     }
 
     @Override
-    public SearchRequest processRequest(SearchRequest request, PipelinedRequestContext requestContext) throws Exception {
+    public SearchRequest processRequest(SearchRequest request, PipelineProcessingContext requestContext) throws Exception {
         // assert request is not null and source is not null
         if (request == null || request.source() == null) {
             throw new IllegalArgumentException("search request must not be null");
@@ -94,9 +94,9 @@ public final class ScriptRequestProcessor extends AbstractProcessor implements S
     }
 
     private static class RequestContextMap extends BasicMap {
-        private final PipelinedRequestContext pipelinedRequestContext;
+        private final PipelineProcessingContext pipelinedRequestContext;
 
-        private RequestContextMap(PipelinedRequestContext pipelinedRequestContext) {
+        private RequestContextMap(PipelineProcessingContext pipelinedRequestContext) {
             this.pipelinedRequestContext = pipelinedRequestContext;
         }
 

--- a/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/ScriptRequestProcessor.java
+++ b/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/ScriptRequestProcessor.java
@@ -23,6 +23,7 @@ import org.opensearch.script.ScriptService;
 import org.opensearch.script.ScriptType;
 import org.opensearch.script.SearchScript;
 import org.opensearch.search.pipeline.AbstractProcessor;
+import org.opensearch.search.pipeline.PipelinedRequestContext;
 import org.opensearch.search.pipeline.Processor;
 import org.opensearch.search.pipeline.SearchRequestProcessor;
 import org.opensearch.search.pipeline.StatefulSearchRequestProcessor;
@@ -74,7 +75,7 @@ public final class ScriptRequestProcessor extends AbstractProcessor implements S
     }
 
     @Override
-    public SearchRequest processRequest(SearchRequest request, Map<String, Object> requestContext) throws Exception {
+    public SearchRequest processRequest(SearchRequest request, PipelinedRequestContext requestContext) throws Exception {
         // assert request is not null and source is not null
         if (request == null || request.source() == null) {
             throw new IllegalArgumentException("search request must not be null");
@@ -87,7 +88,9 @@ public final class ScriptRequestProcessor extends AbstractProcessor implements S
             searchScript = precompiledSearchScript;
         }
         // execute the script with the search request in context
-        searchScript.execute(Map.of("_source", new SearchRequestMap(request), "request_context", requestContext));
+        searchScript.execute(
+            Map.of("_source", new SearchRequestMap(request), "request_context", requestContext.getGenericRequestContext())
+        );
         return request;
     }
 

--- a/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/ScriptRequestProcessor.java
+++ b/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/ScriptRequestProcessor.java
@@ -25,6 +25,7 @@ import org.opensearch.script.SearchScript;
 import org.opensearch.search.pipeline.AbstractProcessor;
 import org.opensearch.search.pipeline.Processor;
 import org.opensearch.search.pipeline.SearchRequestProcessor;
+import org.opensearch.search.pipeline.StatefulSearchRequestProcessor;
 import org.opensearch.search.pipeline.common.helpers.SearchRequestMap;
 
 import java.io.InputStream;
@@ -38,7 +39,7 @@ import static org.opensearch.ingest.ConfigurationUtils.newConfigurationException
  * Processor that evaluates a script with a search request in its context
  * and then returns the modified search request.
  */
-public final class ScriptRequestProcessor extends AbstractProcessor implements SearchRequestProcessor {
+public final class ScriptRequestProcessor extends AbstractProcessor implements StatefulSearchRequestProcessor {
     /**
      * Key to reference this processor type from a search pipeline.
      */
@@ -72,15 +73,8 @@ public final class ScriptRequestProcessor extends AbstractProcessor implements S
         this.scriptService = scriptService;
     }
 
-    /**
-     * Executes the script with the search request in context.
-     *
-     * @param request The search request passed into the script context.
-     * @return The modified search request.
-     * @throws Exception if an error occurs while processing the request.
-     */
     @Override
-    public SearchRequest processRequest(SearchRequest request) throws Exception {
+    public SearchRequest processRequest(SearchRequest request, Map<String, Object> requestContext) throws Exception {
         // assert request is not null and source is not null
         if (request == null || request.source() == null) {
             throw new IllegalArgumentException("search request must not be null");
@@ -93,7 +87,7 @@ public final class ScriptRequestProcessor extends AbstractProcessor implements S
             searchScript = precompiledSearchScript;
         }
         // execute the script with the search request in context
-        searchScript.execute(Map.of("_source", new SearchRequestMap(request)));
+        searchScript.execute(Map.of("_source", new SearchRequestMap(request), "request_context", requestContext));
         return request;
     }
 

--- a/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/ScriptRequestProcessor.java
+++ b/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/ScriptRequestProcessor.java
@@ -27,8 +27,6 @@ import org.opensearch.search.pipeline.PipelineProcessingContext;
 import org.opensearch.search.pipeline.Processor;
 import org.opensearch.search.pipeline.SearchRequestProcessor;
 import org.opensearch.search.pipeline.StatefulSearchRequestProcessor;
-import org.opensearch.search.pipeline.common.helpers.BasicMap;
-import org.opensearch.search.pipeline.common.helpers.SearchRequestMap;
 
 import java.io.InputStream;
 import java.util.HashMap;

--- a/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/SearchPipelineCommonModulePlugin.java
+++ b/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/SearchPipelineCommonModulePlugin.java
@@ -38,12 +38,21 @@ public class SearchPipelineCommonModulePlugin extends Plugin implements SearchPi
             FilterQueryRequestProcessor.TYPE,
             new FilterQueryRequestProcessor.Factory(parameters.namedXContentRegistry),
             ScriptRequestProcessor.TYPE,
-            new ScriptRequestProcessor.Factory(parameters.scriptService)
+            new ScriptRequestProcessor.Factory(parameters.scriptService),
+            OversampleRequestProcessor.TYPE,
+            new OversampleRequestProcessor.Factory()
         );
     }
 
     @Override
     public Map<String, Processor.Factory<SearchResponseProcessor>> getResponseProcessors(Parameters parameters) {
-        return Map.of(RenameFieldResponseProcessor.TYPE, new RenameFieldResponseProcessor.Factory());
+        return Map.of(
+            RenameFieldResponseProcessor.TYPE,
+            new RenameFieldResponseProcessor.Factory(),
+            TruncateHitsResponseProcessor.TYPE,
+            new TruncateHitsResponseProcessor.Factory(),
+            CollapseResponseProcessor.TYPE,
+            new CollapseResponseProcessor.Factory()
+        );
     }
 }

--- a/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/SearchRequestMap.java
+++ b/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/SearchRequestMap.java
@@ -6,7 +6,7 @@
  * compatible open source license.
  */
 
-package org.opensearch.search.pipeline.common.helpers;
+package org.opensearch.search.pipeline.common;
 
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.search.builder.SearchSourceBuilder;
@@ -17,7 +17,7 @@ import java.util.Map;
  * A custom implementation of {@link Map} that provides access to the properties of a {@link SearchRequest}'s
  * {@link SearchSourceBuilder}. The class allows retrieving and modifying specific properties of the search request.
  */
-public class SearchRequestMap extends BasicMap implements Map<String, Object> {
+class SearchRequestMap extends BasicMap implements Map<String, Object> {
 
     private final SearchSourceBuilder source;
 

--- a/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/SearchRequestMapProcessingException.java
+++ b/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/SearchRequestMapProcessingException.java
@@ -6,7 +6,7 @@
  * compatible open source license.
  */
 
-package org.opensearch.search.pipeline.common.helpers;
+package org.opensearch.search.pipeline.common;
 
 import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchWrapperException;
@@ -14,12 +14,12 @@ import org.opensearch.OpenSearchWrapperException;
 /**
  * An exception that indicates an error occurred while processing a {@link SearchRequestMap}.
  */
-public class SearchRequestMapProcessingException extends OpenSearchException implements OpenSearchWrapperException {
+class SearchRequestMapProcessingException extends OpenSearchException implements OpenSearchWrapperException {
 
     /**
      * Constructs a new SearchRequestMapProcessingException with the specified message.
      *
-     * @param msg The error message.
+     * @param msg  The error message.
      * @param args Arguments to substitute in the error message.
      */
     public SearchRequestMapProcessingException(String msg, Object... args) {
@@ -29,9 +29,9 @@ public class SearchRequestMapProcessingException extends OpenSearchException imp
     /**
      * Constructs a new SearchRequestMapProcessingException with the specified message and cause.
      *
-     * @param msg The error message.
+     * @param msg   The error message.
      * @param cause The cause of the exception.
-     * @param args Arguments to substitute in the error message.
+     * @param args  Arguments to substitute in the error message.
      */
     public SearchRequestMapProcessingException(String msg, Throwable cause, Object... args) {
         super(msg, cause, args);

--- a/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/TruncateHitsResponseProcessor.java
+++ b/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/TruncateHitsResponseProcessor.java
@@ -1,0 +1,87 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.pipeline.common;
+
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.ingest.ConfigurationUtils;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.search.pipeline.AbstractProcessor;
+import org.opensearch.search.pipeline.Processor;
+import org.opensearch.search.pipeline.SearchResponseProcessor;
+import org.opensearch.search.pipeline.StatefulSearchResponseProcessor;
+import org.opensearch.search.pipeline.common.helpers.SearchResponseUtil;
+
+import java.util.Map;
+
+/**
+ * Truncates the returned search hits from the {@link SearchResponse}. If no target size is specified in the pipeline, then
+ * we try using the "original_size" value from the request context, which may have been set by {@link OversampleRequestProcessor}.
+ */
+public class TruncateHitsResponseProcessor extends AbstractProcessor implements StatefulSearchResponseProcessor {
+    /**
+     * Key to reference this processor type from a search pipeline.
+     */
+    public static final String TYPE = "truncate_hits";
+    private static final String TARGET_SIZE = "target_size";
+    private final int targetSize;
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    private TruncateHitsResponseProcessor(String tag, String description, boolean ignoreFailure, int targetSize) {
+        super(tag, description, ignoreFailure);
+        this.targetSize = targetSize;
+    }
+
+    @Override
+    public SearchResponse processResponse(SearchRequest request, SearchResponse response, Map<String, Object> requestContext) {
+
+        int size;
+        if (targetSize < 0) {
+            size = (int) requestContext.get(OversampleRequestProcessor.ORIGINAL_SIZE);
+        } else {
+            size = targetSize;
+        }
+        if (response.getHits() != null && response.getHits().getHits().length > size) {
+            SearchHit[] newHits = new SearchHit[size];
+            System.arraycopy(response.getHits().getHits(), 0, newHits, 0, size);
+            SearchHits searchHits = new SearchHits(
+                newHits,
+                response.getHits().getTotalHits(),
+                response.getHits().getMaxScore(),
+                response.getHits().getSortFields(),
+                response.getHits().getCollapseField(),
+                response.getHits().getCollapseValues()
+            );
+            return SearchResponseUtil.replaceHits(searchHits, response);
+        }
+        return response;
+    }
+
+    static class Factory implements Processor.Factory<SearchResponseProcessor> {
+
+        @Override
+        public SearchResponseProcessor create(
+            Map<String, Processor.Factory<SearchResponseProcessor>> processorFactories,
+            String tag,
+            String description,
+            boolean ignoreFailure,
+            Map<String, Object> config,
+            PipelineContext pipelineContext
+        ) throws Exception {
+            int targetSize = ConfigurationUtils.readIntProperty(TYPE, tag, config, TARGET_SIZE, -1);
+            return new TruncateHitsResponseProcessor(tag, description, ignoreFailure, targetSize);
+        }
+    }
+
+}

--- a/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/TruncateHitsResponseProcessor.java
+++ b/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/TruncateHitsResponseProcessor.java
@@ -53,7 +53,7 @@ public class TruncateHitsResponseProcessor extends AbstractProcessor implements 
         int size;
         if (targetSize < 0) { // No value specified in processor config. Use context value instead.
             String key = applyContextPrefix(contextPrefix, OversampleRequestProcessor.ORIGINAL_SIZE);
-            Object o = requestContext.getGenericRequestContext().get(key);
+            Object o = requestContext.getAttribute(key);
             if (o == null) {
                 throw new IllegalStateException("Must specify " + TARGET_SIZE + " unless an earlier processor set " + key);
             }

--- a/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/TruncateHitsResponseProcessor.java
+++ b/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/TruncateHitsResponseProcessor.java
@@ -13,7 +13,7 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.ingest.ConfigurationUtils;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.pipeline.AbstractProcessor;
-import org.opensearch.search.pipeline.PipelinedRequestContext;
+import org.opensearch.search.pipeline.PipelineProcessingContext;
 import org.opensearch.search.pipeline.Processor;
 import org.opensearch.search.pipeline.SearchResponseProcessor;
 import org.opensearch.search.pipeline.StatefulSearchResponseProcessor;
@@ -49,7 +49,7 @@ public class TruncateHitsResponseProcessor extends AbstractProcessor implements 
     }
 
     @Override
-    public SearchResponse processResponse(SearchRequest request, SearchResponse response, PipelinedRequestContext requestContext) {
+    public SearchResponse processResponse(SearchRequest request, SearchResponse response, PipelineProcessingContext requestContext) {
         int size;
         if (targetSize < 0) { // No value specified in processor config. Use context value instead.
             String key = applyContextPrefix(contextPrefix, OversampleRequestProcessor.ORIGINAL_SIZE);

--- a/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/TruncateHitsResponseProcessor.java
+++ b/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/TruncateHitsResponseProcessor.java
@@ -13,6 +13,7 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.ingest.ConfigurationUtils;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.pipeline.AbstractProcessor;
+import org.opensearch.search.pipeline.PipelinedRequestContext;
 import org.opensearch.search.pipeline.Processor;
 import org.opensearch.search.pipeline.SearchResponseProcessor;
 import org.opensearch.search.pipeline.StatefulSearchResponseProcessor;
@@ -48,11 +49,11 @@ public class TruncateHitsResponseProcessor extends AbstractProcessor implements 
     }
 
     @Override
-    public SearchResponse processResponse(SearchRequest request, SearchResponse response, Map<String, Object> requestContext) {
+    public SearchResponse processResponse(SearchRequest request, SearchResponse response, PipelinedRequestContext requestContext) {
         int size;
         if (targetSize < 0) { // No value specified in processor config. Use context value instead.
             String key = applyContextPrefix(contextPrefix, OversampleRequestProcessor.ORIGINAL_SIZE);
-            Object o = requestContext.get(key);
+            Object o = requestContext.getGenericRequestContext().get(key);
             if (o == null) {
                 throw new IllegalStateException("Must specify " + TARGET_SIZE + " unless an earlier processor set " + key);
             }

--- a/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/helpers/BasicMap.java
+++ b/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/helpers/BasicMap.java
@@ -1,0 +1,126 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.pipeline.common.helpers;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * Helper for map abstractions passed to scripting processors. Throws {@link UnsupportedOperationException} for almost
+ * all methods. Subclasses just need to implement get and put.
+ */
+public abstract class BasicMap implements Map<String, Object> {
+
+    /**
+     * No-args constructor.
+     */
+    protected BasicMap() {}
+
+    private static final String UNSUPPORTED_OP_ERR = " Method not supported in Search pipeline script";
+
+    @Override
+    public boolean isEmpty() {
+        throw new UnsupportedOperationException("isEmpty" + UNSUPPORTED_OP_ERR);
+    }
+
+    public int size() {
+        throw new UnsupportedOperationException("size" + UNSUPPORTED_OP_ERR);
+    }
+
+    public boolean containsKey(Object key) {
+        return get(key) != null;
+    }
+
+    public boolean containsValue(Object value) {
+        throw new UnsupportedOperationException("containsValue" + UNSUPPORTED_OP_ERR);
+    }
+
+    public Object remove(Object key) {
+        throw new UnsupportedOperationException("remove" + UNSUPPORTED_OP_ERR);
+    }
+
+    public void putAll(Map<? extends String, ?> m) {
+        throw new UnsupportedOperationException("putAll" + UNSUPPORTED_OP_ERR);
+    }
+
+    public void clear() {
+        throw new UnsupportedOperationException("clear" + UNSUPPORTED_OP_ERR);
+    }
+
+    public Set<String> keySet() {
+        throw new UnsupportedOperationException("keySet" + UNSUPPORTED_OP_ERR);
+    }
+
+    public Collection<Object> values() {
+        throw new UnsupportedOperationException("values" + UNSUPPORTED_OP_ERR);
+    }
+
+    public Set<Map.Entry<String, Object>> entrySet() {
+        throw new UnsupportedOperationException("entrySet" + UNSUPPORTED_OP_ERR);
+    }
+
+    @Override
+    public Object getOrDefault(Object key, Object defaultValue) {
+        throw new UnsupportedOperationException("getOrDefault" + UNSUPPORTED_OP_ERR);
+    }
+
+    @Override
+    public void forEach(BiConsumer<? super String, ? super Object> action) {
+        throw new UnsupportedOperationException("forEach" + UNSUPPORTED_OP_ERR);
+    }
+
+    @Override
+    public void replaceAll(BiFunction<? super String, ? super Object, ?> function) {
+        throw new UnsupportedOperationException("replaceAll" + UNSUPPORTED_OP_ERR);
+    }
+
+    @Override
+    public Object putIfAbsent(String key, Object value) {
+        throw new UnsupportedOperationException("putIfAbsent" + UNSUPPORTED_OP_ERR);
+    }
+
+    @Override
+    public boolean remove(Object key, Object value) {
+        throw new UnsupportedOperationException("remove" + UNSUPPORTED_OP_ERR);
+    }
+
+    @Override
+    public boolean replace(String key, Object oldValue, Object newValue) {
+        throw new UnsupportedOperationException("replace" + UNSUPPORTED_OP_ERR);
+    }
+
+    @Override
+    public Object replace(String key, Object value) {
+        throw new UnsupportedOperationException("replace" + UNSUPPORTED_OP_ERR);
+    }
+
+    @Override
+    public Object computeIfAbsent(String key, Function<? super String, ?> mappingFunction) {
+        throw new UnsupportedOperationException("computeIfAbsent" + UNSUPPORTED_OP_ERR);
+    }
+
+    @Override
+    public Object computeIfPresent(String key, BiFunction<? super String, ? super Object, ?> remappingFunction) {
+        throw new UnsupportedOperationException("computeIfPresent" + UNSUPPORTED_OP_ERR);
+    }
+
+    @Override
+    public Object compute(String key, BiFunction<? super String, ? super Object, ?> remappingFunction) {
+        throw new UnsupportedOperationException("compute" + UNSUPPORTED_OP_ERR);
+    }
+
+    @Override
+    public Object merge(String key, Object value, BiFunction<? super Object, ? super Object, ?> remappingFunction) {
+        throw new UnsupportedOperationException("merge" + UNSUPPORTED_OP_ERR);
+    }
+}

--- a/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/helpers/ContextUtils.java
+++ b/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/helpers/ContextUtils.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.pipeline.common.helpers;
+
+/**
+ * Helpers for working with request-scoped context.
+ */
+public final class ContextUtils {
+    private ContextUtils() {}
+
+    /**
+     * Parameter that can be passed to a stateful processor to avoid collisions between contextual variables by
+     * prefixing them with distinct qualifiers.
+     */
+    public static final String CONTEXT_PREFIX_PARAMETER = "context_prefix";
+
+    /**
+     * Replaces a "global" variable name with one scoped to a given context prefix (unless prefix is null or empty).
+     * @param contextPrefix the prefix qualifier for the variable
+     * @param variableName the generic "global" form of the context variable
+     * @return the variableName prefixed with contextPrefix followed by ".", or just variableName if contextPrefix is null or empty
+     */
+    public static String applyContextPrefix(String contextPrefix, String variableName) {
+        String contextVariable;
+        if (contextPrefix != null && contextPrefix.isEmpty() == false) {
+            contextVariable = contextPrefix + "." + variableName;
+        } else {
+            contextVariable = variableName;
+        }
+        return contextVariable;
+    }
+}

--- a/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/helpers/SearchRequestMap.java
+++ b/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/helpers/SearchRequestMap.java
@@ -11,19 +11,13 @@ package org.opensearch.search.pipeline.common.helpers;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.search.builder.SearchSourceBuilder;
 
-import java.util.Collection;
 import java.util.Map;
-import java.util.Set;
-import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
-import java.util.function.Function;
 
 /**
  * A custom implementation of {@link Map} that provides access to the properties of a {@link SearchRequest}'s
  * {@link SearchSourceBuilder}. The class allows retrieving and modifying specific properties of the search request.
  */
-public class SearchRequestMap implements Map<String, Object> {
-    private static final String UNSUPPORTED_OP_ERR = " Method not supported in Search pipeline script";
+public class SearchRequestMap extends BasicMap implements Map<String, Object> {
 
     private final SearchSourceBuilder source;
 
@@ -37,17 +31,6 @@ public class SearchRequestMap implements Map<String, Object> {
     }
 
     /**
-     * Retrieves the number of properties in the SearchSourceBuilder.
-     *
-     * @return The number of properties in the SearchSourceBuilder.
-     * @throws UnsupportedOperationException always, as the method is not supported.
-     */
-    @Override
-    public int size() {
-        throw new UnsupportedOperationException("size" + UNSUPPORTED_OP_ERR);
-    }
-
-    /**
      * Checks if the SearchSourceBuilder is empty.
      *
      * @return {@code true} if the SearchSourceBuilder is empty, {@code false} otherwise.
@@ -55,29 +38,6 @@ public class SearchRequestMap implements Map<String, Object> {
     @Override
     public boolean isEmpty() {
         return source == null;
-    }
-
-    /**
-     * Checks if the SearchSourceBuilder contains the specified property.
-     *
-     * @param key The property to check for.
-     * @return {@code true} if the SearchSourceBuilder contains the specified property, {@code false} otherwise.
-     */
-    @Override
-    public boolean containsKey(Object key) {
-        return get(key) != null;
-    }
-
-    /**
-     * Checks if the SearchSourceBuilder contains the specified value.
-     *
-     * @param value The value to check for.
-     * @return {@code true} if the SearchSourceBuilder contains the specified value, {@code false} otherwise.
-     * @throws UnsupportedOperationException always, as the method is not supported.
-     */
-    @Override
-    public boolean containsValue(Object value) {
-        throw new UnsupportedOperationException("containsValue" + UNSUPPORTED_OP_ERR);
     }
 
     /**
@@ -176,220 +136,5 @@ public class SearchRequestMap implements Map<String, Object> {
             throw new SearchRequestMapProcessingException("Error while setting value for SearchRequest source property: " + key, e);
         }
         return originalValue;
-    }
-
-    /**
-     * Removes the specified property from the SearchSourceBuilder.
-     *
-     * @param key The name of the property that will be removed.
-     * @return The value associated with the property before it was removed, or null if the property was not found.
-     * @throws UnsupportedOperationException always, as the method is not supported.
-     */
-    @Override
-    public Object remove(Object key) {
-        throw new UnsupportedOperationException("remove" + UNSUPPORTED_OP_ERR);
-    }
-
-    /**
-     * Sets all the properties from the specified map to the SearchSourceBuilder.
-     *
-     * @param m The map containing the properties to be set.
-     * @throws UnsupportedOperationException always, as the method is not supported.
-     */
-    @Override
-    public void putAll(Map<? extends String, ?> m) {
-        throw new UnsupportedOperationException("putAll" + UNSUPPORTED_OP_ERR);
-    }
-
-    /**
-     * Removes all properties from the SearchSourceBuilder.
-     *
-     * @throws UnsupportedOperationException always, as the method is not supported.
-     */
-    @Override
-    public void clear() {
-        throw new UnsupportedOperationException("clear" + UNSUPPORTED_OP_ERR);
-    }
-
-    /**
-     * Returns a set view of the property names in the SearchSourceBuilder.
-     *
-     * @return A set view of the property names in the SearchSourceBuilder.
-     * @throws UnsupportedOperationException always, as the method is not supported.
-     */
-    @Override
-    public Set<String> keySet() {
-        throw new UnsupportedOperationException("keySet" + UNSUPPORTED_OP_ERR);
-    }
-
-    /**
-     * Returns a collection view of the property values in the SearchSourceBuilder.
-     *
-     * @return A collection view of the property values in the SearchSourceBuilder.
-     * @throws UnsupportedOperationException always, as the method is not supported.
-     */
-    @Override
-    public Collection<Object> values() {
-        throw new UnsupportedOperationException("values" + UNSUPPORTED_OP_ERR);
-    }
-
-    /**
-     * Returns a set view of the properties in the SearchSourceBuilder.
-     *
-     * @return A set view of the properties in the SearchSourceBuilder.
-     * @throws UnsupportedOperationException always, as the method is not supported.
-     */
-    @Override
-    public Set<Entry<String, Object>> entrySet() {
-        throw new UnsupportedOperationException("entrySet" + UNSUPPORTED_OP_ERR);
-    }
-
-    /**
-     * Returns the value to which the specified property has, or the defaultValue if the property is not present in the
-     * SearchSourceBuilder.
-     *
-     * @param key The property whose associated value is to be returned.
-     * @param defaultValue The default value to be returned if the property is not present.
-     * @return The value to which the specified property has, or the defaultValue if the property is not present.
-     * @throws UnsupportedOperationException always, as the method is not supported.
-     */
-    @Override
-    public Object getOrDefault(Object key, Object defaultValue) {
-        throw new UnsupportedOperationException("getOrDefault" + UNSUPPORTED_OP_ERR);
-    }
-
-    /**
-     * Performs the given action for each property in the SearchSourceBuilder until all properties have been processed or the
-     * action throws an exception
-     *
-     * @param action The action to be performed for each property.
-     * @throws UnsupportedOperationException always, as the method is not supported.
-     */
-    @Override
-    public void forEach(BiConsumer<? super String, ? super Object> action) {
-        throw new UnsupportedOperationException("forEach" + UNSUPPORTED_OP_ERR);
-    }
-
-    /**
-     * Replaces each property's value with the result of invoking the given function on that property until all properties have
-     * been processed or the function throws an exception.
-     *
-     * @param function The function to apply to each property.
-     * @throws UnsupportedOperationException always, as the method is not supported.
-     */
-    @Override
-    public void replaceAll(BiFunction<? super String, ? super Object, ?> function) {
-        throw new UnsupportedOperationException("replaceAll" + UNSUPPORTED_OP_ERR);
-    }
-
-    /**
-     * If the specified property is not already associated with a value, associates it with the given value and returns null,
-     * else returns the current value.
-     *
-     * @param key The property whose value is to be set if absent.
-     * @param value The value to be associated with the specified property.
-     * @return The current value associated with the property, or null if the property is not present.
-     * @throws UnsupportedOperationException always, as the method is not supported.
-     */
-    @Override
-    public Object putIfAbsent(String key, Object value) {
-        throw new UnsupportedOperationException("putIfAbsent" + UNSUPPORTED_OP_ERR);
-    }
-
-    /**
-     * Removes the property only if it has the given value.
-     *
-     * @param key The property to be removed.
-     * @param value The value expected to be associated with the property.
-     * @return {@code true} if the entry was removed, {@code false} otherwise.
-     * @throws UnsupportedOperationException always, as the method is not supported.
-     */
-    @Override
-    public boolean remove(Object key, Object value) {
-        throw new UnsupportedOperationException("remove" + UNSUPPORTED_OP_ERR);
-    }
-
-    /**
-     * Replaces the specified property only if it has the given value.
-     *
-     * @param key The property to be replaced.
-     * @param oldValue The value expected to be associated with the property.
-     * @param newValue The value to be associated with the property.
-     * @return {@code true} if the property was replaced, {@code false} otherwise.
-     * @throws UnsupportedOperationException always, as the method is not supported.
-     */
-    @Override
-    public boolean replace(String key, Object oldValue, Object newValue) {
-        throw new UnsupportedOperationException("replace" + UNSUPPORTED_OP_ERR);
-    }
-
-    /**
-     * Replaces the specified property only if it has the given value.
-     *
-     * @param key The property to be replaced.
-     * @param value The value to be associated with the property.
-     * @return The previous value associated with the property, or null if the property was not found.
-     * @throws UnsupportedOperationException always, as the method is not supported.
-     */
-    @Override
-    public Object replace(String key, Object value) {
-        throw new UnsupportedOperationException("replace" + UNSUPPORTED_OP_ERR);
-    }
-
-    /**
-     * The computed value associated with the property, or null if the property is not present.
-     *
-     * @param key The property whose value is to be computed if absent.
-     * @param mappingFunction The function to compute a value based on the property.
-     * @return The computed value associated with the property, or null if the property is not present.
-     * @throws UnsupportedOperationException always, as the method is not supported.
-     */
-    @Override
-    public Object computeIfAbsent(String key, Function<? super String, ?> mappingFunction) {
-        throw new UnsupportedOperationException("computeIfAbsent" + UNSUPPORTED_OP_ERR);
-    }
-
-    /**
-     * If the value for the specified property is present, attempts to compute a new mapping given the property and its current
-     * mapped value.
-     *
-     * @param key The property for which the mapping is to be computed.
-     * @param remappingFunction The function to compute a new mapping.
-     * @return The new value associated with the property, or null if the property is not present.
-     * @throws UnsupportedOperationException always, as the method is not supported.
-     */
-    @Override
-    public Object computeIfPresent(String key, BiFunction<? super String, ? super Object, ?> remappingFunction) {
-        throw new UnsupportedOperationException("computeIfPresent" + UNSUPPORTED_OP_ERR);
-    }
-
-    /**
-     * If the value for the specified property is present, attempts to compute a new mapping given the property and its current
-     * mapped value, or removes the property if the computed value is null.
-     *
-     * @param key The property for which the mapping is to be computed.
-     * @param remappingFunction The function to compute a new mapping.
-     * @return The new value associated with the property, or null if the property is not present.
-     * @throws UnsupportedOperationException always, as the method is not supported.
-     */
-    @Override
-    public Object compute(String key, BiFunction<? super String, ? super Object, ?> remappingFunction) {
-        throw new UnsupportedOperationException("compute" + UNSUPPORTED_OP_ERR);
-    }
-
-    /**
-     * If the specified property is not already associated with a value or is associated with null, associates it with the
-     * given non-null value. Otherwise, replaces the associated value with the results of applying the given
-     * remapping function to the current and new values.
-     *
-     * @param key The property for which the mapping is to be merged.
-     * @param value The non-null value to be merged with the existing value.
-     * @param remappingFunction The function to merge the existing and new values.
-     * @return The new value associated with the property, or null if the property is not present.
-     * @throws UnsupportedOperationException always, as the method is not supported.
-     */
-    @Override
-    public Object merge(String key, Object value, BiFunction<? super Object, ? super Object, ?> remappingFunction) {
-        throw new UnsupportedOperationException("merge" + UNSUPPORTED_OP_ERR);
     }
 }

--- a/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/helpers/SearchResponseUtil.java
+++ b/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/helpers/SearchResponseUtil.java
@@ -26,13 +26,15 @@ public final class SearchResponseUtil {
 
     /**
      * Construct a new {@link SearchResponse} based on an existing one, replacing just the {@link SearchHits}.
-     * @param newHits new search hits
+     * @param newHits new {@link SearchHits}
      * @param response the existing search response
-     * @return a new search response where the search hits have been replaced
+     * @return a new search response where the {@link SearchHits} has been replaced
      */
     public static SearchResponse replaceHits(SearchHits newHits, SearchResponse response) {
         SearchResponseSections searchResponseSections;
-        if (response.getAggregations() instanceof InternalAggregations) {
+        if (response.getAggregations() == null || response.getAggregations() instanceof InternalAggregations) {
+            // We either have no aggregations, or we have Writeable InternalAggregations.
+            // Either way, we can produce a Writeable InternalSearchResponse.
             searchResponseSections = new InternalSearchResponse(
                 newHits,
                 (InternalAggregations) response.getAggregations(),
@@ -43,6 +45,7 @@ public final class SearchResponseUtil {
                 response.getNumReducePhases()
             );
         } else {
+            // We have non-Writeable Aggregations, so the whole SearchResponseSections is non-Writeable.
             searchResponseSections = new SearchResponseSections(
                 newHits,
                 response.getAggregations(),
@@ -67,6 +70,12 @@ public final class SearchResponseUtil {
         );
     }
 
+    /**
+     * Convenience method when only replacing the {@link SearchHit} array within the {@link SearchHits} in a {@link SearchResponse}.
+     * @param newHits the new array of {@link SearchHit} elements.
+     * @param response the search response to update
+     * @return a {@link SearchResponse} where the underlying array of {@link SearchHit} within the {@link SearchHits} has been replaced.
+     */
     public static SearchResponse replaceHits(SearchHit[] newHits, SearchResponse response) {
         if (response.getHits() == null) {
             throw new IllegalStateException("Response must have hits");

--- a/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/helpers/SearchResponseUtil.java
+++ b/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/helpers/SearchResponseUtil.java
@@ -9,8 +9,9 @@
 package org.opensearch.search.pipeline.common.helpers;
 
 import org.opensearch.action.search.SearchResponse;
-import org.opensearch.action.search.SearchResponseSections;
 import org.opensearch.search.SearchHits;
+import org.opensearch.search.aggregations.InternalAggregations;
+import org.opensearch.search.internal.InternalSearchResponse;
 import org.opensearch.search.profile.SearchProfileShardResults;
 
 /**
@@ -29,13 +30,13 @@ public final class SearchResponseUtil {
      */
     public static SearchResponse replaceHits(SearchHits newHits, SearchResponse response) {
         return new SearchResponse(
-            new SearchResponseSections(
+            new InternalSearchResponse(
                 newHits,
-                response.getAggregations(),
+                (InternalAggregations) response.getAggregations(),
                 response.getSuggest(),
+                new SearchProfileShardResults(response.getProfileResults()),
                 response.isTimedOut(),
                 response.isTerminatedEarly(),
-                new SearchProfileShardResults(response.getProfileResults()),
                 response.getNumReducePhases()
             ),
             response.getScrollId(),

--- a/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/helpers/SearchResponseUtil.java
+++ b/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/helpers/SearchResponseUtil.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.pipeline.common.helpers;
+
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.search.SearchResponseSections;
+import org.opensearch.search.SearchHits;
+import org.opensearch.search.profile.SearchProfileShardResults;
+
+/**
+ * Helper methods for manipulating {@link SearchResponse}.
+ */
+public final class SearchResponseUtil {
+    private SearchResponseUtil() {
+
+    }
+
+    /**
+     * Construct a new {@link SearchResponse} based on an existing one, replacing just the {@link SearchHits}.
+     * @param newHits new search hits
+     * @param response the existing search response
+     * @return a new search response where the search hits have been replaced
+     */
+    public static SearchResponse replaceHits(SearchHits newHits, SearchResponse response) {
+        return new SearchResponse(
+            new SearchResponseSections(
+                newHits,
+                response.getAggregations(),
+                response.getSuggest(),
+                response.isTimedOut(),
+                response.isTerminatedEarly(),
+                new SearchProfileShardResults(response.getProfileResults()),
+                response.getNumReducePhases()
+            ),
+            response.getScrollId(),
+            response.getTotalShards(),
+            response.getSuccessfulShards(),
+            response.getSkippedShards(),
+            response.getTook().millis(),
+            response.getShardFailures(),
+            response.getClusters(),
+            response.pointInTimeId()
+        );
+    }
+}

--- a/modules/search-pipeline-common/src/test/java/org/opensearch/search/pipeline/common/CollapseResponseProcessorTests.java
+++ b/modules/search-pipeline-common/src/test/java/org/opensearch/search/pipeline/common/CollapseResponseProcessorTests.java
@@ -1,0 +1,86 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.pipeline.common;
+
+import org.apache.lucene.search.TotalHits;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.common.document.DocumentField;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.search.internal.InternalSearchResponse;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class CollapseResponseProcessorTests extends OpenSearchTestCase {
+    public void testWithDocumentFields() {
+        testProcessor(true);
+    }
+
+    public void testWithSourceField() {
+        testProcessor(false);
+    }
+
+    private void testProcessor(boolean includeDocField) {
+        Map<String, Object> config = new HashMap<>(Map.of(CollapseResponseProcessor.COLLAPSE_FIELD, "groupid"));
+        CollapseResponseProcessor processor = new CollapseResponseProcessor.Factory().create(
+            Collections.emptyMap(),
+            null,
+            null,
+            false,
+            config,
+            null
+        );
+        int numHits = randomIntBetween(1, 100);
+        SearchResponse inputResponse = generateResponse(numHits, includeDocField);
+
+        SearchResponse processedResponse = processor.processResponse(new SearchRequest(), inputResponse);
+        if (numHits % 2 == 0) {
+            assertEquals(numHits / 2, processedResponse.getHits().getHits().length);
+        } else {
+            assertEquals(numHits / 2 + 1, processedResponse.getHits().getHits().length);
+        }
+        for (SearchHit collapsedHit : processedResponse.getHits()) {
+            assertEquals(0, collapsedHit.docId() % 2);
+        }
+        assertEquals("groupid", processedResponse.getHits().getCollapseField());
+        assertEquals(processedResponse.getHits().getHits().length, processedResponse.getHits().getCollapseValues().length);
+        for (int i = 0; i < processedResponse.getHits().getHits().length; i++) {
+            assertEquals(i, processedResponse.getHits().getCollapseValues()[i]);
+        }
+    }
+
+    private static SearchResponse generateResponse(int numHits, boolean includeDocField) {
+        SearchHit[] hitsArray = new SearchHit[numHits];
+        for (int i = 0; i < numHits; i++) {
+            Map<String, DocumentField> docFields;
+            int groupValue = i / 2;
+            if (includeDocField) {
+                docFields = Map.of("groupid", new DocumentField("groupid", List.of(groupValue)));
+            } else {
+                docFields = Collections.emptyMap();
+            }
+            SearchHit hit = new SearchHit(i, Integer.toString(i), docFields, Collections.emptyMap());
+            hit.sourceRef(new BytesArray("{\"groupid\": " + groupValue + "}"));
+            hitsArray[i] = hit;
+        }
+        SearchHits searchHits = new SearchHits(
+            hitsArray,
+            new TotalHits(Math.max(numHits, 1000), TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO),
+            1.0f
+        );
+        InternalSearchResponse internalSearchResponse = new InternalSearchResponse(searchHits, null, null, null, false, false, 0);
+        return new SearchResponse(internalSearchResponse, null, 1, 1, 0, 10, null, null);
+    }
+}

--- a/modules/search-pipeline-common/src/test/java/org/opensearch/search/pipeline/common/OversampleRequestProcessorTests.java
+++ b/modules/search-pipeline-common/src/test/java/org/opensearch/search/pipeline/common/OversampleRequestProcessorTests.java
@@ -10,6 +10,7 @@ package org.opensearch.search.pipeline.common;
 
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.pipeline.PipelinedRequestContext;
 import org.opensearch.search.pipeline.common.helpers.ContextUtils;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -25,10 +26,10 @@ public class OversampleRequestProcessorTests extends OpenSearchTestCase {
         OversampleRequestProcessor processor = factory.create(Collections.emptyMap(), null, null, false, config, null);
 
         SearchRequest request = new SearchRequest();
-        Map<String, Object> context = new HashMap<>();
+        PipelinedRequestContext context = new PipelinedRequestContext();
         SearchRequest transformedRequest = processor.processRequest(request, context);
         assertEquals(request, transformedRequest);
-        assertTrue(context.isEmpty());
+        assertTrue(context.getGenericRequestContext().isEmpty());
     }
 
     public void testBasicBehavior() {
@@ -38,11 +39,11 @@ public class OversampleRequestProcessorTests extends OpenSearchTestCase {
 
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().size(10);
         SearchRequest request = new SearchRequest().source(sourceBuilder);
-        Map<String, Object> context = new HashMap<>();
+        PipelinedRequestContext context = new PipelinedRequestContext();
         SearchRequest transformedRequest = processor.processRequest(request, context);
         assertEquals(30, transformedRequest.source().size());
-        assertEquals(1, context.size());
-        assertEquals(10, context.get("original_size"));
+        assertEquals(1, context.getGenericRequestContext().size());
+        assertEquals(10, context.getGenericRequestContext().get("original_size"));
     }
 
     public void testContextPrefix() {
@@ -54,10 +55,10 @@ public class OversampleRequestProcessorTests extends OpenSearchTestCase {
 
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().size(10);
         SearchRequest request = new SearchRequest().source(sourceBuilder);
-        Map<String, Object> context = new HashMap<>();
+        PipelinedRequestContext context = new PipelinedRequestContext();
         SearchRequest transformedRequest = processor.processRequest(request, context);
         assertEquals(30, transformedRequest.source().size());
-        assertEquals(1, context.size());
-        assertEquals(10, context.get("foo.original_size"));
+        assertEquals(1, context.getGenericRequestContext().size());
+        assertEquals(10, context.getGenericRequestContext().get("foo.original_size"));
     }
 }

--- a/modules/search-pipeline-common/src/test/java/org/opensearch/search/pipeline/common/OversampleRequestProcessorTests.java
+++ b/modules/search-pipeline-common/src/test/java/org/opensearch/search/pipeline/common/OversampleRequestProcessorTests.java
@@ -10,7 +10,7 @@ package org.opensearch.search.pipeline.common;
 
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.search.builder.SearchSourceBuilder;
-import org.opensearch.search.pipeline.PipelinedRequestContext;
+import org.opensearch.search.pipeline.PipelineProcessingContext;
 import org.opensearch.search.pipeline.common.helpers.ContextUtils;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -26,7 +26,7 @@ public class OversampleRequestProcessorTests extends OpenSearchTestCase {
         OversampleRequestProcessor processor = factory.create(Collections.emptyMap(), null, null, false, config, null);
 
         SearchRequest request = new SearchRequest();
-        PipelinedRequestContext context = new PipelinedRequestContext();
+        PipelineProcessingContext context = new PipelineProcessingContext();
         SearchRequest transformedRequest = processor.processRequest(request, context);
         assertEquals(request, transformedRequest);
         assertNull(context.getAttribute("original_size"));
@@ -39,7 +39,7 @@ public class OversampleRequestProcessorTests extends OpenSearchTestCase {
 
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().size(10);
         SearchRequest request = new SearchRequest().source(sourceBuilder);
-        PipelinedRequestContext context = new PipelinedRequestContext();
+        PipelineProcessingContext context = new PipelineProcessingContext();
         SearchRequest transformedRequest = processor.processRequest(request, context);
         assertEquals(30, transformedRequest.source().size());
         assertEquals(10, context.getAttribute("original_size"));
@@ -54,7 +54,7 @@ public class OversampleRequestProcessorTests extends OpenSearchTestCase {
 
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().size(10);
         SearchRequest request = new SearchRequest().source(sourceBuilder);
-        PipelinedRequestContext context = new PipelinedRequestContext();
+        PipelineProcessingContext context = new PipelineProcessingContext();
         SearchRequest transformedRequest = processor.processRequest(request, context);
         assertEquals(30, transformedRequest.source().size());
         assertEquals(10, context.getAttribute("foo.original_size"));

--- a/modules/search-pipeline-common/src/test/java/org/opensearch/search/pipeline/common/OversampleRequestProcessorTests.java
+++ b/modules/search-pipeline-common/src/test/java/org/opensearch/search/pipeline/common/OversampleRequestProcessorTests.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.pipeline.common;
+
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.pipeline.common.helpers.ContextUtils;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class OversampleRequestProcessorTests extends OpenSearchTestCase {
+
+    public void testEmptySource() {
+        OversampleRequestProcessor.Factory factory = new OversampleRequestProcessor.Factory();
+        Map<String, Object> config = new HashMap<>(Map.of(OversampleRequestProcessor.SAMPLE_FACTOR, 3.0));
+        OversampleRequestProcessor processor = factory.create(Collections.emptyMap(), null, null, false, config, null);
+
+        SearchRequest request = new SearchRequest();
+        Map<String, Object> context = new HashMap<>();
+        SearchRequest transformedRequest = processor.processRequest(request, context);
+        assertEquals(request, transformedRequest);
+        assertTrue(context.isEmpty());
+    }
+
+    public void testBasicBehavior() {
+        OversampleRequestProcessor.Factory factory = new OversampleRequestProcessor.Factory();
+        Map<String, Object> config = new HashMap<>(Map.of(OversampleRequestProcessor.SAMPLE_FACTOR, 3.0));
+        OversampleRequestProcessor processor = factory.create(Collections.emptyMap(), null, null, false, config, null);
+
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().size(10);
+        SearchRequest request = new SearchRequest().source(sourceBuilder);
+        Map<String, Object> context = new HashMap<>();
+        SearchRequest transformedRequest = processor.processRequest(request, context);
+        assertEquals(30, transformedRequest.source().size());
+        assertEquals(1, context.size());
+        assertEquals(10, context.get("original_size"));
+    }
+
+    public void testContextPrefix() {
+        OversampleRequestProcessor.Factory factory = new OversampleRequestProcessor.Factory();
+        Map<String, Object> config = new HashMap<>(
+            Map.of(OversampleRequestProcessor.SAMPLE_FACTOR, 3.0, ContextUtils.CONTEXT_PREFIX_PARAMETER, "foo")
+        );
+        OversampleRequestProcessor processor = factory.create(Collections.emptyMap(), null, null, false, config, null);
+
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().size(10);
+        SearchRequest request = new SearchRequest().source(sourceBuilder);
+        Map<String, Object> context = new HashMap<>();
+        SearchRequest transformedRequest = processor.processRequest(request, context);
+        assertEquals(30, transformedRequest.source().size());
+        assertEquals(1, context.size());
+        assertEquals(10, context.get("foo.original_size"));
+    }
+}

--- a/modules/search-pipeline-common/src/test/java/org/opensearch/search/pipeline/common/OversampleRequestProcessorTests.java
+++ b/modules/search-pipeline-common/src/test/java/org/opensearch/search/pipeline/common/OversampleRequestProcessorTests.java
@@ -29,7 +29,7 @@ public class OversampleRequestProcessorTests extends OpenSearchTestCase {
         PipelinedRequestContext context = new PipelinedRequestContext();
         SearchRequest transformedRequest = processor.processRequest(request, context);
         assertEquals(request, transformedRequest);
-        assertTrue(context.getGenericRequestContext().isEmpty());
+        assertNull(context.getAttribute("original_size"));
     }
 
     public void testBasicBehavior() {
@@ -42,8 +42,7 @@ public class OversampleRequestProcessorTests extends OpenSearchTestCase {
         PipelinedRequestContext context = new PipelinedRequestContext();
         SearchRequest transformedRequest = processor.processRequest(request, context);
         assertEquals(30, transformedRequest.source().size());
-        assertEquals(1, context.getGenericRequestContext().size());
-        assertEquals(10, context.getGenericRequestContext().get("original_size"));
+        assertEquals(10, context.getAttribute("original_size"));
     }
 
     public void testContextPrefix() {
@@ -58,7 +57,6 @@ public class OversampleRequestProcessorTests extends OpenSearchTestCase {
         PipelinedRequestContext context = new PipelinedRequestContext();
         SearchRequest transformedRequest = processor.processRequest(request, context);
         assertEquals(30, transformedRequest.source().size());
-        assertEquals(1, context.getGenericRequestContext().size());
-        assertEquals(10, context.getGenericRequestContext().get("foo.original_size"));
+        assertEquals(10, context.getAttribute("foo.original_size"));
     }
 }

--- a/modules/search-pipeline-common/src/test/java/org/opensearch/search/pipeline/common/ScriptRequestProcessorTests.java
+++ b/modules/search-pipeline-common/src/test/java/org/opensearch/search/pipeline/common/ScriptRequestProcessorTests.java
@@ -27,8 +27,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import static org.hamcrest.core.Is.is;
-
 public class ScriptRequestProcessorTests extends OpenSearchTestCase {
 
     private ScriptService scriptService;
@@ -87,7 +85,7 @@ public class ScriptRequestProcessorTests extends OpenSearchTestCase {
         searchRequest.source(createSearchSourceBuilder());
 
         assertNotNull(searchRequest);
-        processor.processRequest(searchRequest);
+        processor.processRequest(searchRequest, new HashMap<>());
         assertSearchRequest(searchRequest);
     }
 
@@ -104,7 +102,7 @@ public class ScriptRequestProcessorTests extends OpenSearchTestCase {
         searchRequest.source(createSearchSourceBuilder());
 
         assertNotNull(searchRequest);
-        processor.processRequest(searchRequest);
+        processor.processRequest(searchRequest, new HashMap<>());
         assertSearchRequest(searchRequest);
     }
 
@@ -124,15 +122,15 @@ public class ScriptRequestProcessorTests extends OpenSearchTestCase {
     }
 
     private void assertSearchRequest(SearchRequest searchRequest) {
-        assertThat(searchRequest.source().from(), is(20));
-        assertThat(searchRequest.source().size(), is(30));
-        assertThat(searchRequest.source().explain(), is(false));
-        assertThat(searchRequest.source().version(), is(false));
-        assertThat(searchRequest.source().seqNoAndPrimaryTerm(), is(false));
-        assertThat(searchRequest.source().trackScores(), is(false));
-        assertThat(searchRequest.source().trackTotalHitsUpTo(), is(4));
-        assertThat(searchRequest.source().minScore(), is(2.0f));
-        assertThat(searchRequest.source().timeout(), is(new TimeValue(60, TimeUnit.SECONDS)));
-        assertThat(searchRequest.source().terminateAfter(), is(6));
+        assertEquals(20, searchRequest.source().from());
+        assertEquals(30, searchRequest.source().size());
+        assertFalse(searchRequest.source().explain());
+        assertFalse(searchRequest.source().version());
+        assertFalse(searchRequest.source().seqNoAndPrimaryTerm());
+        assertFalse(searchRequest.source().trackScores());
+        assertEquals(4, searchRequest.source().trackTotalHitsUpTo().intValue());
+        assertEquals(2.0f, searchRequest.source().minScore(), 0.0001);
+        assertEquals(new TimeValue(60, TimeUnit.SECONDS), searchRequest.source().timeout());
+        assertEquals(6, searchRequest.source().terminateAfter());
     }
 }

--- a/modules/search-pipeline-common/src/test/java/org/opensearch/search/pipeline/common/ScriptRequestProcessorTests.java
+++ b/modules/search-pipeline-common/src/test/java/org/opensearch/search/pipeline/common/ScriptRequestProcessorTests.java
@@ -19,7 +19,6 @@ import org.opensearch.script.ScriptType;
 import org.opensearch.script.SearchScript;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.pipeline.PipelineProcessingContext;
-import org.opensearch.search.pipeline.common.helpers.SearchRequestMap;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.Before;
 

--- a/modules/search-pipeline-common/src/test/java/org/opensearch/search/pipeline/common/ScriptRequestProcessorTests.java
+++ b/modules/search-pipeline-common/src/test/java/org/opensearch/search/pipeline/common/ScriptRequestProcessorTests.java
@@ -18,7 +18,7 @@ import org.opensearch.script.ScriptService;
 import org.opensearch.script.ScriptType;
 import org.opensearch.script.SearchScript;
 import org.opensearch.search.builder.SearchSourceBuilder;
-import org.opensearch.search.pipeline.PipelinedRequestContext;
+import org.opensearch.search.pipeline.PipelineProcessingContext;
 import org.opensearch.search.pipeline.common.helpers.SearchRequestMap;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.Before;
@@ -86,7 +86,7 @@ public class ScriptRequestProcessorTests extends OpenSearchTestCase {
         searchRequest.source(createSearchSourceBuilder());
 
         assertNotNull(searchRequest);
-        processor.processRequest(searchRequest, new PipelinedRequestContext());
+        processor.processRequest(searchRequest, new PipelineProcessingContext());
         assertSearchRequest(searchRequest);
     }
 
@@ -103,7 +103,7 @@ public class ScriptRequestProcessorTests extends OpenSearchTestCase {
         searchRequest.source(createSearchSourceBuilder());
 
         assertNotNull(searchRequest);
-        processor.processRequest(searchRequest, new PipelinedRequestContext());
+        processor.processRequest(searchRequest, new PipelineProcessingContext());
         assertSearchRequest(searchRequest);
     }
 

--- a/modules/search-pipeline-common/src/test/java/org/opensearch/search/pipeline/common/ScriptRequestProcessorTests.java
+++ b/modules/search-pipeline-common/src/test/java/org/opensearch/search/pipeline/common/ScriptRequestProcessorTests.java
@@ -18,6 +18,7 @@ import org.opensearch.script.ScriptService;
 import org.opensearch.script.ScriptType;
 import org.opensearch.script.SearchScript;
 import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.pipeline.PipelinedRequestContext;
 import org.opensearch.search.pipeline.common.helpers.SearchRequestMap;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.Before;
@@ -85,7 +86,7 @@ public class ScriptRequestProcessorTests extends OpenSearchTestCase {
         searchRequest.source(createSearchSourceBuilder());
 
         assertNotNull(searchRequest);
-        processor.processRequest(searchRequest, new HashMap<>());
+        processor.processRequest(searchRequest, new PipelinedRequestContext());
         assertSearchRequest(searchRequest);
     }
 
@@ -102,7 +103,7 @@ public class ScriptRequestProcessorTests extends OpenSearchTestCase {
         searchRequest.source(createSearchSourceBuilder());
 
         assertNotNull(searchRequest);
-        processor.processRequest(searchRequest, new HashMap<>());
+        processor.processRequest(searchRequest, new PipelinedRequestContext());
         assertSearchRequest(searchRequest);
     }
 

--- a/modules/search-pipeline-common/src/test/java/org/opensearch/search/pipeline/common/SearchRequestMapTests.java
+++ b/modules/search-pipeline-common/src/test/java/org/opensearch/search/pipeline/common/SearchRequestMapTests.java
@@ -5,7 +5,7 @@
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
  */
-package org.opensearch.search.pipeline.common.helpers;
+package org.opensearch.search.pipeline.common;
 
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.search.builder.SearchSourceBuilder;

--- a/modules/search-pipeline-common/src/test/java/org/opensearch/search/pipeline/common/TruncateHitsResponseProcessorTests.java
+++ b/modules/search-pipeline-common/src/test/java/org/opensearch/search/pipeline/common/TruncateHitsResponseProcessorTests.java
@@ -1,0 +1,87 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.pipeline.common;
+
+import org.apache.lucene.search.TotalHits;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.search.internal.InternalSearchResponse;
+import org.opensearch.search.pipeline.common.helpers.ContextUtils;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class TruncateHitsResponseProcessorTests extends OpenSearchTestCase {
+
+    public void testBasicBehavior() {
+        int targetSize = randomInt(50);
+        TruncateHitsResponseProcessor.Factory factory = new TruncateHitsResponseProcessor.Factory();
+        Map<String, Object> config = new HashMap<>(Map.of(TruncateHitsResponseProcessor.TARGET_SIZE, targetSize));
+        TruncateHitsResponseProcessor processor = factory.create(Collections.emptyMap(), null, null, false, config, null);
+
+        int numHits = randomInt(100);
+        SearchResponse response = constructResponse(numHits);
+        SearchResponse transformedResponse = processor.processResponse(new SearchRequest(), response, Collections.emptyMap());
+        assertEquals(Math.min(targetSize, numHits), transformedResponse.getHits().getHits().length);
+    }
+
+    public void testTargetSizePassedViaContext() {
+        TruncateHitsResponseProcessor.Factory factory = new TruncateHitsResponseProcessor.Factory();
+        TruncateHitsResponseProcessor processor = factory.create(Collections.emptyMap(), null, null, false, Collections.emptyMap(), null);
+
+        int targetSize = randomInt(50);
+        int numHits = randomInt(100);
+        SearchResponse response = constructResponse(numHits);
+        SearchResponse transformedResponse = processor.processResponse(new SearchRequest(), response, Map.of("original_size", targetSize));
+        assertEquals(Math.min(targetSize, numHits), transformedResponse.getHits().getHits().length);
+    }
+
+    public void testTargetSizePassedViaContextWithPrefix() {
+        TruncateHitsResponseProcessor.Factory factory = new TruncateHitsResponseProcessor.Factory();
+        Map<String, Object> config = new HashMap<>(Map.of(ContextUtils.CONTEXT_PREFIX_PARAMETER, "foo"));
+        TruncateHitsResponseProcessor processor = factory.create(Collections.emptyMap(), null, null, false, config, null);
+
+        int targetSize = randomInt(50);
+        int numHits = randomInt(100);
+        SearchResponse response = constructResponse(numHits);
+        SearchResponse transformedResponse = processor.processResponse(
+            new SearchRequest(),
+            response,
+            Map.of("foo.original_size", targetSize)
+        );
+        assertEquals(Math.min(targetSize, numHits), transformedResponse.getHits().getHits().length);
+    }
+
+    public void testTargetSizeMissing() {
+        TruncateHitsResponseProcessor.Factory factory = new TruncateHitsResponseProcessor.Factory();
+        TruncateHitsResponseProcessor processor = factory.create(Collections.emptyMap(), null, null, false, Collections.emptyMap(), null);
+
+        int numHits = randomInt(100);
+        SearchResponse response = constructResponse(numHits);
+        assertThrows(IllegalStateException.class, () -> processor.processResponse(new SearchRequest(), response, Collections.emptyMap()));
+    }
+
+    private static SearchResponse constructResponse(int numHits) {
+        SearchHit[] hitsArray = new SearchHit[numHits];
+        for (int i = 0; i < numHits; i++) {
+            hitsArray[i] = new SearchHit(i, Integer.toString(i), Collections.emptyMap(), Collections.emptyMap());
+        }
+        SearchHits searchHits = new SearchHits(
+            hitsArray,
+            new TotalHits(Math.max(numHits, 1000), TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO),
+            1.0f
+        );
+        InternalSearchResponse internalSearchResponse = new InternalSearchResponse(searchHits, null, null, null, false, false, 0);
+        return new SearchResponse(internalSearchResponse, null, 1, 1, 0, 10, null, null);
+    }
+}

--- a/modules/search-pipeline-common/src/test/java/org/opensearch/search/pipeline/common/TruncateHitsResponseProcessorTests.java
+++ b/modules/search-pipeline-common/src/test/java/org/opensearch/search/pipeline/common/TruncateHitsResponseProcessorTests.java
@@ -14,7 +14,7 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.internal.InternalSearchResponse;
-import org.opensearch.search.pipeline.PipelinedRequestContext;
+import org.opensearch.search.pipeline.PipelineProcessingContext;
 import org.opensearch.search.pipeline.common.helpers.ContextUtils;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -32,7 +32,7 @@ public class TruncateHitsResponseProcessorTests extends OpenSearchTestCase {
 
         int numHits = randomInt(100);
         SearchResponse response = constructResponse(numHits);
-        SearchResponse transformedResponse = processor.processResponse(new SearchRequest(), response, new PipelinedRequestContext());
+        SearchResponse transformedResponse = processor.processResponse(new SearchRequest(), response, new PipelineProcessingContext());
         assertEquals(Math.min(targetSize, numHits), transformedResponse.getHits().getHits().length);
     }
 
@@ -43,7 +43,7 @@ public class TruncateHitsResponseProcessorTests extends OpenSearchTestCase {
         int targetSize = randomInt(50);
         int numHits = randomInt(100);
         SearchResponse response = constructResponse(numHits);
-        PipelinedRequestContext requestContext = new PipelinedRequestContext();
+        PipelineProcessingContext requestContext = new PipelineProcessingContext();
         requestContext.setAttribute("original_size", targetSize);
         SearchResponse transformedResponse = processor.processResponse(new SearchRequest(), response, requestContext);
         assertEquals(Math.min(targetSize, numHits), transformedResponse.getHits().getHits().length);
@@ -57,7 +57,7 @@ public class TruncateHitsResponseProcessorTests extends OpenSearchTestCase {
         int targetSize = randomInt(50);
         int numHits = randomInt(100);
         SearchResponse response = constructResponse(numHits);
-        PipelinedRequestContext requestContext = new PipelinedRequestContext();
+        PipelineProcessingContext requestContext = new PipelineProcessingContext();
         requestContext.setAttribute("foo.original_size", targetSize);
         SearchResponse transformedResponse = processor.processResponse(new SearchRequest(), response, requestContext);
         assertEquals(Math.min(targetSize, numHits), transformedResponse.getHits().getHits().length);
@@ -71,7 +71,7 @@ public class TruncateHitsResponseProcessorTests extends OpenSearchTestCase {
         SearchResponse response = constructResponse(numHits);
         assertThrows(
             IllegalStateException.class,
-            () -> processor.processResponse(new SearchRequest(), response, new PipelinedRequestContext())
+            () -> processor.processResponse(new SearchRequest(), response, new PipelineProcessingContext())
         );
     }
 

--- a/modules/search-pipeline-common/src/test/java/org/opensearch/search/pipeline/common/TruncateHitsResponseProcessorTests.java
+++ b/modules/search-pipeline-common/src/test/java/org/opensearch/search/pipeline/common/TruncateHitsResponseProcessorTests.java
@@ -44,7 +44,7 @@ public class TruncateHitsResponseProcessorTests extends OpenSearchTestCase {
         int numHits = randomInt(100);
         SearchResponse response = constructResponse(numHits);
         PipelinedRequestContext requestContext = new PipelinedRequestContext();
-        requestContext.getGenericRequestContext().put("original_size", targetSize);
+        requestContext.setAttribute("original_size", targetSize);
         SearchResponse transformedResponse = processor.processResponse(new SearchRequest(), response, requestContext);
         assertEquals(Math.min(targetSize, numHits), transformedResponse.getHits().getHits().length);
     }
@@ -58,7 +58,7 @@ public class TruncateHitsResponseProcessorTests extends OpenSearchTestCase {
         int numHits = randomInt(100);
         SearchResponse response = constructResponse(numHits);
         PipelinedRequestContext requestContext = new PipelinedRequestContext();
-        requestContext.getGenericRequestContext().put("foo.original_size", targetSize);
+        requestContext.setAttribute("foo.original_size", targetSize);
         SearchResponse transformedResponse = processor.processResponse(new SearchRequest(), response, requestContext);
         assertEquals(Math.min(targetSize, numHits), transformedResponse.getHits().getHits().length);
     }

--- a/modules/search-pipeline-common/src/yamlRestTest/resources/rest-api-spec/test/search_pipeline/60_oversample_truncate.yml
+++ b/modules/search-pipeline-common/src/yamlRestTest/resources/rest-api-spec/test/search_pipeline/60_oversample_truncate.yml
@@ -1,0 +1,105 @@
+---
+teardown:
+  - do:
+      search_pipeline.delete:
+        id: "my_pipeline"
+        ignore: 404
+
+---
+"Test state propagating from oversample to truncate_hits processor":
+  - do:
+      search_pipeline.put:
+        id: "my_pipeline"
+        body: >
+          {
+            "description": "_description",
+            "request_processors": [
+              {
+                "oversample" : {
+                  "sample_factor" : 2
+                }
+              }
+            ],
+            "response_processors": [
+              {
+                "collapse" : {
+                  "field" : "group_id"
+                }
+              },
+              {
+                "truncate_hits" : {}
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test
+        id: 1
+        body: {
+          "group_id": "a",
+          "popularity" : 1
+        }
+  - do:
+      index:
+        index: test
+        id: 2
+        body: {
+          "group_id": "a",
+          "popularity" : 2
+        }
+  - do:
+      index:
+        index: test
+        id: 3
+        body: {
+          "group_id": "b",
+          "popularity" : 3
+        }
+  - do:
+      index:
+        index: test
+        id: 4
+        body: {
+          "group_id": "b",
+          "popularity" : 4
+        }
+  - do:
+      indices.refresh:
+        index: test
+
+  - do:
+      search:
+        body: {
+          "query" : {
+            "function_score" : {
+              "field_value_factor" : {
+                "field" : "popularity"
+              }
+            }
+          },
+          "size" : 2
+        }
+  - match: { hits.total.value: 4 }
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._id: "4" }
+  - match: { hits.hits.1._id: "3" }
+
+  - do:
+      search:
+        search_pipeline: my_pipeline
+        body: {
+          "query" : {
+            "function_score" : {
+              "field_value_factor" : {
+                "field" : "popularity"
+              }
+            }
+          },
+          "size" : 2
+        }
+  - match: { hits.total.value: 4 }
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._id: "4" }
+  - match: { hits.hits.1._id: "2" }

--- a/modules/search-pipeline-common/src/yamlRestTest/resources/rest-api-spec/test/search_pipeline/70_script_truncate.yml
+++ b/modules/search-pipeline-common/src/yamlRestTest/resources/rest-api-spec/test/search_pipeline/70_script_truncate.yml
@@ -1,0 +1,70 @@
+---
+teardown:
+  - do:
+      search_pipeline.delete:
+        id: "my_pipeline"
+        ignore: 404
+
+---
+"Test state propagating from script request to truncate_hits processor":
+  - do:
+      search_pipeline.put:
+        id: "my_pipeline"
+        body: >
+          {
+            "description": "_description",
+            "request_processors": [
+              {
+                "script" : {
+                  "source" : "ctx.request_context['foo.original_size'] = 2"
+                }
+              }
+            ],
+            "response_processors": [
+              {
+                "truncate_hits" : {
+                  "context_prefix" : "foo"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test
+        id: 1
+        body: {}
+  - do:
+      index:
+        index: test
+        id: 2
+        body: {}
+  - do:
+      index:
+        index: test
+        id: 3
+        body: {}
+  - do:
+      index:
+        index: test
+        id: 4
+        body: {}
+  - do:
+      indices.refresh:
+        index: test
+
+  - do:
+      search:
+        body: {
+        }
+  - match: { hits.total.value: 4 }
+  - length: { hits.hits: 4 }
+
+  - do:
+      search:
+        search_pipeline: my_pipeline
+        body: {
+        }
+  - match: { hits.total.value: 4 }
+  - length: { hits.hits: 2 }

--- a/server/src/main/java/org/opensearch/search/pipeline/Pipeline.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/Pipeline.java
@@ -119,7 +119,7 @@ class Pipeline {
 
     protected void onResponseProcessorFailed(Processor processor) {}
 
-    void transformRequest(SearchRequest request, ActionListener<SearchRequest> requestListener, PipelinedRequestContext requestContext)
+    void transformRequest(SearchRequest request, ActionListener<SearchRequest> requestListener, PipelineProcessingContext requestContext)
         throws SearchPipelineProcessingException {
         if (searchRequestProcessors.isEmpty()) {
             requestListener.onResponse(request);
@@ -179,7 +179,7 @@ class Pipeline {
 
     private ActionListener<SearchRequest> getTerminalSearchRequestActionListener(
         ActionListener<SearchRequest> requestListener,
-        PipelinedRequestContext requestContext
+        PipelineProcessingContext requestContext
     ) {
         final long pipelineStart = relativeTimeSupplier.getAsLong();
 
@@ -198,7 +198,7 @@ class Pipeline {
     ActionListener<SearchResponse> transformResponseListener(
         SearchRequest request,
         ActionListener<SearchResponse> responseListener,
-        PipelinedRequestContext requestContext
+        PipelineProcessingContext requestContext
     ) {
         if (searchResponseProcessors.isEmpty()) {
             // No response transformation necessary
@@ -266,7 +266,7 @@ class Pipeline {
         SearchPhaseContext context,
         String currentPhase,
         String nextPhase,
-        PipelinedRequestContext requestContext
+        PipelineProcessingContext requestContext
     ) throws SearchPipelineProcessingException {
         try {
             for (SearchPhaseResultsProcessor searchPhaseResultsProcessor : searchPhaseResultsProcessors) {

--- a/server/src/main/java/org/opensearch/search/pipeline/PipelineProcessingContext.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/PipelineProcessingContext.java
@@ -14,14 +14,14 @@ import java.util.Map;
 /**
  * A holder for state that is passed through each processor in the pipeline.
  */
-public class PipelinedRequestContext {
+public class PipelineProcessingContext {
     private final Map<String, Object> attributes = new HashMap<>();
 
     /**
      * Set a generic attribute in the state for this request. Overwrites any existing value.
      *
      * @param name the name of the attribute to set
-     * @param value the value to set on the attribute
+     * @param value the value to set on the attributen
      */
     public void setAttribute(String name, Object value) {
         attributes.put(name, value);

--- a/server/src/main/java/org/opensearch/search/pipeline/PipelinedRequest.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/PipelinedRequest.java
@@ -15,8 +15,6 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.search.SearchPhaseResult;
 
-import java.util.Map;
-
 /**
  * Groups a search pipeline based on a request and the request after being transformed by the pipeline.
  *
@@ -24,9 +22,9 @@ import java.util.Map;
  */
 public final class PipelinedRequest extends SearchRequest {
     private final Pipeline pipeline;
-    private final Map<String, Object> requestContext;
+    private final PipelinedRequestContext requestContext;
 
-    PipelinedRequest(Pipeline pipeline, SearchRequest transformedRequest, Map<String, Object> requestContext) {
+    PipelinedRequest(Pipeline pipeline, SearchRequest transformedRequest, PipelinedRequestContext requestContext) {
         super(transformedRequest);
         this.pipeline = pipeline;
         this.requestContext = requestContext;
@@ -46,7 +44,7 @@ public final class PipelinedRequest extends SearchRequest {
         final String currentPhase,
         final String nextPhase
     ) {
-        pipeline.runSearchPhaseResultsTransformer(searchPhaseResult, searchPhaseContext, currentPhase, nextPhase);
+        pipeline.runSearchPhaseResultsTransformer(searchPhaseResult, searchPhaseContext, currentPhase, nextPhase, requestContext);
     }
 
     // Visible for testing

--- a/server/src/main/java/org/opensearch/search/pipeline/PipelinedRequest.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/PipelinedRequest.java
@@ -15,6 +15,8 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.search.SearchPhaseResult;
 
+import java.util.Map;
+
 /**
  * Groups a search pipeline based on a request and the request after being transformed by the pipeline.
  *
@@ -22,18 +24,20 @@ import org.opensearch.search.SearchPhaseResult;
  */
 public final class PipelinedRequest extends SearchRequest {
     private final Pipeline pipeline;
+    private final Map<String, Object> requestContext;
 
-    PipelinedRequest(Pipeline pipeline, SearchRequest transformedRequest) {
+    PipelinedRequest(Pipeline pipeline, SearchRequest transformedRequest, Map<String, Object> requestContext) {
         super(transformedRequest);
         this.pipeline = pipeline;
+        this.requestContext = requestContext;
     }
 
     public void transformRequest(ActionListener<SearchRequest> requestListener) {
-        pipeline.transformRequest(this, requestListener);
+        pipeline.transformRequest(this, requestListener, requestContext);
     }
 
     public ActionListener<SearchResponse> transformResponseListener(ActionListener<SearchResponse> responseListener) {
-        return pipeline.transformResponseListener(this, responseListener);
+        return pipeline.transformResponseListener(this, responseListener, requestContext);
     }
 
     public <Result extends SearchPhaseResult> void transformSearchPhaseResults(

--- a/server/src/main/java/org/opensearch/search/pipeline/PipelinedRequest.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/PipelinedRequest.java
@@ -22,9 +22,9 @@ import org.opensearch.search.SearchPhaseResult;
  */
 public final class PipelinedRequest extends SearchRequest {
     private final Pipeline pipeline;
-    private final PipelinedRequestContext requestContext;
+    private final PipelineProcessingContext requestContext;
 
-    PipelinedRequest(Pipeline pipeline, SearchRequest transformedRequest, PipelinedRequestContext requestContext) {
+    PipelinedRequest(Pipeline pipeline, SearchRequest transformedRequest, PipelineProcessingContext requestContext) {
         super(transformedRequest);
         this.pipeline = pipeline;
         this.requestContext = requestContext;

--- a/server/src/main/java/org/opensearch/search/pipeline/PipelinedRequestContext.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/PipelinedRequestContext.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.pipeline;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A holder for state that is passed through each processor in the pipeline.
+ */
+public class PipelinedRequestContext {
+    private final Map<String, Object> genericRequestContext = new HashMap<>();
+
+    public Map<String, Object> getGenericRequestContext() {
+        return genericRequestContext;
+    }
+}

--- a/server/src/main/java/org/opensearch/search/pipeline/PipelinedRequestContext.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/PipelinedRequestContext.java
@@ -15,9 +15,24 @@ import java.util.Map;
  * A holder for state that is passed through each processor in the pipeline.
  */
 public class PipelinedRequestContext {
-    private final Map<String, Object> genericRequestContext = new HashMap<>();
+    private final Map<String, Object> attributes = new HashMap<>();
 
-    public Map<String, Object> getGenericRequestContext() {
-        return genericRequestContext;
+    /**
+     * Set a generic attribute in the state for this request. Overwrites any existing value.
+     *
+     * @param name the name of the attribute to set
+     * @param value the value to set on the attribute
+     */
+    public void setAttribute(String name, Object value) {
+        attributes.put(name, value);
+    }
+
+    /**
+     * Retrieves a generic attribute value from the state for this request.
+     * @param name the name of the attribute
+     * @return the value of the attribute if previously set (and null otherwise)
+     */
+    public Object getAttribute(String name) {
+        return attributes.get(name);
     }
 }

--- a/server/src/main/java/org/opensearch/search/pipeline/Processor.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/Processor.java
@@ -22,13 +22,6 @@ import java.util.Map;
  */
 public interface Processor {
     /**
-     * Processor configuration key to let the factory know the context for pipeline creation.
-     * <p>
-     * See {@link PipelineSource}.
-     */
-    String PIPELINE_SOURCE = "pipeline_source";
-
-    /**
      * Gets the type of processor
      */
     String getType();

--- a/server/src/main/java/org/opensearch/search/pipeline/SearchPhaseResultsProcessor.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/SearchPhaseResultsProcessor.java
@@ -34,16 +34,16 @@ public interface SearchPhaseResultsProcessor extends Processor {
 
     /**
      * Processes the {@link SearchPhaseResults} obtained from a SearchPhase which will be returned to next
-     * SearchPhase. Receives the {@link PipelinedRequestContext} passed to other processors.
+     * SearchPhase. Receives the {@link PipelineProcessingContext} passed to other processors.
      * @param searchPhaseResult {@link SearchPhaseResults}
      * @param searchPhaseContext {@link SearchContext}
-     * @param requestContext {@link PipelinedRequestContext}
+     * @param requestContext {@link PipelineProcessingContext}
      * @param <Result> {@link SearchPhaseResult}
      */
     default <Result extends SearchPhaseResult> void process(
         final SearchPhaseResults<Result> searchPhaseResult,
         final SearchPhaseContext searchPhaseContext,
-        final PipelinedRequestContext requestContext
+        final PipelineProcessingContext requestContext
     ) {
         process(searchPhaseResult, searchPhaseContext);
     }

--- a/server/src/main/java/org/opensearch/search/pipeline/SearchPhaseResultsProcessor.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/SearchPhaseResultsProcessor.java
@@ -33,6 +33,22 @@ public interface SearchPhaseResultsProcessor extends Processor {
     );
 
     /**
+     * Processes the {@link SearchPhaseResults} obtained from a SearchPhase which will be returned to next
+     * SearchPhase. Receives the {@link PipelinedRequestContext} passed to other processors.
+     * @param searchPhaseResult {@link SearchPhaseResults}
+     * @param searchPhaseContext {@link SearchContext}
+     * @param requestContext {@link PipelinedRequestContext}
+     * @param <Result> {@link SearchPhaseResult}
+     */
+    default <Result extends SearchPhaseResult> void process(
+        final SearchPhaseResults<Result> searchPhaseResult,
+        final SearchPhaseContext searchPhaseContext,
+        final PipelinedRequestContext requestContext
+    ) {
+        process(searchPhaseResult, searchPhaseContext);
+    }
+
+    /**
      * The phase which should have run before, this processor can start executing.
      * @return {@link SearchPhaseName}
      */

--- a/server/src/main/java/org/opensearch/search/pipeline/SearchPipelineService.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/SearchPipelineService.java
@@ -408,7 +408,7 @@ public class SearchPipelineService implements ClusterStateApplier, ReportingServ
                 pipeline = pipelineHolder.pipeline;
             }
         }
-        PipelinedRequestContext requestContext = new PipelinedRequestContext();
+        PipelineProcessingContext requestContext = new PipelineProcessingContext();
         return new PipelinedRequest(pipeline, searchRequest, requestContext);
     }
 

--- a/server/src/main/java/org/opensearch/search/pipeline/SearchPipelineService.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/SearchPipelineService.java
@@ -408,7 +408,8 @@ public class SearchPipelineService implements ClusterStateApplier, ReportingServ
                 pipeline = pipelineHolder.pipeline;
             }
         }
-        return new PipelinedRequest(pipeline, searchRequest);
+        Map<String, Object> requestContext = new HashMap<>();
+        return new PipelinedRequest(pipeline, searchRequest, requestContext);
     }
 
     Map<String, Processor.Factory<SearchRequestProcessor>> getRequestProcessorFactories() {

--- a/server/src/main/java/org/opensearch/search/pipeline/SearchPipelineService.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/SearchPipelineService.java
@@ -408,7 +408,7 @@ public class SearchPipelineService implements ClusterStateApplier, ReportingServ
                 pipeline = pipelineHolder.pipeline;
             }
         }
-        Map<String, Object> requestContext = new HashMap<>();
+        PipelinedRequestContext requestContext = new PipelinedRequestContext();
         return new PipelinedRequest(pipeline, searchRequest, requestContext);
     }
 

--- a/server/src/main/java/org/opensearch/search/pipeline/SearchRequestProcessor.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/SearchRequestProcessor.java
@@ -11,26 +11,28 @@ package org.opensearch.search.pipeline;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.core.action.ActionListener;
 
-import java.util.Map;
-
 /**
  * Interface for a search pipeline processor that modifies a search request.
  */
 public interface SearchRequestProcessor extends Processor {
-
     /**
-     * Transform a {@link SearchRequest}. Executed on the coordinator node before any {@link org.opensearch.action.search.SearchPhase}
-     * executes.
-     * <p>
+     * Process a SearchRequest without receiving request-scoped state.
      * Implement this method if the processor makes no asynchronous calls.
-     * @param request the executed {@link SearchRequest}
-     * @return a new {@link SearchRequest} (or the input {@link SearchRequest} if no changes)
-     * @throws Exception if an error occurs during processing
+     * @param request the search request (which may have been modified by an earlier processor)
+     * @return the modified search request
+     * @throws Exception implementation-specific processing exception
      */
     SearchRequest processRequest(SearchRequest request) throws Exception;
 
-
-    default SearchRequest processRequest(SearchRequest request, Map<String, Object> requestContext) throws Exception {
+    /**
+     * Process a SearchRequest, with request-scoped state shared across processors in the pipeline
+     * Implement this method if the processor makes no asynchronous calls.
+     * @param request the search request (which may have been modified by an earlier processor)
+     * @param requestContext request-scoped state shared across processors in the pipeline
+     * @return the modified search request
+     * @throws Exception implementation-specific processing exception
+     */
+    default SearchRequest processRequest(SearchRequest request, PipelinedRequestContext requestContext) throws Exception {
         return processRequest(request);
     }
 
@@ -42,7 +44,11 @@ public interface SearchRequestProcessor extends Processor {
      * @param request the executed {@link SearchRequest}
      * @param requestListener callback to be invoked on successful processing or on failure
      */
-    default void processRequestAsync(SearchRequest request, Map<String, Object> requestContext, ActionListener<SearchRequest> requestListener) {
+    default void processRequestAsync(
+        SearchRequest request,
+        PipelinedRequestContext requestContext,
+        ActionListener<SearchRequest> requestListener
+    ) {
         try {
             requestListener.onResponse(processRequest(request, requestContext));
         } catch (Exception e) {

--- a/server/src/main/java/org/opensearch/search/pipeline/SearchRequestProcessor.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/SearchRequestProcessor.java
@@ -32,7 +32,7 @@ public interface SearchRequestProcessor extends Processor {
      * @return the modified search request
      * @throws Exception implementation-specific processing exception
      */
-    default SearchRequest processRequest(SearchRequest request, PipelinedRequestContext requestContext) throws Exception {
+    default SearchRequest processRequest(SearchRequest request, PipelineProcessingContext requestContext) throws Exception {
         return processRequest(request);
     }
 
@@ -46,7 +46,7 @@ public interface SearchRequestProcessor extends Processor {
      */
     default void processRequestAsync(
         SearchRequest request,
-        PipelinedRequestContext requestContext,
+        PipelineProcessingContext requestContext,
         ActionListener<SearchRequest> requestListener
     ) {
         try {

--- a/server/src/main/java/org/opensearch/search/pipeline/SearchRequestProcessor.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/SearchRequestProcessor.java
@@ -11,6 +11,8 @@ package org.opensearch.search.pipeline;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.core.action.ActionListener;
 
+import java.util.Map;
+
 /**
  * Interface for a search pipeline processor that modifies a search request.
  */
@@ -27,6 +29,11 @@ public interface SearchRequestProcessor extends Processor {
      */
     SearchRequest processRequest(SearchRequest request) throws Exception;
 
+
+    default SearchRequest processRequest(SearchRequest request, Map<String, Object> requestContext) throws Exception {
+        return processRequest(request);
+    }
+
     /**
      * Transform a {@link SearchRequest}. Executed on the coordinator node before any {@link org.opensearch.action.search.SearchPhase}
      * executes.
@@ -35,9 +42,9 @@ public interface SearchRequestProcessor extends Processor {
      * @param request the executed {@link SearchRequest}
      * @param requestListener callback to be invoked on successful processing or on failure
      */
-    default void processRequestAsync(SearchRequest request, ActionListener<SearchRequest> requestListener) {
+    default void processRequestAsync(SearchRequest request, Map<String, Object> requestContext, ActionListener<SearchRequest> requestListener) {
         try {
-            requestListener.onResponse(processRequest(request));
+            requestListener.onResponse(processRequest(request, requestContext));
         } catch (Exception e) {
             requestListener.onFailure(e);
         }

--- a/server/src/main/java/org/opensearch/search/pipeline/SearchResponseProcessor.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/SearchResponseProcessor.java
@@ -12,6 +12,8 @@ import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.core.action.ActionListener;
 
+import java.util.Map;
+
 /**
  * Interface for a search pipeline processor that modifies a search response.
  */
@@ -28,6 +30,9 @@ public interface SearchResponseProcessor extends Processor {
      */
     SearchResponse processResponse(SearchRequest request, SearchResponse response) throws Exception;
 
+    default SearchResponse processResponse(SearchRequest request, SearchResponse response, Map<String, Object> requestContext) throws Exception {
+        return processResponse(request, response);
+    }
     /**
      * Transform a {@link SearchResponse}, possibly based on the executed {@link SearchRequest}.
      * <p>
@@ -36,9 +41,9 @@ public interface SearchResponseProcessor extends Processor {
      * @param response the current {@link SearchResponse}, possibly modified by earlier processors
      * @param responseListener callback to be invoked on successful processing or on failure
      */
-    default void processResponseAsync(SearchRequest request, SearchResponse response, ActionListener<SearchResponse> responseListener) {
+    default void processResponseAsync(SearchRequest request, SearchResponse response, Map<String, Object> requestContext, ActionListener<SearchResponse> responseListener) {
         try {
-            responseListener.onResponse(processResponse(request, response));
+            responseListener.onResponse(processResponse(request, response, requestContext));
         } catch (Exception e) {
             responseListener.onFailure(e);
         }

--- a/server/src/main/java/org/opensearch/search/pipeline/SearchResponseProcessor.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/SearchResponseProcessor.java
@@ -12,8 +12,6 @@ import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.core.action.ActionListener;
 
-import java.util.Map;
-
 /**
  * Interface for a search pipeline processor that modifies a search response.
  */
@@ -23,25 +21,45 @@ public interface SearchResponseProcessor extends Processor {
      * Transform a {@link SearchResponse}, possibly based on the executed {@link SearchRequest}.
      * <p>
      * Implement this method if the processor makes no asynchronous calls.
-     * @param request the executed {@link SearchRequest}
+     *
+     * @param request  the executed {@link SearchRequest}
      * @param response the current {@link SearchResponse}, possibly modified by earlier processors
      * @return a modified {@link SearchResponse} (or the input {@link SearchResponse} if no changes)
      * @throws Exception if an error occurs during processing
      */
     SearchResponse processResponse(SearchRequest request, SearchResponse response) throws Exception;
 
-    default SearchResponse processResponse(SearchRequest request, SearchResponse response, Map<String, Object> requestContext) throws Exception {
+    /**
+     * Process a SearchResponse, with request-scoped state shared across processors in the pipeline
+     * <p>
+     * Implement this method if the processor makes no asynchronous calls.
+     *
+     * @param request        the (maybe transformed) search request
+     * @param response       the search response (which may have been modified by an earlier processor)
+     * @param requestContext request-scoped state shared across processors in the pipeline
+     * @return the modified search response
+     * @throws Exception implementation-specific processing exception
+     */
+    default SearchResponse processResponse(SearchRequest request, SearchResponse response, PipelinedRequestContext requestContext)
+        throws Exception {
         return processResponse(request, response);
     }
+
     /**
      * Transform a {@link SearchResponse}, possibly based on the executed {@link SearchRequest}.
      * <p>
      * Expert method: Implement this if the processor needs to make asynchronous calls. Otherwise, implement processResponse.
-     * @param request the executed {@link SearchRequest}
-     * @param response the current {@link SearchResponse}, possibly modified by earlier processors
+     *
+     * @param request          the executed {@link SearchRequest}
+     * @param response         the current {@link SearchResponse}, possibly modified by earlier processors
      * @param responseListener callback to be invoked on successful processing or on failure
      */
-    default void processResponseAsync(SearchRequest request, SearchResponse response, Map<String, Object> requestContext, ActionListener<SearchResponse> responseListener) {
+    default void processResponseAsync(
+        SearchRequest request,
+        SearchResponse response,
+        PipelinedRequestContext requestContext,
+        ActionListener<SearchResponse> responseListener
+    ) {
         try {
             responseListener.onResponse(processResponse(request, response, requestContext));
         } catch (Exception e) {

--- a/server/src/main/java/org/opensearch/search/pipeline/SearchResponseProcessor.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/SearchResponseProcessor.java
@@ -40,7 +40,7 @@ public interface SearchResponseProcessor extends Processor {
      * @return the modified search response
      * @throws Exception implementation-specific processing exception
      */
-    default SearchResponse processResponse(SearchRequest request, SearchResponse response, PipelinedRequestContext requestContext)
+    default SearchResponse processResponse(SearchRequest request, SearchResponse response, PipelineProcessingContext requestContext)
         throws Exception {
         return processResponse(request, response);
     }
@@ -57,7 +57,7 @@ public interface SearchResponseProcessor extends Processor {
     default void processResponseAsync(
         SearchRequest request,
         SearchResponse response,
-        PipelinedRequestContext requestContext,
+        PipelineProcessingContext requestContext,
         ActionListener<SearchResponse> responseListener
     ) {
         try {

--- a/server/src/main/java/org/opensearch/search/pipeline/StatefulSearchRequestProcessor.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/StatefulSearchRequestProcessor.java
@@ -9,18 +9,17 @@
 package org.opensearch.search.pipeline;
 
 import org.opensearch.action.search.SearchRequest;
-import org.opensearch.core.action.ActionListener;
-
-import java.util.Map;
 
 /**
  * A specialization of {@link SearchRequestProcessor} that makes use of the request-scoped processor state.
+ * Implementors must implement the processRequest method that accepts request-scoped processor state.
  */
 public interface StatefulSearchRequestProcessor extends SearchRequestProcessor {
     @Override
     default SearchRequest processRequest(SearchRequest request) {
         throw new UnsupportedOperationException();
     }
+
     @Override
-    SearchRequest processRequest(SearchRequest request, Map<String, Object> requestContext) throws Exception;
+    SearchRequest processRequest(SearchRequest request, PipelinedRequestContext requestContext) throws Exception;
 }

--- a/server/src/main/java/org/opensearch/search/pipeline/StatefulSearchRequestProcessor.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/StatefulSearchRequestProcessor.java
@@ -21,5 +21,5 @@ public interface StatefulSearchRequestProcessor extends SearchRequestProcessor {
     }
 
     @Override
-    SearchRequest processRequest(SearchRequest request, PipelinedRequestContext requestContext) throws Exception;
+    SearchRequest processRequest(SearchRequest request, PipelineProcessingContext requestContext) throws Exception;
 }

--- a/server/src/main/java/org/opensearch/search/pipeline/StatefulSearchRequestProcessor.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/StatefulSearchRequestProcessor.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.pipeline;
+
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.core.action.ActionListener;
+
+import java.util.Map;
+
+/**
+ * A specialization of {@link SearchRequestProcessor} that makes use of the request-scoped processor state.
+ */
+public interface StatefulSearchRequestProcessor extends SearchRequestProcessor {
+    @Override
+    default SearchRequest processRequest(SearchRequest request) {
+        throw new UnsupportedOperationException();
+    }
+    @Override
+    SearchRequest processRequest(SearchRequest request, Map<String, Object> requestContext) throws Exception;
+}

--- a/server/src/main/java/org/opensearch/search/pipeline/StatefulSearchResponseProcessor.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/StatefulSearchResponseProcessor.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.pipeline;
+
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.core.action.ActionListener;
+
+import java.util.Map;
+
+/**
+ * A specialization of {@link SearchResponseProcessor} that makes use of the request-scoped processor state.
+ */
+public interface StatefulSearchResponseProcessor extends SearchResponseProcessor {
+    @Override
+    default SearchResponse processResponse(SearchRequest request, SearchResponse response) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    SearchResponse processResponse(SearchRequest request, SearchResponse response, Map<String, Object> requestContext) throws Exception;
+}

--- a/server/src/main/java/org/opensearch/search/pipeline/StatefulSearchResponseProcessor.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/StatefulSearchResponseProcessor.java
@@ -10,12 +10,10 @@ package org.opensearch.search.pipeline;
 
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
-import org.opensearch.core.action.ActionListener;
-
-import java.util.Map;
 
 /**
  * A specialization of {@link SearchResponseProcessor} that makes use of the request-scoped processor state.
+ * Implementors must implement the processResponse method that accepts request-scoped processor state.
  */
 public interface StatefulSearchResponseProcessor extends SearchResponseProcessor {
     @Override
@@ -24,5 +22,5 @@ public interface StatefulSearchResponseProcessor extends SearchResponseProcessor
     }
 
     @Override
-    SearchResponse processResponse(SearchRequest request, SearchResponse response, Map<String, Object> requestContext) throws Exception;
+    SearchResponse processResponse(SearchRequest request, SearchResponse response, PipelinedRequestContext requestContext) throws Exception;
 }

--- a/server/src/main/java/org/opensearch/search/pipeline/StatefulSearchResponseProcessor.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/StatefulSearchResponseProcessor.java
@@ -22,5 +22,6 @@ public interface StatefulSearchResponseProcessor extends SearchResponseProcessor
     }
 
     @Override
-    SearchResponse processResponse(SearchRequest request, SearchResponse response, PipelinedRequestContext requestContext) throws Exception;
+    SearchResponse processResponse(SearchRequest request, SearchResponse response, PipelineProcessingContext requestContext)
+        throws Exception;
 }

--- a/server/src/test/java/org/opensearch/search/pipeline/SearchPipelineServiceTests.java
+++ b/server/src/test/java/org/opensearch/search/pipeline/SearchPipelineServiceTests.java
@@ -41,8 +41,8 @@ import org.opensearch.common.metrics.OperationStats;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.AtomicArray;
 import org.opensearch.common.util.concurrent.OpenSearchExecutors;
-import org.opensearch.core.action.ActionListener;
 import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.breaker.CircuitBreaker;
 import org.opensearch.core.common.breaker.NoopCircuitBreaker;
 import org.opensearch.core.common.bytes.BytesArray;
@@ -1397,8 +1397,8 @@ public class SearchPipelineServiceTests extends OpenSearchTestCase {
         }
 
         @Override
-        public SearchRequest processRequest(SearchRequest request, Map<String, Object> requestContext) throws Exception {
-            stateConsumer.accept(requestContext);
+        public SearchRequest processRequest(SearchRequest request, PipelinedRequestContext requestContext) throws Exception {
+            stateConsumer.accept(requestContext.getGenericRequestContext());
             return request;
         }
     }
@@ -1419,9 +1419,9 @@ public class SearchPipelineServiceTests extends OpenSearchTestCase {
         }
 
         @Override
-        public SearchResponse processResponse(SearchRequest request, SearchResponse response, Map<String, Object> requestContext)
+        public SearchResponse processResponse(SearchRequest request, SearchResponse response, PipelinedRequestContext requestContext)
             throws Exception {
-            stateConsumer.accept(requestContext);
+            stateConsumer.accept(requestContext.getGenericRequestContext());
             return response;
         }
     }

--- a/server/src/test/java/org/opensearch/search/pipeline/SearchPipelineServiceTests.java
+++ b/server/src/test/java/org/opensearch/search/pipeline/SearchPipelineServiceTests.java
@@ -1383,9 +1383,9 @@ public class SearchPipelineServiceTests extends OpenSearchTestCase {
 
     private static class FakeStatefulRequestProcessor extends AbstractProcessor implements StatefulSearchRequestProcessor {
         private final String type;
-        private final Consumer<PipelinedRequestContext> stateConsumer;
+        private final Consumer<PipelineProcessingContext> stateConsumer;
 
-        public FakeStatefulRequestProcessor(String type, Consumer<PipelinedRequestContext> stateConsumer) {
+        public FakeStatefulRequestProcessor(String type, Consumer<PipelineProcessingContext> stateConsumer) {
             super(null, null, false);
             this.type = type;
             this.stateConsumer = stateConsumer;
@@ -1397,7 +1397,7 @@ public class SearchPipelineServiceTests extends OpenSearchTestCase {
         }
 
         @Override
-        public SearchRequest processRequest(SearchRequest request, PipelinedRequestContext requestContext) throws Exception {
+        public SearchRequest processRequest(SearchRequest request, PipelineProcessingContext requestContext) throws Exception {
             stateConsumer.accept(requestContext);
             return request;
         }
@@ -1405,9 +1405,9 @@ public class SearchPipelineServiceTests extends OpenSearchTestCase {
 
     private static class FakeStatefulResponseProcessor extends AbstractProcessor implements StatefulSearchResponseProcessor {
         private final String type;
-        private final Consumer<PipelinedRequestContext> stateConsumer;
+        private final Consumer<PipelineProcessingContext> stateConsumer;
 
-        public FakeStatefulResponseProcessor(String type, Consumer<PipelinedRequestContext> stateConsumer) {
+        public FakeStatefulResponseProcessor(String type, Consumer<PipelineProcessingContext> stateConsumer) {
             super(null, null, false);
             this.type = type;
             this.stateConsumer = stateConsumer;
@@ -1419,7 +1419,7 @@ public class SearchPipelineServiceTests extends OpenSearchTestCase {
         }
 
         @Override
-        public SearchResponse processResponse(SearchRequest request, SearchResponse response, PipelinedRequestContext requestContext)
+        public SearchResponse processResponse(SearchRequest request, SearchResponse response, PipelineProcessingContext requestContext)
             throws Exception {
             stateConsumer.accept(requestContext);
             return response;

--- a/server/src/test/java/org/opensearch/search/pipeline/SearchPipelineServiceTests.java
+++ b/server/src/test/java/org/opensearch/search/pipeline/SearchPipelineServiceTests.java
@@ -42,6 +42,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.AtomicArray;
 import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.common.breaker.CircuitBreaker;
 import org.opensearch.core.common.breaker.NoopCircuitBreaker;
 import org.opensearch.core.common.bytes.BytesArray;
@@ -68,6 +69,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import static org.mockito.ArgumentMatchers.anyString;
@@ -1377,5 +1379,90 @@ public class SearchPipelineServiceTests extends OpenSearchTestCase {
         } catch (Exception e) {
             fail("Wrong exception type: " + e.getClass());
         }
+    }
+
+    private static class FakeStatefulRequestProcessor extends AbstractProcessor implements StatefulSearchRequestProcessor {
+        private final String type;
+        private final Consumer<Map<String, Object>> stateConsumer;
+
+        public FakeStatefulRequestProcessor(String type, Consumer<Map<String, Object>> stateConsumer) {
+            super(null, null, false);
+            this.type = type;
+            this.stateConsumer = stateConsumer;
+        }
+
+        @Override
+        public String getType() {
+            return type;
+        }
+
+        @Override
+        public SearchRequest processRequest(SearchRequest request, Map<String, Object> requestContext) throws Exception {
+            stateConsumer.accept(requestContext);
+            return request;
+        }
+    }
+
+    private static class FakeStatefulResponseProcessor extends AbstractProcessor implements StatefulSearchResponseProcessor {
+        private final String type;
+        private final Consumer<Map<String, Object>> stateConsumer;
+
+        public FakeStatefulResponseProcessor(String type, Consumer<Map<String, Object>> stateConsumer) {
+            super(null, null, false);
+            this.type = type;
+            this.stateConsumer = stateConsumer;
+        }
+
+        @Override
+        public String getType() {
+            return type;
+        }
+
+        @Override
+        public SearchResponse processResponse(SearchRequest request, SearchResponse response, Map<String, Object> requestContext)
+            throws Exception {
+            stateConsumer.accept(requestContext);
+            return response;
+        }
+    }
+
+    public void testStatefulProcessors() throws Exception {
+        AtomicReference<String> contextHolder = new AtomicReference<>();
+        SearchPipelineService searchPipelineService = createWithProcessors(
+            Map.of("write_context", (pf, t, d, igf, cfg, ctx) -> new FakeStatefulRequestProcessor("write_context", (c) -> c.put("a", "b"))),
+            Map.of(
+                "read_context",
+                (pf, t, d, igf, cfg, ctx) -> new FakeStatefulResponseProcessor(
+                    "read_context",
+                    (c) -> contextHolder.set((String) c.get("a"))
+                )
+            ),
+            Collections.emptyMap()
+        );
+
+        SearchPipelineMetadata metadata = new SearchPipelineMetadata(
+            Map.of(
+                "p1",
+                new PipelineConfiguration(
+                    "p1",
+                    new BytesArray(
+                        "{\"request_processors\" : [ { \"write_context\": {} } ], \"response_processors\": [ { \"read_context\": {} }] }"
+                    ),
+                    XContentType.JSON
+                )
+            )
+        );
+        ClusterState clusterState = ClusterState.builder(new ClusterName("_name")).build();
+        ClusterState previousState = clusterState;
+        clusterState = ClusterState.builder(clusterState)
+            .metadata(Metadata.builder().putCustom(SearchPipelineMetadata.TYPE, metadata))
+            .build();
+        searchPipelineService.applyClusterState(new ClusterChangedEvent("", clusterState, previousState));
+
+        PipelinedRequest request = searchPipelineService.resolvePipeline(new SearchRequest().pipeline("p1"));
+        assertNull(contextHolder.get());
+        syncExecutePipeline(request, new SearchResponse(null, null, 0, 0, 0, 0, null, null));
+        assertNotNull(contextHolder.get());
+        assertEquals("b", contextHolder.get());
     }
 }


### PR DESCRIPTION
To handle cases where multiple search pipeline processors need to share information, we will allocate a Map<String, Object> for the lifetime of the request and pass it to each processor to get/set values.


### Description
To handle cases where multiple search pipeline processors need to share information, we will allocate a `Map<String, Object>` for the lifetime of the request and pass it to each processor to get/set values.

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/6722

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
