### PR TITLE
[BUG] Reconstruct pit infos when deserialize GetAllPitNodesResponse

### DIFF
--- a/server/src/main/java/org/opensearch/action/search/GetAllPitNodesResponse.java
+++ b/server/src/main/java/org/opensearch/action/search/GetAllPitNodesResponse.java
@@ -41,6 +41,12 @@ public class GetAllPitNodesResponse extends BaseNodesResponse<GetAllPitNodeRespo
 
     public GetAllPitNodesResponse(StreamInput in) throws IOException {
         super(in);
+        Set<String> uniquePitIds = new HashSet<>();
+        pitInfos.addAll(
+            getNodes().stream()
+                .flatMap(p -> p.getPitInfos().stream().filter(t -> uniquePitIds.add(t.getPitId())))
+                .collect(Collectors.toList())
+        );
     }
 
     public GetAllPitNodesResponse(

--- a/server/src/main/java/org/opensearch/action/search/ListPitInfo.java
+++ b/server/src/main/java/org/opensearch/action/search/ListPitInfo.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.action.search;
 
+import java.io.IOException;
+import java.util.Objects;
 import org.opensearch.core.ParseField;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -15,8 +17,6 @@ import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.core.xcontent.ConstructingObjectParser;
 import org.opensearch.core.xcontent.ToXContentFragment;
 import org.opensearch.core.xcontent.XContentBuilder;
-
-import java.io.IOException;
 
 import static org.opensearch.core.xcontent.ConstructingObjectParser.constructorArg;
 
@@ -78,6 +78,19 @@ public class ListPitInfo implements ToXContentFragment, Writeable {
         builder.field(KEEP_ALIVE.getPreferredName(), keepAlive);
         builder.endObject();
         return builder;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ListPitInfo that = (ListPitInfo) o;
+        return pitId.equals(that.pitId) && creationTime == that.creationTime && keepAlive == that.keepAlive;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(pitId, creationTime, keepAlive);
     }
 
 }

--- a/server/src/main/java/org/opensearch/action/search/ListPitInfo.java
+++ b/server/src/main/java/org/opensearch/action/search/ListPitInfo.java
@@ -8,8 +8,6 @@
 
 package org.opensearch.action.search;
 
-import java.io.IOException;
-import java.util.Objects;
 import org.opensearch.core.ParseField;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -17,6 +15,9 @@ import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.core.xcontent.ConstructingObjectParser;
 import org.opensearch.core.xcontent.ToXContentFragment;
 import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Objects;
 
 import static org.opensearch.core.xcontent.ConstructingObjectParser.constructorArg;
 

--- a/server/src/test/java/org/opensearch/action/search/GetAllPitNodesResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/search/GetAllPitNodesResponseTests.java
@@ -8,12 +8,6 @@
 
 package org.opensearch.action.search;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 import org.opensearch.Version;
 import org.opensearch.action.FailedNodeException;
 import org.opensearch.cluster.ClusterName;
@@ -21,6 +15,13 @@ import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.TransportException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
@@ -73,8 +74,13 @@ public class GetAllPitNodesResponseTests extends OpenSearchTestCase {
         List<GetAllPitNodeResponse> responses = new ArrayList<>();
         List<FailedNodeException> failures = new ArrayList<>();
         for (int i = 0; i < numNodes; i++) {
-            DiscoveryNode node =
-                new DiscoveryNode(randomAlphaOfLength(10), buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT);
+            DiscoveryNode node = new DiscoveryNode(
+                randomAlphaOfLength(10),
+                buildNewFakeTransportAddress(),
+                emptyMap(),
+                emptySet(),
+                Version.CURRENT
+            );
             if (randomBoolean()) {
                 List<ListPitInfo> nodePitInfos = new ArrayList<>();
                 for (int j = 0; j < randomInt(numPits); j++) {
@@ -82,10 +88,9 @@ public class GetAllPitNodesResponseTests extends OpenSearchTestCase {
                 }
                 responses.add(new GetAllPitNodeResponse(node, nodePitInfos));
             } else {
-                failures.add(new FailedNodeException(node.getId(),
-                    randomAlphaOfLength(10),
-                    new TransportException(randomAlphaOfLength(10))
-                ));
+                failures.add(
+                    new FailedNodeException(node.getId(), randomAlphaOfLength(10), new TransportException(randomAlphaOfLength(10)))
+                );
             }
         }
         return new GetAllPitNodesResponse(new ClusterName("test"), responses, failures);

--- a/server/src/test/java/org/opensearch/action/search/GetAllPitNodesResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/search/GetAllPitNodesResponseTests.java
@@ -1,0 +1,93 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.search;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.opensearch.Version;
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.TransportException;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
+
+public class GetAllPitNodesResponseTests extends OpenSearchTestCase {
+    protected void assertEqualInstances(GetAllPitNodesResponse expected, GetAllPitNodesResponse actual) {
+        assertNotSame(expected, actual);
+        Set<ListPitInfo> expectedPitInfos = new HashSet<>(expected.getPitInfos());
+        Set<ListPitInfo> actualPitInfos = new HashSet<>(actual.getPitInfos());
+        assertEquals(expectedPitInfos, actualPitInfos);
+
+        List<GetAllPitNodeResponse> expectedResponses = expected.getNodes();
+        List<GetAllPitNodeResponse> actualResponses = actual.getNodes();
+        assertEquals(expectedResponses.size(), actualResponses.size());
+        for (int i = 0; i < expectedResponses.size(); i++) {
+            assertEquals(expectedResponses.get(i).getNode(), actualResponses.get(i).getNode());
+            Set<ListPitInfo> expectedNodePitInfos = new HashSet<>(expectedResponses.get(i).getPitInfos());
+            Set<ListPitInfo> actualNodePitInfos = new HashSet<>(actualResponses.get(i).getPitInfos());
+            assertEquals(expectedNodePitInfos, actualNodePitInfos);
+        }
+
+        List<FailedNodeException> expectedFailures = expected.failures();
+        List<FailedNodeException> actualFailures = actual.failures();
+        assertEquals(expectedFailures.size(), actualFailures.size());
+        for (int i = 0; i < expectedFailures.size(); i++) {
+            assertEquals(expectedFailures.get(i).nodeId(), actualFailures.get(i).nodeId());
+            assertEquals(expectedFailures.get(i).getMessage(), actualFailures.get(i).getMessage());
+            assertEquals(expectedFailures.get(i).getCause().getClass(), actualFailures.get(i).getCause().getClass());
+        }
+    }
+
+    protected NamedWriteableRegistry getNamedWriteableRegistry() {
+        return new NamedWriteableRegistry(Collections.emptyList());
+    }
+
+    public void testSerialization() throws IOException {
+        GetAllPitNodesResponse response = createTestItem();
+        GetAllPitNodesResponse deserialized = copyWriteable(response, getNamedWriteableRegistry(), GetAllPitNodesResponse::new);
+        assertEqualInstances(response, deserialized);
+    }
+
+    private GetAllPitNodesResponse createTestItem() {
+        int numNodes = randomIntBetween(1, 10);
+        int numPits = randomInt(10);
+        List<ListPitInfo> candidatePitInfos = new ArrayList<>(numPits);
+        for (int i = 0; i < numNodes; i++) {
+            candidatePitInfos.add(new ListPitInfo(randomAlphaOfLength(10), randomLong(), randomLong()));
+        }
+
+        List<GetAllPitNodeResponse> responses = new ArrayList<>();
+        List<FailedNodeException> failures = new ArrayList<>();
+        for (int i = 0; i < numNodes; i++) {
+            DiscoveryNode node =
+                new DiscoveryNode(randomAlphaOfLength(10), buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT);
+            if (randomBoolean()) {
+                List<ListPitInfo> nodePitInfos = new ArrayList<>();
+                for (int j = 0; j < randomInt(numPits); j++) {
+                    nodePitInfos.add(randomFrom(candidatePitInfos));
+                }
+                responses.add(new GetAllPitNodeResponse(node, nodePitInfos));
+            } else {
+                failures.add(new FailedNodeException(node.getId(),
+                    randomAlphaOfLength(10),
+                    new TransportException(randomAlphaOfLength(10))
+                ));
+            }
+        }
+        return new GetAllPitNodesResponse(new ClusterName("test"), responses, failures);
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Today, we haven't reconstructed pit infos when deserialize GetAllPitNodesResponse, which causes corresponding field is empty.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
