### PR TITLE
Fix testClusterRelocationNoPreferenceShardMovementPrimaryFirstEnabled failure due to timeout

### DIFF
--- a/server/src/test/java/org/opensearch/cluster/routing/ShardMovementStrategyTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/ShardMovementStrategyTests.java
@@ -55,24 +55,23 @@ public class ShardMovementStrategyTests extends OpenSearchIntegTestCase {
             .put("cluster.routing.allocation.move.primary_first", movePrimaryFirst);
     }
 
-    public void testClusterGreenAfterPartialRelocationPrimaryFirstShardMovementMovePrimarySettingEnabled() throws InterruptedException {
+    public void testClusterRelocationPrimaryFirstShardMovementMovePrimarySettingEnabled() throws InterruptedException {
         testClusterGreenAfterPartialRelocation(ShardMovementStrategy.PRIMARY_FIRST, true);
     }
 
-    public void testClusterGreenAfterPartialRelocationPrimaryFirstShardMovementMovePrimarySettingDisabled() throws InterruptedException {
+    public void testClusterRelocationPrimaryFirstShardMovementMovePrimarySettingDisabled() throws InterruptedException {
         testClusterGreenAfterPartialRelocation(ShardMovementStrategy.PRIMARY_FIRST, false);
     }
 
-    public void testClusterGreenAfterPartialRelocationReplicaFirstShardMovementPrimaryFirstEnabled() throws InterruptedException {
+    public void testClusterRelocationReplicaFirstShardMovementPrimaryFirstEnabled() throws InterruptedException {
         testClusterGreenAfterPartialRelocation(ShardMovementStrategy.REPLICA_FIRST, true);
     }
 
-    public void testClusterGreenAfterPartialRelocationReplicaFirstShardMovementPrimaryFirstDisabled() throws InterruptedException {
+    public void testClusterRelocationReplicaFirstShardMovementPrimaryFirstDisabled() throws InterruptedException {
         testClusterGreenAfterPartialRelocation(ShardMovementStrategy.REPLICA_FIRST, false);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/9178")
-    public void testClusterGreenAfterPartialRelocationNoPreferenceShardMovementPrimaryFirstEnabled() throws InterruptedException {
+    public void testClusterRelocationNoPreferenceShardMovementPrimaryFirstEnabled() throws InterruptedException {
         testClusterGreenAfterPartialRelocation(ShardMovementStrategy.NO_PREFERENCE, true);
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fixes the flaky timeout issue on testClusterRelocationNoPreferenceShardMovementPrimaryFirstEnabled so it passes every time as expected. 

The issue was incorrect detection of the primary first shard movement strategy for throttling in the event that `ShardMovementStrategy` is set to `NO_PREFERENCE` and `movePrimaryFirst` deprecated setting is set to `true`.
Changed the logic of setting the shard movement strategy value. 

### Related Issues
Resolves #9178 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
