### PR TITLE
Skip upload of segments_N file

### DIFF
--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -4664,7 +4664,10 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         // are uploaded to the remote segment store.
         RemoteSegmentMetadata remoteSegmentMetadata = remoteDirectory.init();
 
-        assert remoteSegmentMetadata != null : "RemoteSegmentMetadata should not be null";
+        if (remoteSegmentMetadata == null) {
+            logger.info("Remote segment metadata is null, this can happen if there is no data in the remote segment store");
+            return;
+        }
 
         Map<String, RemoteSegmentStoreDirectory.UploadedSegmentMetadata> uploadedSegments = remoteDirectory
             .getSegmentsUploadedToRemoteStore()

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -221,7 +221,7 @@ public final class RemoteStoreRefreshListener extends CloseableRetryableRefreshL
                     // Capture replication checkpoint before uploading the segments as upload can take some time and checkpoint can
                     // move.
                     long lastRefreshedCheckpoint = ((InternalEngine) indexShard.getEngine()).lastRefreshedCheckpoint();
-                    Collection<String> localSegmentsPostRefresh = segmentInfos.files(true);
+                    Collection<String> localSegmentsPostRefresh = segmentInfos.files(false);
 
                     // Create a map of file name to size and update the refresh segment tracker
                     updateLocalSizeMapAndTracker(localSegmentsPostRefresh);

--- a/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
@@ -530,7 +530,7 @@ final class StoreRecovery {
         remoteStore.incRef();
         try {
             // Download segments from remote segment store
-            indexShard.syncSegmentsFromRemoteSegmentStore(true, true);
+            indexShard.syncSegmentsFromRemoteSegmentStore(true);
 
             if (store.directory().listAll().length == 0) {
                 store.createEmpty(indexShard.indexSettings().getIndexVersionCreated().luceneVersion);

--- a/server/src/main/java/org/opensearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/PeerRecoveryTargetService.java
@@ -245,7 +245,7 @@ public class PeerRecoveryTargetService implements IndexEventListener {
                     indexShard.prepareForIndexRecovery();
                     final boolean hasRemoteSegmentStore = indexShard.indexSettings().isRemoteStoreEnabled();
                     if (hasRemoteSegmentStore) {
-                        indexShard.syncSegmentsFromRemoteSegmentStore(false, true);
+                        indexShard.syncSegmentsFromRemoteSegmentStore(false);
                     }
                     final boolean hasRemoteTranslog = recoveryTarget.state().getPrimary() == false && indexShard.isRemoteTranslogEnabled();
                     final boolean hasNoTranslog = indexShard.indexSettings().isRemoteSnapshot();

--- a/server/src/test/java/org/opensearch/index/shard/RemoteIndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteIndexShardTests.java
@@ -199,11 +199,6 @@ public class RemoteIndexShardTests extends SegmentReplicationIndexShardTests {
             assertNotNull(primaryEngine);
             final SegmentInfos latestCommit = SegmentInfos.readLatestCommit(primary.store().directory());
             assertEquals("On-disk commit references no segments", Set.of("segments_3"), latestCommit.files(true));
-            assertEquals(
-                "Latest remote commit On-disk commit references no segments",
-                Set.of("segments_3"),
-                primary.remoteStore().readLastCommittedSegmentsInfo().files(true)
-            );
             MatcherAssert.assertThat(
                 "Segments are referenced in memory only",
                 primaryEngine.getSegmentInfosSnapshot().get().files(false),

--- a/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
@@ -423,7 +423,7 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
         assertEquals(0, tracker.getTimeMsLag());
         assertEquals(0, tracker.getRejectionCount());
         assertEquals(tracker.getUploadBytesStarted(), tracker.getUploadBytesSucceeded());
-        assertTrue(tracker.getUploadBytesStarted() > 0);
+        assertEquals(0, tracker.getUploadBytesStarted());
         assertEquals(0, tracker.getUploadBytesFailed());
         assertEquals(0, tracker.getInflightUploads());
         assertEquals(tracker.getTotalUploadsStarted(), tracker.getTotalUploadsSucceeded());
@@ -557,15 +557,11 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
     private void verifyUploadedSegments(RemoteSegmentStoreDirectory remoteSegmentStoreDirectory) throws IOException {
         Map<String, RemoteSegmentStoreDirectory.UploadedSegmentMetadata> uploadedSegments = remoteSegmentStoreDirectory
             .getSegmentsUploadedToRemoteStore();
-        String segmentsNFilename = null;
         try (GatedCloseable<SegmentInfos> segmentInfosGatedCloseable = indexShard.getSegmentInfosSnapshot()) {
             SegmentInfos segmentInfos = segmentInfosGatedCloseable.get();
             for (String file : segmentInfos.files(true)) {
-                if (!RemoteStoreRefreshListener.EXCLUDE_FILES.contains(file)) {
+                if (RemoteStoreRefreshListener.EXCLUDE_FILES.contains(file) == false && file.startsWith(IndexFileNames.SEGMENTS) == false) {
                     assertTrue(uploadedSegments.containsKey(file));
-                }
-                if (file.startsWith(IndexFileNames.SEGMENTS)) {
-                    segmentsNFilename = file;
                 }
             }
         }


### PR DESCRIPTION
### Description
- Currently, while uploading segments to remote segment store, we upload existing `segments_N` file as well.
- But we don't use the `segments_N` file in the download flow as we commit `SegmentInfosSnapshot` that is stored in the form of bytes in remote segment metadata.
- In this change, we skip uploading the `segments_N` file.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/9433

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
