### PR TITLE
Remove spurious SGID bit on directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Deprecated
 
 ### Removed
+- Remove spurious SGID bit on directories ([#9447](https://github.com/opensearch-project/OpenSearch/pull/9447))
 
 ### Fixed
 - Fix ignore_missing parameter has no effect when using template snippet in rename ingest processor ([#9725](https://github.com/opensearch-project/OpenSearch/pull/9725))

--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -213,7 +213,7 @@ Closure commonPackageConfig(String type, boolean jdk, String architecture) {
     configurationFile '/etc/opensearch/jvm.options'
     configurationFile '/etc/opensearch/log4j2.properties'
     from("${packagingFiles}") {
-      dirMode 02750
+      dirMode 0750
       into('/etc')
       permissionGroup 'opensearch'
       includeEmptyDirs true
@@ -223,7 +223,7 @@ Closure commonPackageConfig(String type, boolean jdk, String architecture) {
     }
     from("${packagingFiles}/etc/opensearch") {
       into('/etc/opensearch')
-      dirMode 02750
+      dirMode 0750
       fileMode 0660
       permissionGroup 'opensearch'
       includeEmptyDirs true
@@ -281,8 +281,8 @@ Closure commonPackageConfig(String type, boolean jdk, String architecture) {
         dirMode mode
       }
     }
-    copyEmptyDir('/var/log/opensearch', 'opensearch', 'opensearch', 02750)
-    copyEmptyDir('/var/lib/opensearch', 'opensearch', 'opensearch', 02750)
+    copyEmptyDir('/var/log/opensearch', 'opensearch', 'opensearch', 0750)
+    copyEmptyDir('/var/lib/opensearch', 'opensearch', 'opensearch', 0750)
     copyEmptyDir('/usr/share/opensearch/plugins', 'root', 'root', 0755)
 
     into '/usr/share/opensearch'

--- a/distribution/packages/src/deb/lintian/opensearch
+++ b/distribution/packages/src/deb/lintian/opensearch
@@ -15,11 +15,11 @@ missing-dep-on-jarwrapper
 
 # we prefer to not make our config and log files world readable
 non-standard-file-perm etc/default/opensearch 0660 != 0644
-non-standard-dir-perm etc/opensearch/ 2750 != 0755
-non-standard-dir-perm etc/opensearch/jvm.options.d/ 2750 != 0755
+non-standard-dir-perm etc/opensearch/ 0750 != 0755
+non-standard-dir-perm etc/opensearch/jvm.options.d/ 0750 != 0755
 non-standard-file-perm etc/opensearch/*
-non-standard-dir-perm var/lib/opensearch/ 2750 != 0755
-non-standard-dir-perm var/log/opensearch/ 2750 != 0755
+non-standard-dir-perm var/lib/opensearch/ 0750 != 0755
+non-standard-dir-perm var/log/opensearch/ 0750 != 0755
 executable-is-not-world-readable etc/init.d/opensearch 0750
 non-standard-file-permissions-for-etc-init.d-script etc/init.d/opensearch 0750 != 0755
 

--- a/qa/os/src/test/java/org/opensearch/packaging/util/Packages.java
+++ b/qa/os/src/test/java/org/opensearch/packaging/util/Packages.java
@@ -194,11 +194,11 @@ public class Packages {
 
         // we shell out here because java's posix file permission view doesn't support special modes
         assertThat(opensearch.config, file(Directory, "root", "opensearch", p750));
-        assertThat(sh.run("find \"" + opensearch.config + "\" -maxdepth 0 -printf \"%m\"").stdout, containsString("2750"));
+        assertThat(sh.run("find \"" + opensearch.config + "\" -maxdepth 0 -printf \"%m\"").stdout, containsString("750"));
 
         final Path jvmOptionsDirectory = opensearch.config.resolve("jvm.options.d");
         assertThat(jvmOptionsDirectory, file(Directory, "root", "opensearch", p750));
-        assertThat(sh.run("find \"" + jvmOptionsDirectory + "\" -maxdepth 0 -printf \"%m\"").stdout, containsString("2750"));
+        assertThat(sh.run("find \"" + jvmOptionsDirectory + "\" -maxdepth 0 -printf \"%m\"").stdout, containsString("750"));
 
         Stream.of("opensearch.keystore", "opensearch.yml", "jvm.options", "log4j2.properties")
             .forEach(configFile -> assertThat(opensearch.config(configFile), file(File, "root", "opensearch", p660)));


### PR DESCRIPTION
### Description
While working on improving OpenSearch packaging in https://github.com/opensearch-project/opensearch-build/pull/3898, we saw that some unexpected SGID bit was set on some directories and that we had to remove it to match the default packages behavior of packages on Debian.

The SGID bit can be tracked to https://github.com/rjernst/elasticsearch/commit/a5c18f15b252747bc8c62372bc8e07a36572e441 where it was added so that on first start, the opensearch service has access to the keystore initialized by the root user.  However, when deploying OpenSearch today, the keystore is created by the opensearch user and the SGID bit is not required anymore.

This PR remove the code that sets these SGID bits so that we do not need to clean them anymore when packaging.


### Related Issues
* https://github.com/opensearch-project/opensearch-build/issues/3815
* https://github.com/opensearch-project/opensearch-build/pull/3898

### Check List
- [x] Commits are signed per the DCO using --signoff
