### PR TITLE
Fix updating the parent span

### DIFF
--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/DefaultTracer.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/DefaultTracer.java
@@ -77,7 +77,11 @@ class DefaultTracer implements Tracer {
     private void endSpan(Span span) {
         if (span != null) {
             span.endSpan();
-            setCurrentSpanInContext(span.getParentSpan());
+            if (span.getParentSpan() != null && !span.getParentSpan().hasEnded()) {
+                setCurrentSpanInContext(span.getParentSpan());
+            } else {
+                setCurrentSpanInContext(null);
+            }
         }
     }
 

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/Span.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/Span.java
@@ -90,4 +90,10 @@ public interface Span {
      */
     String getSpanId();
 
+    /**
+     * Returns whether the span is ended or not.
+     * @return Span end Status.
+     */
+    boolean hasEnded();
+
 }

--- a/plugins/telemetry-otel/src/main/java/org/opensearch/telemetry/tracing/OTelSpan.java
+++ b/plugins/telemetry-otel/src/main/java/org/opensearch/telemetry/tracing/OTelSpan.java
@@ -69,6 +69,11 @@ class OTelSpan extends AbstractSpan {
         return delegateSpan.getSpanContext().getSpanId();
     }
 
+    @Override
+    public boolean hasEnded() {
+        return !delegateSpan.isRecording();
+    }
+
     io.opentelemetry.api.trace.Span getDelegateSpan() {
         return delegateSpan;
     }

--- a/plugins/telemetry-otel/src/test/java/org/opensearch/telemetry/tracing/OTelSpanTests.java
+++ b/plugins/telemetry-otel/src/test/java/org/opensearch/telemetry/tracing/OTelSpanTests.java
@@ -31,6 +31,15 @@ public class OTelSpanTests extends OpenSearchTestCase {
         verify(mockSpan).end();
     }
 
+    public void testHasEndSpanTest() {
+        Span mockSpan = getMockSpan();
+        when(mockSpan.isRecording()).thenReturn(false);
+        OTelSpan oTelSpan = new OTelSpan("spanName", mockSpan, null);
+        oTelSpan.endSpan();
+        assertTrue(oTelSpan.hasEnded());
+        verify(mockSpan).end();
+    }
+
     public void testAddAttributeString() {
         Span mockSpan = getMockSpan();
         OTelSpan oTelSpan = new OTelSpan("spanName", mockSpan, null);

--- a/test/telemetry/src/main/java/org/opensearch/test/telemetry/tracing/MockSpan.java
+++ b/test/telemetry/src/main/java/org/opensearch/test/telemetry/tracing/MockSpan.java
@@ -141,10 +141,7 @@ public class MockSpan extends AbstractSpan {
         return spanId;
     }
 
-    /**
-     * Returns whether the span is ended or not.
-     * @return span end status.
-     */
+    @Override
     public boolean hasEnded() {
         synchronized (lock) {
             return hasEnded;


### PR DESCRIPTION
### Description
Tracing framework after ending the current span internally set the parent as a current span in the thread context. But after this change https://github.com/opensearch-project/OpenSearch/issues/8428 now parent can be ended even before the span so the assumption that parent should always be closed after child doesnt hold true. Now setting the already ended parent as a current span doesn't make sense. Adding parent as a current span only if it is still recording

### Related Issues
Resolves #9449
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
