### PR TITLE
Bugfix: remove assert on non-empty translog reader list

### DIFF
--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -426,8 +426,11 @@ public class RemoteFsTranslog extends Translog {
         // are older files that are no longer needed and should be cleaned up. In here, we delete all files that are part
         // of older primary term.
         if (olderPrimaryCleaned.trySet(Boolean.TRUE)) {
+            if (readers.isEmpty()) {
+                logger.info("Translog reader list is empty, returning from deleteStaleRemotePrimaryTerms");
+                return;
+            }
             // First we delete all stale primary terms folders from remote store
-            assert readers.isEmpty() == false : shardId + " Expected non-empty readers";
             long minimumReferencedPrimaryTerm = readers.stream().map(BaseTranslogReader::getPrimaryTerm).min(Long::compare).get();
             translogTransferManager.deletePrimaryTermsAsync(minimumReferencedPrimaryTerm);
         }

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -427,7 +427,7 @@ public class RemoteFsTranslog extends Translog {
         // of older primary term.
         if (olderPrimaryCleaned.trySet(Boolean.TRUE)) {
             if (readers.isEmpty()) {
-                logger.info("Translog reader list is empty, returning from deleteStaleRemotePrimaryTerms");
+                logger.trace("Translog reader list is empty, returning from deleteStaleRemotePrimaryTerms");
                 return;
             }
             // First we delete all stale primary terms folders from remote store


### PR DESCRIPTION
### Description
- Currently, in `RemoteFsTranslog`, as part of `trimUnreferencedReaders`, we delete stale remote primary terms.
- The `deleteStaleRemotePrimaryTerms` function assumes existing list of translog readers to be non empty and have a corresponding assert.
- This assert results in flaky behavior of tests like: https://github.com/opensearch-project/OpenSearch/issues/9455
- In this PR, we remove the assert and return from `deleteStaleRemotePrimaryTerms` if translog reader list is empty.
- It is safe to remove the assert as translog reader list can be empty due to `super.trimUnreferencedReaders()` that is executed prior.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/9455

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
