### PR TITLE
Scoped the default S3 endpoint to region of the client

### DIFF
--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3AsyncService.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3AsyncService.java
@@ -60,7 +60,7 @@ class S3AsyncService implements Closeable {
 
     private static final String STS_ENDPOINT_OVERRIDE_SYSTEM_PROPERTY = "aws.stsEndpointOverride";
 
-    private static final String DEFAULT_S3_ENDPOINT = "s3.amazonaws.com";
+    private static final String GLOBAL_S3_ENDPOINT = "s3.amazonaws.com";
 
     private volatile Map<S3ClientSettings, AmazonAsyncS3Reference> clientsCache = emptyMap();
 
@@ -174,7 +174,11 @@ class S3AsyncService implements Closeable {
         final AwsCredentialsProvider credentials = buildCredentials(logger, clientSettings);
         builder.credentialsProvider(credentials);
 
-        String endpoint = Strings.hasLength(clientSettings.endpoint) ? clientSettings.endpoint : DEFAULT_S3_ENDPOINT;
+        String s3Endpoint = Strings.hasText(clientSettings.region)
+            ? "s3." + Region.of(clientSettings.region).toString() + ".amazonaws.com"
+            : GLOBAL_S3_ENDPOINT;
+
+        String endpoint = Strings.hasLength(clientSettings.endpoint) ? clientSettings.endpoint : s3Endpoint;
         if ((endpoint.startsWith("http://") || endpoint.startsWith("https://")) == false) {
             // Manually add the schema to the endpoint to work around https://github.com/aws/aws-sdk-java/issues/2274
             endpoint = clientSettings.protocol.toString() + "://" + endpoint;

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3Service.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3Service.java
@@ -98,7 +98,7 @@ class S3Service implements Closeable {
 
     private static final String STS_ENDPOINT_OVERRIDE_SYSTEM_PROPERTY = "aws.stsEndpointOverride";
 
-    private static final String DEFAULT_S3_ENDPOINT = "s3.amazonaws.com";
+    private static final String GLOBAL_S3_ENDPOINT = "s3.amazonaws.com";
 
     private volatile Map<S3ClientSettings, AmazonS3Reference> clientsCache = emptyMap();
 
@@ -204,7 +204,11 @@ class S3Service implements Closeable {
         builder.httpClientBuilder(buildHttpClient(clientSettings));
         builder.overrideConfiguration(buildOverrideConfiguration(clientSettings));
 
-        String endpoint = Strings.hasLength(clientSettings.endpoint) ? clientSettings.endpoint : DEFAULT_S3_ENDPOINT;
+        String s3Endpoint = Strings.hasText(clientSettings.region)
+            ? "s3." + Region.of(clientSettings.region).toString() + ".amazonaws.com"
+            : GLOBAL_S3_ENDPOINT;
+
+        String endpoint = Strings.hasLength(clientSettings.endpoint) ? clientSettings.endpoint : s3Endpoint;
         if ((endpoint.startsWith("http://") || endpoint.startsWith("https://")) == false) {
             // Manually add the schema to the endpoint to work around https://github.com/aws/aws-sdk-java/issues/2274
             // TODO: Remove this once fixed in the AWS SDK


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The default S3 endpoint in the repository-s3 plugin was the S3 global endpoint, which caused buckets created in regions other than in `us-east-1` to fail PUT repository calls with a 307 due to delay in the DNS propagation for the new bucket. This change modifies the default endpoint to the region specific one.

### Related Issues
<!-- List any other related issues here -->
- #9265 

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
