### PR TITLE
Handle null partSize in OnDemandBlockSnapshotIndexInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix flaky ResourceAwareTasksTests.testBasicTaskResourceTracking test ([#8993](https://github.com/opensearch-project/OpenSearch/pull/8993))
 - Fix memory leak when using Zstd Dictionary ([#9403](https://github.com/opensearch-project/OpenSearch/pull/9403))
 - Fix range reads in respository-s3 ([9512](https://github.com/opensearch-project/OpenSearch/issues/9512))
+- Handle null partSize in OnDemandBlockSnapshotIndexInput ([#9291](https://github.com/opensearch-project/OpenSearch/issues/9291))
 
 ### Security
 

--- a/server/src/test/java/org/opensearch/index/store/remote/file/OnDemandBlockSnapshotIndexInputTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/file/OnDemandBlockSnapshotIndexInputTests.java
@@ -19,6 +19,8 @@ import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.store.SimpleFSLockFactory;
 import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.Version;
+import org.opensearch.common.lucene.store.ByteArrayIndexInput;
+import org.opensearch.core.common.unit.ByteSizeUnit;
 import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot;
 import org.opensearch.index.store.StoreFileMetadata;
@@ -31,9 +33,12 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ThreadLeakFilters(filters = CleanerDaemonThreadLeakFilter.class)
 public class OnDemandBlockSnapshotIndexInputTests extends OpenSearchTestCase {
@@ -43,7 +48,6 @@ public class OnDemandBlockSnapshotIndexInputTests extends OpenSearchTestCase {
     private static final String FILE_NAME = "File_Name";
     private static final String BLOCK_FILE_PREFIX = FILE_NAME;
     private static final boolean IS_CLONE = false;
-    private static final ByteSizeValue BYTE_SIZE_VALUE = new ByteSizeValue(1L);
     private static final int FILE_SIZE = 29360128;
     private TransferManager transferManager;
     private LockFactory lockFactory;
@@ -74,7 +78,38 @@ public class OnDemandBlockSnapshotIndexInputTests extends OpenSearchTestCase {
         runAllTestsFor(22);
     }
 
-    public void runAllTestsFor(int blockSizeShift) throws Exception {
+    public void testChunkedRepository() throws IOException {
+        final long blockSize = new ByteSizeValue(1, ByteSizeUnit.KB).getBytes();
+        final long repositoryChunkSize = new ByteSizeValue(2, ByteSizeUnit.KB).getBytes();
+        final long fileSize = new ByteSizeValue(3, ByteSizeUnit.KB).getBytes();
+
+        when(transferManager.fetchBlob(any())).thenReturn(new ByteArrayIndexInput("test", new byte[(int) blockSize]));
+        try (
+            FSDirectory directory = new MMapDirectory(path, lockFactory);
+            IndexInput indexInput = new OnDemandBlockSnapshotIndexInput(
+                OnDemandBlockIndexInput.builder()
+                    .resourceDescription(RESOURCE_DESCRIPTION)
+                    .offset(BLOCK_SNAPSHOT_FILE_OFFSET)
+                    .length(FILE_SIZE)
+                    .blockSizeShift((int) (Math.log(blockSize) / Math.log(2)))
+                    .isClone(IS_CLONE),
+                new BlobStoreIndexShardSnapshot.FileInfo(
+                    FILE_NAME,
+                    new StoreFileMetadata(FILE_NAME, fileSize, "", Version.LATEST),
+                    new ByteSizeValue(repositoryChunkSize)
+                ),
+                directory,
+                transferManager
+            )
+        ) {
+            // Seek to the position past the first repository chunk
+            indexInput.seek(repositoryChunkSize);
+        }
+        // Verify the second chunk is requested (i.e. ".part1")
+        verify(transferManager).fetchBlob(argThat(request -> request.getBlobName().equals("File_Name.part1")));
+    }
+
+    private void runAllTestsFor(int blockSizeShift) throws Exception {
         final OnDemandBlockSnapshotIndexInput blockedSnapshotFile = createOnDemandBlockSnapshotIndexInput(blockSizeShift);
         final int blockSize = 1 << blockSizeShift;
         TestGroup.testGetBlock(blockedSnapshotFile, blockSize, FILE_SIZE);
@@ -106,7 +141,7 @@ public class OnDemandBlockSnapshotIndexInputTests extends OpenSearchTestCase {
         fileInfo = new BlobStoreIndexShardSnapshot.FileInfo(
             FILE_NAME,
             new StoreFileMetadata(FILE_NAME, FILE_SIZE, "", Version.LATEST),
-            BYTE_SIZE_VALUE
+            null
         );
 
         int blockSize = 1 << blockSizeShift;
@@ -182,7 +217,7 @@ public class OnDemandBlockSnapshotIndexInputTests extends OpenSearchTestCase {
 
     }
 
-    public static class TestGroup {
+    private static class TestGroup {
 
         public static void testGetBlock(OnDemandBlockSnapshotIndexInput blockedSnapshotFile, int blockSize, int fileSize) {
             // block 0


### PR DESCRIPTION
The `partSize()` value can be null if the underlying repository implementation does not implement file chunking.

### Related Issues
Resolves #9291 


### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
