### PR TITLE
Add support download latest index metadata from remote

### DIFF
--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3BlobContainer.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3BlobContainer.java
@@ -349,11 +349,8 @@ class S3BlobContainer extends AbstractBlobContainer implements VerifyingMultiStr
     }
 
     @Override
-    public List<BlobMetadata> listBlobsByPrefixInSortedOrder(
-        String blobNamePrefix,
-        int limit,
-        BlobNameSortOrder blobNameSortOrder
-    )  throws IOException  {
+    public List<BlobMetadata> listBlobsByPrefixInSortedOrder(String blobNamePrefix, int limit, BlobNameSortOrder blobNameSortOrder)
+        throws IOException {
         // As AWS S3 returns list of keys in Lexicographic order, we don't have to fetch all the keys in order to sort them
         // We fetch only keys as per the given limit to optimize the fetch. If provided sort order is not Lexicographic,
         // we fall-back to default implementation of fetching all the keys and sorting them.

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3BlobContainer.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3BlobContainer.java
@@ -362,10 +362,11 @@ class S3BlobContainer extends AbstractBlobContainer implements VerifyingMultiStr
             }
             String prefix = blobNamePrefix == null ? keyPath : buildKey(blobNamePrefix);
             try (AmazonS3Reference clientReference = blobStore.clientReference()) {
-                return executeListing(clientReference, listObjectsRequest(prefix, limit), limit).stream()
+                List<BlobMetadata> blobs = executeListing(clientReference, listObjectsRequest(prefix, limit), limit).stream()
                     .flatMap(listing -> listing.contents().stream())
                     .map(s3Object -> new PlainBlobMetadata(s3Object.key().substring(keyPath.length()), s3Object.size()))
                     .collect(Collectors.toList());
+                return blobs.subList(0, Math.min(limit, blobs.size()));
             } catch (final Exception e) {
                 throw new IOException("Exception when listing blobs by prefix [" + prefix + "]", e);
             }

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3BlobContainer.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3BlobContainer.java
@@ -349,30 +349,28 @@ class S3BlobContainer extends AbstractBlobContainer implements VerifyingMultiStr
     }
 
     @Override
-    public void listBlobsByPrefixInSortedOrder(
+    public List<BlobMetadata> listBlobsByPrefixInSortedOrder(
         String blobNamePrefix,
         int limit,
-        BlobNameSortOrder blobNameSortOrder,
-        ActionListener<List<BlobMetadata>> listener
-    ) {
+        BlobNameSortOrder blobNameSortOrder
+    )  throws IOException  {
         // As AWS S3 returns list of keys in Lexicographic order, we don't have to fetch all the keys in order to sort them
         // We fetch only keys as per the given limit to optimize the fetch. If provided sort order is not Lexicographic,
         // we fall-back to default implementation of fetching all the keys and sorting them.
         if (blobNameSortOrder != BlobNameSortOrder.LEXICOGRAPHIC) {
-            super.listBlobsByPrefixInSortedOrder(blobNamePrefix, limit, blobNameSortOrder, listener);
+            return super.listBlobsByPrefixInSortedOrder(blobNamePrefix, limit, blobNameSortOrder);
         } else {
             if (limit < 0) {
                 throw new IllegalArgumentException("limit should not be a negative value");
             }
             String prefix = blobNamePrefix == null ? keyPath : buildKey(blobNamePrefix);
             try (AmazonS3Reference clientReference = blobStore.clientReference()) {
-                List<BlobMetadata> blobs = executeListing(clientReference, listObjectsRequest(prefix, limit), limit).stream()
+                return executeListing(clientReference, listObjectsRequest(prefix, limit), limit).stream()
                     .flatMap(listing -> listing.contents().stream())
                     .map(s3Object -> new PlainBlobMetadata(s3Object.key().substring(keyPath.length()), s3Object.size()))
                     .collect(Collectors.toList());
-                listener.onResponse(blobs.subList(0, Math.min(limit, blobs.size())));
             } catch (final Exception e) {
-                listener.onFailure(new IOException("Exception when listing blobs by prefix [" + prefix + "]", e));
+                throw new IOException("Exception when listing blobs by prefix [" + prefix + "]", e);
             }
         }
     }

--- a/server/src/main/java/org/opensearch/common/blobstore/BlobContainer.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/BlobContainer.java
@@ -227,6 +227,9 @@ public interface BlobContainer {
         BlobNameSortOrder blobNameSortOrder,
         ActionListener<List<BlobMetadata>> listener
     ) {
+        if (limit < 0) {
+            throw new IllegalArgumentException("limit should not be a negative value");
+        }
         try {
             listener.onResponse(listBlobsByPrefixInSortedOrder(blobNamePrefix, limit, blobNameSortOrder));
         } catch (Exception e) {

--- a/server/src/main/java/org/opensearch/common/blobstore/BlobContainer.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/BlobContainer.java
@@ -227,15 +227,20 @@ public interface BlobContainer {
         BlobNameSortOrder blobNameSortOrder,
         ActionListener<List<BlobMetadata>> listener
     ) {
-        if (limit < 0) {
-            throw new IllegalArgumentException("limit should not be a negative value");
-        }
         try {
-            List<BlobMetadata> blobNames = new ArrayList<>(listBlobsByPrefix(blobNamePrefix).values());
-            blobNames.sort(blobNameSortOrder.comparator());
-            listener.onResponse(blobNames.subList(0, Math.min(blobNames.size(), limit)));
+            listener.onResponse(listBlobsByPrefixInSortedOrder(blobNamePrefix, limit, blobNameSortOrder));
         } catch (Exception e) {
             listener.onFailure(e);
         }
+    }
+
+    default List<BlobMetadata> listBlobsByPrefixInSortedOrder(String blobNamePrefix, int limit, BlobNameSortOrder blobNameSortOrder)
+        throws IOException {
+        if (limit < 0) {
+            throw new IllegalArgumentException("limit should not be a negative value");
+        }
+        List<BlobMetadata> blobNames = new ArrayList<>(listBlobsByPrefix(blobNamePrefix).values());
+        blobNames.sort(blobNameSortOrder.comparator());
+        return blobNames.subList(0, Math.min(blobNames.size(), limit));
     }
 }

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -388,8 +388,14 @@ public class RemoteClusterStateService implements Closeable {
         return remoteIndexMetadata;
     }
 
-    private IndexMetadata getIndexMetadata(String clusterName, String clusterUUID, UploadedIndexMetadata uploadedIndexMetadata)
-        throws IOException {
+    /**
+     * Fetch index metadata from remote cluster state
+     * @param clusterUUID uuid of cluster state to refer to in remote
+     * @param clusterName name of the cluster
+     * @param uploadedIndexMetadata {@link UploadedIndexMetadata} contains details about remote location of index metadata
+     * @return {@link IndexMetadata}
+     */
+    private IndexMetadata getIndexMetadata(String clusterName, String clusterUUID, UploadedIndexMetadata uploadedIndexMetadata) {
         try {
             return INDEX_METADATA_FORMAT.read(
                 indexMetadataContainer(clusterName, clusterUUID, uploadedIndexMetadata.getIndexUUID()),

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -414,8 +414,8 @@ public class RemoteClusterStateService implements Closeable {
      * @return ClusterMetadataManifest
      */
     public ClusterMetadataManifest getLatestClusterMetadataManifest(String clusterName, String clusterUUID) {
-        String latestMarkerFileName = getLatestManifestFileName(clusterName, clusterUUID);
-        return fetchRemoteClusterMetadataManifest(clusterName, clusterUUID, latestMarkerFileName);
+        String latestManifestFileName = getLatestManifestFileName(clusterName, clusterUUID);
+        return fetchRemoteClusterMetadataManifest(clusterName, clusterUUID, latestManifestFileName);
     }
 
     /**
@@ -431,13 +431,13 @@ public class RemoteClusterStateService implements Closeable {
              * as the manifest file name generated via {@link RemoteClusterStateService#getManifestFileName} ensures
              * when sorted in LEXICOGRAPHIC order the latest uploaded manifest file comes on top.
              */
-            List<BlobMetadata> markerFilesMetadata = manifestContainer(clusterName, clusterUUID).listBlobsByPrefixInSortedOrder(
+            List<BlobMetadata> manifestFilesMetadata = manifestContainer(clusterName, clusterUUID).listBlobsByPrefixInSortedOrder(
                 "manifest" + DELIMITER,
                 1,
                 BlobContainer.BlobNameSortOrder.LEXICOGRAPHIC
             );
-            if (markerFilesMetadata != null && !markerFilesMetadata.isEmpty()) {
-                return markerFilesMetadata.get(0).name();
+            if (manifestFilesMetadata != null && !manifestFilesMetadata.isEmpty()) {
+                return manifestFilesMetadata.get(0).name();
             }
         } catch (IOException e) {
             String errorMsg = "Error while fetching latest manifest file for remote cluster state";

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -373,7 +373,7 @@ public class RemoteClusterStateService implements Closeable {
      * Fetch latest index metadata from remote cluster state
      * @param clusterUUID uuid of cluster state to refer to in remote
      * @param clusterName name of the cluster
-     * @return Map<String, IndexMetadata> latest IndexUUID to IndexMetadata map
+     * @return {@code Map<String, IndexMetadata>} latest IndexUUID to IndexMetadata map
      */
     public Map<String, IndexMetadata> getLatestIndexMetadata(String clusterUUID, String clusterName) throws IOException {
         Map<String, IndexMetadata> remoteIndexMetadata = new HashMap<>();

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -437,7 +437,7 @@ public class RemoteClusterStateService implements Closeable {
             throw new IllegalStateException(errorMsg);
         }
 
-        throw new IllegalStateException("Remote Cluster State not found");
+        throw new IllegalStateException(String.format(Locale.ROOT, "Remote Cluster State not found - %s", clusterUUID));
     }
 
     /**
@@ -455,7 +455,7 @@ public class RemoteClusterStateService implements Closeable {
                 blobStoreRepository.getNamedXContentRegistry()
             );
         } catch (IOException e) {
-            String errorMsg = String.format(Locale.ROOT, "Error while downloading ClusterMetadataManifest - %s", filename);
+            String errorMsg = String.format(Locale.ROOT, "Error while downloading cluster metadata - %s", filename);
             logger.error(errorMsg, e);
             throw new IllegalStateException(errorMsg);
         }

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -38,6 +38,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
@@ -375,17 +376,18 @@ public class RemoteClusterStateService implements Closeable {
      * @param clusterName name of the cluster
      * @return {@code Map<String, IndexMetadata>} latest IndexUUID to IndexMetadata map
      */
-    public Map<String, IndexMetadata> getLatestIndexMetadata(String clusterUUID, String clusterName) throws IOException {
+    public Map<String, IndexMetadata> getLatestIndexMetadata(String clusterName, String clusterUUID) throws IOException {
         Map<String, IndexMetadata> remoteIndexMetadata = new HashMap<>();
-        ClusterMetadataManifest ClusterMetadataManifest = getLatestClusterMetadataManifest(clusterUUID, clusterName);
-        for (UploadedIndexMetadata uploadedIndexMetadata : ClusterMetadataManifest.getIndices()) {
-            IndexMetadata indexMetadata = getIndexMetadata(clusterUUID, clusterName, uploadedIndexMetadata);
+        ClusterMetadataManifest clusterMetadataManifest = getLatestClusterMetadataManifest(clusterName, clusterUUID);
+        assert Objects.equals(clusterUUID, clusterMetadataManifest.getClusterUUID()) : "Corrupt ClusterMetadataManifest found. Cluster UUID mismatch.";
+        for (UploadedIndexMetadata uploadedIndexMetadata : clusterMetadataManifest.getIndices()) {
+            IndexMetadata indexMetadata = getIndexMetadata(clusterName, clusterUUID, uploadedIndexMetadata);
             remoteIndexMetadata.put(uploadedIndexMetadata.getIndexUUID(), indexMetadata);
         }
         return remoteIndexMetadata;
     }
 
-    private IndexMetadata getIndexMetadata(String clusterUUID, String clusterName, UploadedIndexMetadata uploadedIndexMetadata)
+    private IndexMetadata getIndexMetadata(String clusterName, String clusterUUID, UploadedIndexMetadata uploadedIndexMetadata)
         throws IOException {
         try {
             return INDEX_METADATA_FORMAT.read(
@@ -400,7 +402,7 @@ public class RemoteClusterStateService implements Closeable {
                 uploadedIndexMetadata.getUploadedFilename()
             );
             logger.error(errorMsg, e);
-            throw new IllegalStateException(errorMsg);
+            throw new IllegalStateException(errorMsg, e);
         }
     }
 
@@ -410,9 +412,9 @@ public class RemoteClusterStateService implements Closeable {
      * @param clusterName name of the cluster
      * @return ClusterMetadataManifest
      */
-    public ClusterMetadataManifest getLatestClusterMetadataManifest(String clusterUUID, String clusterName) {
-        String latestMarkerFileName = getLatestManifestFileName(clusterUUID, clusterName);
-        return fetchRemoteClusterMetadataManifest(latestMarkerFileName, clusterUUID, clusterName);
+    public ClusterMetadataManifest getLatestClusterMetadataManifest(String clusterName, String clusterUUID) {
+        String latestMarkerFileName = getLatestManifestFileName(clusterName, clusterUUID);
+        return fetchRemoteClusterMetadataManifest(clusterName, clusterUUID, latestMarkerFileName);
     }
 
     /**
@@ -421,9 +423,14 @@ public class RemoteClusterStateService implements Closeable {
      * @param clusterName name of the cluster
      * @return latest ClusterMetadataManifest filename
      */
-    private String getLatestManifestFileName(String clusterUUID, String clusterName) throws IllegalStateException {
+    private String getLatestManifestFileName(String clusterName, String clusterUUID) throws IllegalStateException {
         try {
-            List<BlobMetadata> markerFilesMetadata = manifestContainer(clusterUUID, clusterName).listBlobsByPrefixInSortedOrder(
+            /**
+             * {@link BlobContainer#listBlobsByPrefixInSortedOrder} will get the latest manifest file
+             * as the manifest file name generated via {@link RemoteClusterStateService#getManifestFileName} ensures
+             * when sorted in LEXICOGRAPHIC order the latest uploaded manifest file comes on top.
+             */
+            List<BlobMetadata> markerFilesMetadata = manifestContainer(clusterName, clusterUUID).listBlobsByPrefixInSortedOrder(
                 "manifest" + DELIMITER,
                 1,
                 BlobContainer.BlobNameSortOrder.LEXICOGRAPHIC
@@ -434,7 +441,7 @@ public class RemoteClusterStateService implements Closeable {
         } catch (IOException e) {
             String errorMsg = "Error while fetching latest manifest file for remote cluster state";
             logger.error(errorMsg, e);
-            throw new IllegalStateException(errorMsg);
+            throw new IllegalStateException(errorMsg, e);
         }
 
         throw new IllegalStateException(String.format(Locale.ROOT, "Remote Cluster State not found - %s", clusterUUID));
@@ -446,18 +453,18 @@ public class RemoteClusterStateService implements Closeable {
      * @param clusterName name of the cluster
      * @return ClusterMetadataManifest
      */
-    private ClusterMetadataManifest fetchRemoteClusterMetadataManifest(String filename, String clusterUUID, String clusterName)
+    private ClusterMetadataManifest fetchRemoteClusterMetadataManifest(String clusterName, String clusterUUID, String filename)
         throws IllegalStateException {
         try {
             return RemoteClusterStateService.CLUSTER_METADATA_MANIFEST_FORMAT.read(
-                manifestContainer(clusterUUID, clusterName),
+                manifestContainer(clusterName, clusterUUID),
                 filename,
                 blobStoreRepository.getNamedXContentRegistry()
             );
         } catch (IOException e) {
             String errorMsg = String.format(Locale.ROOT, "Error while downloading cluster metadata - %s", filename);
             logger.error(errorMsg, e);
-            throw new IllegalStateException(errorMsg);
+            throw new IllegalStateException(errorMsg, e);
         }
     }
 }

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -379,7 +379,8 @@ public class RemoteClusterStateService implements Closeable {
     public Map<String, IndexMetadata> getLatestIndexMetadata(String clusterName, String clusterUUID) throws IOException {
         Map<String, IndexMetadata> remoteIndexMetadata = new HashMap<>();
         ClusterMetadataManifest clusterMetadataManifest = getLatestClusterMetadataManifest(clusterName, clusterUUID);
-        assert Objects.equals(clusterUUID, clusterMetadataManifest.getClusterUUID()) : "Corrupt ClusterMetadataManifest found. Cluster UUID mismatch.";
+        assert Objects.equals(clusterUUID, clusterMetadataManifest.getClusterUUID())
+            : "Corrupt ClusterMetadataManifest found. Cluster UUID mismatch.";
         for (UploadedIndexMetadata uploadedIndexMetadata : clusterMetadataManifest.getIndices()) {
             IndexMetadata indexMetadata = getIndexMetadata(clusterName, clusterUUID, uploadedIndexMetadata);
             remoteIndexMetadata.put(uploadedIndexMetadata.getIndexUUID(), indexMetadata);

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -403,13 +403,11 @@ public class RemoteClusterStateService implements Closeable {
                 blobStoreRepository.getNamedXContentRegistry()
             );
         } catch (IOException e) {
-            String errorMsg = String.format(
+            throw new IllegalStateException(String.format(
                 Locale.ROOT,
                 "Error while downloading IndexMetadata - %s",
                 uploadedIndexMetadata.getUploadedFilename()
-            );
-            logger.error(errorMsg, e);
-            throw new IllegalStateException(errorMsg, e);
+            ), e);
         }
     }
 
@@ -446,9 +444,7 @@ public class RemoteClusterStateService implements Closeable {
                 return manifestFilesMetadata.get(0).name();
             }
         } catch (IOException e) {
-            String errorMsg = "Error while fetching latest manifest file for remote cluster state";
-            logger.error(errorMsg, e);
-            throw new IllegalStateException(errorMsg, e);
+            throw new IllegalStateException("Error while fetching latest manifest file for remote cluster state", e);
         }
 
         throw new IllegalStateException(String.format(Locale.ROOT, "Remote Cluster State not found - %s", clusterUUID));
@@ -469,9 +465,7 @@ public class RemoteClusterStateService implements Closeable {
                 blobStoreRepository.getNamedXContentRegistry()
             );
         } catch (IOException e) {
-            String errorMsg = String.format(Locale.ROOT, "Error while downloading cluster metadata - %s", filename);
-            logger.error(errorMsg, e);
-            throw new IllegalStateException(errorMsg, e);
+            throw new IllegalStateException(String.format(Locale.ROOT, "Error while downloading cluster metadata - %s", filename), e);
         }
     }
 }

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -403,11 +403,10 @@ public class RemoteClusterStateService implements Closeable {
                 blobStoreRepository.getNamedXContentRegistry()
             );
         } catch (IOException e) {
-            throw new IllegalStateException(String.format(
-                Locale.ROOT,
-                "Error while downloading IndexMetadata - %s",
-                uploadedIndexMetadata.getUploadedFilename()
-            ), e);
+            throw new IllegalStateException(
+                String.format(Locale.ROOT, "Error while downloading IndexMetadata - %s", uploadedIndexMetadata.getUploadedFilename()),
+                e
+            );
         }
     }
 

--- a/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
@@ -801,6 +801,10 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         return metadata;
     }
 
+    public NamedXContentRegistry getNamedXContentRegistry() {
+        return namedXContentRegistry;
+    }
+
     public Compressor getCompressor() {
         return compressor;
     }

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
@@ -317,7 +317,8 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
         Exception e = assertThrows(
             IllegalStateException.class,
             () -> remoteClusterStateService.getLatestIndexMetadata(
-                clusterState.getClusterName().value(), clusterState.metadata().clusterUUID()
+                clusterState.getClusterName().value(),
+                clusterState.metadata().clusterUUID()
             )
         );
         assertEquals(e.getMessage(), "Error while downloading IndexMetadata - " + uploadedIndexMetadata.getUploadedFilename());

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
@@ -201,7 +201,7 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
         assertThat(manifest.getStateUUID(), is(expectedManifest.getStateUUID()));
     }
 
-    public void testReadLatestMetadataMarkerFailedIOException() throws IOException {
+    public void testReadLatestMetadataManifestFailedIOException() throws IOException {
         final ClusterState clusterState = generateClusterStateWithOneIndex().nodes(nodesWithLocalNodeClusterManager()).build();
 
         BlobContainer blobContainer = mockBlobStoreObjects();
@@ -217,14 +217,14 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
         Exception e = assertThrows(
             IllegalStateException.class,
             () -> remoteClusterStateService.getLatestClusterMetadataManifest(
-                clusterState.metadata().clusterUUID(),
-                clusterState.getClusterName().value()
+                clusterState.getClusterName().value(),
+                clusterState.metadata().clusterUUID()
             )
         );
         assertEquals(e.getMessage(), "Error while fetching latest manifest file for remote cluster state");
     }
 
-    public void testReadLatestMetadataMarkerFailedNoMarkerFileInRemote() throws IOException {
+    public void testReadLatestMetadataManifestFailedNoManifestFileInRemote() throws IOException {
         final ClusterState clusterState = generateClusterStateWithOneIndex().nodes(nodesWithLocalNodeClusterManager()).build();
 
         BlobContainer blobContainer = mockBlobStoreObjects();
@@ -240,14 +240,14 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
         Exception e = assertThrows(
             IllegalStateException.class,
             () -> remoteClusterStateService.getLatestClusterMetadataManifest(
-                clusterState.metadata().clusterUUID(),
-                clusterState.getClusterName().value()
+                clusterState.getClusterName().value(),
+                clusterState.metadata().clusterUUID()
             )
         );
         assertEquals(e.getMessage(), "Remote Cluster State not found - " + clusterState.metadata().clusterUUID());
     }
 
-    public void testReadLatestMetadataMarkerFailedMarkerFileRemoveAfterFetchInRemote() throws IOException {
+    public void testReadLatestMetadataManifestFailedManifestFileRemoveAfterFetchInRemote() throws IOException {
         final ClusterState clusterState = generateClusterStateWithOneIndex().nodes(nodesWithLocalNodeClusterManager()).build();
 
         BlobContainer blobContainer = mockBlobStoreObjects();
@@ -265,14 +265,14 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
         Exception e = assertThrows(
             IllegalStateException.class,
             () -> remoteClusterStateService.getLatestClusterMetadataManifest(
-                clusterState.metadata().clusterUUID(),
-                clusterState.getClusterName().value()
+                clusterState.getClusterName().value(),
+                clusterState.metadata().clusterUUID()
             )
         );
         assertEquals(e.getMessage(), "Error while downloading cluster metadata - manifestFileName");
     }
 
-    public void testReadLatestMetadataMarkerSuccessButNoIndexMetadata() throws IOException {
+    public void testReadLatestMetadataManifestSuccessButNoIndexMetadata() throws IOException {
         final ClusterState clusterState = generateClusterStateWithOneIndex().nodes(nodesWithLocalNodeClusterManager()).build();
         final ClusterMetadataManifest expectedManifest = ClusterMetadataManifest.builder()
             .indices(List.of())
@@ -289,13 +289,13 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
 
         remoteClusterStateService.ensureRepositorySet();
         assertEquals(
-            remoteClusterStateService.getLatestIndexMetadata(clusterState.metadata().clusterUUID(), clusterState.getClusterName().value())
+            remoteClusterStateService.getLatestIndexMetadata(clusterState.getClusterName().value(), clusterState.metadata().clusterUUID())
                 .size(),
             0
         );
     }
 
-    public void testReadLatestMetadataMarkerSuccessButIndexMetadataFetchIOException() throws IOException {
+    public void testReadLatestMetadataManifestSuccessButIndexMetadataFetchIOException() throws IOException {
         final ClusterState clusterState = generateClusterStateWithOneIndex().nodes(nodesWithLocalNodeClusterManager()).build();
         final UploadedIndexMetadata uploadedIndexMetadata = new UploadedIndexMetadata("test-index", "index-uuid", "metadata-filename");
         final List<UploadedIndexMetadata> indices = List.of(uploadedIndexMetadata);
@@ -317,14 +317,13 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
         Exception e = assertThrows(
             IllegalStateException.class,
             () -> remoteClusterStateService.getLatestIndexMetadata(
-                clusterState.metadata().clusterUUID(),
-                clusterState.getClusterName().value()
+                clusterState.getClusterName().value(), clusterState.metadata().clusterUUID()
             )
         );
         assertEquals(e.getMessage(), "Error while downloading IndexMetadata - " + uploadedIndexMetadata.getUploadedFilename());
     }
 
-    public void testReadLatestMetadataMarkerSuccess() throws IOException {
+    public void testReadLatestMetadataManifestSuccess() throws IOException {
         final ClusterState clusterState = generateClusterStateWithOneIndex().nodes(nodesWithLocalNodeClusterManager()).build();
         final UploadedIndexMetadata uploadedIndexMetadata = new UploadedIndexMetadata("test-index", "index-uuid", "metadata-filename");
         final List<UploadedIndexMetadata> indices = List.of(uploadedIndexMetadata);
@@ -342,8 +341,8 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
         mockBlobContainer(mockBlobStoreObjects(), expectedManifest, new HashMap<>());
         remoteClusterStateService.ensureRepositorySet();
         final ClusterMetadataManifest manifest = remoteClusterStateService.getLatestClusterMetadataManifest(
-            clusterState.metadata().clusterUUID(),
-            clusterState.getClusterName().value()
+            clusterState.getClusterName().value(),
+            clusterState.metadata().clusterUUID()
         );
 
         assertThat(manifest.getIndices().size(), is(1));
@@ -386,8 +385,8 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
         mockBlobContainer(mockBlobStoreObjects(), expectedManifest, Map.of(index.getUUID(), indexMetadata));
 
         Map<String, IndexMetadata> indexMetadataMap = remoteClusterStateService.getLatestIndexMetadata(
-            clusterState.metadata().clusterUUID(),
-            clusterState.getClusterName().value()
+            clusterState.getClusterName().value(),
+            clusterState.metadata().clusterUUID()
         );
 
         assertEquals(indexMetadataMap.size(), 1);

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
@@ -244,7 +244,7 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
                 clusterState.getClusterName().value()
             )
         );
-        assertEquals(e.getMessage(), "Remote Cluster State not found");
+        assertEquals(e.getMessage(), "Remote Cluster State not found - " + clusterState.metadata().clusterUUID());
     }
 
     public void testReadLatestMetadataMarkerFailedMarkerFileRemoveAfterFetchInRemote() throws IOException {
@@ -269,7 +269,7 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
                 clusterState.getClusterName().value()
             )
         );
-        assertEquals(e.getMessage(), "Error while downloading ClusterMetadataManifest - manifestFileName");
+        assertEquals(e.getMessage(), "Error while downloading cluster metadata - manifestFileName");
     }
 
     public void testReadLatestMetadataMarkerSuccessButNoIndexMetadata() throws IOException {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
- Adds support to download latest IndexMetadata from remote cluster state.
- Please skip the changes in ClusterMetadataMarker file as it is part of the upload PR - https://github.com/opensearch-project/OpenSearch/pull/9160/files

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
