### PR TITLE
[Remote Store] Fix tests when we restore index without any refresh

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreBaseIntegTestCase.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreBaseIntegTestCase.java
@@ -72,7 +72,7 @@ public class RemoteStoreBaseIntegTestCase extends OpenSearchIntegTestCase {
         Map<String, Long> indexingStats = new HashMap<>();
         for (int i = 0; i < numberOfIterations; i++) {
             if (invokeFlush) {
-                flush(index);
+                flushAndRefresh(index);
             } else {
                 refresh(index);
             }

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreRestoreIT.java
@@ -129,7 +129,6 @@ public class RemoteStoreRestoreIT extends RemoteStoreBaseIntegTestCase {
      * Simulates all data restored using Remote Translog Store.
      * @throws IOException IO Exception.
      */
-    // @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/6188")
     @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/8479")
     public void testRTSRestoreWithNoDataPostCommitPrimaryReplicaDown() throws IOException {
         testRestoreFlowBothPrimaryReplicasDown(1, true, randomIntBetween(1, 5));

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreRestoreIT.java
@@ -38,7 +38,6 @@ public class RemoteStoreRestoreIT extends RemoteStoreBaseIntegTestCase {
     private static final String TOTAL_OPERATIONS = "total-operations";
     private static final String REFRESHED_OR_FLUSHED_OPERATIONS = "refreshed-or-flushed-operations";
     private static final String MAX_SEQ_NO_TOTAL = "max-seq-no-total";
-    private static final String MAX_SEQ_NO_REFRESHED_OR_FLUSHED = "max-seq-no-refreshed-or-flushed";
 
     @Override
     public Settings indexSettings() {
@@ -68,18 +67,18 @@ public class RemoteStoreRestoreIT extends RemoteStoreBaseIntegTestCase {
             );
     }
 
-    private void verifyRestoredData(Map<String, Long> indexStats, boolean checkTotal, String indexName) {
+    private void verifyRestoredData(Map<String, Long> indexStats, String indexName) {
         // This is required to get updated number from already active shards which were not restored
         refresh(indexName);
-        String statsGranularity = checkTotal ? TOTAL_OPERATIONS : REFRESHED_OR_FLUSHED_OPERATIONS;
-        String maxSeqNoGranularity = checkTotal ? MAX_SEQ_NO_TOTAL : MAX_SEQ_NO_REFRESHED_OR_FLUSHED;
         ensureYellowAndNoInitializingShards(indexName);
         ensureGreen(indexName);
-        assertHitCount(client().prepareSearch(indexName).setSize(0).get(), indexStats.get(statsGranularity));
+        assertHitCount(client().prepareSearch(indexName).setSize(0).get(), indexStats.get(TOTAL_OPERATIONS));
         IndexResponse response = indexSingleDoc(indexName);
-        assertEquals(indexStats.get(maxSeqNoGranularity + "-shard-" + response.getShardId().id()) + 1, response.getSeqNo());
+        if (indexStats.containsKey(MAX_SEQ_NO_TOTAL + "-shard-" + response.getShardId().id())) {
+            assertEquals(indexStats.get(MAX_SEQ_NO_TOTAL + "-shard-" + response.getShardId().id()) + 1, response.getSeqNo());
+        }
         refresh(indexName);
-        assertHitCount(client().prepareSearch(indexName).setSize(0).get(), indexStats.get(statsGranularity) + 1);
+        assertHitCount(client().prepareSearch(indexName).setSize(0).get(), indexStats.get(TOTAL_OPERATIONS) + 1);
     }
 
     private void prepareCluster(int numClusterManagerNodes, int numDataOnlyNodes, String indices, int replicaCount, int shardCount) {
@@ -96,7 +95,6 @@ public class RemoteStoreRestoreIT extends RemoteStoreBaseIntegTestCase {
      * Simulates all data restored using Remote Translog Store.
      * @throws IOException IO Exception.
      */
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/6188")
     public void testRemoteTranslogRestoreWithNoDataPostCommit() throws IOException {
         testRestoreFlow(1, true, randomIntBetween(1, 5));
     }
@@ -172,7 +170,7 @@ public class RemoteStoreRestoreIT extends RemoteStoreBaseIntegTestCase {
         // This is required to get updated number from already active shards which were not restored
         assertEquals(shardCount * (1 + replicaCount), getNumShards(INDEX_NAME).totalNumShards);
         assertEquals(replicaCount, getNumShards(INDEX_NAME).numReplicas);
-        verifyRestoredData(indexStats, true, INDEX_NAME);
+        verifyRestoredData(indexStats, INDEX_NAME);
     }
 
     /**
@@ -185,6 +183,8 @@ public class RemoteStoreRestoreIT extends RemoteStoreBaseIntegTestCase {
         prepareCluster(0, 3, INDEX_NAME, 0, shardCount);
         Map<String, Long> indexStats = indexData(numberOfIterations, invokeFlush, INDEX_NAME);
         assertEquals(shardCount, getNumShards(INDEX_NAME).totalNumShards);
+
+        assertHitCount(client().prepareSearch(INDEX_NAME).setSize(0).get(), indexStats.get(REFRESHED_OR_FLUSHED_OPERATIONS));
 
         internalCluster().stopRandomNode(InternalTestCluster.nameFilter(primaryNodeName(INDEX_NAME)));
         ensureRed(INDEX_NAME);
@@ -256,7 +256,7 @@ public class RemoteStoreRestoreIT extends RemoteStoreBaseIntegTestCase {
         ensureGreen(indices);
         for (String index : indices) {
             assertEquals(shardCount, getNumShards(index).totalNumShards);
-            verifyRestoredData(indicesStats.get(index), true, index);
+            verifyRestoredData(indicesStats.get(index), index);
         }
     }
 
@@ -288,7 +288,7 @@ public class RemoteStoreRestoreIT extends RemoteStoreBaseIntegTestCase {
 
         ensureGreen(INDEX_NAME);
         assertEquals(shardCount, getNumShards(INDEX_NAME).totalNumShards);
-        verifyRestoredData(indexStats, true, INDEX_NAME);
+        verifyRestoredData(indexStats, INDEX_NAME);
     }
 
     /**
@@ -340,7 +340,7 @@ public class RemoteStoreRestoreIT extends RemoteStoreBaseIntegTestCase {
 
         for (String index : indices) {
             assertEquals(shardCount, getNumShards(index).totalNumShards);
-            verifyRestoredData(indicesStats.get(index), true, index);
+            verifyRestoredData(indicesStats.get(index), index);
         }
     }
 
@@ -384,9 +384,9 @@ public class RemoteStoreRestoreIT extends RemoteStoreBaseIntegTestCase {
             );
         ensureGreen(indices[0], indices[1]);
         assertEquals(shardCount, getNumShards(indices[0]).totalNumShards);
-        verifyRestoredData(indicesStats.get(indices[0]), true, indices[0]);
+        verifyRestoredData(indicesStats.get(indices[0]), indices[0]);
         assertEquals(shardCount, getNumShards(indices[1]).totalNumShards);
-        verifyRestoredData(indicesStats.get(indices[1]), true, indices[1]);
+        verifyRestoredData(indicesStats.get(indices[1]), indices[1]);
         ensureRed(indices[2], indices[3]);
     }
 
@@ -436,9 +436,9 @@ public class RemoteStoreRestoreIT extends RemoteStoreBaseIntegTestCase {
             );
         ensureGreen(indices[0], indices[1]);
         assertEquals(shardCount, getNumShards(indices[0]).totalNumShards);
-        verifyRestoredData(indicesStats.get(indices[0]), true, indices[0]);
+        verifyRestoredData(indicesStats.get(indices[0]), indices[0]);
         assertEquals(shardCount, getNumShards(indices[1]).totalNumShards);
-        verifyRestoredData(indicesStats.get(indices[1]), true, indices[1]);
+        verifyRestoredData(indicesStats.get(indices[1]), indices[1]);
         ensureRed(indices[2], indices[3]);
     }
 
@@ -447,8 +447,7 @@ public class RemoteStoreRestoreIT extends RemoteStoreBaseIntegTestCase {
      * when the index has no data.
      * @throws IOException IO Exception.
      */
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/6188")
-    public void testRTSRestoreNoData() throws IOException {
+    public void testRTSRestoreDataOnlyInTranslog() throws IOException {
         testRestoreFlow(0, true, randomIntBetween(1, 5));
     }
 

--- a/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
@@ -64,7 +64,9 @@ import org.opensearch.index.snapshots.blobstore.RemoteStoreShardShallowCopySnaps
 import org.opensearch.index.store.RemoteSegmentStoreDirectory;
 import org.opensearch.index.store.RemoteSegmentStoreDirectoryFactory;
 import org.opensearch.index.store.Store;
+import org.opensearch.index.translog.Checkpoint;
 import org.opensearch.index.translog.Translog;
+import org.opensearch.index.translog.TranslogHeader;
 import org.opensearch.indices.recovery.RecoveryState;
 import org.opensearch.indices.replication.common.ReplicationLuceneIndex;
 import org.opensearch.repositories.IndexId;
@@ -74,6 +76,8 @@ import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
 import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -83,6 +87,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static org.opensearch.common.unit.TimeValue.timeValueMillis;
+import static org.opensearch.index.translog.Translog.CHECKPOINT_FILE_NAME;
 
 /**
  * This package private utility class encapsulates the logic to recover an index shard from either an existing index on
@@ -532,13 +537,16 @@ final class StoreRecovery {
             // Download segments from remote segment store
             indexShard.syncSegmentsFromRemoteSegmentStore(true, true);
 
+            indexShard.syncTranslogFilesFromRemoteTranslog();
+
             if (store.directory().listAll().length == 0) {
-                store.createEmpty(indexShard.indexSettings().getIndexVersionCreated().luceneVersion);
-            }
-            if (indexShard.indexSettings.isRemoteTranslogStoreEnabled()) {
-                indexShard.syncTranslogFilesFromRemoteTranslog();
-            } else {
-                bootstrap(indexShard, store);
+                Path location = indexShard.shardPath().resolveTranslog();
+                Checkpoint checkpoint = Checkpoint.read(location.resolve(CHECKPOINT_FILE_NAME));
+                final Path translogFile = location.resolve(Translog.getFilename(checkpoint.getGeneration()));
+                try (FileChannel channel = FileChannel.open(translogFile, StandardOpenOption.READ)) {
+                    TranslogHeader translogHeader = TranslogHeader.read(translogFile, channel);
+                    store.createEmpty(indexShard.indexSettings().getIndexVersionCreated().luceneVersion, translogHeader.getTranslogUUID());
+                }
             }
 
             assert indexShard.shardRouting.primary() : "only primary shards can recover from store";

--- a/server/src/main/java/org/opensearch/index/store/Store.java
+++ b/server/src/main/java/org/opensearch/index/store/Store.java
@@ -1747,13 +1747,13 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
         };
     }
 
-    /**
-     * creates an empty lucene index and a corresponding empty translog. Any existing data will be deleted.
-     */
-    public void createEmpty(Version luceneVersion) throws IOException {
+    public void createEmpty(Version luceneVersion, String translogUUID) throws IOException {
         metadataLock.writeLock().lock();
         try (IndexWriter writer = newEmptyIndexWriter(directory, luceneVersion)) {
             final Map<String, String> map = new HashMap<>();
+            if (translogUUID != null) {
+                map.put(Translog.TRANSLOG_UUID_KEY, translogUUID);
+            }
             map.put(Engine.HISTORY_UUID_KEY, UUIDs.randomBase64UUID());
             map.put(SequenceNumbers.LOCAL_CHECKPOINT_KEY, Long.toString(SequenceNumbers.NO_OPS_PERFORMED));
             map.put(SequenceNumbers.MAX_SEQ_NO, Long.toString(SequenceNumbers.NO_OPS_PERFORMED));
@@ -1762,6 +1762,13 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
         } finally {
             metadataLock.writeLock().unlock();
         }
+    }
+
+    /**
+     * creates an empty lucene index and a corresponding empty translog. Any existing data will be deleted.
+     */
+    public void createEmpty(Version luceneVersion) throws IOException {
+        createEmpty(luceneVersion, null);
     }
 
     /**

--- a/server/src/test/java/org/opensearch/index/store/StoreTests.java
+++ b/server/src/test/java/org/opensearch/index/store/StoreTests.java
@@ -84,6 +84,7 @@ import org.opensearch.index.engine.Engine;
 import org.opensearch.index.seqno.ReplicationTracker;
 import org.opensearch.index.seqno.RetentionLease;
 import org.opensearch.index.seqno.SequenceNumbers;
+import org.opensearch.index.translog.Translog;
 import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.indices.store.TransportNodesListShardStoreMetadata;
 import org.opensearch.test.DummyShardLock;
@@ -1163,6 +1164,42 @@ public class StoreTests extends OpenSearchTestCase {
         Store.MetadataSnapshot metadataSnapshot = store.getMetadata(segmentInfos);
         // loose check for equality
         assertEquals(segmentInfos.getSegmentsFileName(), metadataSnapshot.getSegmentsFile().name());
+        store.close();
+    }
+
+    public void testCreateEmptyStore() throws IOException {
+        final ShardId shardId = new ShardId("index", "_na_", 1);
+        Store store = new Store(shardId, INDEX_SETTINGS, new NIOFSDirectory(createTempDir()), new DummyShardLock(shardId));
+        store.createEmpty(Version.LATEST);
+        SegmentInfos segmentInfos = Lucene.readSegmentInfos(store.directory());
+        assertEquals("-1", segmentInfos.getUserData().get(SequenceNumbers.LOCAL_CHECKPOINT_KEY));
+        assertEquals("-1", segmentInfos.getUserData().get(SequenceNumbers.MAX_SEQ_NO));
+        assertEquals("-1", segmentInfos.getUserData().get(Engine.MAX_UNSAFE_AUTO_ID_TIMESTAMP_COMMIT_ID));
+        assertFalse(segmentInfos.getUserData().containsKey(Translog.TRANSLOG_UUID_KEY));
+        store.close();
+    }
+
+    public void testCreateEmptyStoreWithTranlogUUID() throws IOException {
+        final ShardId shardId = new ShardId("index", "_na_", 1);
+        Store store = new Store(shardId, INDEX_SETTINGS, new NIOFSDirectory(createTempDir()), new DummyShardLock(shardId));
+        store.createEmpty(Version.LATEST, "dummy-translog-UUID");
+        SegmentInfos segmentInfos = Lucene.readSegmentInfos(store.directory());
+        assertEquals("dummy-translog-UUID", segmentInfos.getUserData().get(Translog.TRANSLOG_UUID_KEY));
+        assertEquals("-1", segmentInfos.getUserData().get(SequenceNumbers.LOCAL_CHECKPOINT_KEY));
+        assertEquals("-1", segmentInfos.getUserData().get(SequenceNumbers.MAX_SEQ_NO));
+        assertEquals("-1", segmentInfos.getUserData().get(Engine.MAX_UNSAFE_AUTO_ID_TIMESTAMP_COMMIT_ID));
+        store.close();
+    }
+
+    public void testCreateEmptyWithNullTranlogUUID() throws IOException {
+        final ShardId shardId = new ShardId("index", "_na_", 1);
+        Store store = new Store(shardId, INDEX_SETTINGS, new NIOFSDirectory(createTempDir()), new DummyShardLock(shardId));
+        store.createEmpty(Version.LATEST, null);
+        SegmentInfos segmentInfos = Lucene.readSegmentInfos(store.directory());
+        assertFalse(segmentInfos.getUserData().containsKey(Translog.TRANSLOG_UUID_KEY));
+        assertEquals("-1", segmentInfos.getUserData().get(SequenceNumbers.LOCAL_CHECKPOINT_KEY));
+        assertEquals("-1", segmentInfos.getUserData().get(SequenceNumbers.MAX_SEQ_NO));
+        assertEquals("-1", segmentInfos.getUserData().get(Engine.MAX_UNSAFE_AUTO_ID_TIMESTAMP_COMMIT_ID));
         store.close();
     }
 

--- a/server/src/test/java/org/opensearch/index/store/StoreTests.java
+++ b/server/src/test/java/org/opensearch/index/store/StoreTests.java
@@ -1172,10 +1172,8 @@ public class StoreTests extends OpenSearchTestCase {
         Store store = new Store(shardId, INDEX_SETTINGS, new NIOFSDirectory(createTempDir()), new DummyShardLock(shardId));
         store.createEmpty(Version.LATEST);
         SegmentInfos segmentInfos = Lucene.readSegmentInfos(store.directory());
-        assertEquals("-1", segmentInfos.getUserData().get(SequenceNumbers.LOCAL_CHECKPOINT_KEY));
-        assertEquals("-1", segmentInfos.getUserData().get(SequenceNumbers.MAX_SEQ_NO));
-        assertEquals("-1", segmentInfos.getUserData().get(Engine.MAX_UNSAFE_AUTO_ID_TIMESTAMP_COMMIT_ID));
         assertFalse(segmentInfos.getUserData().containsKey(Translog.TRANSLOG_UUID_KEY));
+        testDefaultUserData(segmentInfos);
         store.close();
     }
 
@@ -1185,9 +1183,7 @@ public class StoreTests extends OpenSearchTestCase {
         store.createEmpty(Version.LATEST, "dummy-translog-UUID");
         SegmentInfos segmentInfos = Lucene.readSegmentInfos(store.directory());
         assertEquals("dummy-translog-UUID", segmentInfos.getUserData().get(Translog.TRANSLOG_UUID_KEY));
-        assertEquals("-1", segmentInfos.getUserData().get(SequenceNumbers.LOCAL_CHECKPOINT_KEY));
-        assertEquals("-1", segmentInfos.getUserData().get(SequenceNumbers.MAX_SEQ_NO));
-        assertEquals("-1", segmentInfos.getUserData().get(Engine.MAX_UNSAFE_AUTO_ID_TIMESTAMP_COMMIT_ID));
+        testDefaultUserData(segmentInfos);
         store.close();
     }
 
@@ -1197,10 +1193,14 @@ public class StoreTests extends OpenSearchTestCase {
         store.createEmpty(Version.LATEST, null);
         SegmentInfos segmentInfos = Lucene.readSegmentInfos(store.directory());
         assertFalse(segmentInfos.getUserData().containsKey(Translog.TRANSLOG_UUID_KEY));
+        testDefaultUserData(segmentInfos);
+        store.close();
+    }
+
+    private void testDefaultUserData(SegmentInfos segmentInfos) {
         assertEquals("-1", segmentInfos.getUserData().get(SequenceNumbers.LOCAL_CHECKPOINT_KEY));
         assertEquals("-1", segmentInfos.getUserData().get(SequenceNumbers.MAX_SEQ_NO));
         assertEquals("-1", segmentInfos.getUserData().get(Engine.MAX_UNSAFE_AUTO_ID_TIMESTAMP_COMMIT_ID));
-        store.close();
     }
 
     public void testGetSegmentMetadataMap() throws IOException {

--- a/server/src/test/java/org/opensearch/index/translog/TranslogHeaderTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/TranslogHeaderTests.java
@@ -132,6 +132,49 @@ public class TranslogHeaderTests extends OpenSearchTestCase {
         });
     }
 
+    public void testCurrentHeaderVersionWithoutUUIDComparison() throws Exception {
+        final String translogUUID = UUIDs.randomBase64UUID();
+        final TranslogHeader outHeader = new TranslogHeader(translogUUID, randomNonNegativeLong());
+        final long generation = randomNonNegativeLong();
+        final Path translogFile = createTempDir().resolve(Translog.getFilename(generation));
+        try (FileChannel channel = FileChannel.open(translogFile, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE)) {
+            outHeader.write(channel, true);
+            assertThat(outHeader.sizeInBytes(), equalTo((int) channel.position()));
+        }
+        try (FileChannel channel = FileChannel.open(translogFile, StandardOpenOption.READ)) {
+            final TranslogHeader inHeader = TranslogHeader.read(translogFile, channel);
+            assertThat(inHeader.getTranslogUUID(), equalTo(translogUUID));
+            assertThat(inHeader.getPrimaryTerm(), equalTo(outHeader.getPrimaryTerm()));
+            assertThat(inHeader.sizeInBytes(), equalTo((int) channel.position()));
+        }
+
+        TestTranslog.corruptFile(logger, random(), translogFile, false);
+        final TranslogCorruptedException corruption = expectThrows(TranslogCorruptedException.class, () -> {
+            try (FileChannel channel = FileChannel.open(translogFile, StandardOpenOption.READ)) {
+                final TranslogHeader translogHeader = TranslogHeader.read(translogFile, channel);
+                assertThat(
+                    "version " + TranslogHeader.VERSION_CHECKPOINTS + " translog",
+                    translogHeader.getPrimaryTerm(),
+                    equalTo(SequenceNumbers.UNASSIGNED_PRIMARY_TERM)
+                );
+                throw new TranslogCorruptedException(translogFile.toString(), "adjusted translog version");
+            } catch (IllegalStateException e) {
+                // corruption corrupted the version byte making this look like a v2, v1 or v0 translog
+                assertThat(
+                    "version " + TranslogHeader.VERSION_CHECKPOINTS + "-or-earlier translog",
+                    e.getMessage(),
+                    anyOf(
+                        containsString("pre-2.0 translog found"),
+                        containsString("pre-1.4 translog found"),
+                        containsString("pre-6.3 translog found")
+                    )
+                );
+                throw new TranslogCorruptedException(translogFile.toString(), "adjusted translog version", e);
+            }
+        });
+        assertThat(corruption.getMessage(), not(containsString("this translog file belongs to a different translog")));
+    }
+
     static void writeHeaderWithoutTerm(FileChannel channel, String translogUUID) throws IOException {
         final OutputStreamStreamOutput out = new OutputStreamStreamOutput(Channels.newOutputStream(channel));
         CodecUtil.writeHeader(new OutputStreamDataOutput(out), TranslogHeader.TRANSLOG_CODEC, TranslogHeader.VERSION_CHECKPOINTS);


### PR DESCRIPTION
### Description
- If we have an index where all the ingested data is in translog alone (the first refresh is not triggered yet), restoring such index from remote store fails due to issue mentioned in https://github.com/opensearch-project/OpenSearch/issues/7923
- This happens as the translog UUID of the downloaded translog files do not match with that of segment files (that are created newly as part of restore)
- In this change, we make sure to create empty store with the same UUID that is present in the remote translog.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/7923

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
