### PR TITLE
Fix range reads in respository-s3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Fix flaky ResourceAwareTasksTests.testBasicTaskResourceTracking test ([#8993](https://github.com/opensearch-project/OpenSearch/pull/8993))
 - Fix memory leak when using Zstd Dictionary ([#9403](https://github.com/opensearch-project/OpenSearch/pull/9403))
+- Fix range reads in respository-s3 ([9512](https://github.com/opensearch-project/OpenSearch/issues/9512))
 
 ### Security
 

--- a/plugins/repository-hdfs/src/test/java/org/opensearch/repositories/hdfs/HdfsBlobStoreRepositoryTests.java
+++ b/plugins/repository-hdfs/src/test/java/org/opensearch/repositories/hdfs/HdfsBlobStoreRepositoryTests.java
@@ -66,4 +66,8 @@ public class HdfsBlobStoreRepositoryTests extends OpenSearchBlobStoreRepositoryI
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         return Collections.singletonList(HdfsPlugin.class);
     }
+
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/9513")
+    @Override
+    public void testReadRange() {}
 }

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/utils/HttpRangeUtils.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/utils/HttpRangeUtils.java
@@ -8,25 +8,14 @@
 
 package org.opensearch.repositories.s3.utils;
 
-import software.amazon.awssdk.core.exception.SdkException;
+public final class HttpRangeUtils {
 
-import org.opensearch.common.collect.Tuple;
-
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-public class HttpRangeUtils {
-
-    private static final Pattern RANGE_PATTERN = Pattern.compile("^bytes=([0-9]+)-([0-9]+)$");
-
-    public static Tuple<Long, Long> fromHttpRangeHeader(String headerValue) {
-        Matcher matcher = RANGE_PATTERN.matcher(headerValue);
-        if (!matcher.find()) {
-            throw SdkException.create("Regex match for Content-Range header {" + headerValue + "} failed", new RuntimeException());
-        }
-        return new Tuple<>(Long.parseLong(matcher.group(1)), Long.parseLong(matcher.group(2)));
-    }
-
+    /**
+     * Provides a byte range string per <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-byte-ranges">RFC 9110</a>
+     * @param start start position (inclusive)
+     * @param end end position (inclusive)
+     * @return A 'bytes=start-end' string
+     */
     public static String toHttpRangeHeader(long start, long end) {
         return "bytes=" + start + "-" + end;
     }

--- a/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/S3RetryingInputStreamTests.java
+++ b/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/S3RetryingInputStreamTests.java
@@ -38,7 +38,6 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 
 import org.opensearch.common.io.Streams;
-import org.opensearch.repositories.s3.utils.HttpRangeUtils;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.ByteArrayInputStream;
@@ -104,11 +103,11 @@ public class S3RetryingInputStreamTests extends OpenSearchTestCase {
     }
 
     private S3RetryingInputStream createInputStream(final byte[] data, final Long start, final Long length) throws IOException {
-        long end = Math.addExact(start, length - 1);
+        final long end = Math.addExact(start, length - 1);
         final S3Client client = mock(S3Client.class);
         when(client.getObject(any(GetObjectRequest.class))).thenReturn(
             new ResponseInputStream<>(
-                GetObjectResponse.builder().contentLength(length).contentRange(HttpRangeUtils.toHttpRangeHeader(start, end)).build(),
+                GetObjectResponse.builder().contentLength(length).build(),
                 new ByteArrayInputStream(data, Math.toIntExact(start), Math.toIntExact(length))
             )
         );


### PR DESCRIPTION
The `readBlob(String, long, long)` method in the S3 repository has been broken since the upgrade to AWS SDK v2. The cause is that the SDK v2 returns the content range length details in a string formatting per the [RFC 9110][1] spec. For example:

```
bytes 0-100/200
```

However, the code was attempting to parse it as:

```
bytes=0-100
```

The fix here is to not parse this string at all and instead use `GetObjectResponse#contentLength`.

Note that the incorrect format matches how a range is specified in a _request_ per the [byte ranges][2] section of the RFC and that is likely the source of the confusion.. We lack any dedicated integration testing of this method so the bug was not caught by any tests. Additionally, the range read is only used by the searchable snapshot feature currently and we have no automated integration testing with the different repository implementations. One other complicating factor is that due to a fallback path that returns `Long.MAX_VALUE - 1` when the range is failed to be parsed, the bug will only manifest as a long overflow error when requesting past the first block and therefore wasn't caught with very simple manual testing.

[1]: https://www.rfc-editor.org/rfc/rfc9110.html#name-content-range
[2]: https://www.rfc-editor.org/rfc/rfc9110.html#name-byte-ranges

### Related Issues
Resolves #9512
Related #9514

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
