### PR TITLE
[BWC and API enforcement] Decorate the existing APIs with proper annotations (part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Feature] Expose term frequency in Painless script score context ([#9081](https://github.com/opensearch-project/OpenSearch/pull/9081))
 - Add support for reading partial files to HDFS repository ([#9513](https://github.com/opensearch-project/OpenSearch/issues/9513))
 - Add support for extensions to search responses using SearchExtBuilder ([#9379](https://github.com/opensearch-project/OpenSearch/pull/9379)) 
+- [BWC and API enforcement] Decorate the existing APIs with proper annotations (part 1) ([#9520](https://github.com/opensearch-project/OpenSearch/pull/9520))
 
 ### Dependencies
 - Bump `org.apache.logging.log4j:log4j-core` from 2.17.1 to 2.20.0 ([#8307](https://github.com/opensearch-project/OpenSearch/pull/8307))

--- a/libs/common/src/main/java/org/opensearch/common/CheckedConsumer.java
+++ b/libs/common/src/main/java/org/opensearch/common/CheckedConsumer.java
@@ -32,6 +32,8 @@
 
 package org.opensearch.common;
 
+import org.opensearch.common.annotation.PublicApi;
+
 import java.util.function.Consumer;
 
 /**
@@ -39,6 +41,7 @@ import java.util.function.Consumer;
  *
  * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 @FunctionalInterface
 public interface CheckedConsumer<T, E extends Exception> {
     void accept(T t) throws E;

--- a/libs/common/src/main/java/org/opensearch/common/action/ActionFuture.java
+++ b/libs/common/src/main/java/org/opensearch/common/action/ActionFuture.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.common.action;
 
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.unit.TimeValue;
 
 import java.util.concurrent.Future;
@@ -42,6 +43,7 @@ import java.util.concurrent.TimeUnit;
  *
  * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public interface ActionFuture<T> extends Future<T> {
 
     /**

--- a/libs/common/src/main/java/org/opensearch/common/lifecycle/Lifecycle.java
+++ b/libs/common/src/main/java/org/opensearch/common/lifecycle/Lifecycle.java
@@ -32,6 +32,8 @@
 
 package org.opensearch.common.lifecycle;
 
+import org.opensearch.common.annotation.PublicApi;
+
 /**
  * Lifecycle state. Allows the following transitions:
  * <ul>
@@ -73,15 +75,17 @@ package org.opensearch.common.lifecycle;
  * }
  * </pre>
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public class Lifecycle {
 
     /**
      * State in the lifecycle
      *
-     * @opensearch.internal
+     * @opensearch.api
      */
+    @PublicApi(since = "1.0.0")
     public enum State {
         INITIALIZED,
         STOPPED,

--- a/libs/common/src/main/java/org/opensearch/common/lifecycle/LifecycleComponent.java
+++ b/libs/common/src/main/java/org/opensearch/common/lifecycle/LifecycleComponent.java
@@ -32,13 +32,15 @@
 
 package org.opensearch.common.lifecycle;
 
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.lease.Releasable;
 
 /**
  * Base interface for a lifecycle component.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public interface LifecycleComponent extends Releasable {
 
     Lifecycle.State lifecycleState();

--- a/libs/common/src/main/java/org/opensearch/common/unit/TimeValue.java
+++ b/libs/common/src/main/java/org/opensearch/common/unit/TimeValue.java
@@ -32,6 +32,8 @@
 
 package org.opensearch.common.unit;
 
+import org.opensearch.common.annotation.PublicApi;
+
 import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
@@ -41,6 +43,7 @@ import java.util.concurrent.TimeUnit;
  *
  * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public class TimeValue implements Comparable<TimeValue> {
 
     /** How many nano-seconds in one milli-second */

--- a/libs/core/src/main/java/org/opensearch/Version.java
+++ b/libs/core/src/main/java/org/opensearch/Version.java
@@ -33,6 +33,7 @@
 package org.opensearch;
 
 import org.opensearch.common.SuppressForbidden;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.xcontent.ToXContentFragment;
 import org.opensearch.core.xcontent.XContentBuilder;
 
@@ -50,6 +51,7 @@ import java.util.Objects;
  *
  * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public class Version implements Comparable<Version>, ToXContentFragment {
     /*
      * The logic for ID is: XXYYZZAA, where XX is major version, YY is minor version, ZZ is revision, and AA is alpha/beta/rc indicator AA

--- a/libs/core/src/main/java/org/opensearch/core/ParseField.java
+++ b/libs/core/src/main/java/org/opensearch/core/ParseField.java
@@ -31,6 +31,7 @@
 
 package org.opensearch.core;
 
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.XContentLocation;
 
@@ -43,7 +44,11 @@ import java.util.function.Supplier;
 /**
  * Holds a field that can be found in a request while parsing and its different
  * variants, which may be deprecated.
+ *
+ * @opensearch.api
+ *
  */
+@PublicApi(since = "1.0.0")
 public class ParseField {
     private final String name;
     private final String[] deprecatedNames;

--- a/libs/core/src/main/java/org/opensearch/core/action/ActionListener.java
+++ b/libs/core/src/main/java/org/opensearch/core/action/ActionListener.java
@@ -37,6 +37,7 @@ import org.opensearch.common.CheckedConsumer;
 import org.opensearch.common.CheckedFunction;
 import org.opensearch.common.CheckedRunnable;
 import org.opensearch.common.CheckedSupplier;
+import org.opensearch.common.annotation.PublicApi;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -48,6 +49,7 @@ import java.util.function.Consumer;
  *
  * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public interface ActionListener<Response> {
     /**
      * Handle action response. This response may constitute a failure or a

--- a/libs/core/src/main/java/org/opensearch/core/common/bytes/BytesReference.java
+++ b/libs/core/src/main/java/org/opensearch/core/common/bytes/BytesReference.java
@@ -35,6 +35,7 @@ package org.opensearch.core.common.bytes;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefIterator;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.common.io.stream.BytesStream;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.util.ByteArray;
@@ -50,8 +51,9 @@ import java.util.ArrayList;
 /**
  * A reference to bytes.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public interface BytesReference extends Comparable<BytesReference>, ToXContentFragment {
 
     /**

--- a/libs/core/src/main/java/org/opensearch/core/common/io/stream/NamedWriteableRegistry.java
+++ b/libs/core/src/main/java/org/opensearch/core/common/io/stream/NamedWriteableRegistry.java
@@ -32,6 +32,8 @@
 
 package org.opensearch.core.common.io.stream;
 
+import org.opensearch.common.annotation.PublicApi;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -45,15 +47,17 @@ import java.util.Objects;
  * The registration is keyed by the combination of the category class of {@link NamedWriteable}, and a name unique
  * to that category.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public class NamedWriteableRegistry {
 
     /**
      * An entry in the registry, made up of a category class and name, and a reader for that category class.
      *
-     * @opensearch.internal
+     * @opensearch.api
      */
+    @PublicApi(since = "1.0.0")
     public static class Entry {
 
         /** The superclass of a {@link NamedWriteable} which will be read by {@link #reader}. */

--- a/libs/core/src/main/java/org/opensearch/core/common/io/stream/StreamInput.java
+++ b/libs/core/src/main/java/org/opensearch/core/common/io/stream/StreamInput.java
@@ -46,6 +46,7 @@ import org.opensearch.OpenSearchException;
 import org.opensearch.Version;
 import org.opensearch.common.CharArrays;
 import org.opensearch.common.Nullable;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.bytes.BytesArray;
@@ -104,8 +105,9 @@ import static org.opensearch.OpenSearchException.readStackTrace;
  * lists, either by storing {@code List}s internally or just converting to and from a {@code List} when calling. This comment is repeated
  * on {@link StreamInput}.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public abstract class StreamInput extends InputStream {
 
     private Version version = Version.CURRENT;

--- a/libs/core/src/main/java/org/opensearch/core/common/io/stream/StreamOutput.java
+++ b/libs/core/src/main/java/org/opensearch/core/common/io/stream/StreamOutput.java
@@ -45,6 +45,7 @@ import org.opensearch.OpenSearchException;
 import org.opensearch.Version;
 import org.opensearch.common.CharArrays;
 import org.opensearch.common.Nullable;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.common.bytes.BytesReference;
@@ -96,8 +97,9 @@ import java.util.function.IntFunction;
  * lists, either by storing {@code List}s internally or just converting to and from a {@code List} when calling. This comment is repeated
  * on {@link StreamInput}.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public abstract class StreamOutput extends OutputStream {
 
     private static final int MAX_NESTED_EXCEPTION_LEVEL = 100;

--- a/libs/core/src/main/java/org/opensearch/core/common/settings/SecureString.java
+++ b/libs/core/src/main/java/org/opensearch/core/common/settings/SecureString.java
@@ -32,6 +32,8 @@
 
 package org.opensearch.core.common.settings;
 
+import org.opensearch.common.annotation.PublicApi;
+
 import java.io.Closeable;
 import java.util.Arrays;
 import java.util.Objects;
@@ -39,8 +41,9 @@ import java.util.Objects;
 /**
  * A String implementations which allows clearing the underlying char array.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public final class SecureString implements CharSequence, Closeable {
 
     private char[] chars;

--- a/libs/core/src/main/java/org/opensearch/core/common/unit/ByteSizeUnit.java
+++ b/libs/core/src/main/java/org/opensearch/core/common/unit/ByteSizeUnit.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.core.common.unit;
 
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
@@ -45,8 +46,9 @@ import java.io.IOException;
  * helps organize and use size representations that may be maintained
  * separately across various contexts.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public enum ByteSizeUnit implements Writeable {
     BYTES {
         @Override

--- a/libs/core/src/main/java/org/opensearch/core/common/unit/ByteSizeValue.java
+++ b/libs/core/src/main/java/org/opensearch/core/common/unit/ByteSizeValue.java
@@ -33,6 +33,7 @@
 package org.opensearch.core.common.unit;
 
 import org.opensearch.OpenSearchParseException;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -47,8 +48,9 @@ import java.util.Objects;
 /**
  * A byte size value
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public class ByteSizeValue implements Writeable, Comparable<ByteSizeValue>, ToXContentFragment {
 
     public static final ByteSizeValue ZERO = new ByteSizeValue(0, ByteSizeUnit.BYTES);

--- a/libs/core/src/main/java/org/opensearch/core/index/Index.java
+++ b/libs/core/src/main/java/org/opensearch/core/index/Index.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.core.index;
 
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.ParseField;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -48,8 +49,9 @@ import java.util.Objects;
 /**
  * A value class representing the basic required properties of an OpenSearch index.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public class Index implements Writeable, ToXContentObject {
 
     public static final Index[] EMPTY_ARRAY = new Index[0];

--- a/libs/core/src/main/java/org/opensearch/core/index/shard/ShardId.java
+++ b/libs/core/src/main/java/org/opensearch/core/index/shard/ShardId.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.core.index.shard;
 
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -45,8 +46,9 @@ import java.io.IOException;
 /**
  * Allows for shard level components to be injected with the shard id.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public class ShardId implements Comparable<ShardId>, ToXContentFragment, Writeable {
 
     private final Index index;

--- a/libs/core/src/main/java/org/opensearch/core/rest/RestStatus.java
+++ b/libs/core/src/main/java/org/opensearch/core/rest/RestStatus.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.core.rest;
 
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.action.ShardOperationFailedException;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -47,6 +48,7 @@ import static java.util.Collections.unmodifiableMap;
  *
  * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public enum RestStatus {
     /**
      * The client SHOULD continue with its request. This interim response is used to inform the client that the

--- a/libs/core/src/main/java/org/opensearch/core/tasks/TaskId.java
+++ b/libs/core/src/main/java/org/opensearch/core/tasks/TaskId.java
@@ -33,6 +33,7 @@
 package org.opensearch.core.tasks;
 
 import org.opensearch.OpenSearchParseException;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -45,8 +46,9 @@ import java.io.IOException;
 /**
  * Task id that consists of node id and id of the task on the node
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public final class TaskId implements Writeable {
 
     public static final TaskId EMPTY_TASK_ID = new TaskId();

--- a/libs/core/src/main/java/org/opensearch/core/xcontent/MediaType.java
+++ b/libs/core/src/main/java/org/opensearch/core/xcontent/MediaType.java
@@ -46,7 +46,7 @@ import java.util.Locale;
  *
  * @opensearch.api
  */
-@PublicApi(since = "1.0.0")
+@PublicApi(since = "2.1.0")
 public interface MediaType extends Writeable {
     /**
      * Returns a type part of a MediaType

--- a/libs/core/src/main/java/org/opensearch/core/xcontent/MediaType.java
+++ b/libs/core/src/main/java/org/opensearch/core/xcontent/MediaType.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.core.xcontent;
 
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.common.io.stream.Writeable;
 
 import java.io.IOException;
@@ -42,7 +43,10 @@ import java.util.Locale;
  * Abstracts a <a href="http://en.wikipedia.org/wiki/Internet_media_type">Media Type</a> and a format parameter.
  * Media types are used as values on Content-Type and Accept headers
  * format is an URL parameter, specifies response media type.
+ *
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public interface MediaType extends Writeable {
     /**
      * Returns a type part of a MediaType

--- a/libs/core/src/main/java/org/opensearch/core/xcontent/NamedXContentRegistry.java
+++ b/libs/core/src/main/java/org/opensearch/core/xcontent/NamedXContentRegistry.java
@@ -33,6 +33,7 @@
 package org.opensearch.core.xcontent;
 
 import org.opensearch.common.CheckedFunction;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.ParseField;
 
 import java.io.IOException;
@@ -49,8 +50,9 @@ import static java.util.Collections.unmodifiableMap;
 /**
  * Main registry for serializable content (e.g., field mappers, aggregations)
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public class NamedXContentRegistry {
     /**
      * The empty {@link NamedXContentRegistry} for use when you are sure that you aren't going to call
@@ -64,6 +66,7 @@ public class NamedXContentRegistry {
     /**
      * An entry in the {@linkplain NamedXContentRegistry} containing the name of the object and the parser that can parse it.
      */
+    @PublicApi(since = "1.0.0")
     public static class Entry {
         /** The class that this entry can read. */
         public final Class<?> categoryClass;

--- a/libs/core/src/main/java/org/opensearch/core/xcontent/XContentBuilder.java
+++ b/libs/core/src/main/java/org/opensearch/core/xcontent/XContentBuilder.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.core.xcontent;
 
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.common.bytes.BytesReference;
 
 import java.io.ByteArrayOutputStream;
@@ -61,6 +62,7 @@ import java.util.function.Function;
 /**
  * A utility to build XContent (ie json).
  */
+@PublicApi(since = "1.0.0")
 public final class XContentBuilder implements Closeable, Flushable {
 
     /**

--- a/server/src/main/java/org/opensearch/bootstrap/BootstrapCheck.java
+++ b/server/src/main/java/org/opensearch/bootstrap/BootstrapCheck.java
@@ -32,18 +32,22 @@
 
 package org.opensearch.bootstrap;
 
+import org.opensearch.common.annotation.PublicApi;
+
 import java.util.Objects;
 
 /**
  * Encapsulates a bootstrap check.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public interface BootstrapCheck {
 
     /**
      * Encapsulate the result of a bootstrap check.
      */
+    @PublicApi(since = "1.0.0")
     final class BootstrapCheckResult {
 
         private final String message;

--- a/server/src/main/java/org/opensearch/bootstrap/BootstrapContext.java
+++ b/server/src/main/java/org/opensearch/bootstrap/BootstrapContext.java
@@ -32,14 +32,16 @@
 package org.opensearch.bootstrap;
 
 import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.env.Environment;
 
 /**
  * Context that is passed to every bootstrap check to make decisions on.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public class BootstrapContext {
     /**
      * The node's environment

--- a/server/src/main/java/org/opensearch/client/AdminClient.java
+++ b/server/src/main/java/org/opensearch/client/AdminClient.java
@@ -32,13 +32,16 @@
 
 package org.opensearch.client;
 
+import org.opensearch.common.annotation.PublicApi;
+
 /**
  * Administrative actions/operations against the cluster or the indices.
  *
  * @see org.opensearch.client.Client#admin()
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public interface AdminClient {
 
     /**

--- a/server/src/main/java/org/opensearch/client/Client.java
+++ b/server/src/main/java/org/opensearch/client/Client.java
@@ -83,6 +83,7 @@ import org.opensearch.action.update.UpdateRequestBuilder;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.action.ActionFuture;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
@@ -102,8 +103,9 @@ import java.util.Map;
  *
  * @see org.opensearch.node.Node#client()
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public interface Client extends OpenSearchClient, Releasable {
 
     Setting<String> CLIENT_TYPE_SETTING_S = new Setting<>("client.type", "node", (s) -> {

--- a/server/src/main/java/org/opensearch/client/ClusterAdminClient.java
+++ b/server/src/main/java/org/opensearch/client/ClusterAdminClient.java
@@ -157,6 +157,7 @@ import org.opensearch.action.search.GetSearchPipelineResponse;
 import org.opensearch.action.search.PutSearchPipelineRequest;
 import org.opensearch.action.support.master.AcknowledgedResponse;
 import org.opensearch.common.action.ActionFuture;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.tasks.TaskId;
@@ -167,8 +168,9 @@ import org.opensearch.core.xcontent.MediaType;
  *
  * @see AdminClient#cluster()
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public interface ClusterAdminClient extends OpenSearchClient {
 
     /**

--- a/server/src/main/java/org/opensearch/client/IndicesAdminClient.java
+++ b/server/src/main/java/org/opensearch/client/IndicesAdminClient.java
@@ -129,6 +129,7 @@ import org.opensearch.action.support.master.AcknowledgedResponse;
 import org.opensearch.cluster.metadata.IndexMetadata.APIBlock;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.action.ActionFuture;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.action.ActionListener;
 
 /**
@@ -136,8 +137,9 @@ import org.opensearch.core.action.ActionListener;
  *
  * @see AdminClient#indices()
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public interface IndicesAdminClient extends OpenSearchClient {
 
     /**

--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -38,6 +38,7 @@ import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.common.Booleans;
 import org.opensearch.common.Nullable;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.regex.Regex;
@@ -76,8 +77,9 @@ import java.util.stream.StreamSupport;
 /**
  * Resolves index name from an expression
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public class IndexNameExpressionResolver {
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(IndexNameExpressionResolver.class);
 

--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexTemplateMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexTemplateMetadata.java
@@ -35,6 +35,7 @@ import org.opensearch.OpenSearchParseException;
 import org.opensearch.cluster.AbstractDiffable;
 import org.opensearch.cluster.Diff;
 import org.opensearch.common.Nullable;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.collect.MapBuilder;
 import org.opensearch.common.compress.CompressedXContent;
 import org.opensearch.common.logging.DeprecationLogger;
@@ -63,8 +64,9 @@ import java.util.Set;
 /**
  * Metadata for Index Templates
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public class IndexTemplateMetadata extends AbstractDiffable<IndexTemplateMetadata> {
 
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(IndexTemplateMetadata.class);

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
@@ -34,6 +34,7 @@ package org.opensearch.cluster.node;
 
 import org.opensearch.Version;
 import org.opensearch.common.UUIDs;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -64,8 +65,9 @@ import static org.opensearch.node.NodeRoleSettings.NODE_ROLES_SETTING;
 /**
  * A discovery node represents a node that is part of the cluster.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public class DiscoveryNode implements Writeable, ToXContentFragment {
 
     static final String COORDINATING_ONLY = "coordinating_only";

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodeRole.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodeRole.java
@@ -35,6 +35,7 @@ package org.opensearch.cluster.node;
 import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.common.Booleans;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
@@ -52,8 +53,9 @@ import java.util.TreeSet;
 /**
  * Represents a node role.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public abstract class DiscoveryNodeRole implements Comparable<DiscoveryNodeRole> {
 
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(DiscoveryNodeRole.class);

--- a/server/src/main/java/org/opensearch/cluster/service/ClusterService.java
+++ b/server/src/main/java/org/opensearch/cluster/service/ClusterService.java
@@ -45,6 +45,7 @@ import org.opensearch.cluster.NodeConnectionsService;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.routing.OperationRouting;
 import org.opensearch.cluster.routing.RerouteService;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.lifecycle.AbstractLifecycleComponent;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
@@ -60,8 +61,9 @@ import java.util.Map;
 /**
  * Main Cluster Service
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public class ClusterService extends AbstractLifecycleComponent {
     private final ClusterManagerService clusterManagerService;
 

--- a/server/src/main/java/org/opensearch/common/inject/Module.java
+++ b/server/src/main/java/org/opensearch/common/inject/Module.java
@@ -29,6 +29,8 @@
 
 package org.opensearch.common.inject;
 
+import org.opensearch.common.annotation.PublicApi;
+
 /**
  * A module contributes configuration information, typically interface
  * bindings, which will be used to create an {@link Injector}. A Guice-based
@@ -43,8 +45,9 @@ package org.opensearch.common.inject;
  * Use scope and binding annotations on these methods to configure the
  * bindings.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public interface Module {
 
     /**

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -78,6 +78,7 @@ import org.opensearch.cluster.service.ClusterApplierService;
 import org.opensearch.cluster.service.ClusterManagerService;
 import org.opensearch.cluster.service.ClusterManagerTaskThrottler;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.logging.Loggers;
 import org.opensearch.common.network.NetworkModule;
 import org.opensearch.common.network.NetworkService;
@@ -166,8 +167,9 @@ import java.util.function.Predicate;
 /**
  * Encapsulates all valid cluster level settings.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public final class ClusterSettings extends AbstractScopedSettings {
 
     public ClusterSettings(final Settings nodeSettings, final Set<Setting<?>> settingsSet) {

--- a/server/src/main/java/org/opensearch/common/settings/SecureSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/SecureSettings.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.common.settings;
 
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.common.settings.SecureString;
 
 import java.io.Closeable;
@@ -43,8 +44,9 @@ import java.util.Set;
 /**
  * An accessor for settings which are securely stored. See {@link SecureSetting}.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public interface SecureSettings extends Closeable {
 
     /** Returns true iff the settings are loaded and retrievable. */

--- a/server/src/main/java/org/opensearch/common/settings/Setting.java
+++ b/server/src/main/java/org/opensearch/common/settings/Setting.java
@@ -38,6 +38,7 @@ import org.opensearch.OpenSearchParseException;
 import org.opensearch.Version;
 import org.opensearch.common.Booleans;
 import org.opensearch.common.Nullable;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.regex.Regex;
 import org.opensearch.common.unit.MemorySizeValue;
@@ -102,15 +103,17 @@ import java.util.stream.Stream;
  * }
  * </pre>
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public class Setting<T> implements ToXContentObject {
 
     /**
      * Property of the setting
      *
-     * @opensearch.internal
+     * @opensearch.api
      */
+    @PublicApi(since = "1.0.0")
     public enum Property {
         /**
          * should be filtered in some api (mask password/credentials)
@@ -635,8 +638,9 @@ public class Setting<T> implements ToXContentObject {
      * Allows a setting to declare a dependency on another setting being set. Optionally, a setting can validate the value of the dependent
      * setting.
      *
-     * @opensearch.internal
+     * @opensearch.api
      */
+    @PublicApi(since = "1.0.0")
     public interface SettingDependency {
 
         /**
@@ -784,8 +788,9 @@ public class Setting<T> implements ToXContentObject {
     /**
      * Allows an affix setting to declare a dependency on another affix setting.
      *
-     * @opensearch.internal
+     * @opensearch.api
      */
+    @PublicApi(since = "1.0.0")
     public interface AffixSettingDependency extends SettingDependency {
 
         @Override
@@ -796,8 +801,9 @@ public class Setting<T> implements ToXContentObject {
     /**
      * An affix setting
      *
-     * @opensearch.internal
+     * @opensearch.api
      */
+    @PublicApi(since = "1.0.0")
     public static class AffixSetting<T> extends Setting<T> {
         private final AffixKey key;
         private final BiFunction<String, String, Setting<T>> delegateFactory;
@@ -1026,9 +1032,10 @@ public class Setting<T> implements ToXContentObject {
      *
      * @param <T> the type of the {@link Setting}
      *
-     * @opensearch.internal
+     * @opensearch.api
      */
     @FunctionalInterface
+    @PublicApi(since = "1.0.0")
     public interface Validator<T> {
 
         /**
@@ -2834,8 +2841,9 @@ public class Setting<T> implements ToXContentObject {
     /**
      * Key for the setting
      *
-     * @opensearch.internal
+     * @opensearch.api
      */
+    @PublicApi(since = "1.0.0")
     public interface Key {
         boolean match(String key);
     }
@@ -2843,8 +2851,9 @@ public class Setting<T> implements ToXContentObject {
     /**
      * A simple key for a setting
      *
-     * @opensearch.internal
+     * @opensearch.api
      */
+    @PublicApi(since = "1.0.0")
     public static class SimpleKey implements Key {
         protected final String key;
 
@@ -2918,8 +2927,9 @@ public class Setting<T> implements ToXContentObject {
      * A key that allows for static pre and suffix. This is used for settings
      * that have dynamic namespaces like for different accounts etc.
      *
-     * @opensearch.internal
+     * @opensearch.api
      */
+    @PublicApi(since = "1.0.0")
     public static final class AffixKey implements Key {
         private final Pattern pattern;
         private final String prefix;

--- a/server/src/main/java/org/opensearch/common/settings/SettingUpgrader.java
+++ b/server/src/main/java/org/opensearch/common/settings/SettingUpgrader.java
@@ -32,6 +32,8 @@
 
 package org.opensearch.common.settings;
 
+import org.opensearch.common.annotation.PublicApi;
+
 import java.util.List;
 
 /**
@@ -39,8 +41,9 @@ import java.util.List;
  *
  * @param <T> the type of the underlying setting
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public interface SettingUpgrader<T> {
 
     /**

--- a/server/src/main/java/org/opensearch/common/settings/Settings.java
+++ b/server/src/main/java/org/opensearch/common/settings/Settings.java
@@ -38,6 +38,7 @@ import org.opensearch.OpenSearchParseException;
 import org.opensearch.Version;
 import org.opensearch.common.Booleans;
 import org.opensearch.common.SetOnce;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.logging.LogConfigurator;
 import org.opensearch.common.unit.MemorySizeValue;
@@ -95,8 +96,9 @@ import static org.opensearch.core.common.unit.ByteSizeValue.parseBytesSizeValue;
 /**
  * An immutable settings implementation.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public final class Settings implements ToXContentFragment {
 
     public static final Settings EMPTY = new Builder().build();
@@ -750,8 +752,9 @@ public final class Settings implements ToXContentFragment {
      * settings implementation. Use {@link Settings#builder()} in order to
      * construct it.
      *
-     * @opensearch.internal
+     * @opensearch.api
      */
+    @PublicApi(since = "1.0.0")
     public static class Builder {
 
         public static final Settings EMPTY_SETTINGS = new Builder().build();

--- a/server/src/main/java/org/opensearch/common/settings/SettingsException.java
+++ b/server/src/main/java/org/opensearch/common/settings/SettingsException.java
@@ -33,6 +33,7 @@
 package org.opensearch.common.settings;
 
 import org.opensearch.OpenSearchException;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.rest.RestStatus;
 
@@ -41,8 +42,9 @@ import java.io.IOException;
 /**
  * A generic failure to handle settings.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public class SettingsException extends OpenSearchException {
 
     public SettingsException(String message) {

--- a/server/src/main/java/org/opensearch/env/Environment.java
+++ b/server/src/main/java/org/opensearch/env/Environment.java
@@ -33,6 +33,7 @@
 package org.opensearch.env;
 
 import org.opensearch.common.SuppressForbidden;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.io.PathUtils;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
@@ -56,8 +57,9 @@ import java.util.stream.Collectors;
 /**
  * The environment of where things exists.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 @SuppressForbidden(reason = "configures paths for the system")
 // TODO: move PathUtils to be package-private here instead of
 // public+forbidden api!

--- a/server/src/main/java/org/opensearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/opensearch/env/NodeEnvironment.java
@@ -53,6 +53,7 @@ import org.opensearch.common.CheckedFunction;
 import org.opensearch.common.Randomness;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.UUIDs;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.settings.Setting;
@@ -108,14 +109,16 @@ import static java.util.Collections.unmodifiableSet;
 /**
  * A component that holds all data paths for a single node.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public final class NodeEnvironment implements Closeable {
     /**
      * A node path.
      *
-     * @opensearch.internal
+     * @opensearch.api
      */
+    @PublicApi(since = "1.0.0")
     public static class NodePath {
         /* ${data.paths}/nodes/{node.id} */
         public final Path path;

--- a/server/src/main/java/org/opensearch/env/ShardLock.java
+++ b/server/src/main/java/org/opensearch/env/ShardLock.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.env;
 
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.index.shard.ShardId;
 
 import java.io.Closeable;
@@ -44,8 +45,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *
  * @see NodeEnvironment
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public abstract class ShardLock implements Closeable {
 
     private final ShardId shardId;

--- a/server/src/main/java/org/opensearch/env/ShardLockObtainFailedException.java
+++ b/server/src/main/java/org/opensearch/env/ShardLockObtainFailedException.java
@@ -33,6 +33,7 @@
 package org.opensearch.env;
 
 import org.opensearch.OpenSearchException;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.index.shard.ShardId;
 
@@ -41,8 +42,9 @@ import java.io.IOException;
 /**
  * Exception used when the in-memory lock for a shard cannot be obtained
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public class ShardLockObtainFailedException extends OpenSearchException {
 
     public ShardLockObtainFailedException(ShardId shardId, String message) {

--- a/server/src/main/java/org/opensearch/index/IndexModule.java
+++ b/server/src/main/java/org/opensearch/index/IndexModule.java
@@ -48,6 +48,7 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.CheckedFunction;
 import org.opensearch.common.SetOnce;
 import org.opensearch.common.TriFunction;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
@@ -119,8 +120,9 @@ import java.util.function.Supplier;
  *      {@link #addSettingsUpdateConsumer(Setting, Consumer)}</li>
  * </ul>
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public final class IndexModule {
 
     public static final Setting<Boolean> NODE_STORE_ALLOW_MMAP = Setting.boolSetting("node.store.allow_mmap", true, Property.NodeScope);

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -36,6 +36,7 @@ import org.apache.lucene.index.MergePolicy;
 import org.apache.lucene.sandbox.index.MergeOnFlushMergePolicy;
 import org.opensearch.Version;
 import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.logging.Loggers;
 import org.opensearch.common.settings.IndexScopedSettings;
 import org.opensearch.common.settings.Setting;
@@ -77,8 +78,9 @@ import static org.opensearch.index.store.remote.directory.RemoteSnapshotDirector
  * a settings consumer at index creation via {@link IndexModule#addSettingsUpdateConsumer(Setting, Consumer)} that will
  * be called for each settings update.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public final class IndexSettings {
     private static final String MERGE_ON_FLUSH_DEFAULT_POLICY = "default";
     private static final String MERGE_ON_FLUSH_MERGE_POLICY = "merge-on-flush";

--- a/server/src/main/java/org/opensearch/index/shard/IndexSettingProvider.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexSettingProvider.java
@@ -32,14 +32,16 @@
 
 package org.opensearch.index.shard;
 
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.settings.Settings;
 
 /**
  * An {@link IndexSettingProvider} is a provider for index level settings that can be set
  * explicitly as a default value (so they show up as "set" for newly created indices)
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public interface IndexSettingProvider {
     /**
      * Returns explicitly set default index {@link Settings} for the given index. This should not

--- a/server/src/main/java/org/opensearch/plugins/Plugin.java
+++ b/server/src/main/java/org/opensearch/plugins/Plugin.java
@@ -40,6 +40,7 @@ import org.opensearch.cluster.metadata.IndexTemplateMetadata;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.node.DiscoveryNodeRole;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.inject.Module;
 import org.opensearch.common.lifecycle.LifecycleComponent;
 import org.opensearch.common.settings.Setting;
@@ -89,6 +90,7 @@ import java.util.function.UnaryOperator;
  *
  * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public abstract class Plugin implements Closeable {
 
     /**

--- a/server/src/main/java/org/opensearch/repositories/RepositoriesService.java
+++ b/server/src/main/java/org/opensearch/repositories/RepositoriesService.java
@@ -56,6 +56,7 @@ import org.opensearch.cluster.node.DiscoveryNodeRole;
 import org.opensearch.cluster.service.ClusterManagerTaskKeys;
 import org.opensearch.cluster.service.ClusterManagerTaskThrottler;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.lifecycle.AbstractLifecycleComponent;
 import org.opensearch.common.regex.Regex;
 import org.opensearch.common.settings.Setting;
@@ -86,8 +87,9 @@ import static org.opensearch.repositories.blobstore.BlobStoreRepository.REMOTE_S
 /**
  * Service responsible for maintaining and providing access to snapshot repositories on nodes.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public class RepositoriesService extends AbstractLifecycleComponent implements ClusterStateApplier {
 
     private static final Logger logger = LogManager.getLogger(RepositoriesService.class);

--- a/server/src/main/java/org/opensearch/script/Script.java
+++ b/server/src/main/java/org/opensearch/script/Script.java
@@ -33,6 +33,7 @@
 package org.opensearch.script;
 
 import org.opensearch.OpenSearchParseException;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
@@ -96,8 +97,9 @@ import java.util.function.BiConsumer;
  * </ul>
  * </ul>
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public final class Script implements ToXContentObject, Writeable {
 
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(Script.class);

--- a/server/src/main/java/org/opensearch/script/ScriptContext.java
+++ b/server/src/main/java/org/opensearch/script/ScriptContext.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.script;
 
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.unit.TimeValue;
 
@@ -70,8 +71,9 @@ import java.lang.reflect.Method;
  * If the variable name starts with an underscore, for example, {@code _score}, the needs method would
  * be {@code boolean needs_score()}.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public final class ScriptContext<FactoryType> {
 
     /** A unique identifier for this context. */

--- a/server/src/main/java/org/opensearch/script/ScriptEngine.java
+++ b/server/src/main/java/org/opensearch/script/ScriptEngine.java
@@ -32,6 +32,8 @@
 
 package org.opensearch.script;
 
+import org.opensearch.common.annotation.PublicApi;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Map;
@@ -40,8 +42,9 @@ import java.util.Set;
 /**
  * A script language implementation.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public interface ScriptEngine extends Closeable {
 
     /**

--- a/server/src/main/java/org/opensearch/script/ScriptService.java
+++ b/server/src/main/java/org/opensearch/script/ScriptService.java
@@ -46,6 +46,7 @@ import org.opensearch.cluster.ClusterStateApplier;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.service.ClusterManagerTaskThrottler;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
@@ -75,8 +76,9 @@ import java.util.stream.Collectors;
 /**
  * Service for scripting
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public class ScriptService implements Closeable, ClusterStateApplier {
 
     private static final Logger logger = LogManager.getLogger(ScriptService.class);

--- a/server/src/main/java/org/opensearch/script/ScriptType.java
+++ b/server/src/main/java/org/opensearch/script/ScriptType.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.script;
 
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.ParseField;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -45,8 +46,9 @@ import java.util.Locale;
  * It's also used to by {@link ScriptService} to determine whether or not a {@link Script} is
  * allowed to be executed based on both default and user-defined settings.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public enum ScriptType implements Writeable {
 
     /**

--- a/server/src/main/java/org/opensearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/opensearch/threadpool/ThreadPool.java
@@ -37,6 +37,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.Version;
 import org.opensearch.common.Nullable;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.SizeValue;
@@ -78,8 +79,9 @@ import static java.util.Collections.unmodifiableMap;
 /**
  * The OpenSearch threadpool class
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
 
     private static final Logger logger = LogManager.getLogger(ThreadPool.class);

--- a/server/src/main/java/org/opensearch/watcher/ResourceWatcherService.java
+++ b/server/src/main/java/org/opensearch/watcher/ResourceWatcherService.java
@@ -33,6 +33,7 @@ package org.opensearch.watcher;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.common.settings.Settings;
@@ -54,8 +55,9 @@ import java.util.concurrent.CopyOnWriteArraySet;
  * registered watcher periodically. The frequency of checks can be specified using {@code resource.reload.interval} setting, which
  * defaults to {@code 60s}. The service can be disabled by setting {@code resource.reload.enabled} setting to {@code false}.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public class ResourceWatcherService implements Closeable {
     private static final Logger logger = LogManager.getLogger(ResourceWatcherService.class);
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
 Decorate the existing APIs with proper annotations. This is merely the first part so we could work through the small changesets vs big bang pull request. The API validations are fully automated (as annotation processor https://github.com/opensearch-project/OpenSearch/issues/9304), here is the sample output (the annotation processor is not part of this pull request since it would generated noisy warnings right now):

```
error: The element org.opensearch.core.xcontent.XContentBuilder is part of the public APIs but is not maked as @PublicApi or @ExperimentalApi (referenced by org.opensearch.Version) 
error: The element org.opensearch.client.Client is part of the public APIs but is not maked as @PublicApi or @ExperimentalApi (referenced by org.opensearch.plugins.Plugin)  
error: The element org.opensearch.cluster.service.ClusterService is part of the public APIs but is not maked as @PublicApi or @ExperimentalApi (referenced by org.opensearch.plugins.Plugin) 
error: The element org.opensearch.threadpool.ThreadPool is part of the public APIs but is not maked as @PublicApi or @ExperimentalApi (referenced by org.opensearch.plugins.Plugin) 
error: The element org.opensearch.watcher.ResourceWatcherService is part of the public APIs but is not maked as @PublicApi or @ExperimentalApi (referenced by org.opensearch.plugins.Plugin) 
error: The element org.opensearch.script.ScriptService is part of the public APIs but is not maked as @PublicApi or @ExperimentalApi (referenced by org.opensearch.plugins.Plugin) 
error: The element org.opensearch.core.xcontent.NamedXContentRegistry is part of the public APIs but is not maked as @PublicApi or @ExperimentalApi (referenced by org.opensearch.plugins.Plugin) 
error: The element org.opensearch.env.Environment is part of the public APIs but is not maked as @PublicApi or @ExperimentalApi (referenced by org.opensearch.plugins.Plugin) 
error: The element org.opensearch.env.NodeEnvironment is part of the public APIs but is not maked as @PublicApi or @ExperimentalApi (referenced by org.opensearch.plugins.Plugin) 
error: The element org.opensearch.core.common.io.stream.NamedWriteableRegistry is part of the public APIs but is not maked as @PublicApi or @ExperimentalApi (referenced by org.opensearch.plugins.Plugin) 
error: The element org.opensearch.cluster.metadata.IndexNameExpressionResolver is part of the public APIs but is not maked as @PublicApi or @ExperimentalApi (referenced by org.opensearch.plugins.Plugin) 
error: The element org.opensearch.index.IndexModule is part of the public APIs but is not maked as @PublicApi or @ExperimentalApi (referenced by org.opensearch.plugins.Plugin) 
error: The element org.opensearch.core.common.io.stream.StreamInput is part of the public APIs but is not maked as @PublicApi or @ExperimentalApi (referenced by org.opensearch.common.settings.SettingsException) 
error: The element org.opensearch.core.common.unit.ByteSizeUnit is part of the public APIs but is not maked as @PublicApi or @ExperimentalApi (referenced by org.opensearch.common.settings.Settings.Builder) 
error: The element org.opensearch.core.xcontent.MediaType is part of the public APIs but is not maked as @PublicApi or @ExperimentalApi (referenced by org.opensearch.common.settings.Settings.Builder) 
error: The element org.opensearch.core.common.io.stream.StreamInput is part of the public APIs but is not maked as @PublicApi or @ExperimentalApi (referenced by org.opensearch.common.settings.Settings) 
error: The element org.opensearch.core.common.io.stream.StreamOutput is part of the public APIs but is not maked as @PublicApi or @ExperimentalApi (referenced by org.opensearch.common.settings.Settings) 
error: The element org.opensearch.core.xcontent.ToXContent.Params is part of the public APIs but is not maked as @PublicApi or @ExperimentalApi (referenced by org.opensearch.common.settings.Settings) 
error: The element org.opensearch.core.xcontent.XContentParser is part of the public APIs but is not maked as @PublicApi or @ExperimentalApi (referenced by org.opensearch.common.settings.Settings) 
error: The element org.opensearch.core.xcontent.XContentParser is part of the public APIs but is not maked as @PublicApi or @ExperimentalApi (referenced by org.opensearch.common.settings.Settings) 
error: The element org.opensearch.core.common.unit.ByteSizeUnit is part of the public APIs but is not maked as @PublicApi or @ExperimentalApi (referenced by org.opensearch.common.settings.Settings.Builder) 
error: The element org.opensearch.core.xcontent.MediaType is part of the public APIs but is not maked as @PublicApi or @ExperimentalApi (referenced by org.opensearch.common.settings.Settings.Builder) 
error: The element org.opensearch.core.xcontent.ToXContent.Params is part of the public APIs but is not maked as @PublicApi or @ExperimentalApi (referenced by org.opensearch.Version)
```

### Related Issues
Part of https://github.com/opensearch-project/OpenSearch/issues/9303

<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
