### PR TITLE
[Backport 2.9] Fix range reads in respository-s3 (#9516)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Fix memory leak when using Zstd Dictionary ([#9403](https://github.com/opensearch-project/OpenSearch/pull/9403))
+- Fix range reads in respository-s3 ([9512](https://github.com/opensearch-project/OpenSearch/issues/9512))
 
 ### Security
 

--- a/plugins/repository-hdfs/src/test/java/org/opensearch/repositories/hdfs/HdfsBlobStoreRepositoryTests.java
+++ b/plugins/repository-hdfs/src/test/java/org/opensearch/repositories/hdfs/HdfsBlobStoreRepositoryTests.java
@@ -65,4 +65,8 @@ public class HdfsBlobStoreRepositoryTests extends OpenSearchBlobStoreRepositoryI
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         return Collections.singletonList(HdfsPlugin.class);
     }
+
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/9513")
+    @Override
+    public void testReadRange() {}
 }

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3RetryingInputStream.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3RetryingInputStream.java
@@ -35,7 +35,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.LegacyESVersion;
-import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.repositories.s3.utils.HttpRangeUtils;
 import software.amazon.awssdk.core.ResponseInputStream;
@@ -120,7 +119,7 @@ class S3RetryingInputStream extends InputStream {
             );
             this.currentStreamLastOffset = Math.addExact(
                 Math.addExact(start, currentOffset),
-                getStreamLength(getObjectResponseInputStream.response())
+                getObjectResponseInputStream.response().contentLength()
             );
             this.currentStream = getObjectResponseInputStream;
             this.isStreamAborted.set(false);
@@ -131,29 +130,6 @@ class S3RetryingInputStream extends InputStream {
                 }
             }
             throw addSuppressedExceptions(e);
-        }
-    }
-
-    private long getStreamLength(final GetObjectResponse getObjectResponse) {
-        try {
-            // Returns the content range of the object if response contains the Content-Range header.
-            if (getObjectResponse.contentRange() != null) {
-                final Tuple<Long, Long> s3ResponseRange = HttpRangeUtils.fromHttpRangeHeader(getObjectResponse.contentRange());
-                assert s3ResponseRange.v2() >= s3ResponseRange.v1() : s3ResponseRange.v2() + " vs " + s3ResponseRange.v1();
-                assert s3ResponseRange.v1() == start + currentOffset : "Content-Range start value ["
-                    + s3ResponseRange.v1()
-                    + "] exceeds start ["
-                    + start
-                    + "] + current offset ["
-                    + currentOffset
-                    + ']';
-                assert s3ResponseRange.v2() == end : "Content-Range end value [" + s3ResponseRange.v2() + "] exceeds end [" + end + ']';
-                return s3ResponseRange.v2() - s3ResponseRange.v1() + 1L;
-            }
-            return getObjectResponse.contentLength();
-        } catch (Exception e) {
-            assert false : e;
-            return Long.MAX_VALUE - 1L; // assume a large stream so that the underlying stream is aborted on closing, unless eof is reached
         }
     }
 

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/utils/HttpRangeUtils.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/utils/HttpRangeUtils.java
@@ -8,24 +8,13 @@
 
 package org.opensearch.repositories.s3.utils;
 
-import org.opensearch.common.collect.Tuple;
-import software.amazon.awssdk.core.exception.SdkException;
-
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-public class HttpRangeUtils {
-
-    private static final Pattern RANGE_PATTERN = Pattern.compile("^bytes=([0-9]+)-([0-9]+)$");
-
-    public static Tuple<Long, Long> fromHttpRangeHeader(String headerValue) {
-        Matcher matcher = RANGE_PATTERN.matcher(headerValue);
-        if (!matcher.find()) {
-            throw SdkException.create("Regex match for Content-Range header {" + headerValue + "} failed", new RuntimeException());
-        }
-        return new Tuple<>(Long.parseLong(matcher.group(1)), Long.parseLong(matcher.group(2)));
-    }
-
+public final class HttpRangeUtils {
+    /**
+     * Provides a byte range string per <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-byte-ranges">RFC 9110</a>
+     * @param start start position (inclusive)
+     * @param end end position (inclusive)
+     * @return A 'bytes=start-end' string
+     */
     public static String toHttpRangeHeader(long start, long end) {
         return "bytes=" + start + "-" + end;
     }

--- a/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/S3RetryingInputStreamTests.java
+++ b/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/S3RetryingInputStreamTests.java
@@ -33,7 +33,6 @@
 package org.opensearch.repositories.s3;
 
 import org.opensearch.common.io.Streams;
-import org.opensearch.repositories.s3.utils.HttpRangeUtils;
 import org.opensearch.test.OpenSearchTestCase;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -103,11 +102,11 @@ public class S3RetryingInputStreamTests extends OpenSearchTestCase {
     }
 
     private S3RetryingInputStream createInputStream(final byte[] data, final Long start, final Long length) throws IOException {
-        long end = Math.addExact(start, length - 1);
+        final long end = Math.addExact(start, length - 1);
         final S3Client client = mock(S3Client.class);
         when(client.getObject(any(GetObjectRequest.class))).thenReturn(
             new ResponseInputStream<>(
-                GetObjectResponse.builder().contentLength(length).contentRange(HttpRangeUtils.toHttpRangeHeader(start, end)).build(),
+                GetObjectResponse.builder().contentLength(length).build(),
                 new ByteArrayInputStream(data, Math.toIntExact(start), Math.toIntExact(length))
             )
         );


### PR DESCRIPTION
Backports 0c839c3e35b4086acb88a276de9d10ece637d318 to `2.9`

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
