### PR TITLE
Removing the vec file extension from INDEX_STORE_HYBRID_NIO_EXTENSIONS, to ensure the no performance degradation for vector search via Lucene Engine.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Rethrow OpenSearch exception for non-concurrent path while using concurrent search ([#9177](https://github.com/opensearch-project/OpenSearch/pull/9177))
 - Improve performance of encoding composite keys in multi-term aggregations ([#9412](https://github.com/opensearch-project/OpenSearch/pull/9412))
 - Fix sort related ITs for concurrent search ([#9177](https://github.com/opensearch-project/OpenSearch/pull/9466)
+- Removing the vec file extension from INDEX_STORE_HYBRID_NIO_EXTENSIONS, to ensure the no performance degradation for vector search via Lucene Engine.([#9528](https://github.com/opensearch-project/OpenSearch/pull/9528)))
 
 ### Deprecated
 

--- a/server/src/main/java/org/opensearch/index/IndexModule.java
+++ b/server/src/main/java/org/opensearch/index/IndexModule.java
@@ -223,7 +223,6 @@ public final class IndexModule {
             "tvd",
             "liv",
             "dii",
-            "vec",
             "vem"
         ),
         Function.identity(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Removing the vec file extension from INDEX_STORE_HYBRID_NIO_EXTENSIONS, to ensure the no performance degradation for vector search via Lucene Engine.

This PR: https://github.com/opensearch-project/OpenSearch/pull/8508/files added .vec file extension in INDEX_STORE_HYBRID_NIO_EXTENSIONS and deprecated the setting : INDEX_STORE_HYBRID_MMAP_EXTENSIONS. Which made .vec not to be Mmapped. This resulted in below problems:
1. K-NN plugin was adding the required files like .vec and .vex to INDEX_STORE_HYBRID_MMAP_EXTENSIONS to make sure that files are Mmapped, for best performance. But now as the setting is deprecated the Unit test started to fail and K-NN plugin need to hack around to make sure that unit tests are succeeding. https://github.com/opensearch-project/k-NN/blob/3df8308bbe7ce6559b559f32920c31a6b0ae3f20/src/test/java/org/opensearch/knn/index/KNNSettingsTests.java#L67-L70
2. As the setting is going to be deprecated there is no point in using that setting. Hence to make sure that K-NN plugin can remove [this](https://github.com/opensearch-project/k-NN/blob/3df8308bbe7ce6559b559f32920c31a6b0ae3f20/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java#L356-L368) piece of code I am removing .vec file from INDEX_STORE_HYBRID_NIO_EXTENSIONS.

This change will ensure that no custom logic is present in k-NN plugin going forward and if new list get created going forward k-NN plugin doesn't require any change.

### Related Issues
NA

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
