### PR TITLE
[Segment Replication] Handle failover in mixed cluster mode

### DIFF
--- a/server/src/main/java/org/opensearch/action/get/TransportMultiGetAction.java
+++ b/server/src/main/java/org/opensearch/action/get/TransportMultiGetAction.java
@@ -38,6 +38,7 @@ import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.block.ClusterBlockLevel;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.routing.Preference;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
@@ -50,8 +51,6 @@ import org.opensearch.transport.TransportService;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import static org.opensearch.action.get.TransportGetAction.shouldForcePrimaryRouting;
 
 /**
  * Perform the multi get action.
@@ -76,6 +75,10 @@ public class TransportMultiGetAction extends HandledTransportAction<MultiGetRequ
         this.clusterService = clusterService;
         this.shardAction = shardAction;
         this.indexNameExpressionResolver = resolver;
+    }
+
+    protected static boolean shouldForcePrimaryRouting(Metadata metadata, boolean realtime, String preference, String indexName) {
+        return metadata.isSegmentReplicationEnabled(indexName) && realtime && preference == null;
     }
 
     @Override
@@ -112,7 +115,7 @@ public class TransportMultiGetAction extends HandledTransportAction<MultiGetRequ
 
             MultiGetShardRequest shardRequest = shardRequests.get(shardId);
             if (shardRequest == null) {
-                if (shouldForcePrimaryRouting(clusterState.getMetadata(), request.realtime, request.preference, concreteSingleIndex)) {
+                if (shouldForcePrimaryRouting(clusterState.getMetadata(), request.realtime(), request.preference(), concreteSingleIndex)) {
                     request.preference(Preference.PRIMARY.type());
                 }
                 shardRequest = new MultiGetShardRequest(request, shardId.getIndexName(), shardId.getId());

--- a/server/src/main/java/org/opensearch/action/get/TransportMultiGetAction.java
+++ b/server/src/main/java/org/opensearch/action/get/TransportMultiGetAction.java
@@ -112,7 +112,7 @@ public class TransportMultiGetAction extends HandledTransportAction<MultiGetRequ
 
             MultiGetShardRequest shardRequest = shardRequests.get(shardId);
             if (shardRequest == null) {
-                if (shouldForcePrimaryRouting(clusterState, request.realtime, request.preference, concreteSingleIndex)) {
+                if (shouldForcePrimaryRouting(clusterState.getMetadata(), request.realtime, request.preference, concreteSingleIndex)) {
                     request.preference(Preference.PRIMARY.type());
                 }
                 shardRequest = new MultiGetShardRequest(request, shardId.getIndexName(), shardId.getId());

--- a/server/src/main/java/org/opensearch/cluster/ClusterState.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterState.java
@@ -61,7 +61,6 @@ import org.opensearch.core.common.io.stream.VersionedNamedWriteable;
 import org.opensearch.core.xcontent.ToXContentFragment;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.discovery.Discovery;
-import org.opensearch.indices.replication.common.ReplicationType;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -408,21 +407,6 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
             && this.nodes().getClusterManagerNodeId().equals(other.nodes().getClusterManagerNodeId())
             && this.version() > other.version();
 
-    }
-
-    /**
-     * Utility to identify whether input index belongs to SEGMENT replication in established cluster state.
-     *
-     * @param indexName Index name
-     * @return true if index belong SEGMENT replication, false otherwise
-     */
-    public boolean isSegmentReplicationEnabled(String indexName) {
-        return Optional.ofNullable(this.getMetadata().index(indexName))
-            .map(
-                indexMetadata -> ReplicationType.parseString(indexMetadata.getSettings().get(IndexMetadata.SETTING_REPLICATION_TYPE))
-                    .equals(ReplicationType.SEGMENT)
-            )
-            .orElse(false);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/Metadata.java
@@ -110,6 +110,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
 
     /**
      * Utility to identify whether input index uses SEGMENT replication strategy in established cluster state metadata.
+     * Note: Method intended for use by other plugins as well.
      *
      * @param indexName Index name
      * @return true if index uses SEGMENT replication, false otherwise

--- a/server/src/main/java/org/opensearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/Metadata.java
@@ -66,6 +66,7 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.gateway.MetadataStateFormat;
 import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.plugins.MapperPlugin;
 
 import java.io.IOException;
@@ -106,6 +107,21 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
     public static final String ALL = "_all";
     public static final String UNKNOWN_CLUSTER_UUID = Strings.UNKNOWN_UUID_VALUE;
     public static final Pattern NUMBER_PATTERN = Pattern.compile("[0-9]+$");
+
+    /**
+     * Utility to identify whether input index uses SEGMENT replication strategy in established cluster state metadata.
+     *
+     * @param indexName Index name
+     * @return true if index uses SEGMENT replication, false otherwise
+     */
+    public boolean isSegmentReplicationEnabled(String indexName) {
+        return Optional.ofNullable(index(indexName))
+            .map(
+                indexMetadata -> ReplicationType.parseString(indexMetadata.getSettings().get(IndexMetadata.SETTING_REPLICATION_TYPE))
+                    .equals(ReplicationType.SEGMENT)
+            )
+            .orElse(false);
+    }
 
     /**
      * Context of the XContent.

--- a/server/src/main/java/org/opensearch/cluster/routing/RoutingNodes.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RoutingNodes.java
@@ -366,6 +366,14 @@ public class RoutingNodes implements Iterable<RoutingNode> {
         return null;
     }
 
+    /**
+     * Returns one active replica shard for the given shard id or <code>null</code> if
+     * no active replica is found.
+     *
+     * Since replicas could possibly be on nodes with an older version of OpenSearch than
+     * the primary is, this will return replicas on the highest version of OpenSearch when document
+     * replication is enabled.
+     */
     public ShardRouting activeReplicaWithHighestVersion(ShardId shardId) {
         // It's possible for replicaNodeVersion to be null, when disassociating dead nodes
         // that have been removed, the shards are failed, and part of the shard failing
@@ -384,6 +392,15 @@ public class RoutingNodes implements Iterable<RoutingNode> {
             .orElse(null);
     }
 
+    /**
+     * Returns one active replica shard for the given shard id or <code>null</code> if
+     * no active replica is found.
+     *
+     * Since replicas could possibly be on nodes with a higher version of OpenSearch than
+     * the primary is, this will return replicas on the oldest version of OpenSearch when segment
+     * replication is enabled to allow for replica to read segments from primary.
+     *
+     */
     public ShardRouting activeReplicaWithOldestVersion(ShardId shardId) {
         // It's possible for replicaNodeVersion to be null. Therefore, we need to protect against the version being null
         // (meaning the node will be going away).

--- a/server/src/test/java/org/opensearch/action/get/TransportGetActionTests.java
+++ b/server/src/test/java/org/opensearch/action/get/TransportGetActionTests.java
@@ -67,24 +67,24 @@ public class TransportGetActionTests extends OpenSearchTestCase {
 
     public void testShouldForcePrimaryRouting() {
 
-        ClusterState clusterState = clusterState(ReplicationType.SEGMENT);
+        Metadata metadata = clusterState(ReplicationType.SEGMENT).getMetadata();
 
         // should return false since preference is set for request
-        assertFalse(TransportGetAction.shouldForcePrimaryRouting(clusterState, true, Preference.REPLICA.type(), "index1"));
+        assertFalse(TransportGetAction.shouldForcePrimaryRouting(metadata, true, Preference.REPLICA.type(), "index1"));
 
         // should return false since request is not realtime
-        assertFalse(TransportGetAction.shouldForcePrimaryRouting(clusterState, false, null, "index1"));
+        assertFalse(TransportGetAction.shouldForcePrimaryRouting(metadata, false, null, "index1"));
 
         // should return true since segment replication is enabled
-        assertTrue(TransportGetAction.shouldForcePrimaryRouting(clusterState, true, null, "index1"));
+        assertTrue(TransportGetAction.shouldForcePrimaryRouting(metadata, true, null, "index1"));
 
         // should return false since index doesn't exist
-        assertFalse(TransportGetAction.shouldForcePrimaryRouting(clusterState, true, null, "index3"));
+        assertFalse(TransportGetAction.shouldForcePrimaryRouting(metadata, true, null, "index3"));
 
-        clusterState = clusterState(ReplicationType.DOCUMENT);
+        metadata = clusterState(ReplicationType.DOCUMENT).getMetadata();
 
         // should fail since document replication enabled
-        assertFalse(TransportGetAction.shouldForcePrimaryRouting(clusterState, true, null, "index1"));
+        assertFalse(TransportGetAction.shouldForcePrimaryRouting(metadata, true, null, "index1"));
 
     }
 

--- a/server/src/test/java/org/opensearch/action/get/TransportMultiGetActionTests.java
+++ b/server/src/test/java/org/opensearch/action/get/TransportMultiGetActionTests.java
@@ -44,6 +44,7 @@ import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.routing.OperationRouting;
+import org.opensearch.cluster.routing.Preference;
 import org.opensearch.cluster.routing.ShardIterator;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
@@ -58,6 +59,7 @@ import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.tasks.TaskId;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.indices.IndicesService;
+import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskManager;
 import org.opensearch.test.OpenSearchTestCase;
@@ -68,6 +70,7 @@ import org.opensearch.transport.TransportService;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -90,6 +93,65 @@ public class TransportMultiGetActionTests extends OpenSearchTestCase {
     private static ClusterService clusterService;
     private static TransportMultiGetAction transportAction;
     private static TransportShardMultiGetAction shardAction;
+
+    private static ClusterState clusterState(ReplicationType replicationType, Index index1, Index index2) throws IOException {
+        return ClusterState.builder(new ClusterName(TransportMultiGetActionTests.class.getSimpleName()))
+            .metadata(
+                new Metadata.Builder().put(
+                    new IndexMetadata.Builder(index1.getName()).settings(
+                        Settings.builder()
+                            .put("index.version.created", Version.CURRENT)
+                            .put("index.number_of_shards", 1)
+                            .put("index.number_of_replicas", 1)
+                            .put(IndexMetadata.SETTING_REPLICATION_TYPE, replicationType)
+                            .put(IndexMetadata.SETTING_INDEX_UUID, index1.getUUID())
+                    )
+                        .putMapping(
+                            XContentHelper.convertToJson(
+                                BytesReference.bytes(
+                                    XContentFactory.jsonBuilder()
+                                        .startObject()
+                                        .startObject("_doc")
+                                        .startObject("_routing")
+                                        .field("required", false)
+                                        .endObject()
+                                        .endObject()
+                                        .endObject()
+                                ),
+                                true,
+                                MediaTypeRegistry.JSON
+                            )
+                        )
+                )
+                    .put(
+                        new IndexMetadata.Builder(index2.getName()).settings(
+                            Settings.builder()
+                                .put("index.version.created", Version.CURRENT)
+                                .put("index.number_of_shards", 1)
+                                .put("index.number_of_replicas", 1)
+                                .put(IndexMetadata.SETTING_REPLICATION_TYPE, replicationType)
+                                .put(IndexMetadata.SETTING_INDEX_UUID, index1.getUUID())
+                        )
+                            .putMapping(
+                                XContentHelper.convertToJson(
+                                    BytesReference.bytes(
+                                        XContentFactory.jsonBuilder()
+                                            .startObject()
+                                            .startObject("_doc")
+                                            .startObject("_routing")
+                                            .field("required", true)
+                                            .endObject()
+                                            .endObject()
+                                            .endObject()
+                                    ),
+                                    true,
+                                    MediaTypeRegistry.JSON
+                                )
+                            )
+                    )
+            )
+            .build();
+    }
 
     @BeforeClass
     public static void beforeClass() throws Exception {
@@ -116,60 +178,7 @@ public class TransportMultiGetActionTests extends OpenSearchTestCase {
 
         final Index index1 = new Index("index1", randomBase64UUID());
         final Index index2 = new Index("index2", randomBase64UUID());
-        final ClusterState clusterState = ClusterState.builder(new ClusterName(TransportMultiGetActionTests.class.getSimpleName()))
-            .metadata(
-                new Metadata.Builder().put(
-                    new IndexMetadata.Builder(index1.getName()).settings(
-                        Settings.builder()
-                            .put("index.version.created", Version.CURRENT)
-                            .put("index.number_of_shards", 1)
-                            .put("index.number_of_replicas", 1)
-                            .put(IndexMetadata.SETTING_INDEX_UUID, index1.getUUID())
-                    )
-                        .putMapping(
-                            XContentHelper.convertToJson(
-                                BytesReference.bytes(
-                                    XContentFactory.jsonBuilder()
-                                        .startObject()
-                                        .startObject("_doc")
-                                        .startObject("_routing")
-                                        .field("required", false)
-                                        .endObject()
-                                        .endObject()
-                                        .endObject()
-                                ),
-                                true,
-                                MediaTypeRegistry.JSON
-                            )
-                        )
-                )
-                    .put(
-                        new IndexMetadata.Builder(index2.getName()).settings(
-                            Settings.builder()
-                                .put("index.version.created", Version.CURRENT)
-                                .put("index.number_of_shards", 1)
-                                .put("index.number_of_replicas", 1)
-                                .put(IndexMetadata.SETTING_INDEX_UUID, index1.getUUID())
-                        )
-                            .putMapping(
-                                XContentHelper.convertToJson(
-                                    BytesReference.bytes(
-                                        XContentFactory.jsonBuilder()
-                                            .startObject()
-                                            .startObject("_doc")
-                                            .startObject("_routing")
-                                            .field("required", true)
-                                            .endObject()
-                                            .endObject()
-                                            .endObject()
-                                    ),
-                                    true,
-                                    MediaTypeRegistry.JSON
-                                )
-                            )
-                    )
-            )
-            .build();
+        ClusterState clusterState = clusterState(randomBoolean() ? ReplicationType.SEGMENT : ReplicationType.DOCUMENT, index1, index2);
 
         final ShardIterator index1ShardIterator = mock(ShardIterator.class);
         when(index1ShardIterator.shardId()).thenReturn(new ShardId(index1, randomInt()));
@@ -282,6 +291,30 @@ public class TransportMultiGetActionTests extends OpenSearchTestCase {
 
         transportAction.execute(task, request.request(), new ActionListenerAdapter());
         assertTrue(shardActionInvoked.get());
+
+    }
+
+    public void testShouldForcePrimaryRouting() throws IOException {
+        final Index index1 = new Index("index1", randomBase64UUID());
+        final Index index2 = new Index("index2", randomBase64UUID());
+        Metadata metadata = clusterState(ReplicationType.SEGMENT, index1, index2).getMetadata();
+
+        // should return false since preference is set for request
+        assertFalse(TransportMultiGetAction.shouldForcePrimaryRouting(metadata, true, Preference.REPLICA.type(), "index1"));
+
+        // should return false since request is not realtime
+        assertFalse(TransportMultiGetAction.shouldForcePrimaryRouting(metadata, false, null, "index2"));
+
+        // should return true since segment replication is enabled
+        assertTrue(TransportMultiGetAction.shouldForcePrimaryRouting(metadata, true, null, "index1"));
+
+        // should return false since index doesn't exist
+        assertFalse(TransportMultiGetAction.shouldForcePrimaryRouting(metadata, true, null, "index3"));
+
+        metadata = clusterState(ReplicationType.DOCUMENT, index1, index2).getMetadata();
+
+        // should fail since document replication enabled
+        assertFalse(TransportGetAction.shouldForcePrimaryRouting(metadata, true, null, "index1"));
 
     }
 

--- a/server/src/test/java/org/opensearch/cluster/ClusterStateTests.java
+++ b/server/src/test/java/org/opensearch/cluster/ClusterStateTests.java
@@ -57,7 +57,6 @@ import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.TestCustomMetadata;
 
@@ -115,39 +114,6 @@ public class ClusterStateTests extends OpenSearchTestCase {
             withClusterManager1a.supersedes(withClusterManager1b),
             equalTo(withClusterManager1a.version() > withClusterManager1b.version())
         );
-    }
-
-    public void testIsSegmentReplicationEnabled() {
-        final String indexName = "test";
-        ClusterState clusterState = ClusterState.builder(CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY)).build();
-        Settings.Builder builder = settings(Version.CURRENT).put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT);
-        IndexMetadata.Builder indexMetadataBuilder = IndexMetadata.builder(indexName)
-            .settings(builder)
-            .numberOfShards(1)
-            .numberOfReplicas(1);
-        Metadata.Builder metadataBuilder = Metadata.builder().put(indexMetadataBuilder);
-        RoutingTable.Builder routingTableBuilder = RoutingTable.builder().addAsNew(indexMetadataBuilder.build());
-        clusterState = ClusterState.builder(clusterState)
-            .metadata(metadataBuilder.build())
-            .routingTable(routingTableBuilder.build())
-            .build();
-        assertTrue(clusterState.isSegmentReplicationEnabled(indexName));
-    }
-
-    public void testIsSegmentReplicationDisabled() {
-        final String indexName = "test";
-        ClusterState clusterState = ClusterState.builder(CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY)).build();
-        IndexMetadata.Builder indexMetadataBuilder = IndexMetadata.builder(indexName)
-            .settings(settings(Version.CURRENT))
-            .numberOfShards(1)
-            .numberOfReplicas(1);
-        Metadata.Builder metadataBuilder = Metadata.builder().put(indexMetadataBuilder);
-        RoutingTable.Builder routingTableBuilder = RoutingTable.builder().addAsNew(indexMetadataBuilder.build());
-        clusterState = ClusterState.builder(clusterState)
-            .metadata(metadataBuilder.build())
-            .routingTable(routingTableBuilder.build())
-            .build();
-        assertFalse(clusterState.isSegmentReplicationEnabled(indexName));
     }
 
     public void testBuilderRejectsNullCustom() {

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataTests.java
@@ -52,6 +52,7 @@ import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.plugins.MapperPlugin;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -1423,6 +1424,29 @@ public class MetadataTests extends OpenSearchTestCase {
         verify(spyBuilder, times(1)).buildMetadataWithRecomputedIndicesLookups();
         verify(spyBuilder, times(0)).buildMetadataWithPreviousIndicesLookups();
         compareMetadata(previousMetadata, builtMetadata, false, true, true);
+    }
+
+    public void testIsSegmentReplicationEnabled() {
+        final String indexName = "test";
+        Settings.Builder builder = settings(Version.CURRENT).put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT);
+        IndexMetadata.Builder indexMetadataBuilder = IndexMetadata.builder(indexName)
+            .settings(builder)
+            .numberOfShards(1)
+            .numberOfReplicas(1);
+        Metadata.Builder metadataBuilder = Metadata.builder().put(indexMetadataBuilder);
+        Metadata metadata = metadataBuilder.build();
+        assertTrue(metadata.isSegmentReplicationEnabled(indexName));
+    }
+
+    public void testIsSegmentReplicationDisabled() {
+        final String indexName = "test";
+        IndexMetadata.Builder indexMetadataBuilder = IndexMetadata.builder(indexName)
+            .settings(settings(Version.CURRENT))
+            .numberOfShards(1)
+            .numberOfReplicas(1);
+        Metadata.Builder metadataBuilder = Metadata.builder().put(indexMetadataBuilder);
+        Metadata metadata = metadataBuilder.build();
+        assertFalse(metadata.isSegmentReplicationEnabled(indexName));
     }
 
     public static Metadata randomMetadata() {

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/FailedNodeRoutingTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/FailedNodeRoutingTests.java
@@ -53,6 +53,7 @@ import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.allocation.decider.ClusterRebalanceAllocationDecider;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.indices.cluster.ClusterStateChanges;
+import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.test.VersionUtils;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
@@ -69,6 +70,7 @@ import java.util.stream.Collectors;
 
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REPLICATION_TYPE;
 import static org.opensearch.cluster.routing.ShardRoutingState.INITIALIZING;
 import static org.opensearch.cluster.routing.ShardRoutingState.STARTED;
 import static org.hamcrest.Matchers.equalTo;
@@ -137,7 +139,15 @@ public class FailedNodeRoutingTests extends OpenSearchAllocationTestCase {
         }
     }
 
+    public void testRandomClusterPromotesOldestReplica() throws InterruptedException {
+        testRandomClusterPromotesReplica(true);
+    }
+
     public void testRandomClusterPromotesNewestReplica() throws InterruptedException {
+        testRandomClusterPromotesReplica(false);
+    }
+
+    void testRandomClusterPromotesReplica(boolean isSegmentReplicationEnabled) throws InterruptedException {
 
         ThreadPool threadPool = new TestThreadPool(getClass().getName());
         ClusterStateChanges cluster = new ClusterStateChanges(xContentRegistry(), threadPool);
@@ -164,6 +174,9 @@ public class FailedNodeRoutingTests extends OpenSearchAllocationTestCase {
             Settings.Builder settingsBuilder = Settings.builder()
                 .put(SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 4))
                 .put(SETTING_NUMBER_OF_REPLICAS, randomIntBetween(2, 4));
+            if (isSegmentReplicationEnabled) {
+                settingsBuilder.put(SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT);
+            }
             CreateIndexRequest request = new CreateIndexRequest(name, settingsBuilder.build()).waitForActiveShards(ActiveShardCount.NONE);
             state = cluster.createIndex(state, request);
             assertTrue(state.metadata().hasIndex(name));
@@ -206,13 +219,23 @@ public class FailedNodeRoutingTests extends OpenSearchAllocationTestCase {
                     Version candidateVer = getNodeVersion(sr, compareState);
                     if (candidateVer != null) {
                         logger.info("--> candidate on {} node; shard routing: {}", candidateVer, sr);
-                        assertTrue(
-                            "candidate was not on the newest version, new primary is on "
-                                + newPrimaryVersion
-                                + " and there is a candidate on "
-                                + candidateVer,
-                            candidateVer.onOrBefore(newPrimaryVersion)
-                        );
+                        if (isSegmentReplicationEnabled) {
+                            assertTrue(
+                                "candidate was not on the oldest version, new primary is on "
+                                    + newPrimaryVersion
+                                    + " and there is a candidate on "
+                                    + candidateVer,
+                                candidateVer.onOrAfter(newPrimaryVersion)
+                            );
+                        } else {
+                            assertTrue(
+                                "candidate was not on the newest version, new primary is on "
+                                    + newPrimaryVersion
+                                    + " and there is a candidate on "
+                                    + candidateVer,
+                                candidateVer.onOrBefore(newPrimaryVersion)
+                            );
+                        }
                     }
                 });
             });

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/FailedShardsRoutingTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/FailedShardsRoutingTests.java
@@ -49,6 +49,7 @@ import org.opensearch.cluster.routing.allocation.command.MoveAllocationCommand;
 import org.opensearch.cluster.routing.allocation.decider.ClusterRebalanceAllocationDecider;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.test.VersionUtils;
 
 import java.util.ArrayList;
@@ -587,7 +588,7 @@ public class FailedShardsRoutingTests extends OpenSearchAllocationTestCase {
         clusterState = startShardsAndReroute(allocation, clusterState, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(0));
         assertThat(clusterState.getRoutingNodes().shardsWithState(STARTED).size(), equalTo(2));
         assertThat(clusterState.getRoutingNodes().shardsWithState(INITIALIZING).size(), equalTo(1));
-        ShardRouting startedReplica = clusterState.getRoutingNodes().activeReplicaWithHighestVersion(shardId);
+        ShardRouting startedReplica = clusterState.getRoutingNodes().activeReplicaBasedOnReplicationStrategy(shardId);
 
         // fail the primary shard, check replicas get removed as well...
         ShardRouting primaryShardToFail = clusterState.routingTable().index("test").shard(0).primaryShard();
@@ -647,10 +648,21 @@ public class FailedShardsRoutingTests extends OpenSearchAllocationTestCase {
     }
 
     public void testReplicaOnNewestVersionIsPromoted() {
+        testReplicaIsPromoted(false);
+    }
+
+    public void testReplicaOnOldestVersionIsPromoted() {
+        testReplicaIsPromoted(true);
+    }
+
+    private void testReplicaIsPromoted(boolean isSegmentReplicationEnabled) {
         AllocationService allocation = createAllocationService(Settings.builder().build());
 
+        Settings.Builder settingsBuilder = isSegmentReplicationEnabled
+            ? settings(Version.CURRENT).put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+            : settings(Version.CURRENT);
         Metadata metadata = Metadata.builder()
-            .put(IndexMetadata.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(3))
+            .put(IndexMetadata.builder("test").settings(settingsBuilder).numberOfShards(1).numberOfReplicas(3))
             .build();
 
         RoutingTable initialRoutingTable = RoutingTable.builder().addAsNew(metadata.index("test")).build();
@@ -714,7 +726,7 @@ public class FailedShardsRoutingTests extends OpenSearchAllocationTestCase {
         assertThat(clusterState.getRoutingNodes().shardsWithState(STARTED).size(), equalTo(4));
         assertThat(clusterState.getRoutingNodes().shardsWithState(UNASSIGNED).size(), equalTo(0));
 
-        ShardRouting startedReplica = clusterState.getRoutingNodes().activeReplicaWithHighestVersion(shardId);
+        ShardRouting startedReplica = clusterState.getRoutingNodes().activeReplicaBasedOnReplicationStrategy(shardId);
         logger.info("--> all shards allocated, replica that should be promoted: {}", startedReplica);
 
         // fail the primary shard again and make sure the correct replica is promoted
@@ -739,13 +751,20 @@ public class FailedShardsRoutingTests extends OpenSearchAllocationTestCase {
                 continue;
             }
             Version nodeVer = cursor.getVersion();
-            assertTrue(
-                "expected node [" + cursor.getId() + "] with version " + nodeVer + " to be before " + replicaNodeVersion,
-                replicaNodeVersion.onOrAfter(nodeVer)
-            );
+            if (isSegmentReplicationEnabled) {
+                assertTrue(
+                    "expected node [" + cursor.getId() + "] with version " + nodeVer + " to be after " + replicaNodeVersion,
+                    replicaNodeVersion.onOrBefore(nodeVer)
+                );
+            } else {
+                assertTrue(
+                    "expected node [" + cursor.getId() + "] with version " + nodeVer + " to be before " + replicaNodeVersion,
+                    replicaNodeVersion.onOrAfter(nodeVer)
+                );
+            }
         }
 
-        startedReplica = clusterState.getRoutingNodes().activeReplicaWithHighestVersion(shardId);
+        startedReplica = clusterState.getRoutingNodes().activeReplicaBasedOnReplicationStrategy(shardId);
         logger.info("--> failing primary shard a second time, should select: {}", startedReplica);
 
         // fail the primary shard again, and ensure the same thing happens
@@ -771,10 +790,17 @@ public class FailedShardsRoutingTests extends OpenSearchAllocationTestCase {
                 continue;
             }
             Version nodeVer = cursor.getVersion();
-            assertTrue(
-                "expected node [" + cursor.getId() + "] with version " + nodeVer + " to be before " + replicaNodeVersion,
-                replicaNodeVersion.onOrAfter(nodeVer)
-            );
+            if (isSegmentReplicationEnabled) {
+                assertTrue(
+                    "expected node [" + cursor.getId() + "] with version " + nodeVer + " to be after " + replicaNodeVersion,
+                    replicaNodeVersion.onOrBefore(nodeVer)
+                );
+            } else {
+                assertTrue(
+                    "expected node [" + cursor.getId() + "] with version " + nodeVer + " to be before " + replicaNodeVersion,
+                    replicaNodeVersion.onOrAfter(nodeVer)
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This change will ensure that the replica that's on the oldest opensearch version is promoted to primary in the event of a failover in a segment replication enabled cluster. This would avoid the problem of replicas on older opensearch versions not being able to read the segments sent by newer opensearch version primaries.

### Related Issues
Resolves #9027 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
