### PR TITLE
[Backport-2.x] Adding extra fields under RemoteStore stats in NodeStats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Make SearchTemplateRequest implement IndicesRequest.Replaceable ([#9122]()https://github.com/opensearch-project/OpenSearch/pull/9122)
 - [BWC and API enforcement] Define the initial set of annotations, their meaning and relations between them ([#9223](https://github.com/opensearch-project/OpenSearch/pull/9223))
 - [Remote Store] Add Segment download stats to remotestore stats API ([#8718](https://github.com/opensearch-project/OpenSearch/pull/8718))
-- [Remote Store] Add remote segment transfer stats on NodesStats API ([#9168](https://github.com/opensearch-project/OpenSearch/pull/9168) [#9393](https://github.com/opensearch-project/OpenSearch/pull/9393))
+- [Remote Store] Add remote segment transfer stats on NodesStats API ([#9168](https://github.com/opensearch-project/OpenSearch/pull/9168) [#9393](https://github.com/opensearch-project/OpenSearch/pull/9393) [#9454](https://github.com/opensearch-project/OpenSearch/pull/9454))
 - [Segment Replication] Support realtime reads for GET requests ([#9212](https://github.com/opensearch-project/OpenSearch/pull/9212))
 - Allow test clusters to run with TLS ([#8900](https://github.com/opensearch-project/OpenSearch/pull/8900))
 - Add jdk.incubator.vector module support for JDK 20+ ([#8601](https://github.com/opensearch-project/OpenSearch/pull/8601))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Make SearchTemplateRequest implement IndicesRequest.Replaceable ([#9122]()https://github.com/opensearch-project/OpenSearch/pull/9122)
 - [BWC and API enforcement] Define the initial set of annotations, their meaning and relations between them ([#9223](https://github.com/opensearch-project/OpenSearch/pull/9223))
 - [Remote Store] Add Segment download stats to remotestore stats API ([#8718](https://github.com/opensearch-project/OpenSearch/pull/8718))
-- [Remote Store] Add remote segment transfer stats on NodesStats API ([#9168](https://github.com/opensearch-project/OpenSearch/pull/9168))
+- [Remote Store] Add remote segment transfer stats on NodesStats API ([#9168](https://github.com/opensearch-project/OpenSearch/pull/9168) [#9393](https://github.com/opensearch-project/OpenSearch/pull/9393))
 - [Segment Replication] Support realtime reads for GET requests ([#9212](https://github.com/opensearch-project/OpenSearch/pull/9212))
 - Allow test clusters to run with TLS ([#8900](https://github.com/opensearch-project/OpenSearch/pull/8900))
 - Add jdk.incubator.vector module support for JDK 20+ ([#8601](https://github.com/opensearch-project/OpenSearch/pull/8601))

--- a/server/src/internalClusterTest/java/org/opensearch/indices/stats/IndexStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/stats/IndexStatsIT.java
@@ -1457,6 +1457,8 @@ public class IndexStatsIT extends OpenSearchIntegTestCase {
         assertEquals(0, remoteSegmentStats.getTotalRefreshBytesLag());
         assertEquals(0, remoteSegmentStats.getMaxRefreshBytesLag());
         assertEquals(0, remoteSegmentStats.getMaxRefreshTimeLag());
+        assertEquals(0, remoteSegmentStats.getTotalUploadTime());
+        assertEquals(0, remoteSegmentStats.getTotalDownloadTime());
     }
 
     /**

--- a/server/src/internalClusterTest/java/org/opensearch/indices/stats/IndexStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/stats/IndexStatsIT.java
@@ -1454,6 +1454,7 @@ public class IndexStatsIT extends OpenSearchIntegTestCase {
         assertEquals(0, remoteSegmentStats.getDownloadBytesStarted());
         assertEquals(0, remoteSegmentStats.getDownloadBytesSucceeded());
         assertEquals(0, remoteSegmentStats.getDownloadBytesFailed());
+        assertEquals(0, remoteSegmentStats.getTotalRefreshBytesLag());
         assertEquals(0, remoteSegmentStats.getMaxRefreshBytesLag());
         assertEquals(0, remoteSegmentStats.getMaxRefreshTimeLag());
     }

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteSegmentStatsFromNodesStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteSegmentStatsFromNodesStatsIT.java
@@ -67,7 +67,7 @@ public class RemoteSegmentStatsFromNodesStatsIT extends RemoteStoreBaseIntegTest
         indexSingleDoc(secondIndex, true);
 
         long cumulativeUploadsSucceeded = 0, cumulativeUploadsStarted = 0, cumulativeUploadsFailed = 0;
-        long max_bytes_lag = 0, max_time_lag = 0;
+        long total_bytes_lag = 0, max_bytes_lag = 0, max_time_lag = 0;
         // Fetch upload stats
         RemoteStoreStatsResponse remoteStoreStatsFirstIndex = client(randomDataNode).admin()
             .cluster()
@@ -77,6 +77,7 @@ public class RemoteSegmentStatsFromNodesStatsIT extends RemoteStoreBaseIntegTest
         cumulativeUploadsSucceeded += remoteStoreStatsFirstIndex.getRemoteStoreStats()[0].getSegmentStats().uploadBytesSucceeded;
         cumulativeUploadsStarted += remoteStoreStatsFirstIndex.getRemoteStoreStats()[0].getSegmentStats().uploadBytesStarted;
         cumulativeUploadsFailed += remoteStoreStatsFirstIndex.getRemoteStoreStats()[0].getSegmentStats().uploadBytesFailed;
+        total_bytes_lag += remoteStoreStatsFirstIndex.getRemoteStoreStats()[0].getSegmentStats().bytesLag;
         max_bytes_lag = Math.max(max_bytes_lag, remoteStoreStatsFirstIndex.getRemoteStoreStats()[0].getSegmentStats().bytesLag);
         max_time_lag = Math.max(max_time_lag, remoteStoreStatsFirstIndex.getRemoteStoreStats()[0].getSegmentStats().refreshTimeLagMs);
 
@@ -85,9 +86,11 @@ public class RemoteSegmentStatsFromNodesStatsIT extends RemoteStoreBaseIntegTest
             .prepareRemoteStoreStats(secondIndex, "0")
             .setLocal(true)
             .get();
+
         cumulativeUploadsSucceeded += remoteStoreStatsSecondIndex.getRemoteStoreStats()[0].getSegmentStats().uploadBytesSucceeded;
         cumulativeUploadsStarted += remoteStoreStatsSecondIndex.getRemoteStoreStats()[0].getSegmentStats().uploadBytesStarted;
         cumulativeUploadsFailed += remoteStoreStatsSecondIndex.getRemoteStoreStats()[0].getSegmentStats().uploadBytesFailed;
+        total_bytes_lag += remoteStoreStatsSecondIndex.getRemoteStoreStats()[0].getSegmentStats().bytesLag;
         max_bytes_lag = Math.max(max_bytes_lag, remoteStoreStatsSecondIndex.getRemoteStoreStats()[0].getSegmentStats().bytesLag);
         max_time_lag = Math.max(max_time_lag, remoteStoreStatsSecondIndex.getRemoteStoreStats()[0].getSegmentStats().refreshTimeLagMs);
 
@@ -101,6 +104,7 @@ public class RemoteSegmentStatsFromNodesStatsIT extends RemoteStoreBaseIntegTest
         assertEquals(cumulativeUploadsSucceeded, remoteSegmentStats.getUploadBytesSucceeded());
         assertEquals(cumulativeUploadsStarted, remoteSegmentStats.getUploadBytesStarted());
         assertEquals(cumulativeUploadsFailed, remoteSegmentStats.getUploadBytesFailed());
+        assertEquals(total_bytes_lag, remoteSegmentStats.getTotalRefreshBytesLag());
         assertEquals(max_bytes_lag, remoteSegmentStats.getMaxRefreshBytesLag());
         assertEquals(max_time_lag, remoteSegmentStats.getMaxRefreshTimeLag());
     }
@@ -173,6 +177,7 @@ public class RemoteSegmentStatsFromNodesStatsIT extends RemoteStoreBaseIntegTest
         assertEquals(0, remoteSegmentStats.getDownloadBytesStarted());
         assertEquals(0, remoteSegmentStats.getDownloadBytesSucceeded());
         assertEquals(0, remoteSegmentStats.getDownloadBytesFailed());
+        assertEquals(0, remoteSegmentStats.getTotalRefreshBytesLag());
         assertEquals(0, remoteSegmentStats.getMaxRefreshBytesLag());
         assertEquals(0, remoteSegmentStats.getMaxRefreshTimeLag());
     }
@@ -181,7 +186,7 @@ public class RemoteSegmentStatsFromNodesStatsIT extends RemoteStoreBaseIntegTest
         for (String dataNode : internalCluster().getDataNodeNames()) {
             long cumulativeUploadsSucceeded = 0, cumulativeUploadsStarted = 0, cumulativeUploadsFailed = 0;
             long cumulativeDownloadsSucceeded = 0, cumulativeDownloadsStarted = 0, cumulativeDownloadsFailed = 0;
-            long max_bytes_lag = 0, max_time_lag = 0;
+            long total_bytes_lag = 0, max_bytes_lag = 0, max_time_lag = 0;
             // Fetch upload stats
             RemoteStoreStatsResponse remoteStoreStatsFirstIndex = client(dataNode).admin()
                 .cluster()
@@ -197,6 +202,7 @@ public class RemoteSegmentStatsFromNodesStatsIT extends RemoteStoreBaseIntegTest
                 .getSegmentStats().directoryFileTransferTrackerStats.transferredBytesStarted;
             cumulativeDownloadsFailed += remoteStoreStatsFirstIndex.getRemoteStoreStats()[0]
                 .getSegmentStats().directoryFileTransferTrackerStats.transferredBytesFailed;
+            total_bytes_lag += remoteStoreStatsFirstIndex.getRemoteStoreStats()[0].getSegmentStats().bytesLag;
             max_bytes_lag = Math.max(max_bytes_lag, remoteStoreStatsFirstIndex.getRemoteStoreStats()[0].getSegmentStats().bytesLag);
             max_time_lag = Math.max(max_time_lag, remoteStoreStatsFirstIndex.getRemoteStoreStats()[0].getSegmentStats().refreshTimeLagMs);
 
@@ -214,6 +220,7 @@ public class RemoteSegmentStatsFromNodesStatsIT extends RemoteStoreBaseIntegTest
                 .getSegmentStats().directoryFileTransferTrackerStats.transferredBytesStarted;
             cumulativeDownloadsFailed += remoteStoreStatsSecondIndex.getRemoteStoreStats()[0]
                 .getSegmentStats().directoryFileTransferTrackerStats.transferredBytesFailed;
+            total_bytes_lag += remoteStoreStatsSecondIndex.getRemoteStoreStats()[0].getSegmentStats().bytesLag;
             max_bytes_lag = Math.max(max_bytes_lag, remoteStoreStatsSecondIndex.getRemoteStoreStats()[0].getSegmentStats().bytesLag);
             max_time_lag = Math.max(max_time_lag, remoteStoreStatsSecondIndex.getRemoteStoreStats()[0].getSegmentStats().refreshTimeLagMs);
 
@@ -230,6 +237,7 @@ public class RemoteSegmentStatsFromNodesStatsIT extends RemoteStoreBaseIntegTest
             assertEquals(cumulativeDownloadsSucceeded, remoteSegmentStats.getDownloadBytesSucceeded());
             assertEquals(cumulativeDownloadsStarted, remoteSegmentStats.getDownloadBytesStarted());
             assertEquals(cumulativeDownloadsFailed, remoteSegmentStats.getDownloadBytesFailed());
+            assertEquals(total_bytes_lag, remoteSegmentStats.getTotalRefreshBytesLag());
             assertEquals(max_bytes_lag, remoteSegmentStats.getMaxRefreshBytesLag());
             assertEquals(max_time_lag, remoteSegmentStats.getMaxRefreshTimeLag());
         }

--- a/server/src/main/java/org/opensearch/index/remote/RemoteSegmentStats.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteSegmentStats.java
@@ -8,7 +8,6 @@
 
 package org.opensearch.index.remote;
 
-import org.opensearch.Version;
 import org.opensearch.action.admin.cluster.remotestore.stats.RemoteStoreStats;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -87,21 +86,9 @@ public class RemoteSegmentStats implements Writeable, ToXContentFragment {
         downloadBytesSucceeded = in.readLong();
         maxRefreshTimeLag = in.readLong();
         maxRefreshBytesLag = in.readLong();
-        /* TODO:
-          Adding version checks here since the base PR of adding remote store stats
-          in SegmentStats has already been merged and backported to 2.x branch.
-
-          Since this is a new field that is being added, we need to have this check in place
-          to ensure BWCs don't break.
-
-          This would have to be removed after the new field addition PRs are also backported to 2.x.
-          If possible we would need to ensure that all field addition PRs are backported at once
-         */
-        if (in.getVersion().onOrAfter(Version.CURRENT)) {
-            totalRefreshBytesLag = in.readLong();
-            totalUploadTime = in.readLong();
-            totalDownloadTime = in.readLong();
-        }
+        totalRefreshBytesLag = in.readLong();
+        totalUploadTime = in.readLong();
+        totalDownloadTime = in.readLong();
     }
 
     /**
@@ -250,21 +237,9 @@ public class RemoteSegmentStats implements Writeable, ToXContentFragment {
         out.writeLong(downloadBytesSucceeded);
         out.writeLong(maxRefreshTimeLag);
         out.writeLong(maxRefreshBytesLag);
-        /* TODO:
-          Adding version checks here since the base PR of adding remote store stats
-          in SegmentStats has already been merged and backported to 2.x branch.
-
-          Since this is a new field that is being added, we need to have this check in place
-          to ensure BWCs don't break.
-
-          This would have to be removed after the new field addition PRs are also backported to 2.x.
-          If possible we would need to ensure that all field addition PRs are backported at once
-         */
-        if (out.getVersion().onOrAfter(Version.CURRENT)) {
-            out.writeLong(totalRefreshBytesLag);
-            out.writeLong(totalUploadTime);
-            out.writeLong(totalDownloadTime);
-        }
+        out.writeLong(totalRefreshBytesLag);
+        out.writeLong(totalUploadTime);
+        out.writeLong(totalDownloadTime);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/remote/RemoteSegmentStats.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteSegmentStats.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.index.remote;
 
+import org.opensearch.Version;
 import org.opensearch.action.admin.cluster.remotestore.stats.RemoteStoreStats;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -61,6 +62,11 @@ public class RemoteSegmentStats implements Writeable, ToXContentFragment {
      * Used to check for data freshness in the remote store
      */
     private long maxRefreshBytesLag;
+    /**
+     * Total refresh lag (in bytes) between local and the remote store
+     * Used to check for data freshness in the remote store
+     */
+    private long totalRefreshBytesLag;
 
     public RemoteSegmentStats() {}
 
@@ -73,6 +79,19 @@ public class RemoteSegmentStats implements Writeable, ToXContentFragment {
         downloadBytesSucceeded = in.readLong();
         maxRefreshTimeLag = in.readLong();
         maxRefreshBytesLag = in.readLong();
+        /* TODO:
+          Adding version checks here since the base PR of adding remote store stats
+          in SegmentStats has already been merged and backported to 2.x branch.
+
+          Since this is a new field that is being added, we need to have this check in place
+          to ensure BWCs don't break.
+
+          This would have to be removed after the new field addition PRs are also backported to 2.x.
+          If possible we would need to ensure that all field addition PRs are backported at once
+         */
+        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+            totalRefreshBytesLag = in.readLong();
+        }
     }
 
     /**
@@ -91,7 +110,11 @@ public class RemoteSegmentStats implements Writeable, ToXContentFragment {
         this.downloadBytesStarted = trackerStats.directoryFileTransferTrackerStats.transferredBytesStarted;
         this.downloadBytesFailed = trackerStats.directoryFileTransferTrackerStats.transferredBytesFailed;
         this.maxRefreshTimeLag = trackerStats.refreshTimeLagMs;
+        // Initializing both total and max bytes lag to the same `bytesLag`
+        // value from the tracker object
+        // Aggregations would be performed on the add method
         this.maxRefreshBytesLag = trackerStats.bytesLag;
+        this.totalRefreshBytesLag = trackerStats.bytesLag;
     }
 
     // Getter and setters. All are visible for testing
@@ -155,8 +178,16 @@ public class RemoteSegmentStats implements Writeable, ToXContentFragment {
         return maxRefreshBytesLag;
     }
 
-    public void setMaxRefreshBytesLag(long maxRefreshBytesLag) {
-        this.maxRefreshBytesLag = maxRefreshBytesLag;
+    public void addMaxRefreshBytesLag(long maxRefreshBytesLag) {
+        this.maxRefreshBytesLag = Math.max(this.maxRefreshBytesLag, maxRefreshBytesLag);
+    }
+
+    public long getTotalRefreshBytesLag() {
+        return totalRefreshBytesLag;
+    }
+
+    public void addTotalRefreshBytesLag(long totalRefreshBytesLag) {
+        this.totalRefreshBytesLag += totalRefreshBytesLag;
     }
 
     /**
@@ -174,6 +205,7 @@ public class RemoteSegmentStats implements Writeable, ToXContentFragment {
             this.downloadBytesSucceeded += existingStats.getDownloadBytesSucceeded();
             this.maxRefreshTimeLag = Math.max(this.maxRefreshTimeLag, existingStats.getMaxRefreshTimeLag());
             this.maxRefreshBytesLag = Math.max(this.maxRefreshBytesLag, existingStats.getMaxRefreshBytesLag());
+            this.totalRefreshBytesLag += existingStats.getTotalRefreshBytesLag();
         }
     }
 
@@ -187,33 +219,53 @@ public class RemoteSegmentStats implements Writeable, ToXContentFragment {
         out.writeLong(downloadBytesSucceeded);
         out.writeLong(maxRefreshTimeLag);
         out.writeLong(maxRefreshBytesLag);
+        /* TODO:
+          Adding version checks here since the base PR of adding remote store stats
+          in SegmentStats has already been merged and backported to 2.x branch.
+
+          Since this is a new field that is being added, we need to have this check in place
+          to ensure BWCs don't break.
+
+          This would have to be removed after the new field addition PRs are also backported to 2.x.
+          If possible we would need to ensure that all field addition PRs are backported at once
+         */
+        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+            out.writeLong(totalRefreshBytesLag);
+        }
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(Fields.REMOTE_STORE);
         builder.startObject(Fields.UPLOAD);
+        buildUploadStats(builder);
+        builder.endObject();
+        builder.startObject(Fields.DOWNLOAD);
+        buildDownloadStats(builder);
+        builder.endObject();
+        builder.endObject();
+        return builder;
+    }
+
+    private void buildUploadStats(XContentBuilder builder) throws IOException {
         builder.startObject(Fields.TOTAL_UPLOADS);
         builder.humanReadableField(Fields.STARTED_BYTES, Fields.STARTED, new ByteSizeValue(uploadBytesStarted));
         builder.humanReadableField(Fields.SUCCEEDED_BYTES, Fields.SUCCEEDED, new ByteSizeValue(uploadBytesSucceeded));
         builder.humanReadableField(Fields.FAILED_BYTES, Fields.FAILED, new ByteSizeValue(uploadBytesFailed));
         builder.endObject();
-        builder.humanReadableField(Fields.MAX_REFRESH_TIME_LAG_IN_MILLIS, Fields.MAX_REFRESH_TIME_LAG, new TimeValue(maxRefreshTimeLag));
-        builder.humanReadableField(
-            Fields.MAX_REFRESH_SIZE_LAG_IN_MILLIS,
-            Fields.MAX_REFRESH_SIZE_LAG,
-            new ByteSizeValue(maxRefreshBytesLag)
-        );
+        builder.startObject(Fields.REFRESH_SIZE_LAG);
+        builder.humanReadableField(Fields.TOTAL_BYTES, Fields.TOTAL, new ByteSizeValue(totalRefreshBytesLag));
+        builder.humanReadableField(Fields.MAX_BYTES, Fields.MAX, new ByteSizeValue(maxRefreshBytesLag));
         builder.endObject();
-        builder.startObject(Fields.DOWNLOAD);
+        builder.humanReadableField(Fields.MAX_REFRESH_TIME_LAG_IN_MILLIS, Fields.MAX_REFRESH_TIME_LAG, new TimeValue(maxRefreshTimeLag));
+    }
+
+    private void buildDownloadStats(XContentBuilder builder) throws IOException {
         builder.startObject(Fields.TOTAL_DOWNLOADS);
         builder.humanReadableField(Fields.STARTED_BYTES, Fields.STARTED, new ByteSizeValue(downloadBytesStarted));
         builder.humanReadableField(Fields.SUCCEEDED_BYTES, Fields.SUCCEEDED, new ByteSizeValue(downloadBytesSucceeded));
         builder.humanReadableField(Fields.FAILED_BYTES, Fields.FAILED, new ByteSizeValue(downloadBytesFailed));
         builder.endObject();
-        builder.endObject();
-        builder.endObject();
-        return builder;
     }
 
     static final class Fields {
@@ -222,15 +274,18 @@ public class RemoteSegmentStats implements Writeable, ToXContentFragment {
         static final String DOWNLOAD = "download";
         static final String TOTAL_UPLOADS = "total_uploads";
         static final String TOTAL_DOWNLOADS = "total_downloads";
+        static final String MAX_REFRESH_TIME_LAG = "max_refresh_time_lag";
+        static final String MAX_REFRESH_TIME_LAG_IN_MILLIS = "max_refresh_time_lag_in_millis";
+        static final String REFRESH_SIZE_LAG = "refresh_size_lag";
         static final String STARTED = "started";
         static final String STARTED_BYTES = "started_bytes";
         static final String FAILED = "failed";
         static final String FAILED_BYTES = "failed_bytes";
         static final String SUCCEEDED = "succeeded";
         static final String SUCCEEDED_BYTES = "succeeded_bytes";
-        static final String MAX_REFRESH_TIME_LAG = "max_refresh_time_lag";
-        static final String MAX_REFRESH_TIME_LAG_IN_MILLIS = "max_refresh_time_lag_in_millis";
-        static final String MAX_REFRESH_SIZE_LAG = "max_refresh_size_lag";
-        static final String MAX_REFRESH_SIZE_LAG_IN_MILLIS = "max_refresh_size_lag_in_bytes";
+        static final String TOTAL = "total";
+        static final String TOTAL_BYTES = "total_bytes";
+        static final String MAX = "max";
+        static final String MAX_BYTES = "max_bytes";
     }
 }

--- a/server/src/main/java/org/opensearch/index/remote/RemoteSegmentTransferTracker.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteSegmentTransferTracker.java
@@ -96,17 +96,17 @@ public class RemoteSegmentTransferTracker {
     /**
      * Cumulative sum of size in bytes of segment files for which upload has started during remote refresh.
      */
-    private volatile long uploadBytesStarted;
+    private final AtomicLong uploadBytesStarted = new AtomicLong();
 
     /**
      * Cumulative sum of size in bytes of segment files for which upload has failed during remote refresh.
      */
-    private volatile long uploadBytesFailed;
+    private final AtomicLong uploadBytesFailed = new AtomicLong();
 
     /**
      * Cumulative sum of size in bytes of segment files for which upload has succeeded during remote refresh.
      */
-    private volatile long uploadBytesSucceeded;
+    private final AtomicLong uploadBytesSucceeded = new AtomicLong();
 
     /**
      * Cumulative sum of count of remote refreshes that have started.
@@ -122,6 +122,11 @@ public class RemoteSegmentTransferTracker {
      * Cumulative sum of count of remote refreshes that have succeeded.
      */
     private volatile long totalUploadsSucceeded;
+
+    /**
+     * Cumulative sum of time taken in remote refresh (in milliseconds) [Tracked per file]
+     */
+    private AtomicLong totalUploadTimeInMs = new AtomicLong();
 
     /**
      * Cumulative sum of rejection counts for this shard.
@@ -316,31 +321,31 @@ public class RemoteSegmentTransferTracker {
     }
 
     public long getUploadBytesStarted() {
-        return uploadBytesStarted;
+        return uploadBytesStarted.get();
     }
 
     public void addUploadBytesStarted(long size) {
-        uploadBytesStarted += size;
+        uploadBytesStarted.getAndAdd(size);
     }
 
     public long getUploadBytesFailed() {
-        return uploadBytesFailed;
+        return uploadBytesFailed.get();
     }
 
     public void addUploadBytesFailed(long size) {
-        uploadBytesFailed += size;
+        uploadBytesFailed.getAndAdd(size);
     }
 
     public long getUploadBytesSucceeded() {
-        return uploadBytesSucceeded;
+        return uploadBytesSucceeded.get();
     }
 
     public void addUploadBytesSucceeded(long size) {
-        uploadBytesSucceeded += size;
+        uploadBytesSucceeded.getAndAdd(size);
     }
 
     public long getInflightUploadBytes() {
-        return uploadBytesStarted - uploadBytesFailed - uploadBytesSucceeded;
+        return uploadBytesStarted.get() - uploadBytesFailed.get() - uploadBytesSucceeded.get();
     }
 
     public long getTotalUploadsStarted() {
@@ -508,7 +513,7 @@ public class RemoteSegmentTransferTracker {
         return uploadTimeMsMovingAverageReference.get().getAverage();
     }
 
-    public void addUploadTimeMs(long timeMs) {
+    public void addTimeForCompletedUploadSync(long timeMs) {
         synchronized (uploadTimeMsMutex) {
             this.uploadTimeMsMovingAverageReference.get().record(timeMs);
         }
@@ -525,6 +530,14 @@ public class RemoteSegmentTransferTracker {
         }
     }
 
+    public void addTotalUploadTimeInMs(long fileUploadTimeInMs) {
+        this.totalUploadTimeInMs.addAndGet(fileUploadTimeInMs);
+    }
+
+    public long getTotalUploadTimeInMs() {
+        return totalUploadTimeInMs.get();
+    }
+
     public DirectoryFileTransferTracker getDirectoryFileTransferTracker() {
         return directoryFileTransferTracker;
     }
@@ -537,9 +550,9 @@ public class RemoteSegmentTransferTracker {
             timeMsLag,
             localRefreshSeqNo,
             remoteRefreshSeqNo,
-            uploadBytesStarted,
-            uploadBytesSucceeded,
-            uploadBytesFailed,
+            uploadBytesStarted.get(),
+            uploadBytesSucceeded.get(),
+            uploadBytesFailed.get(),
             totalUploadsStarted,
             totalUploadsSucceeded,
             totalUploadsFailed,
@@ -550,6 +563,7 @@ public class RemoteSegmentTransferTracker {
             uploadBytesPerSecMovingAverageReference.get().getAverage(),
             uploadTimeMsMovingAverageReference.get().getAverage(),
             getBytesLag(),
+            totalUploadTimeInMs.get(),
             directoryFileTransferTracker.stats()
         );
     }
@@ -578,6 +592,7 @@ public class RemoteSegmentTransferTracker {
         public final long lastSuccessfulRemoteRefreshBytes;
         public final double uploadBytesMovingAverage;
         public final double uploadBytesPerSecMovingAverage;
+        public final long totalUploadTimeInMs;
         public final double uploadTimeMovingAverage;
         public final long bytesLag;
         public final DirectoryFileTransferTracker.Stats directoryFileTransferTrackerStats;
@@ -602,6 +617,7 @@ public class RemoteSegmentTransferTracker {
             double uploadBytesPerSecMovingAverage,
             double uploadTimeMovingAverage,
             long bytesLag,
+            long totalUploadTimeInMs,
             DirectoryFileTransferTracker.Stats directoryFileTransferTrackerStats
         ) {
             this.shardId = shardId;
@@ -623,6 +639,7 @@ public class RemoteSegmentTransferTracker {
             this.uploadBytesPerSecMovingAverage = uploadBytesPerSecMovingAverage;
             this.uploadTimeMovingAverage = uploadTimeMovingAverage;
             this.bytesLag = bytesLag;
+            this.totalUploadTimeInMs = totalUploadTimeInMs;
             this.directoryFileTransferTrackerStats = directoryFileTransferTrackerStats;
         }
 
@@ -647,6 +664,7 @@ public class RemoteSegmentTransferTracker {
                 this.uploadBytesPerSecMovingAverage = in.readDouble();
                 this.uploadTimeMovingAverage = in.readDouble();
                 this.bytesLag = in.readLong();
+                this.totalUploadTimeInMs = in.readLong();
                 this.directoryFileTransferTrackerStats = in.readOptionalWriteable(DirectoryFileTransferTracker.Stats::new);
             } catch (IOException e) {
                 throw e;
@@ -674,6 +692,7 @@ public class RemoteSegmentTransferTracker {
             out.writeDouble(uploadBytesPerSecMovingAverage);
             out.writeDouble(uploadTimeMovingAverage);
             out.writeLong(bytesLag);
+            out.writeLong(totalUploadTimeInMs);
             out.writeOptionalWriteable(directoryFileTransferTrackerStats);
         }
 
@@ -702,6 +721,7 @@ public class RemoteSegmentTransferTracker {
                 && Double.compare(this.uploadBytesPerSecMovingAverage, other.uploadBytesPerSecMovingAverage) == 0
                 && Double.compare(this.uploadTimeMovingAverage, other.uploadTimeMovingAverage) == 0
                 && this.bytesLag == other.bytesLag
+                && this.totalUploadTimeInMs == other.totalUploadTimeInMs
                 && this.directoryFileTransferTrackerStats.equals(other.directoryFileTransferTrackerStats);
         }
 
@@ -727,6 +747,7 @@ public class RemoteSegmentTransferTracker {
                 uploadBytesPerSecMovingAverage,
                 uploadTimeMovingAverage,
                 bytesLag,
+                totalUploadTimeInMs,
                 directoryFileTransferTrackerStats
             );
         }

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -89,7 +89,6 @@ public final class RemoteStoreRefreshListener extends CloseableRetryableRefreshL
     private long primaryTerm;
     private volatile Iterator<TimeValue> backoffDelayIterator;
     private final SegmentReplicationCheckpointPublisher checkpointPublisher;
-    private final UploadListener statsListener;
 
     public RemoteStoreRefreshListener(
         IndexShard indexShard,
@@ -117,26 +116,6 @@ public final class RemoteStoreRefreshListener extends CloseableRetryableRefreshL
         this.segmentTracker = segmentTracker;
         resetBackOffDelayIterator();
         this.checkpointPublisher = checkpointPublisher;
-        this.statsListener = new UploadListener() {
-            @Override
-            public void beforeUpload(String file) {
-                // Start tracking the upload bytes started
-                segmentTracker.addUploadBytesStarted(segmentTracker.getLatestLocalFileNameLengthMap().get(file));
-            }
-
-            @Override
-            public void onSuccess(String file) {
-                // Track upload success
-                segmentTracker.addUploadBytesSucceeded(segmentTracker.getLatestLocalFileNameLengthMap().get(file));
-                segmentTracker.addToLatestUploadedFiles(file);
-            }
-
-            @Override
-            public void onFailure(String file) {
-                // Track upload failure
-                segmentTracker.addUploadBytesFailed(segmentTracker.getLatestLocalFileNameLengthMap().get(file));
-            }
-        };
     }
 
     @Override
@@ -374,6 +353,8 @@ public final class RemoteStoreRefreshListener extends CloseableRetryableRefreshL
         GroupedActionListener<Void> batchUploadListener = new GroupedActionListener<>(mappedListener, filteredFiles.size());
 
         for (String src : filteredFiles) {
+            // Initializing listener here to ensure that the stats increment operations are thread-safe
+            UploadListener statsListener = createUploadListener();
             ActionListener<Void> aggregatedListener = ActionListener.wrap(resp -> {
                 statsListener.onSuccess(src);
                 batchUploadListener.onResponse(resp);
@@ -444,10 +425,41 @@ public final class RemoteStoreRefreshListener extends CloseableRetryableRefreshL
             segmentTracker.incrementTotalUploadsSucceeded();
             segmentTracker.addUploadBytes(bytesUploaded);
             segmentTracker.addUploadBytesPerSec((bytesUploaded * 1_000L) / Math.max(1, timeTakenInMS));
-            segmentTracker.addUploadTimeMs(timeTakenInMS);
+            segmentTracker.addTimeForCompletedUploadSync(timeTakenInMS);
         } else {
             segmentTracker.incrementTotalUploadsFailed();
         }
+    }
+
+    /**
+     * Creates an {@link UploadListener} containing the stats population logic which would be triggered before and after segment upload events
+     */
+    private UploadListener createUploadListener() {
+        return new UploadListener() {
+            private long uploadStartTime = 0;
+
+            @Override
+            public void beforeUpload(String file) {
+                // Start tracking the upload bytes started
+                segmentTracker.addUploadBytesStarted(segmentTracker.getLatestLocalFileNameLengthMap().get(file));
+                uploadStartTime = System.currentTimeMillis();
+            }
+
+            @Override
+            public void onSuccess(String file) {
+                // Track upload success
+                segmentTracker.addUploadBytesSucceeded(segmentTracker.getLatestLocalFileNameLengthMap().get(file));
+                segmentTracker.addToLatestUploadedFiles(file);
+                segmentTracker.addTotalUploadTimeInMs(Math.max(1, System.currentTimeMillis() - uploadStartTime));
+            }
+
+            @Override
+            public void onFailure(String file) {
+                // Track upload failure
+                segmentTracker.addUploadBytesFailed(segmentTracker.getLatestLocalFileNameLengthMap().get(file));
+                segmentTracker.addTotalUploadTimeInMs(Math.max(1, System.currentTimeMillis() - uploadStartTime));
+            }
+        };
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/store/DirectoryFileTransferTracker.java
+++ b/server/src/main/java/org/opensearch/index/store/DirectoryFileTransferTracker.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.index.store;
 
+import org.apache.lucene.store.Directory;
 import org.opensearch.common.util.MovingAverage;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -15,128 +16,150 @@ import org.opensearch.core.common.io.stream.Writeable;
 
 import java.io.IOException;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * Tracks the amount of bytes transferred between two {@link org.apache.lucene.store.Directory} instances
+ * Tracks the amount of bytes transferred between two {@link Directory} instances
  *
  * @opensearch.internal
  */
 public class DirectoryFileTransferTracker {
     /**
-     * Cumulative size of files (in bytes) attempted to be transferred over from the source {@link org.apache.lucene.store.Directory}
+     * Cumulative size of files (in bytes) attempted to be transferred over from the source {@link Directory}
      */
-    private volatile long transferredBytesStarted;
+    private final AtomicLong transferredBytesStarted = new AtomicLong();
 
     /**
-     * Cumulative size of files (in bytes) successfully transferred over from the source {@link org.apache.lucene.store.Directory}
+     * Cumulative size of files (in bytes) successfully transferred over from the source {@link Directory}
      */
-    private volatile long transferredBytesFailed;
+    private final AtomicLong transferredBytesFailed = new AtomicLong();
 
     /**
-     * Cumulative size of files (in bytes) failed in transfer over from the source {@link org.apache.lucene.store.Directory}
+     * Cumulative size of files (in bytes) failed in transfer over from the source {@link Directory}
      */
-    private volatile long transferredBytesSucceeded;
+    private final AtomicLong transferredBytesSucceeded = new AtomicLong();
 
     /**
-     * Time in milliseconds for the last successful transfer from the source {@link org.apache.lucene.store.Directory}
+     * Time in milliseconds for the last successful transfer from the source {@link Directory}
      */
-    private volatile long lastTransferTimestampMs;
+    private final AtomicLong lastTransferTimestampMs = new AtomicLong();
 
     /**
-     * Provides moving average over the last N total size in bytes of files transferred from the source {@link org.apache.lucene.store.Directory}.
+     * Cumulative time in milliseconds spent in successful transfers from the source {@link Directory}
+     */
+    private final AtomicLong totalTransferTimeInMs = new AtomicLong();
+
+    /**
+     * Provides moving average over the last N total size in bytes of files transferred from the source {@link Directory}.
      * N is window size
      */
-    private volatile MovingAverage transferredBytesMovingAverageReference;
+    private final AtomicReference<MovingAverage> transferredBytesMovingAverageReference;
 
-    private volatile long lastSuccessfulTransferInBytes;
+    private final AtomicLong lastSuccessfulTransferInBytes = new AtomicLong();
 
     /**
-     * Provides moving average over the last N transfer speed (in bytes/s) of segment files transferred from the source {@link org.apache.lucene.store.Directory}.
+     * Provides moving average over the last N transfer speed (in bytes/s) of segment files transferred from the source {@link Directory}.
      * N is window size
      */
-    private volatile MovingAverage transferredBytesPerSecMovingAverageReference;
+    private final AtomicReference<MovingAverage> transferredBytesPerSecMovingAverageReference;
 
     private final int DIRECTORY_FILES_TRANSFER_DEFAULT_WINDOW_SIZE = 20;
 
+    // Getters and Setters, all are visible for testing
     public long getTransferredBytesStarted() {
-        return transferredBytesStarted;
+        return transferredBytesStarted.get();
     }
 
     public void addTransferredBytesStarted(long size) {
-        transferredBytesStarted += size;
+        transferredBytesStarted.getAndAdd(size);
     }
 
     public long getTransferredBytesFailed() {
-        return transferredBytesFailed;
+        return transferredBytesFailed.get();
     }
 
-    public void addTransferredBytesFailed(long size) {
-        transferredBytesFailed += size;
+    public void addTransferredBytesFailed(long size, long startTimeInMs) {
+        transferredBytesFailed.getAndAdd(size);
+        addTotalTransferTimeInMs(Math.max(1, System.currentTimeMillis() - startTimeInMs));
     }
 
     public long getTransferredBytesSucceeded() {
-        return transferredBytesSucceeded;
+        return transferredBytesSucceeded.get();
     }
 
     public void addTransferredBytesSucceeded(long size, long startTimeInMs) {
-        transferredBytesSucceeded += size;
-        updateLastSuccessfulTransferSize(size);
+        transferredBytesSucceeded.getAndAdd(size);
+        updateSuccessfulTransferSize(size);
         long currentTimeInMs = System.currentTimeMillis();
         updateLastTransferTimestampMs(currentTimeInMs);
         long timeTakenInMS = Math.max(1, currentTimeInMs - startTimeInMs);
+        addTotalTransferTimeInMs(timeTakenInMS);
         addTransferredBytesPerSec((size * 1_000L) / timeTakenInMS);
     }
 
     public boolean isTransferredBytesPerSecAverageReady() {
-        return transferredBytesPerSecMovingAverageReference.isReady();
+        return transferredBytesPerSecMovingAverageReference.get().isReady();
     }
 
     public double getTransferredBytesPerSecAverage() {
-        return transferredBytesPerSecMovingAverageReference.getAverage();
+        return transferredBytesPerSecMovingAverageReference.get().getAverage();
     }
 
-    // Visible for testing
     public void addTransferredBytesPerSec(long bytesPerSec) {
-        this.transferredBytesPerSecMovingAverageReference.record(bytesPerSec);
+        this.transferredBytesPerSecMovingAverageReference.get().record(bytesPerSec);
     }
 
     public boolean isTransferredBytesAverageReady() {
-        return transferredBytesMovingAverageReference.isReady();
+        return transferredBytesMovingAverageReference.get().isReady();
     }
 
     public double getTransferredBytesAverage() {
-        return transferredBytesMovingAverageReference.getAverage();
+        return transferredBytesMovingAverageReference.get().getAverage();
     }
 
-    // Visible for testing
-    public void updateLastSuccessfulTransferSize(long size) {
-        lastSuccessfulTransferInBytes = size;
-        this.transferredBytesMovingAverageReference.record(size);
+    public void updateLastSuccessfulTransferInBytes(long size) {
+        lastSuccessfulTransferInBytes.set(size);
+    }
+
+    public void updateSuccessfulTransferSize(long size) {
+        updateLastSuccessfulTransferInBytes(size);
+        this.transferredBytesMovingAverageReference.get().record(size);
     }
 
     public long getLastTransferTimestampMs() {
-        return lastTransferTimestampMs;
+        return lastTransferTimestampMs.get();
     }
 
-    // Visible for testing
     public void updateLastTransferTimestampMs(long downloadTimestampInMs) {
-        this.lastTransferTimestampMs = downloadTimestampInMs;
+        this.lastTransferTimestampMs.set(downloadTimestampInMs);
+    }
+
+    public void addTotalTransferTimeInMs(long totalTransferTimeInMs) {
+        this.totalTransferTimeInMs.addAndGet(totalTransferTimeInMs);
+    }
+
+    public long getTotalTransferTimeInMs() {
+        return totalTransferTimeInMs.get();
     }
 
     public DirectoryFileTransferTracker() {
-        transferredBytesMovingAverageReference = new MovingAverage(DIRECTORY_FILES_TRANSFER_DEFAULT_WINDOW_SIZE);
-        transferredBytesPerSecMovingAverageReference = new MovingAverage(DIRECTORY_FILES_TRANSFER_DEFAULT_WINDOW_SIZE);
+        transferredBytesMovingAverageReference = new AtomicReference<>(new MovingAverage(DIRECTORY_FILES_TRANSFER_DEFAULT_WINDOW_SIZE));
+        transferredBytesPerSecMovingAverageReference = new AtomicReference<>(
+            new MovingAverage(DIRECTORY_FILES_TRANSFER_DEFAULT_WINDOW_SIZE)
+        );
     }
 
     public DirectoryFileTransferTracker.Stats stats() {
         return new Stats(
-            transferredBytesStarted,
-            transferredBytesFailed,
-            transferredBytesSucceeded,
-            lastTransferTimestampMs,
-            transferredBytesMovingAverageReference.getAverage(),
-            lastSuccessfulTransferInBytes,
-            transferredBytesPerSecMovingAverageReference.getAverage()
+            transferredBytesStarted.get(),
+            transferredBytesFailed.get(),
+            transferredBytesSucceeded.get(),
+            lastTransferTimestampMs.get(),
+            totalTransferTimeInMs.get(),
+            transferredBytesMovingAverageReference.get().getAverage(),
+            lastSuccessfulTransferInBytes.get(),
+            transferredBytesPerSecMovingAverageReference.get().getAverage()
         );
     }
 
@@ -150,6 +173,7 @@ public class DirectoryFileTransferTracker {
         public final long transferredBytesFailed;
         public final long transferredBytesSucceeded;
         public final long lastTransferTimestampMs;
+        public final long totalTransferTimeInMs;
         public final double transferredBytesMovingAverage;
         public final long lastSuccessfulTransferInBytes;
         public final double transferredBytesPerSecMovingAverage;
@@ -159,6 +183,7 @@ public class DirectoryFileTransferTracker {
             long transferredBytesFailed,
             long downloadBytesSucceeded,
             long lastTransferTimestampMs,
+            long totalTransferTimeInMs,
             double transferredBytesMovingAverage,
             long lastSuccessfulTransferInBytes,
             double transferredBytesPerSecMovingAverage
@@ -167,6 +192,7 @@ public class DirectoryFileTransferTracker {
             this.transferredBytesFailed = transferredBytesFailed;
             this.transferredBytesSucceeded = downloadBytesSucceeded;
             this.lastTransferTimestampMs = lastTransferTimestampMs;
+            this.totalTransferTimeInMs = totalTransferTimeInMs;
             this.transferredBytesMovingAverage = transferredBytesMovingAverage;
             this.lastSuccessfulTransferInBytes = lastSuccessfulTransferInBytes;
             this.transferredBytesPerSecMovingAverage = transferredBytesPerSecMovingAverage;
@@ -177,6 +203,7 @@ public class DirectoryFileTransferTracker {
             this.transferredBytesFailed = in.readLong();
             this.transferredBytesSucceeded = in.readLong();
             this.lastTransferTimestampMs = in.readLong();
+            this.totalTransferTimeInMs = in.readLong();
             this.transferredBytesMovingAverage = in.readDouble();
             this.lastSuccessfulTransferInBytes = in.readLong();
             this.transferredBytesPerSecMovingAverage = in.readDouble();
@@ -188,6 +215,7 @@ public class DirectoryFileTransferTracker {
             out.writeLong(transferredBytesFailed);
             out.writeLong(transferredBytesSucceeded);
             out.writeLong(lastTransferTimestampMs);
+            out.writeLong(totalTransferTimeInMs);
             out.writeDouble(transferredBytesMovingAverage);
             out.writeLong(lastSuccessfulTransferInBytes);
             out.writeDouble(transferredBytesPerSecMovingAverage);
@@ -203,6 +231,7 @@ public class DirectoryFileTransferTracker {
                 && transferredBytesFailed == stats.transferredBytesFailed
                 && transferredBytesSucceeded == stats.transferredBytesSucceeded
                 && lastTransferTimestampMs == stats.lastTransferTimestampMs
+                && totalTransferTimeInMs == stats.totalTransferTimeInMs
                 && Double.compare(stats.transferredBytesMovingAverage, transferredBytesMovingAverage) == 0
                 && lastSuccessfulTransferInBytes == stats.lastSuccessfulTransferInBytes
                 && Double.compare(stats.transferredBytesPerSecMovingAverage, transferredBytesPerSecMovingAverage) == 0;
@@ -215,6 +244,7 @@ public class DirectoryFileTransferTracker {
                 transferredBytesFailed,
                 transferredBytesSucceeded,
                 lastTransferTimestampMs,
+                totalTransferTimeInMs,
                 transferredBytesMovingAverage,
                 lastSuccessfulTransferInBytes,
                 transferredBytesPerSecMovingAverage

--- a/server/src/main/java/org/opensearch/index/store/Store.java
+++ b/server/src/main/java/org/opensearch/index/store/Store.java
@@ -950,14 +950,14 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
             long fileSize = from.fileLength(src);
             beforeDownload(fileSize);
             boolean success = false;
+            long startTime = System.currentTimeMillis();
             try {
-                long startTime = System.currentTimeMillis();
                 super.copyFrom(from, src, dest, context);
                 success = true;
                 afterDownload(fileSize, startTime);
             } finally {
                 if (!success) {
-                    downloadFailed(fileSize);
+                    downloadFailed(fileSize, startTime);
                 }
             }
         }
@@ -983,8 +983,8 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
         /**
          * Updates the amount of bytes failed in download
          */
-        private void downloadFailed(long fileSize) {
-            directoryFileTransferTracker.addTransferredBytesFailed(fileSize);
+        private void downloadFailed(long fileSize, long startTimeInMs) {
+            directoryFileTransferTracker.addTransferredBytesFailed(fileSize, startTimeInMs);
         }
     }
 

--- a/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -460,6 +460,8 @@ public class NodeStatsTests extends OpenSearchTestCase {
                     assertEquals(remoteSegmentStats.getMaxRefreshTimeLag(), deserializedRemoteSegmentStats.getMaxRefreshTimeLag());
                     assertEquals(remoteSegmentStats.getMaxRefreshBytesLag(), deserializedRemoteSegmentStats.getMaxRefreshBytesLag());
                     assertEquals(remoteSegmentStats.getTotalRefreshBytesLag(), deserializedRemoteSegmentStats.getTotalRefreshBytesLag());
+                    assertEquals(remoteSegmentStats.getTotalUploadTime(), deserializedRemoteSegmentStats.getTotalUploadTime());
+                    assertEquals(remoteSegmentStats.getTotalDownloadTime(), deserializedRemoteSegmentStats.getTotalDownloadTime());
                 }
             }
         }
@@ -793,6 +795,8 @@ public class NodeStatsTests extends OpenSearchTestCase {
             remoteSegmentStats.addTotalRefreshBytesLag(5L);
             remoteSegmentStats.addMaxRefreshBytesLag(2L);
             remoteSegmentStats.setMaxRefreshTimeLag(2L);
+            remoteSegmentStats.addTotalUploadTime(20L);
+            remoteSegmentStats.addTotalDownloadTime(20L);
         }
         return indicesStats;
     }

--- a/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -459,6 +459,7 @@ public class NodeStatsTests extends OpenSearchTestCase {
                     assertEquals(remoteSegmentStats.getUploadBytesFailed(), deserializedRemoteSegmentStats.getUploadBytesFailed());
                     assertEquals(remoteSegmentStats.getMaxRefreshTimeLag(), deserializedRemoteSegmentStats.getMaxRefreshTimeLag());
                     assertEquals(remoteSegmentStats.getMaxRefreshBytesLag(), deserializedRemoteSegmentStats.getMaxRefreshBytesLag());
+                    assertEquals(remoteSegmentStats.getTotalRefreshBytesLag(), deserializedRemoteSegmentStats.getTotalRefreshBytesLag());
                 }
             }
         }
@@ -789,7 +790,8 @@ public class NodeStatsTests extends OpenSearchTestCase {
             remoteSegmentStats.addDownloadBytesStarted(10L);
             remoteSegmentStats.addDownloadBytesSucceeded(10L);
             remoteSegmentStats.addDownloadBytesFailed(1L);
-            remoteSegmentStats.setMaxRefreshBytesLag(5L);
+            remoteSegmentStats.addTotalRefreshBytesLag(5L);
+            remoteSegmentStats.addMaxRefreshBytesLag(2L);
             remoteSegmentStats.setMaxRefreshTimeLag(2L);
         }
         return indicesStats;

--- a/server/src/test/java/org/opensearch/action/admin/cluster/remotestore/stats/RemoteStoreStatsTestHelper.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/remotestore/stats/RemoteStoreStatsTestHelper.java
@@ -46,6 +46,7 @@ public class RemoteStoreStatsTestHelper {
             0,
             0,
             0,
+            10,
             createZeroDirectoryFileTransferStats()
         );
     }
@@ -53,6 +54,7 @@ public class RemoteStoreStatsTestHelper {
     static RemoteSegmentTransferTracker.Stats createStatsForNewReplica(ShardId shardId) {
         return new RemoteSegmentTransferTracker.Stats(
             shardId,
+            0,
             0,
             0,
             0,
@@ -96,16 +98,17 @@ public class RemoteStoreStatsTestHelper {
             0,
             0,
             100,
+            10,
             createSampleDirectoryFileTransferStats()
         );
     }
 
     static DirectoryFileTransferTracker.Stats createSampleDirectoryFileTransferStats() {
-        return new DirectoryFileTransferTracker.Stats(10, 0, 10, 12345, 5, 5, 5);
+        return new DirectoryFileTransferTracker.Stats(10, 0, 10, 12345, 5, 5, 5, 10);
     }
 
     static DirectoryFileTransferTracker.Stats createZeroDirectoryFileTransferStats() {
-        return new DirectoryFileTransferTracker.Stats(0, 0, 0, 0, 0, 0, 0);
+        return new DirectoryFileTransferTracker.Stats(0, 0, 0, 0, 0, 0, 0, 0);
     }
 
     static ShardRouting createShardRouting(ShardId shardId, boolean isPrimary) {

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStorePressureServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStorePressureServiceTests.java
@@ -108,7 +108,7 @@ public class RemoteStorePressureServiceTests extends OpenSearchTestCase {
         pressureTracker.updateRemoteRefreshSeqNo(3);
         AtomicLong sum = new AtomicLong();
         IntStream.range(0, 20).forEach(i -> {
-            pressureTracker.addUploadTimeMs(i);
+            pressureTracker.addTimeForCompletedUploadSync(i);
             sum.addAndGet(i);
         });
         double avg = (double) sum.get() / 20;


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Backporting https://github.com/opensearch-project/OpenSearch/pull/9393 and https://github.com/opensearch-project/OpenSearch/pull/9454 to `2.x` branch

Removing version checks also in this backport PR. Changes in `main` to remove the version checks would follow this PR.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
