### PR TITLE
[Remote Store] Removing version checks from RemoteSegmentStats

### DIFF
--- a/server/src/main/java/org/opensearch/index/remote/RemoteSegmentStats.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteSegmentStats.java
@@ -8,7 +8,6 @@
 
 package org.opensearch.index.remote;
 
-import org.opensearch.Version;
 import org.opensearch.action.admin.cluster.remotestore.stats.RemoteStoreStats;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -87,21 +86,9 @@ public class RemoteSegmentStats implements Writeable, ToXContentFragment {
         downloadBytesSucceeded = in.readLong();
         maxRefreshTimeLag = in.readLong();
         maxRefreshBytesLag = in.readLong();
-        /* TODO:
-          Adding version checks here since the base PR of adding remote store stats
-          in SegmentStats has already been merged and backported to 2.x branch.
-
-          Since this is a new field that is being added, we need to have this check in place
-          to ensure BWCs don't break.
-
-          This would have to be removed after the new field addition PRs are also backported to 2.x.
-          If possible we would need to ensure that all field addition PRs are backported at once
-         */
-        if (in.getVersion().onOrAfter(Version.CURRENT)) {
-            totalRefreshBytesLag = in.readLong();
-            totalUploadTime = in.readLong();
-            totalDownloadTime = in.readLong();
-        }
+        totalRefreshBytesLag = in.readLong();
+        totalUploadTime = in.readLong();
+        totalDownloadTime = in.readLong();
     }
 
     /**
@@ -250,21 +237,9 @@ public class RemoteSegmentStats implements Writeable, ToXContentFragment {
         out.writeLong(downloadBytesSucceeded);
         out.writeLong(maxRefreshTimeLag);
         out.writeLong(maxRefreshBytesLag);
-        /* TODO:
-          Adding version checks here since the base PR of adding remote store stats
-          in SegmentStats has already been merged and backported to 2.x branch.
-
-          Since this is a new field that is being added, we need to have this check in place
-          to ensure BWCs don't break.
-
-          This would have to be removed after the new field addition PRs are also backported to 2.x.
-          If possible we would need to ensure that all field addition PRs are backported at once
-         */
-        if (out.getVersion().onOrAfter(Version.CURRENT)) {
-            out.writeLong(totalRefreshBytesLag);
-            out.writeLong(totalUploadTime);
-            out.writeLong(totalDownloadTime);
-        }
+        out.writeLong(totalRefreshBytesLag);
+        out.writeLong(totalUploadTime);
+        out.writeLong(totalDownloadTime);
     }
 
     @Override


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Removing version checks from `RemoteSegmentStats` to retain BwC. This PR should be followed after https://github.com/opensearch-project/OpenSearch/pull/9544 is merged

<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
