### PR TITLE
[Remote Store] Add tracker factory to manage remote store stats trackers

### DIFF
--- a/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/stats/TransportRemoteStoreStatsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/stats/TransportRemoteStoreStatsAction.java
@@ -24,7 +24,7 @@ import org.opensearch.core.action.support.DefaultShardOperationFailedException;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.remote.RemoteSegmentTransferTracker;
-import org.opensearch.index.remote.RemoteStorePressureService;
+import org.opensearch.index.remote.RemoteStoreStatsTrackerFactory;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.shard.ShardNotFoundException;
 import org.opensearch.indices.IndicesService;
@@ -50,7 +50,7 @@ public class TransportRemoteStoreStatsAction extends TransportBroadcastByNodeAct
 
     private final IndicesService indicesService;
 
-    private final RemoteStorePressureService remoteStorePressureService;
+    private final RemoteStoreStatsTrackerFactory remoteStoreStatsTrackerFactory;
 
     @Inject
     public TransportRemoteStoreStatsAction(
@@ -59,7 +59,7 @@ public class TransportRemoteStoreStatsAction extends TransportBroadcastByNodeAct
         IndicesService indicesService,
         ActionFilters actionFilters,
         IndexNameExpressionResolver indexNameExpressionResolver,
-        RemoteStorePressureService remoteStorePressureService
+        RemoteStoreStatsTrackerFactory remoteStoreStatsTrackerFactory
     ) {
         super(
             RemoteStoreStatsAction.NAME,
@@ -71,7 +71,7 @@ public class TransportRemoteStoreStatsAction extends TransportBroadcastByNodeAct
             ThreadPool.Names.MANAGEMENT
         );
         this.indicesService = indicesService;
-        this.remoteStorePressureService = remoteStorePressureService;
+        this.remoteStoreStatsTrackerFactory = remoteStoreStatsTrackerFactory;
     }
 
     /**
@@ -153,7 +153,7 @@ public class TransportRemoteStoreStatsAction extends TransportBroadcastByNodeAct
             throw new ShardNotFoundException(indexShard.shardId());
         }
 
-        RemoteSegmentTransferTracker remoteSegmentTransferTracker = remoteStorePressureService.getRemoteSegmentTransferTracker(
+        RemoteSegmentTransferTracker remoteSegmentTransferTracker = remoteStoreStatsTrackerFactory.getRemoteSegmentTransferTracker(
             indexShard.shardId()
         );
         assert Objects.nonNull(remoteSegmentTransferTracker);

--- a/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/stats/TransportRemoteStoreStatsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/stats/TransportRemoteStoreStatsAction.java
@@ -153,7 +153,7 @@ public class TransportRemoteStoreStatsAction extends TransportBroadcastByNodeAct
             throw new ShardNotFoundException(indexShard.shardId());
         }
 
-        RemoteSegmentTransferTracker remoteSegmentTransferTracker = remoteStorePressureService.getRemoteRefreshSegmentTracker(
+        RemoteSegmentTransferTracker remoteSegmentTransferTracker = remoteStorePressureService.getRemoteSegmentTransferTracker(
             indexShard.shardId()
         );
         assert Objects.nonNull(remoteSegmentTransferTracker);

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -656,9 +656,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 RemoteStorePressureSettings.BYTES_LAG_VARIANCE_FACTOR,
                 RemoteStorePressureSettings.UPLOAD_TIME_LAG_VARIANCE_FACTOR,
                 RemoteStorePressureSettings.MIN_CONSECUTIVE_FAILURES_LIMIT,
-                RemoteStorePressureSettings.UPLOAD_BYTES_MOVING_AVERAGE_WINDOW_SIZE,
-                RemoteStorePressureSettings.UPLOAD_BYTES_PER_SEC_MOVING_AVERAGE_WINDOW_SIZE,
-                RemoteStorePressureSettings.UPLOAD_TIME_MOVING_AVERAGE_WINDOW_SIZE,
+                RemoteStorePressureSettings.MOVING_AVERAGE_WINDOW_SIZE,
 
                 // Related to monitoring of task cancellation
                 TaskCancellationMonitoringSettings.IS_ENABLED_SETTING,

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -106,6 +106,7 @@ import org.opensearch.index.ShardIndexingPressureMemoryManager;
 import org.opensearch.index.ShardIndexingPressureSettings;
 import org.opensearch.index.ShardIndexingPressureStore;
 import org.opensearch.index.remote.RemoteStorePressureSettings;
+import org.opensearch.index.remote.RemoteStoreStatsTrackerFactory;
 import org.opensearch.index.store.remote.filecache.FileCache;
 import org.opensearch.indices.IndexingMemoryController;
 import org.opensearch.indices.IndicesQueryCache;
@@ -656,7 +657,9 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 RemoteStorePressureSettings.BYTES_LAG_VARIANCE_FACTOR,
                 RemoteStorePressureSettings.UPLOAD_TIME_LAG_VARIANCE_FACTOR,
                 RemoteStorePressureSettings.MIN_CONSECUTIVE_FAILURES_LIMIT,
-                RemoteStorePressureSettings.MOVING_AVERAGE_WINDOW_SIZE,
+
+                // Settings related to Remote Store stats
+                RemoteStoreStatsTrackerFactory.MOVING_AVERAGE_WINDOW_SIZE,
 
                 // Related to monitoring of task cancellation
                 TaskCancellationMonitoringSettings.IS_ENABLED_SETTING,

--- a/server/src/main/java/org/opensearch/index/IndexService.java
+++ b/server/src/main/java/org/opensearch/index/IndexService.java
@@ -78,7 +78,7 @@ import org.opensearch.index.fielddata.IndexFieldDataService;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.query.SearchIndexNameMatcher;
-import org.opensearch.index.remote.RemoteStorePressureService;
+import org.opensearch.index.remote.RemoteStoreStatsTrackerFactory;
 import org.opensearch.index.seqno.RetentionLeaseSyncer;
 import org.opensearch.index.shard.IndexEventListener;
 import org.opensearch.index.shard.IndexShard;
@@ -443,7 +443,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         final Consumer<ShardId> globalCheckpointSyncer,
         final RetentionLeaseSyncer retentionLeaseSyncer,
         final SegmentReplicationCheckpointPublisher checkpointPublisher,
-        final RemoteStorePressureService remoteStorePressureService
+        final RemoteStoreStatsTrackerFactory remoteStoreStatsTrackerFactory
     ) throws IOException {
         Objects.requireNonNull(retentionLeaseSyncer);
         /*
@@ -512,7 +512,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                 translogFactorySupplier,
                 this.indexSettings.isSegRepEnabled() ? checkpointPublisher : null,
                 remoteStore,
-                remoteStorePressureService
+                remoteStoreStatsTrackerFactory
             );
             eventListener.indexShardStateChanged(indexShard, null, indexShard.state(), "shard created");
             eventListener.afterIndexShardCreated(indexShard);

--- a/server/src/main/java/org/opensearch/index/remote/RemoteStorePressureService.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStorePressureService.java
@@ -54,16 +54,6 @@ public class RemoteStorePressureService {
     }
 
     /**
-     * Get {@code RemoteSegmentTransferTracker} only if the underlying Index has remote segments integration enabled.
-     *
-     * @param shardId shard id
-     * @return the tracker if index is remote-backed, else null.
-     */
-    public RemoteSegmentTransferTracker getRemoteSegmentTransferTracker(ShardId shardId) {
-        return remoteStoreStatsTrackerFactory.getRemoteSegmentTransferTracker(shardId);
-    }
-
-    /**
      * Check if remote refresh segments backpressure is enabled. This is backed by a cluster level setting.
      *
      * @return true if enabled, else false.

--- a/server/src/main/java/org/opensearch/index/remote/RemoteStorePressureService.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStorePressureService.java
@@ -59,7 +59,7 @@ public class RemoteStorePressureService {
      * @param shardId shard id
      * @return the tracker if index is remote-backed, else null.
      */
-    public RemoteSegmentTransferTracker getRemoteRefreshSegmentTracker(ShardId shardId) {
+    public RemoteSegmentTransferTracker getRemoteSegmentTransferTracker(ShardId shardId) {
         return remoteStoreStatsTrackerFactory.getRemoteSegmentTransferTracker(shardId);
     }
 

--- a/server/src/main/java/org/opensearch/index/remote/RemoteStorePressureService.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStorePressureService.java
@@ -83,13 +83,6 @@ public class RemoteStorePressureService {
         }
     }
 
-    void updateMovingAverageWindowSize(int updatedSize) {
-        remoteStoreStatsTrackerFactory.updateMovingAverageWindowSize(
-            RemoteSegmentTransferTracker::updateMovingAverageWindowSize,
-            updatedSize
-        );
-    }
-
     /**
      * Abstract class for validating if lag is acceptable or not.
      *

--- a/server/src/main/java/org/opensearch/index/remote/RemoteStorePressureSettings.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStorePressureSettings.java
@@ -26,8 +26,6 @@ public class RemoteStorePressureSettings {
         private static final double VARIANCE_FACTOR_MIN_VALUE = 1.0;
         private static final int MIN_CONSECUTIVE_FAILURES_LIMIT = 5;
         private static final int MIN_CONSECUTIVE_FAILURES_LIMIT_MIN_VALUE = 1;
-        static final int MOVING_AVERAGE_WINDOW_SIZE = 20;
-        static final int MOVING_AVERAGE_WINDOW_SIZE_MIN_VALUE = 5;
     }
 
     public static final Setting<Boolean> REMOTE_REFRESH_SEGMENT_PRESSURE_ENABLED = Setting.boolSetting(
@@ -57,14 +55,6 @@ public class RemoteStorePressureSettings {
         "remote_store.segment.pressure.consecutive_failures.limit",
         Defaults.MIN_CONSECUTIVE_FAILURES_LIMIT,
         Defaults.MIN_CONSECUTIVE_FAILURES_LIMIT_MIN_VALUE,
-        Setting.Property.Dynamic,
-        Setting.Property.NodeScope
-    );
-
-    public static final Setting<Integer> MOVING_AVERAGE_WINDOW_SIZE = Setting.intSetting(
-        "remote_store.pressure.moving_average_window_size",
-        Defaults.MOVING_AVERAGE_WINDOW_SIZE,
-        Defaults.MOVING_AVERAGE_WINDOW_SIZE_MIN_VALUE,
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
@@ -99,10 +89,6 @@ public class RemoteStorePressureSettings {
 
         this.minConsecutiveFailuresLimit = MIN_CONSECUTIVE_FAILURES_LIMIT.get(settings);
         clusterSettings.addSettingsUpdateConsumer(MIN_CONSECUTIVE_FAILURES_LIMIT, this::setMinConsecutiveFailuresLimit);
-
-        this.movingAverageWindowSize = MOVING_AVERAGE_WINDOW_SIZE.get(settings);
-        clusterSettings.addSettingsUpdateConsumer(MOVING_AVERAGE_WINDOW_SIZE, remoteStorePressureService::updateMovingAverageWindowSize);
-        clusterSettings.addSettingsUpdateConsumer(MOVING_AVERAGE_WINDOW_SIZE, this::setMovingAverageWindowSize);
     }
 
     public boolean isRemoteRefreshSegmentPressureEnabled() {
@@ -143,10 +129,6 @@ public class RemoteStorePressureSettings {
 
     public void setMinConsecutiveFailuresLimit(int minConsecutiveFailuresLimit) {
         this.minConsecutiveFailuresLimit = minConsecutiveFailuresLimit;
-    }
-
-    public int getMovingAverageWindowSize() {
-        return movingAverageWindowSize;
     }
 
     public void setMovingAverageWindowSize(int movingAverageWindowSize) {

--- a/server/src/main/java/org/opensearch/index/remote/RemoteStorePressureSettings.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStorePressureSettings.java
@@ -20,14 +20,14 @@ import org.opensearch.common.settings.Settings;
  */
 public class RemoteStorePressureSettings {
 
-    private static class Defaults {
+    static class Defaults {
         private static final double BYTES_LAG_VARIANCE_FACTOR = 10.0;
         private static final double UPLOAD_TIME_LAG_VARIANCE_FACTOR = 10.0;
         private static final double VARIANCE_FACTOR_MIN_VALUE = 1.0;
         private static final int MIN_CONSECUTIVE_FAILURES_LIMIT = 5;
         private static final int MIN_CONSECUTIVE_FAILURES_LIMIT_MIN_VALUE = 1;
-        private static final int MOVING_AVERAGE_WINDOW_SIZE = 20;
-        private static final int MOVING_AVERAGE_WINDOW_SIZE_MIN_VALUE = 5;
+        static final int MOVING_AVERAGE_WINDOW_SIZE = 20;
+        static final int MOVING_AVERAGE_WINDOW_SIZE_MIN_VALUE = 5;
     }
 
     public static final Setting<Boolean> REMOTE_REFRESH_SEGMENT_PRESSURE_ENABLED = Setting.boolSetting(

--- a/server/src/main/java/org/opensearch/index/remote/RemoteStorePressureSettings.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStorePressureSettings.java
@@ -26,9 +26,7 @@ public class RemoteStorePressureSettings {
         private static final double VARIANCE_FACTOR_MIN_VALUE = 1.0;
         private static final int MIN_CONSECUTIVE_FAILURES_LIMIT = 5;
         private static final int MIN_CONSECUTIVE_FAILURES_LIMIT_MIN_VALUE = 1;
-        private static final int UPLOAD_BYTES_MOVING_AVERAGE_WINDOW_SIZE = 20;
-        private static final int UPLOAD_BYTES_PER_SEC_MOVING_AVERAGE_WINDOW_SIZE = 20;
-        private static final int UPLOAD_TIME_MOVING_AVERAGE_WINDOW_SIZE = 20;
+        private static final int MOVING_AVERAGE_WINDOW_SIZE = 20;
         private static final int MOVING_AVERAGE_WINDOW_SIZE_MIN_VALUE = 5;
     }
 
@@ -63,25 +61,9 @@ public class RemoteStorePressureSettings {
         Setting.Property.NodeScope
     );
 
-    public static final Setting<Integer> UPLOAD_BYTES_MOVING_AVERAGE_WINDOW_SIZE = Setting.intSetting(
-        "remote_store.segment.pressure.upload_bytes_moving_average_window_size",
-        Defaults.UPLOAD_BYTES_MOVING_AVERAGE_WINDOW_SIZE,
-        Defaults.MOVING_AVERAGE_WINDOW_SIZE_MIN_VALUE,
-        Setting.Property.Dynamic,
-        Setting.Property.NodeScope
-    );
-
-    public static final Setting<Integer> UPLOAD_BYTES_PER_SEC_MOVING_AVERAGE_WINDOW_SIZE = Setting.intSetting(
-        "remote_store.segment.pressure.upload_bytes_per_sec_moving_average_window_size",
-        Defaults.UPLOAD_BYTES_PER_SEC_MOVING_AVERAGE_WINDOW_SIZE,
-        Defaults.MOVING_AVERAGE_WINDOW_SIZE_MIN_VALUE,
-        Setting.Property.Dynamic,
-        Setting.Property.NodeScope
-    );
-
-    public static final Setting<Integer> UPLOAD_TIME_MOVING_AVERAGE_WINDOW_SIZE = Setting.intSetting(
-        "remote_store.segment.pressure.upload_time_moving_average_window_size",
-        Defaults.UPLOAD_TIME_MOVING_AVERAGE_WINDOW_SIZE,
+    public static final Setting<Integer> MOVING_AVERAGE_WINDOW_SIZE = Setting.intSetting(
+        "remote_store.pressure.moving_average_window_size",
+        Defaults.MOVING_AVERAGE_WINDOW_SIZE,
         Defaults.MOVING_AVERAGE_WINDOW_SIZE_MIN_VALUE,
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
@@ -97,16 +79,12 @@ public class RemoteStorePressureSettings {
 
     private volatile int minConsecutiveFailuresLimit;
 
-    private volatile int uploadBytesMovingAverageWindowSize;
-
-    private volatile int uploadBytesPerSecMovingAverageWindowSize;
-
-    private volatile int uploadTimeMovingAverageWindowSize;
+    private volatile int movingAverageWindowSize;
 
     public RemoteStorePressureSettings(
         ClusterService clusterService,
         Settings settings,
-        RemoteStorePressureService remoteUploadPressureService
+        RemoteStorePressureService remoteStorePressureService
     ) {
         ClusterSettings clusterSettings = clusterService.getClusterSettings();
 
@@ -122,29 +100,9 @@ public class RemoteStorePressureSettings {
         this.minConsecutiveFailuresLimit = MIN_CONSECUTIVE_FAILURES_LIMIT.get(settings);
         clusterSettings.addSettingsUpdateConsumer(MIN_CONSECUTIVE_FAILURES_LIMIT, this::setMinConsecutiveFailuresLimit);
 
-        this.uploadBytesMovingAverageWindowSize = UPLOAD_BYTES_MOVING_AVERAGE_WINDOW_SIZE.get(settings);
-        clusterSettings.addSettingsUpdateConsumer(
-            UPLOAD_BYTES_MOVING_AVERAGE_WINDOW_SIZE,
-            remoteUploadPressureService::updateUploadBytesMovingAverageWindowSize
-        );
-        clusterSettings.addSettingsUpdateConsumer(UPLOAD_BYTES_MOVING_AVERAGE_WINDOW_SIZE, this::setUploadBytesMovingAverageWindowSize);
-
-        this.uploadBytesPerSecMovingAverageWindowSize = UPLOAD_BYTES_PER_SEC_MOVING_AVERAGE_WINDOW_SIZE.get(settings);
-        clusterSettings.addSettingsUpdateConsumer(
-            UPLOAD_BYTES_PER_SEC_MOVING_AVERAGE_WINDOW_SIZE,
-            remoteUploadPressureService::updateUploadBytesPerSecMovingAverageWindowSize
-        );
-        clusterSettings.addSettingsUpdateConsumer(
-            UPLOAD_BYTES_PER_SEC_MOVING_AVERAGE_WINDOW_SIZE,
-            this::setUploadBytesPerSecMovingAverageWindowSize
-        );
-
-        this.uploadTimeMovingAverageWindowSize = UPLOAD_TIME_MOVING_AVERAGE_WINDOW_SIZE.get(settings);
-        clusterSettings.addSettingsUpdateConsumer(
-            UPLOAD_TIME_MOVING_AVERAGE_WINDOW_SIZE,
-            remoteUploadPressureService::updateUploadTimeMsMovingAverageWindowSize
-        );
-        clusterSettings.addSettingsUpdateConsumer(UPLOAD_TIME_MOVING_AVERAGE_WINDOW_SIZE, this::setUploadTimeMovingAverageWindowSize);
+        this.movingAverageWindowSize = MOVING_AVERAGE_WINDOW_SIZE.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(MOVING_AVERAGE_WINDOW_SIZE, remoteStorePressureService::updateMovingAverageWindowSize);
+        clusterSettings.addSettingsUpdateConsumer(MOVING_AVERAGE_WINDOW_SIZE, this::setMovingAverageWindowSize);
     }
 
     public boolean isRemoteRefreshSegmentPressureEnabled() {
@@ -187,27 +145,11 @@ public class RemoteStorePressureSettings {
         this.minConsecutiveFailuresLimit = minConsecutiveFailuresLimit;
     }
 
-    public int getUploadBytesMovingAverageWindowSize() {
-        return uploadBytesMovingAverageWindowSize;
+    public int getMovingAverageWindowSize() {
+        return movingAverageWindowSize;
     }
 
-    public void setUploadBytesMovingAverageWindowSize(int uploadBytesMovingAverageWindowSize) {
-        this.uploadBytesMovingAverageWindowSize = uploadBytesMovingAverageWindowSize;
-    }
-
-    public int getUploadBytesPerSecMovingAverageWindowSize() {
-        return uploadBytesPerSecMovingAverageWindowSize;
-    }
-
-    public void setUploadBytesPerSecMovingAverageWindowSize(int uploadBytesPerSecMovingAverageWindowSize) {
-        this.uploadBytesPerSecMovingAverageWindowSize = uploadBytesPerSecMovingAverageWindowSize;
-    }
-
-    public int getUploadTimeMovingAverageWindowSize() {
-        return uploadTimeMovingAverageWindowSize;
-    }
-
-    public void setUploadTimeMovingAverageWindowSize(int uploadTimeMovingAverageWindowSize) {
-        this.uploadTimeMovingAverageWindowSize = uploadTimeMovingAverageWindowSize;
+    public void setMovingAverageWindowSize(int movingAverageWindowSize) {
+        this.movingAverageWindowSize = movingAverageWindowSize;
     }
 }

--- a/server/src/main/java/org/opensearch/index/remote/RemoteStorePressureSettings.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStorePressureSettings.java
@@ -69,8 +69,6 @@ public class RemoteStorePressureSettings {
 
     private volatile int minConsecutiveFailuresLimit;
 
-    private volatile int movingAverageWindowSize;
-
     public RemoteStorePressureSettings(
         ClusterService clusterService,
         Settings settings,
@@ -129,9 +127,5 @@ public class RemoteStorePressureSettings {
 
     public void setMinConsecutiveFailuresLimit(int minConsecutiveFailuresLimit) {
         this.minConsecutiveFailuresLimit = minConsecutiveFailuresLimit;
-    }
-
-    public void setMovingAverageWindowSize(int movingAverageWindowSize) {
-        this.movingAverageWindowSize = movingAverageWindowSize;
     }
 }

--- a/server/src/main/java/org/opensearch/index/remote/RemoteStoreStatsTrackerFactory.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStoreStatsTrackerFactory.java
@@ -67,11 +67,11 @@ public class RemoteStoreStatsTrackerFactory implements IndexEventListener {
     }
 
     void updateMovingAverageWindowSize(BiConsumer<RemoteSegmentTransferTracker, Integer> biConsumer, int updatedSize) {
+        remoteSegmentTrackerMap.values().forEach(tracker -> biConsumer.accept(tracker, updatedSize));
         movingAverageWindowSize = updatedSize;
-        remoteSegmentTrackerMap.values().forEach(tracker -> biConsumer.accept(tracker, movingAverageWindowSize));
     }
 
-    RemoteSegmentTransferTracker getRemoteSegmentTransferTracker(ShardId shardId) {
+    public RemoteSegmentTransferTracker getRemoteSegmentTransferTracker(ShardId shardId) {
         return remoteSegmentTrackerMap.get(shardId);
     }
 

--- a/server/src/main/java/org/opensearch/index/remote/RemoteStoreStatsTrackerFactory.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStoreStatsTrackerFactory.java
@@ -1,0 +1,76 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.remote;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ConcurrentCollections;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.index.shard.IndexEventListener;
+import org.opensearch.index.shard.IndexShard;
+
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import static org.opensearch.index.remote.RemoteStorePressureSettings.MOVING_AVERAGE_WINDOW_SIZE;
+
+/**
+ * Factory to manage stats trackers for Remote Store operations
+ *
+ * @opensearch.internal
+ */
+public class RemoteStoreStatsTrackerFactory implements IndexEventListener {
+    private static final Logger logger = LogManager.getLogger(RemoteStoreStatsTrackerFactory.class);
+
+    /**
+     * Number of data points to consider for a moving average statistic
+     */
+    private volatile int movingAverageWindowSize;
+
+    /**
+     * Keeps map of remote-backed index shards and their corresponding backpressure tracker.
+     */
+    private final Map<ShardId, RemoteSegmentTransferTracker> remoteSegmentTrackerMap = ConcurrentCollections.newConcurrentMap();
+
+    @Inject
+    public RemoteStoreStatsTrackerFactory(Settings settings) {
+        this.movingAverageWindowSize = MOVING_AVERAGE_WINDOW_SIZE.get(settings);
+    }
+
+    @Override
+    public void afterIndexShardCreated(IndexShard indexShard) {
+        if (indexShard.indexSettings().isRemoteStoreEnabled() == false) {
+            return;
+        }
+        ShardId shardId = indexShard.shardId();
+        remoteSegmentTrackerMap.put(
+            shardId,
+            new RemoteSegmentTransferTracker(shardId, indexShard.store().getDirectoryFileTransferTracker(), movingAverageWindowSize)
+        );
+        logger.trace("Created RemoteSegmentTransferTracker for shardId={}", shardId);
+    }
+
+    @Override
+    public void afterIndexShardClosed(ShardId shardId, IndexShard indexShard, Settings indexSettings) {
+        RemoteSegmentTransferTracker remoteSegmentTransferTracker = remoteSegmentTrackerMap.remove(shardId);
+        if (remoteSegmentTransferTracker != null) {
+            logger.trace("Deleted RemoteSegmentTransferTracker for shardId={}", shardId);
+        }
+    }
+
+    void updateMovingAverageWindowSize(BiConsumer<RemoteSegmentTransferTracker, Integer> biConsumer, int updatedSize) {
+        remoteSegmentTrackerMap.values().forEach(tracker -> biConsumer.accept(tracker, updatedSize));
+    }
+
+    RemoteSegmentTransferTracker getRemoteSegmentTransferTracker(ShardId shardId) {
+        return remoteSegmentTrackerMap.get(shardId);
+    }
+}

--- a/server/src/main/java/org/opensearch/index/remote/RemoteStoreStatsTrackerFactory.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStoreStatsTrackerFactory.java
@@ -67,10 +67,16 @@ public class RemoteStoreStatsTrackerFactory implements IndexEventListener {
     }
 
     void updateMovingAverageWindowSize(BiConsumer<RemoteSegmentTransferTracker, Integer> biConsumer, int updatedSize) {
-        remoteSegmentTrackerMap.values().forEach(tracker -> biConsumer.accept(tracker, updatedSize));
+        movingAverageWindowSize = updatedSize;
+        remoteSegmentTrackerMap.values().forEach(tracker -> biConsumer.accept(tracker, movingAverageWindowSize));
     }
 
     RemoteSegmentTransferTracker getRemoteSegmentTransferTracker(ShardId shardId) {
         return remoteSegmentTrackerMap.get(shardId);
+    }
+
+    // visible for testing
+    long getMovingAverageWindowSize() {
+        return movingAverageWindowSize;
     }
 }

--- a/server/src/main/java/org/opensearch/index/remote/RemoteStoreStatsTrackerFactory.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStoreStatsTrackerFactory.java
@@ -68,6 +68,8 @@ public class RemoteStoreStatsTrackerFactory implements IndexEventListener {
 
     void updateMovingAverageWindowSize(BiConsumer<RemoteSegmentTransferTracker, Integer> biConsumer, int updatedSize) {
         remoteSegmentTrackerMap.values().forEach(tracker -> biConsumer.accept(tracker, updatedSize));
+
+        // Update movingAverageWindowSize only if the trackers were successfully updated
         movingAverageWindowSize = updatedSize;
     }
 

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1386,7 +1386,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         // Populate remote_store stats only if the index is remote store backed
         if (indexSettings.isRemoteStoreEnabled()) {
             segmentsStats.addRemoteSegmentStats(
-                new RemoteSegmentStats(remoteStorePressureService.getRemoteRefreshSegmentTracker(shardId).stats())
+                new RemoteSegmentStats(remoteStorePressureService.getRemoteSegmentTransferTracker(shardId).stats())
             );
         }
         return segmentsStats;
@@ -3696,7 +3696,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                     this,
                     // Add the checkpoint publisher if the Segment Replciation via remote store is enabled.
                     indexSettings.isSegRepWithRemoteEnabled() ? this.checkpointPublisher : SegmentReplicationCheckpointPublisher.EMPTY,
-                    remoteStorePressureService.getRemoteRefreshSegmentTracker(shardId())
+                    remoteStorePressureService.getRemoteSegmentTransferTracker(shardId())
                 )
             );
         }

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -147,7 +147,7 @@ import org.opensearch.index.merge.MergeStats;
 import org.opensearch.index.recovery.RecoveryStats;
 import org.opensearch.index.refresh.RefreshStats;
 import org.opensearch.index.remote.RemoteSegmentStats;
-import org.opensearch.index.remote.RemoteStorePressureService;
+import org.opensearch.index.remote.RemoteStoreStatsTrackerFactory;
 import org.opensearch.index.search.stats.SearchStats;
 import org.opensearch.index.search.stats.ShardSearchStats;
 import org.opensearch.index.seqno.ReplicationTracker;
@@ -333,7 +333,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     private final Store remoteStore;
     private final BiFunction<IndexSettings, ShardRouting, TranslogFactory> translogFactorySupplier;
     private final boolean isTimeSeriesIndex;
-    private final RemoteStorePressureService remoteStorePressureService;
+    private final RemoteStoreStatsTrackerFactory remoteStoreStatsTrackerFactory;
 
     private final List<ReferenceManager.RefreshListener> internalRefreshListener = new ArrayList<>();
 
@@ -361,7 +361,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         final BiFunction<IndexSettings, ShardRouting, TranslogFactory> translogFactorySupplier,
         @Nullable final SegmentReplicationCheckpointPublisher checkpointPublisher,
         @Nullable final Store remoteStore,
-        final RemoteStorePressureService remoteStorePressureService
+        final RemoteStoreStatsTrackerFactory remoteStoreStatsTrackerFactory
     ) throws IOException {
         super(shardRouting.shardId(), indexSettings);
         assert shardRouting.initializing();
@@ -456,7 +456,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         this.isTimeSeriesIndex = (mapperService == null || mapperService.documentMapper() == null)
             ? false
             : mapperService.documentMapper().mappers().containsTimeStampField();
-        this.remoteStorePressureService = remoteStorePressureService;
+        this.remoteStoreStatsTrackerFactory = remoteStoreStatsTrackerFactory;
     }
 
     public ThreadPool getThreadPool() {
@@ -546,8 +546,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     }
 
     /** Only used for testing **/
-    protected RemoteStorePressureService getRemoteStorePressureService() {
-        return remoteStorePressureService;
+    protected RemoteStoreStatsTrackerFactory getRemoteStoreStatsTrackerFactory() {
+        return remoteStoreStatsTrackerFactory;
     }
 
     @Override
@@ -1386,7 +1386,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         // Populate remote_store stats only if the index is remote store backed
         if (indexSettings.isRemoteStoreEnabled()) {
             segmentsStats.addRemoteSegmentStats(
-                new RemoteSegmentStats(remoteStorePressureService.getRemoteSegmentTransferTracker(shardId).stats())
+                new RemoteSegmentStats(remoteStoreStatsTrackerFactory.getRemoteSegmentTransferTracker(shardId).stats())
             );
         }
         return segmentsStats;
@@ -3696,7 +3696,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                     this,
                     // Add the checkpoint publisher if the Segment Replciation via remote store is enabled.
                     indexSettings.isSegRepWithRemoteEnabled() ? this.checkpointPublisher : SegmentReplicationCheckpointPublisher.EMPTY,
-                    remoteStorePressureService.getRemoteSegmentTransferTracker(shardId())
+                    remoteStoreStatsTrackerFactory.getRemoteSegmentTransferTracker(shardId())
                 )
             );
         }

--- a/server/src/main/java/org/opensearch/indices/IndicesModule.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesModule.java
@@ -71,6 +71,7 @@ import org.opensearch.index.mapper.SourceFieldMapper;
 import org.opensearch.index.mapper.TextFieldMapper;
 import org.opensearch.index.mapper.VersionFieldMapper;
 import org.opensearch.index.remote.RemoteStorePressureService;
+import org.opensearch.index.remote.RemoteStoreStatsTrackerFactory;
 import org.opensearch.index.seqno.GlobalCheckpointSyncAction;
 import org.opensearch.index.seqno.RetentionLeaseBackgroundSyncAction;
 import org.opensearch.index.seqno.RetentionLeaseSyncAction;
@@ -289,6 +290,7 @@ public class IndicesModule extends AbstractModule {
         bind(SegmentReplicationCheckpointPublisher.class).asEagerSingleton();
         bind(SegmentReplicationPressureService.class).asEagerSingleton();
         if (FeatureFlags.isEnabled(FeatureFlags.REMOTE_STORE)) {
+            bind(RemoteStoreStatsTrackerFactory.class).asEagerSingleton();
             bind(RemoteStorePressureService.class).asEagerSingleton();
         }
     }

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -121,7 +121,7 @@ import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryRewriteContext;
 import org.opensearch.index.recovery.RecoveryStats;
 import org.opensearch.index.refresh.RefreshStats;
-import org.opensearch.index.remote.RemoteStorePressureService;
+import org.opensearch.index.remote.RemoteStoreStatsTrackerFactory;
 import org.opensearch.index.search.stats.SearchStats;
 import org.opensearch.index.seqno.RetentionLeaseStats;
 import org.opensearch.index.seqno.RetentionLeaseSyncer;
@@ -978,7 +978,7 @@ public class IndicesService extends AbstractLifecycleComponent
         final RetentionLeaseSyncer retentionLeaseSyncer,
         final DiscoveryNode targetNode,
         final DiscoveryNode sourceNode,
-        final RemoteStorePressureService remoteStorePressureService
+        final RemoteStoreStatsTrackerFactory remoteStoreStatsTrackerFactory
     ) throws IOException {
         Objects.requireNonNull(retentionLeaseSyncer);
         ensureChangesAllowed();
@@ -990,7 +990,7 @@ public class IndicesService extends AbstractLifecycleComponent
             globalCheckpointSyncer,
             retentionLeaseSyncer,
             checkpointPublisher,
-            remoteStorePressureService
+            remoteStoreStatsTrackerFactory
         );
         indexShard.addShardFailureCallback(onShardFailure);
         indexShard.startRecovery(recoveryState, recoveryTargetService, recoveryListener, repositoriesService, mapping -> {

--- a/server/src/test/java/org/opensearch/action/admin/cluster/remotestore/stats/TransportRemoteStoreStatsActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/remotestore/stats/TransportRemoteStoreStatsActionTests.java
@@ -28,7 +28,7 @@ import org.opensearch.core.index.Index;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.remote.RemoteSegmentTransferTracker;
-import org.opensearch.index.remote.RemoteStorePressureService;
+import org.opensearch.index.remote.RemoteStoreStatsTrackerFactory;
 import org.opensearch.index.shard.IndexShardTestCase;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.replication.common.ReplicationType;
@@ -53,7 +53,7 @@ import static org.mockito.Mockito.when;
 
 public class TransportRemoteStoreStatsActionTests extends IndexShardTestCase {
     private IndicesService indicesService;
-    private RemoteStorePressureService pressureService;
+    private RemoteStoreStatsTrackerFactory remoteStoreStatsTrackerFactory;
     private IndexMetadata remoteStoreIndexMetadata;
     private TransportService transportService;
     private ClusterService clusterService;
@@ -67,7 +67,7 @@ public class TransportRemoteStoreStatsActionTests extends IndexShardTestCase {
         indicesService = mock(IndicesService.class);
         IndexService indexService = mock(IndexService.class);
         clusterService = mock(ClusterService.class);
-        pressureService = mock(RemoteStorePressureService.class);
+        remoteStoreStatsTrackerFactory = mock(RemoteStoreStatsTrackerFactory.class);
         MockTransport mockTransport = new MockTransport();
         localNode = new DiscoveryNode("node0", buildNewFakeTransportAddress(), Version.CURRENT);
         remoteStoreIndexMetadata = IndexMetadata.builder(INDEX.getName())
@@ -90,7 +90,7 @@ public class TransportRemoteStoreStatsActionTests extends IndexShardTestCase {
             Collections.emptySet()
         );
 
-        when(pressureService.getRemoteSegmentTransferTracker(any())).thenReturn(mock(RemoteSegmentTransferTracker.class));
+        when(remoteStoreStatsTrackerFactory.getRemoteSegmentTransferTracker(any())).thenReturn(mock(RemoteSegmentTransferTracker.class));
         when(indicesService.indexService(INDEX)).thenReturn(indexService);
         when(indexService.getIndexSettings()).thenReturn(new IndexSettings(remoteStoreIndexMetadata, Settings.EMPTY));
         statsAction = new TransportRemoteStoreStatsAction(
@@ -99,7 +99,7 @@ public class TransportRemoteStoreStatsActionTests extends IndexShardTestCase {
             indicesService,
             mock(ActionFilters.class),
             mock(IndexNameExpressionResolver.class),
-            pressureService
+            remoteStoreStatsTrackerFactory
         );
 
     }

--- a/server/src/test/java/org/opensearch/action/admin/cluster/remotestore/stats/TransportRemoteStoreStatsActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/remotestore/stats/TransportRemoteStoreStatsActionTests.java
@@ -90,7 +90,7 @@ public class TransportRemoteStoreStatsActionTests extends IndexShardTestCase {
             Collections.emptySet()
         );
 
-        when(pressureService.getRemoteRefreshSegmentTracker(any())).thenReturn(mock(RemoteSegmentTransferTracker.class));
+        when(pressureService.getRemoteSegmentTransferTracker(any())).thenReturn(mock(RemoteSegmentTransferTracker.class));
         when(indicesService.indexService(INDEX)).thenReturn(indexService);
         when(indexService.getIndexSettings()).thenReturn(new IndexSettings(remoteStoreIndexMetadata, Settings.EMPTY));
         statsAction = new TransportRemoteStoreStatsAction(

--- a/server/src/test/java/org/opensearch/index/remote/RemoteSegmentTransferTrackerTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteSegmentTransferTrackerTests.java
@@ -497,9 +497,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getUploadBytesMovingAverageWindowSize(),
-            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
-            pressureSettings.getUploadTimeMovingAverageWindowSize()
+            pressureSettings.getMovingAverageWindowSize()
         );
         long timeToAdd = randomLongBetween(100, 200);
         pressureTracker.getDirectoryFileTransferTracker().addTotalTransferTimeInMs(timeToAdd);

--- a/server/src/test/java/org/opensearch/index/remote/RemoteSegmentTransferTrackerTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteSegmentTransferTrackerTests.java
@@ -359,26 +359,26 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
     }
 
     public void testIsUploadBytesAverageReady() {
-        int uploadBytesMovingAverageWindowSize = pressureSettings.getMovingAverageWindowSize();
-        pressureTracker = new RemoteSegmentTransferTracker(shardId, directoryFileTransferTracker, uploadBytesMovingAverageWindowSize);
+        int movingAverageWindowSize = pressureSettings.getMovingAverageWindowSize();
+        pressureTracker = new RemoteSegmentTransferTracker(shardId, directoryFileTransferTracker, movingAverageWindowSize);
         assertFalse(pressureTracker.isUploadBytesAverageReady());
 
         long sum = 0;
-        for (int i = 1; i < uploadBytesMovingAverageWindowSize; i++) {
+        for (int i = 1; i < movingAverageWindowSize; i++) {
             pressureTracker.addUploadBytes(i);
             sum += i;
             assertFalse(pressureTracker.isUploadBytesAverageReady());
             assertEquals((double) sum / i, pressureTracker.getUploadBytesAverage(), 0.0d);
         }
 
-        pressureTracker.addUploadBytes(uploadBytesMovingAverageWindowSize);
-        sum += uploadBytesMovingAverageWindowSize;
+        pressureTracker.addUploadBytes(movingAverageWindowSize);
+        sum += movingAverageWindowSize;
         assertTrue(pressureTracker.isUploadBytesAverageReady());
-        assertEquals((double) sum / uploadBytesMovingAverageWindowSize, pressureTracker.getUploadBytesAverage(), 0.0d);
+        assertEquals((double) sum / movingAverageWindowSize, pressureTracker.getUploadBytesAverage(), 0.0d);
 
         pressureTracker.addUploadBytes(100);
         sum = sum + 100 - 1;
-        assertEquals((double) sum / uploadBytesMovingAverageWindowSize, pressureTracker.getUploadBytesAverage(), 0.0d);
+        assertEquals((double) sum / movingAverageWindowSize, pressureTracker.getUploadBytesAverage(), 0.0d);
     }
 
     public void testIsUploadBytesPerSecAverageReady() {

--- a/server/src/test/java/org/opensearch/index/remote/RemoteSegmentTransferTrackerTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteSegmentTransferTrackerTests.java
@@ -35,7 +35,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
 
     private ShardId shardId;
 
-    private RemoteSegmentTransferTracker pressureTracker;
+    private RemoteSegmentTransferTracker transferTracker;
 
     private DirectoryFileTransferTracker directoryFileTransferTracker;
 
@@ -60,185 +60,185 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
     }
 
     public void testGetShardId() {
-        pressureTracker = new RemoteSegmentTransferTracker(
+        transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
             pressureSettings.getMovingAverageWindowSize()
         );
-        assertEquals(shardId, pressureTracker.getShardId());
+        assertEquals(shardId, transferTracker.getShardId());
     }
 
     public void testUpdateLocalRefreshSeqNo() {
-        pressureTracker = new RemoteSegmentTransferTracker(
+        transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
             pressureSettings.getMovingAverageWindowSize()
         );
         long refreshSeqNo = 2;
-        pressureTracker.updateLocalRefreshSeqNo(refreshSeqNo);
-        assertEquals(refreshSeqNo, pressureTracker.getLocalRefreshSeqNo());
+        transferTracker.updateLocalRefreshSeqNo(refreshSeqNo);
+        assertEquals(refreshSeqNo, transferTracker.getLocalRefreshSeqNo());
     }
 
     public void testUpdateRemoteRefreshSeqNo() {
-        pressureTracker = new RemoteSegmentTransferTracker(
+        transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
             pressureSettings.getMovingAverageWindowSize()
         );
         long refreshSeqNo = 4;
-        pressureTracker.updateRemoteRefreshSeqNo(refreshSeqNo);
-        assertEquals(refreshSeqNo, pressureTracker.getRemoteRefreshSeqNo());
+        transferTracker.updateRemoteRefreshSeqNo(refreshSeqNo);
+        assertEquals(refreshSeqNo, transferTracker.getRemoteRefreshSeqNo());
     }
 
     public void testUpdateLocalRefreshTimeMs() {
-        pressureTracker = new RemoteSegmentTransferTracker(
+        transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
             pressureSettings.getMovingAverageWindowSize()
         );
         long refreshTimeMs = System.nanoTime() / 1_000_000L + randomIntBetween(10, 100);
-        pressureTracker.updateLocalRefreshTimeMs(refreshTimeMs);
-        assertEquals(refreshTimeMs, pressureTracker.getLocalRefreshTimeMs());
+        transferTracker.updateLocalRefreshTimeMs(refreshTimeMs);
+        assertEquals(refreshTimeMs, transferTracker.getLocalRefreshTimeMs());
     }
 
     public void testUpdateRemoteRefreshTimeMs() {
-        pressureTracker = new RemoteSegmentTransferTracker(
+        transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
             pressureSettings.getMovingAverageWindowSize()
         );
         long refreshTimeMs = System.nanoTime() / 1_000_000 + randomIntBetween(10, 100);
-        pressureTracker.updateRemoteRefreshTimeMs(refreshTimeMs);
-        assertEquals(refreshTimeMs, pressureTracker.getRemoteRefreshTimeMs());
+        transferTracker.updateRemoteRefreshTimeMs(refreshTimeMs);
+        assertEquals(refreshTimeMs, transferTracker.getRemoteRefreshTimeMs());
     }
 
     public void testLastDownloadTimestampMs() {
-        pressureTracker = new RemoteSegmentTransferTracker(
+        transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
             pressureSettings.getMovingAverageWindowSize()
         );
         long currentTimeInMs = System.currentTimeMillis();
-        pressureTracker.getDirectoryFileTransferTracker().updateLastTransferTimestampMs(currentTimeInMs);
-        assertEquals(currentTimeInMs, pressureTracker.getDirectoryFileTransferTracker().getLastTransferTimestampMs());
+        transferTracker.getDirectoryFileTransferTracker().updateLastTransferTimestampMs(currentTimeInMs);
+        assertEquals(currentTimeInMs, transferTracker.getDirectoryFileTransferTracker().getLastTransferTimestampMs());
     }
 
     public void testComputeSeqNoLagOnUpdate() {
-        pressureTracker = new RemoteSegmentTransferTracker(
+        transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
             pressureSettings.getMovingAverageWindowSize()
         );
         int localRefreshSeqNo = randomIntBetween(50, 100);
         int remoteRefreshSeqNo = randomIntBetween(20, 50);
-        pressureTracker.updateLocalRefreshSeqNo(localRefreshSeqNo);
-        assertEquals(localRefreshSeqNo, pressureTracker.getRefreshSeqNoLag());
-        pressureTracker.updateRemoteRefreshSeqNo(remoteRefreshSeqNo);
-        assertEquals(localRefreshSeqNo - remoteRefreshSeqNo, pressureTracker.getRefreshSeqNoLag());
+        transferTracker.updateLocalRefreshSeqNo(localRefreshSeqNo);
+        assertEquals(localRefreshSeqNo, transferTracker.getRefreshSeqNoLag());
+        transferTracker.updateRemoteRefreshSeqNo(remoteRefreshSeqNo);
+        assertEquals(localRefreshSeqNo - remoteRefreshSeqNo, transferTracker.getRefreshSeqNoLag());
     }
 
     public void testComputeTimeLagOnUpdate() {
-        pressureTracker = new RemoteSegmentTransferTracker(
+        transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
             pressureSettings.getMovingAverageWindowSize()
         );
-        long currentLocalRefreshTimeMs = pressureTracker.getLocalRefreshTimeMs();
+        long currentLocalRefreshTimeMs = transferTracker.getLocalRefreshTimeMs();
         long currentTimeMs = System.nanoTime() / 1_000_000L;
         long localRefreshTimeMs = currentTimeMs + randomIntBetween(100, 500);
         long remoteRefreshTimeMs = currentTimeMs + randomIntBetween(50, 99);
-        pressureTracker.updateLocalRefreshTimeMs(localRefreshTimeMs);
-        assertEquals(localRefreshTimeMs - currentLocalRefreshTimeMs, pressureTracker.getTimeMsLag());
-        pressureTracker.updateRemoteRefreshTimeMs(remoteRefreshTimeMs);
-        assertEquals(localRefreshTimeMs - remoteRefreshTimeMs, pressureTracker.getTimeMsLag());
+        transferTracker.updateLocalRefreshTimeMs(localRefreshTimeMs);
+        assertEquals(localRefreshTimeMs - currentLocalRefreshTimeMs, transferTracker.getTimeMsLag());
+        transferTracker.updateRemoteRefreshTimeMs(remoteRefreshTimeMs);
+        assertEquals(localRefreshTimeMs - remoteRefreshTimeMs, transferTracker.getTimeMsLag());
     }
 
     public void testAddUploadBytesStarted() {
-        pressureTracker = new RemoteSegmentTransferTracker(
+        transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
             pressureSettings.getMovingAverageWindowSize()
         );
         long bytesToAdd = randomLongBetween(1000, 1000000);
-        pressureTracker.addUploadBytesStarted(bytesToAdd);
-        assertEquals(bytesToAdd, pressureTracker.getUploadBytesStarted());
+        transferTracker.addUploadBytesStarted(bytesToAdd);
+        assertEquals(bytesToAdd, transferTracker.getUploadBytesStarted());
         long moreBytesToAdd = randomLongBetween(1000, 10000);
-        pressureTracker.addUploadBytesStarted(moreBytesToAdd);
-        assertEquals(bytesToAdd + moreBytesToAdd, pressureTracker.getUploadBytesStarted());
+        transferTracker.addUploadBytesStarted(moreBytesToAdd);
+        assertEquals(bytesToAdd + moreBytesToAdd, transferTracker.getUploadBytesStarted());
     }
 
     public void testAddUploadBytesFailed() {
-        pressureTracker = new RemoteSegmentTransferTracker(
+        transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
             pressureSettings.getMovingAverageWindowSize()
         );
         long bytesToAdd = randomLongBetween(1000, 1000000);
-        pressureTracker.addUploadBytesFailed(bytesToAdd);
-        assertEquals(bytesToAdd, pressureTracker.getUploadBytesFailed());
+        transferTracker.addUploadBytesFailed(bytesToAdd);
+        assertEquals(bytesToAdd, transferTracker.getUploadBytesFailed());
         long moreBytesToAdd = randomLongBetween(1000, 10000);
-        pressureTracker.addUploadBytesFailed(moreBytesToAdd);
-        assertEquals(bytesToAdd + moreBytesToAdd, pressureTracker.getUploadBytesFailed());
+        transferTracker.addUploadBytesFailed(moreBytesToAdd);
+        assertEquals(bytesToAdd + moreBytesToAdd, transferTracker.getUploadBytesFailed());
     }
 
     public void testAddUploadBytesSucceeded() {
-        pressureTracker = new RemoteSegmentTransferTracker(
+        transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
             pressureSettings.getMovingAverageWindowSize()
         );
         long bytesToAdd = randomLongBetween(1000, 1000000);
-        pressureTracker.addUploadBytesSucceeded(bytesToAdd);
-        assertEquals(bytesToAdd, pressureTracker.getUploadBytesSucceeded());
+        transferTracker.addUploadBytesSucceeded(bytesToAdd);
+        assertEquals(bytesToAdd, transferTracker.getUploadBytesSucceeded());
         long moreBytesToAdd = randomLongBetween(1000, 10000);
-        pressureTracker.addUploadBytesSucceeded(moreBytesToAdd);
-        assertEquals(bytesToAdd + moreBytesToAdd, pressureTracker.getUploadBytesSucceeded());
+        transferTracker.addUploadBytesSucceeded(moreBytesToAdd);
+        assertEquals(bytesToAdd + moreBytesToAdd, transferTracker.getUploadBytesSucceeded());
     }
 
     public void testAddDownloadBytesStarted() {
-        pressureTracker = new RemoteSegmentTransferTracker(
+        transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
             pressureSettings.getMovingAverageWindowSize()
         );
         long bytesToAdd = randomLongBetween(1000, 1000000);
-        pressureTracker.getDirectoryFileTransferTracker().addTransferredBytesStarted(bytesToAdd);
-        assertEquals(bytesToAdd, pressureTracker.getDirectoryFileTransferTracker().getTransferredBytesStarted());
+        transferTracker.getDirectoryFileTransferTracker().addTransferredBytesStarted(bytesToAdd);
+        assertEquals(bytesToAdd, transferTracker.getDirectoryFileTransferTracker().getTransferredBytesStarted());
         long moreBytesToAdd = randomLongBetween(1000, 10000);
-        pressureTracker.getDirectoryFileTransferTracker().addTransferredBytesStarted(moreBytesToAdd);
-        assertEquals(bytesToAdd + moreBytesToAdd, pressureTracker.getDirectoryFileTransferTracker().getTransferredBytesStarted());
+        transferTracker.getDirectoryFileTransferTracker().addTransferredBytesStarted(moreBytesToAdd);
+        assertEquals(bytesToAdd + moreBytesToAdd, transferTracker.getDirectoryFileTransferTracker().getTransferredBytesStarted());
     }
 
     public void testAddDownloadBytesFailed() {
-        pressureTracker = new RemoteSegmentTransferTracker(
+        transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
             pressureSettings.getMovingAverageWindowSize()
         );
         long bytesToAdd = randomLongBetween(1000, 1000000);
-        pressureTracker.getDirectoryFileTransferTracker().addTransferredBytesFailed(bytesToAdd, System.currentTimeMillis());
-        assertEquals(bytesToAdd, pressureTracker.getDirectoryFileTransferTracker().getTransferredBytesFailed());
+        transferTracker.getDirectoryFileTransferTracker().addTransferredBytesFailed(bytesToAdd, System.currentTimeMillis());
+        assertEquals(bytesToAdd, transferTracker.getDirectoryFileTransferTracker().getTransferredBytesFailed());
         long moreBytesToAdd = randomLongBetween(1000, 10000);
-        pressureTracker.getDirectoryFileTransferTracker().addTransferredBytesFailed(moreBytesToAdd, System.currentTimeMillis());
-        assertEquals(bytesToAdd + moreBytesToAdd, pressureTracker.getDirectoryFileTransferTracker().getTransferredBytesFailed());
+        transferTracker.getDirectoryFileTransferTracker().addTransferredBytesFailed(moreBytesToAdd, System.currentTimeMillis());
+        assertEquals(bytesToAdd + moreBytesToAdd, transferTracker.getDirectoryFileTransferTracker().getTransferredBytesFailed());
     }
 
     public void testAddDownloadBytesSucceeded() {
-        pressureTracker = new RemoteSegmentTransferTracker(
+        transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
             pressureSettings.getMovingAverageWindowSize()
         );
         long bytesToAdd = randomLongBetween(1000, 1000000);
-        pressureTracker.getDirectoryFileTransferTracker().addTransferredBytesSucceeded(bytesToAdd, System.currentTimeMillis());
-        assertEquals(bytesToAdd, pressureTracker.getDirectoryFileTransferTracker().getTransferredBytesSucceeded());
+        transferTracker.getDirectoryFileTransferTracker().addTransferredBytesSucceeded(bytesToAdd, System.currentTimeMillis());
+        assertEquals(bytesToAdd, transferTracker.getDirectoryFileTransferTracker().getTransferredBytesSucceeded());
         long moreBytesToAdd = randomLongBetween(1000, 10000);
-        pressureTracker.getDirectoryFileTransferTracker().addTransferredBytesSucceeded(moreBytesToAdd, System.currentTimeMillis());
-        assertEquals(bytesToAdd + moreBytesToAdd, pressureTracker.getDirectoryFileTransferTracker().getTransferredBytesSucceeded());
+        transferTracker.getDirectoryFileTransferTracker().addTransferredBytesSucceeded(moreBytesToAdd, System.currentTimeMillis());
+        assertEquals(bytesToAdd + moreBytesToAdd, transferTracker.getDirectoryFileTransferTracker().getTransferredBytesSucceeded());
     }
 
     public void testGetInflightUploadBytes() {
-        pressureTracker = new RemoteSegmentTransferTracker(
+        transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
             pressureSettings.getMovingAverageWindowSize()
@@ -246,92 +246,92 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         long bytesStarted = randomLongBetween(10000, 100000);
         long bytesSucceeded = randomLongBetween(1000, 10000);
         long bytesFailed = randomLongBetween(100, 1000);
-        pressureTracker.addUploadBytesStarted(bytesStarted);
-        pressureTracker.addUploadBytesSucceeded(bytesSucceeded);
-        pressureTracker.addUploadBytesFailed(bytesFailed);
-        assertEquals(bytesStarted - bytesSucceeded - bytesFailed, pressureTracker.getInflightUploadBytes());
+        transferTracker.addUploadBytesStarted(bytesStarted);
+        transferTracker.addUploadBytesSucceeded(bytesSucceeded);
+        transferTracker.addUploadBytesFailed(bytesFailed);
+        assertEquals(bytesStarted - bytesSucceeded - bytesFailed, transferTracker.getInflightUploadBytes());
     }
 
     public void testIncrementTotalUploadsStarted() {
-        pressureTracker = new RemoteSegmentTransferTracker(
+        transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
             pressureSettings.getMovingAverageWindowSize()
         );
-        pressureTracker.incrementTotalUploadsStarted();
-        assertEquals(1, pressureTracker.getTotalUploadsStarted());
-        pressureTracker.incrementTotalUploadsStarted();
-        assertEquals(2, pressureTracker.getTotalUploadsStarted());
+        transferTracker.incrementTotalUploadsStarted();
+        assertEquals(1, transferTracker.getTotalUploadsStarted());
+        transferTracker.incrementTotalUploadsStarted();
+        assertEquals(2, transferTracker.getTotalUploadsStarted());
     }
 
     public void testIncrementTotalUploadsFailed() {
-        pressureTracker = new RemoteSegmentTransferTracker(
+        transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
             pressureSettings.getMovingAverageWindowSize()
         );
-        pressureTracker.incrementTotalUploadsFailed();
-        assertEquals(1, pressureTracker.getTotalUploadsFailed());
-        pressureTracker.incrementTotalUploadsFailed();
-        assertEquals(2, pressureTracker.getTotalUploadsFailed());
+        transferTracker.incrementTotalUploadsFailed();
+        assertEquals(1, transferTracker.getTotalUploadsFailed());
+        transferTracker.incrementTotalUploadsFailed();
+        assertEquals(2, transferTracker.getTotalUploadsFailed());
     }
 
     public void testIncrementTotalUploadSucceeded() {
-        pressureTracker = new RemoteSegmentTransferTracker(
+        transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
             pressureSettings.getMovingAverageWindowSize()
         );
-        pressureTracker.incrementTotalUploadsSucceeded();
-        assertEquals(1, pressureTracker.getTotalUploadsSucceeded());
-        pressureTracker.incrementTotalUploadsSucceeded();
-        assertEquals(2, pressureTracker.getTotalUploadsSucceeded());
+        transferTracker.incrementTotalUploadsSucceeded();
+        assertEquals(1, transferTracker.getTotalUploadsSucceeded());
+        transferTracker.incrementTotalUploadsSucceeded();
+        assertEquals(2, transferTracker.getTotalUploadsSucceeded());
     }
 
     public void testGetInflightUploads() {
-        pressureTracker = new RemoteSegmentTransferTracker(
+        transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
             pressureSettings.getMovingAverageWindowSize()
         );
-        pressureTracker.incrementTotalUploadsStarted();
-        assertEquals(1, pressureTracker.getInflightUploads());
-        pressureTracker.incrementTotalUploadsStarted();
-        assertEquals(2, pressureTracker.getInflightUploads());
-        pressureTracker.incrementTotalUploadsSucceeded();
-        assertEquals(1, pressureTracker.getInflightUploads());
-        pressureTracker.incrementTotalUploadsFailed();
-        assertEquals(0, pressureTracker.getInflightUploads());
+        transferTracker.incrementTotalUploadsStarted();
+        assertEquals(1, transferTracker.getInflightUploads());
+        transferTracker.incrementTotalUploadsStarted();
+        assertEquals(2, transferTracker.getInflightUploads());
+        transferTracker.incrementTotalUploadsSucceeded();
+        assertEquals(1, transferTracker.getInflightUploads());
+        transferTracker.incrementTotalUploadsFailed();
+        assertEquals(0, transferTracker.getInflightUploads());
     }
 
     public void testIncrementRejectionCount() {
-        pressureTracker = new RemoteSegmentTransferTracker(
+        transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
             pressureSettings.getMovingAverageWindowSize()
         );
-        pressureTracker.incrementRejectionCount();
-        assertEquals(1, pressureTracker.getRejectionCount());
-        pressureTracker.incrementRejectionCount();
-        assertEquals(2, pressureTracker.getRejectionCount());
+        transferTracker.incrementRejectionCount();
+        assertEquals(1, transferTracker.getRejectionCount());
+        transferTracker.incrementRejectionCount();
+        assertEquals(2, transferTracker.getRejectionCount());
     }
 
     public void testGetConsecutiveFailureCount() {
-        pressureTracker = new RemoteSegmentTransferTracker(
+        transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
             pressureSettings.getMovingAverageWindowSize()
         );
-        pressureTracker.incrementTotalUploadsFailed();
-        assertEquals(1, pressureTracker.getConsecutiveFailureCount());
-        pressureTracker.incrementTotalUploadsFailed();
-        assertEquals(2, pressureTracker.getConsecutiveFailureCount());
-        pressureTracker.incrementTotalUploadsSucceeded();
-        assertEquals(0, pressureTracker.getConsecutiveFailureCount());
+        transferTracker.incrementTotalUploadsFailed();
+        assertEquals(1, transferTracker.getConsecutiveFailureCount());
+        transferTracker.incrementTotalUploadsFailed();
+        assertEquals(2, transferTracker.getConsecutiveFailureCount());
+        transferTracker.incrementTotalUploadsSucceeded();
+        assertEquals(0, transferTracker.getConsecutiveFailureCount());
     }
 
     public void testComputeBytesLag() {
-        pressureTracker = new RemoteSegmentTransferTracker(
+        transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
             pressureSettings.getMovingAverageWindowSize()
@@ -341,194 +341,194 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         Map<String, Long> fileSizeMap = new HashMap<>();
         fileSizeMap.put("a", 100L);
         fileSizeMap.put("b", 105L);
-        pressureTracker.updateLatestLocalFileNameLengthMap(fileSizeMap.keySet(), fileSizeMap::get);
-        assertEquals(205L, pressureTracker.getBytesLag());
+        transferTracker.updateLatestLocalFileNameLengthMap(fileSizeMap.keySet(), fileSizeMap::get);
+        assertEquals(205L, transferTracker.getBytesLag());
 
-        pressureTracker.addToLatestUploadedFiles("a");
-        assertEquals(105L, pressureTracker.getBytesLag());
+        transferTracker.addToLatestUploadedFiles("a");
+        assertEquals(105L, transferTracker.getBytesLag());
 
         fileSizeMap.put("c", 115L);
-        pressureTracker.updateLatestLocalFileNameLengthMap(fileSizeMap.keySet(), fileSizeMap::get);
-        assertEquals(220L, pressureTracker.getBytesLag());
+        transferTracker.updateLatestLocalFileNameLengthMap(fileSizeMap.keySet(), fileSizeMap::get);
+        assertEquals(220L, transferTracker.getBytesLag());
 
-        pressureTracker.addToLatestUploadedFiles("b");
-        assertEquals(115L, pressureTracker.getBytesLag());
+        transferTracker.addToLatestUploadedFiles("b");
+        assertEquals(115L, transferTracker.getBytesLag());
 
-        pressureTracker.addToLatestUploadedFiles("c");
-        assertEquals(0L, pressureTracker.getBytesLag());
+        transferTracker.addToLatestUploadedFiles("c");
+        assertEquals(0L, transferTracker.getBytesLag());
     }
 
     public void testIsUploadBytesAverageReady() {
         int movingAverageWindowSize = pressureSettings.getMovingAverageWindowSize();
-        pressureTracker = new RemoteSegmentTransferTracker(shardId, directoryFileTransferTracker, movingAverageWindowSize);
-        assertFalse(pressureTracker.isUploadBytesAverageReady());
+        transferTracker = new RemoteSegmentTransferTracker(shardId, directoryFileTransferTracker, movingAverageWindowSize);
+        assertFalse(transferTracker.isUploadBytesAverageReady());
 
         long sum = 0;
         for (int i = 1; i < movingAverageWindowSize; i++) {
-            pressureTracker.addUploadBytes(i);
+            transferTracker.addUploadBytes(i);
             sum += i;
-            assertFalse(pressureTracker.isUploadBytesAverageReady());
-            assertEquals((double) sum / i, pressureTracker.getUploadBytesAverage(), 0.0d);
+            assertFalse(transferTracker.isUploadBytesAverageReady());
+            assertEquals((double) sum / i, transferTracker.getUploadBytesAverage(), 0.0d);
         }
 
-        pressureTracker.addUploadBytes(movingAverageWindowSize);
+        transferTracker.addUploadBytes(movingAverageWindowSize);
         sum += movingAverageWindowSize;
-        assertTrue(pressureTracker.isUploadBytesAverageReady());
-        assertEquals((double) sum / movingAverageWindowSize, pressureTracker.getUploadBytesAverage(), 0.0d);
+        assertTrue(transferTracker.isUploadBytesAverageReady());
+        assertEquals((double) sum / movingAverageWindowSize, transferTracker.getUploadBytesAverage(), 0.0d);
 
-        pressureTracker.addUploadBytes(100);
+        transferTracker.addUploadBytes(100);
         sum = sum + 100 - 1;
-        assertEquals((double) sum / movingAverageWindowSize, pressureTracker.getUploadBytesAverage(), 0.0d);
+        assertEquals((double) sum / movingAverageWindowSize, transferTracker.getUploadBytesAverage(), 0.0d);
     }
 
     public void testIsUploadBytesPerSecAverageReady() {
         int movingAverageWindowSize = pressureSettings.getMovingAverageWindowSize();
-        pressureTracker = new RemoteSegmentTransferTracker(shardId, directoryFileTransferTracker, movingAverageWindowSize);
-        assertFalse(pressureTracker.isUploadBytesPerSecAverageReady());
+        transferTracker = new RemoteSegmentTransferTracker(shardId, directoryFileTransferTracker, movingAverageWindowSize);
+        assertFalse(transferTracker.isUploadBytesPerSecAverageReady());
 
         long sum = 0;
         for (int i = 1; i < movingAverageWindowSize; i++) {
-            pressureTracker.addUploadBytesPerSec(i);
+            transferTracker.addUploadBytesPerSec(i);
             sum += i;
-            assertFalse(pressureTracker.isUploadBytesPerSecAverageReady());
-            assertEquals((double) sum / i, pressureTracker.getUploadBytesPerSecAverage(), 0.0d);
+            assertFalse(transferTracker.isUploadBytesPerSecAverageReady());
+            assertEquals((double) sum / i, transferTracker.getUploadBytesPerSecAverage(), 0.0d);
         }
 
-        pressureTracker.addUploadBytesPerSec(movingAverageWindowSize);
+        transferTracker.addUploadBytesPerSec(movingAverageWindowSize);
         sum += movingAverageWindowSize;
-        assertTrue(pressureTracker.isUploadBytesPerSecAverageReady());
-        assertEquals((double) sum / movingAverageWindowSize, pressureTracker.getUploadBytesPerSecAverage(), 0.0d);
+        assertTrue(transferTracker.isUploadBytesPerSecAverageReady());
+        assertEquals((double) sum / movingAverageWindowSize, transferTracker.getUploadBytesPerSecAverage(), 0.0d);
 
-        pressureTracker.addUploadBytesPerSec(100);
+        transferTracker.addUploadBytesPerSec(100);
         sum = sum + 100 - 1;
-        assertEquals((double) sum / movingAverageWindowSize, pressureTracker.getUploadBytesPerSecAverage(), 0.0d);
+        assertEquals((double) sum / movingAverageWindowSize, transferTracker.getUploadBytesPerSecAverage(), 0.0d);
     }
 
     public void testIsUploadTimeMsAverageReady() {
         int movingAverageWindowSize = pressureSettings.getMovingAverageWindowSize();
-        pressureTracker = new RemoteSegmentTransferTracker(shardId, directoryFileTransferTracker, movingAverageWindowSize);
-        assertFalse(pressureTracker.isUploadTimeMsAverageReady());
+        transferTracker = new RemoteSegmentTransferTracker(shardId, directoryFileTransferTracker, movingAverageWindowSize);
+        assertFalse(transferTracker.isUploadTimeMsAverageReady());
 
         long sum = 0;
         for (int i = 1; i < movingAverageWindowSize; i++) {
-            pressureTracker.addTimeForCompletedUploadSync(i);
+            transferTracker.addTimeForCompletedUploadSync(i);
             sum += i;
-            assertFalse(pressureTracker.isUploadTimeMsAverageReady());
-            assertEquals((double) sum / i, pressureTracker.getUploadTimeMsAverage(), 0.0d);
+            assertFalse(transferTracker.isUploadTimeMsAverageReady());
+            assertEquals((double) sum / i, transferTracker.getUploadTimeMsAverage(), 0.0d);
         }
 
-        pressureTracker.addTimeForCompletedUploadSync(movingAverageWindowSize);
+        transferTracker.addTimeForCompletedUploadSync(movingAverageWindowSize);
         sum += movingAverageWindowSize;
-        assertTrue(pressureTracker.isUploadTimeMsAverageReady());
-        assertEquals((double) sum / movingAverageWindowSize, pressureTracker.getUploadTimeMsAverage(), 0.0d);
+        assertTrue(transferTracker.isUploadTimeMsAverageReady());
+        assertEquals((double) sum / movingAverageWindowSize, transferTracker.getUploadTimeMsAverage(), 0.0d);
 
-        pressureTracker.addTimeForCompletedUploadSync(100);
+        transferTracker.addTimeForCompletedUploadSync(100);
         sum = sum + 100 - 1;
-        assertEquals((double) sum / movingAverageWindowSize, pressureTracker.getUploadTimeMsAverage(), 0.0d);
+        assertEquals((double) sum / movingAverageWindowSize, transferTracker.getUploadTimeMsAverage(), 0.0d);
     }
 
     public void testIsDownloadBytesAverageReady() {
-        pressureTracker = new RemoteSegmentTransferTracker(
+        transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
             pressureSettings.getMovingAverageWindowSize()
         );
-        assertFalse(pressureTracker.getDirectoryFileTransferTracker().isTransferredBytesAverageReady());
+        assertFalse(transferTracker.getDirectoryFileTransferTracker().isTransferredBytesAverageReady());
 
         long sum = 0;
         for (int i = 1; i < 20; i++) {
-            pressureTracker.getDirectoryFileTransferTracker().updateSuccessfulTransferSize(i);
+            transferTracker.getDirectoryFileTransferTracker().updateSuccessfulTransferSize(i);
             sum += i;
-            assertFalse(pressureTracker.getDirectoryFileTransferTracker().isTransferredBytesAverageReady());
-            assertEquals((double) sum / i, pressureTracker.getDirectoryFileTransferTracker().getTransferredBytesAverage(), 0.0d);
+            assertFalse(transferTracker.getDirectoryFileTransferTracker().isTransferredBytesAverageReady());
+            assertEquals((double) sum / i, transferTracker.getDirectoryFileTransferTracker().getTransferredBytesAverage(), 0.0d);
         }
 
-        pressureTracker.getDirectoryFileTransferTracker().updateSuccessfulTransferSize(20);
+        transferTracker.getDirectoryFileTransferTracker().updateSuccessfulTransferSize(20);
         sum += 20;
-        assertTrue(pressureTracker.getDirectoryFileTransferTracker().isTransferredBytesAverageReady());
-        assertEquals((double) sum / 20, pressureTracker.getDirectoryFileTransferTracker().getTransferredBytesAverage(), 0.0d);
+        assertTrue(transferTracker.getDirectoryFileTransferTracker().isTransferredBytesAverageReady());
+        assertEquals((double) sum / 20, transferTracker.getDirectoryFileTransferTracker().getTransferredBytesAverage(), 0.0d);
 
-        pressureTracker.getDirectoryFileTransferTracker().updateSuccessfulTransferSize(100);
+        transferTracker.getDirectoryFileTransferTracker().updateSuccessfulTransferSize(100);
         sum = sum + 100 - 1;
-        assertEquals((double) sum / 20, pressureTracker.getDirectoryFileTransferTracker().getTransferredBytesAverage(), 0.0d);
+        assertEquals((double) sum / 20, transferTracker.getDirectoryFileTransferTracker().getTransferredBytesAverage(), 0.0d);
     }
 
     public void testIsDownloadBytesPerSecAverageReady() {
-        pressureTracker = new RemoteSegmentTransferTracker(
+        transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
             pressureSettings.getMovingAverageWindowSize()
         );
-        assertFalse(pressureTracker.getDirectoryFileTransferTracker().isTransferredBytesPerSecAverageReady());
+        assertFalse(transferTracker.getDirectoryFileTransferTracker().isTransferredBytesPerSecAverageReady());
 
         long sum = 0;
         for (int i = 1; i < 20; i++) {
-            pressureTracker.getDirectoryFileTransferTracker().addTransferredBytesPerSec(i);
+            transferTracker.getDirectoryFileTransferTracker().addTransferredBytesPerSec(i);
             sum += i;
-            assertFalse(pressureTracker.getDirectoryFileTransferTracker().isTransferredBytesPerSecAverageReady());
-            assertEquals((double) sum / i, pressureTracker.getDirectoryFileTransferTracker().getTransferredBytesPerSecAverage(), 0.0d);
+            assertFalse(transferTracker.getDirectoryFileTransferTracker().isTransferredBytesPerSecAverageReady());
+            assertEquals((double) sum / i, transferTracker.getDirectoryFileTransferTracker().getTransferredBytesPerSecAverage(), 0.0d);
         }
 
-        pressureTracker.getDirectoryFileTransferTracker().addTransferredBytesPerSec(20);
+        transferTracker.getDirectoryFileTransferTracker().addTransferredBytesPerSec(20);
         sum += 20;
-        assertTrue(pressureTracker.getDirectoryFileTransferTracker().isTransferredBytesPerSecAverageReady());
-        assertEquals((double) sum / 20, pressureTracker.getDirectoryFileTransferTracker().getTransferredBytesPerSecAverage(), 0.0d);
+        assertTrue(transferTracker.getDirectoryFileTransferTracker().isTransferredBytesPerSecAverageReady());
+        assertEquals((double) sum / 20, transferTracker.getDirectoryFileTransferTracker().getTransferredBytesPerSecAverage(), 0.0d);
 
-        pressureTracker.getDirectoryFileTransferTracker().addTransferredBytesPerSec(100);
+        transferTracker.getDirectoryFileTransferTracker().addTransferredBytesPerSec(100);
         sum = sum + 100 - 1;
-        assertEquals((double) sum / 20, pressureTracker.getDirectoryFileTransferTracker().getTransferredBytesPerSecAverage(), 0.0d);
+        assertEquals((double) sum / 20, transferTracker.getDirectoryFileTransferTracker().getTransferredBytesPerSecAverage(), 0.0d);
     }
 
     public void testAddTotalUploadTimeInMs() {
-        pressureTracker = new RemoteSegmentTransferTracker(
+        transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
             pressureSettings.getMovingAverageWindowSize()
         );
         long timeToAdd = randomLongBetween(100, 200);
-        pressureTracker.addTotalUploadTimeInMs(timeToAdd);
-        assertEquals(timeToAdd, pressureTracker.getTotalUploadTimeInMs());
+        transferTracker.addTotalUploadTimeInMs(timeToAdd);
+        assertEquals(timeToAdd, transferTracker.getTotalUploadTimeInMs());
         long moreTimeToAdd = randomLongBetween(100, 200);
-        pressureTracker.addTotalUploadTimeInMs(moreTimeToAdd);
-        assertEquals(timeToAdd + moreTimeToAdd, pressureTracker.getTotalUploadTimeInMs());
+        transferTracker.addTotalUploadTimeInMs(moreTimeToAdd);
+        assertEquals(timeToAdd + moreTimeToAdd, transferTracker.getTotalUploadTimeInMs());
     }
 
     public void testAddTotalTransferTimeMs() {
-        pressureTracker = new RemoteSegmentTransferTracker(
+        transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
             pressureSettings.getMovingAverageWindowSize()
         );
         long timeToAdd = randomLongBetween(100, 200);
-        pressureTracker.getDirectoryFileTransferTracker().addTotalTransferTimeInMs(timeToAdd);
-        assertEquals(timeToAdd, pressureTracker.getDirectoryFileTransferTracker().getTotalTransferTimeInMs());
+        transferTracker.getDirectoryFileTransferTracker().addTotalTransferTimeInMs(timeToAdd);
+        assertEquals(timeToAdd, transferTracker.getDirectoryFileTransferTracker().getTotalTransferTimeInMs());
         long moreTimeToAdd = randomLongBetween(100, 200);
-        pressureTracker.getDirectoryFileTransferTracker().addTotalTransferTimeInMs(moreTimeToAdd);
-        assertEquals(timeToAdd + moreTimeToAdd, pressureTracker.getDirectoryFileTransferTracker().getTotalTransferTimeInMs());
+        transferTracker.getDirectoryFileTransferTracker().addTotalTransferTimeInMs(moreTimeToAdd);
+        assertEquals(timeToAdd + moreTimeToAdd, transferTracker.getDirectoryFileTransferTracker().getTotalTransferTimeInMs());
     }
 
     /**
      * Tests whether RemoteSegmentTransferTracker.Stats object generated correctly from RemoteSegmentTransferTracker.
      * */
     public void testStatsObjectCreation() {
-        pressureTracker = constructTracker();
-        RemoteSegmentTransferTracker.Stats pressureTrackerStats = pressureTracker.stats();
-        assertEquals(pressureTracker.getShardId(), pressureTrackerStats.shardId);
-        assertEquals(pressureTracker.getTimeMsLag(), (int) pressureTrackerStats.refreshTimeLagMs);
-        assertEquals(pressureTracker.getLocalRefreshSeqNo(), (int) pressureTrackerStats.localRefreshNumber);
-        assertEquals(pressureTracker.getRemoteRefreshSeqNo(), (int) pressureTrackerStats.remoteRefreshNumber);
-        assertEquals(pressureTracker.getBytesLag(), (int) pressureTrackerStats.bytesLag);
-        assertEquals(pressureTracker.getRejectionCount(), (int) pressureTrackerStats.rejectionCount);
-        assertEquals(pressureTracker.getConsecutiveFailureCount(), (int) pressureTrackerStats.consecutiveFailuresCount);
-        assertEquals(pressureTracker.getUploadBytesStarted(), (int) pressureTrackerStats.uploadBytesStarted);
-        assertEquals(pressureTracker.getUploadBytesSucceeded(), (int) pressureTrackerStats.uploadBytesSucceeded);
-        assertEquals(pressureTracker.getUploadBytesFailed(), (int) pressureTrackerStats.uploadBytesFailed);
-        assertEquals(pressureTracker.getUploadBytesAverage(), pressureTrackerStats.uploadBytesMovingAverage, 0);
-        assertEquals(pressureTracker.getUploadBytesPerSecAverage(), pressureTrackerStats.uploadBytesPerSecMovingAverage, 0);
-        assertEquals(pressureTracker.getUploadTimeMsAverage(), pressureTrackerStats.uploadTimeMovingAverage, 0);
-        assertEquals(pressureTracker.getTotalUploadsStarted(), (int) pressureTrackerStats.totalUploadsStarted);
-        assertEquals(pressureTracker.getTotalUploadsSucceeded(), (int) pressureTrackerStats.totalUploadsSucceeded);
-        assertEquals(pressureTracker.getTotalUploadsFailed(), (int) pressureTrackerStats.totalUploadsFailed);
+        transferTracker = constructTracker();
+        RemoteSegmentTransferTracker.Stats transferTrackerStats = transferTracker.stats();
+        assertEquals(transferTracker.getShardId(), transferTrackerStats.shardId);
+        assertEquals(transferTracker.getTimeMsLag(), (int) transferTrackerStats.refreshTimeLagMs);
+        assertEquals(transferTracker.getLocalRefreshSeqNo(), (int) transferTrackerStats.localRefreshNumber);
+        assertEquals(transferTracker.getRemoteRefreshSeqNo(), (int) transferTrackerStats.remoteRefreshNumber);
+        assertEquals(transferTracker.getBytesLag(), (int) transferTrackerStats.bytesLag);
+        assertEquals(transferTracker.getRejectionCount(), (int) transferTrackerStats.rejectionCount);
+        assertEquals(transferTracker.getConsecutiveFailureCount(), (int) transferTrackerStats.consecutiveFailuresCount);
+        assertEquals(transferTracker.getUploadBytesStarted(), (int) transferTrackerStats.uploadBytesStarted);
+        assertEquals(transferTracker.getUploadBytesSucceeded(), (int) transferTrackerStats.uploadBytesSucceeded);
+        assertEquals(transferTracker.getUploadBytesFailed(), (int) transferTrackerStats.uploadBytesFailed);
+        assertEquals(transferTracker.getUploadBytesAverage(), transferTrackerStats.uploadBytesMovingAverage, 0);
+        assertEquals(transferTracker.getUploadBytesPerSecAverage(), transferTrackerStats.uploadBytesPerSecMovingAverage, 0);
+        assertEquals(transferTracker.getUploadTimeMsAverage(), transferTrackerStats.uploadTimeMovingAverage, 0);
+        assertEquals(transferTracker.getTotalUploadsStarted(), (int) transferTrackerStats.totalUploadsStarted);
+        assertEquals(transferTracker.getTotalUploadsSucceeded(), (int) transferTrackerStats.totalUploadsSucceeded);
+        assertEquals(transferTracker.getTotalUploadsFailed(), (int) transferTrackerStats.totalUploadsFailed);
     }
 
     /**
@@ -536,62 +536,62 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
      * This comes into play during internode data transfer.
      */
     public void testStatsObjectCreationViaStream() throws IOException {
-        pressureTracker = constructTracker();
-        RemoteSegmentTransferTracker.Stats pressureTrackerStats = pressureTracker.stats();
+        transferTracker = constructTracker();
+        RemoteSegmentTransferTracker.Stats transferTrackerStats = transferTracker.stats();
         try (BytesStreamOutput out = new BytesStreamOutput()) {
-            pressureTrackerStats.writeTo(out);
+            transferTrackerStats.writeTo(out);
             try (StreamInput in = out.bytes().streamInput()) {
                 RemoteSegmentTransferTracker.Stats deserializedStats = new RemoteSegmentTransferTracker.Stats(in);
-                assertEquals(deserializedStats.shardId, pressureTrackerStats.shardId);
-                assertEquals((int) deserializedStats.refreshTimeLagMs, (int) pressureTrackerStats.refreshTimeLagMs);
-                assertEquals((int) deserializedStats.localRefreshNumber, (int) pressureTrackerStats.localRefreshNumber);
-                assertEquals((int) deserializedStats.remoteRefreshNumber, (int) pressureTrackerStats.remoteRefreshNumber);
-                assertEquals((int) deserializedStats.bytesLag, (int) pressureTrackerStats.bytesLag);
-                assertEquals((int) deserializedStats.rejectionCount, (int) pressureTrackerStats.rejectionCount);
-                assertEquals((int) deserializedStats.consecutiveFailuresCount, (int) pressureTrackerStats.consecutiveFailuresCount);
-                assertEquals((int) deserializedStats.uploadBytesStarted, (int) pressureTrackerStats.uploadBytesStarted);
-                assertEquals((int) deserializedStats.uploadBytesSucceeded, (int) pressureTrackerStats.uploadBytesSucceeded);
-                assertEquals((int) deserializedStats.uploadBytesFailed, (int) pressureTrackerStats.uploadBytesFailed);
-                assertEquals((int) deserializedStats.uploadBytesMovingAverage, pressureTrackerStats.uploadBytesMovingAverage, 0);
+                assertEquals(deserializedStats.shardId, transferTrackerStats.shardId);
+                assertEquals((int) deserializedStats.refreshTimeLagMs, (int) transferTrackerStats.refreshTimeLagMs);
+                assertEquals((int) deserializedStats.localRefreshNumber, (int) transferTrackerStats.localRefreshNumber);
+                assertEquals((int) deserializedStats.remoteRefreshNumber, (int) transferTrackerStats.remoteRefreshNumber);
+                assertEquals((int) deserializedStats.bytesLag, (int) transferTrackerStats.bytesLag);
+                assertEquals((int) deserializedStats.rejectionCount, (int) transferTrackerStats.rejectionCount);
+                assertEquals((int) deserializedStats.consecutiveFailuresCount, (int) transferTrackerStats.consecutiveFailuresCount);
+                assertEquals((int) deserializedStats.uploadBytesStarted, (int) transferTrackerStats.uploadBytesStarted);
+                assertEquals((int) deserializedStats.uploadBytesSucceeded, (int) transferTrackerStats.uploadBytesSucceeded);
+                assertEquals((int) deserializedStats.uploadBytesFailed, (int) transferTrackerStats.uploadBytesFailed);
+                assertEquals((int) deserializedStats.uploadBytesMovingAverage, transferTrackerStats.uploadBytesMovingAverage, 0);
                 assertEquals(
                     (int) deserializedStats.uploadBytesPerSecMovingAverage,
-                    pressureTrackerStats.uploadBytesPerSecMovingAverage,
+                    transferTrackerStats.uploadBytesPerSecMovingAverage,
                     0
                 );
-                assertEquals((int) deserializedStats.uploadTimeMovingAverage, pressureTrackerStats.uploadTimeMovingAverage, 0);
-                assertEquals((int) deserializedStats.totalUploadsStarted, (int) pressureTrackerStats.totalUploadsStarted);
-                assertEquals((int) deserializedStats.totalUploadsSucceeded, (int) pressureTrackerStats.totalUploadsSucceeded);
-                assertEquals((int) deserializedStats.totalUploadsFailed, (int) pressureTrackerStats.totalUploadsFailed);
+                assertEquals((int) deserializedStats.uploadTimeMovingAverage, transferTrackerStats.uploadTimeMovingAverage, 0);
+                assertEquals((int) deserializedStats.totalUploadsStarted, (int) transferTrackerStats.totalUploadsStarted);
+                assertEquals((int) deserializedStats.totalUploadsSucceeded, (int) transferTrackerStats.totalUploadsSucceeded);
+                assertEquals((int) deserializedStats.totalUploadsFailed, (int) transferTrackerStats.totalUploadsFailed);
                 assertEquals(
                     (int) deserializedStats.directoryFileTransferTrackerStats.transferredBytesStarted,
-                    (int) pressureTrackerStats.directoryFileTransferTrackerStats.transferredBytesStarted
+                    (int) transferTrackerStats.directoryFileTransferTrackerStats.transferredBytesStarted
                 );
                 assertEquals(
                     (int) deserializedStats.directoryFileTransferTrackerStats.transferredBytesSucceeded,
-                    (int) pressureTrackerStats.directoryFileTransferTrackerStats.transferredBytesSucceeded
+                    (int) transferTrackerStats.directoryFileTransferTrackerStats.transferredBytesSucceeded
                 );
                 assertEquals(
                     (int) deserializedStats.directoryFileTransferTrackerStats.transferredBytesPerSecMovingAverage,
-                    (int) pressureTrackerStats.directoryFileTransferTrackerStats.transferredBytesPerSecMovingAverage
+                    (int) transferTrackerStats.directoryFileTransferTrackerStats.transferredBytesPerSecMovingAverage
                 );
             }
         }
     }
 
     private RemoteSegmentTransferTracker constructTracker() {
-        RemoteSegmentTransferTracker segmentPressureTracker = new RemoteSegmentTransferTracker(
+        RemoteSegmentTransferTracker transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             new DirectoryFileTransferTracker(),
             pressureSettings.getMovingAverageWindowSize()
         );
-        segmentPressureTracker.incrementTotalUploadsFailed();
-        segmentPressureTracker.addTimeForCompletedUploadSync(System.nanoTime() / 1_000_000L + randomIntBetween(10, 100));
-        segmentPressureTracker.addUploadBytes(99);
-        segmentPressureTracker.updateRemoteRefreshTimeMs(System.nanoTime() / 1_000_000L + randomIntBetween(10, 100));
-        segmentPressureTracker.incrementRejectionCount();
-        segmentPressureTracker.getDirectoryFileTransferTracker().addTransferredBytesStarted(10);
-        segmentPressureTracker.getDirectoryFileTransferTracker().addTransferredBytesSucceeded(10, System.currentTimeMillis());
-        segmentPressureTracker.getDirectoryFileTransferTracker().addTransferredBytesPerSec(5);
-        return segmentPressureTracker;
+        transferTracker.incrementTotalUploadsFailed();
+        transferTracker.addTimeForCompletedUploadSync(System.nanoTime() / 1_000_000L + randomIntBetween(10, 100));
+        transferTracker.addUploadBytes(99);
+        transferTracker.updateRemoteRefreshTimeMs(System.nanoTime() / 1_000_000L + randomIntBetween(10, 100));
+        transferTracker.incrementRejectionCount();
+        transferTracker.getDirectoryFileTransferTracker().addTransferredBytesStarted(10);
+        transferTracker.getDirectoryFileTransferTracker().addTransferredBytesSucceeded(10, System.currentTimeMillis());
+        transferTracker.getDirectoryFileTransferTracker().addTransferredBytesPerSec(5);
+        return transferTracker;
     }
 }

--- a/server/src/test/java/org/opensearch/index/remote/RemoteSegmentTransferTrackerTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteSegmentTransferTrackerTests.java
@@ -23,12 +23,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.mockito.Mockito.mock;
-
 public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
-
-    private RemoteStorePressureSettings pressureSettings;
-
+    private RemoteStoreStatsTrackerFactory remoteStoreStatsTrackerFactory;
     private ClusterService clusterService;
 
     private ThreadPool threadPool;
@@ -48,7 +44,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
             new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
             threadPool
         );
-        pressureSettings = new RemoteStorePressureSettings(clusterService, Settings.EMPTY, mock(RemoteStorePressureService.class));
+        remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(clusterService, Settings.EMPTY);
         shardId = new ShardId("index", "uuid", 0);
         directoryFileTransferTracker = new DirectoryFileTransferTracker();
     }
@@ -63,7 +59,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getMovingAverageWindowSize()
+            remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
         );
         assertEquals(shardId, transferTracker.getShardId());
     }
@@ -72,7 +68,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getMovingAverageWindowSize()
+            remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
         );
         long refreshSeqNo = 2;
         transferTracker.updateLocalRefreshSeqNo(refreshSeqNo);
@@ -83,7 +79,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getMovingAverageWindowSize()
+            remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
         );
         long refreshSeqNo = 4;
         transferTracker.updateRemoteRefreshSeqNo(refreshSeqNo);
@@ -94,7 +90,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getMovingAverageWindowSize()
+            remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
         );
         long refreshTimeMs = System.nanoTime() / 1_000_000L + randomIntBetween(10, 100);
         transferTracker.updateLocalRefreshTimeMs(refreshTimeMs);
@@ -105,7 +101,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getMovingAverageWindowSize()
+            remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
         );
         long refreshTimeMs = System.nanoTime() / 1_000_000 + randomIntBetween(10, 100);
         transferTracker.updateRemoteRefreshTimeMs(refreshTimeMs);
@@ -116,7 +112,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getMovingAverageWindowSize()
+            remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
         );
         long currentTimeInMs = System.currentTimeMillis();
         transferTracker.getDirectoryFileTransferTracker().updateLastTransferTimestampMs(currentTimeInMs);
@@ -127,7 +123,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getMovingAverageWindowSize()
+            remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
         );
         int localRefreshSeqNo = randomIntBetween(50, 100);
         int remoteRefreshSeqNo = randomIntBetween(20, 50);
@@ -141,7 +137,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getMovingAverageWindowSize()
+            remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
         );
         long currentLocalRefreshTimeMs = transferTracker.getLocalRefreshTimeMs();
         long currentTimeMs = System.nanoTime() / 1_000_000L;
@@ -157,7 +153,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getMovingAverageWindowSize()
+            remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
         );
         long bytesToAdd = randomLongBetween(1000, 1000000);
         transferTracker.addUploadBytesStarted(bytesToAdd);
@@ -171,7 +167,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getMovingAverageWindowSize()
+            remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
         );
         long bytesToAdd = randomLongBetween(1000, 1000000);
         transferTracker.addUploadBytesFailed(bytesToAdd);
@@ -185,7 +181,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getMovingAverageWindowSize()
+            remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
         );
         long bytesToAdd = randomLongBetween(1000, 1000000);
         transferTracker.addUploadBytesSucceeded(bytesToAdd);
@@ -199,7 +195,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getMovingAverageWindowSize()
+            remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
         );
         long bytesToAdd = randomLongBetween(1000, 1000000);
         transferTracker.getDirectoryFileTransferTracker().addTransferredBytesStarted(bytesToAdd);
@@ -213,7 +209,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getMovingAverageWindowSize()
+            remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
         );
         long bytesToAdd = randomLongBetween(1000, 1000000);
         transferTracker.getDirectoryFileTransferTracker().addTransferredBytesFailed(bytesToAdd, System.currentTimeMillis());
@@ -227,7 +223,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getMovingAverageWindowSize()
+            remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
         );
         long bytesToAdd = randomLongBetween(1000, 1000000);
         transferTracker.getDirectoryFileTransferTracker().addTransferredBytesSucceeded(bytesToAdd, System.currentTimeMillis());
@@ -241,7 +237,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getMovingAverageWindowSize()
+            remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
         );
         long bytesStarted = randomLongBetween(10000, 100000);
         long bytesSucceeded = randomLongBetween(1000, 10000);
@@ -256,7 +252,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getMovingAverageWindowSize()
+            remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
         );
         transferTracker.incrementTotalUploadsStarted();
         assertEquals(1, transferTracker.getTotalUploadsStarted());
@@ -268,7 +264,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getMovingAverageWindowSize()
+            remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
         );
         transferTracker.incrementTotalUploadsFailed();
         assertEquals(1, transferTracker.getTotalUploadsFailed());
@@ -280,7 +276,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getMovingAverageWindowSize()
+            remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
         );
         transferTracker.incrementTotalUploadsSucceeded();
         assertEquals(1, transferTracker.getTotalUploadsSucceeded());
@@ -292,7 +288,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getMovingAverageWindowSize()
+            remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
         );
         transferTracker.incrementTotalUploadsStarted();
         assertEquals(1, transferTracker.getInflightUploads());
@@ -308,7 +304,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getMovingAverageWindowSize()
+            remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
         );
         transferTracker.incrementRejectionCount();
         assertEquals(1, transferTracker.getRejectionCount());
@@ -320,7 +316,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getMovingAverageWindowSize()
+            remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
         );
         transferTracker.incrementTotalUploadsFailed();
         assertEquals(1, transferTracker.getConsecutiveFailureCount());
@@ -334,7 +330,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getMovingAverageWindowSize()
+            remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
         );
 
         // Create local file size map
@@ -359,7 +355,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
     }
 
     public void testIsUploadBytesAverageReady() {
-        int movingAverageWindowSize = pressureSettings.getMovingAverageWindowSize();
+        int movingAverageWindowSize = remoteStoreStatsTrackerFactory.getMovingAverageWindowSize();
         transferTracker = new RemoteSegmentTransferTracker(shardId, directoryFileTransferTracker, movingAverageWindowSize);
         assertFalse(transferTracker.isUploadBytesAverageReady());
 
@@ -382,7 +378,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
     }
 
     public void testIsUploadBytesPerSecAverageReady() {
-        int movingAverageWindowSize = pressureSettings.getMovingAverageWindowSize();
+        int movingAverageWindowSize = remoteStoreStatsTrackerFactory.getMovingAverageWindowSize();
         transferTracker = new RemoteSegmentTransferTracker(shardId, directoryFileTransferTracker, movingAverageWindowSize);
         assertFalse(transferTracker.isUploadBytesPerSecAverageReady());
 
@@ -405,7 +401,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
     }
 
     public void testIsUploadTimeMsAverageReady() {
-        int movingAverageWindowSize = pressureSettings.getMovingAverageWindowSize();
+        int movingAverageWindowSize = remoteStoreStatsTrackerFactory.getMovingAverageWindowSize();
         transferTracker = new RemoteSegmentTransferTracker(shardId, directoryFileTransferTracker, movingAverageWindowSize);
         assertFalse(transferTracker.isUploadTimeMsAverageReady());
 
@@ -431,7 +427,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getMovingAverageWindowSize()
+            remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
         );
         assertFalse(transferTracker.getDirectoryFileTransferTracker().isTransferredBytesAverageReady());
 
@@ -457,7 +453,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getMovingAverageWindowSize()
+            remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
         );
         assertFalse(transferTracker.getDirectoryFileTransferTracker().isTransferredBytesPerSecAverageReady());
 
@@ -483,7 +479,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getMovingAverageWindowSize()
+            remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
         );
         long timeToAdd = randomLongBetween(100, 200);
         transferTracker.addTotalUploadTimeInMs(timeToAdd);
@@ -497,7 +493,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getMovingAverageWindowSize()
+            remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
         );
         long timeToAdd = randomLongBetween(100, 200);
         transferTracker.getDirectoryFileTransferTracker().addTotalTransferTimeInMs(timeToAdd);
@@ -582,7 +578,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         RemoteSegmentTransferTracker transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             new DirectoryFileTransferTracker(),
-            pressureSettings.getMovingAverageWindowSize()
+            remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
         );
         transferTracker.incrementTotalUploadsFailed();
         transferTracker.addTimeForCompletedUploadSync(System.nanoTime() / 1_000_000L + randomIntBetween(10, 100));

--- a/server/src/test/java/org/opensearch/index/remote/RemoteSegmentTransferTrackerTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteSegmentTransferTrackerTests.java
@@ -63,9 +63,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getUploadBytesMovingAverageWindowSize(),
-            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
-            pressureSettings.getUploadTimeMovingAverageWindowSize()
+            pressureSettings.getMovingAverageWindowSize()
         );
         assertEquals(shardId, pressureTracker.getShardId());
     }
@@ -74,9 +72,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getUploadBytesMovingAverageWindowSize(),
-            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
-            pressureSettings.getUploadTimeMovingAverageWindowSize()
+            pressureSettings.getMovingAverageWindowSize()
         );
         long refreshSeqNo = 2;
         pressureTracker.updateLocalRefreshSeqNo(refreshSeqNo);
@@ -87,9 +83,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getUploadBytesMovingAverageWindowSize(),
-            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
-            pressureSettings.getUploadTimeMovingAverageWindowSize()
+            pressureSettings.getMovingAverageWindowSize()
         );
         long refreshSeqNo = 4;
         pressureTracker.updateRemoteRefreshSeqNo(refreshSeqNo);
@@ -100,9 +94,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getUploadBytesMovingAverageWindowSize(),
-            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
-            pressureSettings.getUploadTimeMovingAverageWindowSize()
+            pressureSettings.getMovingAverageWindowSize()
         );
         long refreshTimeMs = System.nanoTime() / 1_000_000L + randomIntBetween(10, 100);
         pressureTracker.updateLocalRefreshTimeMs(refreshTimeMs);
@@ -113,9 +105,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getUploadBytesMovingAverageWindowSize(),
-            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
-            pressureSettings.getUploadTimeMovingAverageWindowSize()
+            pressureSettings.getMovingAverageWindowSize()
         );
         long refreshTimeMs = System.nanoTime() / 1_000_000 + randomIntBetween(10, 100);
         pressureTracker.updateRemoteRefreshTimeMs(refreshTimeMs);
@@ -126,9 +116,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getUploadBytesMovingAverageWindowSize(),
-            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
-            pressureSettings.getUploadTimeMovingAverageWindowSize()
+            pressureSettings.getMovingAverageWindowSize()
         );
         long currentTimeInMs = System.currentTimeMillis();
         pressureTracker.getDirectoryFileTransferTracker().updateLastTransferTimestampMs(currentTimeInMs);
@@ -139,9 +127,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getUploadBytesMovingAverageWindowSize(),
-            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
-            pressureSettings.getUploadTimeMovingAverageWindowSize()
+            pressureSettings.getMovingAverageWindowSize()
         );
         int localRefreshSeqNo = randomIntBetween(50, 100);
         int remoteRefreshSeqNo = randomIntBetween(20, 50);
@@ -155,9 +141,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getUploadBytesMovingAverageWindowSize(),
-            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
-            pressureSettings.getUploadTimeMovingAverageWindowSize()
+            pressureSettings.getMovingAverageWindowSize()
         );
         long currentLocalRefreshTimeMs = pressureTracker.getLocalRefreshTimeMs();
         long currentTimeMs = System.nanoTime() / 1_000_000L;
@@ -173,9 +157,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getUploadBytesMovingAverageWindowSize(),
-            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
-            pressureSettings.getUploadTimeMovingAverageWindowSize()
+            pressureSettings.getMovingAverageWindowSize()
         );
         long bytesToAdd = randomLongBetween(1000, 1000000);
         pressureTracker.addUploadBytesStarted(bytesToAdd);
@@ -189,9 +171,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getUploadBytesMovingAverageWindowSize(),
-            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
-            pressureSettings.getUploadTimeMovingAverageWindowSize()
+            pressureSettings.getMovingAverageWindowSize()
         );
         long bytesToAdd = randomLongBetween(1000, 1000000);
         pressureTracker.addUploadBytesFailed(bytesToAdd);
@@ -205,9 +185,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getUploadBytesMovingAverageWindowSize(),
-            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
-            pressureSettings.getUploadTimeMovingAverageWindowSize()
+            pressureSettings.getMovingAverageWindowSize()
         );
         long bytesToAdd = randomLongBetween(1000, 1000000);
         pressureTracker.addUploadBytesSucceeded(bytesToAdd);
@@ -221,9 +199,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getUploadBytesMovingAverageWindowSize(),
-            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
-            pressureSettings.getUploadTimeMovingAverageWindowSize()
+            pressureSettings.getMovingAverageWindowSize()
         );
         long bytesToAdd = randomLongBetween(1000, 1000000);
         pressureTracker.getDirectoryFileTransferTracker().addTransferredBytesStarted(bytesToAdd);
@@ -237,9 +213,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getUploadBytesMovingAverageWindowSize(),
-            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
-            pressureSettings.getUploadTimeMovingAverageWindowSize()
+            pressureSettings.getMovingAverageWindowSize()
         );
         long bytesToAdd = randomLongBetween(1000, 1000000);
         pressureTracker.getDirectoryFileTransferTracker().addTransferredBytesFailed(bytesToAdd, System.currentTimeMillis());
@@ -253,9 +227,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getUploadBytesMovingAverageWindowSize(),
-            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
-            pressureSettings.getUploadTimeMovingAverageWindowSize()
+            pressureSettings.getMovingAverageWindowSize()
         );
         long bytesToAdd = randomLongBetween(1000, 1000000);
         pressureTracker.getDirectoryFileTransferTracker().addTransferredBytesSucceeded(bytesToAdd, System.currentTimeMillis());
@@ -269,9 +241,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getUploadBytesMovingAverageWindowSize(),
-            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
-            pressureSettings.getUploadTimeMovingAverageWindowSize()
+            pressureSettings.getMovingAverageWindowSize()
         );
         long bytesStarted = randomLongBetween(10000, 100000);
         long bytesSucceeded = randomLongBetween(1000, 10000);
@@ -286,9 +256,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getUploadBytesMovingAverageWindowSize(),
-            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
-            pressureSettings.getUploadTimeMovingAverageWindowSize()
+            pressureSettings.getMovingAverageWindowSize()
         );
         pressureTracker.incrementTotalUploadsStarted();
         assertEquals(1, pressureTracker.getTotalUploadsStarted());
@@ -300,9 +268,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getUploadBytesMovingAverageWindowSize(),
-            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
-            pressureSettings.getUploadTimeMovingAverageWindowSize()
+            pressureSettings.getMovingAverageWindowSize()
         );
         pressureTracker.incrementTotalUploadsFailed();
         assertEquals(1, pressureTracker.getTotalUploadsFailed());
@@ -314,9 +280,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getUploadBytesMovingAverageWindowSize(),
-            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
-            pressureSettings.getUploadTimeMovingAverageWindowSize()
+            pressureSettings.getMovingAverageWindowSize()
         );
         pressureTracker.incrementTotalUploadsSucceeded();
         assertEquals(1, pressureTracker.getTotalUploadsSucceeded());
@@ -328,9 +292,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getUploadBytesMovingAverageWindowSize(),
-            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
-            pressureSettings.getUploadTimeMovingAverageWindowSize()
+            pressureSettings.getMovingAverageWindowSize()
         );
         pressureTracker.incrementTotalUploadsStarted();
         assertEquals(1, pressureTracker.getInflightUploads());
@@ -346,9 +308,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getUploadBytesMovingAverageWindowSize(),
-            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
-            pressureSettings.getUploadTimeMovingAverageWindowSize()
+            pressureSettings.getMovingAverageWindowSize()
         );
         pressureTracker.incrementRejectionCount();
         assertEquals(1, pressureTracker.getRejectionCount());
@@ -360,9 +320,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getUploadBytesMovingAverageWindowSize(),
-            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
-            pressureSettings.getUploadTimeMovingAverageWindowSize()
+            pressureSettings.getMovingAverageWindowSize()
         );
         pressureTracker.incrementTotalUploadsFailed();
         assertEquals(1, pressureTracker.getConsecutiveFailureCount());
@@ -376,9 +334,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getUploadBytesMovingAverageWindowSize(),
-            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
-            pressureSettings.getUploadTimeMovingAverageWindowSize()
+            pressureSettings.getMovingAverageWindowSize()
         );
 
         // Create local file size map
@@ -403,14 +359,8 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
     }
 
     public void testIsUploadBytesAverageReady() {
-        int uploadBytesMovingAverageWindowSize = pressureSettings.getUploadBytesMovingAverageWindowSize();
-        pressureTracker = new RemoteSegmentTransferTracker(
-            shardId,
-            directoryFileTransferTracker,
-            uploadBytesMovingAverageWindowSize,
-            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
-            pressureSettings.getUploadTimeMovingAverageWindowSize()
-        );
+        int uploadBytesMovingAverageWindowSize = pressureSettings.getMovingAverageWindowSize();
+        pressureTracker = new RemoteSegmentTransferTracker(shardId, directoryFileTransferTracker, uploadBytesMovingAverageWindowSize);
         assertFalse(pressureTracker.isUploadBytesAverageReady());
 
         long sum = 0;
@@ -432,70 +382,56 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
     }
 
     public void testIsUploadBytesPerSecAverageReady() {
-        int uploadBytesPerSecMovingAverageWindowSize = pressureSettings.getUploadBytesPerSecMovingAverageWindowSize();
-        pressureTracker = new RemoteSegmentTransferTracker(
-            shardId,
-            directoryFileTransferTracker,
-            pressureSettings.getUploadBytesMovingAverageWindowSize(),
-            uploadBytesPerSecMovingAverageWindowSize,
-            pressureSettings.getUploadTimeMovingAverageWindowSize()
-        );
+        int movingAverageWindowSize = pressureSettings.getMovingAverageWindowSize();
+        pressureTracker = new RemoteSegmentTransferTracker(shardId, directoryFileTransferTracker, movingAverageWindowSize);
         assertFalse(pressureTracker.isUploadBytesPerSecAverageReady());
 
         long sum = 0;
-        for (int i = 1; i < uploadBytesPerSecMovingAverageWindowSize; i++) {
+        for (int i = 1; i < movingAverageWindowSize; i++) {
             pressureTracker.addUploadBytesPerSec(i);
             sum += i;
             assertFalse(pressureTracker.isUploadBytesPerSecAverageReady());
             assertEquals((double) sum / i, pressureTracker.getUploadBytesPerSecAverage(), 0.0d);
         }
 
-        pressureTracker.addUploadBytesPerSec(uploadBytesPerSecMovingAverageWindowSize);
-        sum += uploadBytesPerSecMovingAverageWindowSize;
+        pressureTracker.addUploadBytesPerSec(movingAverageWindowSize);
+        sum += movingAverageWindowSize;
         assertTrue(pressureTracker.isUploadBytesPerSecAverageReady());
-        assertEquals((double) sum / uploadBytesPerSecMovingAverageWindowSize, pressureTracker.getUploadBytesPerSecAverage(), 0.0d);
+        assertEquals((double) sum / movingAverageWindowSize, pressureTracker.getUploadBytesPerSecAverage(), 0.0d);
 
         pressureTracker.addUploadBytesPerSec(100);
         sum = sum + 100 - 1;
-        assertEquals((double) sum / uploadBytesPerSecMovingAverageWindowSize, pressureTracker.getUploadBytesPerSecAverage(), 0.0d);
+        assertEquals((double) sum / movingAverageWindowSize, pressureTracker.getUploadBytesPerSecAverage(), 0.0d);
     }
 
     public void testIsUploadTimeMsAverageReady() {
-        int uploadTimeMovingAverageWindowSize = pressureSettings.getUploadTimeMovingAverageWindowSize();
-        pressureTracker = new RemoteSegmentTransferTracker(
-            shardId,
-            directoryFileTransferTracker,
-            pressureSettings.getUploadBytesMovingAverageWindowSize(),
-            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
-            uploadTimeMovingAverageWindowSize
-        );
+        int movingAverageWindowSize = pressureSettings.getMovingAverageWindowSize();
+        pressureTracker = new RemoteSegmentTransferTracker(shardId, directoryFileTransferTracker, movingAverageWindowSize);
         assertFalse(pressureTracker.isUploadTimeMsAverageReady());
 
         long sum = 0;
-        for (int i = 1; i < uploadTimeMovingAverageWindowSize; i++) {
+        for (int i = 1; i < movingAverageWindowSize; i++) {
             pressureTracker.addTimeForCompletedUploadSync(i);
             sum += i;
             assertFalse(pressureTracker.isUploadTimeMsAverageReady());
             assertEquals((double) sum / i, pressureTracker.getUploadTimeMsAverage(), 0.0d);
         }
 
-        pressureTracker.addTimeForCompletedUploadSync(uploadTimeMovingAverageWindowSize);
-        sum += uploadTimeMovingAverageWindowSize;
+        pressureTracker.addTimeForCompletedUploadSync(movingAverageWindowSize);
+        sum += movingAverageWindowSize;
         assertTrue(pressureTracker.isUploadTimeMsAverageReady());
-        assertEquals((double) sum / uploadTimeMovingAverageWindowSize, pressureTracker.getUploadTimeMsAverage(), 0.0d);
+        assertEquals((double) sum / movingAverageWindowSize, pressureTracker.getUploadTimeMsAverage(), 0.0d);
 
         pressureTracker.addTimeForCompletedUploadSync(100);
         sum = sum + 100 - 1;
-        assertEquals((double) sum / uploadTimeMovingAverageWindowSize, pressureTracker.getUploadTimeMsAverage(), 0.0d);
+        assertEquals((double) sum / movingAverageWindowSize, pressureTracker.getUploadTimeMsAverage(), 0.0d);
     }
 
     public void testIsDownloadBytesAverageReady() {
         pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getUploadBytesMovingAverageWindowSize(),
-            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
-            pressureSettings.getUploadTimeMovingAverageWindowSize()
+            pressureSettings.getMovingAverageWindowSize()
         );
         assertFalse(pressureTracker.getDirectoryFileTransferTracker().isTransferredBytesAverageReady());
 
@@ -521,9 +457,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getUploadBytesMovingAverageWindowSize(),
-            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
-            pressureSettings.getUploadTimeMovingAverageWindowSize()
+            pressureSettings.getMovingAverageWindowSize()
         );
         assertFalse(pressureTracker.getDirectoryFileTransferTracker().isTransferredBytesPerSecAverageReady());
 
@@ -549,9 +483,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         pressureTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
-            pressureSettings.getUploadBytesMovingAverageWindowSize(),
-            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
-            pressureSettings.getUploadTimeMovingAverageWindowSize()
+            pressureSettings.getMovingAverageWindowSize()
         );
         long timeToAdd = randomLongBetween(100, 200);
         pressureTracker.addTotalUploadTimeInMs(timeToAdd);
@@ -652,9 +584,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         RemoteSegmentTransferTracker segmentPressureTracker = new RemoteSegmentTransferTracker(
             shardId,
             new DirectoryFileTransferTracker(),
-            pressureSettings.getUploadBytesMovingAverageWindowSize(),
-            pressureSettings.getUploadBytesPerSecMovingAverageWindowSize(),
-            pressureSettings.getUploadTimeMovingAverageWindowSize()
+            pressureSettings.getMovingAverageWindowSize()
         );
         segmentPressureTracker.incrementTotalUploadsFailed();
         segmentPressureTracker.addTimeForCompletedUploadSync(System.nanoTime() / 1_000_000L + randomIntBetween(10, 100));

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStorePressureServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStorePressureServiceTests.java
@@ -75,7 +75,7 @@ public class RemoteStorePressureServiceTests extends OpenSearchTestCase {
         pressureService = new RemoteStorePressureService(clusterService, Settings.EMPTY, remoteStoreStatsTrackerFactory);
         remoteStoreStatsTrackerFactory.afterIndexShardCreated(indexShard);
 
-        RemoteSegmentTransferTracker pressureTracker = pressureService.getRemoteSegmentTransferTracker(shardId);
+        RemoteSegmentTransferTracker pressureTracker = remoteStoreStatsTrackerFactory.getRemoteSegmentTransferTracker(shardId);
         pressureTracker.updateLocalRefreshSeqNo(6);
 
         // 1. time lag more than dynamic threshold

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStorePressureServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStorePressureServiceTests.java
@@ -41,6 +41,8 @@ public class RemoteStorePressureServiceTests extends OpenSearchTestCase {
 
     private RemoteStorePressureService pressureService;
 
+    private RemoteStoreStatsTrackerFactory remoteStoreStatsTrackerFactory;
+
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -60,7 +62,8 @@ public class RemoteStorePressureServiceTests extends OpenSearchTestCase {
     }
 
     public void testIsSegmentsUploadBackpressureEnabled() {
-        pressureService = new RemoteStorePressureService(clusterService, Settings.EMPTY);
+        remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(Settings.EMPTY);
+        pressureService = new RemoteStorePressureService(clusterService, Settings.EMPTY, remoteStoreStatsTrackerFactory);
         assertFalse(pressureService.isSegmentsUploadBackpressureEnabled());
 
         Settings newSettings = Settings.builder()
@@ -73,33 +76,36 @@ public class RemoteStorePressureServiceTests extends OpenSearchTestCase {
 
     public void testAfterIndexShardCreatedForRemoteBackedIndex() {
         IndexShard indexShard = createIndexShard(shardId, true);
-        pressureService = new RemoteStorePressureService(clusterService, Settings.EMPTY);
-        pressureService.afterIndexShardCreated(indexShard);
+        remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(Settings.EMPTY);
+        pressureService = new RemoteStorePressureService(clusterService, Settings.EMPTY, remoteStoreStatsTrackerFactory);
+        remoteStoreStatsTrackerFactory.afterIndexShardCreated(indexShard);
         assertNotNull(pressureService.getRemoteRefreshSegmentTracker(indexShard.shardId()));
     }
 
     public void testAfterIndexShardCreatedForNonRemoteBackedIndex() {
         IndexShard indexShard = createIndexShard(shardId, false);
-        pressureService = new RemoteStorePressureService(clusterService, Settings.EMPTY);
-        pressureService.afterIndexShardCreated(indexShard);
+        remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(Settings.EMPTY);
+        pressureService = new RemoteStorePressureService(clusterService, Settings.EMPTY, remoteStoreStatsTrackerFactory);
+        remoteStoreStatsTrackerFactory.afterIndexShardCreated(indexShard);
         assertNull(pressureService.getRemoteRefreshSegmentTracker(indexShard.shardId()));
     }
 
     public void testAfterIndexShardClosed() {
         IndexShard indexShard = createIndexShard(shardId, true);
-        pressureService = new RemoteStorePressureService(clusterService, Settings.EMPTY);
-        pressureService.afterIndexShardCreated(indexShard);
+        remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(Settings.EMPTY);
+        pressureService = new RemoteStorePressureService(clusterService, Settings.EMPTY, remoteStoreStatsTrackerFactory);
+        remoteStoreStatsTrackerFactory.afterIndexShardCreated(indexShard);
         assertNotNull(pressureService.getRemoteRefreshSegmentTracker(shardId));
-
-        pressureService.afterIndexShardClosed(shardId, indexShard, indexShard.indexSettings().getSettings());
+        remoteStoreStatsTrackerFactory.afterIndexShardClosed(shardId, indexShard, indexShard.indexSettings().getSettings());
         assertNull(pressureService.getRemoteRefreshSegmentTracker(shardId));
     }
 
     public void testValidateSegmentUploadLag() {
         // Create the pressure tracker
         IndexShard indexShard = createIndexShard(shardId, true);
-        pressureService = new RemoteStorePressureService(clusterService, Settings.EMPTY);
-        pressureService.afterIndexShardCreated(indexShard);
+        remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(Settings.EMPTY);
+        pressureService = new RemoteStorePressureService(clusterService, Settings.EMPTY, remoteStoreStatsTrackerFactory);
+        remoteStoreStatsTrackerFactory.afterIndexShardCreated(indexShard);
 
         RemoteSegmentTransferTracker pressureTracker = pressureService.getRemoteRefreshSegmentTracker(shardId);
         pressureTracker.updateLocalRefreshSeqNo(6);

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStorePressureServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStorePressureServiceTests.java
@@ -56,7 +56,7 @@ public class RemoteStorePressureServiceTests extends OpenSearchTestCase {
     }
 
     public void testIsSegmentsUploadBackpressureEnabled() {
-        remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(Settings.EMPTY);
+        remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(clusterService, Settings.EMPTY);
         pressureService = new RemoteStorePressureService(clusterService, Settings.EMPTY, remoteStoreStatsTrackerFactory);
         assertFalse(pressureService.isSegmentsUploadBackpressureEnabled());
 
@@ -71,7 +71,7 @@ public class RemoteStorePressureServiceTests extends OpenSearchTestCase {
     public void testValidateSegmentUploadLag() {
         // Create the pressure tracker
         IndexShard indexShard = createIndexShard(shardId, true);
-        remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(Settings.EMPTY);
+        remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(clusterService, Settings.EMPTY);
         pressureService = new RemoteStorePressureService(clusterService, Settings.EMPTY, remoteStoreStatsTrackerFactory);
         remoteStoreStatsTrackerFactory.afterIndexShardCreated(indexShard);
 

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStorePressureSettingsTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStorePressureSettingsTests.java
@@ -63,14 +63,8 @@ public class RemoteStorePressureSettingsTests extends OpenSearchTestCase {
         // Check minimum consecutive failures limit default value
         assertEquals(5, pressureSettings.getMinConsecutiveFailuresLimit());
 
-        // Check upload bytes moving average window size default value
-        assertEquals(20, pressureSettings.getUploadBytesMovingAverageWindowSize());
-
-        // Check upload bytes per sec moving average window size default value
-        assertEquals(20, pressureSettings.getUploadBytesPerSecMovingAverageWindowSize());
-
-        // Check upload time moving average window size default value
-        assertEquals(20, pressureSettings.getUploadTimeMovingAverageWindowSize());
+        // Check moving average window size default value
+        assertEquals(20, pressureSettings.getMovingAverageWindowSize());
     }
 
     public void testGetConfiguredSettings() {
@@ -79,9 +73,7 @@ public class RemoteStorePressureSettingsTests extends OpenSearchTestCase {
             .put(RemoteStorePressureSettings.BYTES_LAG_VARIANCE_FACTOR.getKey(), 50.0)
             .put(RemoteStorePressureSettings.UPLOAD_TIME_LAG_VARIANCE_FACTOR.getKey(), 60.0)
             .put(RemoteStorePressureSettings.MIN_CONSECUTIVE_FAILURES_LIMIT.getKey(), 121)
-            .put(RemoteStorePressureSettings.UPLOAD_BYTES_MOVING_AVERAGE_WINDOW_SIZE.getKey(), 102)
-            .put(RemoteStorePressureSettings.UPLOAD_BYTES_PER_SEC_MOVING_AVERAGE_WINDOW_SIZE.getKey(), 103)
-            .put(RemoteStorePressureSettings.UPLOAD_TIME_MOVING_AVERAGE_WINDOW_SIZE.getKey(), 104)
+            .put(RemoteStorePressureSettings.MOVING_AVERAGE_WINDOW_SIZE.getKey(), 102)
             .build();
         RemoteStorePressureSettings pressureSettings = new RemoteStorePressureSettings(
             clusterService,
@@ -101,14 +93,8 @@ public class RemoteStorePressureSettingsTests extends OpenSearchTestCase {
         // Check minimum consecutive failures limit configured value
         assertEquals(121, pressureSettings.getMinConsecutiveFailuresLimit());
 
-        // Check upload bytes moving average window size configured value
-        assertEquals(102, pressureSettings.getUploadBytesMovingAverageWindowSize());
-
-        // Check upload bytes per sec moving average window size configured value
-        assertEquals(103, pressureSettings.getUploadBytesPerSecMovingAverageWindowSize());
-
-        // Check upload time moving average window size configured value
-        assertEquals(104, pressureSettings.getUploadTimeMovingAverageWindowSize());
+        // Check moving average window size configured value
+        assertEquals(102, pressureSettings.getMovingAverageWindowSize());
     }
 
     public void testUpdateAfterGetDefaultSettings() {
@@ -123,9 +109,7 @@ public class RemoteStorePressureSettingsTests extends OpenSearchTestCase {
             .put(RemoteStorePressureSettings.BYTES_LAG_VARIANCE_FACTOR.getKey(), 50.0)
             .put(RemoteStorePressureSettings.UPLOAD_TIME_LAG_VARIANCE_FACTOR.getKey(), 60.0)
             .put(RemoteStorePressureSettings.MIN_CONSECUTIVE_FAILURES_LIMIT.getKey(), 121)
-            .put(RemoteStorePressureSettings.UPLOAD_BYTES_MOVING_AVERAGE_WINDOW_SIZE.getKey(), 102)
-            .put(RemoteStorePressureSettings.UPLOAD_BYTES_PER_SEC_MOVING_AVERAGE_WINDOW_SIZE.getKey(), 103)
-            .put(RemoteStorePressureSettings.UPLOAD_TIME_MOVING_AVERAGE_WINDOW_SIZE.getKey(), 104)
+            .put(RemoteStorePressureSettings.MOVING_AVERAGE_WINDOW_SIZE.getKey(), 102)
             .build();
         clusterService.getClusterSettings().applySettings(newSettings);
 
@@ -141,14 +125,8 @@ public class RemoteStorePressureSettingsTests extends OpenSearchTestCase {
         // Check minimum consecutive failures limit updated
         assertEquals(121, pressureSettings.getMinConsecutiveFailuresLimit());
 
-        // Check upload bytes moving average window size updated
-        assertEquals(102, pressureSettings.getUploadBytesMovingAverageWindowSize());
-
-        // Check upload bytes per sec moving average window size updated
-        assertEquals(103, pressureSettings.getUploadBytesPerSecMovingAverageWindowSize());
-
-        // Check upload time moving average window size updated
-        assertEquals(104, pressureSettings.getUploadTimeMovingAverageWindowSize());
+        // Check moving average window size updated
+        assertEquals(102, pressureSettings.getMovingAverageWindowSize());
     }
 
     public void testUpdateAfterGetConfiguredSettings() {
@@ -157,9 +135,7 @@ public class RemoteStorePressureSettingsTests extends OpenSearchTestCase {
             .put(RemoteStorePressureSettings.BYTES_LAG_VARIANCE_FACTOR.getKey(), 50.0)
             .put(RemoteStorePressureSettings.UPLOAD_TIME_LAG_VARIANCE_FACTOR.getKey(), 60.0)
             .put(RemoteStorePressureSettings.MIN_CONSECUTIVE_FAILURES_LIMIT.getKey(), 121)
-            .put(RemoteStorePressureSettings.UPLOAD_BYTES_MOVING_AVERAGE_WINDOW_SIZE.getKey(), 102)
-            .put(RemoteStorePressureSettings.UPLOAD_BYTES_PER_SEC_MOVING_AVERAGE_WINDOW_SIZE.getKey(), 103)
-            .put(RemoteStorePressureSettings.UPLOAD_TIME_MOVING_AVERAGE_WINDOW_SIZE.getKey(), 104)
+            .put(RemoteStorePressureSettings.MOVING_AVERAGE_WINDOW_SIZE.getKey(), 102)
             .build();
         RemoteStorePressureSettings pressureSettings = new RemoteStorePressureSettings(
             clusterService,
@@ -171,9 +147,7 @@ public class RemoteStorePressureSettingsTests extends OpenSearchTestCase {
             .put(RemoteStorePressureSettings.BYTES_LAG_VARIANCE_FACTOR.getKey(), 40.0)
             .put(RemoteStorePressureSettings.UPLOAD_TIME_LAG_VARIANCE_FACTOR.getKey(), 50.0)
             .put(RemoteStorePressureSettings.MIN_CONSECUTIVE_FAILURES_LIMIT.getKey(), 111)
-            .put(RemoteStorePressureSettings.UPLOAD_BYTES_MOVING_AVERAGE_WINDOW_SIZE.getKey(), 112)
-            .put(RemoteStorePressureSettings.UPLOAD_BYTES_PER_SEC_MOVING_AVERAGE_WINDOW_SIZE.getKey(), 113)
-            .put(RemoteStorePressureSettings.UPLOAD_TIME_MOVING_AVERAGE_WINDOW_SIZE.getKey(), 114)
+            .put(RemoteStorePressureSettings.MOVING_AVERAGE_WINDOW_SIZE.getKey(), 112)
             .build();
 
         clusterService.getClusterSettings().applySettings(newSettings);
@@ -190,58 +164,32 @@ public class RemoteStorePressureSettingsTests extends OpenSearchTestCase {
         // Check minimum consecutive failures limit updated
         assertEquals(111, pressureSettings.getMinConsecutiveFailuresLimit());
 
-        // Check upload bytes moving average window size updated
-        assertEquals(112, pressureSettings.getUploadBytesMovingAverageWindowSize());
-
-        // Check upload bytes per sec moving average window size updated
-        assertEquals(113, pressureSettings.getUploadBytesPerSecMovingAverageWindowSize());
-
-        // Check upload time moving average window size updated
-        assertEquals(114, pressureSettings.getUploadTimeMovingAverageWindowSize());
+        // Check moving average window size updated
+        assertEquals(112, pressureSettings.getMovingAverageWindowSize());
     }
 
     public void testUpdateTriggeredInRemotePressureServiceOnUpdateSettings() {
 
-        int toUpdateVal1 = 1121, toUpdateVal2 = 1123, toUpdateVal3 = 1125;
+        int toUpdateVal1 = 1121;
 
-        AtomicInteger updatedUploadBytesWindowSize = new AtomicInteger();
-        AtomicInteger updatedUploadBytesPerSecWindowSize = new AtomicInteger();
-        AtomicInteger updatedUploadTimeWindowSize = new AtomicInteger();
+        AtomicInteger movingAverageWindowSize = new AtomicInteger();
 
         RemoteStorePressureService pressureService = mock(RemoteStorePressureService.class);
 
         // Upload bytes
         doAnswer(invocation -> {
-            updatedUploadBytesWindowSize.set(invocation.getArgument(0));
+            movingAverageWindowSize.set(invocation.getArgument(0));
             return null;
-        }).when(pressureService).updateUploadBytesMovingAverageWindowSize(anyInt());
-
-        // Upload bytes per sec
-        doAnswer(invocation -> {
-            updatedUploadBytesPerSecWindowSize.set(invocation.getArgument(0));
-            return null;
-        }).when(pressureService).updateUploadBytesPerSecMovingAverageWindowSize(anyInt());
-
-        // Upload time
-        doAnswer(invocation -> {
-            updatedUploadTimeWindowSize.set(invocation.getArgument(0));
-            return null;
-        }).when(pressureService).updateUploadTimeMsMovingAverageWindowSize(anyInt());
+        }).when(pressureService).updateMovingAverageWindowSize(anyInt());
 
         RemoteStorePressureSettings pressureSettings = new RemoteStorePressureSettings(clusterService, Settings.EMPTY, pressureService);
         Settings newSettings = Settings.builder()
-            .put(RemoteStorePressureSettings.UPLOAD_BYTES_MOVING_AVERAGE_WINDOW_SIZE.getKey(), toUpdateVal1)
-            .put(RemoteStorePressureSettings.UPLOAD_BYTES_PER_SEC_MOVING_AVERAGE_WINDOW_SIZE.getKey(), toUpdateVal2)
-            .put(RemoteStorePressureSettings.UPLOAD_TIME_MOVING_AVERAGE_WINDOW_SIZE.getKey(), toUpdateVal3)
+            .put(RemoteStorePressureSettings.MOVING_AVERAGE_WINDOW_SIZE.getKey(), toUpdateVal1)
             .build();
         clusterService.getClusterSettings().applySettings(newSettings);
 
         // Assertions
-        assertEquals(toUpdateVal1, pressureSettings.getUploadBytesMovingAverageWindowSize());
-        assertEquals(toUpdateVal1, updatedUploadBytesWindowSize.get());
-        assertEquals(toUpdateVal2, pressureSettings.getUploadBytesPerSecMovingAverageWindowSize());
-        assertEquals(toUpdateVal2, updatedUploadBytesPerSecWindowSize.get());
-        assertEquals(toUpdateVal3, pressureSettings.getUploadTimeMovingAverageWindowSize());
-        assertEquals(toUpdateVal3, updatedUploadTimeWindowSize.get());
+        assertEquals(toUpdateVal1, pressureSettings.getMovingAverageWindowSize());
+        assertEquals(toUpdateVal1, movingAverageWindowSize.get());
     }
 }

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStorePressureSettingsTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStorePressureSettingsTests.java
@@ -73,7 +73,10 @@ public class RemoteStorePressureSettingsTests extends OpenSearchTestCase {
             .put(RemoteStorePressureSettings.BYTES_LAG_VARIANCE_FACTOR.getKey(), 50.0)
             .put(RemoteStorePressureSettings.UPLOAD_TIME_LAG_VARIANCE_FACTOR.getKey(), 60.0)
             .put(RemoteStorePressureSettings.MIN_CONSECUTIVE_FAILURES_LIMIT.getKey(), 121)
-            .put(RemoteStorePressureSettings.MOVING_AVERAGE_WINDOW_SIZE.getKey(), 102)
+            .put(
+                RemoteStorePressureSettings.MOVING_AVERAGE_WINDOW_SIZE.getKey(),
+                RemoteStorePressureSettings.Defaults.MOVING_AVERAGE_WINDOW_SIZE_MIN_VALUE
+            )
             .build();
         RemoteStorePressureSettings pressureSettings = new RemoteStorePressureSettings(
             clusterService,
@@ -94,7 +97,24 @@ public class RemoteStorePressureSettingsTests extends OpenSearchTestCase {
         assertEquals(121, pressureSettings.getMinConsecutiveFailuresLimit());
 
         // Check moving average window size configured value
-        assertEquals(102, pressureSettings.getMovingAverageWindowSize());
+        assertEquals(
+            RemoteStorePressureSettings.Defaults.MOVING_AVERAGE_WINDOW_SIZE_MIN_VALUE,
+            pressureSettings.getMovingAverageWindowSize()
+        );
+    }
+
+    public void testInvalidMovingAverageWindowSize() {
+        Settings settings = Settings.builder()
+            .put(
+                RemoteStorePressureSettings.MOVING_AVERAGE_WINDOW_SIZE.getKey(),
+                RemoteStorePressureSettings.Defaults.MOVING_AVERAGE_WINDOW_SIZE_MIN_VALUE - 1
+            )
+            .build();
+        assertThrows(
+            "Failed to parse value",
+            IllegalArgumentException.class,
+            () -> new RemoteStorePressureSettings(clusterService, settings, mock(RemoteStorePressureService.class))
+        );
     }
 
     public void testUpdateAfterGetDefaultSettings() {

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStoreStatsTrackerFactoryTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStoreStatsTrackerFactoryTests.java
@@ -1,0 +1,74 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.remote;
+
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.test.OpenSearchTestCase;
+
+import static org.opensearch.index.remote.RemoteStoreTestsHelper.createIndexShard;
+
+public class RemoteStoreStatsTrackerFactoryTests extends OpenSearchTestCase {
+    private ShardId shardId;
+    private IndexShard indexShard;
+    private RemoteStoreStatsTrackerFactory remoteStoreStatsTrackerFactory;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        shardId = new ShardId("index", "uuid", 0);
+        indexShard = createIndexShard(shardId, true);
+        remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(Settings.EMPTY);
+    }
+
+    public void testAfterIndexShardCreatedForRemoteBackedIndex() {
+        remoteStoreStatsTrackerFactory.afterIndexShardCreated(indexShard);
+        assertNotNull(remoteStoreStatsTrackerFactory.getRemoteSegmentTransferTracker(indexShard.shardId()));
+    }
+
+    public void testAfterIndexShardCreatedForNonRemoteBackedIndex() {
+        indexShard = createIndexShard(shardId, false);
+        remoteStoreStatsTrackerFactory.afterIndexShardCreated(indexShard);
+        assertNull(remoteStoreStatsTrackerFactory.getRemoteSegmentTransferTracker(indexShard.shardId()));
+    }
+
+    public void testAfterIndexShardClosed() {
+        remoteStoreStatsTrackerFactory.afterIndexShardCreated(indexShard);
+        assertNotNull(remoteStoreStatsTrackerFactory.getRemoteSegmentTransferTracker(shardId));
+        remoteStoreStatsTrackerFactory.afterIndexShardClosed(shardId, indexShard, indexShard.indexSettings().getSettings());
+        assertNull(remoteStoreStatsTrackerFactory.getRemoteSegmentTransferTracker(shardId));
+    }
+
+    public void testUpdateMovingAverageWindowSize() {
+        remoteStoreStatsTrackerFactory.afterIndexShardCreated(indexShard);
+
+        ShardId shardId2 = new ShardId("index", "uuid", 1);
+        IndexShard indexShard2 = createIndexShard(shardId2, true);
+        remoteStoreStatsTrackerFactory.afterIndexShardCreated(indexShard2);
+
+        int defaultSize = RemoteStorePressureSettings.Defaults.MOVING_AVERAGE_WINDOW_SIZE;
+        assertEquals(defaultSize, remoteStoreStatsTrackerFactory.getMovingAverageWindowSize());
+        assertFalse(remoteStoreStatsTrackerFactory.getRemoteSegmentTransferTracker(shardId).isUploadBytesAverageReady());
+        assertFalse(remoteStoreStatsTrackerFactory.getRemoteSegmentTransferTracker(shardId).isUploadBytesPerSecAverageReady());
+        assertFalse(remoteStoreStatsTrackerFactory.getRemoteSegmentTransferTracker(shardId).isUploadTimeMsAverageReady());
+        assertFalse(remoteStoreStatsTrackerFactory.getRemoteSegmentTransferTracker(shardId2).isUploadBytesAverageReady());
+        assertFalse(remoteStoreStatsTrackerFactory.getRemoteSegmentTransferTracker(shardId2).isUploadBytesPerSecAverageReady());
+        assertFalse(remoteStoreStatsTrackerFactory.getRemoteSegmentTransferTracker(shardId2).isUploadTimeMsAverageReady());
+
+        int updatedSize = 0;
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> remoteStoreStatsTrackerFactory.updateMovingAverageWindowSize(
+                RemoteSegmentTransferTracker::updateMovingAverageWindowSize,
+                updatedSize
+            )
+        );
+    }
+}

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStoreStatsTrackerFactoryTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStoreStatsTrackerFactoryTests.java
@@ -18,9 +18,6 @@ import static org.opensearch.index.remote.RemoteStoreTestsHelper.createIndexShar
 public class RemoteStoreStatsTrackerFactoryTests extends OpenSearchTestCase {
     private ShardId shardId;
     private IndexShard indexShard;
-
-    private ShardId shardId2;
-    private IndexShard indexShard2;
     private RemoteStoreStatsTrackerFactory remoteStoreStatsTrackerFactory;
 
     @Override
@@ -29,8 +26,6 @@ public class RemoteStoreStatsTrackerFactoryTests extends OpenSearchTestCase {
         shardId = new ShardId("index", "uuid", 0);
         indexShard = createIndexShard(shardId, true);
         remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(Settings.EMPTY);
-        shardId2 = null;
-        indexShard2 = null;
     }
 
     public void testAfterIndexShardCreatedForRemoteBackedIndex() {
@@ -51,54 +46,8 @@ public class RemoteStoreStatsTrackerFactoryTests extends OpenSearchTestCase {
         assertNull(remoteStoreStatsTrackerFactory.getRemoteSegmentTransferTracker(shardId));
     }
 
-    public void testUpdateMovingAverageWindowSizeZero() {
-        remoteStoreStatsTrackerFactory.afterIndexShardCreated(indexShard);
-        createSecondShard();
-
-        int defaultSize = RemoteStorePressureSettings.Defaults.MOVING_AVERAGE_WINDOW_SIZE;
-        assertDefaultSize(defaultSize);
-
-        int updatedSize = 0;
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> remoteStoreStatsTrackerFactory.updateMovingAverageWindowSize(
-                RemoteSegmentTransferTracker::updateMovingAverageWindowSize,
-                updatedSize
-            )
-        );
-        assertEquals(defaultSize, remoteStoreStatsTrackerFactory.getMovingAverageWindowSize());
-    }
-
-    public void testUpdateMovingAverageWindowSizeLessThanMinAllowed() {
-        remoteStoreStatsTrackerFactory.afterIndexShardCreated(indexShard);
-        createSecondShard();
-
-        int defaultSize = RemoteStorePressureSettings.Defaults.MOVING_AVERAGE_WINDOW_SIZE;
-        assertDefaultSize(defaultSize);
-
-        int updatedSize = RemoteStorePressureSettings.Defaults.MOVING_AVERAGE_WINDOW_SIZE_MIN_VALUE - 1;
-        // TODO: The following exception isn't thrown currently
-        // assertThrows(
-        // IllegalArgumentException.class,
-        // () -> remoteStoreStatsTrackerFactory.updateMovingAverageWindowSize(
-        // RemoteSegmentTransferTracker::updateMovingAverageWindowSize,
-        // updatedSize
-        // )
-        // );
-        // assertEquals(defaultSize, remoteStoreStatsTrackerFactory.getMovingAverageWindowSize());
-        remoteStoreStatsTrackerFactory.updateMovingAverageWindowSize(
-            RemoteSegmentTransferTracker::updateMovingAverageWindowSize,
-            updatedSize
-        );
-        assertEquals(updatedSize, remoteStoreStatsTrackerFactory.getMovingAverageWindowSize());
-    }
-
     public void testUpdateMovingAverageWindowSizeMinAllowed() {
         remoteStoreStatsTrackerFactory.afterIndexShardCreated(indexShard);
-        createSecondShard();
-
-        int defaultSize = RemoteStorePressureSettings.Defaults.MOVING_AVERAGE_WINDOW_SIZE;
-        assertDefaultSize(defaultSize);
 
         int updatedSize = RemoteStorePressureSettings.Defaults.MOVING_AVERAGE_WINDOW_SIZE_MIN_VALUE;
         remoteStoreStatsTrackerFactory.updateMovingAverageWindowSize(
@@ -106,23 +55,5 @@ public class RemoteStoreStatsTrackerFactoryTests extends OpenSearchTestCase {
             updatedSize
         );
         assertEquals(updatedSize, remoteStoreStatsTrackerFactory.getMovingAverageWindowSize());
-    }
-
-    private void assertDefaultSize(int defaultSize) {
-        assertEquals(defaultSize, remoteStoreStatsTrackerFactory.getMovingAverageWindowSize());
-        assertFalse(remoteStoreStatsTrackerFactory.getRemoteSegmentTransferTracker(shardId).isUploadBytesAverageReady());
-        assertFalse(remoteStoreStatsTrackerFactory.getRemoteSegmentTransferTracker(shardId).isUploadBytesPerSecAverageReady());
-        assertFalse(remoteStoreStatsTrackerFactory.getRemoteSegmentTransferTracker(shardId).isUploadTimeMsAverageReady());
-        if (shardId2 != null) {
-            assertFalse(remoteStoreStatsTrackerFactory.getRemoteSegmentTransferTracker(shardId2).isUploadBytesAverageReady());
-            assertFalse(remoteStoreStatsTrackerFactory.getRemoteSegmentTransferTracker(shardId2).isUploadBytesPerSecAverageReady());
-            assertFalse(remoteStoreStatsTrackerFactory.getRemoteSegmentTransferTracker(shardId2).isUploadTimeMsAverageReady());
-        }
-    }
-
-    private void createSecondShard() {
-        shardId2 = new ShardId("index", "uuid", 1);
-        indexShard2 = createIndexShard(shardId2, true);
-        remoteStoreStatsTrackerFactory.afterIndexShardCreated(indexShard2);
     }
 }

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStoreStatsTrackerFactoryTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStoreStatsTrackerFactoryTests.java
@@ -8,14 +8,21 @@
 
 package org.opensearch.index.remote;
 
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
 
 import static org.opensearch.index.remote.RemoteStoreTestsHelper.createIndexShard;
 
 public class RemoteStoreStatsTrackerFactoryTests extends OpenSearchTestCase {
+    private ThreadPool threadPool;
+    private ClusterService clusterService;
+    private Settings settings;
     private ShardId shardId;
     private IndexShard indexShard;
     private RemoteStoreStatsTrackerFactory remoteStoreStatsTrackerFactory;
@@ -25,7 +32,21 @@ public class RemoteStoreStatsTrackerFactoryTests extends OpenSearchTestCase {
         super.setUp();
         shardId = new ShardId("index", "uuid", 0);
         indexShard = createIndexShard(shardId, true);
-        remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(Settings.EMPTY);
+        threadPool = new TestThreadPool(getTestName());
+        settings = Settings.builder()
+            .put(
+                RemoteStoreStatsTrackerFactory.MOVING_AVERAGE_WINDOW_SIZE.getKey(),
+                RemoteStoreStatsTrackerFactory.Defaults.MOVING_AVERAGE_WINDOW_SIZE_MIN_VALUE
+            )
+            .build();
+        clusterService = new ClusterService(settings, new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS), threadPool);
+        remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(clusterService, settings);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        threadPool.shutdownNow();
     }
 
     public void testAfterIndexShardCreatedForRemoteBackedIndex() {
@@ -46,14 +67,53 @@ public class RemoteStoreStatsTrackerFactoryTests extends OpenSearchTestCase {
         assertNull(remoteStoreStatsTrackerFactory.getRemoteSegmentTransferTracker(shardId));
     }
 
-    public void testUpdateMovingAverageWindowSizeMinAllowed() {
-        remoteStoreStatsTrackerFactory.afterIndexShardCreated(indexShard);
-
-        int updatedSize = RemoteStorePressureSettings.Defaults.MOVING_AVERAGE_WINDOW_SIZE_MIN_VALUE;
-        remoteStoreStatsTrackerFactory.updateMovingAverageWindowSize(
-            RemoteSegmentTransferTracker::updateMovingAverageWindowSize,
-            updatedSize
+    public void testGetConfiguredSettings() {
+        assertEquals(
+            RemoteStoreStatsTrackerFactory.Defaults.MOVING_AVERAGE_WINDOW_SIZE_MIN_VALUE,
+            remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
         );
-        assertEquals(updatedSize, remoteStoreStatsTrackerFactory.getMovingAverageWindowSize());
+    }
+
+    public void testInvalidMovingAverageWindowSize() {
+        Settings settings = Settings.builder()
+            .put(
+                RemoteStoreStatsTrackerFactory.MOVING_AVERAGE_WINDOW_SIZE.getKey(),
+                RemoteStoreStatsTrackerFactory.Defaults.MOVING_AVERAGE_WINDOW_SIZE_MIN_VALUE - 1
+            )
+            .build();
+        assertThrows(
+            "Failed to parse value",
+            IllegalArgumentException.class,
+            () -> new RemoteStoreStatsTrackerFactory(
+                new ClusterService(settings, new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS), threadPool),
+                settings
+            )
+        );
+    }
+
+    public void testUpdateAfterGetConfiguredSettings() {
+        assertEquals(
+            RemoteStoreStatsTrackerFactory.Defaults.MOVING_AVERAGE_WINDOW_SIZE_MIN_VALUE,
+            remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
+        );
+
+        Settings newSettings = Settings.builder().put(RemoteStoreStatsTrackerFactory.MOVING_AVERAGE_WINDOW_SIZE.getKey(), 102).build();
+
+        clusterService.getClusterSettings().applySettings(newSettings);
+
+        // Check moving average window size updated
+        assertEquals(102, remoteStoreStatsTrackerFactory.getMovingAverageWindowSize());
+    }
+
+    public void testGetDefaultSettings() {
+        remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(
+            new ClusterService(Settings.EMPTY, new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS), threadPool),
+            Settings.EMPTY
+        );
+        // Check moving average window size updated
+        assertEquals(
+            RemoteStoreStatsTrackerFactory.Defaults.MOVING_AVERAGE_WINDOW_SIZE,
+            remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
+        );
     }
 }

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStoreTestsHelper.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStoreTestsHelper.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.remote;
+
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.index.store.Store;
+import org.opensearch.indices.replication.common.ReplicationType;
+import org.opensearch.test.IndexSettingsModule;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Helper functions for Remote Store tests
+ */
+public class RemoteStoreTestsHelper {
+    static IndexShard createIndexShard(ShardId shardId, boolean remoteStoreEnabled) {
+        Settings settings = Settings.builder()
+            .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+            .put(IndexMetadata.SETTING_REMOTE_STORE_ENABLED, String.valueOf(remoteStoreEnabled))
+            .build();
+        IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test_index", settings);
+        Store store = mock(Store.class);
+        IndexShard indexShard = mock(IndexShard.class);
+        when(indexShard.indexSettings()).thenReturn(indexSettings);
+        when(indexShard.shardId()).thenReturn(shardId);
+        when(indexShard.store()).thenReturn(store);
+        return indexShard;
+    }
+}

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -1822,7 +1822,7 @@ public class IndexShardTests extends IndexShardTestCase {
                 .build()
         );
         RemoteSegmentTransferTracker remoteRefreshSegmentTracker = shard.getRemoteStorePressureService()
-            .getRemoteRefreshSegmentTracker(shard.shardId);
+            .getRemoteSegmentTransferTracker(shard.shardId);
         populateSampleRemoteStoreStats(remoteRefreshSegmentTracker);
         ShardStats shardStats = new ShardStats(
             shard.routingEntry(),

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -1821,7 +1821,7 @@ public class IndexShardTests extends IndexShardTestCase {
                 .put(IndexMetadata.SETTING_REMOTE_STORE_ENABLED, true)
                 .build()
         );
-        RemoteSegmentTransferTracker remoteRefreshSegmentTracker = shard.getRemoteStorePressureService()
+        RemoteSegmentTransferTracker remoteRefreshSegmentTracker = shard.getRemoteStoreStatsTrackerFactory()
             .getRemoteSegmentTransferTracker(shard.shardId);
         populateSampleRemoteStoreStats(remoteRefreshSegmentTracker);
         ShardStats shardStats = new ShardStats(

--- a/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
@@ -27,7 +27,6 @@ import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.engine.InternalEngineFactory;
 import org.opensearch.index.engine.NRTReplicationEngineFactory;
 import org.opensearch.index.remote.RemoteSegmentTransferTracker;
-import org.opensearch.index.remote.RemoteStorePressureService;
 import org.opensearch.index.remote.RemoteStoreStatsTrackerFactory;
 import org.opensearch.index.store.RemoteDirectory;
 import org.opensearch.index.store.RemoteSegmentStoreDirectory;
@@ -61,7 +60,6 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
     private IndexShard indexShard;
     private ClusterService clusterService;
     private RemoteStoreRefreshListener remoteStoreRefreshListener;
-    private RemoteStorePressureService remoteStorePressureService;
     private RemoteStoreStatsTrackerFactory remoteStoreStatsTrackerFactory;
 
     public void setup(boolean primary, int numberOfDocs) throws IOException {
@@ -87,7 +85,6 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
             threadPool
         );
         remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(clusterService, Settings.EMPTY);
-        remoteStorePressureService = new RemoteStorePressureService(clusterService, Settings.EMPTY, remoteStoreStatsTrackerFactory);
         remoteStoreStatsTrackerFactory.afterIndexShardCreated(indexShard);
         RemoteSegmentTransferTracker tracker = remoteStoreStatsTrackerFactory.getRemoteSegmentTransferTracker(indexShard.shardId());
         remoteStoreRefreshListener = new RemoteStoreRefreshListener(indexShard, SegmentReplicationCheckpointPublisher.EMPTY, tracker);
@@ -543,11 +540,9 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
             new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
             threadPool
         );
-        remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(clusterService, Settings.EMPTY);
-        RemoteStoreStatsTrackerFactory remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(clusterService, Settings.EMPTY);
+        RemoteStoreStatsTrackerFactory remoteStoreStatsTrackerFactory = indexShard.getRemoteStoreStatsTrackerFactory();
         when(shard.indexSettings()).thenReturn(indexShard.indexSettings());
         when(shard.shardId()).thenReturn(indexShard.shardId());
-        remoteStoreStatsTrackerFactory.afterIndexShardCreated(shard);
         RemoteSegmentTransferTracker tracker = remoteStoreStatsTrackerFactory.getRemoteSegmentTransferTracker(indexShard.shardId());
         RemoteStoreRefreshListener refreshListener = new RemoteStoreRefreshListener(shard, emptyCheckpointPublisher, tracker);
         refreshListener.afterRefresh(true);

--- a/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
@@ -89,7 +89,7 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
         remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(Settings.EMPTY);
         remoteStorePressureService = new RemoteStorePressureService(clusterService, Settings.EMPTY, remoteStoreStatsTrackerFactory);
         remoteStoreStatsTrackerFactory.afterIndexShardCreated(indexShard);
-        RemoteSegmentTransferTracker tracker = remoteStorePressureService.getRemoteRefreshSegmentTracker(indexShard.shardId());
+        RemoteSegmentTransferTracker tracker = remoteStorePressureService.getRemoteSegmentTransferTracker(indexShard.shardId());
         remoteStoreRefreshListener = new RemoteStoreRefreshListener(indexShard, SegmentReplicationCheckpointPublisher.EMPTY, tracker);
     }
 
@@ -328,7 +328,7 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
         assertBusy(() -> assertEquals(0, refreshCountLatch.getCount()));
         assertBusy(() -> assertEquals(0, successLatch.getCount()));
         RemoteStorePressureService pressureService = tuple.v2();
-        RemoteSegmentTransferTracker segmentTracker = pressureService.getRemoteRefreshSegmentTracker(indexShard.shardId());
+        RemoteSegmentTransferTracker segmentTracker = pressureService.getRemoteSegmentTransferTracker(indexShard.shardId());
         assertNoLagAndTotalUploadsFailed(segmentTracker, 0);
     }
 
@@ -349,7 +349,7 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
         assertBusy(() -> assertEquals(0, refreshCountLatch.getCount()));
         assertBusy(() -> assertEquals(0, successLatch.getCount()));
         RemoteStorePressureService pressureService = tuple.v2();
-        RemoteSegmentTransferTracker segmentTracker = pressureService.getRemoteRefreshSegmentTracker(indexShard.shardId());
+        RemoteSegmentTransferTracker segmentTracker = pressureService.getRemoteSegmentTransferTracker(indexShard.shardId());
         assertNoLagAndTotalUploadsFailed(segmentTracker, 1);
     }
 
@@ -395,7 +395,7 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
         assertBusy(() -> assertEquals(0, refreshCountLatch.getCount()));
         assertBusy(() -> assertEquals(0, successLatch.getCount()));
         RemoteStorePressureService pressureService = tuple.v2();
-        RemoteSegmentTransferTracker segmentTracker = pressureService.getRemoteRefreshSegmentTracker(indexShard.shardId());
+        RemoteSegmentTransferTracker segmentTracker = pressureService.getRemoteSegmentTransferTracker(indexShard.shardId());
         assertNoLagAndTotalUploadsFailed(segmentTracker, 2);
     }
 
@@ -412,7 +412,7 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
         Tuple<RemoteStoreRefreshListener, RemoteStorePressureService> tuple = mockIndexShardWithRetryAndScheduleRefresh(1);
         RemoteStoreRefreshListener listener = tuple.v1();
         RemoteStorePressureService pressureService = tuple.v2();
-        RemoteSegmentTransferTracker tracker = pressureService.getRemoteRefreshSegmentTracker(indexShard.shardId());
+        RemoteSegmentTransferTracker tracker = pressureService.getRemoteSegmentTransferTracker(indexShard.shardId());
         assertNoLag(tracker);
         indexDocs(100, randomIntBetween(100, 200));
         indexShard.refresh("test");
@@ -551,7 +551,7 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
         when(shard.indexSettings()).thenReturn(indexShard.indexSettings());
         when(shard.shardId()).thenReturn(indexShard.shardId());
         remoteStoreStatsTrackerFactory.afterIndexShardCreated(shard);
-        RemoteSegmentTransferTracker tracker = remoteStorePressureService.getRemoteRefreshSegmentTracker(indexShard.shardId());
+        RemoteSegmentTransferTracker tracker = remoteStorePressureService.getRemoteSegmentTransferTracker(indexShard.shardId());
         RemoteStoreRefreshListener refreshListener = new RemoteStoreRefreshListener(shard, emptyCheckpointPublisher, tracker);
         refreshListener.afterRefresh(true);
         return Tuple.tuple(refreshListener, remoteStorePressureService);

--- a/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
@@ -86,7 +86,7 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
             new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
             threadPool
         );
-        remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(Settings.EMPTY);
+        remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(clusterService, Settings.EMPTY);
         remoteStorePressureService = new RemoteStorePressureService(clusterService, Settings.EMPTY, remoteStoreStatsTrackerFactory);
         remoteStoreStatsTrackerFactory.afterIndexShardCreated(indexShard);
         RemoteSegmentTransferTracker tracker = remoteStoreStatsTrackerFactory.getRemoteSegmentTransferTracker(indexShard.shardId());
@@ -543,8 +543,8 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
             new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
             threadPool
         );
-        remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(Settings.EMPTY);
-        RemoteStoreStatsTrackerFactory remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(Settings.EMPTY);
+        remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(clusterService, Settings.EMPTY);
+        RemoteStoreStatsTrackerFactory remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(clusterService, Settings.EMPTY);
         when(shard.indexSettings()).thenReturn(indexShard.indexSettings());
         when(shard.shardId()).thenReturn(indexShard.shardId());
         remoteStoreStatsTrackerFactory.afterIndexShardCreated(shard);

--- a/server/src/test/java/org/opensearch/indices/cluster/AbstractIndicesClusterStateServiceTestCase.java
+++ b/server/src/test/java/org/opensearch/indices/cluster/AbstractIndicesClusterStateServiceTestCase.java
@@ -46,7 +46,7 @@ import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.IndexSettings;
-import org.opensearch.index.remote.RemoteStorePressureService;
+import org.opensearch.index.remote.RemoteStoreStatsTrackerFactory;
 import org.opensearch.index.seqno.RetentionLeaseSyncer;
 import org.opensearch.index.shard.IndexEventListener;
 import org.opensearch.index.shard.IndexShard;
@@ -264,7 +264,7 @@ public abstract class AbstractIndicesClusterStateServiceTestCase extends OpenSea
             final RetentionLeaseSyncer retentionLeaseSyncer,
             final DiscoveryNode targetNode,
             final DiscoveryNode sourceNode,
-            final RemoteStorePressureService remoteStorePressureService
+            final RemoteStoreStatsTrackerFactory remoteStoreStatsTrackerFactory
         ) throws IOException {
             failRandomly();
             RecoveryState recoveryState = new RecoveryState(shardRouting, targetNode, sourceNode);

--- a/server/src/test/java/org/opensearch/indices/cluster/IndicesClusterStateServiceRandomUpdatesTests.java
+++ b/server/src/test/java/org/opensearch/indices/cluster/IndicesClusterStateServiceRandomUpdatesTests.java
@@ -582,6 +582,7 @@ public class IndicesClusterStateServiceRandomUpdatesTests extends AbstractIndice
             primaryReplicaSyncer,
             s -> {},
             RetentionLeaseSyncer.EMPTY,
+            null,
             null
         );
     }

--- a/server/src/test/java/org/opensearch/indices/cluster/IndicesClusterStateServiceRandomUpdatesTests.java
+++ b/server/src/test/java/org/opensearch/indices/cluster/IndicesClusterStateServiceRandomUpdatesTests.java
@@ -582,7 +582,6 @@ public class IndicesClusterStateServiceRandomUpdatesTests extends AbstractIndice
             primaryReplicaSyncer,
             s -> {},
             RetentionLeaseSyncer.EMPTY,
-            null,
             null
         );
     }

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -2127,7 +2127,6 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                     ),
                     RetentionLeaseSyncer.EMPTY,
                     SegmentReplicationCheckpointPublisher.EMPTY,
-                    mock(RemoteStorePressureService.class),
                     mock(RemoteStoreStatsTrackerFactory.class)
                 );
 

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -178,6 +178,7 @@ import org.opensearch.index.IndexingPressureService;
 import org.opensearch.index.SegmentReplicationPressureService;
 import org.opensearch.index.analysis.AnalysisRegistry;
 import org.opensearch.index.remote.RemoteStorePressureService;
+import org.opensearch.index.remote.RemoteStoreStatsTrackerFactory;
 import org.opensearch.index.seqno.GlobalCheckpointSyncAction;
 import org.opensearch.index.seqno.RetentionLeaseSyncer;
 import org.opensearch.index.shard.PrimaryReplicaSyncer;
@@ -2126,7 +2127,8 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                     ),
                     RetentionLeaseSyncer.EMPTY,
                     SegmentReplicationCheckpointPublisher.EMPTY,
-                    mock(RemoteStorePressureService.class)
+                    mock(RemoteStorePressureService.class),
+                    mock(RemoteStoreStatsTrackerFactory.class)
                 );
 
                 final SystemIndices systemIndices = new SystemIndices(emptyMap());

--- a/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
@@ -97,7 +97,6 @@ import org.opensearch.index.engine.InternalEngineFactory;
 import org.opensearch.index.engine.NRTReplicationEngineFactory;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.SourceToParse;
-import org.opensearch.index.remote.RemoteStorePressureService;
 import org.opensearch.index.remote.RemoteStoreStatsTrackerFactory;
 import org.opensearch.index.replication.TestReplicationSource;
 import org.opensearch.index.seqno.ReplicationTracker;
@@ -641,7 +640,6 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
                 clusterSettings
             );
             Store remoteStore = null;
-            RemoteStorePressureService remoteStorePressureService = null;
             RemoteStoreStatsTrackerFactory remoteStoreStatsTrackerFactory = null;
             RepositoriesService mockRepoSvc = mock(RepositoriesService.class);
 
@@ -658,11 +656,6 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
                 remoteStore = createRemoteStore(remotePath, routing, indexMetadata);
 
                 remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(indexSettings.getSettings());
-                remoteStorePressureService = new RemoteStorePressureService(
-                    clusterService,
-                    indexSettings.getSettings(),
-                    remoteStoreStatsTrackerFactory
-                );
                 BlobStoreRepository repo = createRepository(remotePath);
                 when(mockRepoSvc.repository(any())).thenAnswer(invocationOnMock -> repo);
             }
@@ -702,7 +695,7 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
                 translogFactorySupplier,
                 checkpointPublisher,
                 remoteStore,
-                remoteStorePressureService
+                remoteStoreStatsTrackerFactory
             );
             indexShard.addShardFailureCallback(DEFAULT_SHARD_FAILURE_HANDLER);
             if (remoteStoreStatsTrackerFactory != null) {

--- a/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
@@ -655,7 +655,7 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
 
                 remoteStore = createRemoteStore(remotePath, routing, indexMetadata);
 
-                remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(indexSettings.getSettings());
+                remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(clusterService, indexSettings.getSettings());
                 BlobStoreRepository repo = createRepository(remotePath);
                 when(mockRepoSvc.repository(any())).thenAnswer(invocationOnMock -> repo);
             }


### PR DESCRIPTION
### Description

1. Currently, `RemoteSegmentTransferTracker` is strongly coupled with `RemoteStorePressureService`. `RemoteStorePressureService` is the provider of the trackers while it should just be consuming it. This PR decouples `RemoteSegmentTransferTracker` from `RemoteStorePressureService` by introducing the concept of a factory that manages the stats trackers.
2. Currently, `RemoteSegmentTransferTracker` allows setting a different moving average window size for upload bytes, upload speed, and upload time. These don't add much value and would rather deteriorate the user experience. We change these to apply a single window size for moving average stat calculations.

### Related Issues
#8311

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
