### PR TITLE
Added performance improvement for datetime field parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Change http code on create index API with bad input raising NotXContentException from 500 to 400 ([#4773](https://github.com/opensearch-project/OpenSearch/pull/4773))
 - Improve summary error message for invalid setting updates ([#4792](https://github.com/opensearch-project/OpenSearch/pull/4792))
 - Return 409 Conflict HTTP status instead of 503 on failure to concurrently execute snapshots ([#8986](https://github.com/opensearch-project/OpenSearch/pull/5855))
+- Performance improvement for Datetime field caching ([#4558](https://github.com/opensearch-project/OpenSearch/issues/4558))
 
 ### Deprecated
 

--- a/distribution/src/config/opensearch.yml
+++ b/distribution/src/config/opensearch.yml
@@ -121,3 +121,9 @@ ${path.logs}
 # index searcher threadpool.
 #
 #opensearch.experimental.feature.concurrent_segment_search.enabled: false
+#
+#
+# Gates the optimization of datetime formatters caching along with change in default datetime formatter
+# Once there is no observed impact on performance, this feature flag can be removed.
+#
+#opensearch.experimental.optimization.datetime_formatter_caching.enabled: true

--- a/distribution/src/config/opensearch.yml
+++ b/distribution/src/config/opensearch.yml
@@ -126,4 +126,4 @@ ${path.logs}
 # Gates the optimization of datetime formatters caching along with change in default datetime formatter
 # Once there is no observed impact on performance, this feature flag can be removed.
 #
-#opensearch.experimental.optimization.datetime_formatter_caching.enabled: true
+#opensearch.experimental.optimization.datetime_formatter_caching.enabled: false

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DateHistogramIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DateHistogramIT.java
@@ -124,7 +124,7 @@ public class DateHistogramIT extends ParameterizedOpenSearchIntegTestCase {
     }
 
     private ZonedDateTime date(String date) {
-        return DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(date));
+        return DateFormatters.from(DateFieldMapper.getDefaultDateTimeFormatter().parse(date));
     }
 
     private static String format(ZonedDateTime date, String pattern) {
@@ -1624,8 +1624,8 @@ public class DateHistogramIT extends ParameterizedOpenSearchIntegTestCase {
                 .setSettings(Settings.builder().put("requests.cache.enable", true).put("number_of_shards", 1).put("number_of_replicas", 1))
                 .get()
         );
-        String date = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.format(date(1, 1));
-        String date2 = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.format(date(2, 1));
+        String date = DateFieldMapper.getDefaultDateTimeFormatter().format(date(1, 1));
+        String date2 = DateFieldMapper.getDefaultDateTimeFormatter().format(date(2, 1));
         indexRandom(
             true,
             client().prepareIndex("cache_test_idx").setId("1").setSource("d", date),

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DateHistogramOffsetIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DateHistogramOffsetIT.java
@@ -92,7 +92,7 @@ public class DateHistogramOffsetIT extends ParameterizedOpenSearchIntegTestCase 
     }
 
     private ZonedDateTime date(String date) {
-        return DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(date));
+        return DateFormatters.from(DateFieldMapper.getDefaultDateTimeFormatter().parse(date));
     }
 
     @Before

--- a/server/src/main/java/org/opensearch/common/joda/JodaDateFormatter.java
+++ b/server/src/main/java/org/opensearch/common/joda/JodaDateFormatter.java
@@ -126,6 +126,11 @@ public class JodaDateFormatter implements DateFormatter {
     }
 
     @Override
+    public String printPattern() {
+        throw new UnsupportedOperationException("JodaDateFormatter does not have a print pattern");
+    }
+
+    @Override
     public Locale locale() {
         return printer.getLocale();
     }

--- a/server/src/main/java/org/opensearch/common/settings/FeatureFlagSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/FeatureFlagSettings.java
@@ -39,7 +39,8 @@ public class FeatureFlagSettings extends AbstractScopedSettings {
                 FeatureFlags.EXTENSIONS_SETTING,
                 FeatureFlags.IDENTITY_SETTING,
                 FeatureFlags.CONCURRENT_SEGMENT_SEARCH_SETTING,
-                FeatureFlags.TELEMETRY_SETTING
+                FeatureFlags.TELEMETRY_SETTING,
+                FeatureFlags.DATETIME_FORMATTER_CACHING_SETTING
             )
         )
     );

--- a/server/src/main/java/org/opensearch/common/time/DateFormatter.java
+++ b/server/src/main/java/org/opensearch/common/time/DateFormatter.java
@@ -127,6 +127,14 @@ public interface DateFormatter {
     String pattern();
 
     /**
+     * A name based format for this formatter. Can be one of the registered formatters like <code>epoch_millis</code> or
+     * a configured format like <code>HH:mm:ss</code>
+     *
+     * @return The name of this formatter
+     */
+    String printPattern();
+
+    /**
      * Returns the configured locale of the date formatter
      *
      * @return The locale of this formatter
@@ -147,7 +155,7 @@ public interface DateFormatter {
      */
     DateMathParser toDateMathParser();
 
-    static DateFormatter forPattern(String input) {
+    static DateFormatter forPattern(String input, String printPattern, Boolean canCacheFormatter) {
 
         if (Strings.hasLength(input) == false) {
             throw new IllegalArgumentException("No date pattern provided");
@@ -158,7 +166,28 @@ public interface DateFormatter {
         List<String> patterns = splitCombinedPatterns(format);
         List<DateFormatter> formatters = patterns.stream().map(DateFormatters::forPattern).collect(Collectors.toList());
 
-        return JavaDateFormatter.combined(input, formatters);
+        DateFormatter printFormatter = formatters.get(0);
+        if (Strings.hasLength(printPattern)) {
+            String printFormat = strip8Prefix(printPattern);
+            try {
+                printFormatter = DateFormatters.forPattern(printFormat);
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("Invalid print format: " + e.getMessage(), e);
+            }
+        }
+        return JavaDateFormatter.combined(input, formatters, printFormatter, canCacheFormatter);
+    }
+
+    static DateFormatter forPattern(String input) {
+        return forPattern(input, null, false);
+    }
+
+    static DateFormatter forPattern(String input, String printPattern) {
+        return forPattern(input, printPattern, false);
+    }
+
+    static DateFormatter forPattern(String input, Boolean canCacheFormatter) {
+        return forPattern(input, null, canCacheFormatter);
     }
 
     static String strip8Prefix(String input) {

--- a/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
+++ b/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
@@ -56,6 +56,11 @@ public class FeatureFlags {
     public static final String TELEMETRY = "opensearch.experimental.feature.telemetry.enabled";
 
     /**
+     * Gates the optimization of datetime formatters caching along with change in default datetime formatter.
+     */
+    public static final String DATETIME_FORMATTER_CACHING = "opensearch.experimental.optimization.datetime_formatter_caching.enabled";
+
+    /**
      * Should store the settings from opensearch.yml.
      */
     private static Settings settings;
@@ -98,6 +103,12 @@ public class FeatureFlags {
     public static final Setting<Boolean> CONCURRENT_SEGMENT_SEARCH_SETTING = Setting.boolSetting(
         CONCURRENT_SEGMENT_SEARCH,
         false,
+        Property.NodeScope
+    );
+
+    public static final Setting<Boolean> DATETIME_FORMATTER_CACHING_SETTING = Setting.boolSetting(
+        DATETIME_FORMATTER_CACHING,
+        true,
         Property.NodeScope
     );
 }

--- a/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
+++ b/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
@@ -88,6 +88,17 @@ public class FeatureFlags {
         return settings != null && settings.getAsBoolean(featureFlagName, false);
     }
 
+    public static boolean isEnabled(Setting<Boolean> featureFlag) {
+        if ("true".equalsIgnoreCase(System.getProperty(featureFlag.getKey()))) {
+            // TODO: Remove the if condition once FeatureFlags are only supported via opensearch.yml
+            return true;
+        } else if (settings != null) {
+            return featureFlag.get(settings);
+        } else {
+            return featureFlag.getDefault(Settings.EMPTY);
+        }
+    }
+
     public static final Setting<Boolean> SEGMENT_REPLICATION_EXPERIMENTAL_SETTING = Setting.boolSetting(
         SEGMENT_REPLICATION_EXPERIMENTAL,
         false,

--- a/server/src/main/java/org/opensearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DateFieldMapper.java
@@ -52,6 +52,7 @@ import org.opensearch.common.time.DateFormatters;
 import org.opensearch.common.time.DateMathParser;
 import org.opensearch.common.time.DateUtils;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.common.util.LocaleUtils;
 import org.opensearch.index.fielddata.IndexFieldData;
 import org.opensearch.index.fielddata.IndexNumericFieldData.NumericType;
@@ -100,6 +101,12 @@ public final class DateFieldMapper extends ParametrizedFieldMapper {
         "strict_date_time_no_millis||strict_date_optional_time||epoch_millis",
         "strict_date_optional_time"
     );
+
+    public static DateFormatter getDefaultDateTimeFormatter() {
+        return FeatureFlags.isEnabled(FeatureFlags.DATETIME_FORMATTER_CACHING_SETTING)
+            ? DEFAULT_DATE_TIME_FORMATTER
+            : LEGACY_DEFAULT_DATE_TIME_FORMATTER;
+    }
 
     /**
      * Resolution of the date time
@@ -231,13 +238,13 @@ public final class DateFieldMapper extends ParametrizedFieldMapper {
             "format",
             false,
             m -> toType(m).format,
-            DEFAULT_DATE_TIME_FORMATTER.pattern()
+            getDefaultDateTimeFormatter().pattern()
         );
         private final Parameter<String> printFormat = Parameter.stringParam(
             "print_format",
             false,
             m -> toType(m).printFormat,
-            DEFAULT_DATE_TIME_FORMATTER.printPattern()
+            getDefaultDateTimeFormatter().printPattern()
         ).acceptsNull();
         private final Parameter<Locale> locale = new Parameter<>(
             "locale",
@@ -365,7 +372,7 @@ public final class DateFieldMapper extends ParametrizedFieldMapper {
         }
 
         public DateFieldType(String name) {
-            this(name, true, false, true, DEFAULT_DATE_TIME_FORMATTER, Resolution.MILLISECONDS, null, Collections.emptyMap());
+            this(name, true, false, true, getDefaultDateTimeFormatter(), Resolution.MILLISECONDS, null, Collections.emptyMap());
         }
 
         public DateFieldType(String name, DateFormatter dateFormatter) {
@@ -373,7 +380,7 @@ public final class DateFieldMapper extends ParametrizedFieldMapper {
         }
 
         public DateFieldType(String name, Resolution resolution) {
-            this(name, true, false, true, DEFAULT_DATE_TIME_FORMATTER, resolution, null, Collections.emptyMap());
+            this(name, true, false, true, getDefaultDateTimeFormatter(), resolution, null, Collections.emptyMap());
         }
 
         public DateFieldType(String name, Resolution resolution, DateFormatter dateFormatter) {

--- a/server/src/main/java/org/opensearch/index/mapper/RangeFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/RangeFieldMapper.java
@@ -95,7 +95,7 @@ public class RangeFieldMapper extends ParametrizedFieldMapper {
      */
     public static class Defaults {
         public static final Explicit<Boolean> COERCE = new Explicit<>(true, false);
-        public static final DateFormatter DATE_FORMATTER = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER;
+        public static final DateFormatter DATE_FORMATTER = DateFieldMapper.getDefaultDateTimeFormatter();
     }
 
     // this is private since it has a different default

--- a/server/src/main/java/org/opensearch/index/mapper/RangeType.java
+++ b/server/src/main/java/org/opensearch/index/mapper/RangeType.java
@@ -313,7 +313,7 @@ public enum RangeType {
         ) {
             ZoneId zone = (timeZone == null) ? ZoneOffset.UTC : timeZone;
 
-            DateMathParser dateMathParser = (parser == null) ? DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.toDateMathParser() : parser;
+            DateMathParser dateMathParser = (parser == null) ? DateFieldMapper.getDefaultDateTimeFormatter().toDateMathParser() : parser;
             boolean roundUp = includeLower == false; // using "gt" should round lower bound up
             Long low = lowerTerm == null
                 ? minValue()

--- a/server/src/main/java/org/opensearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/RootObjectMapper.java
@@ -72,7 +72,7 @@ public class RootObjectMapper extends ObjectMapper {
      */
     public static class Defaults {
         public static final DateFormatter[] DYNAMIC_DATE_TIME_FORMATTERS = new DateFormatter[] {
-            DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER,
+            DateFieldMapper.getDefaultDateTimeFormatter(),
             DateFormatter.forPattern("yyyy/MM/dd HH:mm:ss||yyyy/MM/dd||epoch_millis") };
         public static final boolean DATE_DETECTION = true;
         public static final boolean NUMERIC_DETECTION = false;

--- a/server/src/main/java/org/opensearch/script/ScoreScriptUtils.java
+++ b/server/src/main/java/org/opensearch/script/ScoreScriptUtils.java
@@ -343,11 +343,14 @@ public final class ScoreScriptUtils {
     /**
      * Limitations: since script functions don't have access to DateFieldMapper,
      * decay functions on dates are limited to dates in the default format and default time zone,
+     * Further, since script module gets initialized before the featureflags are loaded,
+     * we cannot use the feature flag to gate the usage of the new default date format.
      * Also, using calculations with <code>now</code> are not allowed.
      *
      */
     private static final ZoneId defaultZoneId = ZoneId.of("UTC");
-    private static final DateMathParser dateParser = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.toDateMathParser();
+    // ToDo: use new default date formatter once feature flag is removed
+    private static final DateMathParser dateParser = DateFieldMapper.LEGACY_DEFAULT_DATE_TIME_FORMATTER.toDateMathParser();
 
     /**
      * Linear date decay

--- a/server/src/main/java/org/opensearch/search/DocValueFormat.java
+++ b/server/src/main/java/org/opensearch/search/DocValueFormat.java
@@ -243,7 +243,12 @@ public interface DocValueFormat extends NamedWriteable {
         }
 
         public DateTime(StreamInput in) throws IOException {
-            this.formatter = DateFormatter.forPattern(in.readString());
+            if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+                this.formatter = DateFormatter.forPattern(in.readString(), in.readOptionalString());
+            } else {
+                this.formatter = DateFormatter.forPattern(in.readString());
+            }
+
             this.parser = formatter.toDateMathParser();
             String zoneId = in.readString();
             this.timeZone = ZoneId.of(zoneId);
@@ -260,7 +265,14 @@ public interface DocValueFormat extends NamedWriteable {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeString(formatter.pattern());
+            if (out.getVersion().before(Version.V_3_0_0) && formatter.equals(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER)) {
+                out.writeString(DateFieldMapper.LEGACY_DEFAULT_DATE_TIME_FORMATTER.pattern()); // required for backwards compatibility
+            } else {
+                out.writeString(formatter.pattern());
+            }
+            if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+                out.writeOptionalString(formatter.printPattern());
+            }
             out.writeString(timeZone.getId());
             out.writeVInt(resolution.ordinal());
             if (out.getVersion().before(Version.V_3_0_0)) {

--- a/server/src/main/java/org/opensearch/search/aggregations/support/CoreValuesSourceType.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/support/CoreValuesSourceType.java
@@ -411,7 +411,7 @@ public enum CoreValuesSourceType implements ValuesSourceType {
         @Override
         public DocValueFormat getFormatter(String format, ZoneId tz) {
             return new DocValueFormat.DateTime(
-                format == null ? DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER : DateFormatter.forPattern(format),
+                format == null ? DateFieldMapper.getDefaultDateTimeFormatter() : DateFormatter.forPattern(format),
                 tz == null ? ZoneOffset.UTC : tz,
                 // If we were just looking at fields, we could read the resolution from the field settings, but we need to deal with script
                 // output, which has no way to indicate the resolution, so we need to default to something. Milliseconds is the standard.

--- a/server/src/main/java/org/opensearch/search/aggregations/support/ValueType.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/support/ValueType.java
@@ -61,7 +61,7 @@ public enum ValueType implements Writeable {
         "date",
         "date",
         CoreValuesSourceType.DATE,
-        new DocValueFormat.DateTime(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER, ZoneOffset.UTC, DateFieldMapper.Resolution.MILLISECONDS)
+        new DocValueFormat.DateTime(DateFieldMapper.getDefaultDateTimeFormatter(), ZoneOffset.UTC, DateFieldMapper.Resolution.MILLISECONDS)
     ),
     IP((byte) 6, "ip", "ip", CoreValuesSourceType.IP, DocValueFormat.IP),
     // TODO: what is the difference between "number" and "numeric"?

--- a/server/src/test/java/org/opensearch/action/search/BottomSortValuesCollectorTests.java
+++ b/server/src/test/java/org/opensearch/action/search/BottomSortValuesCollectorTests.java
@@ -46,7 +46,6 @@ import org.opensearch.test.OpenSearchTestCase;
 import java.time.ZoneId;
 import java.util.Arrays;
 
-import static org.opensearch.index.mapper.DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.apache.lucene.search.TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO;
@@ -136,7 +135,11 @@ public class BottomSortValuesCollectorTests extends OpenSearchTestCase {
         for (boolean reverse : new boolean[] { true, false }) {
             SortField[] sortFields = new SortField[] { new SortField("foo", SortField.Type.LONG, reverse) };
             DocValueFormat[] sortFormats = new DocValueFormat[] {
-                new DocValueFormat.DateTime(DEFAULT_DATE_TIME_FORMATTER, ZoneId.of("UTC"), DateFieldMapper.Resolution.MILLISECONDS) };
+                new DocValueFormat.DateTime(
+                    DateFieldMapper.getDefaultDateTimeFormatter(),
+                    ZoneId.of("UTC"),
+                    DateFieldMapper.Resolution.MILLISECONDS
+                ) };
             BottomSortValuesCollector collector = new BottomSortValuesCollector(3, sortFields);
             collector.consumeTopDocs(
                 createTopDocs(sortFields[0], 100, newDateArray("2017-06-01T12:18:20Z", "2018-04-03T15:10:27Z", "2013-06-01T13:10:20Z")),
@@ -170,7 +173,11 @@ public class BottomSortValuesCollectorTests extends OpenSearchTestCase {
         for (boolean reverse : new boolean[] { true, false }) {
             SortField[] sortFields = new SortField[] { new SortField("foo", SortField.Type.LONG, reverse) };
             DocValueFormat[] sortFormats = new DocValueFormat[] {
-                new DocValueFormat.DateTime(DEFAULT_DATE_TIME_FORMATTER, ZoneId.of("UTC"), DateFieldMapper.Resolution.NANOSECONDS) };
+                new DocValueFormat.DateTime(
+                    DateFieldMapper.getDefaultDateTimeFormatter(),
+                    ZoneId.of("UTC"),
+                    DateFieldMapper.Resolution.NANOSECONDS
+                ) };
             BottomSortValuesCollector collector = new BottomSortValuesCollector(3, sortFields);
             collector.consumeTopDocs(
                 createTopDocs(sortFields[0], 100, newDateNanoArray("2017-06-01T12:18:20Z", "2018-04-03T15:10:27Z", "2013-06-01T13:10:20Z")),
@@ -242,7 +249,7 @@ public class BottomSortValuesCollectorTests extends OpenSearchTestCase {
     private Object[] newDateArray(String... values) {
         Long[] longs = new Long[values.length];
         for (int i = 0; i < values.length; i++) {
-            longs[i] = DEFAULT_DATE_TIME_FORMATTER.parseMillis(values[i]);
+            longs[i] = DateFieldMapper.getDefaultDateTimeFormatter().parseMillis(values[i]);
         }
         return longs;
     }
@@ -250,7 +257,7 @@ public class BottomSortValuesCollectorTests extends OpenSearchTestCase {
     private Object[] newDateNanoArray(String... values) {
         Long[] longs = new Long[values.length];
         for (int i = 0; i < values.length; i++) {
-            longs[i] = DateUtils.toNanoSeconds(DEFAULT_DATE_TIME_FORMATTER.parseMillis(values[i]));
+            longs[i] = DateUtils.toNanoSeconds(DateFieldMapper.getDefaultDateTimeFormatter().parseMillis(values[i]));
         }
         return longs;
     }

--- a/server/src/test/java/org/opensearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/DateFieldMapperTests.java
@@ -66,6 +66,7 @@ public class DateFieldMapperTests extends MapperTestCase {
         checker.registerConflictCheck("index", b -> b.field("index", false));
         checker.registerConflictCheck("store", b -> b.field("store", true));
         checker.registerConflictCheck("format", b -> b.field("format", "yyyy-MM-dd"));
+        checker.registerConflictCheck("print_format", b -> b.field("print_format", "yyyy-MM-dd"));
         checker.registerConflictCheck("locale", b -> b.field("locale", "es"));
         checker.registerConflictCheck("null_value", b -> b.field("null_value", "34500000"));
         checker.registerUpdateCheck(b -> b.field("ignore_malformed", true), m -> assertTrue(((DateFieldMapper) m).getIgnoreMalformed()));
@@ -148,7 +149,7 @@ public class DateFieldMapperTests extends MapperTestCase {
     public void testIgnoreMalformed() throws IOException {
         testIgnoreMalformedForValue(
             "2016-03-99",
-            "failed to parse date field [2016-03-99] with format [strict_date_optional_time||epoch_millis]"
+            "failed to parse date field [2016-03-99] with format [strict_date_time_no_millis||strict_date_optional_time||epoch_millis]"
         );
         testIgnoreMalformedForValue("-2147483648", "Invalid value for Year (valid values -999999999 - 999999999): -2147483648");
         testIgnoreMalformedForValue("-522000000", "long overflow");

--- a/server/src/test/java/org/opensearch/index/mapper/DateFieldTypeTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/DateFieldTypeTests.java
@@ -107,7 +107,7 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
         w.addDocument(doc);
         DirectoryReader reader = DirectoryReader.open(w);
 
-        DateMathParser alternateFormat = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.toDateMathParser();
+        DateMathParser alternateFormat = DateFieldMapper.getDefaultDateTimeFormatter().toDateMathParser();
         doTestIsFieldWithinQuery(ft, reader, null, null);
         doTestIsFieldWithinQuery(ft, reader, null, alternateFormat);
         doTestIsFieldWithinQuery(ft, reader, DateTimeZone.UTC, null);
@@ -158,7 +158,7 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
 
     public void testValueFormat() {
         MappedFieldType ft = new DateFieldType("field");
-        long instant = DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse("2015-10-12T14:10:55"))
+        long instant = DateFormatters.from(DateFieldMapper.getDefaultDateTimeFormatter().parse("2015-10-12T14:10:55"))
             .toInstant()
             .toEpochMilli();
 
@@ -167,14 +167,14 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
         assertEquals("2015", new DateFieldType("field").docValueFormat("YYYY", ZoneOffset.UTC).format(instant));
         assertEquals(instant, ft.docValueFormat(null, ZoneOffset.UTC).parseLong("2015-10-12T14:10:55", false, null));
         assertEquals(instant + 999, ft.docValueFormat(null, ZoneOffset.UTC).parseLong("2015-10-12T14:10:55", true, null));
-        long i = DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse("2015-10-13")).toInstant().toEpochMilli();
+        long i = DateFormatters.from(DateFieldMapper.getDefaultDateTimeFormatter().parse("2015-10-13")).toInstant().toEpochMilli();
         assertEquals(i - 1, ft.docValueFormat(null, ZoneOffset.UTC).parseLong("2015-10-12||/d", true, null));
     }
 
     public void testValueForSearch() {
         MappedFieldType ft = new DateFieldType("field");
         String date = "2015-10-12T12:09:55.000Z";
-        long instant = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseMillis(date);
+        long instant = DateFieldMapper.getDefaultDateTimeFormatter().parseMillis(date);
         assertEquals(date, ft.valueForDisplay(instant));
     }
 
@@ -205,7 +205,7 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
         );
         MappedFieldType ft = new DateFieldType("field");
         String date = "2015-10-12T14:10:55";
-        long instant = DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(date)).toInstant().toEpochMilli();
+        long instant = DateFormatters.from(DateFieldMapper.getDefaultDateTimeFormatter().parse(date)).toInstant().toEpochMilli();
         Query expected = new IndexOrDocValuesQuery(
             LongPoint.newRangeQuery("field", instant, instant + 999),
             SortedNumericDocValuesField.newSlowRangeQuery("field", instant, instant + 999)
@@ -217,7 +217,7 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
             false,
             false,
             true,
-            DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER,
+            DateFieldMapper.getDefaultDateTimeFormatter(),
             Resolution.MILLISECONDS,
             null,
             Collections.emptyMap()
@@ -254,8 +254,8 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
         MappedFieldType ft = new DateFieldType("field");
         String date1 = "2015-10-12T14:10:55";
         String date2 = "2016-04-28T11:33:52";
-        long instant1 = DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(date1)).toInstant().toEpochMilli();
-        long instant2 = DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(date2)).toInstant().toEpochMilli() + 999;
+        long instant1 = DateFormatters.from(DateFieldMapper.getDefaultDateTimeFormatter().parse(date1)).toInstant().toEpochMilli();
+        long instant2 = DateFormatters.from(DateFieldMapper.getDefaultDateTimeFormatter().parse(date2)).toInstant().toEpochMilli() + 999;
         Query expected = new IndexOrDocValuesQuery(
             LongPoint.newRangeQuery("field", instant1, instant2),
             SortedNumericDocValuesField.newSlowRangeQuery("field", instant1, instant2)
@@ -280,7 +280,7 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
             false,
             false,
             true,
-            DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER,
+            DateFieldMapper.getDefaultDateTimeFormatter(),
             Resolution.MILLISECONDS,
             null,
             Collections.emptyMap()
@@ -326,8 +326,8 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
         MappedFieldType ft = new DateFieldType("field");
         String date1 = "2015-10-12T14:10:55";
         String date2 = "2016-04-28T11:33:52";
-        long instant1 = DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(date1)).toInstant().toEpochMilli();
-        long instant2 = DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(date2)).toInstant().toEpochMilli() + 999;
+        long instant1 = DateFormatters.from(DateFieldMapper.getDefaultDateTimeFormatter().parse(date1)).toInstant().toEpochMilli();
+        long instant2 = DateFormatters.from(DateFieldMapper.getDefaultDateTimeFormatter().parse(date2)).toInstant().toEpochMilli() + 999;
 
         Query pointQuery = LongPoint.newRangeQuery("field", instant1, instant2);
         Query dvQuery = SortedNumericDocValuesField.newSlowRangeQuery("field", instant1, instant2);

--- a/server/src/test/java/org/opensearch/index/mapper/RangeFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/RangeFieldMapperTests.java
@@ -361,7 +361,12 @@ public class RangeFieldMapperTests extends AbstractNumericFieldMapperTestCase {
 
             // if type is date_range we check that the mapper contains the default format and locale
             // otherwise it should not contain a locale or format
-            assertTrue(got, got.contains("\"format\":\"strict_date_optional_time||epoch_millis\"") == type.equals("date_range"));
+            assertTrue(
+                got,
+                got.contains("\"format\":\"strict_date_time_no_millis||strict_date_optional_time||epoch_millis\"") == type.equals(
+                    "date_range"
+                )
+            );
             assertTrue(got, got.contains("\"locale\":" + "\"" + Locale.ROOT + "\"") == type.equals("date_range"));
         }
     }

--- a/server/src/test/java/org/opensearch/index/mapper/RangeFieldTypeTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/RangeFieldTypeTests.java
@@ -265,7 +265,9 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
         );
         assertThat(
             ex.getMessage(),
-            containsString("failed to parse date field [2016-15-06T15:29:50+08:00] with format [strict_date_optional_time||epoch_millis]")
+            containsString(
+                "failed to parse date field [2016-15-06T15:29:50+08:00] with format [strict_date_time_no_millis||strict_date_optional_time||epoch_millis]"
+            )
         );
 
         // setting mapping format which is compatible with those dates

--- a/server/src/test/java/org/opensearch/index/query/RangeQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/RangeQueryBuilderTests.java
@@ -87,8 +87,8 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
                 ZonedDateTime start = now.minusMillis(randomIntBetween(0, 1000000)).atZone(ZoneOffset.UTC);
                 ZonedDateTime end = now.plusMillis(randomIntBetween(0, 1000000)).atZone(ZoneOffset.UTC);
                 query = new RangeQueryBuilder(randomFrom(DATE_FIELD_NAME, DATE_RANGE_FIELD_NAME, DATE_ALIAS_FIELD_NAME));
-                query.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.format(start));
-                query.to(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.format(end));
+                query.from(DateFieldMapper.getDefaultDateTimeFormatter().format(start));
+                query.to(DateFieldMapper.getDefaultDateTimeFormatter().format(end));
                 // Create timestamp option only then we have a date mapper,
                 // otherwise we could trigger exception.
                 if (createShardContext().getMapperService().fieldType(DATE_FIELD_NAME) != null) {

--- a/server/src/test/java/org/opensearch/search/aggregations/AggregatorBaseTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/AggregatorBaseTests.java
@@ -135,7 +135,7 @@ public class AggregatorBaseTests extends OpenSearchSingleNodeTestCase {
             indexed,
             false,
             true,
-            DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER,
+            DateFieldMapper.getDefaultDateTimeFormatter(),
             resolution,
             null,
             Collections.emptyMap()
@@ -184,7 +184,7 @@ public class AggregatorBaseTests extends OpenSearchSingleNodeTestCase {
                 assertNull(pointReaderShim(mockSearchContext(null), null, getVSConfig("number", resolution, false, context)));
             }
             // Check that we decode a dates "just like" the doc values instance.
-            Instant expected = Instant.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse("2020-01-01T00:00:00Z"));
+            Instant expected = Instant.from(DateFieldMapper.getDefaultDateTimeFormatter().parse("2020-01-01T00:00:00Z"));
             byte[] scratch = new byte[8];
             LongPoint.encodeDimension(DateFieldMapper.Resolution.MILLISECONDS.convert(expected), scratch, 0);
             assertThat(

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTestCase.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTestCase.java
@@ -125,7 +125,7 @@ public abstract class DateHistogramAggregatorTestCase extends AggregatorTestCase
             isSearchable,
             false,
             true,
-            DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER,
+            DateFieldMapper.getDefaultDateTimeFormatter(),
             useNanosecondResolution ? DateFieldMapper.Resolution.NANOSECONDS : DateFieldMapper.Resolution.MILLISECONDS,
             null,
             Collections.emptyMap()

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTests.java
@@ -1245,7 +1245,7 @@ public class DateHistogramAggregatorTests extends DateHistogramAggregatorTestCas
     }
 
     private static long asLong(String dateTime) {
-        return DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(dateTime)).toInstant().toEpochMilli();
+        return DateFormatters.from(DateFieldMapper.getDefaultDateTimeFormatter().parse(dateTime)).toInstant().toEpochMilli();
     }
 
     private static long asLong(String dateTime, DateFieldMapper.DateFieldType fieldType) {

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/histogram/DateRangeHistogramAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/histogram/DateRangeHistogramAggregatorTests.java
@@ -1086,7 +1086,7 @@ public class DateRangeHistogramAggregatorTests extends AggregatorTestCase {
     }
 
     private static long asLong(String dateTime) {
-        return DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(dateTime)).toInstant().toEpochMilli();
+        return DateFormatters.from(DateFieldMapper.getDefaultDateTimeFormatter().parse(dateTime)).toInstant().toEpochMilli();
     }
 
     private static ZonedDateTime asZDT(String dateTime) {

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/range/DateRangeAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/range/DateRangeAggregatorTests.java
@@ -273,7 +273,7 @@ public class DateRangeAggregatorTests extends AggregatorTestCase {
             true,
             false,
             true,
-            DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER,
+            DateFieldMapper.getDefaultDateTimeFormatter(),
             resolution,
             null,
             Collections.emptyMap()

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/range/RangeAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/range/RangeAggregatorTests.java
@@ -136,7 +136,7 @@ public class RangeAggregatorTests extends AggregatorTestCase {
             true,
             false,
             true,
-            DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER,
+            DateFieldMapper.getDefaultDateTimeFormatter(),
             DateFieldMapper.Resolution.NANOSECONDS,
             null,
             Collections.emptyMap()
@@ -167,7 +167,7 @@ public class RangeAggregatorTests extends AggregatorTestCase {
             true,
             false,
             true,
-            DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER,
+            DateFieldMapper.getDefaultDateTimeFormatter(),
             DateFieldMapper.Resolution.NANOSECONDS,
             null,
             Collections.emptyMap()

--- a/server/src/test/java/org/opensearch/search/aggregations/pipeline/AvgBucketAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/pipeline/AvgBucketAggregatorTests.java
@@ -144,6 +144,6 @@ public class AvgBucketAggregatorTests extends AggregatorTestCase {
     }
 
     private static long asLong(String dateTime) {
-        return DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(dateTime)).toInstant().toEpochMilli();
+        return DateFormatters.from(DateFieldMapper.getDefaultDateTimeFormatter().parse(dateTime)).toInstant().toEpochMilli();
     }
 }

--- a/server/src/test/java/org/opensearch/search/aggregations/pipeline/CumulativeSumAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/pipeline/CumulativeSumAggregatorTests.java
@@ -344,6 +344,6 @@ public class CumulativeSumAggregatorTests extends AggregatorTestCase {
     }
 
     private static long asLong(String dateTime) {
-        return DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(dateTime)).toInstant().toEpochMilli();
+        return DateFormatters.from(DateFieldMapper.getDefaultDateTimeFormatter().parse(dateTime)).toInstant().toEpochMilli();
     }
 }

--- a/server/src/test/java/org/opensearch/search/aggregations/pipeline/MovFnAggrgatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/pipeline/MovFnAggrgatorTests.java
@@ -169,6 +169,6 @@ public class MovFnAggrgatorTests extends AggregatorTestCase {
     }
 
     private static long asLong(String dateTime) {
-        return DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(dateTime)).toInstant().toEpochMilli();
+        return DateFormatters.from(DateFieldMapper.getDefaultDateTimeFormatter().parse(dateTime)).toInstant().toEpochMilli();
     }
 }

--- a/test/framework/src/main/java/org/opensearch/search/aggregations/composite/BaseCompositeAggregatorTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/search/aggregations/composite/BaseCompositeAggregatorTestCase.java
@@ -305,6 +305,6 @@ public class BaseCompositeAggregatorTestCase extends AggregatorTestCase {
     }
 
     protected static long asLong(String dateTime) {
-        return DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(dateTime)).toInstant().toEpochMilli();
+        return DateFormatters.from(DateFieldMapper.getDefaultDateTimeFormatter().parse(dateTime)).toInstant().toEpochMilli();
     }
 }


### PR DESCRIPTION
Signed-off-by: Prabhat Sharma [ptsharma@amazon.com](mailto:ptsharma@amazon.com)
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR adds caching of last used datetime field parser on a shard level in case of no explicit format specified for the datetime field in mapping i.e. for default datetime mapping. This also adds `strict_date_time_no_millis` as additional formatter in default date time formats to improve the efficiency of formatting for most common log date format of `yyyy-MM-dd'T'HH:mm:ssZ`

This PR also adds `printFormat` to control format for string conversion of epochs back to datetime during search requests

### Related Issues
Resolves #4558
Also addresses issue #10118

<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
