### PR TITLE
Fix GH runners memory issue by increasing swapfile

### DIFF
--- a/.github/workflows/check-compatibility.yml
+++ b/.github/workflows/check-compatibility.yml
@@ -15,6 +15,15 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Increase swapfile
+        run: |
+          sudo swapoff -a
+          sudo fallocate -l 10G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          sudo swapon --show
+
       - name: Run compatibility task
         run: ./gradlew checkCompatibility -i | tee $HOME/gradlew-check.out
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Compatibility-check workflow runs are frequently [failing](https://github.com/opensearch-project/OpenSearch/actions/workflows/check-compatibility.yml) with shutdown signal sent to GH runners.

```
The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.
```
This change increases the swapfile on the GH ubuntu runner to 10G as suggested [here](https://github.com/actions/runner-images/discussions/7188#discussioncomment-6750749). Tried in my fork and triggered 10 simultaneous runs https://github.com/gaiksaya/OpenSearch/actions/workflows/check-compatibility.yml and all of them passed.
### Related Issues
Resolves #9549
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
