### PR TITLE
[Backport] [2.x] For sort request on timeseries field use non concurrent search path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix sort related ITs for concurrent search ([#9177](https://github.com/opensearch-project/OpenSearch/pull/9466)
 - [Remote Store] Implicitly use replication type SEGMENT for remote store clusters ([#9264](https://github.com/opensearch-project/OpenSearch/pull/9264))
 - Separate request-based and settings-based concurrent segment search controls and introduce AggregatorFactory method to determine concurrent search support ([#9469](https://github.com/opensearch-project/OpenSearch/pull/9469))
+- Use non-concurrent path for sort request on timeseries index and field([#9562](https://github.com/opensearch-project/OpenSearch/pull/9562))
 
 ### Deprecated
 

--- a/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
@@ -64,7 +64,6 @@ import org.apache.lucene.util.BitSetIterator;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.CombinedBitSet;
 import org.apache.lucene.util.SparseFixedBitSet;
-import org.opensearch.cluster.metadata.DataStream;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.lucene.search.TopDocsAndMaxScore;
 import org.opensearch.search.DocValueFormat;
@@ -269,10 +268,11 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
 
     @Override
     protected void search(List<LeafReaderContext> leaves, Weight weight, Collector collector) throws IOException {
-        if (shouldReverseLeafReaderContexts()) {
-            // reverse the segment search order if this flag is true.
-            // Certain queries can benefit if we reverse the segment read order,
-            // for example time series based queries if searched for desc sort order.
+        // Time series based workload by default traverses segments in desc order i.e. latest to the oldest order.
+        // This is actually beneficial for search queries to start search on latest segments first for time series workload.
+        // That can slow down ASC order queries on timestamp workload. So to avoid that slowdown, we will reverse leaf
+        // reader order here.
+        if (searchContext.shouldUseTimeSeriesDescSortOptimization()) {
             for (int i = leaves.size() - 1; i >= 0; i--) {
                 searchLeaf(leaves.get(i), weight, collector);
             }
@@ -514,26 +514,6 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
             }
         }
         return true;
-    }
-
-    private boolean shouldReverseLeafReaderContexts() {
-        // Time series based workload by default traverses segments in desc order i.e. latest to the oldest order.
-        // This is actually beneficial for search queries to start search on latest segments first for time series workload.
-        // That can slow down ASC order queries on timestamp workload. So to avoid that slowdown, we will reverse leaf
-        // reader order here.
-        if (searchContext.indexShard().isTimeSeriesDescSortOptimizationEnabled()) {
-            // Only reverse order for asc order sort queries
-            if (searchContext.sort() != null
-                && searchContext.sort().sort != null
-                && searchContext.sort().sort.getSort() != null
-                && searchContext.sort().sort.getSort().length > 0
-                && searchContext.sort().sort.getSort()[0].getReverse() == false
-                && searchContext.sort().sort.getSort()[0].getField() != null
-                && searchContext.sort().sort.getSort()[0].getField().equals(DataStream.TIMESERIES_FIELDNAME)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     // package-private for testing

--- a/server/src/main/java/org/opensearch/search/internal/FilteredSearchContext.java
+++ b/server/src/main/java/org/opensearch/search/internal/FilteredSearchContext.java
@@ -564,4 +564,9 @@ public abstract class FilteredSearchContext extends SearchContext {
     public boolean shouldUseConcurrentSearch() {
         return in.shouldUseConcurrentSearch();
     }
+
+    @Override
+    public boolean shouldUseTimeSeriesDescSortOptimization() {
+        return in.shouldUseTimeSeriesDescSortOptimization();
+    }
 }

--- a/server/src/main/java/org/opensearch/search/internal/SearchContext.java
+++ b/server/src/main/java/org/opensearch/search/internal/SearchContext.java
@@ -485,4 +485,6 @@ public abstract class SearchContext implements Releasable {
     public abstract void setBucketCollectorProcessor(BucketCollectorProcessor bucketCollectorProcessor);
 
     public abstract BucketCollectorProcessor bucketCollectorProcessor();
+
+    public abstract boolean shouldUseTimeSeriesDescSortOptimization();
 }

--- a/server/src/main/java/org/opensearch/search/query/QueryPhaseSearcherWrapper.java
+++ b/server/src/main/java/org/opensearch/search/query/QueryPhaseSearcherWrapper.java
@@ -58,9 +58,10 @@ public class QueryPhaseSearcherWrapper implements QueryPhaseSearcher {
         boolean hasTimeout
     ) throws IOException {
         if (searchContext.shouldUseConcurrentSearch()) {
-            LOGGER.info("Using concurrent search over segments (experimental)");
+            LOGGER.debug("Using concurrent search over segments (experimental) for request with context id {}", searchContext.id());
             return concurrentQueryPhaseSearcher.searchWith(searchContext, searcher, query, collectors, hasFilterCollector, hasTimeout);
         } else {
+            LOGGER.debug("Using non-concurrent search over segments for request with context id {}", searchContext.id());
             return defaultQueryPhaseSearcher.searchWith(searchContext, searcher, query, collectors, hasFilterCollector, hasTimeout);
         }
     }
@@ -73,9 +74,13 @@ public class QueryPhaseSearcherWrapper implements QueryPhaseSearcher {
     @Override
     public AggregationProcessor aggregationProcessor(SearchContext searchContext) {
         if (searchContext.shouldUseConcurrentSearch()) {
-            LOGGER.info("Using concurrent search over segments (experimental)");
+            LOGGER.debug(
+                "Using concurrent aggregation processor over segments (experimental) for request with context id {}",
+                searchContext.id()
+            );
             return concurrentQueryPhaseSearcher.aggregationProcessor(searchContext);
         } else {
+            LOGGER.debug("Using non-concurrent aggregation processor over segments for request with context id {}", searchContext.id());
             return defaultQueryPhaseSearcher.aggregationProcessor(searchContext);
         }
     }

--- a/server/src/main/java/org/opensearch/search/sort/SortAndFormats.java
+++ b/server/src/main/java/org/opensearch/search/sort/SortAndFormats.java
@@ -32,6 +32,7 @@
 package org.opensearch.search.sort;
 
 import org.apache.lucene.search.Sort;
+import org.opensearch.cluster.metadata.DataStream;
 import org.opensearch.search.DocValueFormat;
 
 /**
@@ -50,6 +51,15 @@ public final class SortAndFormats {
         }
         this.sort = sort;
         this.formats = formats;
+    }
+
+    /**
+     * @return true: if sort is on timestamp field, false: otherwise
+     */
+    public boolean isSortOnTimeSeriesField() {
+        return sort.getSort().length > 0
+            && sort.getSort()[0].getField() != null
+            && sort.getSort()[0].getField().equals(DataStream.TIMESERIES_FIELDNAME);
     }
 
 }

--- a/test/framework/src/main/java/org/opensearch/test/TestSearchContext.java
+++ b/test/framework/src/main/java/org/opensearch/test/TestSearchContext.java
@@ -680,6 +680,15 @@ public class TestSearchContext extends SearchContext {
         return bucketCollectorProcessor;
     }
 
+    @Override
+    public boolean shouldUseTimeSeriesDescSortOptimization() {
+        return indexShard != null
+            && indexShard.isTimeSeriesDescSortOptimizationEnabled()
+            && sort != null
+            && sort.isSortOnTimeSeriesField()
+            && sort.sort.getSort()[0].getReverse() == false;
+    }
+
     /**
      * Clean the query results by consuming all of it
      */


### PR DESCRIPTION

### Description
Backport of https://github.com/opensearch-project/OpenSearch/pull/9562

### Related Issues
Resolves #https://github.com/opensearch-project/OpenSearch/issues/9538


### Check List
- [X] New functionality includes testing.
  - [ ] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
