### PR TITLE
[Remote Store] Avoiding Translog Deletion in case of relocating shards. 

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteIndexPrimaryRelocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteIndexPrimaryRelocationIT.java
@@ -63,8 +63,7 @@ public class RemoteIndexPrimaryRelocationIT extends IndexPrimaryRelocationIT {
             .put(FeatureFlags.SEGMENT_REPLICATION_EXPERIMENTAL, "true")
             .build();
     }
-
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/9191")
+    
     public void testPrimaryRelocationWhileIndexing() throws Exception {
         super.testPrimaryRelocationWhileIndexing();
     }

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteIndexPrimaryRelocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteIndexPrimaryRelocationIT.java
@@ -63,8 +63,4 @@ public class RemoteIndexPrimaryRelocationIT extends IndexPrimaryRelocationIT {
             .put(FeatureFlags.SEGMENT_REPLICATION_EXPERIMENTAL, "true")
             .build();
     }
-
-    public void testPrimaryRelocationWhileIndexing() throws Exception {
-        super.testPrimaryRelocationWhileIndexing();
-    }
 }

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteIndexPrimaryRelocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteIndexPrimaryRelocationIT.java
@@ -63,7 +63,7 @@ public class RemoteIndexPrimaryRelocationIT extends IndexPrimaryRelocationIT {
             .put(FeatureFlags.SEGMENT_REPLICATION_EXPERIMENTAL, "true")
             .build();
     }
-    
+
     public void testPrimaryRelocationWhileIndexing() throws Exception {
         super.testPrimaryRelocationWhileIndexing();
     }

--- a/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
+++ b/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
@@ -105,7 +105,7 @@ public final class EngineConfig {
     private final LongSupplier globalCheckpointSupplier;
     private final Supplier<RetentionLeases> retentionLeasesSupplier;
     private final boolean isReadOnlyReplica;
-    private final IndexShard.IndexShardConfig indexShardConfig;
+    private final IndexShard.IndexShardConfigSupplier indexShardConfigSupplier;
     private final Comparator<LeafReader> leafSorter;
 
     /**
@@ -266,7 +266,7 @@ public final class EngineConfig {
         this.primaryTermSupplier = builder.primaryTermSupplier;
         this.tombstoneDocSupplier = builder.tombstoneDocSupplier;
         this.isReadOnlyReplica = builder.isReadOnlyReplica;
-        this.indexShardConfig = builder.indexShardConfig;
+        this.indexShardConfigSupplier = builder.indexShardConfigSupplier;
         this.translogFactory = builder.translogFactory;
         this.leafSorter = builder.leafSorter;
     }
@@ -477,8 +477,8 @@ public final class EngineConfig {
      * Returns the underlying primaryModeSupplier.
      * @return the primary mode supplier.
      */
-    public IndexShard.IndexShardConfig getIndexShardConfig() {
-        return indexShardConfig;
+    public IndexShard.IndexShardConfigSupplier getIndexShardConfigSupplier() {
+        return indexShardConfigSupplier;
     }
 
     /**
@@ -555,7 +555,7 @@ public final class EngineConfig {
         private TombstoneDocSupplier tombstoneDocSupplier;
         private TranslogDeletionPolicyFactory translogDeletionPolicyFactory;
         private boolean isReadOnlyReplica;
-        private IndexShard.IndexShardConfig indexShardConfig;
+        private IndexShard.IndexShardConfigSupplier indexShardConfigSupplier;
         private TranslogFactory translogFactory = new InternalTranslogFactory();
         Comparator<LeafReader> leafSorter;
 
@@ -679,8 +679,8 @@ public final class EngineConfig {
             return this;
         }
 
-        public Builder indexShardConfig(IndexShard.IndexShardConfig indexShardConfig) {
-            this.indexShardConfig = indexShardConfig;
+        public Builder indexShardConfig(IndexShard.IndexShardConfigSupplier indexShardConfigSupplier) {
+            this.indexShardConfigSupplier = indexShardConfigSupplier;
             return this;
         }
 

--- a/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
+++ b/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
@@ -53,6 +53,7 @@ import org.opensearch.index.codec.CodecService;
 import org.opensearch.index.codec.CodecSettings;
 import org.opensearch.index.mapper.ParsedDocument;
 import org.opensearch.index.seqno.RetentionLeases;
+import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.store.Store;
 import org.opensearch.index.translog.InternalTranslogFactory;
 import org.opensearch.index.translog.TranslogConfig;
@@ -65,7 +66,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.BooleanSupplier;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
@@ -105,7 +105,7 @@ public final class EngineConfig {
     private final LongSupplier globalCheckpointSupplier;
     private final Supplier<RetentionLeases> retentionLeasesSupplier;
     private final boolean isReadOnlyReplica;
-    private final BooleanSupplier primaryModeSupplier;
+    private final IndexShard.IndexShardConfig indexShardConfig;
     private final Comparator<LeafReader> leafSorter;
 
     /**
@@ -266,7 +266,7 @@ public final class EngineConfig {
         this.primaryTermSupplier = builder.primaryTermSupplier;
         this.tombstoneDocSupplier = builder.tombstoneDocSupplier;
         this.isReadOnlyReplica = builder.isReadOnlyReplica;
-        this.primaryModeSupplier = builder.primaryModeSupplier;
+        this.indexShardConfig = builder.indexShardConfig;
         this.translogFactory = builder.translogFactory;
         this.leafSorter = builder.leafSorter;
     }
@@ -477,8 +477,8 @@ public final class EngineConfig {
      * Returns the underlying primaryModeSupplier.
      * @return the primary mode supplier.
      */
-    public BooleanSupplier getPrimaryModeSupplier() {
-        return primaryModeSupplier;
+    public IndexShard.IndexShardConfig getIndexShardConfig() {
+        return indexShardConfig;
     }
 
     /**
@@ -555,7 +555,7 @@ public final class EngineConfig {
         private TombstoneDocSupplier tombstoneDocSupplier;
         private TranslogDeletionPolicyFactory translogDeletionPolicyFactory;
         private boolean isReadOnlyReplica;
-        private BooleanSupplier primaryModeSupplier;
+        private IndexShard.IndexShardConfig indexShardConfig;
         private TranslogFactory translogFactory = new InternalTranslogFactory();
         Comparator<LeafReader> leafSorter;
 
@@ -679,8 +679,8 @@ public final class EngineConfig {
             return this;
         }
 
-        public Builder primaryModeSupplier(BooleanSupplier primaryModeSupplier) {
-            this.primaryModeSupplier = primaryModeSupplier;
+        public Builder indexShardConfig(IndexShard.IndexShardConfig indexShardConfig) {
+            this.indexShardConfig = indexShardConfig;
             return this;
         }
 

--- a/server/src/main/java/org/opensearch/index/engine/EngineConfigFactory.java
+++ b/server/src/main/java/org/opensearch/index/engine/EngineConfigFactory.java
@@ -152,7 +152,7 @@ public class EngineConfigFactory {
         LongSupplier primaryTermSupplier,
         EngineConfig.TombstoneDocSupplier tombstoneDocSupplier,
         boolean isReadOnlyReplica,
-        IndexShard.IndexShardConfig indexShardConfig,
+        IndexShard.IndexShardConfigSupplier indexShardConfigSupplier,
         TranslogFactory translogFactory,
         Comparator<LeafReader> leafSorter
     ) {
@@ -185,7 +185,7 @@ public class EngineConfigFactory {
             .primaryTermSupplier(primaryTermSupplier)
             .tombstoneDocSupplier(tombstoneDocSupplier)
             .readOnlyReplica(isReadOnlyReplica)
-            .indexShardConfig(indexShardConfig)
+            .indexShardConfig(indexShardConfigSupplier)
             .translogFactory(translogFactory)
             .leafSorter(leafSorter)
             .build();

--- a/server/src/main/java/org/opensearch/index/engine/EngineConfigFactory.java
+++ b/server/src/main/java/org/opensearch/index/engine/EngineConfigFactory.java
@@ -27,6 +27,7 @@ import org.opensearch.index.codec.CodecServiceConfig;
 import org.opensearch.index.codec.CodecServiceFactory;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.seqno.RetentionLeases;
+import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.store.Store;
 import org.opensearch.index.translog.TranslogConfig;
 import org.opensearch.index.translog.TranslogDeletionPolicyFactory;
@@ -40,7 +41,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.BooleanSupplier;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
@@ -152,7 +152,7 @@ public class EngineConfigFactory {
         LongSupplier primaryTermSupplier,
         EngineConfig.TombstoneDocSupplier tombstoneDocSupplier,
         boolean isReadOnlyReplica,
-        BooleanSupplier primaryModeSupplier,
+        IndexShard.IndexShardConfig indexShardConfig,
         TranslogFactory translogFactory,
         Comparator<LeafReader> leafSorter
     ) {
@@ -185,7 +185,7 @@ public class EngineConfigFactory {
             .primaryTermSupplier(primaryTermSupplier)
             .tombstoneDocSupplier(tombstoneDocSupplier)
             .readOnlyReplica(isReadOnlyReplica)
-            .primaryModeSupplier(primaryModeSupplier)
+            .indexShardConfig(indexShardConfig)
             .translogFactory(translogFactory)
             .leafSorter(leafSorter)
             .build();

--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -292,7 +292,7 @@ public class InternalEngine extends Engine {
                     new CompositeTranslogEventListener(Arrays.asList(internalTranslogEventListener, translogEventListener), shardId),
                     this::ensureOpen,
                     engineConfig.getTranslogFactory(),
-                    engineConfig.getPrimaryModeSupplier()
+                    engineConfig.getIndexShardConfig()
                 );
                 this.translogManager = translogManagerRef;
                 this.softDeletesPolicy = newSoftDeletesPolicy();

--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -292,7 +292,7 @@ public class InternalEngine extends Engine {
                     new CompositeTranslogEventListener(Arrays.asList(internalTranslogEventListener, translogEventListener), shardId),
                     this::ensureOpen,
                     engineConfig.getTranslogFactory(),
-                    engineConfig.getIndexShardConfig()
+                    engineConfig.getIndexShardConfigSupplier()
                 );
                 this.translogManager = translogManagerRef;
                 this.softDeletesPolicy = newSoftDeletesPolicy();

--- a/server/src/main/java/org/opensearch/index/engine/NRTReplicationEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/NRTReplicationEngine.java
@@ -118,7 +118,7 @@ public class NRTReplicationEngine extends Engine {
                 },
                 this,
                 engineConfig.getTranslogFactory(),
-                engineConfig.getIndexShardConfig()
+                engineConfig.getIndexShardConfigSupplier()
             );
             this.translogManager = translogManagerRef;
         } catch (IOException e) {

--- a/server/src/main/java/org/opensearch/index/engine/NRTReplicationEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/NRTReplicationEngine.java
@@ -118,7 +118,7 @@ public class NRTReplicationEngine extends Engine {
                 },
                 this,
                 engineConfig.getTranslogFactory(),
-                engineConfig.getPrimaryModeSupplier()
+                engineConfig.getIndexShardConfig()
             );
             this.translogManager = translogManagerRef;
         } catch (IOException e) {

--- a/server/src/main/java/org/opensearch/index/engine/NoOpEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/NoOpEngine.java
@@ -203,7 +203,7 @@ public final class NoOpEngine extends ReadOnlyEngine {
                                         engineConfig.getGlobalCheckpointSupplier(),
                                         engineConfig.getPrimaryTermSupplier(),
                                         seqNo -> {},
-                                        engineConfig.getPrimaryModeSupplier()
+                                        engineConfig.getIndexShardConfig()
                                     )
                             ) {
                                 translog.trimUnreferencedReaders();

--- a/server/src/main/java/org/opensearch/index/engine/NoOpEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/NoOpEngine.java
@@ -203,7 +203,7 @@ public final class NoOpEngine extends ReadOnlyEngine {
                                         engineConfig.getGlobalCheckpointSupplier(),
                                         engineConfig.getPrimaryTermSupplier(),
                                         seqNo -> {},
-                                        engineConfig.getIndexShardConfig()
+                                        engineConfig.getIndexShardConfigSupplier()
                                     )
                             ) {
                                 translog.trimUnreferencedReaders();

--- a/server/src/main/java/org/opensearch/index/engine/ReadOnlyEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/ReadOnlyEngine.java
@@ -278,7 +278,7 @@ public class ReadOnlyEngine extends Engine {
                     config.getGlobalCheckpointSupplier(),
                     config.getPrimaryTermSupplier(),
                     seqNo -> {},
-                    config.getIndexShardConfig()
+                    config.getIndexShardConfigSupplier()
                 )
         ) {
             return translog.stats();

--- a/server/src/main/java/org/opensearch/index/engine/ReadOnlyEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/ReadOnlyEngine.java
@@ -278,7 +278,7 @@ public class ReadOnlyEngine extends Engine {
                     config.getGlobalCheckpointSupplier(),
                     config.getPrimaryTermSupplier(),
                     seqNo -> {},
-                    config.getPrimaryModeSupplier()
+                    config.getIndexShardConfig()
                 )
         ) {
             return translog.stats();

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -338,11 +338,16 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
 
     private final List<ReferenceManager.RefreshListener> internalRefreshListener = new ArrayList<>();
 
-    static public class IndexShardConfig {
+    /**
+     * An OpenSearch index shard config supplier
+     *
+     * @opensearch.internal
+     */
+    static public class IndexShardConfigSupplier {
         BooleanSupplier primaryModeSupplier;
         BooleanSupplier relocatingSupplier;
 
-        public IndexShardConfig(BooleanSupplier primaryModeSupplier, BooleanSupplier relocatingSupplier) {
+        public IndexShardConfigSupplier(BooleanSupplier primaryModeSupplier, BooleanSupplier relocatingSupplier) {
             this.primaryModeSupplier = primaryModeSupplier;
             this.relocatingSupplier = relocatingSupplier;
         }
@@ -3752,7 +3757,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             () -> getOperationPrimaryTerm(),
             tombstoneDocSupplier(),
             isReadOnlyReplica,
-            new IndexShardConfig(replicationTracker::isPrimaryMode, () -> shardRouting.relocating()),
+            new IndexShardConfigSupplier(replicationTracker::isPrimaryMode, () -> shardRouting.relocating()),
             translogFactorySupplier.apply(indexSettings, shardRouting),
             isTimeSeriesDescSortOptimizationEnabled() ? DataStream.TIMESERIES_LEAF_SORTER : null // DESC @timestamp default order for
                                                                                                  // timeseries

--- a/server/src/main/java/org/opensearch/index/translog/InternalTranslogFactory.java
+++ b/server/src/main/java/org/opensearch/index/translog/InternalTranslogFactory.java
@@ -8,8 +8,9 @@
 
 package org.opensearch.index.translog;
 
+import org.opensearch.index.shard.IndexShard;
+
 import java.io.IOException;
-import java.util.function.BooleanSupplier;
 import java.util.function.LongConsumer;
 import java.util.function.LongSupplier;
 
@@ -22,13 +23,13 @@ public class InternalTranslogFactory implements TranslogFactory {
 
     @Override
     public Translog newTranslog(
-        TranslogConfig translogConfig,
-        String translogUUID,
-        TranslogDeletionPolicy translogDeletionPolicy,
-        LongSupplier globalCheckpointSupplier,
-        LongSupplier primaryTermSupplier,
-        LongConsumer persistedSequenceNumberConsumer,
-        BooleanSupplier primaryModeSupplier
+            TranslogConfig translogConfig,
+            String translogUUID,
+            TranslogDeletionPolicy translogDeletionPolicy,
+            LongSupplier globalCheckpointSupplier,
+            LongSupplier primaryTermSupplier,
+            LongConsumer persistedSequenceNumberConsumer,
+            IndexShard.IndexShardConfig indexShardConfig
     ) throws IOException {
 
         return new LocalTranslog(

--- a/server/src/main/java/org/opensearch/index/translog/InternalTranslogFactory.java
+++ b/server/src/main/java/org/opensearch/index/translog/InternalTranslogFactory.java
@@ -23,13 +23,13 @@ public class InternalTranslogFactory implements TranslogFactory {
 
     @Override
     public Translog newTranslog(
-            TranslogConfig translogConfig,
-            String translogUUID,
-            TranslogDeletionPolicy translogDeletionPolicy,
-            LongSupplier globalCheckpointSupplier,
-            LongSupplier primaryTermSupplier,
-            LongConsumer persistedSequenceNumberConsumer,
-            IndexShard.IndexShardConfig indexShardConfig
+        TranslogConfig translogConfig,
+        String translogUUID,
+        TranslogDeletionPolicy translogDeletionPolicy,
+        LongSupplier globalCheckpointSupplier,
+        LongSupplier primaryTermSupplier,
+        LongConsumer persistedSequenceNumberConsumer,
+        IndexShard.IndexShardConfigSupplier indexShardConfigSupplier
     ) throws IOException {
 
         return new LocalTranslog(

--- a/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
@@ -17,12 +17,12 @@ import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.engine.LifecycleAware;
 import org.opensearch.index.seqno.LocalCheckpointTracker;
+import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.translog.listener.TranslogEventListener;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.BooleanSupplier;
 import java.util.function.LongConsumer;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
@@ -57,7 +57,7 @@ public class InternalTranslogManager implements TranslogManager, Closeable {
         TranslogEventListener translogEventListener,
         LifecycleAware engineLifeCycleAware,
         TranslogFactory translogFactory,
-        BooleanSupplier primaryModeSupplier
+        IndexShard.IndexShardConfig indexShardConfig
     ) throws IOException {
         this.shardId = shardId;
         this.readLock = readLock;
@@ -70,7 +70,7 @@ public class InternalTranslogManager implements TranslogManager, Closeable {
             if (tracker != null) {
                 tracker.markSeqNoAsPersisted(seqNo);
             }
-        }, translogUUID, translogFactory, primaryModeSupplier);
+        }, translogUUID, translogFactory, indexShardConfig);
         assert translog.getGeneration() != null;
         this.translog = translog;
         assert pendingTranslogRecovery.get() == false : "translog recovery can't be pending before we set it";
@@ -357,7 +357,7 @@ public class InternalTranslogManager implements TranslogManager, Closeable {
         LongConsumer persistedSequenceNumberConsumer,
         String translogUUID,
         TranslogFactory translogFactory,
-        BooleanSupplier primaryModeSupplier
+        IndexShard.IndexShardConfig indexShardConfig
     ) throws IOException {
         return translogFactory.newTranslog(
             translogConfig,
@@ -366,7 +366,7 @@ public class InternalTranslogManager implements TranslogManager, Closeable {
             globalCheckpointSupplier,
             primaryTermSupplier,
             persistedSequenceNumberConsumer,
-            primaryModeSupplier
+            indexShardConfig
         );
     }
 

--- a/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
@@ -57,7 +57,7 @@ public class InternalTranslogManager implements TranslogManager, Closeable {
         TranslogEventListener translogEventListener,
         LifecycleAware engineLifeCycleAware,
         TranslogFactory translogFactory,
-        IndexShard.IndexShardConfig indexShardConfig
+        IndexShard.IndexShardConfigSupplier indexShardConfigSupplier
     ) throws IOException {
         this.shardId = shardId;
         this.readLock = readLock;
@@ -70,7 +70,7 @@ public class InternalTranslogManager implements TranslogManager, Closeable {
             if (tracker != null) {
                 tracker.markSeqNoAsPersisted(seqNo);
             }
-        }, translogUUID, translogFactory, indexShardConfig);
+        }, translogUUID, translogFactory, indexShardConfigSupplier);
         assert translog.getGeneration() != null;
         this.translog = translog;
         assert pendingTranslogRecovery.get() == false : "translog recovery can't be pending before we set it";
@@ -357,7 +357,7 @@ public class InternalTranslogManager implements TranslogManager, Closeable {
         LongConsumer persistedSequenceNumberConsumer,
         String translogUUID,
         TranslogFactory translogFactory,
-        IndexShard.IndexShardConfig indexShardConfig
+        IndexShard.IndexShardConfigSupplier indexShardConfigSupplier
     ) throws IOException {
         return translogFactory.newTranslog(
             translogConfig,
@@ -366,7 +366,7 @@ public class InternalTranslogManager implements TranslogManager, Closeable {
             globalCheckpointSupplier,
             primaryTermSupplier,
             persistedSequenceNumberConsumer,
-            indexShardConfig
+            indexShardConfigSupplier
         );
     }
 

--- a/server/src/main/java/org/opensearch/index/translog/RemoteBlobStoreInternalTranslogFactory.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteBlobStoreInternalTranslogFactory.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.index.translog;
 
+import org.opensearch.index.shard.IndexShard;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.repositories.Repository;
 import org.opensearch.repositories.RepositoryMissingException;
@@ -15,7 +16,6 @@ import org.opensearch.repositories.blobstore.BlobStoreRepository;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
-import java.util.function.BooleanSupplier;
 import java.util.function.LongConsumer;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
@@ -54,7 +54,7 @@ public class RemoteBlobStoreInternalTranslogFactory implements TranslogFactory {
         LongSupplier globalCheckpointSupplier,
         LongSupplier primaryTermSupplier,
         LongConsumer persistedSequenceNumberConsumer,
-        BooleanSupplier primaryModeSupplier
+        IndexShard.IndexShardConfig indexShardConfig
     ) throws IOException {
 
         assert repository instanceof BlobStoreRepository : "repository should be instance of BlobStoreRepository";
@@ -68,7 +68,7 @@ public class RemoteBlobStoreInternalTranslogFactory implements TranslogFactory {
             persistedSequenceNumberConsumer,
             blobStoreRepository,
             threadPool,
-            primaryModeSupplier
+            indexShardConfig
         );
     }
 

--- a/server/src/main/java/org/opensearch/index/translog/RemoteBlobStoreInternalTranslogFactory.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteBlobStoreInternalTranslogFactory.java
@@ -54,7 +54,7 @@ public class RemoteBlobStoreInternalTranslogFactory implements TranslogFactory {
         LongSupplier globalCheckpointSupplier,
         LongSupplier primaryTermSupplier,
         LongConsumer persistedSequenceNumberConsumer,
-        IndexShard.IndexShardConfig indexShardConfig
+        IndexShard.IndexShardConfigSupplier indexShardConfigSupplier
     ) throws IOException {
 
         assert repository instanceof BlobStoreRepository : "repository should be instance of BlobStoreRepository";
@@ -68,7 +68,7 @@ public class RemoteBlobStoreInternalTranslogFactory implements TranslogFactory {
             persistedSequenceNumberConsumer,
             blobStoreRepository,
             threadPool,
-            indexShardConfig
+            indexShardConfigSupplier
         );
     }
 

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -82,13 +82,13 @@ public class RemoteFsTranslog extends Translog {
         LongConsumer persistedSequenceNumberConsumer,
         BlobStoreRepository blobStoreRepository,
         ThreadPool threadPool,
-        IndexShard.IndexShardConfig indexShardConfig
+        IndexShard.IndexShardConfigSupplier indexShardConfigSupplier
     ) throws IOException {
         super(config, translogUUID, deletionPolicy, globalCheckpointSupplier, primaryTermSupplier, persistedSequenceNumberConsumer);
         logger = Loggers.getLogger(getClass(), shardId);
         this.blobStoreRepository = blobStoreRepository;
-        this.primaryModeSupplier = indexShardConfig.getPrimaryModeSupplier();
-        this.relocatingSupplier = indexShardConfig.getRelocatingSupplier();
+        this.primaryModeSupplier = indexShardConfigSupplier.getPrimaryModeSupplier();
+        this.relocatingSupplier = indexShardConfigSupplier.getRelocatingSupplier();
         fileTransferTracker = new FileTransferTracker(shardId);
         this.translogTransferManager = buildTranslogTransferManager(blobStoreRepository, threadPool, shardId, fileTransferTracker);
         try {
@@ -388,7 +388,7 @@ public class RemoteFsTranslog extends Translog {
             return;
         }
 
-        if(relocatingSupplier.getAsBoolean() == true) {
+        if (relocatingSupplier.getAsBoolean() == true) {
             return;
         }
 

--- a/server/src/main/java/org/opensearch/index/translog/TranslogFactory.java
+++ b/server/src/main/java/org/opensearch/index/translog/TranslogFactory.java
@@ -8,8 +8,9 @@
 
 package org.opensearch.index.translog;
 
+import org.opensearch.index.shard.IndexShard;
+
 import java.io.IOException;
-import java.util.function.BooleanSupplier;
 import java.util.function.LongConsumer;
 import java.util.function.LongSupplier;
 
@@ -29,6 +30,6 @@ public interface TranslogFactory {
         final LongSupplier globalCheckpointSupplier,
         final LongSupplier primaryTermSupplier,
         final LongConsumer persistedSequenceNumberConsumer,
-        final BooleanSupplier primaryModeSupplier
+        final IndexShard.IndexShardConfig indexShardConfig
     ) throws IOException;
 }

--- a/server/src/main/java/org/opensearch/index/translog/TranslogFactory.java
+++ b/server/src/main/java/org/opensearch/index/translog/TranslogFactory.java
@@ -30,6 +30,6 @@ public interface TranslogFactory {
         final LongSupplier globalCheckpointSupplier,
         final LongSupplier primaryTermSupplier,
         final LongConsumer persistedSequenceNumberConsumer,
-        final IndexShard.IndexShardConfig indexShardConfig
+        final IndexShard.IndexShardConfigSupplier indexShardConfigSupplier
     ) throws IOException;
 }

--- a/server/src/main/java/org/opensearch/index/translog/WriteOnlyTranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/WriteOnlyTranslogManager.java
@@ -12,10 +12,10 @@ import org.opensearch.common.util.concurrent.ReleasableLock;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.engine.LifecycleAware;
 import org.opensearch.index.seqno.LocalCheckpointTracker;
+import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.translog.listener.TranslogEventListener;
 
 import java.io.IOException;
-import java.util.function.BooleanSupplier;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
@@ -38,7 +38,7 @@ public class WriteOnlyTranslogManager extends InternalTranslogManager {
         TranslogEventListener translogEventListener,
         LifecycleAware engineLifecycleAware,
         TranslogFactory translogFactory,
-        BooleanSupplier primaryModeSupplier
+        IndexShard.IndexShardConfig indexShardConfig
     ) throws IOException {
         super(
             translogConfig,
@@ -52,7 +52,7 @@ public class WriteOnlyTranslogManager extends InternalTranslogManager {
             translogEventListener,
             engineLifecycleAware,
             translogFactory,
-            primaryModeSupplier
+            indexShardConfig
         );
     }
 

--- a/server/src/main/java/org/opensearch/index/translog/WriteOnlyTranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/WriteOnlyTranslogManager.java
@@ -38,7 +38,7 @@ public class WriteOnlyTranslogManager extends InternalTranslogManager {
         TranslogEventListener translogEventListener,
         LifecycleAware engineLifecycleAware,
         TranslogFactory translogFactory,
-        IndexShard.IndexShardConfig indexShardConfig
+        IndexShard.IndexShardConfigSupplier indexShardConfigSupplier
     ) throws IOException {
         super(
             translogConfig,
@@ -52,7 +52,7 @@ public class WriteOnlyTranslogManager extends InternalTranslogManager {
             translogEventListener,
             engineLifecycleAware,
             translogFactory,
-            indexShardConfig
+            indexShardConfigSupplier
         );
     }
 

--- a/server/src/test/java/org/opensearch/index/engine/EngineConfigFactoryTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/EngineConfigFactoryTests.java
@@ -16,6 +16,7 @@ import org.opensearch.index.IndexSettings;
 import org.opensearch.index.codec.CodecService;
 import org.opensearch.index.codec.CodecServiceFactory;
 import org.opensearch.index.seqno.RetentionLeases;
+import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.translog.InternalTranslogFactory;
 import org.opensearch.index.translog.TranslogDeletionPolicy;
 import org.opensearch.index.translog.TranslogDeletionPolicyFactory;
@@ -68,7 +69,7 @@ public class EngineConfigFactoryTests extends OpenSearchTestCase {
             null,
             null,
             false,
-            () -> Boolean.TRUE,
+            new IndexShard.IndexShardConfig(() -> Boolean.TRUE, () -> Boolean.FALSE),
             new InternalTranslogFactory(),
             null
         );
@@ -148,7 +149,7 @@ public class EngineConfigFactoryTests extends OpenSearchTestCase {
             null,
             null,
             false,
-            () -> Boolean.TRUE,
+            new IndexShard.IndexShardConfig(() -> Boolean.TRUE, () -> Boolean.FALSE),
             new InternalTranslogFactory(),
             null
         );

--- a/server/src/test/java/org/opensearch/index/engine/EngineConfigFactoryTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/EngineConfigFactoryTests.java
@@ -69,7 +69,7 @@ public class EngineConfigFactoryTests extends OpenSearchTestCase {
             null,
             null,
             false,
-            new IndexShard.IndexShardConfig(() -> Boolean.TRUE, () -> Boolean.FALSE),
+            new IndexShard.IndexShardConfigSupplier(() -> Boolean.TRUE, () -> Boolean.FALSE),
             new InternalTranslogFactory(),
             null
         );
@@ -149,7 +149,7 @@ public class EngineConfigFactoryTests extends OpenSearchTestCase {
             null,
             null,
             false,
-            new IndexShard.IndexShardConfig(() -> Boolean.TRUE, () -> Boolean.FALSE),
+            new IndexShard.IndexShardConfigSupplier(() -> Boolean.TRUE, () -> Boolean.FALSE),
             new InternalTranslogFactory(),
             null
         );

--- a/server/src/test/java/org/opensearch/index/translog/InternalTranslogManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/InternalTranslogManagerTests.java
@@ -24,9 +24,9 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import static org.hamcrest.Matchers.equalTo;
 import static org.opensearch.index.seqno.SequenceNumbers.NO_OPS_PERFORMED;
 import static org.opensearch.index.translog.TranslogDeletionPolicies.createTranslogDeletionPolicy;
+import static org.hamcrest.Matchers.equalTo;
 
 public class InternalTranslogManagerTests extends TranslogManagerTestCase {
 
@@ -50,7 +50,7 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
                 TranslogEventListener.NOOP_TRANSLOG_EVENT_LISTENER,
                 () -> {},
                 new InternalTranslogFactory(),
-                new IndexShard.IndexShardConfig(() -> Boolean.TRUE, () -> Boolean.FALSE)
+                new IndexShard.IndexShardConfigSupplier(() -> Boolean.TRUE, () -> Boolean.FALSE)
             );
             final int docs = randomIntBetween(1, 100);
             for (int i = 0; i < docs; i++) {
@@ -90,7 +90,7 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
                 },
                 () -> {},
                 new InternalTranslogFactory(),
-                new IndexShard.IndexShardConfig(() -> Boolean.TRUE, () -> Boolean.FALSE)
+                new IndexShard.IndexShardConfigSupplier(() -> Boolean.TRUE, () -> Boolean.FALSE)
             );
             AtomicInteger opsRecovered = new AtomicInteger();
             int opsRecoveredFromTranslog = translogManager.recoverFromTranslog((snapshot) -> {
@@ -129,7 +129,7 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
                 TranslogEventListener.NOOP_TRANSLOG_EVENT_LISTENER,
                 () -> {},
                 new InternalTranslogFactory(),
-                new IndexShard.IndexShardConfig(() -> Boolean.TRUE, () -> Boolean.FALSE)
+                new IndexShard.IndexShardConfigSupplier(() -> Boolean.TRUE, () -> Boolean.FALSE)
             );
             final int docs = randomIntBetween(1, 100);
             for (int i = 0; i < docs; i++) {
@@ -159,7 +159,7 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
                 TranslogEventListener.NOOP_TRANSLOG_EVENT_LISTENER,
                 () -> {},
                 new InternalTranslogFactory(),
-                new IndexShard.IndexShardConfig(() -> Boolean.TRUE, () -> Boolean.FALSE)
+                new IndexShard.IndexShardConfigSupplier(() -> Boolean.TRUE, () -> Boolean.FALSE)
             );
             AtomicInteger opsRecovered = new AtomicInteger();
             int opsRecoveredFromTranslog = translogManager.recoverFromTranslog((snapshot) -> {
@@ -194,7 +194,7 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
                 TranslogEventListener.NOOP_TRANSLOG_EVENT_LISTENER,
                 () -> {},
                 new InternalTranslogFactory(),
-                new IndexShard.IndexShardConfig(() -> Boolean.TRUE, () -> Boolean.FALSE)
+                new IndexShard.IndexShardConfigSupplier(() -> Boolean.TRUE, () -> Boolean.FALSE)
             );
             final int docs = randomIntBetween(1, 100);
             for (int i = 0; i < docs; i++) {
@@ -226,7 +226,7 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
                 TranslogEventListener.NOOP_TRANSLOG_EVENT_LISTENER,
                 () -> {},
                 new InternalTranslogFactory(),
-                new IndexShard.IndexShardConfig(() -> Boolean.TRUE, () -> Boolean.FALSE)
+                new IndexShard.IndexShardConfigSupplier(() -> Boolean.TRUE, () -> Boolean.FALSE)
             );
             AtomicInteger opsRecovered = new AtomicInteger();
             int opsRecoveredFromTranslog = translogManager.recoverFromTranslog((snapshot) -> {
@@ -275,7 +275,7 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
                 },
                 () -> {},
                 new InternalTranslogFactory(),
-                new IndexShard.IndexShardConfig(() -> Boolean.TRUE, () -> Boolean.FALSE)
+                new IndexShard.IndexShardConfigSupplier(() -> Boolean.TRUE, () -> Boolean.FALSE)
             );
             translogManagerAtomicReference.set(translogManager);
             Engine.Index index = indexForDoc(doc);

--- a/server/src/test/java/org/opensearch/index/translog/InternalTranslogManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/InternalTranslogManagerTests.java
@@ -14,6 +14,7 @@ import org.opensearch.index.engine.Engine;
 import org.opensearch.index.mapper.ParsedDocument;
 import org.opensearch.index.seqno.LocalCheckpointTracker;
 import org.opensearch.index.seqno.SequenceNumbers;
+import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.translog.listener.TranslogEventListener;
 
 import java.io.IOException;
@@ -23,9 +24,9 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.opensearch.index.seqno.SequenceNumbers.NO_OPS_PERFORMED;
 import static org.opensearch.index.translog.TranslogDeletionPolicies.createTranslogDeletionPolicy;
-import static org.hamcrest.Matchers.equalTo;
 
 public class InternalTranslogManagerTests extends TranslogManagerTestCase {
 
@@ -49,7 +50,7 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
                 TranslogEventListener.NOOP_TRANSLOG_EVENT_LISTENER,
                 () -> {},
                 new InternalTranslogFactory(),
-                () -> Boolean.TRUE
+                new IndexShard.IndexShardConfig(() -> Boolean.TRUE, () -> Boolean.FALSE)
             );
             final int docs = randomIntBetween(1, 100);
             for (int i = 0; i < docs; i++) {
@@ -89,7 +90,7 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
                 },
                 () -> {},
                 new InternalTranslogFactory(),
-                () -> Boolean.TRUE
+                new IndexShard.IndexShardConfig(() -> Boolean.TRUE, () -> Boolean.FALSE)
             );
             AtomicInteger opsRecovered = new AtomicInteger();
             int opsRecoveredFromTranslog = translogManager.recoverFromTranslog((snapshot) -> {
@@ -128,7 +129,7 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
                 TranslogEventListener.NOOP_TRANSLOG_EVENT_LISTENER,
                 () -> {},
                 new InternalTranslogFactory(),
-                () -> Boolean.TRUE
+                new IndexShard.IndexShardConfig(() -> Boolean.TRUE, () -> Boolean.FALSE)
             );
             final int docs = randomIntBetween(1, 100);
             for (int i = 0; i < docs; i++) {
@@ -158,7 +159,7 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
                 TranslogEventListener.NOOP_TRANSLOG_EVENT_LISTENER,
                 () -> {},
                 new InternalTranslogFactory(),
-                () -> Boolean.TRUE
+                new IndexShard.IndexShardConfig(() -> Boolean.TRUE, () -> Boolean.FALSE)
             );
             AtomicInteger opsRecovered = new AtomicInteger();
             int opsRecoveredFromTranslog = translogManager.recoverFromTranslog((snapshot) -> {
@@ -193,7 +194,7 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
                 TranslogEventListener.NOOP_TRANSLOG_EVENT_LISTENER,
                 () -> {},
                 new InternalTranslogFactory(),
-                () -> Boolean.TRUE
+                new IndexShard.IndexShardConfig(() -> Boolean.TRUE, () -> Boolean.FALSE)
             );
             final int docs = randomIntBetween(1, 100);
             for (int i = 0; i < docs; i++) {
@@ -225,7 +226,7 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
                 TranslogEventListener.NOOP_TRANSLOG_EVENT_LISTENER,
                 () -> {},
                 new InternalTranslogFactory(),
-                () -> Boolean.TRUE
+                new IndexShard.IndexShardConfig(() -> Boolean.TRUE, () -> Boolean.FALSE)
             );
             AtomicInteger opsRecovered = new AtomicInteger();
             int opsRecoveredFromTranslog = translogManager.recoverFromTranslog((snapshot) -> {
@@ -274,7 +275,7 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
                 },
                 () -> {},
                 new InternalTranslogFactory(),
-                () -> Boolean.TRUE
+                new IndexShard.IndexShardConfig(() -> Boolean.TRUE, () -> Boolean.FALSE)
             );
             translogManagerAtomicReference.set(translogManager);
             Engine.Index index = indexForDoc(doc);

--- a/server/src/test/java/org/opensearch/index/translog/RemoteFSTranslogTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/RemoteFSTranslogTests.java
@@ -15,6 +15,8 @@ import org.apache.lucene.store.ByteArrayDataOutput;
 import org.apache.lucene.store.DataOutput;
 import org.apache.lucene.tests.mockfile.FilterFileChannel;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.junit.After;
+import org.junit.Before;
 import org.opensearch.OpenSearchException;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.RepositoryMetadata;
@@ -43,6 +45,7 @@ import org.opensearch.index.engine.MissingHistoryOperationsException;
 import org.opensearch.index.seqno.LocalCheckpointTracker;
 import org.opensearch.index.seqno.LocalCheckpointTrackerTests;
 import org.opensearch.index.seqno.SequenceNumbers;
+import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.translog.transfer.BlobStoreTransferService;
 import org.opensearch.indices.recovery.RecoverySettings;
 import org.opensearch.indices.replication.common.ReplicationType;
@@ -53,8 +56,6 @@ import org.opensearch.test.IndexSettingsModule;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
-import org.junit.After;
-import org.junit.Before;
 
 import java.io.Closeable;
 import java.io.EOFException;
@@ -89,14 +90,14 @@ import java.util.function.LongConsumer;
 import java.util.zip.CRC32;
 import java.util.zip.CheckedInputStream;
 
-import static org.opensearch.common.util.BigArrays.NON_RECYCLING_INSTANCE;
-import static org.opensearch.index.translog.RemoteFsTranslog.TRANSLOG;
-import static org.opensearch.index.translog.SnapshotMatchers.containsOperationsInAnyOrder;
-import static org.opensearch.index.translog.TranslogDeletionPolicies.createTranslogDeletionPolicy;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.opensearch.common.util.BigArrays.NON_RECYCLING_INSTANCE;
+import static org.opensearch.index.translog.RemoteFsTranslog.TRANSLOG;
+import static org.opensearch.index.translog.SnapshotMatchers.containsOperationsInAnyOrder;
+import static org.opensearch.index.translog.TranslogDeletionPolicies.createTranslogDeletionPolicy;
 
 @LuceneTestCase.SuppressFileSystems("ExtrasFS")
 
@@ -172,7 +173,7 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
             getPersistedSeqNoConsumer(),
             repository,
             threadPool,
-            primaryMode::get
+            new IndexShard.IndexShardConfig(primaryMode::get, () -> Boolean.FALSE)
         );
 
     }
@@ -1223,7 +1224,7 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
                 persistedSeqNos::add,
                 repository,
                 threadPool,
-                () -> Boolean.TRUE
+                new IndexShard.IndexShardConfig(() -> Boolean.TRUE, () -> Boolean.FALSE)
             ) {
                 @Override
                 ChannelFactory getChannelFactory() {
@@ -1329,7 +1330,7 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
                 persistedSeqNos::add,
                 repository,
                 threadPool,
-                () -> Boolean.TRUE
+                new IndexShard.IndexShardConfig(() -> Boolean.TRUE, () -> Boolean.FALSE)
             ) {
                 @Override
                 ChannelFactory getChannelFactory() {

--- a/server/src/test/java/org/opensearch/index/translog/RemoteFSTranslogTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/RemoteFSTranslogTests.java
@@ -15,8 +15,6 @@ import org.apache.lucene.store.ByteArrayDataOutput;
 import org.apache.lucene.store.DataOutput;
 import org.apache.lucene.tests.mockfile.FilterFileChannel;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.After;
-import org.junit.Before;
 import org.opensearch.OpenSearchException;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.RepositoryMetadata;
@@ -56,6 +54,8 @@ import org.opensearch.test.IndexSettingsModule;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
+import org.junit.After;
+import org.junit.Before;
 
 import java.io.Closeable;
 import java.io.EOFException;
@@ -90,14 +90,14 @@ import java.util.function.LongConsumer;
 import java.util.zip.CRC32;
 import java.util.zip.CheckedInputStream;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.opensearch.common.util.BigArrays.NON_RECYCLING_INSTANCE;
 import static org.opensearch.index.translog.RemoteFsTranslog.TRANSLOG;
 import static org.opensearch.index.translog.SnapshotMatchers.containsOperationsInAnyOrder;
 import static org.opensearch.index.translog.TranslogDeletionPolicies.createTranslogDeletionPolicy;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 
 @LuceneTestCase.SuppressFileSystems("ExtrasFS")
 
@@ -173,7 +173,7 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
             getPersistedSeqNoConsumer(),
             repository,
             threadPool,
-            new IndexShard.IndexShardConfig(primaryMode::get, () -> Boolean.FALSE)
+            new IndexShard.IndexShardConfigSupplier(primaryMode::get, () -> Boolean.FALSE)
         );
 
     }
@@ -1224,7 +1224,7 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
                 persistedSeqNos::add,
                 repository,
                 threadPool,
-                new IndexShard.IndexShardConfig(() -> Boolean.TRUE, () -> Boolean.FALSE)
+                new IndexShard.IndexShardConfigSupplier(() -> Boolean.TRUE, () -> Boolean.FALSE)
             ) {
                 @Override
                 ChannelFactory getChannelFactory() {
@@ -1330,7 +1330,7 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
                 persistedSeqNos::add,
                 repository,
                 threadPool,
-                new IndexShard.IndexShardConfig(() -> Boolean.TRUE, () -> Boolean.FALSE)
+                new IndexShard.IndexShardConfigSupplier(() -> Boolean.TRUE, () -> Boolean.FALSE)
             ) {
                 @Override
                 ChannelFactory getChannelFactory() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

In Primary to Primary relocation , there can be concurrent upload and download of translog.
While translog files are getting downloaded by new primary, it might hence be deleted by the relocating primary
Hence we need to avoid to deletion when shard is in `RELOCATING` state . 


### Related Issues

Resolves #9191

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
