### PR TITLE
remove redundent column headers in pit segments response

### DIFF
--- a/server/src/main/java/org/opensearch/rest/action/cat/RestPitSegmentsAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestPitSegmentsAction.java
@@ -120,23 +120,7 @@ public class RestPitSegmentsAction extends AbstractCatAction {
         Table table = getTableWithHeader(request);
 
         DiscoveryNodes nodes = this.nodesInCluster.get();
-        table.startRow();
-        table.addCell("index", "default:true;alias:i,idx;desc:index name");
-        table.addCell("shard", "default:true;alias:s,sh;desc:shard name");
-        table.addCell("prirep", "alias:p,pr,primaryOrReplica;default:true;desc:primary or replica");
-        table.addCell("ip", "default:true;desc:ip of node where it lives");
-        table.addCell("id", "default:false;desc:unique id of node where it lives");
-        table.addCell("segment", "default:true;alias:seg;desc:segment name");
-        table.addCell("generation", "default:true;alias:g,gen;text-align:right;desc:segment generation");
-        table.addCell("docs.count", "default:true;alias:dc,docsCount;text-align:right;desc:number of docs in segment");
-        table.addCell("docs.deleted", "default:true;alias:dd,docsDeleted;text-align:right;desc:number of deleted docs in segment");
-        table.addCell("size", "default:true;alias:si;text-align:right;desc:segment size in bytes");
-        table.addCell("size.memory", "default:true;alias:sm,sizeMemory;text-align:right;desc:segment memory in bytes");
-        table.addCell("committed", "default:true;alias:ic,isCommitted;desc:is segment committed");
-        table.addCell("searchable", "default:true;alias:is,isSearchable;desc:is segment searched");
-        table.addCell("version", "default:true;alias:v,ver;desc:version");
-        table.addCell("compound", "default:true;alias:ico,isCompound;desc:is segment compound");
-        table.endRow();
+
         for (IndexSegments indexSegments : indicesSegments.values()) {
             Map<Integer, IndexShardSegments> shards = indexSegments.getShards();
             for (IndexShardSegments indexShardSegments : shards.values()) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Today, CAT APIs decide whether to include column headers based on query parameter `v`, but these headers are included by default in pit segments response.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
