### PR TITLE
[Tracing Framework] Redefine telemetry context restoration and propagation

### DIFF
--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/Context.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/Context.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.telemetry.tracing;
+
+import org.opensearch.telemetry.tracing.attributes.Attributes;
+
+/**
+ * Context for span details.
+ */
+public final class Context {
+    private final String spanName;
+    private final Attributes attributes;
+
+    /**
+     * Constructor.
+     * @param spanName span name.
+     * @param attributes attributes.
+     */
+    public Context(String spanName, Attributes attributes) {
+        this.spanName = spanName;
+        this.attributes = attributes;
+    }
+
+    /**
+     * Returns the span name.
+     * @return span name
+     */
+    public String getSpanName() {
+        return spanName;
+    }
+
+    /**
+     * Returns the span attributes.
+     * @return attributes.
+     */
+    public Attributes getAttributes() {
+        return attributes;
+    }
+}

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/DefaultScopedSpan.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/DefaultScopedSpan.java
@@ -1,0 +1,92 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.telemetry.tracing;
+
+import java.util.Objects;
+import java.util.function.BiConsumer;
+
+/**
+ * Default implementation of Scope
+ *
+ * @opensearch.internal
+ */
+final class DefaultScopedSpan implements ScopedSpan {
+
+    private final Span span;
+
+    private final SpanScope spanScope;
+
+    private final BiConsumer<Span, SpanScope> onCloseConsumer;
+
+    /**
+     * Creates Scope instance for the given span
+     *
+     * @param span underlying span
+     * @param onCloseConsumer consumer to execute on scope close
+     */
+    public DefaultScopedSpan(Span span, SpanScope spanScope, BiConsumer<Span, SpanScope> onCloseConsumer) {
+        this.span = Objects.requireNonNull(span);
+        this.spanScope = Objects.requireNonNull(spanScope);
+        this.onCloseConsumer = Objects.requireNonNull(onCloseConsumer);
+    }
+
+    @Override
+    public void addSpanAttribute(String key, String value) {
+        span.addAttribute(key, value);
+    }
+
+    @Override
+    public void addSpanAttribute(String key, long value) {
+        span.addAttribute(key, value);
+    }
+
+    @Override
+    public void addSpanAttribute(String key, double value) {
+        span.addAttribute(key, value);
+    }
+
+    @Override
+    public void addSpanAttribute(String key, boolean value) {
+        span.addAttribute(key, value);
+    }
+
+    @Override
+    public void addSpanEvent(String event) {
+        span.addEvent(event);
+    }
+
+    @Override
+    public void setError(Exception exception) {
+        span.setError(exception);
+    }
+
+    /**
+     * Executes the runnable to end the scope
+     */
+    @Override
+    public void close() {
+        onCloseConsumer.accept(span, spanScope);
+    }
+
+    /**
+     * Returns span.
+     * @return
+     */
+    Span getSpan() {
+        return span;
+    }
+
+    /**
+     * Returns {@link SpanScope}
+     * @return spanScope
+     */
+    SpanScope getSpanScope() {
+        return spanScope;
+    }
+}

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/DefaultSpanScope.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/DefaultSpanScope.java
@@ -8,65 +8,37 @@
 
 package org.opensearch.telemetry.tracing;
 
+import java.util.Objects;
 import java.util.function.Consumer;
 
 /**
- * Default implementation of Scope
- *
- * @opensearch.internal
+ * Default implementation for {@link SpanScope}
  */
-final class DefaultSpanScope implements SpanScope {
-
+public class DefaultSpanScope implements SpanScope {
     private final Span span;
-
-    private final Consumer<Span> onCloseConsumer;
-
-    /**
-     * Creates Scope instance for the given span
-     *
-     * @param span underlying span
-     * @param onCloseConsumer consumer to execute on scope close
-     */
-    public DefaultSpanScope(Span span, Consumer<Span> onCloseConsumer) {
-        this.span = span;
-        this.onCloseConsumer = onCloseConsumer;
-    }
-
-    @Override
-    public void addSpanAttribute(String key, String value) {
-        span.addAttribute(key, value);
-    }
-
-    @Override
-    public void addSpanAttribute(String key, long value) {
-        span.addAttribute(key, value);
-    }
-
-    @Override
-    public void addSpanAttribute(String key, double value) {
-        span.addAttribute(key, value);
-    }
-
-    @Override
-    public void addSpanAttribute(String key, boolean value) {
-        span.addAttribute(key, value);
-    }
-
-    @Override
-    public void addSpanEvent(String event) {
-        span.addEvent(event);
-    }
-
-    @Override
-    public void setError(Exception exception) {
-        span.setError(exception);
-    }
+    private final SpanScope beforeAttachedSpanScope;
+    private final Consumer<SpanScope> onCloseConsumer;
 
     /**
-     * Executes the runnable to end the scope
+     * Constructor
+     * @param span span
+     * @param beforeAttachedSpanScope before attached span scope.
+     * @param onCloseConsumer close consumer
      */
+    public DefaultSpanScope(Span span, SpanScope beforeAttachedSpanScope, Consumer<SpanScope> onCloseConsumer) {
+        this.span = Objects.requireNonNull(span);
+        this.beforeAttachedSpanScope = beforeAttachedSpanScope;
+        this.onCloseConsumer = Objects.requireNonNull(onCloseConsumer);
+    }
+
     @Override
     public void close() {
-        onCloseConsumer.accept(span);
+        onCloseConsumer.accept(beforeAttachedSpanScope);
     }
+
+    @Override
+    public Span getSpan() {
+        return span;
+    }
+
 }

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/DefaultTracer.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/DefaultTracer.java
@@ -41,7 +41,7 @@ class DefaultTracer implements Tracer {
     }
 
     @Override
-    public SpanScope startSpan(Context context) {
+    public SpanScope startSpan(SpanCreationContext context) {
         return startSpan(context.getSpanName(), context.getAttributes());
     }
 

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/DefaultTracer.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/DefaultTracer.java
@@ -41,6 +41,11 @@ class DefaultTracer implements Tracer {
     }
 
     @Override
+    public SpanScope startSpan(Context context) {
+        return startSpan(context.getSpanName(), context.getAttributes());
+    }
+
+    @Override
     public SpanScope startSpan(String spanName) {
         return startSpan(spanName, Attributes.EMPTY);
     }

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/DefaultTracer.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/DefaultTracer.java
@@ -27,36 +27,42 @@ class DefaultTracer implements Tracer {
     static final String THREAD_NAME = "th_name";
 
     private final TracingTelemetry tracingTelemetry;
-    private final TracerContextStorage<String, Span> tracerContextStorage;
+    private final TracerContextStorage<String, Span> spanTracerContextStorage;
+    private final TracerContextStorage<String, SpanScope> spanScopeTracerContextStorage;
 
     /**
      * Creates DefaultTracer instance
      *
      * @param tracingTelemetry tracing telemetry instance
-     * @param tracerContextStorage storage used for storing current span context
+     * @param spanTracerContextStorage storage used for storing current span context
      */
-    public DefaultTracer(TracingTelemetry tracingTelemetry, TracerContextStorage<String, Span> tracerContextStorage) {
+    public DefaultTracer(
+        TracingTelemetry tracingTelemetry,
+        TracerContextStorage<String, Span> spanTracerContextStorage,
+        TracerContextStorage<String, SpanScope> spanScopeTracerContextStorage
+    ) {
         this.tracingTelemetry = tracingTelemetry;
-        this.tracerContextStorage = tracerContextStorage;
+        this.spanTracerContextStorage = spanTracerContextStorage;
+        this.spanScopeTracerContextStorage = spanScopeTracerContextStorage;
     }
 
     @Override
-    public SpanScope startSpan(SpanCreationContext context) {
+    public Span startSpan(SpanCreationContext context) {
         return startSpan(context.getSpanName(), context.getAttributes());
     }
 
     @Override
-    public SpanScope startSpan(String spanName) {
+    public Span startSpan(String spanName) {
         return startSpan(spanName, Attributes.EMPTY);
     }
 
     @Override
-    public SpanScope startSpan(String spanName, Attributes attributes) {
+    public Span startSpan(String spanName, Attributes attributes) {
         return startSpan(spanName, (SpanContext) null, attributes);
     }
 
     @Override
-    public SpanScope startSpan(String spanName, SpanContext parentSpan, Attributes attributes) {
+    public Span startSpan(String spanName, SpanContext parentSpan, Attributes attributes) {
         Span span = null;
         if (parentSpan != null) {
             span = createSpan(spanName, parentSpan.getSpan(), attributes);
@@ -65,7 +71,7 @@ class DefaultTracer implements Tracer {
         }
         setCurrentSpanInContext(span);
         addDefaultAttributes(span);
-        return new DefaultSpanScope(span, (scopeSpan) -> endSpan(scopeSpan));
+        return span;
     }
 
     @Override
@@ -74,12 +80,63 @@ class DefaultTracer implements Tracer {
     }
 
     private Span getCurrentSpanInternal() {
-        return tracerContextStorage.get(TracerContextStorage.CURRENT_SPAN);
+        return spanTracerContextStorage.get(TracerContextStorage.CURRENT_SPAN);
     }
 
     public SpanContext getCurrentSpan() {
-        final Span currentSpan = tracerContextStorage.get(TracerContextStorage.CURRENT_SPAN);
+        final Span currentSpan = spanTracerContextStorage.get(TracerContextStorage.CURRENT_SPAN);
         return (currentSpan == null) ? null : new SpanContext(currentSpan);
+    }
+
+    private SpanScope getCurrentSpanScope() {
+        return spanScopeTracerContextStorage.get(TracerContextStorage.CURRENT_SPAN_SCOPE);
+    }
+
+    @Override
+    public ScopedSpan startScopedSpan(SpanCreationContext spanCreationContext) {
+        Span span = startSpan(spanCreationContext);
+        SpanScope spanScope = createSpanScope(span);
+        return new DefaultScopedSpan(
+            span,
+            spanScope,
+            (spanToBeClosed, scopeSpanToBeClosed) -> endScopedSpan(spanToBeClosed, scopeSpanToBeClosed)
+        );
+    }
+
+    @Override
+    public ScopedSpan startScopedSpan(SpanCreationContext spanCreationContext, SpanContext parentSpan) {
+        Span span = startSpan(spanCreationContext.getSpanName(), parentSpan, spanCreationContext.getAttributes());
+        SpanScope spanScope = createSpanScope(span);
+        return new DefaultScopedSpan(
+            span,
+            spanScope,
+            (spanToBeClosed, scopeSpanToBeClosed) -> endScopedSpan(spanToBeClosed, scopeSpanToBeClosed)
+        );
+    }
+
+    @Override
+    public SpanScope createSpanScope(Span span) {
+        SpanScope defaultSpanScope = new DefaultSpanScope(span, getCurrentSpanScope(), (spanScope) -> closeSpanScope(spanScope));
+        setCurrentSpanScopeInContext(defaultSpanScope);
+        return defaultSpanScope;
+    }
+
+    private void closeSpanScope(SpanScope beforeAttachedSpanScope) {
+        setCurrentSpanScopeInContext(beforeAttachedSpanScope);
+        if (beforeAttachedSpanScope != null) {
+            setCurrentSpanInContext(beforeAttachedSpanScope.getSpan());
+        } else {
+            setCurrentSpanInContext(null);
+        }
+    }
+
+    private void setCurrentSpanScopeInContext(SpanScope spanScope) {
+        spanScopeTracerContextStorage.put(TracerContextStorage.CURRENT_SPAN_SCOPE, spanScope);
+    }
+
+    private void endScopedSpan(Span span, SpanScope spanScope) {
+        endSpan(span);
+        spanScope.close();
     }
 
     private void endSpan(Span span) {
@@ -94,7 +151,7 @@ class DefaultTracer implements Tracer {
     }
 
     private void setCurrentSpanInContext(Span span) {
-        tracerContextStorage.put(TracerContextStorage.CURRENT_SPAN, span);
+        spanTracerContextStorage.put(TracerContextStorage.CURRENT_SPAN, span);
     }
 
     /**
@@ -106,7 +163,7 @@ class DefaultTracer implements Tracer {
     }
 
     @Override
-    public SpanScope startSpan(String spanName, Map<String, List<String>> headers, Attributes attributes) {
+    public Span startSpan(String spanName, Map<String, List<String>> headers, Attributes attributes) {
         Optional<Span> propagatedSpan = tracingTelemetry.getContextPropagator().extractFromHeaders(headers);
         return startSpan(spanName, propagatedSpan.map(SpanContext::new).orElse(null), attributes);
     }

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/ScopedSpan.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/ScopedSpan.java
@@ -1,0 +1,74 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.telemetry.tracing;
+
+import org.opensearch.telemetry.tracing.noop.NoopScopedSpan;
+
+/**
+ * An auto-closeable that represents scoped span.
+ * It provides interface for all the span operations.
+ */
+public interface ScopedSpan extends AutoCloseable {
+    /**
+     * No-op Scope implementation
+     */
+    ScopedSpan NO_OP = new NoopScopedSpan();
+
+    /**
+     * Adds string attribute to the {@link Span}.
+     *
+     * @param key   attribute key
+     * @param value attribute value
+     */
+    void addSpanAttribute(String key, String value);
+
+    /**
+     * Adds long attribute to the {@link Span}.
+     *
+     * @param key   attribute key
+     * @param value attribute value
+     */
+    void addSpanAttribute(String key, long value);
+
+    /**
+     * Adds double attribute to the {@link Span}.
+     *
+     * @param key   attribute key
+     * @param value attribute value
+     */
+    void addSpanAttribute(String key, double value);
+
+    /**
+     * Adds boolean attribute to the {@link Span}.
+     *
+     * @param key   attribute key
+     * @param value attribute value
+     */
+    void addSpanAttribute(String key, boolean value);
+
+    /**
+     * Adds an event to the {@link Span}.
+     *
+     * @param event event name
+     */
+    void addSpanEvent(String event);
+
+    /**
+     * Records error in the span
+     *
+     * @param exception exception to be recorded
+     */
+    void setError(Exception exception);
+
+    /**
+     * closes the scope
+     */
+    @Override
+    void close();
+}

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/SpanCreationContext.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/SpanCreationContext.java
@@ -13,7 +13,7 @@ import org.opensearch.telemetry.tracing.attributes.Attributes;
 /**
  * Context for span details.
  */
-public final class Context {
+public final class SpanCreationContext {
     private final String spanName;
     private final Attributes attributes;
 
@@ -22,7 +22,7 @@ public final class Context {
      * @param spanName span name.
      * @param attributes attributes.
      */
-    public Context(String spanName, Attributes attributes) {
+    public SpanCreationContext(String spanName, Attributes attributes) {
         this.spanName = spanName;
         this.attributes = attributes;
     }

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/SpanScope.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/SpanScope.java
@@ -12,63 +12,20 @@ import org.opensearch.telemetry.tracing.noop.NoopSpanScope;
 
 /**
  * An auto-closeable that represents scope of the span.
- * It provides interface for all the span operations.
  */
 public interface SpanScope extends AutoCloseable {
+
     /**
      * No-op Scope implementation
      */
     SpanScope NO_OP = new NoopSpanScope();
 
-    /**
-     * Adds string attribute to the {@link Span}.
-     *
-     * @param key   attribute key
-     * @param value attribute value
-     */
-    void addSpanAttribute(String key, String value);
-
-    /**
-     * Adds long attribute to the {@link Span}.
-     *
-     * @param key   attribute key
-     * @param value attribute value
-     */
-    void addSpanAttribute(String key, long value);
-
-    /**
-     * Adds double attribute to the {@link Span}.
-     *
-     * @param key   attribute key
-     * @param value attribute value
-     */
-    void addSpanAttribute(String key, double value);
-
-    /**
-     * Adds boolean attribute to the {@link Span}.
-     *
-     * @param key   attribute key
-     * @param value attribute value
-     */
-    void addSpanAttribute(String key, boolean value);
-
-    /**
-     * Adds an event to the {@link Span}.
-     *
-     * @param event event name
-     */
-    void addSpanEvent(String event);
-
-    /**
-     * Records error in the span
-     *
-     * @param exception exception to be recorded
-     */
-    void setError(Exception exception);
-
-    /**
-     * closes the scope
-     */
     @Override
     void close();
+
+    /**
+     * Returns span attached with the {@link SpanScope}
+     * @return span.
+     */
+    Span getSpan();
 }

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/SpanScopeReference.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/SpanScopeReference.java
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.telemetry.tracing;
+
+/**
+ * Wrapper class to hold reference of {@link SpanScope}
+ *
+ * @opensearch.internal
+ */
+final class SpanScopeReference {
+
+    private SpanScope spanScope;
+
+    /**
+     * Creates the wrapper with given spanScope
+     * @param spanScope the spanScope object to wrap
+     */
+    public SpanScopeReference(SpanScope spanScope) {
+        this.spanScope = spanScope;
+    }
+
+    /**
+     * Returns the spanScope object
+     * @return underlying spanScope
+     */
+    public SpanScope getSpanScope() {
+        return spanScope;
+    }
+
+    /**
+     * Updates the underlying span
+     * @param spanScope underlying span
+     */
+    public void setSpanScope(SpanScope spanScope) {
+        this.spanScope = spanScope;
+    }
+}

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/Tracer.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/Tracer.java
@@ -20,44 +20,71 @@ import java.io.Closeable;
  * All methods on the Tracer object are multi-thread safe.
  */
 public interface Tracer extends HttpTracer, Closeable {
-
     /**
      * Starts the {@link Span} with given {@link SpanCreationContext}
      *
      * @param context span context
-     * @return scope of the span, must be closed with explicit close or with try-with-resource
+     * @return span, must be closed.
      */
-    SpanScope startSpan(SpanCreationContext context);
+    Span startSpan(SpanCreationContext context);
 
     /**
      * Starts the {@link Span} with given name
      *
      * @param spanName span name
-     * @return scope of the span, must be closed with explicit close or with try-with-resource
+     * @return span, must be closed.
      */
-    SpanScope startSpan(String spanName);
+    Span startSpan(String spanName);
 
     /**
      * Starts the {@link Span} with given name and attributes. This is required in cases when some attribute based
      * decision needs to be made before starting the span. Very useful in the case of Sampling.
-     * @param spanName span name.
+     *
+     * @param spanName   span name.
      * @param attributes attributes to be added.
-     * @return scope of the span, must be closed with explicit close or with try-with-resource
+     * @return span, must be closed.
      */
-    SpanScope startSpan(String spanName, Attributes attributes);
+    Span startSpan(String spanName, Attributes attributes);
 
     /**
      * Starts the {@link Span} with the given name, parent and attributes.
-     * @param spanName span name.
+     *
+     * @param spanName   span name.
      * @param parentSpan parent span.
      * @param attributes attributes to be added.
-     * @return scope of the span, must be closed with explicit close or with try-with-resource
+     * @return span, must be closed.
      */
-    SpanScope startSpan(String spanName, SpanContext parentSpan, Attributes attributes);
+    Span startSpan(String spanName, SpanContext parentSpan, Attributes attributes);
 
     /**
      * Returns the current span.
      * @return current wrapped span.
      */
     SpanContext getCurrentSpan();
+
+    /**
+     * Start the span and scoped it. This must be used for scenarios where {@link SpanScope} and {@link Span} lifecycles
+     * are same and ends within the same thread where created.
+     * @param spanCreationContext span creation context
+     * @return scope of the span, must be closed with explicit close or with try-with-resource
+     */
+    ScopedSpan startScopedSpan(SpanCreationContext spanCreationContext);
+
+    /**
+     * Start the span and scoped it. This must be used for scenarios where {@link SpanScope} and {@link Span} lifecycles
+     * are same and ends within the same thread where created.
+     * @param spanCreationContext span creation context
+     * @param parentSpan parent span.
+     * @return scope of the span, must be closed with explicit close or with try-with-resource
+     */
+    ScopedSpan startScopedSpan(SpanCreationContext spanCreationContext, SpanContext parentSpan);
+
+    /**
+     * Creates the Span Scope for a current thread. It's mandatory to scope the span just after creation so that it will
+     * automatically manage the attach /detach to the current thread.
+     * @param span span to be scoped
+     * @return ScopedSpan
+     */
+    SpanScope createSpanScope(Span span);
+
 }

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/Tracer.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/Tracer.java
@@ -22,12 +22,12 @@ import java.io.Closeable;
 public interface Tracer extends HttpTracer, Closeable {
 
     /**
-     * Starts the {@link Span} with given {@link Context}
+     * Starts the {@link Span} with given {@link SpanCreationContext}
      *
      * @param context span context
      * @return scope of the span, must be closed with explicit close or with try-with-resource
      */
-    SpanScope startSpan(Context context);
+    SpanScope startSpan(SpanCreationContext context);
 
     /**
      * Starts the {@link Span} with given name

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/Tracer.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/Tracer.java
@@ -22,6 +22,14 @@ import java.io.Closeable;
 public interface Tracer extends HttpTracer, Closeable {
 
     /**
+     * Starts the {@link Span} with given {@link Context}
+     *
+     * @param context span context
+     * @return scope of the span, must be closed with explicit close or with try-with-resource
+     */
+    SpanScope startSpan(Context context);
+
+    /**
      * Starts the {@link Span} with given name
      *
      * @param spanName span name

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/TracerContextStorage.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/TracerContextStorage.java
@@ -22,6 +22,11 @@ public interface TracerContextStorage<K, V> {
     String CURRENT_SPAN = "current_span";
 
     /**
+     * Key for storing the current span.
+     */
+    String CURRENT_SPAN_SCOPE = "current_span_scope";
+
+    /**
      * Fetches value corresponding to key
      * @param key of the tracing context
      * @return value for key

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/http/HttpTracer.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/http/HttpTracer.java
@@ -9,7 +9,6 @@
 package org.opensearch.telemetry.tracing.http;
 
 import org.opensearch.telemetry.tracing.Span;
-import org.opensearch.telemetry.tracing.SpanScope;
 import org.opensearch.telemetry.tracing.attributes.Attributes;
 
 import java.util.List;
@@ -28,7 +27,7 @@ public interface HttpTracer {
      * @param spanName span name.
      * @param header http request header.
      * @param attributes span attributes.
-     * @return scope of the span, must be closed with explicit close or with try-with-resource
+     * @return span.
      */
-    SpanScope startSpan(String spanName, Map<String, List<String>> header, Attributes attributes);
+    Span startSpan(String spanName, Map<String, List<String>> header, Attributes attributes);
 }

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/noop/NoopScopedSpan.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/noop/NoopScopedSpan.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.telemetry.tracing.noop;
+
+import org.opensearch.telemetry.tracing.ScopedSpan;
+
+/**
+ * No-op implementation of SpanScope
+ *
+ * @opensearch.internal
+ */
+public final class NoopScopedSpan implements ScopedSpan {
+
+    /**
+     * No-args constructor
+     */
+    public NoopScopedSpan() {}
+
+    @Override
+    public void addSpanAttribute(String key, String value) {
+
+    }
+
+    @Override
+    public void addSpanAttribute(String key, long value) {
+
+    }
+
+    @Override
+    public void addSpanAttribute(String key, double value) {
+
+    }
+
+    @Override
+    public void addSpanAttribute(String key, boolean value) {
+
+    }
+
+    @Override
+    public void addSpanEvent(String event) {
+
+    }
+
+    @Override
+    public void setError(Exception exception) {
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/noop/NoopSpan.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/noop/NoopSpan.java
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.telemetry.tracing.noop;
+
+import org.opensearch.telemetry.tracing.Span;
+
+/**
+ * No-op implementation of {@link org.opensearch.telemetry.tracing.Span}
+ */
+public class NoopSpan implements Span {
+
+    /**
+     * No-op Span instance
+     */
+    public final static NoopSpan INSTANCE = new NoopSpan();
+
+    private NoopSpan() {
+
+    }
+
+    @Override
+    public void endSpan() {
+
+    }
+
+    @Override
+    public Span getParentSpan() {
+        return null;
+    }
+
+    @Override
+    public String getSpanName() {
+        return "noop-span";
+    }
+
+    @Override
+    public void addAttribute(String key, String value) {
+
+    }
+
+    @Override
+    public void addAttribute(String key, Long value) {
+
+    }
+
+    @Override
+    public void addAttribute(String key, Double value) {
+
+    }
+
+    @Override
+    public void addAttribute(String key, Boolean value) {
+
+    }
+
+    @Override
+    public void setError(Exception exception) {
+
+    }
+
+    @Override
+    public void addEvent(String event) {
+
+    }
+
+    @Override
+    public String getTraceId() {
+        return "noop-trace-id";
+    }
+
+    @Override
+    public String getSpanId() {
+        return "noop-span-id";
+    }
+}

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/noop/NoopSpanScope.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/noop/NoopSpanScope.java
@@ -8,52 +8,27 @@
 
 package org.opensearch.telemetry.tracing.noop;
 
+import org.opensearch.telemetry.tracing.Span;
 import org.opensearch.telemetry.tracing.SpanScope;
 
 /**
- * No-op implementation of SpanScope
- *
- * @opensearch.internal
+ * No-op implementation of {@link SpanScope}
  */
-public final class NoopSpanScope implements SpanScope {
-
+public class NoopSpanScope implements SpanScope {
     /**
-     * No-args constructor
+     * Constructor.
      */
-    public NoopSpanScope() {}
-
-    @Override
-    public void addSpanAttribute(String key, String value) {
-
-    }
-
-    @Override
-    public void addSpanAttribute(String key, long value) {
-
-    }
-
-    @Override
-    public void addSpanAttribute(String key, double value) {
-
-    }
-
-    @Override
-    public void addSpanAttribute(String key, boolean value) {
-
-    }
-
-    @Override
-    public void addSpanEvent(String event) {
-
-    }
-
-    @Override
-    public void setError(Exception exception) {
+    public NoopSpanScope() {
 
     }
 
     @Override
     public void close() {
 
+    }
+
+    @Override
+    public Span getSpan() {
+        return NoopSpan.INSTANCE;
     }
 }

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/noop/NoopTracer.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/noop/NoopTracer.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.telemetry.tracing.noop;
 
+import org.opensearch.telemetry.tracing.ScopedSpan;
+import org.opensearch.telemetry.tracing.Span;
 import org.opensearch.telemetry.tracing.SpanContext;
 import org.opensearch.telemetry.tracing.SpanCreationContext;
 import org.opensearch.telemetry.tracing.SpanScope;
@@ -32,28 +34,43 @@ public class NoopTracer implements Tracer {
     private NoopTracer() {}
 
     @Override
-    public SpanScope startSpan(SpanCreationContext context) {
-        return SpanScope.NO_OP;
+    public Span startSpan(SpanCreationContext context) {
+        return NoopSpan.INSTANCE;
     }
 
     @Override
-    public SpanScope startSpan(String spanName) {
-        return SpanScope.NO_OP;
+    public Span startSpan(String spanName) {
+        return NoopSpan.INSTANCE;
     }
 
     @Override
-    public SpanScope startSpan(String spanName, Attributes attributes) {
-        return SpanScope.NO_OP;
+    public Span startSpan(String spanName, Attributes attributes) {
+        return NoopSpan.INSTANCE;
     }
 
     @Override
-    public SpanScope startSpan(String spanName, SpanContext parentSpan, Attributes attributes) {
-        return SpanScope.NO_OP;
+    public Span startSpan(String spanName, SpanContext parentSpan, Attributes attributes) {
+        return NoopSpan.INSTANCE;
     }
 
     @Override
     public SpanContext getCurrentSpan() {
-        return null;
+        return new SpanContext(NoopSpan.INSTANCE);
+    }
+
+    @Override
+    public ScopedSpan startScopedSpan(SpanCreationContext spanCreationContext) {
+        return ScopedSpan.NO_OP;
+    }
+
+    @Override
+    public ScopedSpan startScopedSpan(SpanCreationContext spanCreationContext, SpanContext parentSpan) {
+        return ScopedSpan.NO_OP;
+    }
+
+    @Override
+    public SpanScope createSpanScope(Span span) {
+        return SpanScope.NO_OP;
     }
 
     @Override
@@ -62,7 +79,7 @@ public class NoopTracer implements Tracer {
     }
 
     @Override
-    public SpanScope startSpan(String spanName, Map<String, List<String>> header, Attributes attributes) {
-        return SpanScope.NO_OP;
+    public Span startSpan(String spanName, Map<String, List<String>> header, Attributes attributes) {
+        return NoopSpan.INSTANCE;
     }
 }

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/noop/NoopTracer.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/noop/NoopTracer.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.telemetry.tracing.noop;
 
+import org.opensearch.telemetry.tracing.Context;
 import org.opensearch.telemetry.tracing.SpanContext;
 import org.opensearch.telemetry.tracing.SpanScope;
 import org.opensearch.telemetry.tracing.Tracer;
@@ -29,6 +30,11 @@ public class NoopTracer implements Tracer {
     public static final Tracer INSTANCE = new NoopTracer();
 
     private NoopTracer() {}
+
+    @Override
+    public SpanScope startSpan(Context context) {
+        return SpanScope.NO_OP;
+    }
 
     @Override
     public SpanScope startSpan(String spanName) {

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/noop/NoopTracer.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/noop/NoopTracer.java
@@ -8,8 +8,8 @@
 
 package org.opensearch.telemetry.tracing.noop;
 
-import org.opensearch.telemetry.tracing.Context;
 import org.opensearch.telemetry.tracing.SpanContext;
+import org.opensearch.telemetry.tracing.SpanCreationContext;
 import org.opensearch.telemetry.tracing.SpanScope;
 import org.opensearch.telemetry.tracing.Tracer;
 import org.opensearch.telemetry.tracing.attributes.Attributes;
@@ -32,7 +32,7 @@ public class NoopTracer implements Tracer {
     private NoopTracer() {}
 
     @Override
-    public SpanScope startSpan(Context context) {
+    public SpanScope startSpan(SpanCreationContext context) {
         return SpanScope.NO_OP;
     }
 

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/runnable/TraceableRunnable.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/runnable/TraceableRunnable.java
@@ -8,8 +8,9 @@
 
 package org.opensearch.telemetry.tracing.runnable;
 
+import org.opensearch.telemetry.tracing.ScopedSpan;
 import org.opensearch.telemetry.tracing.SpanContext;
-import org.opensearch.telemetry.tracing.SpanScope;
+import org.opensearch.telemetry.tracing.SpanCreationContext;
 import org.opensearch.telemetry.tracing.Tracer;
 import org.opensearch.telemetry.tracing.attributes.Attributes;
 
@@ -41,7 +42,7 @@ public class TraceableRunnable implements Runnable {
 
     @Override
     public void run() {
-        try (SpanScope spanScope = tracer.startSpan(spanName, parent, attributes)) {
+        try (ScopedSpan spanScope = tracer.startScopedSpan(new SpanCreationContext(spanName, attributes), parent)) {
             runnable.run();
         }
     }

--- a/libs/telemetry/src/test/java/org/opensearch/telemetry/tracing/DefaultScopedSpanTests.java
+++ b/libs/telemetry/src/test/java/org/opensearch/telemetry/tracing/DefaultScopedSpanTests.java
@@ -10,26 +10,28 @@ package org.opensearch.telemetry.tracing;
 
 import org.opensearch.test.OpenSearchTestCase;
 
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class DefaultSpanScopeTests extends OpenSearchTestCase {
+public class DefaultScopedSpanTests extends OpenSearchTestCase {
 
     @SuppressWarnings("unchecked")
     public void testClose() {
         Span mockSpan = mock(Span.class);
-        Consumer<Span> mockConsumer = mock(Consumer.class);
-        DefaultSpanScope defaultSpanScope = new DefaultSpanScope(mockSpan, mockConsumer);
+        SpanScope mockSpanScope = mock(SpanScope.class);
+        BiConsumer<Span, SpanScope> mockConsumer = mock(BiConsumer.class);
+        DefaultScopedSpan defaultSpanScope = new DefaultScopedSpan(mockSpan, mockSpanScope, mockConsumer);
         defaultSpanScope.close();
 
-        verify(mockConsumer).accept(mockSpan);
+        verify(mockConsumer).accept(mockSpan, mockSpanScope);
     }
 
     public void testAddSpanAttributeString() {
         Span mockSpan = mock(Span.class);
-        DefaultSpanScope defaultSpanScope = new DefaultSpanScope(mockSpan, null);
+        SpanScope mockSpanScope = mock(SpanScope.class);
+        DefaultScopedSpan defaultSpanScope = new DefaultScopedSpan(mockSpan, mockSpanScope, (a, b) -> {});
         defaultSpanScope.addSpanAttribute("key", "value");
 
         verify(mockSpan).addAttribute("key", "value");
@@ -37,7 +39,8 @@ public class DefaultSpanScopeTests extends OpenSearchTestCase {
 
     public void testAddSpanAttributeLong() {
         Span mockSpan = mock(Span.class);
-        DefaultSpanScope defaultSpanScope = new DefaultSpanScope(mockSpan, null);
+        SpanScope mockSpanScope = mock(SpanScope.class);
+        DefaultScopedSpan defaultSpanScope = new DefaultScopedSpan(mockSpan, mockSpanScope, (a, b) -> {});
         defaultSpanScope.addSpanAttribute("key", 1L);
 
         verify(mockSpan).addAttribute("key", 1L);
@@ -45,7 +48,8 @@ public class DefaultSpanScopeTests extends OpenSearchTestCase {
 
     public void testAddSpanAttributeDouble() {
         Span mockSpan = mock(Span.class);
-        DefaultSpanScope defaultSpanScope = new DefaultSpanScope(mockSpan, null);
+        SpanScope mockSpanScope = mock(SpanScope.class);
+        DefaultScopedSpan defaultSpanScope = new DefaultScopedSpan(mockSpan, mockSpanScope, (a, b) -> {});
         defaultSpanScope.addSpanAttribute("key", 1.0);
 
         verify(mockSpan).addAttribute("key", 1.0);
@@ -53,7 +57,8 @@ public class DefaultSpanScopeTests extends OpenSearchTestCase {
 
     public void testAddSpanAttributeBoolean() {
         Span mockSpan = mock(Span.class);
-        DefaultSpanScope defaultSpanScope = new DefaultSpanScope(mockSpan, null);
+        SpanScope mockSpanScope = mock(SpanScope.class);
+        DefaultScopedSpan defaultSpanScope = new DefaultScopedSpan(mockSpan, mockSpanScope, (a, b) -> {});
         defaultSpanScope.addSpanAttribute("key", true);
 
         verify(mockSpan).addAttribute("key", true);
@@ -61,7 +66,8 @@ public class DefaultSpanScopeTests extends OpenSearchTestCase {
 
     public void testAddEvent() {
         Span mockSpan = mock(Span.class);
-        DefaultSpanScope defaultSpanScope = new DefaultSpanScope(mockSpan, null);
+        SpanScope mockSpanScope = mock(SpanScope.class);
+        DefaultScopedSpan defaultSpanScope = new DefaultScopedSpan(mockSpan, mockSpanScope, (a, b) -> {});
         defaultSpanScope.addSpanEvent("eventName");
 
         verify(mockSpan).addEvent("eventName");
@@ -69,7 +75,8 @@ public class DefaultSpanScopeTests extends OpenSearchTestCase {
 
     public void testSetError() {
         Span mockSpan = mock(Span.class);
-        DefaultSpanScope defaultSpanScope = new DefaultSpanScope(mockSpan, null);
+        SpanScope mockSpanScope = mock(SpanScope.class);
+        DefaultScopedSpan defaultSpanScope = new DefaultScopedSpan(mockSpan, mockSpanScope, (a, b) -> {});
         Exception ex = new Exception("error");
         defaultSpanScope.setError(ex);
 

--- a/libs/telemetry/src/test/java/org/opensearch/telemetry/tracing/DefaultTracerTests.java
+++ b/libs/telemetry/src/test/java/org/opensearch/telemetry/tracing/DefaultTracerTests.java
@@ -17,10 +17,6 @@ import org.opensearch.test.telemetry.tracing.MockTracingTelemetry;
 import org.junit.Assert;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -108,26 +104,12 @@ public class DefaultTracerTests extends OpenSearchTestCase {
         Assert.assertEquals(parentSpan.getSpan(), defaultTracer.getCurrentSpan().getSpan().getParentSpan());
     }
 
-    public void testHttpTracer() {
-        String traceId = "trace_id";
-        String spanId = "span_id";
-        TracingTelemetry tracingTelemetry = new MockTracingTelemetry();
-
-        DefaultTracer defaultTracer = new DefaultTracer(
-            tracingTelemetry,
-            new ThreadContextBasedTracerContextStorage(new ThreadContext(Settings.EMPTY), tracingTelemetry)
-        );
-
-        Map<String, List<String>> requestHeaders = new HashMap<>();
-        requestHeaders.put("traceparent", Arrays.asList(traceId + "~" + spanId));
-
-        SpanScope spanScope = defaultTracer.startSpan("test_span", requestHeaders, Attributes.EMPTY);
-        SpanContext currentSpan = defaultTracer.getCurrentSpan();
-        assertNotNull(currentSpan);
-        assertEquals(traceId, currentSpan.getSpan().getTraceId());
-        assertEquals(traceId, currentSpan.getSpan().getParentSpan().getTraceId());
-        assertEquals(spanId, currentSpan.getSpan().getParentSpan().getSpanId());
-        spanScope.close();
+    public void testCreateSpanWithContext() {
+        DefaultTracer defaultTracer = new DefaultTracer(mockTracingTelemetry, mockTracerContextStorage);
+        Attributes attributes = Attributes.create().addAttribute("name", "value");
+        when(mockTracingTelemetry.createSpan("span_name", mockParentSpan, attributes)).thenReturn(mockSpan);
+        defaultTracer.startSpan(new Context("span_name", attributes));
+        verify(mockTracingTelemetry).createSpan("span_name", mockParentSpan, attributes);
     }
 
     public void testCreateSpanWithNullParent() {
@@ -137,7 +119,7 @@ public class DefaultTracerTests extends OpenSearchTestCase {
             new ThreadContextBasedTracerContextStorage(new ThreadContext(Settings.EMPTY), tracingTelemetry)
         );
 
-        defaultTracer.startSpan("span_name");
+        defaultTracer.startSpan("span_name", null, Attributes.EMPTY);
 
         Assert.assertEquals("span_name", defaultTracer.getCurrentSpan().getSpan().getSpanName());
         Assert.assertEquals(null, defaultTracer.getCurrentSpan().getSpan().getParentSpan());

--- a/libs/telemetry/src/test/java/org/opensearch/telemetry/tracing/DefaultTracerTests.java
+++ b/libs/telemetry/src/test/java/org/opensearch/telemetry/tracing/DefaultTracerTests.java
@@ -14,7 +14,6 @@ import org.opensearch.telemetry.tracing.attributes.Attributes;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.telemetry.tracing.MockSpan;
 import org.opensearch.test.telemetry.tracing.MockTracingTelemetry;
-import org.junit.Assert;
 
 import java.io.IOException;
 
@@ -28,9 +27,12 @@ import static org.mockito.Mockito.when;
 public class DefaultTracerTests extends OpenSearchTestCase {
 
     private TracingTelemetry mockTracingTelemetry;
-    private TracerContextStorage<String, Span> mockTracerContextStorage;
+    private TracerContextStorage<String, Span> mockTracerContextSpanStorage;
+    private TracerContextStorage<String, SpanScope> mockTracerContextSpanScopeStorage;
     private Span mockSpan;
     private Span mockParentSpan;
+
+    private SpanScope mockSpanScope;
 
     @Override
     public void setUp() throws Exception {
@@ -44,15 +46,23 @@ public class DefaultTracerTests extends OpenSearchTestCase {
     }
 
     public void testCreateSpan() {
-        DefaultTracer defaultTracer = new DefaultTracer(mockTracingTelemetry, mockTracerContextStorage);
+        DefaultTracer defaultTracer = new DefaultTracer(
+            mockTracingTelemetry,
+            mockTracerContextSpanStorage,
+            mockTracerContextSpanScopeStorage
+        );
 
         defaultTracer.startSpan("span_name");
 
-        Assert.assertEquals("span_name", defaultTracer.getCurrentSpan().getSpan().getSpanName());
+        assertEquals("span_name", defaultTracer.getCurrentSpan().getSpan().getSpanName());
     }
 
     public void testCreateSpanWithAttributesWithMock() {
-        DefaultTracer defaultTracer = new DefaultTracer(mockTracingTelemetry, mockTracerContextStorage);
+        DefaultTracer defaultTracer = new DefaultTracer(
+            mockTracingTelemetry,
+            mockTracerContextSpanStorage,
+            mockTracerContextSpanScopeStorage
+        );
         Attributes attributes = Attributes.create().addAttribute("name", "value");
         when(mockTracingTelemetry.createSpan("span_name", mockParentSpan, attributes)).thenReturn(mockSpan);
         defaultTracer.startSpan("span_name", attributes);
@@ -60,19 +70,25 @@ public class DefaultTracerTests extends OpenSearchTestCase {
     }
 
     public void testCreateSpanWithAttributesWithParentMock() {
-        DefaultTracer defaultTracer = new DefaultTracer(mockTracingTelemetry, mockTracerContextStorage);
+        DefaultTracer defaultTracer = new DefaultTracer(
+            mockTracingTelemetry,
+            mockTracerContextSpanStorage,
+            mockTracerContextSpanScopeStorage
+        );
         Attributes attributes = Attributes.create().addAttribute("name", "value");
         when(mockTracingTelemetry.createSpan("span_name", mockParentSpan, attributes)).thenReturn(mockSpan);
         defaultTracer.startSpan("span_name", new SpanContext(mockParentSpan), attributes);
         verify(mockTracingTelemetry).createSpan("span_name", mockParentSpan, attributes);
-        verify(mockTracerContextStorage, never()).get(TracerContextStorage.CURRENT_SPAN);
+        verify(mockTracerContextSpanStorage, never()).get(TracerContextStorage.CURRENT_SPAN);
     }
 
     public void testCreateSpanWithAttributes() {
         TracingTelemetry tracingTelemetry = new MockTracingTelemetry();
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         DefaultTracer defaultTracer = new DefaultTracer(
             tracingTelemetry,
-            new ThreadContextBasedTracerContextStorage(new ThreadContext(Settings.EMPTY), tracingTelemetry)
+            new ThreadContextSpanStorage(threadContext, tracingTelemetry),
+            new ThreadContextSpanScopeStorage(threadContext)
         );
 
         defaultTracer.startSpan(
@@ -80,18 +96,19 @@ public class DefaultTracerTests extends OpenSearchTestCase {
             Attributes.create().addAttribute("key1", 1.0).addAttribute("key2", 2l).addAttribute("key3", true).addAttribute("key4", "key4")
         );
 
-        Assert.assertEquals("span_name", defaultTracer.getCurrentSpan().getSpan().getSpanName());
-        Assert.assertEquals(1.0, ((MockSpan) defaultTracer.getCurrentSpan().getSpan()).getAttribute("key1"));
-        Assert.assertEquals(2l, ((MockSpan) defaultTracer.getCurrentSpan().getSpan()).getAttribute("key2"));
-        Assert.assertEquals(true, ((MockSpan) defaultTracer.getCurrentSpan().getSpan()).getAttribute("key3"));
-        Assert.assertEquals("key4", ((MockSpan) defaultTracer.getCurrentSpan().getSpan()).getAttribute("key4"));
+        assertEquals("span_name", defaultTracer.getCurrentSpan().getSpan().getSpanName());
+        assertEquals(1.0, ((MockSpan) defaultTracer.getCurrentSpan().getSpan()).getAttribute("key1"));
+        assertEquals(2l, ((MockSpan) defaultTracer.getCurrentSpan().getSpan()).getAttribute("key2"));
+        assertEquals(true, ((MockSpan) defaultTracer.getCurrentSpan().getSpan()).getAttribute("key3"));
+        assertEquals("key4", ((MockSpan) defaultTracer.getCurrentSpan().getSpan()).getAttribute("key4"));
     }
 
     public void testCreateSpanWithParent() {
         TracingTelemetry tracingTelemetry = new MockTracingTelemetry();
         DefaultTracer defaultTracer = new DefaultTracer(
             tracingTelemetry,
-            new ThreadContextBasedTracerContextStorage(new ThreadContext(Settings.EMPTY), tracingTelemetry)
+            new ThreadContextSpanStorage(new ThreadContext(Settings.EMPTY), tracingTelemetry),
+            mockTracerContextSpanScopeStorage
         );
 
         defaultTracer.startSpan("span_name", null);
@@ -100,12 +117,16 @@ public class DefaultTracerTests extends OpenSearchTestCase {
 
         defaultTracer.startSpan("span_name_1", parentSpan, Attributes.EMPTY);
 
-        Assert.assertEquals("span_name_1", defaultTracer.getCurrentSpan().getSpan().getSpanName());
-        Assert.assertEquals(parentSpan.getSpan(), defaultTracer.getCurrentSpan().getSpan().getParentSpan());
+        assertEquals("span_name_1", defaultTracer.getCurrentSpan().getSpan().getSpanName());
+        assertEquals(parentSpan.getSpan(), defaultTracer.getCurrentSpan().getSpan().getParentSpan());
     }
 
     public void testCreateSpanWithContext() {
-        DefaultTracer defaultTracer = new DefaultTracer(mockTracingTelemetry, mockTracerContextStorage);
+        DefaultTracer defaultTracer = new DefaultTracer(
+            mockTracingTelemetry,
+            mockTracerContextSpanStorage,
+            mockTracerContextSpanScopeStorage
+        );
         Attributes attributes = Attributes.create().addAttribute("name", "value");
         when(mockTracingTelemetry.createSpan("span_name", mockParentSpan, attributes)).thenReturn(mockSpan);
         defaultTracer.startSpan(new SpanCreationContext("span_name", attributes));
@@ -114,27 +135,115 @@ public class DefaultTracerTests extends OpenSearchTestCase {
 
     public void testCreateSpanWithNullParent() {
         TracingTelemetry tracingTelemetry = new MockTracingTelemetry();
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         DefaultTracer defaultTracer = new DefaultTracer(
             tracingTelemetry,
-            new ThreadContextBasedTracerContextStorage(new ThreadContext(Settings.EMPTY), tracingTelemetry)
+            new ThreadContextSpanStorage(threadContext, tracingTelemetry),
+            new ThreadContextSpanScopeStorage(threadContext)
         );
 
-        defaultTracer.startSpan("span_name", null, Attributes.EMPTY);
+        defaultTracer.startSpan("span_name", (SpanContext) null, Attributes.EMPTY);
 
-        Assert.assertEquals("span_name", defaultTracer.getCurrentSpan().getSpan().getSpanName());
-        Assert.assertEquals(null, defaultTracer.getCurrentSpan().getSpan().getParentSpan());
+        assertEquals("span_name", defaultTracer.getCurrentSpan().getSpan().getSpanName());
+        assertEquals(null, defaultTracer.getCurrentSpan().getSpan().getParentSpan());
     }
 
-    public void testEndSpanByClosingScope() {
-        DefaultTracer defaultTracer = new DefaultTracer(mockTracingTelemetry, mockTracerContextStorage);
-        try (SpanScope spanScope = defaultTracer.startSpan("span_name")) {
-            verify(mockTracerContextStorage).put(TracerContextStorage.CURRENT_SPAN, mockSpan);
-        }
-        verify(mockTracerContextStorage).put(TracerContextStorage.CURRENT_SPAN, mockParentSpan);
+    public void testEndSpanByClosingScopedSpan() {
+        TracingTelemetry tracingTelemetry = new MockTracingTelemetry();
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        ThreadContextSpanStorage spanTracerStorage = new ThreadContextSpanStorage(threadContext, tracingTelemetry);
+        ThreadContextSpanScopeStorage spanScopeTracerContextStorage = new ThreadContextSpanScopeStorage(threadContext);
+        DefaultTracer defaultTracer = new DefaultTracer(tracingTelemetry, spanTracerStorage, spanScopeTracerContextStorage);
+        ScopedSpan scopedSpan = defaultTracer.startScopedSpan(new SpanCreationContext("span_name", Attributes.EMPTY));
+        assertEquals("span_name", defaultTracer.getCurrentSpan().getSpan().getSpanName());
+        assertEquals(
+            ((DefaultScopedSpan) scopedSpan).getSpanScope(),
+            spanScopeTracerContextStorage.getCurrentSpanScope(TracerContextStorage.CURRENT_SPAN_SCOPE)
+        );
+        scopedSpan.close();
+        assertTrue(((MockSpan) ((DefaultScopedSpan) scopedSpan).getSpan()).hasEnded());
+        assertEquals(null, defaultTracer.getCurrentSpan());
+        assertEquals(null, spanScopeTracerContextStorage.getCurrentSpanScope(TracerContextStorage.CURRENT_SPAN_SCOPE));
+
+    }
+
+    public void testEndSpanByClosingScopedSpanMultiple() {
+        TracingTelemetry tracingTelemetry = new MockTracingTelemetry();
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        ThreadContextSpanStorage spanTracerStorage = new ThreadContextSpanStorage(threadContext, tracingTelemetry);
+        ThreadContextSpanScopeStorage spanScopeTracerContextStorage = new ThreadContextSpanScopeStorage(threadContext);
+        DefaultTracer defaultTracer = new DefaultTracer(tracingTelemetry, spanTracerStorage, spanScopeTracerContextStorage);
+        ScopedSpan scopedSpan = defaultTracer.startScopedSpan(new SpanCreationContext("span_name", Attributes.EMPTY));
+        ScopedSpan scopedSpan1 = defaultTracer.startScopedSpan(new SpanCreationContext("span_name_1", Attributes.EMPTY));
+
+        assertEquals("span_name_1", defaultTracer.getCurrentSpan().getSpan().getSpanName());
+        assertEquals(
+            ((DefaultScopedSpan) scopedSpan1).getSpanScope(),
+            spanScopeTracerContextStorage.getCurrentSpanScope(TracerContextStorage.CURRENT_SPAN_SCOPE)
+        );
+
+        scopedSpan1.close();
+        assertTrue(((MockSpan) ((DefaultScopedSpan) scopedSpan1).getSpan()).hasEnded());
+        assertEquals("span_name", defaultTracer.getCurrentSpan().getSpan().getSpanName());
+        assertEquals(
+            ((DefaultScopedSpan) scopedSpan).getSpanScope(),
+            spanScopeTracerContextStorage.getCurrentSpanScope(TracerContextStorage.CURRENT_SPAN_SCOPE)
+        );
+
+        scopedSpan.close();
+        assertTrue(((MockSpan) ((DefaultScopedSpan) scopedSpan).getSpan()).hasEnded());
+        assertEquals(null, defaultTracer.getCurrentSpan());
+        assertEquals(null, spanScopeTracerContextStorage.getCurrentSpanScope(TracerContextStorage.CURRENT_SPAN_SCOPE));
+
+    }
+
+    public void testEndSpanByClosingSpanScope() {
+        TracingTelemetry tracingTelemetry = new MockTracingTelemetry();
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        ThreadContextSpanStorage spanTracerStorage = new ThreadContextSpanStorage(threadContext, tracingTelemetry);
+        ThreadContextSpanScopeStorage spanScopeTracerContextStorage = new ThreadContextSpanScopeStorage(threadContext);
+        DefaultTracer defaultTracer = new DefaultTracer(tracingTelemetry, spanTracerStorage, spanScopeTracerContextStorage);
+        Span span = defaultTracer.startSpan(new SpanCreationContext("span_name", Attributes.EMPTY));
+        SpanScope spanScope = defaultTracer.createSpanScope(span);
+        assertEquals("span_name", defaultTracer.getCurrentSpan().getSpan().getSpanName());
+        assertEquals(spanScope, spanScopeTracerContextStorage.getCurrentSpanScope(TracerContextStorage.CURRENT_SPAN_SCOPE));
+
+        spanScope.close();
+        assertEquals(null, defaultTracer.getCurrentSpan());
+        assertFalse(((MockSpan) span).hasEnded());
+
+    }
+
+    public void testEndSpanByClosingSpanScopeMultiple() {
+        TracingTelemetry tracingTelemetry = new MockTracingTelemetry();
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        ThreadContextSpanStorage spanTracerStorage = new ThreadContextSpanStorage(threadContext, tracingTelemetry);
+        ThreadContextSpanScopeStorage spanScopeTracerContextStorage = new ThreadContextSpanScopeStorage(threadContext);
+        DefaultTracer defaultTracer = new DefaultTracer(tracingTelemetry, spanTracerStorage, spanScopeTracerContextStorage);
+        Span span = defaultTracer.startSpan(new SpanCreationContext("span_name", Attributes.EMPTY));
+        Span span1 = defaultTracer.startSpan(new SpanCreationContext("span_name_1", Attributes.EMPTY));
+        SpanScope spanScope = defaultTracer.createSpanScope(span);
+        SpanScope spanScope1 = defaultTracer.createSpanScope(span1);
+        assertEquals("span_name_1", defaultTracer.getCurrentSpan().getSpan().getSpanName());
+        assertEquals(spanScope1, spanScopeTracerContextStorage.getCurrentSpanScope(TracerContextStorage.CURRENT_SPAN_SCOPE));
+
+        spanScope1.close();
+
+        assertEquals("span_name", defaultTracer.getCurrentSpan().getSpan().getSpanName());
+        assertEquals(spanScope, spanScopeTracerContextStorage.getCurrentSpanScope(TracerContextStorage.CURRENT_SPAN_SCOPE));
+        assertFalse(((MockSpan) span1).hasEnded());
+        assertFalse(((MockSpan) span).hasEnded());
+        spanScope.close();
+
+        assertEquals(null, defaultTracer.getCurrentSpan());
+        assertEquals(null, spanScopeTracerContextStorage.getCurrentSpanScope(TracerContextStorage.CURRENT_SPAN_SCOPE));
+        assertFalse(((MockSpan) span).hasEnded());
+        assertFalse(((MockSpan) span1).hasEnded());
+
     }
 
     public void testClose() throws IOException {
-        Tracer defaultTracer = new DefaultTracer(mockTracingTelemetry, mockTracerContextStorage);
+        Tracer defaultTracer = new DefaultTracer(mockTracingTelemetry, mockTracerContextSpanStorage, mockTracerContextSpanScopeStorage);
 
         defaultTracer.close();
 
@@ -146,14 +255,17 @@ public class DefaultTracerTests extends OpenSearchTestCase {
         mockTracingTelemetry = mock(TracingTelemetry.class);
         mockSpan = mock(Span.class);
         mockParentSpan = mock(Span.class);
-        mockTracerContextStorage = mock(TracerContextStorage.class);
+        mockSpanScope = mock(SpanScope.class);
+        mockTracerContextSpanStorage = mock(TracerContextStorage.class);
+        mockTracerContextSpanScopeStorage = mock(TracerContextStorage.class);
         when(mockSpan.getSpanName()).thenReturn("span_name");
         when(mockSpan.getSpanId()).thenReturn("span_id");
         when(mockSpan.getTraceId()).thenReturn("trace_id");
         when(mockSpan.getParentSpan()).thenReturn(mockParentSpan);
         when(mockParentSpan.getSpanId()).thenReturn("parent_span_id");
         when(mockParentSpan.getTraceId()).thenReturn("trace_id");
-        when(mockTracerContextStorage.get(TracerContextStorage.CURRENT_SPAN)).thenReturn(mockParentSpan, mockSpan);
+        when(mockTracerContextSpanStorage.get(TracerContextStorage.CURRENT_SPAN)).thenReturn(mockParentSpan, mockSpan);
+        when(mockTracerContextSpanScopeStorage.get(TracerContextStorage.CURRENT_SPAN)).thenReturn(mockSpanScope);
         when(mockTracingTelemetry.createSpan(eq("span_name"), eq(mockParentSpan), any(Attributes.class))).thenReturn(mockSpan);
     }
 }

--- a/libs/telemetry/src/test/java/org/opensearch/telemetry/tracing/DefaultTracerTests.java
+++ b/libs/telemetry/src/test/java/org/opensearch/telemetry/tracing/DefaultTracerTests.java
@@ -108,7 +108,7 @@ public class DefaultTracerTests extends OpenSearchTestCase {
         DefaultTracer defaultTracer = new DefaultTracer(mockTracingTelemetry, mockTracerContextStorage);
         Attributes attributes = Attributes.create().addAttribute("name", "value");
         when(mockTracingTelemetry.createSpan("span_name", mockParentSpan, attributes)).thenReturn(mockSpan);
-        defaultTracer.startSpan(new Context("span_name", attributes));
+        defaultTracer.startSpan(new SpanCreationContext("span_name", attributes));
         verify(mockTracingTelemetry).createSpan("span_name", mockParentSpan, attributes);
     }
 

--- a/server/src/main/java/org/opensearch/telemetry/tracing/AttributeNames.java
+++ b/server/src/main/java/org/opensearch/telemetry/tracing/AttributeNames.java
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.telemetry.tracing;
+
+/**
+ * Hold the Attribute names to avoid the duplication and consistensy.
+ */
+public final class AttributeNames {
+
+    /**
+     * Constructor
+     */
+    private AttributeNames() {
+
+    }
+
+    /**
+     * HTTP Protocol Version
+     */
+    public static final String HTTP_PROTOCOL_VERSION = "http.version";
+
+    /**
+     * HTTP method
+     */
+    public static final String HTTP_METHOD = "http.method";
+
+    /**
+     * HTTP Request URI.
+     */
+    public static final String HTTP_URI = "http.uri";
+
+    /**
+     * Rest Request ID.
+     */
+    public static final String REST_REQ_ID = "rest.request_id";
+
+    /**
+     * Rest Request Raw Path.
+     */
+    public static final String REST_REQ_RAW_PATH = "rest.raw_path";
+
+    /**
+     * Trace key. To be used for on demand sampling.
+     */
+    public static final String TRACE = "trace";
+
+    /**
+     * Transport Service send request target host.
+     */
+    public static final String TRANSPORT_TARGET_HOST = "target_host";
+
+    /**
+     * Action Name.
+     */
+    public static final String TRANSPORT_ACTION = "action";
+}

--- a/server/src/main/java/org/opensearch/telemetry/tracing/SpanBuilder.java
+++ b/server/src/main/java/org/opensearch/telemetry/tracing/SpanBuilder.java
@@ -18,42 +18,49 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Utility class, helps in creating the {@link Context} for span.
+ * Utility class, helps in creating the {@link SpanCreationContext} for span.
  */
-public class SpanBuilder {
+public final class SpanBuilder {
 
     private static final List<String> HEADERS_TO_BE_ADDED_AS_ATTRIBUTES = Arrays.asList(AttributeNames.TRACE);
     /**
      * Attribute name Separator
      */
-    public static final String SEPARATOR = " ";
+    private static final String SEPARATOR = " ";
 
     /**
-     * Creates {@link Context} from the {@link HttpRequest}
+     * Constructor
+     */
+    private SpanBuilder() {
+
+    }
+
+    /**
+     * Creates {@link SpanCreationContext} from the {@link HttpRequest}
      * @param request Http request.
      * @return context.
      */
-    public static Context from(HttpRequest request) {
-        return new Context(createSpanName(request), buildSpanAttributes(request));
+    public static SpanCreationContext from(HttpRequest request) {
+        return new SpanCreationContext(createSpanName(request), buildSpanAttributes(request));
     }
 
     /**
-     * Creates {@link Context} from the {@link RestRequest}
+     * Creates {@link SpanCreationContext} from the {@link RestRequest}
      * @param request Rest request
      * @return context
      */
-    public static Context from(RestRequest request) {
-        return new Context(createSpanName(request), buildSpanAttributes(request));
+    public static SpanCreationContext from(RestRequest request) {
+        return new SpanCreationContext(createSpanName(request), buildSpanAttributes(request));
     }
 
     /**
-     * Creates {@link Context} from Transport action and connection details.
+     * Creates {@link SpanCreationContext} from Transport action and connection details.
      * @param action action.
      * @param connection transport connection.
      * @return context
      */
-    public static Context from(String action, Transport.Connection connection) {
-        return new Context(createSpanName(action, connection), buildSpanAttributes(action, connection));
+    public static SpanCreationContext from(String action, Transport.Connection connection) {
+        return new SpanCreationContext(createSpanName(action, connection), buildSpanAttributes(action, connection));
     }
 
     private static String createSpanName(HttpRequest httpRequest) {

--- a/server/src/main/java/org/opensearch/telemetry/tracing/SpanBuilder.java
+++ b/server/src/main/java/org/opensearch/telemetry/tracing/SpanBuilder.java
@@ -1,0 +1,117 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.telemetry.tracing;
+
+import org.opensearch.core.common.Strings;
+import org.opensearch.http.HttpRequest;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.telemetry.tracing.attributes.Attributes;
+import org.opensearch.transport.Transport;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Utility class, helps in creating the {@link Context} for span.
+ */
+public class SpanBuilder {
+
+    private static final List<String> HEADERS_TO_BE_ADDED_AS_ATTRIBUTES = Arrays.asList(AttributeNames.TRACE);
+    /**
+     * Attribute name Separator
+     */
+    public static final String SEPARATOR = " ";
+
+    /**
+     * Creates {@link Context} from the {@link HttpRequest}
+     * @param request Http request.
+     * @return context.
+     */
+    public static Context from(HttpRequest request) {
+        return new Context(createSpanName(request), buildSpanAttributes(request));
+    }
+
+    /**
+     * Creates {@link Context} from the {@link RestRequest}
+     * @param request Rest request
+     * @return context
+     */
+    public static Context from(RestRequest request) {
+        return new Context(createSpanName(request), buildSpanAttributes(request));
+    }
+
+    /**
+     * Creates {@link Context} from Transport action and connection details.
+     * @param action action.
+     * @param connection transport connection.
+     * @return context
+     */
+    public static Context from(String action, Transport.Connection connection) {
+        return new Context(createSpanName(action, connection), buildSpanAttributes(action, connection));
+    }
+
+    private static String createSpanName(HttpRequest httpRequest) {
+        return httpRequest.method().name() + SEPARATOR + httpRequest.uri();
+    }
+
+    private static Attributes buildSpanAttributes(HttpRequest httpRequest) {
+        Attributes attributes = Attributes.create()
+            .addAttribute(AttributeNames.HTTP_URI, httpRequest.uri())
+            .addAttribute(AttributeNames.HTTP_METHOD, httpRequest.method().name())
+            .addAttribute(AttributeNames.HTTP_PROTOCOL_VERSION, httpRequest.protocolVersion().name());
+        populateHeader(httpRequest, attributes);
+        return attributes;
+    }
+
+    private static void populateHeader(HttpRequest httpRequest, Attributes attributes) {
+        HEADERS_TO_BE_ADDED_AS_ATTRIBUTES.forEach(x -> {
+            if (httpRequest.getHeaders() != null && httpRequest.getHeaders().get(x) != null) {
+                attributes.addAttribute(x, Strings.collectionToCommaDelimitedString(httpRequest.getHeaders().get(x)));
+            }
+        });
+    }
+
+    private static String createSpanName(RestRequest restRequest) {
+        String spanName = "rest_request";
+        if (restRequest != null) {
+            try {
+                String methodName = restRequest.method().name();
+                // path() does the decoding, which may give error
+                String path = restRequest.path();
+                spanName = methodName + SEPARATOR + path;
+            } catch (Exception e) {
+                // swallow the exception and keep the default name.
+            }
+        }
+        return spanName;
+    }
+
+    private static Attributes buildSpanAttributes(RestRequest restRequest) {
+        if (restRequest != null) {
+            return Attributes.create()
+                .addAttribute(AttributeNames.REST_REQ_ID, restRequest.getRequestId())
+                .addAttribute(AttributeNames.REST_REQ_RAW_PATH, restRequest.rawPath());
+        } else {
+            return Attributes.EMPTY;
+        }
+    }
+
+    private static String createSpanName(String action, Transport.Connection connection) {
+        return action + SEPARATOR + (connection.getNode() != null ? connection.getNode().getHostAddress() : null);
+    }
+
+    private static Attributes buildSpanAttributes(String action, Transport.Connection connection) {
+        Attributes attributes = Attributes.create().addAttribute(AttributeNames.TRANSPORT_ACTION, action);
+        if (connection != null && connection.getNode() != null) {
+            attributes.addAttribute(AttributeNames.TRANSPORT_TARGET_HOST, connection.getNode().getHostAddress());
+        }
+        return attributes;
+    }
+
+}

--- a/server/src/main/java/org/opensearch/telemetry/tracing/ThreadContextSpanScopeStorage.java
+++ b/server/src/main/java/org/opensearch/telemetry/tracing/ThreadContextSpanScopeStorage.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.telemetry.tracing;
+
+import org.opensearch.common.util.concurrent.ThreadContext;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Core's ThreadContext based TracerContextStorage implementation
+ *
+ * @opensearch.internal
+ */
+public class ThreadContextSpanScopeStorage implements TracerContextStorage<String, SpanScope> {
+
+    private final ThreadContext threadContext;
+
+    public ThreadContextSpanScopeStorage(ThreadContext threadContext) {
+        this.threadContext = Objects.requireNonNull(threadContext);
+    }
+
+    @Override
+    public SpanScope get(String key) {
+        return getCurrentSpanScope(key);
+    }
+
+    @Override
+    public void put(String key, SpanScope spanScope) {
+        SpanScopeReference currentSpanRef = threadContext.getTransient(key);
+        if (currentSpanRef == null) {
+            threadContext.putTransient(key, new SpanScopeReference(spanScope));
+        } else {
+            currentSpanRef.setSpanScope(spanScope);
+        }
+    }
+
+    SpanScope getCurrentSpanScope(String key) {
+        return spanFromThreadContext(key).orElse(null);
+    }
+
+    private Optional<SpanScope> spanFromThreadContext(String key) {
+        SpanScopeReference currentSpanScopeRef = threadContext.getTransient(key);
+        return (currentSpanScopeRef == null) ? Optional.empty() : Optional.ofNullable(currentSpanScopeRef.getSpanScope());
+    }
+
+}

--- a/server/src/main/java/org/opensearch/telemetry/tracing/ThreadContextSpanStorage.java
+++ b/server/src/main/java/org/opensearch/telemetry/tracing/ThreadContextSpanStorage.java
@@ -21,13 +21,13 @@ import java.util.Optional;
  *
  * @opensearch.internal
  */
-public class ThreadContextBasedTracerContextStorage implements TracerContextStorage<String, Span>, ThreadContextStatePropagator {
+public class ThreadContextSpanStorage implements TracerContextStorage<String, Span>, ThreadContextStatePropagator {
 
     private final ThreadContext threadContext;
 
     private final TracingTelemetry tracingTelemetry;
 
-    public ThreadContextBasedTracerContextStorage(ThreadContext threadContext, TracingTelemetry tracingTelemetry) {
+    public ThreadContextSpanStorage(ThreadContext threadContext, TracingTelemetry tracingTelemetry) {
         this.threadContext = Objects.requireNonNull(threadContext);
         this.tracingTelemetry = Objects.requireNonNull(tracingTelemetry);
         this.threadContext.registerThreadContextStatePropagator(this);
@@ -40,9 +40,6 @@ public class ThreadContextBasedTracerContextStorage implements TracerContextStor
 
     @Override
     public void put(String key, Span span) {
-        if (span == null) {
-            return;
-        }
         SpanReference currentSpanRef = threadContext.getTransient(key);
         if (currentSpanRef == null) {
             threadContext.putTransient(key, new SpanReference(span));

--- a/server/src/main/java/org/opensearch/telemetry/tracing/TracerFactory.java
+++ b/server/src/main/java/org/opensearch/telemetry/tracing/TracerFactory.java
@@ -66,11 +66,11 @@ public class TracerFactory implements Closeable {
     }
 
     private Tracer createDefaultTracer(TracingTelemetry tracingTelemetry, ThreadContext threadContext) {
-        TracerContextStorage<String, Span> tracerContextStorage = new ThreadContextBasedTracerContextStorage(
-            threadContext,
-            tracingTelemetry
-        );
-        return new DefaultTracer(tracingTelemetry, tracerContextStorage);
+        TracerContextStorage<String, Span> tracerContextSpanStorage = new ThreadContextSpanStorage(threadContext, tracingTelemetry);
+
+        TracerContextStorage<String, SpanScope> tracerContextSpanScopeStorage = new ThreadContextSpanScopeStorage(threadContext);
+
+        return new DefaultTracer(tracingTelemetry, tracerContextSpanStorage, tracerContextSpanScopeStorage);
     }
 
     private Tracer createWrappedTracer(Tracer defaultTracer) {

--- a/server/src/main/java/org/opensearch/telemetry/tracing/WrappedTracer.java
+++ b/server/src/main/java/org/opensearch/telemetry/tracing/WrappedTracer.java
@@ -38,7 +38,7 @@ final class WrappedTracer implements Tracer {
     }
 
     @Override
-    public SpanScope startSpan(Context context) {
+    public SpanScope startSpan(SpanCreationContext context) {
         return startSpan(context.getSpanName(), context.getAttributes());
     }
 

--- a/server/src/main/java/org/opensearch/telemetry/tracing/WrappedTracer.java
+++ b/server/src/main/java/org/opensearch/telemetry/tracing/WrappedTracer.java
@@ -38,17 +38,17 @@ final class WrappedTracer implements Tracer {
     }
 
     @Override
-    public SpanScope startSpan(SpanCreationContext context) {
+    public Span startSpan(SpanCreationContext context) {
         return startSpan(context.getSpanName(), context.getAttributes());
     }
 
     @Override
-    public SpanScope startSpan(String spanName) {
+    public Span startSpan(String spanName) {
         return startSpan(spanName, Attributes.EMPTY);
     }
 
     @Override
-    public SpanScope startSpan(String spanName, Attributes attributes) {
+    public Span startSpan(String spanName, Attributes attributes) {
         return startSpan(spanName, (SpanContext) null, attributes);
     }
 
@@ -59,7 +59,22 @@ final class WrappedTracer implements Tracer {
     }
 
     @Override
-    public SpanScope startSpan(String spanName, SpanContext parentSpan, Attributes attributes) {
+    public ScopedSpan startScopedSpan(SpanCreationContext spanCreationContext) {
+        return startScopedSpan(spanCreationContext, null);
+    }
+
+    @Override
+    public ScopedSpan startScopedSpan(SpanCreationContext spanCreationContext, SpanContext parentSpan) {
+        return getDelegateTracer().startScopedSpan(spanCreationContext, parentSpan);
+    }
+
+    @Override
+    public SpanScope createSpanScope(Span span) {
+        return getDelegateTracer().createSpanScope(span);
+    }
+
+    @Override
+    public Span startSpan(String spanName, SpanContext parentSpan, Attributes attributes) {
         Tracer delegateTracer = getDelegateTracer();
         return delegateTracer.startSpan(spanName, parentSpan, attributes);
     }
@@ -75,7 +90,7 @@ final class WrappedTracer implements Tracer {
     }
 
     @Override
-    public SpanScope startSpan(String spanName, Map<String, List<String>> headers, Attributes attributes) {
+    public Span startSpan(String spanName, Map<String, List<String>> headers, Attributes attributes) {
         return defaultTracer.startSpan(spanName, headers, attributes);
     }
 }

--- a/server/src/main/java/org/opensearch/telemetry/tracing/WrappedTracer.java
+++ b/server/src/main/java/org/opensearch/telemetry/tracing/WrappedTracer.java
@@ -38,6 +38,11 @@ final class WrappedTracer implements Tracer {
     }
 
     @Override
+    public SpanScope startSpan(Context context) {
+        return startSpan(context.getSpanName(), context.getAttributes());
+    }
+
+    @Override
     public SpanScope startSpan(String spanName) {
         return startSpan(spanName, Attributes.EMPTY);
     }

--- a/server/src/test/java/org/opensearch/cluster/routing/ShardMovementStrategyTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/ShardMovementStrategyTests.java
@@ -25,6 +25,10 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class ShardMovementStrategyTests extends OpenSearchIntegTestCase {
 
+    protected boolean addMockTelemetryPlugin() {
+        return false;
+    }
+
     protected String startDataOnlyNode(final String zone) {
         final Settings settings = Settings.builder().put("node.attr.zone", zone).build();
         return internalCluster().startDataOnlyNode(settings);

--- a/server/src/test/java/org/opensearch/telemetry/tracing/SpanBuilderTests.java
+++ b/server/src/test/java/org/opensearch/telemetry/tracing/SpanBuilderTests.java
@@ -1,0 +1,158 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.telemetry.tracing;
+
+import org.opensearch.Version;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.network.NetworkAddress;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.transport.TransportAddress;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.http.HttpRequest;
+import org.opensearch.http.HttpResponse;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.telemetry.tracing.attributes.Attributes;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.Transport;
+import org.opensearch.transport.TransportException;
+import org.opensearch.transport.TransportRequest;
+import org.opensearch.transport.TransportRequestOptions;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class SpanBuilderTests extends OpenSearchTestCase {
+
+    public void testHttpRequestContext() {
+        HttpRequest httpRequest = createHttpRequest();
+        Context context = SpanBuilder.from(httpRequest);
+        Attributes attributes = context.getAttributes();
+        assertEquals("GET /_test", context.getSpanName());
+        assertEquals("true", attributes.getAttributesMap().get(AttributeNames.TRACE));
+        assertEquals("GET", attributes.getAttributesMap().get(AttributeNames.HTTP_METHOD));
+        assertEquals("HTTP_1_0", attributes.getAttributesMap().get(AttributeNames.HTTP_PROTOCOL_VERSION));
+        assertEquals("/_test", attributes.getAttributesMap().get(AttributeNames.HTTP_URI));
+    }
+
+    public void testRestRequestContext() {
+        RestRequest restRequest = RestRequest.request(null, createHttpRequest(), null);
+        Context context = SpanBuilder.from(restRequest);
+        Attributes attributes = context.getAttributes();
+        assertEquals("GET /_test", context.getSpanName());
+        assertEquals("/_test", attributes.getAttributesMap().get(AttributeNames.REST_REQ_RAW_PATH));
+        assertNotNull(attributes.getAttributesMap().get(AttributeNames.REST_REQ_ID));
+    }
+
+    public void testRestRequestContextForNull() {
+        Context context = SpanBuilder.from((RestRequest) null);
+        assertEquals("rest_request", context.getSpanName());
+        assertEquals(Attributes.EMPTY, context.getAttributes());
+    }
+
+    public void testTransportContext() {
+        String action = "test-action";
+        Transport.Connection connection = createTransportConnection();
+        Context context = SpanBuilder.from(action, connection);
+        Attributes attributes = context.getAttributes();
+        assertEquals(action + SpanBuilder.SEPARATOR + NetworkAddress.format(TransportAddress.META_ADDRESS), context.getSpanName());
+        assertEquals(connection.getNode().getHostAddress(), attributes.getAttributesMap().get(AttributeNames.TRANSPORT_TARGET_HOST));
+    }
+
+    private static Transport.Connection createTransportConnection() {
+        return new Transport.Connection() {
+            @Override
+            public DiscoveryNode getNode() {
+                return new DiscoveryNode("local", new TransportAddress(TransportAddress.META_ADDRESS, 9200), Version.V_2_0_0);
+            }
+
+            @Override
+            public void sendRequest(long requestId, String action, TransportRequest request, TransportRequestOptions options)
+                throws IOException, TransportException {
+
+            }
+
+            @Override
+            public void addCloseListener(ActionListener<Void> listener) {
+
+            }
+
+            @Override
+            public boolean isClosed() {
+                return false;
+            }
+
+            @Override
+            public void close() {
+
+            }
+        };
+    }
+
+    private static HttpRequest createHttpRequest() {
+        return new HttpRequest() {
+            @Override
+            public RestRequest.Method method() {
+                return RestRequest.Method.GET;
+            }
+
+            @Override
+            public String uri() {
+                return "/_test";
+            }
+
+            @Override
+            public BytesReference content() {
+                return null;
+            }
+
+            @Override
+            public Map<String, List<String>> getHeaders() {
+                return Map.of("trace", Arrays.asList("true"));
+            }
+
+            @Override
+            public List<String> strictCookies() {
+                return null;
+            }
+
+            @Override
+            public HttpVersion protocolVersion() {
+                return HttpVersion.HTTP_1_0;
+            }
+
+            @Override
+            public HttpRequest removeHeader(String header) {
+                return null;
+            }
+
+            @Override
+            public HttpResponse createResponse(RestStatus status, BytesReference content) {
+                return null;
+            }
+
+            @Override
+            public Exception getInboundException() {
+                return null;
+            }
+
+            @Override
+            public void release() {
+
+            }
+
+            @Override
+            public HttpRequest releaseAndCopy() {
+                return null;
+            }
+        };
+    }
+}

--- a/server/src/test/java/org/opensearch/telemetry/tracing/SpanBuilderTests.java
+++ b/server/src/test/java/org/opensearch/telemetry/tracing/SpanBuilderTests.java
@@ -34,7 +34,7 @@ public class SpanBuilderTests extends OpenSearchTestCase {
 
     public void testHttpRequestContext() {
         HttpRequest httpRequest = createHttpRequest();
-        Context context = SpanBuilder.from(httpRequest);
+        SpanCreationContext context = SpanBuilder.from(httpRequest);
         Attributes attributes = context.getAttributes();
         assertEquals("GET /_test", context.getSpanName());
         assertEquals("true", attributes.getAttributesMap().get(AttributeNames.TRACE));
@@ -45,7 +45,7 @@ public class SpanBuilderTests extends OpenSearchTestCase {
 
     public void testRestRequestContext() {
         RestRequest restRequest = RestRequest.request(null, createHttpRequest(), null);
-        Context context = SpanBuilder.from(restRequest);
+        SpanCreationContext context = SpanBuilder.from(restRequest);
         Attributes attributes = context.getAttributes();
         assertEquals("GET /_test", context.getSpanName());
         assertEquals("/_test", attributes.getAttributesMap().get(AttributeNames.REST_REQ_RAW_PATH));
@@ -53,7 +53,7 @@ public class SpanBuilderTests extends OpenSearchTestCase {
     }
 
     public void testRestRequestContextForNull() {
-        Context context = SpanBuilder.from((RestRequest) null);
+        SpanCreationContext context = SpanBuilder.from((RestRequest) null);
         assertEquals("rest_request", context.getSpanName());
         assertEquals(Attributes.EMPTY, context.getAttributes());
     }
@@ -61,9 +61,9 @@ public class SpanBuilderTests extends OpenSearchTestCase {
     public void testTransportContext() {
         String action = "test-action";
         Transport.Connection connection = createTransportConnection();
-        Context context = SpanBuilder.from(action, connection);
+        SpanCreationContext context = SpanBuilder.from(action, connection);
         Attributes attributes = context.getAttributes();
-        assertEquals(action + SpanBuilder.SEPARATOR + NetworkAddress.format(TransportAddress.META_ADDRESS), context.getSpanName());
+        assertEquals(action + " " + NetworkAddress.format(TransportAddress.META_ADDRESS), context.getSpanName());
         assertEquals(connection.getNode().getHostAddress(), attributes.getAttributesMap().get(AttributeNames.TRANSPORT_TARGET_HOST));
     }
 

--- a/server/src/test/java/org/opensearch/telemetry/tracing/TracerFactoryTests.java
+++ b/server/src/test/java/org/opensearch/telemetry/tracing/TracerFactoryTests.java
@@ -15,6 +15,8 @@ import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.telemetry.Telemetry;
 import org.opensearch.telemetry.TelemetrySettings;
+import org.opensearch.telemetry.tracing.attributes.Attributes;
+import org.opensearch.telemetry.tracing.noop.NoopSpan;
 import org.opensearch.telemetry.tracing.noop.NoopTracer;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.After;
@@ -46,7 +48,23 @@ public class TracerFactoryTests extends OpenSearchTestCase {
         Tracer tracer = tracerFactory.getTracer();
 
         assertTrue(tracer instanceof NoopTracer);
-        assertTrue(tracer.startSpan("foo") == SpanScope.NO_OP);
+        assertTrue(tracer.startSpan("foo") == NoopSpan.INSTANCE);
+        assertTrue(tracer.startScopedSpan(new SpanCreationContext("foo", Attributes.EMPTY)) == ScopedSpan.NO_OP);
+        assertTrue(tracer.startScopedSpan(new SpanCreationContext("foo", Attributes.EMPTY)) == ScopedSpan.NO_OP);
+        assertTrue(tracer.createSpanScope(tracer.startSpan("foo")) == SpanScope.NO_OP);
+    }
+
+    public void testGetTracerWithUnavailableTracingTelemetry() {
+        Settings settings = Settings.builder().put(TelemetrySettings.TRACER_ENABLED_SETTING.getKey(), false).build();
+        TelemetrySettings telemetrySettings = new TelemetrySettings(settings, new ClusterSettings(settings, getClusterSettings()));
+        Telemetry mockTelemetry = mock(Telemetry.class);
+        when(mockTelemetry.getTracingTelemetry()).thenReturn(mock(TracingTelemetry.class));
+        tracerFactory = new TracerFactory(telemetrySettings, Optional.empty(), new ThreadContext(Settings.EMPTY));
+
+        Tracer tracer = tracerFactory.getTracer();
+
+        assertTrue(tracer instanceof NoopTracer);
+        assertTrue(tracer.startScopedSpan(new SpanCreationContext("foo", Attributes.EMPTY)) == ScopedSpan.NO_OP);
     }
 
     public void testGetTracerWithAvailableTracingTelemetryReturnsWrappedTracer() {


### PR DESCRIPTION
### Description
Context is not being managed properly in case of Async scenarios. It defines a clear distinction between span and scopes. Scope is specific to the current thread whereas span can outlive the scopes. Scopes help in providing the short-living context propagation. More details/discussion regarding this issue can be found here -  https://github.com/opensearch-project/OpenSearch/pull/9450
### Related Issues
Resolves #9449 
<!-- List any other related issues here -->
https://github.com/opensearch-project/OpenSearch/pull/9450
https://github.com/opensearch-project/OpenSearch/pull/9449


### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
