### PR TITLE
Segment Replication - Block snapshot creation if the target primary shard has not completed failover.

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/SegmentReplicationSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/SegmentReplicationSnapshotIT.java
@@ -28,7 +28,6 @@ import org.opensearch.test.OpenSearchIntegTestCase;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REPLICATION_TYPE;

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/SegmentReplicationSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/SegmentReplicationSnapshotIT.java
@@ -19,7 +19,9 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.index.IndexService;
 import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.shard.IndexShard;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.test.InternalTestCluster;
@@ -28,6 +30,7 @@ import org.opensearch.test.OpenSearchIntegTestCase;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REPLICATION_TYPE;
@@ -137,6 +140,54 @@ public class SegmentReplicationSnapshotIT extends AbstractSnapshotIntegTestCase 
 
         // Assertions
         assertEquals(restoreSnapshotResponse.status(), RestStatus.ACCEPTED);
+        ensureGreen(RESTORED_INDEX_NAME);
+        GetSettingsResponse settingsResponse = client().admin()
+            .indices()
+            .getSettings(new GetSettingsRequest().indices(RESTORED_INDEX_NAME))
+            .get();
+        assertEquals(settingsResponse.getSetting(RESTORED_INDEX_NAME, "index.replication.type"), "SEGMENT");
+        SearchResponse resp = client().prepareSearch(RESTORED_INDEX_NAME).setQuery(QueryBuilders.matchAllQuery()).get();
+        assertHitCount(resp, DOC_COUNT);
+    }
+
+    public void testCreateSnapshotOnNewlyElectedPrimaryBeforePrimaryMode() throws Exception {
+        // Start cluster with one primary and one replica node
+        List<String> nodes = startClusterWithSettings(segRepEnableIndexSettings(), 1);
+        // drop the primary - will be first in this list.
+        // Snapshot declaration
+        Path absolutePath = randomRepoPath().toAbsolutePath();
+        createRepository(REPOSITORY_NAME, "fs", absolutePath);
+        final String primary = nodes.get(0);
+        final String replica = nodes.get(1);
+        internalCluster().stopRandomNode(InternalTestCluster.nameFilter(primary));
+        // Create snapshot - this will occasionally fail because the replica has not completed promotion.
+        CreateSnapshotResponse createSnapshotResponse = client().admin()
+            .cluster()
+            .prepareCreateSnapshot(REPOSITORY_NAME, SNAPSHOT_NAME)
+            .setWaitForCompletion(true)
+            .setIndices(INDEX_NAME)
+            .get();
+
+        final SnapshotInfo snapshotInfo = createSnapshotResponse.getSnapshotInfo();
+        if (snapshotInfo.failedShards() > 0) {
+            final List<SnapshotShardFailure> failures = snapshotInfo.shardFailures();
+            assertEquals(1, failures.size());
+            final SnapshotShardFailure failure = failures.get(0);
+            assertTrue(failure.reason().contains("cannot proceed until promotion is complete"));
+            final IndexShard indexShard = getIndexShard(replica, INDEX_NAME);
+            assertBusy(() -> { assertTrue(indexShard.isPrimaryMode()); });
+            createSnapshot();
+        }
+
+        // Delete index
+        assertAcked(client().admin().indices().delete(new DeleteIndexRequest(INDEX_NAME)).get());
+        assertFalse("index [" + INDEX_NAME + "] should have been deleted", indexExists(INDEX_NAME));
+
+        RestoreSnapshotResponse restoreSnapshotResponse = restoreSnapshotWithSettings(null);
+
+        // Assertions
+        assertEquals(restoreSnapshotResponse.status(), RestStatus.ACCEPTED);
+        internalCluster().startDataOnlyNode();
         ensureGreen(RESTORED_INDEX_NAME);
         GetSettingsResponse settingsResponse = client().admin()
             .indices()
@@ -305,5 +356,13 @@ public class SegmentReplicationSnapshotIT extends AbstractSnapshotIntegTestCase 
         Index index = resolveIndex(RESTORED_INDEX_NAME);
         IndicesService indicesService = internalCluster().getInstance(IndicesService.class);
         assertEquals(indicesService.indexService(index).getIndexSettings().isSegRepEnabled(), false);
+    }
+
+    protected IndexShard getIndexShard(String node, String indexName) {
+        final Index index = resolveIndex(indexName);
+        IndicesService indicesService = internalCluster().getInstance(IndicesService.class, node);
+        IndexService indexService = indicesService.indexServiceSafe(index);
+        final Optional<Integer> shardId = indexService.shardIds().stream().findFirst();
+        return indexService.getShard(shardId.get());
     }
 }

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotShardsService.java
@@ -379,6 +379,12 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
             if (indexShard.routingEntry().primary() == false) {
                 throw new IndexShardSnapshotFailedException(shardId, "snapshot should be performed only on primary");
             }
+            if (indexShard.indexSettings().isSegRepEnabled() && indexShard.isPrimaryMode() == false) {
+                throw new IndexShardSnapshotFailedException(
+                    shardId,
+                    "snapshot triggered on a new primary following failover and cannot proceed until promotion is complete"
+                );
+            }
             if (indexShard.routingEntry().relocating()) {
                 // do not snapshot when in the process of relocation of primaries so we won't get conflicts
                 throw new IndexShardSnapshotFailedException(shardId, "cannot snapshot while relocating");

--- a/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
@@ -16,6 +16,12 @@ import org.opensearch.action.admin.indices.flush.FlushRequest;
 import org.opensearch.action.admin.indices.forcemerge.ForceMergeRequest;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.cluster.ClusterChangedEvent;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.SnapshotsInProgress;
+import org.opensearch.cluster.ClusterChangedEvent;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.SnapshotsInProgress;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.routing.IndexShardRoutingTable;
 import org.opensearch.cluster.routing.ShardRouting;
@@ -28,7 +34,11 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.CancellableThreads;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.index.IndexService;
+import org.opensearch.index.IndexService;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.SegmentReplicationShardStats;
 import org.opensearch.index.engine.DocIdSeqNoAndSource;
@@ -40,10 +50,14 @@ import org.opensearch.index.engine.ReadOnlyEngine;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.replication.OpenSearchIndexLevelReplicationTestCase;
 import org.opensearch.index.replication.TestReplicationSource;
+import org.opensearch.index.snapshots.IndexShardSnapshotStatus;
+import org.opensearch.index.snapshots.IndexShardSnapshotStatus;
 import org.opensearch.index.store.Store;
 import org.opensearch.index.store.StoreFileMetadata;
 import org.opensearch.index.translog.SnapshotMatchers;
 import org.opensearch.index.translog.Translog;
+import org.opensearch.indices.IndicesService;
+import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.recovery.RecoverySettings;
 import org.opensearch.indices.recovery.RecoveryTarget;
 import org.opensearch.indices.replication.CheckpointInfoResponse;
@@ -60,6 +74,18 @@ import org.opensearch.indices.replication.common.ReplicationFailedException;
 import org.opensearch.indices.replication.common.ReplicationListener;
 import org.opensearch.indices.replication.common.ReplicationState;
 import org.opensearch.indices.replication.common.ReplicationType;
+import org.opensearch.repositories.IndexId;
+import org.opensearch.snapshots.Snapshot;
+import org.opensearch.snapshots.SnapshotId;
+import org.opensearch.snapshots.SnapshotInfoTests;
+import org.opensearch.snapshots.SnapshotShardsService;
+import org.opensearch.test.VersionUtils;
+import org.opensearch.repositories.IndexId;
+import org.opensearch.snapshots.Snapshot;
+import org.opensearch.snapshots.SnapshotId;
+import org.opensearch.snapshots.SnapshotInfoTests;
+import org.opensearch.snapshots.SnapshotShardsService;
+import org.opensearch.test.VersionUtils;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 import org.junit.Assert;
@@ -69,6 +95,7 @@ import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -79,6 +106,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.opensearch.index.engine.EngineTestCase.assertAtMostOneLuceneDocumentPerSequenceNumber;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasToString;
@@ -857,6 +885,80 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
             assertReplicaCaughtUp(primaryShard);
             shards.assertAllEqual(5);
         }
+    }
+
+    public void testSnapshotWhileFailoverIncomplete() throws Exception {
+        final NRTReplicationEngineFactory engineFactory = new NRTReplicationEngineFactory();
+        final NRTReplicationEngineFactory spy = spy(engineFactory);
+        try (ReplicationGroup shards = createGroup(1, settings, indexMapping, spy, createTempDir())) {
+            final IndexShard primaryShard = shards.getPrimary();
+            final IndexShard replicaShard = shards.getReplicas().get(0);
+            shards.startAll();
+            shards.indexDocs(10);
+            shards.refresh("test");
+            replicateSegments(primaryShard, shards.getReplicas());
+            shards.assertAllEqual(10);
+
+            final SnapshotShardsService shardsService = getSnapshotShardsService(replicaShard);
+            final Snapshot snapshot = new Snapshot(randomAlphaOfLength(10), new SnapshotId(randomAlphaOfLength(5), randomAlphaOfLength(5)));
+
+            final ClusterState initState = addSnapshotIndex(clusterService.state(), snapshot, replicaShard, SnapshotsInProgress.State.INIT);
+            shardsService.clusterChanged(new ClusterChangedEvent("test", initState, clusterService.state()));
+
+            CountDownLatch latch = new CountDownLatch(1);
+            doAnswer(ans -> {
+                final Engine engineOrNull = replicaShard.getEngineOrNull();
+                assertNotNull(engineOrNull);
+                assertTrue(engineOrNull instanceof ReadOnlyEngine);
+                shards.assertAllEqual(10);
+                shardsService.clusterChanged(new ClusterChangedEvent("test", addSnapshotIndex(clusterService.state(), snapshot, replicaShard, SnapshotsInProgress.State.STARTED), initState));
+                latch.countDown();
+                return ans.callRealMethod();
+            }).when(spy).newReadWriteEngine(any());
+            shards.promoteReplicaToPrimary(replicaShard).get();
+            latch.await();
+            assertBusy(() -> {
+                final IndexShardSnapshotStatus.Copy copy = shardsService.currentSnapshotShards(snapshot).get(replicaShard.shardId).asCopy();
+                final IndexShardSnapshotStatus.Stage stage = copy.getStage();
+                assertEquals(IndexShardSnapshotStatus.Stage.FAILURE, stage);
+                assertNotNull(copy.getFailure());
+                assertTrue(copy.getFailure().contains("snapshot triggered on a new primary following failover and cannot proceed until promotion is complete"));
+            });
+        }
+    }
+
+    private SnapshotShardsService getSnapshotShardsService(IndexShard replicaShard) {
+        final TransportService transportService = mock(TransportService.class);
+        when(transportService.getThreadPool()).thenReturn(threadPool);
+        final IndicesService indicesService = mock(IndicesService.class);
+        final IndexService indexService = mock(IndexService.class);
+        when(indicesService.indexServiceSafe(any())).thenReturn(indexService);
+        when(indexService.getShardOrNull(anyInt())).thenReturn(replicaShard);
+        return new SnapshotShardsService(settings, clusterService, createRepositoriesService(), transportService, indicesService);
+    }
+
+    private ClusterState addSnapshotIndex(ClusterState state, Snapshot snapshot, IndexShard shard, SnapshotsInProgress.State snapshotState) {
+        final Map<ShardId, SnapshotsInProgress.ShardSnapshotStatus> shardsBuilder = new HashMap<>();
+        ShardRouting shardRouting = shard.shardRouting;
+        shardsBuilder.put(shardRouting.shardId(), new SnapshotsInProgress.ShardSnapshotStatus(state.getNodes().getLocalNode().getId(), "1"));
+        final SnapshotsInProgress.Entry entry = new SnapshotsInProgress.Entry(
+            snapshot,
+            randomBoolean(),
+            false,
+            snapshotState,
+            Collections.singletonList(new IndexId(index.getName(), index.getUUID())),
+            Collections.emptyList(),
+            randomNonNegativeLong(),
+            randomLong(),
+            shardsBuilder,
+            null,
+            SnapshotInfoTests.randomUserMetadata(),
+            VersionUtils.randomVersion(random()),
+            false
+        );
+        return ClusterState.builder(state)
+            .putCustom(SnapshotsInProgress.TYPE, SnapshotsInProgress.of(Collections.singletonList(entry)))
+            .build();
     }
 
     private void assertReplicaCaughtUp(IndexShard primaryShard) {

--- a/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
@@ -19,9 +19,6 @@ import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.cluster.ClusterChangedEvent;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.SnapshotsInProgress;
-import org.opensearch.cluster.ClusterChangedEvent;
-import org.opensearch.cluster.ClusterState;
-import org.opensearch.cluster.SnapshotsInProgress;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.routing.IndexShardRoutingTable;
 import org.opensearch.cluster.routing.ShardRouting;
@@ -35,9 +32,7 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.CancellableThreads;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.shard.ShardId;
-import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
-import org.opensearch.index.IndexService;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.SegmentReplicationShardStats;
@@ -51,12 +46,10 @@ import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.replication.OpenSearchIndexLevelReplicationTestCase;
 import org.opensearch.index.replication.TestReplicationSource;
 import org.opensearch.index.snapshots.IndexShardSnapshotStatus;
-import org.opensearch.index.snapshots.IndexShardSnapshotStatus;
 import org.opensearch.index.store.Store;
 import org.opensearch.index.store.StoreFileMetadata;
 import org.opensearch.index.translog.SnapshotMatchers;
 import org.opensearch.index.translog.Translog;
-import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.recovery.RecoverySettings;
 import org.opensearch.indices.recovery.RecoveryTarget;
@@ -74,12 +67,6 @@ import org.opensearch.indices.replication.common.ReplicationFailedException;
 import org.opensearch.indices.replication.common.ReplicationListener;
 import org.opensearch.indices.replication.common.ReplicationState;
 import org.opensearch.indices.replication.common.ReplicationType;
-import org.opensearch.repositories.IndexId;
-import org.opensearch.snapshots.Snapshot;
-import org.opensearch.snapshots.SnapshotId;
-import org.opensearch.snapshots.SnapshotInfoTests;
-import org.opensearch.snapshots.SnapshotShardsService;
-import org.opensearch.test.VersionUtils;
 import org.opensearch.repositories.IndexId;
 import org.opensearch.snapshots.Snapshot;
 import org.opensearch.snapshots.SnapshotId;
@@ -106,11 +93,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.opensearch.index.engine.EngineTestCase.assertAtMostOneLuceneDocumentPerSequenceNumber;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -911,7 +898,13 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
                 assertNotNull(engineOrNull);
                 assertTrue(engineOrNull instanceof ReadOnlyEngine);
                 shards.assertAllEqual(10);
-                shardsService.clusterChanged(new ClusterChangedEvent("test", addSnapshotIndex(clusterService.state(), snapshot, replicaShard, SnapshotsInProgress.State.STARTED), initState));
+                shardsService.clusterChanged(
+                    new ClusterChangedEvent(
+                        "test",
+                        addSnapshotIndex(clusterService.state(), snapshot, replicaShard, SnapshotsInProgress.State.STARTED),
+                        initState
+                    )
+                );
                 latch.countDown();
                 return ans.callRealMethod();
             }).when(spy).newReadWriteEngine(any());
@@ -922,7 +915,10 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
                 final IndexShardSnapshotStatus.Stage stage = copy.getStage();
                 assertEquals(IndexShardSnapshotStatus.Stage.FAILURE, stage);
                 assertNotNull(copy.getFailure());
-                assertTrue(copy.getFailure().contains("snapshot triggered on a new primary following failover and cannot proceed until promotion is complete"));
+                assertTrue(
+                    copy.getFailure()
+                        .contains("snapshot triggered on a new primary following failover and cannot proceed until promotion is complete")
+                );
             });
         }
     }
@@ -937,10 +933,18 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
         return new SnapshotShardsService(settings, clusterService, createRepositoriesService(), transportService, indicesService);
     }
 
-    private ClusterState addSnapshotIndex(ClusterState state, Snapshot snapshot, IndexShard shard, SnapshotsInProgress.State snapshotState) {
+    private ClusterState addSnapshotIndex(
+        ClusterState state,
+        Snapshot snapshot,
+        IndexShard shard,
+        SnapshotsInProgress.State snapshotState
+    ) {
         final Map<ShardId, SnapshotsInProgress.ShardSnapshotStatus> shardsBuilder = new HashMap<>();
         ShardRouting shardRouting = shard.shardRouting;
-        shardsBuilder.put(shardRouting.shardId(), new SnapshotsInProgress.ShardSnapshotStatus(state.getNodes().getLocalNode().getId(), "1"));
+        shardsBuilder.put(
+            shardRouting.shardId(),
+            new SnapshotsInProgress.ShardSnapshotStatus(state.getNodes().getLocalNode().getId(), "1")
+        );
         final SnapshotsInProgress.Entry entry = new SnapshotsInProgress.Entry(
             snapshot,
             randomBoolean(),


### PR DESCRIPTION
### Description
This change prevents snapshots from being taken with segment replication during shard promotion.  This prevents snapshots from being taken on stale data.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/9626

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
