### PR TITLE
Optimize read write lock constructs during translog upload to remote store

### DIFF
--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -60,6 +60,7 @@ public class RemoteFsTranslog extends Translog {
     private final BooleanSupplier primaryModeSupplier;
     private final RemoteTranslogTransferTracker remoteTranslogTransferTracker;
     private volatile long maxRemoteTranslogGenerationUploaded;
+    private final Object uploadMutex = new Object();
 
     private volatile long minSeqNoToKeep;
 
@@ -237,11 +238,20 @@ public class RemoteFsTranslog extends Translog {
 
     @Override
     public boolean ensureSynced(Location location) throws IOException {
-        try (ReleasableLock ignored = writeLock.acquire()) {
-            assert location.generation <= current.getGeneration();
-            if (location.generation == current.getGeneration()) {
-                ensureOpen();
-                return prepareAndUpload(primaryTermSupplier.getAsLong(), location.generation);
+        try {
+            boolean shouldUpload = false;
+            try (ReleasableLock ignored = writeLock.acquire()) {
+                assert location.generation <= current.getGeneration();
+                if (location.generation == current.getGeneration()) {
+                    ensureOpen();
+                    if (prepareForUpload(location.generation) == false) {
+                        return false;
+                    }
+                    shouldUpload = true;
+                }
+            }
+            if (shouldUpload) {
+                return performUpload(primaryTermSupplier.getAsLong(), location.generation);
             }
         } catch (final Exception ex) {
             closeOnTragicEvent(ex);
@@ -256,10 +266,12 @@ public class RemoteFsTranslog extends Translog {
         if (current.totalOperations() == 0 && primaryTermSupplier.getAsLong() == current.getPrimaryTerm()) {
             return;
         }
-        prepareAndUpload(primaryTermSupplier.getAsLong(), null);
+        if (prepareForUpload(null)) {
+            performUpload(primaryTermSupplier.getAsLong(), null);
+        }
     }
 
-    private boolean prepareAndUpload(Long primaryTerm, Long generation) throws IOException {
+    private boolean prepareForUpload(Long generation) throws IOException {
         try (Releasable ignored = writeLock.acquire()) {
             if (generation == null || generation == current.getGeneration()) {
                 try {
@@ -275,23 +287,30 @@ public class RemoteFsTranslog extends Translog {
                     closeOnTragicEvent(e);
                     throw e;
                 }
-            } else if (generation < current.getGeneration()) {
-                return false;
-            }
+                return true;
+            } else return generation >= current.getGeneration();
+        }
+    }
 
-            // Do we need remote writes in sync fashion ?
-            // If we don't , we should swallow FileAlreadyExistsException while writing to remote store
-            // and also verify for same during primary-primary relocation
-            // Writing remote in sync fashion doesn't hurt as global ckp update
-            // is not updated in remote translog except in primary to primary recovery.
-            if (generation == null) {
-                if (closed.get() == false) {
-                    return upload(primaryTerm, current.getGeneration() - 1);
+    private boolean performUpload(Long primaryTerm, Long generation) throws IOException {
+        synchronized (uploadMutex) {
+            try (Releasable ignored = readLock.acquire()) {
+                // Do we need remote writes in sync fashion ?
+                // If we don't , we should swallow FileAlreadyExistsException while writing to remote store
+                // and also verify for same during primary-primary relocation
+                // Writing remote in sync fashion doesn't hurt as global ckp update
+                // is not updated in remote translog except in primary to primary recovery.
+                long generationToUpload;
+                if (generation == null) {
+                    if (closed.get() == false) {
+                        generationToUpload = current.getGeneration() - 1;
+                    } else {
+                        generationToUpload = current.getGeneration();
+                    }
                 } else {
-                    return upload(primaryTerm, current.getGeneration());
+                    generationToUpload = generation;
                 }
-            } else {
-                return upload(primaryTerm, generation);
+                return upload(primaryTerm, generationToUpload);
             }
         }
     }
@@ -344,7 +363,9 @@ public class RemoteFsTranslog extends Translog {
     public void sync() throws IOException {
         try {
             if (syncToDisk() || syncNeeded()) {
-                prepareAndUpload(primaryTermSupplier.getAsLong(), null);
+                if (prepareForUpload(null)) {
+                    performUpload(primaryTermSupplier.getAsLong(), null);
+                }
             }
         } catch (final Exception e) {
             tragedy.setTragicException(e);
@@ -528,8 +549,6 @@ public class RemoteFsTranslog extends Translog {
 
         @Override
         public void onUploadComplete(TransferSnapshot transferSnapshot) throws IOException {
-            transferReleasable.close();
-            closeFilesIfNoPendingRetentionLocks();
             maxRemoteTranslogGenerationUploaded = generation;
             minRemoteGenReferenced = getMinFileGeneration();
             logger.trace("uploaded translog for {} {} ", primaryTerm, generation);
@@ -537,13 +556,16 @@ public class RemoteFsTranslog extends Translog {
 
         @Override
         public void onUploadFailed(TransferSnapshot transferSnapshot, Exception ex) throws IOException {
-            transferReleasable.close();
-            closeFilesIfNoPendingRetentionLocks();
             if (ex instanceof IOException) {
                 throw (IOException) ex;
             } else {
                 throw (RuntimeException) ex;
             }
+        }
+
+        @Override
+        public void close() {
+            transferReleasable.close();
         }
     }
 }

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -373,7 +373,7 @@ public class RemoteFsTranslog extends Translog {
     @Override
     public void sync() throws IOException {
         try {
-            if (syncToDisk() || syncNeeded() || prepareForUpload(null)) {
+            if ((syncToDisk() || syncNeeded()) && prepareForUpload(null)) {
                 performUpload(primaryTermSupplier.getAsLong(), null);
             }
         } catch (final Exception e) {

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogCheckpointTransferSnapshot.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogCheckpointTransferSnapshot.java
@@ -164,7 +164,6 @@ public class TranslogCheckpointTransferSnapshot implements TransferSnapshot, Clo
             translogTransferSnapshot.setMinTranslogGeneration(highestGenMinTranslogGeneration);
 
             assert this.primaryTerm == highestGenPrimaryTerm : "inconsistent primary term";
-            assert this.generation == highestGeneration : " inconsistent generation ";
             final long finalHighestGeneration = highestGeneration;
             assert LongStream.iterate(lowestGeneration, i -> i + 1)
                 .limit(highestGeneration)

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
@@ -191,6 +191,8 @@ public class TranslogTransferManager {
             captureStatsOnUploadFailure();
             translogTransferListener.onUploadFailed(transferSnapshot, ex);
             return false;
+        } finally {
+            translogTransferListener.close();
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
@@ -109,7 +109,7 @@ public class TranslogTransferManager {
         long prevUploadBytesSucceeded = remoteTranslogTransferTracker.getUploadBytesSucceeded();
         long prevUploadTimeInMillis = remoteTranslogTransferTracker.getTotalUploadTimeInMillis();
 
-        try {
+        try (translogTransferListener) {
             toUpload.addAll(fileTransferTracker.exclusionFilter(transferSnapshot.getTranslogFileSnapshots()));
             toUpload.addAll(fileTransferTracker.exclusionFilter((transferSnapshot.getCheckpointFileSnapshots())));
             if (toUpload.isEmpty()) {
@@ -191,8 +191,6 @@ public class TranslogTransferManager {
             captureStatsOnUploadFailure();
             translogTransferListener.onUploadFailed(transferSnapshot, ex);
             return false;
-        } finally {
-            translogTransferListener.close();
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/translog/transfer/listener/TranslogTransferListener.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/listener/TranslogTransferListener.java
@@ -10,6 +10,7 @@ package org.opensearch.index.translog.transfer.listener;
 
 import org.opensearch.index.translog.transfer.TransferSnapshot;
 
+import java.io.Closeable;
 import java.io.IOException;
 
 /**
@@ -17,7 +18,7 @@ import java.io.IOException;
  *
  * @opensearch.internal
  */
-public interface TranslogTransferListener {
+public interface TranslogTransferListener extends Closeable {
     /**
      * Invoked when the transfer of {@link TransferSnapshot} succeeds
      * @param transferSnapshot the transfer snapshot
@@ -32,8 +33,4 @@ public interface TranslogTransferListener {
      * @throws IOException the exception during the transfer of data
      */
     void onUploadFailed(TransferSnapshot transferSnapshot, Exception ex) throws IOException;
-
-    default void close() {
-
-    }
 }

--- a/server/src/main/java/org/opensearch/index/translog/transfer/listener/TranslogTransferListener.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/listener/TranslogTransferListener.java
@@ -32,4 +32,8 @@ public interface TranslogTransferListener {
      * @throws IOException the exception during the transfer of data
      */
     void onUploadFailed(TransferSnapshot transferSnapshot, Exception ex) throws IOException;
+
+    default void close() {
+
+    }
 }

--- a/server/src/main/java/org/opensearch/index/translog/transfer/listener/TranslogTransferListener.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/listener/TranslogTransferListener.java
@@ -10,7 +10,6 @@ package org.opensearch.index.translog.transfer.listener;
 
 import org.opensearch.index.translog.transfer.TransferSnapshot;
 
-import java.io.Closeable;
 import java.io.IOException;
 
 /**
@@ -18,7 +17,7 @@ import java.io.IOException;
  *
  * @opensearch.internal
  */
-public interface TranslogTransferListener extends Closeable {
+public interface TranslogTransferListener extends AutoCloseable {
     /**
      * Invoked when the transfer of {@link TransferSnapshot} succeeds
      * @param transferSnapshot the transfer snapshot

--- a/server/src/test/java/org/opensearch/index/translog/RemoteFsTranslogTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/RemoteFsTranslogTests.java
@@ -108,7 +108,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @LuceneTestCase.SuppressFileSystems("ExtrasFS")
-
 public class RemoteFsTranslogTests extends OpenSearchTestCase {
 
     protected final ShardId shardId = new ShardId("index", "_na_", 1);

--- a/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
@@ -168,6 +168,9 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
             public void onUploadFailed(TransferSnapshot transferSnapshot, Exception ex) {
                 translogTransferFailed.incrementAndGet();
             }
+
+            @Override
+            public void close() {}
         }));
         assertEquals(4, fileTransferSucceeded.get());
         assertEquals(0, fileTransferFailed.get());


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Optimize read write lock constructs during translog upload to remote store

### Related Issues
Resolves #10013
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
