### PR TITLE
[Remote state] Integrate remote cluster state in publish/commit flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - APIs for performing async blob reads and async downloads from the repository using multiple streams ([#9592](https://github.com/opensearch-project/OpenSearch/issues/9592))
 - Introduce cluster default remote translog buffer interval setting ([#9584](https://github.com/opensearch-project/OpenSearch/pull/9584))
 - Add average concurrency metric for concurrent segment search ([#9670](https://github.com/opensearch-project/OpenSearch/issues/9670))
+- [Remote state] Integrate remote cluster state in publish/commit flow ([#9665](https://github.com/opensearch-project/OpenSearch/pull/9665))
 
 ### Dependencies
 - Bump `org.apache.logging.log4j:log4j-core` from 2.17.1 to 2.20.0 ([#8307](https://github.com/opensearch-project/OpenSearch/pull/8307))

--- a/server/src/main/java/org/opensearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/Coordinator.java
@@ -48,7 +48,6 @@ import org.opensearch.cluster.coordination.CoordinationMetadata.VotingConfigurat
 import org.opensearch.cluster.coordination.CoordinationState.VoteCollection;
 import org.opensearch.cluster.coordination.FollowersChecker.FollowerCheckRequest;
 import org.opensearch.cluster.coordination.JoinHelper.InitialJoinAccumulator;
-import org.opensearch.cluster.coordination.PersistedStateRegistry.PersistedStateType;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodes;
@@ -825,15 +824,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
     protected void doStart() {
         synchronized (mutex) {
             CoordinationState.PersistedState persistedState = persistedStateSupplier.get();
-            coordinationState.set(
-                new CoordinationState(
-                    getLocalNode(),
-                    persistedState,
-                    electionStrategy,
-                    persistedStateRegistry.getPersistedState(PersistedStateType.REMOTE),
-                    settings
-                )
-            );
+            coordinationState.set(new CoordinationState(getLocalNode(), persistedStateRegistry, electionStrategy, settings));
             peerFinder.setCurrentTerm(getCurrentTerm());
             configuredHostsResolver.start();
             final ClusterState lastAcceptedState = coordinationState.get().getLastAcceptedState();
@@ -1320,10 +1311,6 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
                 leaderChecker.setCurrentNodes(publishNodes);
                 followersChecker.setCurrentNodes(publishNodes);
                 lagDetector.setTrackedNodes(publishNodes);
-                // Publishing the current state to remote store before sending the cluster state to other nodes.
-                // This is to ensure the remote store is the single source of truth for current state. Even if the current node
-                // goes down after sending the cluster state to other nodes, we should be able to read the remote state and
-                // recover the cluster.
                 coordinationState.get().handlePrePublish(clusterState);
                 publication.start(followersChecker.getFaultyNodes());
             }

--- a/server/src/main/java/org/opensearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/Coordinator.java
@@ -823,7 +823,6 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
     @Override
     protected void doStart() {
         synchronized (mutex) {
-            CoordinationState.PersistedState persistedState = persistedStateSupplier.get();
             coordinationState.set(new CoordinationState(getLocalNode(), persistedStateRegistry, electionStrategy, settings));
             peerFinder.setCurrentTerm(getCurrentTerm());
             configuredHostsResolver.start();

--- a/server/src/main/java/org/opensearch/cluster/coordination/PersistedStateRegistry.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/PersistedStateRegistry.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.coordination;
+
+import org.opensearch.cluster.coordination.CoordinationState.PersistedState;
+import org.opensearch.common.util.io.IOUtils;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A class which encapsulates the PersistedStates
+ *
+ * @opensearch.internal
+ */
+public class PersistedStateRegistry implements Closeable {
+
+    public PersistedStateRegistry() {}
+
+    /**
+     * Distinct Types PersistedState which can be present on a node
+     */
+    public enum PersistedStateType {
+        LOCAL,
+        REMOTE;
+    }
+
+    private final Map<PersistedStateType, PersistedState> persistedStates = new ConcurrentHashMap<>();
+
+    public void addPersistedState(PersistedStateType persistedStateType, PersistedState persistedState) {
+        PersistedState existingState = this.persistedStates.putIfAbsent(persistedStateType, persistedState);
+        assert existingState == null : "should only be set once, but already have " + existingState;
+    }
+
+    public PersistedState getPersistedState(PersistedStateType persistedStateType) {
+        return this.persistedStates.get(persistedStateType);
+    }
+
+    @Override
+    public void close() throws IOException {
+        IOUtils.close(persistedStates.values());
+    }
+
+}

--- a/server/src/main/java/org/opensearch/discovery/DiscoveryModule.java
+++ b/server/src/main/java/org/opensearch/discovery/DiscoveryModule.java
@@ -37,6 +37,7 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.coordination.Coordinator;
 import org.opensearch.cluster.coordination.ElectionStrategy;
+import org.opensearch.cluster.coordination.PersistedStateRegistry;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.routing.RerouteService;
 import org.opensearch.cluster.routing.allocation.AllocationService;
@@ -129,7 +130,8 @@ public class DiscoveryModule {
         Path configFile,
         GatewayMetaState gatewayMetaState,
         RerouteService rerouteService,
-        NodeHealthService nodeHealthService
+        NodeHealthService nodeHealthService,
+        PersistedStateRegistry persistedStateRegistry
     ) {
         final Collection<BiConsumer<DiscoveryNode, ClusterState>> joinValidators = new ArrayList<>();
         final Map<String, Supplier<SeedHostsProvider>> hostProviders = new HashMap<>();
@@ -205,7 +207,8 @@ public class DiscoveryModule {
                 new Random(Randomness.get().nextLong()),
                 rerouteService,
                 electionStrategy,
-                nodeHealthService
+                nodeHealthService,
+                persistedStateRegistry
             );
         } else {
             throw new IllegalArgumentException("Unknown discovery type [" + discoveryType + "]");

--- a/server/src/main/java/org/opensearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/opensearch/gateway/GatewayMetaState.java
@@ -45,6 +45,8 @@ import org.opensearch.cluster.ClusterStateApplier;
 import org.opensearch.cluster.coordination.CoordinationMetadata;
 import org.opensearch.cluster.coordination.CoordinationState.PersistedState;
 import org.opensearch.cluster.coordination.InMemoryPersistedState;
+import org.opensearch.cluster.coordination.PersistedStateRegistry;
+import org.opensearch.cluster.coordination.PersistedStateRegistry.PersistedStateType;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IndexTemplateMetadata;
 import org.opensearch.cluster.metadata.Manifest;
@@ -52,7 +54,6 @@ import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.metadata.MetadataIndexUpgradeService;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.common.SetOnce;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.AbstractRunnable;
@@ -83,6 +84,7 @@ import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
 import static org.opensearch.common.util.concurrent.OpenSearchExecutors.daemonThreadFactory;
+import static org.opensearch.gateway.remote.RemoteClusterStateService.REMOTE_CLUSTER_STATE_ENABLED_SETTING;
 
 /**
  * Loads (and maybe upgrades) cluster metadata at startup, and persistently stores cluster metadata for future restarts.
@@ -103,17 +105,16 @@ public class GatewayMetaState implements Closeable {
      */
     public static final String STALE_STATE_CONFIG_NODE_ID = "STALE_STATE_CONFIG";
 
-    // Set by calling start()
-    private final SetOnce<PersistedState> persistedState = new SetOnce<>();
+    private PersistedStateRegistry persistedStateRegistry;
 
     public PersistedState getPersistedState() {
-        final PersistedState persistedState = this.persistedState.get();
+        final PersistedState persistedState = persistedStateRegistry.getPersistedState(PersistedStateType.LOCAL);
         assert persistedState != null : "not started";
         return persistedState;
     }
 
     public Metadata getMetadata() {
-        return getPersistedState().getLastAcceptedState().metadata();
+        return persistedStateRegistry.getPersistedState(PersistedStateType.LOCAL).getLastAcceptedState().metadata();
     }
 
     public void start(
@@ -123,9 +124,13 @@ public class GatewayMetaState implements Closeable {
         MetaStateService metaStateService,
         MetadataIndexUpgradeService metadataIndexUpgradeService,
         MetadataUpgrader metadataUpgrader,
-        PersistedClusterStateService persistedClusterStateService
+        PersistedClusterStateService persistedClusterStateService,
+        RemoteClusterStateService remoteClusterStateService,
+        PersistedStateRegistry persistedStateRegistry
     ) {
-        assert persistedState.get() == null : "should only start once, but already have " + persistedState.get();
+        this.persistedStateRegistry = persistedStateRegistry;
+        assert persistedStateRegistry.getPersistedState(PersistedStateType.LOCAL) == null : "should only start once, but already have "
+            + persistedStateRegistry.getPersistedState(PersistedStateType.LOCAL);
 
         if (DiscoveryNode.isClusterManagerNode(settings) || DiscoveryNode.isDataNode(settings)) {
             try {
@@ -147,6 +152,7 @@ public class GatewayMetaState implements Closeable {
                 }
 
                 PersistedState persistedState = null;
+                PersistedState remotePersistedState = null;
                 boolean success = false;
                 try {
                     final ClusterState clusterState = prepareInitialClusterState(
@@ -160,6 +166,9 @@ public class GatewayMetaState implements Closeable {
 
                     if (DiscoveryNode.isClusterManagerNode(settings)) {
                         persistedState = new LucenePersistedState(persistedClusterStateService, currentTerm, clusterState);
+                        if (REMOTE_CLUSTER_STATE_ENABLED_SETTING.get(settings) == true) {
+                            remotePersistedState = new RemotePersistedState(remoteClusterStateService);
+                        }
                     } else {
                         persistedState = new AsyncLucenePersistedState(
                             settings,
@@ -181,10 +190,14 @@ public class GatewayMetaState implements Closeable {
                 } finally {
                     if (success == false) {
                         IOUtils.closeWhileHandlingException(persistedState);
+                        IOUtils.closeWhileHandlingException(remotePersistedState);
                     }
                 }
 
-                this.persistedState.set(persistedState);
+                persistedStateRegistry.addPersistedState(PersistedStateType.LOCAL, persistedState);
+                if (remotePersistedState != null) {
+                    persistedStateRegistry.addPersistedState(PersistedStateType.REMOTE, remotePersistedState);
+                }
             } catch (IOException e) {
                 throw new OpenSearchException("failed to load metadata", e);
             }
@@ -211,7 +224,7 @@ public class GatewayMetaState implements Closeable {
                     throw new UncheckedIOException(e);
                 }
             }
-            persistedState.set(new InMemoryPersistedState(currentTerm, clusterState));
+            persistedStateRegistry.addPersistedState(PersistedStateType.LOCAL, new InMemoryPersistedState(currentTerm, clusterState));
         }
     }
 
@@ -330,12 +343,12 @@ public class GatewayMetaState implements Closeable {
 
     @Override
     public void close() throws IOException {
-        IOUtils.close(persistedState.get());
+        IOUtils.close(persistedStateRegistry);
     }
 
     // visible for testing
     public boolean allPendingAsyncStatesWritten() {
-        final PersistedState ps = persistedState.get();
+        final PersistedState ps = persistedStateRegistry.getPersistedState(PersistedStateType.LOCAL);
         if (ps instanceof AsyncLucenePersistedState) {
             return ((AsyncLucenePersistedState) ps).allPendingAsyncStatesWritten();
         } else {

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -92,7 +92,7 @@ public class RemoteClusterStateService implements Closeable {
     private final String nodeId;
     private final Supplier<RepositoriesService> repositoriesService;
     private final Settings settings;
-    private final LongSupplier relativeTimeMillisSupplier;
+    private final LongSupplier relativeTimeNanosSupplier;
     private BlobStoreRepository blobStoreRepository;
     private volatile TimeValue slowWriteLoggingThreshold;
 
@@ -101,12 +101,13 @@ public class RemoteClusterStateService implements Closeable {
         Supplier<RepositoriesService> repositoriesService,
         Settings settings,
         ClusterSettings clusterSettings,
-        LongSupplier relativeTimeMillisSupplier
+        LongSupplier relativeTimeNanosSupplier
     ) {
+        assert REMOTE_CLUSTER_STATE_ENABLED_SETTING.get(settings) == true : "Remote cluster state is not enabled";
         this.nodeId = nodeId;
         this.repositoriesService = repositoriesService;
         this.settings = settings;
-        this.relativeTimeMillisSupplier = relativeTimeMillisSupplier;
+        this.relativeTimeNanosSupplier = relativeTimeNanosSupplier;
         this.slowWriteLoggingThreshold = clusterSettings.get(SLOW_WRITE_LOGGING_THRESHOLD);
         clusterSettings.addSettingsUpdateConsumer(SLOW_WRITE_LOGGING_THRESHOLD, this::setSlowWriteLoggingThreshold);
     }
@@ -119,7 +120,7 @@ public class RemoteClusterStateService implements Closeable {
      */
     @Nullable
     public ClusterMetadataManifest writeFullMetadata(ClusterState clusterState) throws IOException {
-        final long startTimeMillis = relativeTimeMillisSupplier.getAsLong();
+        final long startTimeNanos = relativeTimeNanosSupplier.getAsLong();
         if (clusterState.nodes().isLocalNodeElectedClusterManager() == false) {
             logger.error("Local node is not elected cluster manager. Exiting");
             return null;
@@ -145,7 +146,7 @@ public class RemoteClusterStateService implements Closeable {
             allUploadedIndexMetadata.add(uploadedIndexMetadata);
         }
         final ClusterMetadataManifest manifest = uploadManifest(clusterState, allUploadedIndexMetadata, false);
-        final long durationMillis = relativeTimeMillisSupplier.getAsLong() - startTimeMillis;
+        final long durationMillis = TimeValue.nsecToMSec(relativeTimeNanosSupplier.getAsLong() - startTimeNanos);
         if (durationMillis >= slowWriteLoggingThreshold.getMillis()) {
             logger.warn(
                 "writing cluster state took [{}ms] which is above the warn threshold of [{}]; " + "wrote full state with [{}] indices",
@@ -177,7 +178,7 @@ public class RemoteClusterStateService implements Closeable {
         ClusterState clusterState,
         ClusterMetadataManifest previousManifest
     ) throws IOException {
-        final long startTimeMillis = relativeTimeMillisSupplier.getAsLong();
+        final long startTimeNanos = relativeTimeNanosSupplier.getAsLong();
         if (clusterState.nodes().isLocalNodeElectedClusterManager() == false) {
             logger.error("Local node is not elected cluster manager. Exiting");
             return null;
@@ -229,7 +230,7 @@ public class RemoteClusterStateService implements Closeable {
             allUploadedIndexMetadata.values().stream().collect(Collectors.toList()),
             false
         );
-        final long durationMillis = relativeTimeMillisSupplier.getAsLong() - startTimeMillis;
+        final long durationMillis = TimeValue.nsecToMSec(relativeTimeNanosSupplier.getAsLong() - startTimeNanos);
         if (durationMillis >= slowWriteLoggingThreshold.getMillis()) {
             logger.warn(
                 "writing cluster state took [{}ms] which is above the warn threshold of [{}]; "

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -103,7 +103,6 @@ public class RemoteClusterStateService implements Closeable {
         ClusterSettings clusterSettings,
         LongSupplier relativeTimeMillisSupplier
     ) {
-        assert REMOTE_CLUSTER_STATE_ENABLED_SETTING.get(settings) == true : "Remote cluster state is not enabled";
         this.nodeId = nodeId;
         this.repositoriesService = repositoriesService;
         this.settings = settings;
@@ -280,6 +279,7 @@ public class RemoteClusterStateService implements Closeable {
         if (blobStoreRepository != null) {
             return;
         }
+        assert REMOTE_CLUSTER_STATE_ENABLED_SETTING.get(settings) == true : "Remote cluster state is not enabled";
         final String remoteStoreRepo = REMOTE_CLUSTER_STATE_REPOSITORY_SETTING.get(settings);
         assert remoteStoreRepo != null : "Remote Cluster State repository is not configured";
         final Repository repository = repositoriesService.get().repository(remoteStoreRepo);

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -676,7 +676,7 @@ public class Node implements Closeable {
                 repositoriesServiceReference::get,
                 settings,
                 clusterService.getClusterSettings(),
-                threadPool::relativeTimeInMillis
+                threadPool::preciseRelativeTimeInNanos
             );
 
             // collect engine factory providers from plugins

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -671,13 +671,18 @@ public class Node implements Closeable {
                 clusterService.getClusterSettings(),
                 threadPool::relativeTimeInMillis
             );
-            final RemoteClusterStateService remoteClusterStateService = new RemoteClusterStateService(
-                nodeEnvironment.nodeId(),
-                repositoriesServiceReference::get,
-                settings,
-                clusterService.getClusterSettings(),
-                threadPool::preciseRelativeTimeInNanos
-            );
+            final RemoteClusterStateService remoteClusterStateService;
+            if (RemoteClusterStateService.REMOTE_CLUSTER_STATE_ENABLED_SETTING.get(settings) == true) {
+                remoteClusterStateService = new RemoteClusterStateService(
+                    nodeEnvironment.nodeId(),
+                    repositoriesServiceReference::get,
+                    settings,
+                    clusterService.getClusterSettings(),
+                    threadPool::preciseRelativeTimeInNanos
+                );
+            } else {
+                remoteClusterStateService = null;
+            }
 
             // collect engine factory providers from plugins
             final Collection<EnginePlugin> enginePlugins = pluginsService.filterPlugins(EnginePlugin.class);

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -671,17 +671,17 @@ public class Node implements Closeable {
                 clusterService.getClusterSettings(),
                 threadPool::relativeTimeInMillis
             );
-            final RemoteClusterStateService remoteClusterStateService;
+            final SetOnce<RemoteClusterStateService> remoteClusterStateServiceReference = new SetOnce<>();
             if (RemoteClusterStateService.REMOTE_CLUSTER_STATE_ENABLED_SETTING.get(settings) == true) {
-                remoteClusterStateService = new RemoteClusterStateService(
-                    nodeEnvironment.nodeId(),
-                    repositoriesServiceReference::get,
-                    settings,
-                    clusterService.getClusterSettings(),
-                    threadPool::preciseRelativeTimeInNanos
+                remoteClusterStateServiceReference.set(
+                    new RemoteClusterStateService(
+                        nodeEnvironment.nodeId(),
+                        repositoriesServiceReference::get,
+                        settings,
+                        clusterService.getClusterSettings(),
+                        threadPool::preciseRelativeTimeInNanos
+                    )
                 );
-            } else {
-                remoteClusterStateService = null;
             }
 
             // collect engine factory providers from plugins
@@ -1171,7 +1171,7 @@ public class Node implements Closeable {
                 b.bind(SystemIndices.class).toInstance(systemIndices);
                 b.bind(IdentityService.class).toInstance(identityService);
                 b.bind(Tracer.class).toInstance(tracer);
-                b.bind(RemoteClusterStateService.class).toInstance(remoteClusterStateService);
+                b.bind(RemoteClusterStateService.class).toProvider(remoteClusterStateServiceReference::get);
                 b.bind(PersistedStateRegistry.class).toInstance(persistedStateRegistry);
             });
             injector = modules.createInjector();

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -671,17 +671,17 @@ public class Node implements Closeable {
                 clusterService.getClusterSettings(),
                 threadPool::relativeTimeInMillis
             );
-            final SetOnce<RemoteClusterStateService> remoteClusterStateServiceReference = new SetOnce<>();
+            final RemoteClusterStateService remoteClusterStateService;
             if (RemoteClusterStateService.REMOTE_CLUSTER_STATE_ENABLED_SETTING.get(settings) == true) {
-                remoteClusterStateServiceReference.set(
-                    new RemoteClusterStateService(
-                        nodeEnvironment.nodeId(),
-                        repositoriesServiceReference::get,
-                        settings,
-                        clusterService.getClusterSettings(),
-                        threadPool::preciseRelativeTimeInNanos
-                    )
+                remoteClusterStateService = new RemoteClusterStateService(
+                    nodeEnvironment.nodeId(),
+                    repositoriesServiceReference::get,
+                    settings,
+                    clusterService.getClusterSettings(),
+                    threadPool::preciseRelativeTimeInNanos
                 );
+            } else {
+                remoteClusterStateService = null;
             }
 
             // collect engine factory providers from plugins
@@ -1171,7 +1171,7 @@ public class Node implements Closeable {
                 b.bind(SystemIndices.class).toInstance(systemIndices);
                 b.bind(IdentityService.class).toInstance(identityService);
                 b.bind(Tracer.class).toInstance(tracer);
-                b.bind(RemoteClusterStateService.class).toProvider(remoteClusterStateServiceReference::get);
+                b.bind(RemoteClusterStateService.class).toProvider(() -> remoteClusterStateService);
                 b.bind(PersistedStateRegistry.class).toInstance(persistedStateRegistry);
             });
             injector = modules.createInjector();

--- a/server/src/test/java/org/opensearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/CoordinatorTests.java
@@ -1256,7 +1256,7 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
 
             final ClusterNode newNode = cluster1.new ClusterNode(
                 nextNodeIndex.getAndIncrement(), nodeInOtherCluster.getLocalNode(), n -> cluster1.new MockPersistedState(
-                    n, nodeInOtherCluster.persistedState, Function.identity(), Function.identity()
+                    n, nodeInOtherCluster.persistedStateRegistry, Function.identity(), Function.identity()
                 ), nodeInOtherCluster.nodeSettings, () -> new StatusInfo(StatusInfo.Status.HEALTHY, "healthy-info")
             );
 

--- a/server/src/test/java/org/opensearch/cluster/coordination/NodeJoinTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/NodeJoinTests.java
@@ -260,7 +260,8 @@ public class NodeJoinTests extends OpenSearchTestCase {
             random,
             (s, p, r) -> {},
             ElectionStrategy.DEFAULT_INSTANCE,
-            nodeHealthService
+            nodeHealthService,
+            new PersistedStateRegistry()
         );
         transportService.start();
         transportService.acceptIncomingRequests();

--- a/server/src/test/java/org/opensearch/cluster/coordination/NodeJoinTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/NodeJoinTests.java
@@ -38,6 +38,7 @@ import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.OpenSearchAllocationTestCase;
 import org.opensearch.cluster.block.ClusterBlocks;
 import org.opensearch.cluster.coordination.CoordinationMetadata.VotingConfiguration;
+import org.opensearch.cluster.coordination.PersistedStateRegistry.PersistedStateType;
 import org.opensearch.cluster.decommission.DecommissionAttribute;
 import org.opensearch.cluster.decommission.DecommissionAttributeMetadata;
 import org.opensearch.cluster.decommission.DecommissionStatus;
@@ -245,6 +246,8 @@ public class NodeJoinTests extends OpenSearchTestCase {
             clusterSettings,
             Collections.emptySet()
         );
+        final PersistedStateRegistry persistedStateRegistry = persistedStateRegistry();
+        persistedStateRegistry.addPersistedState(PersistedStateType.LOCAL, new InMemoryPersistedState(term, initialState));
         coordinator = new Coordinator(
             "test_node",
             Settings.EMPTY,
@@ -253,7 +256,7 @@ public class NodeJoinTests extends OpenSearchTestCase {
             writableRegistry(),
             OpenSearchAllocationTestCase.createAllocationService(Settings.EMPTY),
             clusterManagerService,
-            () -> new InMemoryPersistedState(term, initialState),
+            () -> persistedStateRegistry.getPersistedState(PersistedStateType.LOCAL),
             r -> emptyList(),
             new NoOpClusterApplier(),
             Collections.emptyList(),
@@ -261,7 +264,7 @@ public class NodeJoinTests extends OpenSearchTestCase {
             (s, p, r) -> {},
             ElectionStrategy.DEFAULT_INSTANCE,
             nodeHealthService,
-            new PersistedStateRegistry()
+            persistedStateRegistry
         );
         transportService.start();
         transportService.acceptIncomingRequests();

--- a/server/src/test/java/org/opensearch/cluster/coordination/PreVoteCollectorTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/PreVoteCollectorTests.java
@@ -35,6 +35,7 @@ package org.opensearch.cluster.coordination;
 import org.opensearch.Version;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.coordination.CoordinationMetadata.VotingConfiguration;
+import org.opensearch.cluster.coordination.PersistedStateRegistry.PersistedStateType;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.settings.Settings;
@@ -290,11 +291,19 @@ public class PreVoteCollectorTests extends OpenSearchTestCase {
         DiscoveryNode[] votingNodes = votingNodesSet.toArray(new DiscoveryNode[0]);
         startAndRunCollector(votingNodes);
 
+        PersistedStateRegistry persistedStateRegistry = persistedStateRegistry();
+        persistedStateRegistry.addPersistedState(
+            PersistedStateType.LOCAL,
+            new InMemoryPersistedState(currentTerm, makeClusterState(votingNodes))
+        );
+        persistedStateRegistry.addPersistedState(
+            PersistedStateType.REMOTE,
+            new InMemoryPersistedState(currentTerm, makeClusterState(votingNodes))
+        );
         final CoordinationState coordinationState = new CoordinationState(
             localNode,
-            new InMemoryPersistedState(currentTerm, makeClusterState(votingNodes)),
+            persistedStateRegistry,
             ElectionStrategy.DEFAULT_INSTANCE,
-            new InMemoryPersistedState(currentTerm, makeClusterState(votingNodes)),
             Settings.EMPTY
         );
 

--- a/server/src/test/java/org/opensearch/cluster/coordination/PreVoteCollectorTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/PreVoteCollectorTests.java
@@ -293,7 +293,9 @@ public class PreVoteCollectorTests extends OpenSearchTestCase {
         final CoordinationState coordinationState = new CoordinationState(
             localNode,
             new InMemoryPersistedState(currentTerm, makeClusterState(votingNodes)),
-            ElectionStrategy.DEFAULT_INSTANCE
+            ElectionStrategy.DEFAULT_INSTANCE,
+            new InMemoryPersistedState(currentTerm, makeClusterState(votingNodes)),
+            Settings.EMPTY
         );
 
         final long newTerm = randomLongBetween(currentTerm + 1, Long.MAX_VALUE);

--- a/server/src/test/java/org/opensearch/cluster/coordination/PreVoteCollectorTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/PreVoteCollectorTests.java
@@ -296,10 +296,6 @@ public class PreVoteCollectorTests extends OpenSearchTestCase {
             PersistedStateType.LOCAL,
             new InMemoryPersistedState(currentTerm, makeClusterState(votingNodes))
         );
-        persistedStateRegistry.addPersistedState(
-            PersistedStateType.REMOTE,
-            new InMemoryPersistedState(currentTerm, makeClusterState(votingNodes))
-        );
         final CoordinationState coordinationState = new CoordinationState(
             localNode,
             persistedStateRegistry,

--- a/server/src/test/java/org/opensearch/cluster/coordination/PublicationTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/PublicationTests.java
@@ -94,7 +94,6 @@ public class PublicationTests extends OpenSearchTestCase {
             );
             PersistedStateRegistry persistedStateRegistry = persistedStateRegistry();
             persistedStateRegistry.addPersistedState(PersistedStateType.LOCAL, new InMemoryPersistedState(0L, initialState));
-            persistedStateRegistry.addPersistedState(PersistedStateType.REMOTE, new InMemoryPersistedState(0L, initialState));
             coordinationState = new CoordinationState(localNode, persistedStateRegistry, ElectionStrategy.DEFAULT_INSTANCE, Settings.EMPTY);
         }
 

--- a/server/src/test/java/org/opensearch/cluster/coordination/PublicationTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/PublicationTests.java
@@ -35,6 +35,7 @@ package org.opensearch.cluster.coordination;
 import org.opensearch.Version;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.coordination.CoordinationMetadata.VotingConfiguration;
+import org.opensearch.cluster.coordination.PersistedStateRegistry.PersistedStateType;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodeRole;
 import org.opensearch.cluster.node.DiscoveryNodes;
@@ -91,13 +92,10 @@ public class PublicationTests extends OpenSearchTestCase {
                 CoordinationMetadata.VotingConfiguration.EMPTY_CONFIG,
                 0L
             );
-            coordinationState = new CoordinationState(
-                localNode,
-                new InMemoryPersistedState(0L, initialState),
-                ElectionStrategy.DEFAULT_INSTANCE,
-                new InMemoryPersistedState(0L, initialState),
-                Settings.EMPTY
-            );
+            PersistedStateRegistry persistedStateRegistry = persistedStateRegistry();
+            persistedStateRegistry.addPersistedState(PersistedStateType.LOCAL, new InMemoryPersistedState(0L, initialState));
+            persistedStateRegistry.addPersistedState(PersistedStateType.REMOTE, new InMemoryPersistedState(0L, initialState));
+            coordinationState = new CoordinationState(localNode, persistedStateRegistry, ElectionStrategy.DEFAULT_INSTANCE, Settings.EMPTY);
         }
 
         final DiscoveryNode localNode;

--- a/server/src/test/java/org/opensearch/cluster/coordination/PublicationTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/PublicationTests.java
@@ -94,7 +94,9 @@ public class PublicationTests extends OpenSearchTestCase {
             coordinationState = new CoordinationState(
                 localNode,
                 new InMemoryPersistedState(0L, initialState),
-                ElectionStrategy.DEFAULT_INSTANCE
+                ElectionStrategy.DEFAULT_INSTANCE,
+                new InMemoryPersistedState(0L, initialState),
+                Settings.EMPTY
             );
         }
 

--- a/server/src/test/java/org/opensearch/discovery/DiscoveryModuleTests.java
+++ b/server/src/test/java/org/opensearch/discovery/DiscoveryModuleTests.java
@@ -34,6 +34,7 @@ package org.opensearch.discovery;
 import org.opensearch.Version;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.coordination.Coordinator;
+import org.opensearch.cluster.coordination.PersistedStateRegistry;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.routing.RerouteService;
 import org.opensearch.cluster.service.ClusterApplier;
@@ -120,7 +121,8 @@ public class DiscoveryModuleTests extends OpenSearchTestCase {
             createTempDir().toAbsolutePath(),
             gatewayMetaState,
             mock(RerouteService.class),
-            null
+            null,
+            new PersistedStateRegistry()
         );
     }
 

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
@@ -79,6 +79,20 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
         Assert.assertThat(manifest, nullValue());
     }
 
+    public void testFailInitializationWhenRemoteStateDisabled() throws IOException {
+        final Settings settings = Settings.builder().build();
+        assertThrows(
+            AssertionError.class,
+            () -> new RemoteClusterStateService(
+                "test-node-id",
+                repositoriesServiceSupplier,
+                settings,
+                new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+                () -> 0L
+            )
+        );
+    }
+
     public void testFailWriteFullMetadataWhenRepositoryNotSet() {
         final ClusterState clusterState = generateClusterStateWithOneIndex().nodes(nodesWithLocalNodeClusterManager()).build();
         doThrow(new RepositoryMissingException("repository missing")).when(repositoriesService).repository("remote_store_repository");

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
@@ -79,20 +79,6 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
         Assert.assertThat(manifest, nullValue());
     }
 
-    public void testFailInitializationWhenRemoteStateDisabled() throws IOException {
-        final Settings settings = Settings.builder().build();
-        assertThrows(
-            AssertionError.class,
-            () -> new RemoteClusterStateService(
-                "test-node-id",
-                repositoriesServiceSupplier,
-                settings,
-                new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
-                () -> 0L
-            )
-        );
-    }
-
     public void testFailWriteFullMetadataWhenRepositoryNotSet() {
         final ClusterState clusterState = generateClusterStateWithOneIndex().nodes(nodesWithLocalNodeClusterManager()).build();
         doThrow(new RepositoryMissingException("repository missing")).when(repositoriesService).repository("remote_store_repository");

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -130,6 +130,7 @@ import org.opensearch.cluster.coordination.DeterministicTaskQueue;
 import org.opensearch.cluster.coordination.ElectionStrategy;
 import org.opensearch.cluster.coordination.InMemoryPersistedState;
 import org.opensearch.cluster.coordination.MockSinglePrioritizingExecutor;
+import org.opensearch.cluster.coordination.PersistedStateRegistry;
 import org.opensearch.cluster.metadata.AliasValidator;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
@@ -2507,7 +2508,8 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                     random(),
                     rerouteService,
                     ElectionStrategy.DEFAULT_INSTANCE,
-                    () -> new StatusInfo(HEALTHY, "healthy-info")
+                    () -> new StatusInfo(HEALTHY, "healthy-info"),
+                    new PersistedStateRegistry()
                 );
                 clusterManagerService.setClusterStatePublisher(coordinator);
                 coordinator.start();

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -131,6 +131,7 @@ import org.opensearch.cluster.coordination.ElectionStrategy;
 import org.opensearch.cluster.coordination.InMemoryPersistedState;
 import org.opensearch.cluster.coordination.MockSinglePrioritizingExecutor;
 import org.opensearch.cluster.coordination.PersistedStateRegistry;
+import org.opensearch.cluster.coordination.PersistedStateRegistry.PersistedStateType;
 import org.opensearch.cluster.metadata.AliasValidator;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
@@ -2489,6 +2490,8 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                     initialState.term(),
                     stateForNode(initialState, node)
                 );
+                final PersistedStateRegistry persistedStateRegistry = persistedStateRegistry();
+                persistedStateRegistry.addPersistedState(PersistedStateType.LOCAL, persistedState);
                 coordinator = new Coordinator(
                     node.getName(),
                     clusterService.getSettings(),
@@ -2509,7 +2512,7 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                     rerouteService,
                     ElectionStrategy.DEFAULT_INSTANCE,
                     () -> new StatusInfo(HEALTHY, "healthy-info"),
-                    new PersistedStateRegistry()
+                    persistedStateRegistry
                 );
                 clusterManagerService.setClusterStatePublisher(coordinator);
                 coordinator.start();

--- a/test/framework/src/main/java/org/opensearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -846,7 +846,7 @@ public class AbstractCoordinatorTestCase extends OpenSearchTestCase {
                         nodeEnvironment = newNodeEnvironment();
                         nodeEnvironments.add(nodeEnvironment);
                         final MockGatewayMetaState gatewayMetaState = new MockGatewayMetaState(localNode, bigArrays);
-                        gatewayMetaState.start(Settings.EMPTY, nodeEnvironment, xContentRegistry());
+                        gatewayMetaState.start(Settings.EMPTY, nodeEnvironment, xContentRegistry(), persistedStateRegistry());
                         delegate = gatewayMetaState.getPersistedState();
                     } else {
                         nodeEnvironment = null;
@@ -890,7 +890,7 @@ public class AbstractCoordinatorTestCase extends OpenSearchTestCase {
                             }
                         }
                         final MockGatewayMetaState gatewayMetaState = new MockGatewayMetaState(newLocalNode, bigArrays);
-                        gatewayMetaState.start(Settings.EMPTY, nodeEnvironment, xContentRegistry());
+                        gatewayMetaState.start(Settings.EMPTY, nodeEnvironment, xContentRegistry(), persistedStateRegistry());
                         delegate = gatewayMetaState.getPersistedState();
                     } else {
                         nodeEnvironment = null;
@@ -1144,7 +1144,8 @@ public class AbstractCoordinatorTestCase extends OpenSearchTestCase {
                     Randomness.get(),
                     (s, p, r) -> {},
                     getElectionStrategy(),
-                    nodeHealthService
+                    nodeHealthService,
+                    new PersistedStateRegistry()
                 );
                 clusterManagerService.setClusterStatePublisher(coordinator);
                 final GatewayService gatewayService = new GatewayService(

--- a/test/framework/src/main/java/org/opensearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -49,6 +49,7 @@ import org.opensearch.cluster.coordination.AbstractCoordinatorTestCase.Cluster.C
 import org.opensearch.cluster.coordination.CoordinationMetadata.VotingConfiguration;
 import org.opensearch.cluster.coordination.LinearizabilityChecker.History;
 import org.opensearch.cluster.coordination.LinearizabilityChecker.SequentialSpec;
+import org.opensearch.cluster.coordination.PersistedStateRegistry.PersistedStateType;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodeRole;
@@ -864,11 +865,12 @@ public class AbstractCoordinatorTestCase extends OpenSearchTestCase {
 
             MockPersistedState(
                 DiscoveryNode newLocalNode,
-                MockPersistedState oldState,
+                PersistedStateRegistry persistedStateRegistry,
                 Function<Metadata, Metadata> adaptGlobalMetadata,
                 Function<Long, Long> adaptCurrentTerm
             ) {
                 try {
+                    MockPersistedState oldState = (MockPersistedState) persistedStateRegistry.getPersistedState(PersistedStateType.LOCAL);
                     if (oldState.nodeEnvironment != null) {
                         nodeEnvironment = oldState.nodeEnvironment;
                         final Metadata updatedMetadata = adaptGlobalMetadata.apply(oldState.getLastAcceptedState().metadata());
@@ -1025,7 +1027,7 @@ public class AbstractCoordinatorTestCase extends OpenSearchTestCase {
             private final int nodeIndex;
             Coordinator coordinator;
             private final DiscoveryNode localNode;
-            final MockPersistedState persistedState;
+            final PersistedStateRegistry persistedStateRegistry;
             final Settings nodeSettings;
             private AckedFakeThreadPoolClusterManagerService clusterManagerService;
             private DisruptableClusterApplierService clusterApplierService;
@@ -1056,7 +1058,9 @@ public class AbstractCoordinatorTestCase extends OpenSearchTestCase {
                 this.nodeIndex = nodeIndex;
                 this.localNode = localNode;
                 this.nodeSettings = nodeSettings;
-                persistedState = persistedStateSupplier.apply(localNode);
+                final MockPersistedState persistedState = persistedStateSupplier.apply(localNode);
+                persistedStateRegistry = persistedStateRegistry();
+                persistedStateRegistry.addPersistedState(PersistedStateType.LOCAL, persistedState);
                 assertTrue("must use a fresh PersistedState", openPersistedStates.add(persistedState));
                 boolean success = false;
                 try {
@@ -1145,7 +1149,7 @@ public class AbstractCoordinatorTestCase extends OpenSearchTestCase {
                     (s, p, r) -> {},
                     getElectionStrategy(),
                     nodeHealthService,
-                    new PersistedStateRegistry()
+                    persistedStateRegistry
                 );
                 clusterManagerService.setClusterStatePublisher(coordinator);
                 final GatewayService gatewayService = new GatewayService(
@@ -1205,14 +1209,14 @@ public class AbstractCoordinatorTestCase extends OpenSearchTestCase {
                 return new ClusterNode(
                     nodeIndex,
                     newLocalNode,
-                    node -> new MockPersistedState(newLocalNode, persistedState, adaptGlobalMetadata, adaptCurrentTerm),
+                    node -> new MockPersistedState(newLocalNode, persistedStateRegistry, adaptGlobalMetadata, adaptCurrentTerm),
                     nodeSettings,
                     nodeHealthService
                 );
             }
 
             private CoordinationState.PersistedState getPersistedState() {
-                return persistedState;
+                return persistedStateRegistry.getPersistedState(PersistedStateType.LOCAL);
             }
 
             String getId() {

--- a/test/framework/src/main/java/org/opensearch/cluster/coordination/CoordinationStateTestCluster.java
+++ b/test/framework/src/main/java/org/opensearch/cluster/coordination/CoordinationStateTestCluster.java
@@ -128,6 +128,8 @@ public class CoordinationStateTestCluster {
 
         DiscoveryNode localNode;
         CoordinationState.PersistedState persistedState;
+        CoordinationState.PersistedState remotePersistedState;
+
         CoordinationState state;
 
         ClusterNode(DiscoveryNode localNode, ElectionStrategy electionStrategy) {
@@ -143,8 +145,20 @@ public class CoordinationStateTestCluster {
                     0L
                 )
             );
+            remotePersistedState = new InMemoryPersistedState(
+                0L,
+                clusterState(
+                    0L,
+                    0L,
+                    localNode,
+                    CoordinationMetadata.VotingConfiguration.EMPTY_CONFIG,
+                    CoordinationMetadata.VotingConfiguration.EMPTY_CONFIG,
+                    0L
+                )
+            );
+
             this.electionStrategy = electionStrategy;
-            state = new CoordinationState(localNode, persistedState, electionStrategy);
+            state = new CoordinationState(localNode, persistedState, electionStrategy, remotePersistedState, Settings.EMPTY);
         }
 
         void reboot() {
@@ -183,7 +197,7 @@ public class CoordinationStateTestCluster {
                 localNode.getVersion()
             );
 
-            state = new CoordinationState(localNode, persistedState, electionStrategy);
+            state = new CoordinationState(localNode, persistedState, electionStrategy, remotePersistedState, Settings.EMPTY);
         }
 
         void setInitialState(CoordinationMetadata.VotingConfiguration initialConfig, long initialValue) {

--- a/test/framework/src/main/java/org/opensearch/cluster/coordination/CoordinationStateTestCluster.java
+++ b/test/framework/src/main/java/org/opensearch/cluster/coordination/CoordinationStateTestCluster.java
@@ -34,6 +34,7 @@ package org.opensearch.cluster.coordination;
 
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.coordination.PersistedStateRegistry.PersistedStateType;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodeRole;
@@ -129,6 +130,7 @@ public class CoordinationStateTestCluster {
         DiscoveryNode localNode;
         CoordinationState.PersistedState persistedState;
         CoordinationState.PersistedState remotePersistedState;
+        PersistedStateRegistry persistedStateRegistry;
 
         CoordinationState state;
 
@@ -156,9 +158,12 @@ public class CoordinationStateTestCluster {
                     0L
                 )
             );
+            persistedStateRegistry = new PersistedStateRegistry();
+            persistedStateRegistry.addPersistedState(PersistedStateType.LOCAL, persistedState);
+            persistedStateRegistry.addPersistedState(PersistedStateType.REMOTE, remotePersistedState);
 
             this.electionStrategy = electionStrategy;
-            state = new CoordinationState(localNode, persistedState, electionStrategy, remotePersistedState, Settings.EMPTY);
+            state = new CoordinationState(localNode, persistedStateRegistry, electionStrategy, Settings.EMPTY);
         }
 
         void reboot() {
@@ -197,7 +202,7 @@ public class CoordinationStateTestCluster {
                 localNode.getVersion()
             );
 
-            state = new CoordinationState(localNode, persistedState, electionStrategy, remotePersistedState, Settings.EMPTY);
+            state = new CoordinationState(localNode, persistedStateRegistry, electionStrategy, Settings.EMPTY);
         }
 
         void setInitialState(CoordinationMetadata.VotingConfiguration initialConfig, long initialValue) {

--- a/test/framework/src/main/java/org/opensearch/cluster/coordination/CoordinationStateTestCluster.java
+++ b/test/framework/src/main/java/org/opensearch/cluster/coordination/CoordinationStateTestCluster.java
@@ -129,7 +129,6 @@ public class CoordinationStateTestCluster {
 
         DiscoveryNode localNode;
         CoordinationState.PersistedState persistedState;
-        CoordinationState.PersistedState remotePersistedState;
         PersistedStateRegistry persistedStateRegistry;
 
         CoordinationState state;
@@ -147,20 +146,8 @@ public class CoordinationStateTestCluster {
                     0L
                 )
             );
-            remotePersistedState = new InMemoryPersistedState(
-                0L,
-                clusterState(
-                    0L,
-                    0L,
-                    localNode,
-                    CoordinationMetadata.VotingConfiguration.EMPTY_CONFIG,
-                    CoordinationMetadata.VotingConfiguration.EMPTY_CONFIG,
-                    0L
-                )
-            );
             persistedStateRegistry = new PersistedStateRegistry();
             persistedStateRegistry.addPersistedState(PersistedStateType.LOCAL, persistedState);
-            persistedStateRegistry.addPersistedState(PersistedStateType.REMOTE, remotePersistedState);
 
             this.electionStrategy = electionStrategy;
             state = new CoordinationState(localNode, persistedStateRegistry, electionStrategy, Settings.EMPTY);

--- a/test/framework/src/main/java/org/opensearch/gateway/MockGatewayMetaState.java
+++ b/test/framework/src/main/java/org/opensearch/gateway/MockGatewayMetaState.java
@@ -88,7 +88,12 @@ public class MockGatewayMetaState extends GatewayMetaState {
         return ClusterStateUpdaters.setLocalNode(clusterState, localNode);
     }
 
-    public void start(Settings settings, NodeEnvironment nodeEnvironment, NamedXContentRegistry xContentRegistry, PersistedStateRegistry persistedStateRegistry) {
+    public void start(
+        Settings settings,
+        NodeEnvironment nodeEnvironment,
+        NamedXContentRegistry xContentRegistry,
+        PersistedStateRegistry persistedStateRegistry
+    ) {
         final TransportService transportService = mock(TransportService.class);
         when(transportService.getThreadPool()).thenReturn(mock(ThreadPool.class));
         final ClusterService clusterService = mock(ClusterService.class);

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchTestCase.java
@@ -65,6 +65,7 @@ import org.opensearch.Version;
 import org.opensearch.bootstrap.BootstrapForTesting;
 import org.opensearch.client.Requests;
 import org.opensearch.cluster.ClusterModule;
+import org.opensearch.cluster.coordination.PersistedStateRegistry;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.CheckedRunnable;
@@ -1541,6 +1542,14 @@ public abstract class OpenSearchTestCase extends LuceneTestCase {
      */
     protected NamedWriteableRegistry writableRegistry() {
         return new NamedWriteableRegistry(ClusterModule.getNamedWriteables());
+    }
+
+    /**
+     * The {@link PersistedStateRegistry} to use for this test. Subclasses should override and use liberally.
+     * @return
+     */
+    protected PersistedStateRegistry persistedStateRegistry() {
+        return new PersistedStateRegistry();
     }
 
     /**

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchTestCase.java
@@ -1546,7 +1546,6 @@ public abstract class OpenSearchTestCase extends LuceneTestCase {
 
     /**
      * The {@link PersistedStateRegistry} to use for this test. Subclasses should override and use liberally.
-     * @return
      */
     protected PersistedStateRegistry persistedStateRegistry() {
         return new PersistedStateRegistry();


### PR DESCRIPTION
### Description
Follow up PR for : https://github.com/opensearch-project/OpenSearch/pull/9160
In the above PR, RemotePersistedState and RemoteClusterStateService were created. In the current PR, these classes are integrated into the cluster state publish flow. The upload of cluster metadata will happen just before the cluster state publish request is sent to all nodes

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/9338

Previous PR in forked repo: https://github.com/soosinha/OpenSearch/pull/3

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
