### PR TITLE
Mute RemoteIndexShardTests primary promotion flaky tests

### DIFF
--- a/server/src/test/java/org/opensearch/index/shard/RemoteIndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteIndexShardTests.java
@@ -64,18 +64,22 @@ public class RemoteIndexShardTests extends SegmentReplicationIndexShardTests {
         return createGroup(numberOfReplicas, settings, indexMapping, new NRTReplicationEngineFactory(), createTempDir());
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/9624")
     public void testNRTReplicaWithRemoteStorePromotedAsPrimaryRefreshRefresh() throws Exception {
         testNRTReplicaWithRemoteStorePromotedAsPrimary(false, false);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/9624")
     public void testNRTReplicaWithRemoteStorePromotedAsPrimaryRefreshCommit() throws Exception {
         testNRTReplicaWithRemoteStorePromotedAsPrimary(false, true);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/9624")
     public void testNRTReplicaWithRemoteStorePromotedAsPrimaryCommitRefresh() throws Exception {
         testNRTReplicaWithRemoteStorePromotedAsPrimary(true, false);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/9624")
     public void testNRTReplicaWithRemoteStorePromotedAsPrimaryCommitCommit() throws Exception {
         testNRTReplicaWithRemoteStorePromotedAsPrimary(true, true);
     }


### PR DESCRIPTION
### Description
Mutes RemoteIndexShardTests tests which are flaky and causing gradle check failures. These tests were originallly introduced in https://github.com/opensearch-project/OpenSearch/pull/5579 and then refactored to separate test class `RemoteIndexShardTests` in https://github.com/opensearch-project/OpenSearch/pull/8767.  I added this test class for retry consideration in https://github.com/opensearch-project/OpenSearch/pull/9597 hoping to see reduction in gradle check failures but it did not help and in most cases all retry attempts fails - resulting in gradle check failures. I think muting them for now is the right decision until these tests are fixed. 

CC @sachinpkale @mch2 @anasalkouz 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
Relates https://github.com/opensearch-project/OpenSearch/issues/9624

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
