### PR TITLE
[Remote Store] Mute RemoteIndexRecoveryIT.testReplicaRecovery flaky test

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteIndexRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteIndexRecoveryIT.java
@@ -171,4 +171,10 @@ public class RemoteIndexRecoveryIT extends IndexRecoveryIT {
     public void testReplicaRecovery() {
 
     }
+
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/9580")
+    public void testRerouteRecovery() {
+
+    }
+
 }


### PR DESCRIPTION
### Description
Mute RemoteIndexRecoveryIT.testReplicaRecovery flaky test as it has caused a flurry of gradle check failures. This test was probably missed in https://github.com/opensearch-project/OpenSearch/pull/8812 where remaining flaky tests were overridden in RemoteIndexRecoveryIT. 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
Relates: https://github.com/opensearch-project/OpenSearch/issues/9580
Relates: https://github.com/opensearch-project/OpenSearch/issues/8919

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
