### PR TITLE
Disable shard/segment level search_after short cutting if track_total_hits != false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix condition to remove index create block ([#9437](https://github.com/opensearch-project/OpenSearch/pull/9437))
 - Add support to clear archived index setting ([#9019](https://github.com/opensearch-project/OpenSearch/pull/9019))
 - [Segment Replication] Fixed bug where replica shard temporarily serves stale data during an engine reset ([#9495](https://github.com/opensearch-project/OpenSearch/pull/9495))
+- Disable shard/segment level search_after short cutting if track_total_hits != false ([#9683](https://github.com/opensearch-project/OpenSearch/pull/9683))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
@@ -511,7 +511,12 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
                     ctx,
                     primarySortField
                 );
-                return SearchService.canMatchSearchAfter(searchContext.searchAfter(), minMax, primarySortField);
+                return SearchService.canMatchSearchAfter(
+                    searchContext.searchAfter(),
+                    minMax,
+                    primarySortField,
+                    searchContext.trackTotalHitsUpTo()
+                );
             }
         }
         return true;

--- a/server/src/test/java/org/opensearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/opensearch/search/SearchServiceTests.java
@@ -1756,7 +1756,7 @@ public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
         MinAndMax<?> minMax = new MinAndMax<Long>(0L, 9L);
         FieldSortBuilder primarySort = new FieldSortBuilder("test");
         primarySort.order(SortOrder.ASC);
-        assertEquals(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort), false);
+        assertEquals(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort, SearchContext.TRACK_TOTAL_HITS_DISABLED), false);
     }
 
     /**
@@ -1769,7 +1769,7 @@ public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
         MinAndMax<?> minMax = new MinAndMax<Long>(0L, 9L);
         FieldSortBuilder primarySort = new FieldSortBuilder("test");
         primarySort.order(SortOrder.ASC);
-        assertEquals(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort), true);
+        assertEquals(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort, SearchContext.TRACK_TOTAL_HITS_DISABLED), true);
     }
 
     /**
@@ -1782,7 +1782,7 @@ public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
         MinAndMax<?> minMax = new MinAndMax<Long>(0L, 9L);
         FieldSortBuilder primarySort = new FieldSortBuilder("test");
         primarySort.order(SortOrder.ASC);
-        assertEquals(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort), true);
+        assertEquals(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort, SearchContext.TRACK_TOTAL_HITS_DISABLED), true);
     }
 
     /**
@@ -1795,7 +1795,7 @@ public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
         MinAndMax<?> minMax = new MinAndMax<Long>(0L, 9L);
         FieldSortBuilder primarySort = new FieldSortBuilder("test");
         primarySort.order(SortOrder.DESC);
-        assertEquals(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort), true);
+        assertEquals(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort, SearchContext.TRACK_TOTAL_HITS_DISABLED), true);
     }
 
     /**
@@ -1808,7 +1808,7 @@ public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
         MinAndMax<?> minMax = new MinAndMax<Long>(0L, 9L);
         FieldSortBuilder primarySort = new FieldSortBuilder("test");
         primarySort.order(SortOrder.DESC);
-        assertEquals(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort), false);
+        assertEquals(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort, SearchContext.TRACK_TOTAL_HITS_DISABLED), false);
     }
 
     /**
@@ -1821,7 +1821,7 @@ public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
         MinAndMax<?> minMax = new MinAndMax<Long>(0L, 9L);
         FieldSortBuilder primarySort = new FieldSortBuilder("test");
         primarySort.order(SortOrder.DESC);
-        assertEquals(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort), true);
+        assertEquals(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort, SearchContext.TRACK_TOTAL_HITS_DISABLED), true);
     }
 
     /**
@@ -1835,9 +1835,24 @@ public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
         FieldSortBuilder primarySort = new FieldSortBuilder("test");
         primarySort.order(SortOrder.DESC);
         // Should be false without missing values
-        assertEquals(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort), false);
+        assertEquals(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort, SearchContext.TRACK_TOTAL_HITS_DISABLED), false);
         primarySort.missing("_last");
         // Should be true with missing values
-        assertEquals(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort), true);
+        assertEquals(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort, SearchContext.TRACK_TOTAL_HITS_DISABLED), true);
+    }
+
+    /**
+     * Test for DESC order search_after query with track_total_hits=true.
+     * Min = 0L, Max = 9L, search_after = -1L
+     * With above min/max and search_after, it should not match, but since
+     * track_total_hits = true,
+     * Expected result is canMatch = true
+     */
+    public void testCanMatchSearchAfterDescLessThanMinWithTrackTotalhits() throws IOException {
+        FieldDoc searchAfter = new FieldDoc(0, 0, new Long[] { -1L });
+        MinAndMax<?> minMax = new MinAndMax<Long>(0L, 9L);
+        FieldSortBuilder primarySort = new FieldSortBuilder("test");
+        primarySort.order(SortOrder.DESC);
+        assertEquals(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort, 1000), true);
     }
 }


### PR DESCRIPTION
## Description

### Context
Any `_search` query return `hits.total.value` in response like mentioned in below example. Which specifies how many hits are matching actual query (sort/search_after are not part of query).

i.e, check response for below query
```
GET logs-*/_search
{
        "query": {
          "match_all": {}
        },
        "sort" : [
          {"@timestamp" : "asc"}
        ],
        "search_after": ["1998-06-01"]
}
```
Response [partial]
```
{
  "took": 25,
  "timed_out": false,
  "_shards": {
    "total": 35,
    "successful": 35,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": {
      "value": 10000,
      "relation": "gte"
    },
    "max_score": null,
    "hits": [
      {
        "_ind
```

This `hits.total.value` is capped at `10000` max as lucene can match at max 10000 documents in results.

If you want exact match in `hits.total.value`, we need to add `track_total_hits=true` in request parameter.
i.e.
```
GET logs-*/_search?track_total_hits=true
{
        "query": {
          "match_all": {}
        },
        "sort" : [
          {"@timestamp" : "asc"}
        ],
        "search_after": ["1998-06-01"]
}
```
Response for above query [partial]
```
{
  "took": 32,
  "timed_out": false,
  "_shards": {
    "total": 35,
    "successful": 35,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": {
      "value": 247249096,
      "relation": "eq"
    },
    "max_score": null,
    "hits": [
```
If you check, it has exact matching value `247249096` in `hits.total.value`.

Above calculation results on additional computational costs on `_search` query to track total matching hits. So for performance sensitive queries, it is recommended to provide `track_total_hits=falsle`.
i.e
```
GET logs-*/_search?track_total_hits=false
{
        "query": {
          "match_all": {}
        },
        "sort" : [
          {"@timestamp" : "asc"}
        ],
        "search_after": ["1998-06-01"]
}
```
Response from above search query [partial]
```
{
  "took": 14,
  "timed_out": false,
  "_shards": {
    "total": 35,
    "successful": 35,
    "skipped": 25,
    "failed": 0
  },
  "hits": {
    "max_score": null,
```

Default behaviour for _search queries if `track_total_hits` is not provided as request input, is track matching hits up to 10000 documents as mentioned above.


### Issue
Now with introduction of shard/segment level shortcutting [#6596] for `search_after` queries, it will skip issuing _search request for those shards/segments. So we will end up *NOT* tracking those documents hits which are matching query for that skipped shards/segmetns because of `search_after` based skipping.
This was caught in this issue. https://github.com/opensearch-project/OpenSearch/issues/9013.

### Related Issues
Resolves #9013 

### Resolution in this PR
Use `search_after` shortcutting only if `track_total_hits=false` provided.

### Additional note
There is no latency impact on _search queries even if we dont use shard/segment level skipping logic, now that we have this optimization available in Lucene itself with https://github.com/apache/lucene/pull/12334.
It will end up issuing network call for search request for that shard but lucene query will return immediately since no matching documents and there wont be any fetch phase.
yeah I agree it will end up issuing additional network calls from coordinator to shard replica hosted data nodes.

I tested with 3 nodes cluster `http_logs` with 5 indices with 5 shards each. Latencies are almost similar. So no side -effect on performance with disabling this shortcutting if track_total_hits is not false.
This is P50, units are in ms.
No difference for P90, p99 as well.

| Data Node Type.      | Sort Mode | With track_total_hits != false | track_total_hits = false |
| ----------- | ----------- | -------- | -------- |
| r6g.2xlarge  | asc with after    | 41       | 39  |
| r6g.2xlarge  | desc with after | 103        | 101 |


### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
