### PR TITLE
Add async segment file download support from remote store within OpenSearch core

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/multipart/RemoteStoreMultipartIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/multipart/RemoteStoreMultipartIT.java
@@ -104,6 +104,7 @@ public class RemoteStoreMultipartIT extends RemoteStoreIT {
         } else {
             return super.buildRepositoryMetadata(node, name);
         }
+
     }
 
     public void testRateLimitedRemoteUploads() throws Exception {

--- a/server/src/main/java/org/opensearch/index/IndexService.java
+++ b/server/src/main/java/org/opensearch/index/IndexService.java
@@ -481,7 +481,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             Store remoteStore = null;
             if (this.indexSettings.isRemoteStoreEnabled()) {
                 Directory remoteDirectory = remoteDirectoryFactory.newDirectory(this.indexSettings, path);
-                remoteStore = new Store(shardId, this.indexSettings, remoteDirectory, lock, Store.OnClose.EMPTY);
+                remoteStore = new Store(shardId, this.indexSettings, remoteDirectory, lock, Store.OnClose.EMPTY, path);
             }
 
             Directory directory = directoryFactory.newDirectory(this.indexSettings, path);
@@ -490,7 +490,8 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                 this.indexSettings,
                 directory,
                 lock,
-                new StoreCloseListener(shardId, () -> eventListener.onStoreClosed(shardId))
+                new StoreCloseListener(shardId, () -> eventListener.onStoreClosed(shardId)),
+                path
             );
             eventListener.onStoreCreated(shardId);
             indexShard = new IndexShard(

--- a/server/src/main/java/org/opensearch/indices/replication/RemoteStoreReplicationSource.java
+++ b/server/src/main/java/org/opensearch/indices/replication/RemoteStoreReplicationSource.java
@@ -13,18 +13,20 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FilterDirectory;
-import org.apache.lucene.store.IOContext;
 import org.apache.lucene.util.Version;
+import org.opensearch.action.support.GroupedActionListener;
 import org.opensearch.common.concurrent.GatedCloseable;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.shard.IndexShardState;
+import org.opensearch.index.shard.ShardPath;
 import org.opensearch.index.store.RemoteSegmentStoreDirectory;
 import org.opensearch.index.store.Store;
 import org.opensearch.index.store.StoreFileMetadata;
 import org.opensearch.index.store.remote.metadata.RemoteSegmentMetadata;
 import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -106,29 +108,47 @@ public class RemoteStoreReplicationSource implements SegmentReplicationSource {
             logger.trace("Downloading segments files from remote store {}", filesToFetch);
 
             RemoteSegmentMetadata remoteSegmentMetadata = remoteDirectory.readLatestMetadataFile();
-            List<StoreFileMetadata> downloadedSegments = new ArrayList<>();
+            List<StoreFileMetadata> toDownloadSegments = new ArrayList<>();
             Collection<String> directoryFiles = List.of(indexShard.store().directory().listAll());
             if (remoteSegmentMetadata != null) {
                 try {
                     indexShard.store().incRef();
                     indexShard.remoteStore().incRef();
                     final Directory storeDirectory = indexShard.store().directory();
+                    final ShardPath shardPath = indexShard.shardPath();
                     for (StoreFileMetadata fileMetadata : filesToFetch) {
                         String file = fileMetadata.name();
                         assert directoryFiles.contains(file) == false : "Local store already contains the file " + file;
-                        storeDirectory.copyFrom(remoteDirectory, file, file, IOContext.DEFAULT);
-                        downloadedSegments.add(fileMetadata);
+                        toDownloadSegments.add(fileMetadata);
                     }
-                    logger.trace("Downloaded segments from remote store {}", downloadedSegments);
+                    downloadSegments(storeDirectory, remoteDirectory, toDownloadSegments, shardPath, listener);
+                    logger.trace("Downloaded segments from remote store {}", toDownloadSegments);
                 } finally {
                     indexShard.store().decRef();
                     indexShard.remoteStore().decRef();
                 }
             }
-            listener.onResponse(new GetSegmentFilesResponse(downloadedSegments));
         } catch (Exception e) {
             listener.onFailure(e);
         }
+    }
+
+    private void downloadSegments(
+        Directory storeDirectory,
+        RemoteSegmentStoreDirectory remoteStoreDirectory,
+        List<StoreFileMetadata> toDownloadSegments,
+        ShardPath shardPath,
+        ActionListener<GetSegmentFilesResponse> completionListener
+    ) {
+        final Path indexPath = shardPath == null ? null : shardPath.resolveIndex();
+        final GroupedActionListener<Void> batchDownloadListener = new GroupedActionListener<>(
+            ActionListener.map(completionListener, v -> new GetSegmentFilesResponse(toDownloadSegments)),
+            toDownloadSegments.size()
+        );
+        ActionListener<String> segmentsDownloadListener = ActionListener.map(batchDownloadListener, result -> null);
+        toDownloadSegments.forEach(
+            fileMetadata -> remoteStoreDirectory.copyTo(fileMetadata.name(), storeDirectory, indexPath, segmentsDownloadListener)
+        );
     }
 
     @Override

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -1780,7 +1780,7 @@ public class IndexShardTests extends IndexShardTestCase {
             }
         };
 
-        try (Store store = createStore(shardId, new IndexSettings(metadata, Settings.EMPTY), directory)) {
+        try (Store store = createStore(shardId, new IndexSettings(metadata, Settings.EMPTY), directory, shardPath)) {
             IndexShard shard = newShard(
                 shardRouting,
                 shardPath,

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -28,6 +28,7 @@ import org.opensearch.common.io.VersionedCodecStreamWrapper;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.lucene.store.ByteArrayIndexInput;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesReference;
@@ -46,6 +47,7 @@ import org.junit.Before;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -61,6 +63,8 @@ import org.mockito.Mockito;
 import static org.opensearch.test.RemoteStoreTestUtils.createMetadataFileBytes;
 import static org.opensearch.test.RemoteStoreTestUtils.getDummyMetadata;
 import static org.hamcrest.CoreMatchers.is;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -514,6 +518,114 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         assertTrue(latch.await(5000, TimeUnit.SECONDS));
         assertTrue(remoteSegmentStoreDirectory.getSegmentsUploadedToRemoteStore().containsKey(filename));
         storeDirectory.close();
+    }
+
+    public void testCopyFilesToMultipart() throws Exception {
+        Settings settings = Settings.builder().build();
+        FeatureFlags.initializeFeatureFlags(settings);
+
+        String filename = "_0.cfe";
+        populateMetadata();
+        remoteSegmentStoreDirectory.init();
+
+        Directory storeDirectory = mock(Directory.class);
+        AsyncMultiStreamBlobContainer blobContainer = mock(AsyncMultiStreamBlobContainer.class);
+        when(remoteDataDirectory.getBlobContainer()).thenReturn(blobContainer);
+
+        Mockito.doAnswer(invocation -> {
+            ActionListener<String> completionListener = invocation.getArgument(3);
+            completionListener.onResponse(invocation.getArgument(0));
+            return null;
+        }).when(blobContainer).asyncBlobDownload(any(), any(), any(), any());
+
+        CountDownLatch downloadLatch = new CountDownLatch(1);
+        ActionListener<String> completionListener = new ActionListener<String>() {
+            @Override
+            public void onResponse(String unused) {
+                downloadLatch.countDown();
+            }
+
+            @Override
+            public void onFailure(Exception e) {}
+        };
+        Path path = createTempDir();
+        remoteSegmentStoreDirectory.copyTo(filename, storeDirectory, path, completionListener);
+        assertTrue(downloadLatch.await(5000, TimeUnit.SECONDS));
+        verify(blobContainer, times(1)).asyncBlobDownload(contains(filename), eq(path.resolve(filename)), any(), any());
+        verify(storeDirectory, times(0)).copyFrom(any(), any(), any(), any());
+    }
+
+    public void testCopyFilesTo() throws Exception {
+        String filename = "_0.cfe";
+        populateMetadata();
+        remoteSegmentStoreDirectory.init();
+
+        Directory storeDirectory = mock(Directory.class);
+        CountDownLatch downloadLatch = new CountDownLatch(1);
+        ActionListener<String> completionListener = new ActionListener<>() {
+            @Override
+            public void onResponse(String unused) {
+                downloadLatch.countDown();
+            }
+
+            @Override
+            public void onFailure(Exception e) {}
+        };
+        Path path = createTempDir();
+        remoteSegmentStoreDirectory.copyTo(filename, storeDirectory, path, completionListener);
+        assertTrue(downloadLatch.await(5000, TimeUnit.MILLISECONDS));
+        verify(storeDirectory, times(1)).copyFrom(any(), eq(filename), eq(filename), eq(IOContext.DEFAULT));
+    }
+
+    public void testCopyFilesToEmptyPath() throws Exception {
+        String filename = "_0.cfe";
+        populateMetadata();
+        remoteSegmentStoreDirectory.init();
+
+        Directory storeDirectory = mock(Directory.class);
+        AsyncMultiStreamBlobContainer blobContainer = mock(AsyncMultiStreamBlobContainer.class);
+        when(remoteDataDirectory.getBlobContainer()).thenReturn(blobContainer);
+
+        CountDownLatch downloadLatch = new CountDownLatch(1);
+        ActionListener<String> completionListener = new ActionListener<>() {
+            @Override
+            public void onResponse(String unused) {
+                downloadLatch.countDown();
+            }
+
+            @Override
+            public void onFailure(Exception e) {}
+        };
+        remoteSegmentStoreDirectory.copyTo(filename, storeDirectory, null, completionListener);
+        assertTrue(downloadLatch.await(5000, TimeUnit.MILLISECONDS));
+        verify(storeDirectory, times(1)).copyFrom(any(), eq(filename), eq(filename), eq(IOContext.DEFAULT));
+    }
+
+    public void testCopyFilesToException() throws Exception {
+        String filename = "_0.cfe";
+        populateMetadata();
+        remoteSegmentStoreDirectory.init();
+
+        Directory storeDirectory = mock(Directory.class);
+        Mockito.doThrow(new IOException())
+            .when(storeDirectory)
+            .copyFrom(any(Directory.class), anyString(), anyString(), any(IOContext.class));
+        CountDownLatch downloadLatch = new CountDownLatch(1);
+        ActionListener<String> completionListener = new ActionListener<>() {
+            @Override
+            public void onResponse(String unused) {
+
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                downloadLatch.countDown();
+            }
+        };
+        Path path = createTempDir();
+        remoteSegmentStoreDirectory.copyTo(filename, storeDirectory, path, completionListener);
+        assertTrue(downloadLatch.await(5000, TimeUnit.MILLISECONDS));
+        verify(storeDirectory, times(1)).copyFrom(any(), eq(filename), eq(filename), eq(IOContext.DEFAULT));
     }
 
     public void testCopyFilesFromMultipartIOException() throws Exception {

--- a/server/src/test/java/org/opensearch/index/store/StoreTests.java
+++ b/server/src/test/java/org/opensearch/index/store/StoreTests.java
@@ -84,6 +84,7 @@ import org.opensearch.index.engine.Engine;
 import org.opensearch.index.seqno.ReplicationTracker;
 import org.opensearch.index.seqno.RetentionLease;
 import org.opensearch.index.seqno.SequenceNumbers;
+import org.opensearch.index.shard.ShardPath;
 import org.opensearch.index.translog.Translog;
 import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.indices.store.TransportNodesListShardStoreMetadata;
@@ -798,7 +799,7 @@ public class StoreTests extends OpenSearchTestCase {
             assertEquals(shardId, theLock.getShardId());
             assertEquals(lock, theLock);
             count.incrementAndGet();
-        });
+        }, null);
         assertEquals(count.get(), 0);
 
         final int iters = randomIntBetween(1, 10);
@@ -807,6 +808,26 @@ public class StoreTests extends OpenSearchTestCase {
         }
 
         assertEquals(count.get(), 1);
+    }
+
+    public void testStoreShardPath() {
+        final ShardId shardId = new ShardId("index", "_na_", 1);
+        final Settings settings = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, org.opensearch.Version.CURRENT)
+            .put(Store.INDEX_STORE_STATS_REFRESH_INTERVAL_SETTING.getKey(), TimeValue.timeValueMinutes(0))
+            .build();
+        final Path path = createTempDir().resolve(shardId.getIndex().getUUID()).resolve(String.valueOf(shardId.id()));
+        final ShardPath shardPath = new ShardPath(false, path, path, shardId);
+        final Store store = new Store(
+            shardId,
+            IndexSettingsModule.newIndexSettings("index", settings),
+            StoreTests.newDirectory(random()),
+            new DummyShardLock(shardId),
+            Store.OnClose.EMPTY,
+            shardPath
+        );
+        assertEquals(shardPath, store.shardPath());
+        store.close();
     }
 
     public void testStoreStats() throws IOException {

--- a/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
@@ -272,11 +272,11 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
     }
 
     protected Store createStore(IndexSettings indexSettings, ShardPath shardPath) throws IOException {
-        return createStore(shardPath.getShardId(), indexSettings, newFSDirectory(shardPath.resolveIndex()));
+        return createStore(shardPath.getShardId(), indexSettings, newFSDirectory(shardPath.resolveIndex()), shardPath);
     }
 
-    protected Store createStore(ShardId shardId, IndexSettings indexSettings, Directory directory) throws IOException {
-        return new Store(shardId, indexSettings, directory, new DummyShardLock(shardId));
+    protected Store createStore(ShardId shardId, IndexSettings indexSettings, Directory directory, ShardPath shardPath) throws IOException {
+        return new Store(shardId, indexSettings, directory, new DummyShardLock(shardId), Store.OnClose.EMPTY, shardPath);
     }
 
     protected Releasable acquirePrimaryOperationPermitBlockingly(IndexShard indexShard) throws ExecutionException, InterruptedException {
@@ -654,7 +654,7 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
                     remotePath = createTempDir();
                 }
 
-                remoteStore = createRemoteStore(remotePath, routing, indexMetadata);
+                remoteStore = createRemoteStore(remotePath, routing, indexMetadata, shardPath);
 
                 remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(clusterService, indexSettings.getSettings());
                 BlobStoreRepository repo = createRepository(remotePath);
@@ -768,11 +768,12 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
         return repositoriesService;
     }
 
-    protected Store createRemoteStore(Path path, ShardRouting shardRouting, IndexMetadata metadata) throws IOException {
+    protected Store createRemoteStore(Path path, ShardRouting shardRouting, IndexMetadata metadata, ShardPath shardPath)
+        throws IOException {
         Settings nodeSettings = Settings.builder().put("node.name", shardRouting.currentNodeId()).build();
         ShardId shardId = shardRouting.shardId();
         RemoteSegmentStoreDirectory remoteSegmentStoreDirectory = createRemoteSegmentStoreDirectory(shardId, path);
-        return createStore(shardId, new IndexSettings(metadata, nodeSettings), remoteSegmentStoreDirectory);
+        return createStore(shardId, new IndexSettings(metadata, nodeSettings), remoteSegmentStoreDirectory, shardPath);
     }
 
     protected RemoteSegmentStoreDirectory createRemoteSegmentStoreDirectory(ShardId shardId, Path path) throws IOException {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
- This PR builds on top of #9592 and utilizes the new APIs within core
- The APIs will be used within the `RemoteSegmentStoreDirectory` path to copy over segment files from the remote store.
- Logically, the caller will not see any difference within the workings of download segments but the files will be parallelized and each file will support multiple streams for download due to the async nature of the APIs.

### Related Issues
Resolves #8596 
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
