### PR TITLE
[Remote Cluster State] Remove stale remote cluster state

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/gateway/remote/RemoteClusterStateServiceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/gateway/remote/RemoteClusterStateServiceIT.java
@@ -1,0 +1,107 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.gateway.remote;
+
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.blobstore.BlobPath;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.remotestore.RemoteStoreBaseIntegTestCase;
+import org.opensearch.repositories.RepositoriesService;
+import org.opensearch.repositories.blobstore.BlobStoreRepository;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
+import static org.opensearch.gateway.remote.RemoteClusterStateService.REMOTE_CLUSTER_STATE_ENABLED_SETTING;
+import static org.opensearch.gateway.remote.RemoteClusterStateService.REMOTE_CLUSTER_STATE_REPOSITORY_SETTING;
+
+public class RemoteClusterStateServiceIT extends RemoteStoreBaseIntegTestCase {
+
+    private static String INDEX_NAME = "test-index";
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(REMOTE_CLUSTER_STATE_ENABLED_SETTING.getKey(), true)
+            .put(REMOTE_CLUSTER_STATE_REPOSITORY_SETTING.getKey(), REPOSITORY_NAME)
+            .build();
+    }
+
+    private void prepareCluster(int numClusterManagerNodes, int numDataOnlyNodes, String indices, int replicaCount, int shardCount) {
+        internalCluster().startClusterManagerOnlyNodes(numClusterManagerNodes);
+        internalCluster().startDataOnlyNodes(numDataOnlyNodes);
+        for (String index : indices.split(",")) {
+            createIndex(index, remoteStoreIndexSettings(replicaCount, shardCount));
+            ensureYellowAndNoInitializingShards(index);
+            ensureGreen(index);
+        }
+    }
+
+    private Map<String, Long> initialTestSetup(int shardCount, int replicaCount, int dataNodeCount, int clusterManagerNodeCount) {
+        prepareCluster(clusterManagerNodeCount, dataNodeCount, INDEX_NAME, replicaCount, shardCount);
+        Map<String, Long> indexStats = indexData(1, false, INDEX_NAME);
+        assertEquals(shardCount * (replicaCount + 1), getNumShards(INDEX_NAME).totalNumShards);
+        ensureGreen(INDEX_NAME);
+        return indexStats;
+    }
+
+    public void testFullClusterRestoreStaleDelete() throws Exception {
+        int shardCount = randomIntBetween(1, 2);
+        int replicaCount = 1;
+        int dataNodeCount = shardCount * (replicaCount + 1);
+        int clusterManagerNodeCount = 1;
+
+        initialTestSetup(shardCount, replicaCount, dataNodeCount, clusterManagerNodeCount);
+        setReplicaCount(0);
+        setReplicaCount(1);
+        setReplicaCount(0);
+        setReplicaCount(1);
+        setReplicaCount(0);
+        setReplicaCount(1);
+        setReplicaCount(0);
+        setReplicaCount(1);
+        setReplicaCount(0);
+
+        RemoteClusterStateService remoteClusterStateService = internalCluster().getClusterManagerNodeInstance(
+            RemoteClusterStateService.class
+        );
+
+        RepositoriesService repositoriesService = internalCluster().getClusterManagerNodeInstance(RepositoriesService.class);
+
+        BlobStoreRepository repository = (BlobStoreRepository) repositoriesService.repository(REPOSITORY_NAME);
+        BlobPath baseMetadataPath = repository.basePath()
+            .add(
+                Base64.getUrlEncoder()
+                    .withoutPadding()
+                    .encodeToString(getClusterState().getClusterName().value().getBytes(StandardCharsets.UTF_8))
+            )
+            .add("cluster-state")
+            .add(getClusterState().metadata().clusterUUID());
+
+        assertEquals(repository.blobStore().blobContainer(baseMetadataPath.add("manifest")).listBlobsByPrefix("manifest").size(), 4);
+
+        Map<String, IndexMetadata> indexMetadataMap = remoteClusterStateService.getLatestIndexMetadata(
+            cluster().getClusterName(),
+            getClusterState().metadata().clusterUUID()
+        );
+        assertEquals(indexMetadataMap.values().stream().findFirst().get().getNumberOfReplicas(), 0);
+        assertEquals(indexMetadataMap.values().stream().findFirst().get().getNumberOfShards(), shardCount);
+    }
+
+    private void setReplicaCount(int replicaCount) {
+        client().admin()
+            .indices()
+            .prepareUpdateSettings(INDEX_NAME)
+            .setSettings(Settings.builder().put(SETTING_NUMBER_OF_REPLICAS, replicaCount))
+            .get();
+    }
+}

--- a/server/src/internalClusterTest/java/org/opensearch/gateway/remote/RemoteClusterStateServiceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/gateway/remote/RemoteClusterStateServiceIT.java
@@ -14,6 +14,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.remotestore.RemoteStoreBaseIntegTestCase;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.repositories.blobstore.BlobStoreRepository;
+import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.junit.annotations.TestIssueLogging;
 
 import java.nio.charset.StandardCharsets;
@@ -23,6 +24,7 @@ import java.util.Map;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
 import static org.opensearch.gateway.remote.RemoteClusterStateService.REMOTE_CLUSTER_STATE_ENABLED_SETTING;
 
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
 public class RemoteClusterStateServiceIT extends RemoteStoreBaseIntegTestCase {
 
     private static String INDEX_NAME = "test-index";

--- a/server/src/internalClusterTest/java/org/opensearch/gateway/remote/RemoteClusterStateServiceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/gateway/remote/RemoteClusterStateServiceIT.java
@@ -15,7 +15,6 @@ import org.opensearch.remotestore.RemoteStoreBaseIntegTestCase;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.repositories.blobstore.BlobStoreRepository;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.junit.annotations.TestIssueLogging;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -52,7 +51,6 @@ public class RemoteClusterStateServiceIT extends RemoteStoreBaseIntegTestCase {
         return indexStats;
     }
 
-    @TestIssueLogging(value = "_root:INFO", issueUrl = "https://github.com/opensearch-project/OpenSearch/issues/7923")
     public void testFullClusterRestoreStaleDelete() throws Exception {
         int shardCount = randomIntBetween(1, 2);
         int replicaCount = 1;

--- a/server/src/internalClusterTest/java/org/opensearch/gateway/remote/RemoteClusterStateServiceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/gateway/remote/RemoteClusterStateServiceIT.java
@@ -84,7 +84,7 @@ public class RemoteClusterStateServiceIT extends RemoteStoreBaseIntegTestCase {
             .add("cluster-state")
             .add(getClusterState().metadata().clusterUUID());
 
-        assertEquals(repository.blobStore().blobContainer(baseMetadataPath.add("manifest")).listBlobsByPrefix("manifest").size(), 10);
+        assertEquals(10, repository.blobStore().blobContainer(baseMetadataPath.add("manifest")).listBlobsByPrefix("manifest").size());
 
         Map<String, IndexMetadata> indexMetadataMap = remoteClusterStateService.getLatestIndexMetadata(
             cluster().getClusterName(),

--- a/server/src/main/java/org/opensearch/gateway/remote/ClusterMetadataManifest.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/ClusterMetadataManifest.java
@@ -423,8 +423,13 @@ public class ClusterMetadataManifest implements Writeable, ToXContentFragment {
             this.uploadedFilename = in.readString();
         }
 
-        public String getUploadedFilename() {
+        public String getUploadedFilePath() {
             return uploadedFilename;
+        }
+
+        public String getUploadedFilename() {
+            String[] splitPath = uploadedFilename.split("/");
+            return splitPath[splitPath.length - 1];
         }
 
         public String getIndexName() {
@@ -440,7 +445,7 @@ public class ClusterMetadataManifest implements Writeable, ToXContentFragment {
             return builder.startObject()
                 .field(INDEX_NAME_FIELD.getPreferredName(), getIndexName())
                 .field(INDEX_UUID_FIELD.getPreferredName(), getIndexUUID())
-                .field(UPLOADED_FILENAME_FIELD.getPreferredName(), getUploadedFilename())
+                .field(UPLOADED_FILENAME_FIELD.getPreferredName(), getUploadedFilePath())
                 .endObject();
         }
 

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -607,7 +607,7 @@ public class RemoteClusterStateService implements Closeable {
         for (String clusterUUID : clusterUUIDs) {
             try {
                 Optional<ClusterMetadataManifest> manifest = getLatestClusterMetadataManifest(clusterName, clusterUUID);
-                manifestsByClusterUUID.put(clusterUUID, manifest.get());
+                manifest.ifPresent(clusterMetadataManifest -> manifestsByClusterUUID.put(clusterUUID, clusterMetadataManifest));
             } catch (Exception e) {
                 throw new IllegalStateException(
                     String.format(Locale.ROOT, "Exception in fetching manifest for clusterUUID: %s", clusterUUID)

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -18,6 +18,7 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.blobstore.BlobContainer;
 import org.opensearch.common.blobstore.BlobMetadata;
+import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
@@ -28,12 +29,14 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.Index;
 import org.opensearch.gateway.remote.ClusterMetadataManifest.UploadedIndexMetadata;
 import org.opensearch.index.remote.RemoteStoreUtils;
+import org.opensearch.index.translog.transfer.BlobStoreTransferService;
 import org.opensearch.node.Node;
 import org.opensearch.node.remotestore.RemoteStoreNodeAttribute;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.repositories.Repository;
 import org.opensearch.repositories.blobstore.BlobStoreRepository;
 import org.opensearch.repositories.blobstore.ChecksumBlobStoreFormat;
+import org.opensearch.threadpool.ThreadPool;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -42,6 +45,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -69,6 +73,12 @@ public class RemoteClusterStateService implements Closeable {
 
     public static final String METADATA_MANIFEST_NAME_FORMAT = "%s";
 
+    public static final int RETAINED_MANIFESTS = 3;
+
+    public static final String DELIMITER = "__";
+
+    private static final Logger logger = LogManager.getLogger(RemoteClusterStateService.class);
+
     public static final int INDEX_METADATA_UPLOAD_WAIT_MILLIS = 20000;
 
     public static final ChecksumBlobStoreFormat<IndexMetadata> INDEX_METADATA_FORMAT = new ChecksumBlobStoreFormat<>(
@@ -92,9 +102,6 @@ public class RemoteClusterStateService implements Closeable {
         Property.Final
     );
 
-    private static final Logger logger = LogManager.getLogger(RemoteClusterStateService.class);
-
-    public static final String DELIMITER = "__";
     private static final String CLUSTER_STATE_PATH_TOKEN = "cluster-state";
     private static final String INDEX_PATH_TOKEN = "index";
     private static final String MANIFEST_PATH_TOKEN = "manifest";
@@ -105,6 +112,7 @@ public class RemoteClusterStateService implements Closeable {
     private final Supplier<RepositoriesService> repositoriesService;
     private final Settings settings;
     private final LongSupplier relativeTimeNanosSupplier;
+    private final ThreadPool threadpool;
     private BlobStoreRepository blobStoreRepository;
     private volatile TimeValue slowWriteLoggingThreshold;
 
@@ -113,13 +121,15 @@ public class RemoteClusterStateService implements Closeable {
         Supplier<RepositoriesService> repositoriesService,
         Settings settings,
         ClusterSettings clusterSettings,
-        LongSupplier relativeTimeNanosSupplier
+        LongSupplier relativeTimeNanosSupplier,
+        ThreadPool threadPool
     ) {
         assert isRemoteStoreClusterStateEnabled(settings) : "Remote cluster state is not enabled";
         this.nodeId = nodeId;
         this.repositoriesService = repositoriesService;
         this.settings = settings;
         this.relativeTimeNanosSupplier = relativeTimeNanosSupplier;
+        this.threadpool = threadPool;
         this.slowWriteLoggingThreshold = clusterSettings.get(SLOW_WRITE_LOGGING_THRESHOLD);
         clusterSettings.addSettingsUpdateConsumer(SLOW_WRITE_LOGGING_THRESHOLD, this::setSlowWriteLoggingThreshold);
     }
@@ -233,6 +243,7 @@ public class RemoteClusterStateService implements Closeable {
             previousManifest.getPreviousClusterUUID(),
             false
         );
+        deleteClusterMetadataMarker(clusterState.getClusterName().value(), clusterState.metadata().clusterUUID(), RETAINED_MANIFESTS);
         final long durationMillis = TimeValue.nsecToMSec(relativeTimeNanosSupplier.getAsLong() - startTimeNanos);
         if (durationMillis >= slowWriteLoggingThreshold.getMillis()) {
             logger.warn(
@@ -439,26 +450,19 @@ public class RemoteClusterStateService implements Closeable {
     private BlobContainer indexMetadataContainer(String clusterName, String clusterUUID, String indexUUID) {
         // 123456789012_test-cluster/cluster-state/dsgYj10Nkso7/index/ftqsCnn9TgOX
         return blobStoreRepository.blobStore()
-            .blobContainer(
-                blobStoreRepository.basePath()
-                    .add(encodeString(clusterName))
-                    .add(CLUSTER_STATE_PATH_TOKEN)
-                    .add(clusterUUID)
-                    .add(INDEX_PATH_TOKEN)
-                    .add(indexUUID)
-            );
+            .blobContainer(getCusterMetadataBasePath(clusterName, clusterUUID).add(INDEX_PATH_TOKEN).add(indexUUID));
     }
 
     private BlobContainer manifestContainer(String clusterName, String clusterUUID) {
         // 123456789012_test-cluster/cluster-state/dsgYj10Nkso7/manifest
-        return blobStoreRepository.blobStore()
-            .blobContainer(
-                blobStoreRepository.basePath()
-                    .add(encodeString(clusterName))
-                    .add(CLUSTER_STATE_PATH_TOKEN)
-                    .add(clusterUUID)
-                    .add(MANIFEST_PATH_TOKEN)
-            );
+        return blobStoreRepository.blobStore().blobContainer(getManifestFolderPath(clusterName, clusterUUID));
+    }
+
+    private BlobPath getCusterMetadataBasePath(String clusterName, String clusterUUID) {
+        return blobStoreRepository.basePath()
+            .add(encodeString(clusterName))
+            .add(CLUSTER_STATE_PATH_TOKEN)
+            .add(clusterUUID);
     }
 
     private BlobContainer clusterUUIDContainer(String clusterName) {
@@ -476,13 +480,12 @@ public class RemoteClusterStateService implements Closeable {
 
     private static String getManifestFileName(long term, long version) {
         // 123456789012_test-cluster/cluster-state/dsgYj10Nkso7/manifest/manifest_2147483642_2147483637_456536447
-        return String.join(
-            DELIMITER,
-            MANIFEST_FILE_PREFIX,
-            RemoteStoreUtils.invertLong(term),
-            RemoteStoreUtils.invertLong(version),
-            RemoteStoreUtils.invertLong(System.currentTimeMillis())
-        );
+        return String.join(DELIMITER, getManifestFileNamePrefix(term, version), RemoteStoreUtils.invertLong(System.currentTimeMillis()));
+    }
+
+    private static String getManifestFileNamePrefix(long term, long version) {
+        // 123456789012_test-cluster/cluster-state/dsgYj10Nkso7/manifest/manifest_2147483642_2147483637
+        return String.join(DELIMITER, MANIFEST_PATH_TOKEN, RemoteStoreUtils.invertLong(term), RemoteStoreUtils.invertLong(version));
     }
 
     private static String indexMetadataFileName(IndexMetadata indexMetadata) {
@@ -492,6 +495,10 @@ public class RemoteClusterStateService implements Closeable {
             String.valueOf(indexMetadata.getVersion()),
             String.valueOf(System.currentTimeMillis())
         );
+    }
+
+    private BlobPath getManifestFolderPath(String clusterName, String clusterUUID) {
+        return getCusterMetadataBasePath(clusterName, clusterUUID).add(MANIFEST_PATH_TOKEN);
     }
 
     /**
@@ -708,6 +715,98 @@ public class RemoteClusterStateService implements Closeable {
 
         public IndexMetadataTransferException(String errorDesc, Throwable cause) {
             super(errorDesc, cause);
+        }
+    }
+
+    /**
+     * Deletes older than last {@code versionsToRetain} manifests. Also cleans up unreferenced IndexMetadata associated with older manifests
+     * @param clusterName name of the cluster
+     * @param clusterUUID uuid of cluster state to refer to in remote
+     * @param manifestsToRetain no of latest manifest files to keep in remote
+     */
+    public void deleteClusterMetadataMarker(String clusterName, String clusterUUID, int manifestsToRetain) {
+        BlobStoreTransferService transferService = new BlobStoreTransferService(blobStoreRepository.blobStore(), threadpool);
+
+        synchronized (this) {
+            transferService.listAllInSortedOrderAsync(
+                ThreadPool.Names.REMOTE_PURGE,
+                getManifestFolderPath(clusterName, clusterUUID),
+                MANIFEST_PATH_TOKEN,
+                Integer.MAX_VALUE,
+                new ActionListener<>() {
+                    int evaluatedManifestCount = 1;
+
+                    @Override
+                    public void onResponse(List<BlobMetadata> blobMetadata) {
+                        Set<String> filesToKeep = new HashSet<>();
+                        List<String> stalePaths = new ArrayList<>();
+                        blobMetadata.forEach(manifestBlobMetadata -> {
+                            ClusterMetadataManifest clusterMetadataManifest = fetchRemoteClusterMetadataManifest(
+                                clusterName,
+                                clusterUUID,
+                                manifestBlobMetadata.name()
+                            );
+                            if (evaluatedManifestCount <= manifestsToRetain) {
+                                clusterMetadataManifest.getIndices()
+                                    .forEach(uploadedIndexMetadata -> filesToKeep.add(uploadedIndexMetadata.getUploadedFilename()));
+                            } else {
+                                stalePaths.add(new BlobPath().add(MANIFEST_PATH_TOKEN).buildAsString() + manifestBlobMetadata.name());
+                                clusterMetadataManifest.getIndices().forEach(uploadedIndexMetadata -> {
+                                    if (filesToKeep.contains(uploadedIndexMetadata.getUploadedFilename()) == false) {
+                                        stalePaths.add(
+                                            new BlobPath().add(INDEX_PATH_TOKEN).add(uploadedIndexMetadata.getIndexUUID()).buildAsString()
+                                                + uploadedIndexMetadata.getUploadedFilename()
+                                                + ".dat"
+                                        );
+                                    }
+                                });
+                            }
+                            evaluatedManifestCount += 1;
+                        });
+
+                        logger.info(String.format(Locale.ROOT, "Deleting stale files from remote - %s", stalePaths));
+
+                        if (stalePaths.toArray().length == 0) {
+                            logger.trace("No stale Remote Cluster Metadata files found");
+                            return;
+                        }
+
+                        transferService.deleteBlobsAsync(
+                            ThreadPool.Names.REMOTE_PURGE,
+                            getCusterMetadataBasePath(clusterName, clusterUUID),
+                            stalePaths,
+                            new ActionListener<>() {
+                                @Override
+                                public void onResponse(Void unused) {
+                                    logger.info(
+                                        String.format(Locale.ROOT, "Deleted [%s] stale Remote Cluster Metadata files", stalePaths.size())
+                                    );
+                                }
+
+                                @Override
+                                public void onFailure(Exception e) {
+                                    logger.error(
+                                        new ParameterizedMessage(
+                                            "Exception occurred while deleting stale Remote Cluster Metadata files - {}",
+                                            stalePaths
+                                        )
+                                    );
+                                }
+                            }
+                        );
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        logger.error(
+                            new ParameterizedMessage(
+                                "Exception occurred while deleting Remote Cluster Metadata for clusterUUIDs {}",
+                                clusterUUID
+                            )
+                        );
+                    }
+                }
+            );
         }
     }
 }

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -745,13 +745,18 @@ public class RemoteClusterStateService implements Closeable {
 
                     @Override
                     public void onFailure(Exception e) {
-                        logger.error(new ParameterizedMessage("Exception occurred while deleting all remote cluster metadata for cluster UUID {}", clusterUUID), e);
+                        logger.error(
+                            new ParameterizedMessage(
+                                "Exception occurred while deleting all remote cluster metadata for cluster UUID {}",
+                                clusterUUID
+                            ),
+                            e
+                        );
                     }
                 }
             );
         });
     }
-
 
     /**
      * Deletes older than last {@code versionsToRetain} manifests. Also cleans up unreferenced IndexMetadata associated with older manifests
@@ -762,7 +767,7 @@ public class RemoteClusterStateService implements Closeable {
     private void deleteStaleClusterMetadata(String clusterName, String clusterUUID, int manifestsToRetain) {
         if (deleteStaleMetadataRunning.compareAndSet(false, true) == false) {
             logger.info("Delete stale cluster metadata task is already in progress.");
-             return;
+            return;
         }
         getBlobStoreTransferService().listAllInSortedOrderAsync(
             ThreadPool.Names.REMOTE_PURGE,

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -831,11 +831,11 @@ public class RemoteClusterStateService implements Closeable {
                     clusterUUID,
                     blobMetadata.name()
                 );
-                staleManifestPaths.add(new BlobPath().add("manifest").buildAsString() + blobMetadata.name());
+                staleManifestPaths.add(new BlobPath().add(MANIFEST_PATH_TOKEN).buildAsString() + blobMetadata.name());
                 clusterMetadataManifest.getIndices().forEach(uploadedIndexMetadata -> {
                     if (filesToKeep.contains(uploadedIndexMetadata.getUploadedFilename()) == false) {
                         staleIndexMetadataPaths.add(
-                            new BlobPath().add("index").add(uploadedIndexMetadata.getIndexUUID()).buildAsString()
+                            new BlobPath().add(INDEX_PATH_TOKEN).add(uploadedIndexMetadata.getIndexUUID()).buildAsString()
                                 + uploadedIndexMetadata.getUploadedFilename()
                                 + ".dat"
                         );

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -778,20 +778,11 @@ public class RemoteClusterStateService implements Closeable {
                 @Override
                 public void onResponse(List<BlobMetadata> blobMetadata) {
                     if (blobMetadata.size() > manifestsToRetain) {
-                        List<ClusterMetadataManifest> allManifests = blobMetadata.stream()
-                            .map(
-                                mainfestBlobMetadata -> fetchRemoteClusterMetadataManifest(
-                                    clusterName,
-                                    clusterUUID,
-                                    mainfestBlobMetadata.name()
-                                )
-                            )
-                            .collect(Collectors.toList());
                         deleteClusterMetadata(
                             clusterName,
                             clusterUUID,
                             blobMetadata.subList(0, manifestsToRetain - 1),
-                            blobMetadata.subList(manifestsToRetain - 1, allManifests.size())
+                            blobMetadata.subList(manifestsToRetain - 1, blobMetadata.size())
                         );
                     }
                     deleteStaleMetadataRunning.set(false);

--- a/server/src/main/java/org/opensearch/index/recovery/RemoteStoreRestoreService.java
+++ b/server/src/main/java/org/opensearch/index/recovery/RemoteStoreRestoreService.java
@@ -147,7 +147,7 @@ public class RemoteStoreRestoreService {
                     .forEach(indexMetadata -> {
                         indexMetadataMap.put(indexMetadata.getIndex().getName(), new Tuple<>(true, indexMetadata));
                     });
-            } catch (IOException e) {
+            } catch (Exception e) {
                 throw new IllegalStateException("Unable to restore remote index metadata", e);
             }
         } else {

--- a/server/src/main/java/org/opensearch/index/recovery/RemoteStoreRestoreService.java
+++ b/server/src/main/java/org/opensearch/index/recovery/RemoteStoreRestoreService.java
@@ -36,7 +36,6 @@ import org.opensearch.repositories.IndexId;
 import org.opensearch.snapshots.RestoreInfo;
 import org.opensearch.snapshots.RestoreService;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -688,7 +688,8 @@ public class Node implements Closeable {
                     repositoriesServiceReference::get,
                     settings,
                     clusterService.getClusterSettings(),
-                    threadPool::preciseRelativeTimeInNanos
+                    threadPool::preciseRelativeTimeInNanos,
+                    threadPool
                 );
             } else {
                 remoteClusterStateService = null;

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
@@ -130,6 +130,7 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
     public void teardown() throws Exception {
         super.tearDown();
         remoteClusterStateService.close();
+        threadPool.shutdown();
     }
 
     public void testFailWriteFullMetadataNonClusterManagerNode() throws IOException {

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
@@ -41,6 +41,9 @@ import org.opensearch.repositories.blobstore.BlobStoreRepository;
 import org.opensearch.repositories.fs.FsRepository;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.VersionUtils;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 
@@ -82,6 +85,7 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
     private RepositoriesService repositoriesService;
     private BlobStoreRepository blobStoreRepository;
     private BlobStore blobStore;
+    private final ThreadPool threadPool = new TestThreadPool(getClass().getName());
 
     @Before
     public void setup() {
@@ -117,8 +121,15 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
             repositoriesServiceSupplier,
             settings,
             new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
-            () -> 0L
+            () -> 0L,
+            threadPool
         );
+    }
+
+    @After
+    public void teardown() throws Exception {
+        super.tearDown();
+        remoteClusterStateService.close();
     }
 
     public void testFailWriteFullMetadataNonClusterManagerNode() throws IOException {
@@ -127,7 +138,7 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
         Assert.assertThat(manifest, nullValue());
     }
 
-    public void testFailInitializationWhenRemoteStateDisabled() throws IOException {
+    public void testFailInitializationWhenRemoteStateDisabled() {
         final Settings settings = Settings.builder().build();
         assertThrows(
             AssertionError.class,
@@ -136,7 +147,8 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
                 repositoriesServiceSupplier,
                 settings,
                 new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
-                () -> 0L
+                () -> 0L,
+                threadPool
             )
         );
     }

--- a/test/framework/src/main/java/org/opensearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -844,14 +844,16 @@ public class AbstractCoordinatorTestCase extends OpenSearchTestCase {
             private final CoordinationState.PersistedState delegate;
             private final NodeEnvironment nodeEnvironment;
 
+            private MockGatewayMetaState mockGatewayMetaState;
+
             MockPersistedState(DiscoveryNode localNode) {
                 try {
                     if (rarely()) {
                         nodeEnvironment = newNodeEnvironment();
                         nodeEnvironments.add(nodeEnvironment);
-                        final MockGatewayMetaState gatewayMetaState = new MockGatewayMetaState(localNode, bigArrays);
-                        gatewayMetaState.start(Settings.EMPTY, nodeEnvironment, xContentRegistry(), persistedStateRegistry());
-                        delegate = gatewayMetaState.getPersistedState();
+                        mockGatewayMetaState = new MockGatewayMetaState(localNode, bigArrays);
+                        mockGatewayMetaState.start(Settings.EMPTY, nodeEnvironment, xContentRegistry(), persistedStateRegistry());
+                        delegate = mockGatewayMetaState.getPersistedState();
                     } else {
                         nodeEnvironment = null;
                         delegate = new InMemoryPersistedState(

--- a/test/framework/src/main/java/org/opensearch/gateway/MockGatewayMetaState.java
+++ b/test/framework/src/main/java/org/opensearch/gateway/MockGatewayMetaState.java
@@ -48,6 +48,8 @@ import org.opensearch.env.NodeEnvironment;
 import org.opensearch.gateway.remote.RemoteClusterStateService;
 import org.opensearch.index.recovery.RemoteStoreRestoreService;
 import org.opensearch.plugins.MetadataUpgrader;
+import org.opensearch.repositories.RepositoriesService;
+import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
@@ -101,6 +103,12 @@ public class MockGatewayMetaState extends GatewayMetaState {
     ClusterState prepareInitialClusterState(TransportService transportService, ClusterService clusterService, ClusterState clusterState) {
         // Just set localNode here, not to mess with ClusterService and IndicesService mocking
         return ClusterStateUpdaters.setLocalNode(clusterState, localNode);
+    }
+
+    @Override
+    public void close() throws IOException {
+        super.close();
+        threadPool.shutdown();
     }
 
     public void start(

--- a/test/framework/src/main/java/org/opensearch/gateway/MockGatewayMetaState.java
+++ b/test/framework/src/main/java/org/opensearch/gateway/MockGatewayMetaState.java
@@ -48,8 +48,6 @@ import org.opensearch.env.NodeEnvironment;
 import org.opensearch.gateway.remote.RemoteClusterStateService;
 import org.opensearch.index.recovery.RemoteStoreRestoreService;
 import org.opensearch.plugins.MetadataUpgrader;
-import org.opensearch.repositories.RepositoriesService;
-import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 

--- a/test/framework/src/main/java/org/opensearch/gateway/MockGatewayMetaState.java
+++ b/test/framework/src/main/java/org/opensearch/gateway/MockGatewayMetaState.java
@@ -108,7 +108,6 @@ public class MockGatewayMetaState extends GatewayMetaState {
     @Override
     public void close() throws IOException {
         super.close();
-        threadPool.shutdown();
     }
 
     public void start(


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
- With Remote Cluster State https://github.com/opensearch-project/OpenSearch/issues/9143, we have multiple files in blob store related to cluster state. 
- Overtime few of these files will become stale and we only need files references by latest cluster state.
- This change ensures these stale unreferenced files are cleaned with every cluster state write to remote

### Related Issues
Resolves #9343 
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
