### PR TITLE
[Segment Replication] Adding segment replication statistics rolled up at index, node and cluster level (#9709)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - APIs for performing async blob reads and async downloads from the repository using multiple streams ([#9592](https://github.com/opensearch-project/OpenSearch/issues/9592))
 - Introduce cluster default remote translog buffer interval setting ([#9584](https://github.com/opensearch-project/OpenSearch/pull/9584))
 - Added encryption-sdk lib to provide encryption and decryption capabilities ([#8466](https://github.com/opensearch-project/OpenSearch/pull/8466) [#9289](https://github.com/opensearch-project/OpenSearch/pull/9289))
+- [Segment Replication] Adding segment replication statistics rolled up at index, node and cluster level ([#9709](https://github.com/opensearch-project/OpenSearch/pull/9709))
 
 ### Dependencies
 - Bump `org.apache.logging.log4j:log4j-core` from 2.17.1 to 2.20.0 ([#8307](https://github.com/opensearch-project/OpenSearch/pull/8307))

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationBaseIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationBaseIT.java
@@ -241,7 +241,7 @@ public class SegmentReplicationBaseIT extends OpenSearchIntegTestCase {
 
     protected void assertReplicaCheckpointUpdated(IndexShard primaryShard) throws Exception {
         assertBusy(() -> {
-            Set<SegmentReplicationShardStats> groupStats = primaryShard.getReplicationStats();
+            Set<SegmentReplicationShardStats> groupStats = primaryShard.getReplicationStatsForTrackedReplicas();
             assertEquals(primaryShard.indexSettings().getNumberOfReplicas(), groupStats.size());
             for (SegmentReplicationShardStats shardStat : groupStats) {
                 assertEquals(0, shardStat.getCheckpointsBehindCount());

--- a/server/src/main/java/org/opensearch/index/ReplicationStats.java
+++ b/server/src/main/java/org/opensearch/index/ReplicationStats.java
@@ -1,0 +1,97 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index;
+
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.common.unit.ByteSizeValue;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+/**
+ * ReplicationStats is used to provide segment replication statistics at an index,
+ * node and cluster level on a segment replication enabled cluster.
+ *
+ * @opensearch.internal
+ */
+public class ReplicationStats implements ToXContentFragment, Writeable {
+
+    public long maxBytesBehind;
+    public long maxReplicationLag;
+    public long totalBytesBehind;
+
+    public ReplicationStats(long maxBytesBehind, long totalBytesBehind, long maxReplicationLag) {
+        this.maxBytesBehind = maxBytesBehind;
+        this.totalBytesBehind = totalBytesBehind;
+        this.maxReplicationLag = maxReplicationLag;
+    }
+
+    public ReplicationStats(StreamInput in) throws IOException {
+        this.maxBytesBehind = in.readVLong();
+        this.totalBytesBehind = in.readVLong();
+        this.maxReplicationLag = in.readVLong();
+    }
+
+    public ReplicationStats() {
+
+    }
+
+    public void add(ReplicationStats other) {
+        if (other != null) {
+            maxBytesBehind = Math.max(other.maxBytesBehind, maxBytesBehind);
+            totalBytesBehind += other.totalBytesBehind;
+            maxReplicationLag = Math.max(other.maxReplicationLag, maxReplicationLag);
+        }
+    }
+
+    public long getMaxBytesBehind() {
+        return this.maxBytesBehind;
+    }
+
+    public long getTotalBytesBehind() {
+        return this.totalBytesBehind;
+    }
+
+    public long getMaxReplicationLag() {
+        return this.maxReplicationLag;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVLong(maxBytesBehind);
+        out.writeVLong(totalBytesBehind);
+        out.writeVLong(maxReplicationLag);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(Fields.SEGMENT_REPLICATION);
+        builder.field(Fields.MAX_BYTES_BEHIND, new ByteSizeValue(maxBytesBehind).toString());
+        builder.field(Fields.TOTAL_BYTES_BEHIND, new ByteSizeValue(totalBytesBehind).toString());
+        builder.field(Fields.MAX_REPLICATION_LAG, new TimeValue(maxReplicationLag));
+        builder.endObject();
+        return builder;
+    }
+
+    /**
+     * Fields for segment replication statistics
+     *
+     * @opensearch.internal
+     */
+    static final class Fields {
+        static final String SEGMENT_REPLICATION = "segment_replication";
+        static final String MAX_BYTES_BEHIND = "max_bytes_behind";
+        static final String TOTAL_BYTES_BEHIND = "total_bytes_behind";
+        static final String MAX_REPLICATION_LAG = "max_replication_lag";
+    }
+}

--- a/server/src/main/java/org/opensearch/index/SegmentReplicationPressureService.java
+++ b/server/src/main/java/org/opensearch/index/SegmentReplicationPressureService.java
@@ -153,7 +153,7 @@ public class SegmentReplicationPressureService implements Closeable {
     }
 
     private void validateReplicationGroup(IndexShard shard) {
-        final Set<SegmentReplicationShardStats> replicaStats = shard.getReplicationStats();
+        final Set<SegmentReplicationShardStats> replicaStats = shard.getReplicationStatsForTrackedReplicas();
         final Set<SegmentReplicationShardStats> staleReplicas = getStaleReplicas(replicaStats);
         if (staleReplicas.isEmpty() == false) {
             // inSyncIds always considers the primary id, so filter it out.

--- a/server/src/main/java/org/opensearch/index/SegmentReplicationStatsTracker.java
+++ b/server/src/main/java/org/opensearch/index/SegmentReplicationStatsTracker.java
@@ -59,7 +59,7 @@ public class SegmentReplicationStatsTracker {
     public SegmentReplicationPerGroupStats getStatsForShard(IndexShard indexShard) {
         return new SegmentReplicationPerGroupStats(
             indexShard.shardId(),
-            indexShard.getReplicationStats(),
+            indexShard.getReplicationStatsForTrackedReplicas(),
             Optional.ofNullable(rejectionCount.get(indexShard.shardId())).map(AtomicInteger::get).orElse(0)
         );
     }

--- a/server/src/main/java/org/opensearch/index/engine/SegmentsStats.java
+++ b/server/src/main/java/org/opensearch/index/engine/SegmentsStats.java
@@ -39,6 +39,7 @@ import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.core.xcontent.ToXContentFragment;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.ReplicationStats;
 import org.opensearch.index.remote.RemoteSegmentStats;
 
 import java.io.IOException;
@@ -61,6 +62,11 @@ public class SegmentsStats implements Writeable, ToXContentFragment {
     private final Map<String, Long> fileSizes;
     private final RemoteSegmentStats remoteSegmentStats;
     private static final ByteSizeValue ZERO_BYTE_SIZE_VALUE = new ByteSizeValue(0L);
+
+    /**
+     * Segment replication statistics.
+     */
+    private final ReplicationStats replicationStats;
 
     /*
      * A map to provide a best-effort approach describing Lucene index files.
@@ -93,6 +99,7 @@ public class SegmentsStats implements Writeable, ToXContentFragment {
     public SegmentsStats() {
         fileSizes = new HashMap<>();
         remoteSegmentStats = new RemoteSegmentStats();
+        replicationStats = new ReplicationStats();
     }
 
     public SegmentsStats(StreamInput in) throws IOException {
@@ -117,6 +124,11 @@ public class SegmentsStats implements Writeable, ToXContentFragment {
             remoteSegmentStats = in.readOptionalWriteable(RemoteSegmentStats::new);
         } else {
             remoteSegmentStats = new RemoteSegmentStats();
+        }
+        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+            replicationStats = in.readOptionalWriteable(ReplicationStats::new);
+        } else {
+            replicationStats = new ReplicationStats();
         }
     }
 
@@ -144,6 +156,10 @@ public class SegmentsStats implements Writeable, ToXContentFragment {
         this.remoteSegmentStats.add(remoteSegmentStats);
     }
 
+    public void addReplicationStats(ReplicationStats replicationStats) {
+        this.replicationStats.add(replicationStats);
+    }
+
     public void addFileSizes(final Map<String, Long> newFileSizes) {
         newFileSizes.forEach((k, v) -> this.fileSizes.merge(k, v, (a, b) -> {
             assert a != null;
@@ -163,6 +179,7 @@ public class SegmentsStats implements Writeable, ToXContentFragment {
         addBitsetMemoryInBytes(mergeStats.bitsetMemoryInBytes);
         addFileSizes(mergeStats.fileSizes);
         addRemoteSegmentStats(mergeStats.remoteSegmentStats);
+        addReplicationStats(mergeStats.replicationStats);
     }
 
     /**
@@ -215,6 +232,10 @@ public class SegmentsStats implements Writeable, ToXContentFragment {
         return remoteSegmentStats;
     }
 
+    public ReplicationStats getReplicationStats() {
+        return replicationStats;
+    }
+
     /**
      * Returns the max timestamp that is used to de-optimize documents with auto-generated IDs in the engine.
      * This is used to ensure we don't add duplicate documents when we assume an append only case based on auto-generated IDs
@@ -239,6 +260,7 @@ public class SegmentsStats implements Writeable, ToXContentFragment {
         builder.humanReadableField(Fields.FIXED_BIT_SET_MEMORY_IN_BYTES, Fields.FIXED_BIT_SET, getBitsetMemory());
         builder.field(Fields.MAX_UNSAFE_AUTO_ID_TIMESTAMP, maxUnsafeAutoIdTimestamp);
         remoteSegmentStats.toXContent(builder, params);
+        replicationStats.toXContent(builder, params);
         builder.startObject(Fields.FILE_SIZES);
         for (Map.Entry<String, Long> entry : fileSizes.entrySet()) {
             builder.startObject(entry.getKey());
@@ -307,6 +329,9 @@ public class SegmentsStats implements Writeable, ToXContentFragment {
         out.writeMap(this.fileSizes, StreamOutput::writeString, StreamOutput::writeLong);
         if (out.getVersion().onOrAfter(Version.V_2_10_0)) {
             out.writeOptionalWriteable(remoteSegmentStats);
+        }
+        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+            out.writeOptionalWriteable(replicationStats);
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/engine/SegmentsStats.java
+++ b/server/src/main/java/org/opensearch/index/engine/SegmentsStats.java
@@ -122,12 +122,9 @@ public class SegmentsStats implements Writeable, ToXContentFragment {
         fileSizes = in.readMap(StreamInput::readString, StreamInput::readLong);
         if (in.getVersion().onOrAfter(Version.V_2_10_0)) {
             remoteSegmentStats = in.readOptionalWriteable(RemoteSegmentStats::new);
-        } else {
-            remoteSegmentStats = new RemoteSegmentStats();
-        }
-        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
             replicationStats = in.readOptionalWriteable(ReplicationStats::new);
         } else {
+            remoteSegmentStats = new RemoteSegmentStats();
             replicationStats = new ReplicationStats();
         }
     }
@@ -329,8 +326,6 @@ public class SegmentsStats implements Writeable, ToXContentFragment {
         out.writeMap(this.fileSizes, StreamOutput::writeString, StreamOutput::writeLong);
         if (out.getVersion().onOrAfter(Version.V_2_10_0)) {
             out.writeOptionalWriteable(remoteSegmentStats);
-        }
-        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
             out.writeOptionalWriteable(replicationStats);
         }
     }

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -111,6 +111,7 @@ import org.opensearch.index.IndexModule;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.IndexSettings;
+import org.opensearch.index.ReplicationStats;
 import org.opensearch.index.SegmentReplicationShardStats;
 import org.opensearch.index.VersionType;
 import org.opensearch.index.cache.IndexCache;
@@ -1394,6 +1395,9 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             segmentsStats.addRemoteSegmentStats(
                 new RemoteSegmentStats(remoteStoreStatsTrackerFactory.getRemoteSegmentTransferTracker(shardId).stats())
             );
+        }
+        if (indexSettings.isSegRepEnabled()) {
+            segmentsStats.addReplicationStats(getReplicationStats());
         }
         return segmentsStats;
     }
@@ -2941,8 +2945,22 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
      * @return {@link Tuple} V1 - TimeValue in ms - mean replication lag for this primary to its entire group,
      * V2 - Set of {@link SegmentReplicationShardStats} per shard in this primary's replication group.
      */
-    public Set<SegmentReplicationShardStats> getReplicationStats() {
+    public Set<SegmentReplicationShardStats> getReplicationStatsForTrackedReplicas() {
         return replicationTracker.getSegmentReplicationStats();
+    }
+
+    public ReplicationStats getReplicationStats() {
+        if (indexSettings.isSegRepEnabled() && routingEntry().primary()) {
+            final Set<SegmentReplicationShardStats> stats = getReplicationStatsForTrackedReplicas();
+            long maxBytesBehind = stats.stream().mapToLong(SegmentReplicationShardStats::getBytesBehindCount).max().orElse(0L);
+            long totalBytesBehind = stats.stream().mapToLong(SegmentReplicationShardStats::getBytesBehindCount).sum();
+            long maxReplicationLag = stats.stream()
+                .mapToLong(SegmentReplicationShardStats::getCurrentReplicationTimeMillis)
+                .max()
+                .orElse(0L);
+            return new ReplicationStats(maxBytesBehind, totalBytesBehind, maxReplicationLag);
+        }
+        return new ReplicationStats();
     }
 
     /**

--- a/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -46,6 +46,7 @@ import org.opensearch.core.indices.breaker.AllCircuitBreakerStats;
 import org.opensearch.core.indices.breaker.CircuitBreakerStats;
 import org.opensearch.discovery.DiscoveryStats;
 import org.opensearch.http.HttpStats;
+import org.opensearch.index.ReplicationStats;
 import org.opensearch.index.remote.RemoteSegmentStats;
 import org.opensearch.indices.NodeIndicesStats;
 import org.opensearch.ingest.IngestStats;
@@ -462,6 +463,12 @@ public class NodeStatsTests extends OpenSearchTestCase {
                     assertEquals(remoteSegmentStats.getTotalRefreshBytesLag(), deserializedRemoteSegmentStats.getTotalRefreshBytesLag());
                     assertEquals(remoteSegmentStats.getTotalUploadTime(), deserializedRemoteSegmentStats.getTotalUploadTime());
                     assertEquals(remoteSegmentStats.getTotalDownloadTime(), deserializedRemoteSegmentStats.getTotalDownloadTime());
+                    ReplicationStats replicationStats = nodeIndicesStats.getSegments().getReplicationStats();
+
+                    ReplicationStats deserializedReplicationStats = deserializedNodeIndicesStats.getSegments().getReplicationStats();
+                    assertEquals(replicationStats.getMaxBytesBehind(), deserializedReplicationStats.getMaxBytesBehind());
+                    assertEquals(replicationStats.getTotalBytesBehind(), deserializedReplicationStats.getTotalBytesBehind());
+                    assertEquals(replicationStats.getMaxReplicationLag(), deserializedReplicationStats.getMaxReplicationLag());
                 }
             }
         }

--- a/server/src/test/java/org/opensearch/index/SegmentReplicationPressureServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/SegmentReplicationPressureServiceTests.java
@@ -114,7 +114,7 @@ public class SegmentReplicationPressureServiceTests extends OpenSearchIndexLevel
 
             indexInBatches(5, shards, primaryShard);
 
-            Set<SegmentReplicationShardStats> replicationStats = primaryShard.getReplicationStats();
+            Set<SegmentReplicationShardStats> replicationStats = primaryShard.getReplicationStatsForTrackedReplicas();
             assertEquals(1, replicationStats.size());
             SegmentReplicationShardStats shardStats = replicationStats.stream().findFirst().get();
             assertEquals(5, shardStats.getCheckpointsBehindCount());
@@ -142,7 +142,7 @@ public class SegmentReplicationPressureServiceTests extends OpenSearchIndexLevel
             indexInBatches(1, shards, primaryShard);
 
             assertBusy(() -> {
-                Set<SegmentReplicationShardStats> replicationStats = primaryShard.getReplicationStats();
+                Set<SegmentReplicationShardStats> replicationStats = primaryShard.getReplicationStatsForTrackedReplicas();
                 assertEquals(1, replicationStats.size());
                 SegmentReplicationShardStats shardStats = replicationStats.stream().findFirst().get();
                 assertTrue(shardStats.getCurrentReplicationTimeMillis() > TimeValue.timeValueSeconds(5).millis());
@@ -164,7 +164,7 @@ public class SegmentReplicationPressureServiceTests extends OpenSearchIndexLevel
             SegmentReplicationPressureService service = buildPressureService(settings, primaryShard);
 
             assertBusy(() -> {
-                Set<SegmentReplicationShardStats> replicationStats = primaryShard.getReplicationStats();
+                Set<SegmentReplicationShardStats> replicationStats = primaryShard.getReplicationStatsForTrackedReplicas();
                 assertEquals(3, replicationStats.size());
                 SegmentReplicationShardStats shardStats = replicationStats.stream().findFirst().get();
                 assertTrue(shardStats.getCurrentReplicationTimeMillis() > TimeValue.timeValueSeconds(5).millis());
@@ -211,7 +211,7 @@ public class SegmentReplicationPressureServiceTests extends OpenSearchIndexLevel
             indexInBatches(5, shards, primaryShard);
 
             // assert that replica shard is few checkpoints behind primary
-            Set<SegmentReplicationShardStats> replicationStats = primaryShard.getReplicationStats();
+            Set<SegmentReplicationShardStats> replicationStats = primaryShard.getReplicationStatsForTrackedReplicas();
             assertEquals(1, replicationStats.size());
             SegmentReplicationShardStats shardStats = replicationStats.stream().findFirst().get();
             assertEquals(5, shardStats.getCheckpointsBehindCount());
@@ -243,7 +243,7 @@ public class SegmentReplicationPressureServiceTests extends OpenSearchIndexLevel
             indexInBatches(5, shards, primaryShard);
 
             // assert that replica shard is few checkpoints behind primary
-            Set<SegmentReplicationShardStats> replicationStats = primaryShard.getReplicationStats();
+            Set<SegmentReplicationShardStats> replicationStats = primaryShard.getReplicationStatsForTrackedReplicas();
             assertEquals(1, replicationStats.size());
             SegmentReplicationShardStats shardStats = replicationStats.stream().findFirst().get();
             assertEquals(5, shardStats.getCheckpointsBehindCount());

--- a/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
@@ -843,7 +843,7 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
                 .mapToLong(StoreFileMetadata::length)
                 .sum();
 
-            Set<SegmentReplicationShardStats> postRefreshStats = primaryShard.getReplicationStats();
+            Set<SegmentReplicationShardStats> postRefreshStats = primaryShard.getReplicationStatsForTrackedReplicas();
             SegmentReplicationShardStats shardStats = postRefreshStats.stream().findFirst().get();
             assertEquals(1, shardStats.getCheckpointsBehindCount());
             assertEquals(initialCheckpointSize, shardStats.getBytesBehindCount());
@@ -863,7 +863,7 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
             final Store.RecoveryDiff diff = Store.segmentReplicationDiff(segmentMetadataMap, replicaShard.getSegmentMetadataMap());
             final long sizeAfterDeleteAndCommit = diff.missing.stream().mapToLong(StoreFileMetadata::length).sum();
 
-            final Set<SegmentReplicationShardStats> statsAfterFlush = primaryShard.getReplicationStats();
+            final Set<SegmentReplicationShardStats> statsAfterFlush = primaryShard.getReplicationStatsForTrackedReplicas();
             shardStats = statsAfterFlush.stream().findFirst().get();
             assertEquals(sizeAfterDeleteAndCommit, shardStats.getBytesBehindCount());
             assertEquals(1, shardStats.getCheckpointsBehindCount());
@@ -966,7 +966,7 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
     }
 
     private void assertReplicaCaughtUp(IndexShard primaryShard) {
-        Set<SegmentReplicationShardStats> initialStats = primaryShard.getReplicationStats();
+        Set<SegmentReplicationShardStats> initialStats = primaryShard.getReplicationStatsForTrackedReplicas();
         assertEquals(initialStats.size(), 1);
         SegmentReplicationShardStats shardStats = initialStats.stream().findFirst().get();
         assertEquals(0, shardStats.getCheckpointsBehindCount());


### PR DESCRIPTION
Manual backport of https://github.com/opensearch-project/OpenSearch/pull/9709 to 2.x branch