### PR TITLE
Unmute testIndexingWithPrimaryOnBwcNodes

### DIFF
--- a/qa/mixed-cluster/src/test/java/org/opensearch/backwards/IndexingIT.java
+++ b/qa/mixed-cluster/src/test/java/org/opensearch/backwards/IndexingIT.java
@@ -114,7 +114,6 @@ public class IndexingIT extends OpenSearchRestTestCase {
      * This test verifies that segment replication does not break when primary shards are on lower OS version. It does this
      * by verifying replica shards contains same number of documents as primary's.
      */
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/9685")
     public void testIndexingWithPrimaryOnBwcNodes() throws Exception {
         if (UPGRADE_FROM_VERSION.before(Version.V_2_4_0)) {
             logger.info("--> Skip test for version {} where segment replication feature is not available", UPGRADE_FROM_VERSION);


### PR DESCRIPTION
### Description
https://github.com/opensearch-project/OpenSearch/pull/9686 temporarily muted `testIndexingWithPrimaryOnBwcNodes` due to addition of new field (StoreFileMetadata map) in ReplicationCheckpoint class. As the change is backported to 2.x, we can unmute testIndexingWithPrimaryOnBwcNodes test.

### Related Issues
Resolves #None
Relates: #9685 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
