### PR TITLE
[Segment Replication] Update version back to 2_10_0 in Segmentstats.

### DIFF
--- a/server/src/main/java/org/opensearch/index/engine/SegmentsStats.java
+++ b/server/src/main/java/org/opensearch/index/engine/SegmentsStats.java
@@ -122,12 +122,9 @@ public class SegmentsStats implements Writeable, ToXContentFragment {
         fileSizes = in.readMap(StreamInput::readString, StreamInput::readLong);
         if (in.getVersion().onOrAfter(Version.V_2_10_0)) {
             remoteSegmentStats = in.readOptionalWriteable(RemoteSegmentStats::new);
-        } else {
-            remoteSegmentStats = new RemoteSegmentStats();
-        }
-        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
             replicationStats = in.readOptionalWriteable(ReplicationStats::new);
         } else {
+            remoteSegmentStats = new RemoteSegmentStats();
             replicationStats = new ReplicationStats();
         }
     }
@@ -329,8 +326,6 @@ public class SegmentsStats implements Writeable, ToXContentFragment {
         out.writeMap(this.fileSizes, StreamOutput::writeString, StreamOutput::writeLong);
         if (out.getVersion().onOrAfter(Version.V_2_10_0)) {
             out.writeOptionalWriteable(remoteSegmentStats);
-        }
-        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
             out.writeOptionalWriteable(replicationStats);
         }
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
With this [PR](https://github.com/opensearch-project/OpenSearch/pull/9709) we have temporarily changed the version from 2_10_0 to 3_0_0. As the PR is merged and backported we can now revert it back to 2_10_0

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
