### PR TITLE
Add Peter Nied as a Maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @reta @anasalkouz @andrross @reta @Bukhtawar @CEHENKLE @dblock @gbbafna @setiah @kartg @kotwanikunal @mch2 @nknize @owaiskazi19 @Rishikesh1159 @ryanbogan @saratvemulapalli @shwetathareja @dreamer-89 @tlfeng @VachaShah @dbwiddis @sachinpkale @sohami @msfroh
+*   @reta @anasalkouz @andrross @Bukhtawar @CEHENKLE @dblock @gbbafna @setiah @kartg @kotwanikunal @mch2 @nknize @owaiskazi19 @peternied @Rishikesh1159 @ryanbogan @saratvemulapalli @shwetathareja @dreamer-89 @tlfeng @VachaShah @dbwiddis @sachinpkale @sohami @msfroh

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -22,6 +22,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Michael Froh             | [msfroh](https://github.com/msfroh)                     | Amazon      |
 | Nick Knize               | [nknize](https://github.com/nknize)                     | Amazon      |
 | Owais Kazi               | [owaiskazi19](https://github.com/owaiskazi19)           | Amazon      |
+| Peter Nied               | [peternied](https://github.com/peternied)               | Amazon      |
 | Rabi Panda               | [adnapibar](https://github.com/adnapibar)               | Independent |
 | Rishikesh Pasham         | [Rishikesh1159](https://github.com/Rishikesh1159)       | Amazon      |
 | Ryan Bogan               | [ryanbogan](https://github.com/ryanbogan)               | Amazon      |


### PR DESCRIPTION
Peter has contributed to OpenSearch in a multitude of ways but primarily as a code reviewer.  He has reviewed 93 PRs:
https://github.com/opensearch-project/OpenSearch/pulls?q=is%3Apr+reviewed-by%3Apeternied
 
Peter has created 60 issues on the OpenSearch repo, many associated with security and identity discussions:
https://github.com/opensearch-project/OpenSearch/issues?q=is%3Aissue+author%3Apeternied
 
Peter has been active on the OpenSearch repo since its early days, when he helped with the initial Jenkins CI setup (Jenkins and DCO enforcement):
https://github.com/opensearch-project/OpenSearch/pull/96
https://github.com/opensearch-project/OpenSearch/pull/123
https://github.com/opensearch-project/OpenSearch/pull/152
 
Peter led the Identity feature and authored multiple associated PRs including vitally important documentation:
https://github.com/opensearch-project/OpenSearch/pull/4430
https://github.com/opensearch-project/OpenSearch/pull/4515
https://github.com/opensearch-project/OpenSearch/pull/4583
https://github.com/opensearch-project/OpenSearch/pull/4612
https://github.com/opensearch-project/OpenSearch/pull/4916
https://github.com/opensearch-project/OpenSearch/pull/5301
https://github.com/opensearch-project/OpenSearch/pull/5469
https://github.com/opensearch-project/OpenSearch/pull/5513

The maintainers have voted and agreed to this nomination, following [the process here](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#nomination).