### PR TITLE
Cancel in-progress gradle check workflow on new push

### DIFF
--- a/.github/workflows/gradle-check.yml
+++ b/.github/workflows/gradle-check.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read # to fetch code (actions/checkout)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   gradle-check:
     if: github.repository == 'opensearch-project/OpenSearch'


### PR DESCRIPTION
### Description
Gradle checks take 30+ minutes to complete. It is quite common to push a commit to a PR, then quickly discover a new change is needed and push an updated commit, which results in two workflows running and both post a result comment to the PR. By deduping and canceling we will reduce load on the GitHub action runner (probably not on the Jenkins server unless the cancellation can propagate to Jenkins) and reduce noise on the PR.

Note I took this implementation from the suggestion on [this stack overflow question](https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre).

### Related Issues
Relates #9699

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
