### PR TITLE
Decrease store refcount on any failure to create NRTReplicationEngine

### DIFF
--- a/server/src/test/java/org/opensearch/index/engine/NRTReplicationEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/NRTReplicationEngineTests.java
@@ -80,9 +80,17 @@ public class NRTReplicationEngineTests extends EngineTestCase {
         final Store nrtEngineStore = createStore(INDEX_SETTINGS, newDirectory());
         try {
             // Passing null translogPath to induce failure
-            final EngineConfig replicaConfig = config(defaultSettings, nrtEngineStore, null, NoMergePolicy.INSTANCE, null, null, globalCheckpoint::get);
+            final EngineConfig replicaConfig = config(
+                defaultSettings,
+                nrtEngineStore,
+                null,
+                NoMergePolicy.INSTANCE,
+                null,
+                null,
+                globalCheckpoint::get
+            );
             new NRTReplicationEngine(replicaConfig);
-        } catch(Exception e) {
+        } catch (Exception e) {
             // Ignore as engine creation will fail
         }
         assertEquals(1, nrtEngineStore.refCount());

--- a/server/src/test/java/org/opensearch/index/engine/NRTReplicationEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/NRTReplicationEngineTests.java
@@ -75,6 +75,20 @@ public class NRTReplicationEngineTests extends EngineTestCase {
         }
     }
 
+    public void testCreateEngineWithException() throws IOException {
+        final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
+        final Store nrtEngineStore = createStore(INDEX_SETTINGS, newDirectory());
+        try {
+            // Passing null translogPath to induce failure
+            final EngineConfig replicaConfig = config(defaultSettings, nrtEngineStore, null, NoMergePolicy.INSTANCE, null, null, globalCheckpoint::get);
+            new NRTReplicationEngine(replicaConfig);
+        } catch(Exception e) {
+            // Ignore as engine creation will fail
+        }
+        assertEquals(1, nrtEngineStore.refCount());
+        nrtEngineStore.close();
+    }
+
     public void testEngineWritesOpsToTranslog() throws Exception {
         final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
 


### PR DESCRIPTION
### Description
- Currently, NRTReplicationEngine calls `store.incRef()` in the constructor and corresponding `store.decRef()` is only called on IOException.
- But in case of exceptions like `TranslogCorruptedException`, store is not de-referenced causing ShardLock issues.
- In this PR, we make sure to always call `store.decRef()` if there is a failure in creating NRTReplicationEngine.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
