### PR TITLE
Restore cluster metadata during bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Remote state] Integrate remote cluster state in publish/commit flow ([#9665](https://github.com/opensearch-project/OpenSearch/pull/9665))
 - [Segment Replication] Adding segment replication statistics rolled up at index, node and cluster level ([#9709](https://github.com/opensearch-project/OpenSearch/pull/9709))
 - [Remote Store] Changes to introduce repository registration during bootstrap via node attributes. ([#9105](https://github.com/opensearch-project/OpenSearch/pull/9105))
+- [Remote state] Auto restore index metadata from last known cluster state ([#9831](https://github.com/opensearch-project/OpenSearch/pull/9831))
 
 ### Dependencies
 - Bump `org.apache.logging.log4j:log4j-core` from 2.17.1 to 2.20.0 ([#8307](https://github.com/opensearch-project/OpenSearch/pull/8307))

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -1335,6 +1335,10 @@ public class Node implements Closeable {
         injector.getInstance(PeerRecoverySourceService.class).start();
         injector.getInstance(SegmentReplicationSourceService.class).start();
 
+        final RemoteClusterStateService remoteClusterStateService = injector.getInstance(RemoteClusterStateService.class);
+        if (remoteClusterStateService != null) {
+            remoteClusterStateService.start();
+        }
         // Load (and maybe upgrade) the metadata stored on disk
         final GatewayMetaState gatewayMetaState = injector.getInstance(GatewayMetaState.class);
         gatewayMetaState.start(
@@ -1346,7 +1350,8 @@ public class Node implements Closeable {
             injector.getInstance(MetadataUpgrader.class),
             injector.getInstance(PersistedClusterStateService.class),
             injector.getInstance(RemoteClusterStateService.class),
-            injector.getInstance(PersistedStateRegistry.class)
+            injector.getInstance(PersistedStateRegistry.class),
+            injector.getInstance(RemoteStoreRestoreService.class)
         );
         if (Assertions.ENABLED) {
             try {

--- a/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryRemoteIndexTests.java
+++ b/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryRemoteIndexTests.java
@@ -106,7 +106,7 @@ public class BlobStoreRepositoryRemoteIndexTests extends BlobStoreRepositoryHelp
             .put("node.attr." + REMOTE_STORE_CLUSTER_STATE_REPOSITORY_NAME_ATTRIBUTE_KEY, repoName)
             .put(repoTypeAttributeKey, FsRepository.TYPE)
             .put(repoSettingsAttributeKeyPrefix + "location", repoPath)
-            .put(RemoteClusterStateService.REMOTE_CLUSTER_STATE_ENABLED_SETTING.getKey(), true)
+            .put(RemoteClusterStateService.REMOTE_CLUSTER_STATE_ENABLED_SETTING.getKey(), false)
             .build();
     }
 

--- a/test/framework/src/main/java/org/opensearch/gateway/MockGatewayMetaState.java
+++ b/test/framework/src/main/java/org/opensearch/gateway/MockGatewayMetaState.java
@@ -46,16 +46,13 @@ import org.opensearch.common.util.BigArrays;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.env.NodeEnvironment;
 import org.opensearch.gateway.remote.RemoteClusterStateService;
+import org.opensearch.index.recovery.RemoteStoreRestoreService;
 import org.opensearch.plugins.MetadataUpgrader;
-import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.function.Supplier;
 
-import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.isRemoteStoreClusterStateEnabled;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -68,10 +65,26 @@ import static org.mockito.Mockito.when;
 public class MockGatewayMetaState extends GatewayMetaState {
     private final DiscoveryNode localNode;
     private final BigArrays bigArrays;
+    private final RemoteClusterStateService remoteClusterStateService;
+    private final RemoteStoreRestoreService remoteStoreRestoreService;
 
     public MockGatewayMetaState(DiscoveryNode localNode, BigArrays bigArrays) {
         this.localNode = localNode;
         this.bigArrays = bigArrays;
+        this.remoteClusterStateService = mock(RemoteClusterStateService.class);
+        this.remoteStoreRestoreService = mock(RemoteStoreRestoreService.class);
+    }
+
+    public MockGatewayMetaState(
+        DiscoveryNode localNode,
+        BigArrays bigArrays,
+        RemoteClusterStateService remoteClusterStateService,
+        RemoteStoreRestoreService remoteStoreRestoreService
+    ) {
+        this.localNode = localNode;
+        this.bigArrays = bigArrays;
+        this.remoteClusterStateService = remoteClusterStateService;
+        this.remoteStoreRestoreService = remoteStoreRestoreService;
     }
 
     @Override
@@ -108,26 +121,6 @@ public class MockGatewayMetaState extends GatewayMetaState {
         } catch (IOException e) {
             throw new AssertionError(e);
         }
-        Supplier<RemoteClusterStateService> remoteClusterStateServiceSupplier = () -> {
-            if (isRemoteStoreClusterStateEnabled(settings)) {
-                return new RemoteClusterStateService(
-                    nodeEnvironment.nodeId(),
-                    () -> new RepositoriesService(
-                        settings,
-                        clusterService,
-                        transportService,
-                        Collections.emptyMap(),
-                        Collections.emptyMap(),
-                        transportService.getThreadPool()
-                    ),
-                    settings,
-                    new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
-                    () -> 0L
-                );
-            } else {
-                return null;
-            }
-        };
         start(
             settings,
             transportService,
@@ -142,8 +135,9 @@ public class MockGatewayMetaState extends GatewayMetaState {
                 new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
                 () -> 0L
             ),
-            remoteClusterStateServiceSupplier.get(),
-            persistedStateRegistry
+            remoteClusterStateService,
+            persistedStateRegistry,
+            remoteStoreRestoreService
         );
     }
 }


### PR DESCRIPTION
### Description
Follow up PR of https://github.com/opensearch-project/OpenSearch/pull/9746
This PR uses the logic to fetch previous cluster UUID of the above PR to restore the index metadata during bootstrap.

### Related Issues
Resolves #9821 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
