### PR TITLE
[Backport] [2.x] [Concurrent Segment Search]: Add support for query profiler with concurrent aggregation (#9248)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Removing the vec file extension from INDEX_STORE_HYBRID_NIO_EXTENSIONS, to ensure the no performance degradation for vector search via Lucene Engine.([#9528](https://github.com/opensearch-project/OpenSearch/pull/9528)))
 - Cleanup Unreferenced file on segment merge failure ([#9503](https://github.com/opensearch-project/OpenSearch/pull/9503))
 - Move ZStd to a plugin ([#9658](https://github.com/opensearch-project/OpenSearch/pull/9658))
+- Add support for query profiler with concurrent aggregation ([#9248](https://github.com/opensearch-project/OpenSearch/pull/9248))
 
 ### Deprecated
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/profile/query/QueryProfilerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/profile/query/QueryProfilerIT.java
@@ -32,6 +32,8 @@
 
 package org.opensearch.search.profile.query;
 
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
 import org.apache.lucene.tests.util.English;
 import org.opensearch.action.index.IndexRequestBuilder;
 import org.opensearch.action.search.MultiSearchResponse;
@@ -40,20 +42,23 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchType;
 import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.profile.ProfileResult;
 import org.opensearch.search.profile.ProfileShardResult;
 import org.opensearch.search.sort.SortOrder;
-import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.opensearch.search.SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING;
 import static org.opensearch.search.profile.query.RandomQueryGenerator.randomQueryBuilder;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.equalTo;
@@ -61,8 +66,32 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 
-public class QueryProfilerIT extends OpenSearchIntegTestCase {
+public class QueryProfilerIT extends ParameterizedOpenSearchIntegTestCase {
+    private final boolean concurrentSearchEnabled;
+    private static final String MAX_PREFIX = "max_";
+    private static final String MIN_PREFIX = "min_";
+    private static final String AVG_PREFIX = "avg_";
+    private static final String TIMING_TYPE_COUNT_SUFFIX = "_count";
+
+    public QueryProfilerIT(Settings settings, boolean concurrentSearchEnabled) {
+        super(settings);
+        this.concurrentSearchEnabled = concurrentSearchEnabled;
+    }
+
+    @ParametersFactory
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(
+            new Object[] { Settings.builder().put(CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING.getKey(), false).build(), false },
+            new Object[] { Settings.builder().put(CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING.getKey(), true).build(), true }
+        );
+    }
+
+    @Override
+    protected Settings featureFlagSettings() {
+        return Settings.builder().put(super.featureFlagSettings()).put(FeatureFlags.CONCURRENT_SEGMENT_SEARCH, "true").build();
+    }
 
     /**
      * This test simply checks to make sure nothing crashes.  Test indexes 100-150 documents,
@@ -229,6 +258,7 @@ public class QueryProfilerIT extends OpenSearchIntegTestCase {
                     assertEquals(result.getLuceneDescription(), "field1:one");
                     assertThat(result.getTime(), greaterThan(0L));
                     assertNotNull(result.getTimeBreakdown());
+                    assertQueryProfileResult(result);
                 }
 
                 CollectorResult result = searchProfiles.getCollectorResult();
@@ -271,6 +301,7 @@ public class QueryProfilerIT extends OpenSearchIntegTestCase {
                     assertThat(result.getTime(), greaterThan(0L));
                     assertNotNull(result.getTimeBreakdown());
                     assertEquals(result.getProfiledChildren().size(), 2);
+                    assertQueryProfileResult(result);
 
                     // Check the children
                     List<ProfileResult> children = result.getProfiledChildren();
@@ -282,12 +313,14 @@ public class QueryProfilerIT extends OpenSearchIntegTestCase {
                     assertThat(childProfile.getTime(), greaterThan(0L));
                     assertNotNull(childProfile.getTimeBreakdown());
                     assertEquals(childProfile.getProfiledChildren().size(), 0);
+                    assertQueryProfileResult(childProfile);
 
                     childProfile = children.get(1);
                     assertEquals(childProfile.getQueryName(), "TermQuery");
                     assertEquals(childProfile.getLuceneDescription(), "field1:two");
                     assertThat(childProfile.getTime(), greaterThan(0L));
                     assertNotNull(childProfile.getTimeBreakdown());
+                    assertQueryProfileResult(childProfile);
                 }
 
                 CollectorResult result = searchProfiles.getCollectorResult();
@@ -330,6 +363,7 @@ public class QueryProfilerIT extends OpenSearchIntegTestCase {
                     assertNotNull(result.getLuceneDescription());
                     assertThat(result.getTime(), greaterThan(0L));
                     assertNotNull(result.getTimeBreakdown());
+                    assertQueryProfileResult(result);
                 }
 
                 CollectorResult result = searchProfiles.getCollectorResult();
@@ -375,6 +409,7 @@ public class QueryProfilerIT extends OpenSearchIntegTestCase {
                     assertNotNull(result.getLuceneDescription());
                     assertThat(result.getTime(), greaterThan(0L));
                     assertNotNull(result.getTimeBreakdown());
+                    assertQueryProfileResult(result);
                 }
 
                 CollectorResult result = searchProfiles.getCollectorResult();
@@ -415,6 +450,7 @@ public class QueryProfilerIT extends OpenSearchIntegTestCase {
                     assertNotNull(result.getLuceneDescription());
                     assertThat(result.getTime(), greaterThan(0L));
                     assertNotNull(result.getTimeBreakdown());
+                    assertQueryProfileResult(result);
                 }
 
                 CollectorResult result = searchProfiles.getCollectorResult();
@@ -455,6 +491,7 @@ public class QueryProfilerIT extends OpenSearchIntegTestCase {
                     assertNotNull(result.getLuceneDescription());
                     assertThat(result.getTime(), greaterThan(0L));
                     assertNotNull(result.getTimeBreakdown());
+                    assertQueryProfileResult(result);
                 }
 
                 CollectorResult result = searchProfiles.getCollectorResult();
@@ -494,6 +531,7 @@ public class QueryProfilerIT extends OpenSearchIntegTestCase {
                     assertNotNull(result.getLuceneDescription());
                     assertThat(result.getTime(), greaterThan(0L));
                     assertNotNull(result.getTimeBreakdown());
+                    assertQueryProfileResult(result);
                 }
 
                 CollectorResult result = searchProfiles.getCollectorResult();
@@ -547,6 +585,7 @@ public class QueryProfilerIT extends OpenSearchIntegTestCase {
                     assertNotNull(result.getLuceneDescription());
                     assertThat(result.getTime(), greaterThan(0L));
                     assertNotNull(result.getTimeBreakdown());
+                    assertQueryProfileResult(result);
                 }
 
                 CollectorResult result = searchProfiles.getCollectorResult();
@@ -577,6 +616,37 @@ public class QueryProfilerIT extends OpenSearchIntegTestCase {
 
         SearchResponse resp = client().prepareSearch().setQuery(q).setProfile(false).get();
         assertThat("Profile response element should be an empty map", resp.getProfileResults().size(), equalTo(0));
+    }
+
+    private void assertQueryProfileResult(ProfileResult result) {
+        Map<String, Long> breakdown = result.getTimeBreakdown();
+        Long maxSliceTime = result.getMaxSliceTime();
+        Long minSliceTime = result.getMinSliceTime();
+        Long avgSliceTime = result.getAvgSliceTime();
+        if (concurrentSearchEnabled) {
+            assertNotNull(maxSliceTime);
+            assertNotNull(minSliceTime);
+            assertNotNull(avgSliceTime);
+            assertThat(breakdown.size(), equalTo(66));
+            for (QueryTimingType queryTimingType : QueryTimingType.values()) {
+                if (queryTimingType != QueryTimingType.CREATE_WEIGHT) {
+                    String maxTimingType = MAX_PREFIX + queryTimingType;
+                    String minTimingType = MIN_PREFIX + queryTimingType;
+                    String avgTimingType = AVG_PREFIX + queryTimingType;
+                    assertNotNull(breakdown.get(maxTimingType));
+                    assertNotNull(breakdown.get(minTimingType));
+                    assertNotNull(breakdown.get(avgTimingType));
+                    assertNotNull(breakdown.get(maxTimingType + TIMING_TYPE_COUNT_SUFFIX));
+                    assertNotNull(breakdown.get(minTimingType + TIMING_TYPE_COUNT_SUFFIX));
+                    assertNotNull(breakdown.get(avgTimingType + TIMING_TYPE_COUNT_SUFFIX));
+                }
+            }
+        } else {
+            assertThat(maxSliceTime, is(nullValue()));
+            assertThat(minSliceTime, is(nullValue()));
+            assertThat(avgSliceTime, is(nullValue()));
+            assertThat(breakdown.size(), equalTo(27));
+        }
     }
 
 }

--- a/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
@@ -300,6 +300,9 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
         final LeafCollector leafCollector;
         try {
             cancellable.checkCancelled();
+            if (weight instanceof ProfileWeight) {
+                ((ProfileWeight) weight).associateCollectorToLeaves(ctx, collector);
+            }
             weight = wrapWeight(weight);
             // See please https://github.com/apache/lucene/pull/964
             collector.setWeight(weight);

--- a/server/src/main/java/org/opensearch/search/profile/AbstractInternalProfileTree.java
+++ b/server/src/main/java/org/opensearch/search/profile/AbstractInternalProfileTree.java
@@ -180,6 +180,10 @@ public abstract class AbstractInternalProfileTree<PB extends AbstractProfileBrea
         // calculating the same times over and over...but worth the effort?
         String type = getTypeFromElement(element);
         String description = getDescriptionFromElement(element);
+        return createProfileResult(type, description, breakdown, childrenProfileResults);
+    }
+
+    protected ProfileResult createProfileResult(String type, String description, PB breakdown, List<ProfileResult> childrenProfileResults) {
         return new ProfileResult(
             type,
             description,

--- a/server/src/main/java/org/opensearch/search/profile/AbstractProfileBreakdown.java
+++ b/server/src/main/java/org/opensearch/search/profile/AbstractProfileBreakdown.java
@@ -80,6 +80,7 @@ public abstract class AbstractProfileBreakdown<T extends Enum<T>> {
         for (T timingType : this.timingTypes) {
             map.put(timingType.toString(), this.timings[timingType.ordinal()].getApproximateTiming());
             map.put(timingType + TIMING_TYPE_COUNT_SUFFIX, this.timings[timingType.ordinal()].getCount());
+            map.put(timingType + TIMING_TYPE_START_TIME_SUFFIX, this.timings[timingType.ordinal()].getEarliestTimerStartTime());
         }
         return Collections.unmodifiableMap(map);
     }
@@ -87,11 +88,11 @@ public abstract class AbstractProfileBreakdown<T extends Enum<T>> {
     /**
      * Fetch extra debugging information.
      */
-    protected Map<String, Object> toDebugMap() {
+    public Map<String, Object> toDebugMap() {
         return emptyMap();
     }
 
-    public final long toNodeTime() {
+    public long toNodeTime() {
         long total = 0;
         for (T timingType : timingTypes) {
             total += timings[timingType.ordinal()].getApproximateTiming();

--- a/server/src/main/java/org/opensearch/search/profile/ContextualProfileBreakdown.java
+++ b/server/src/main/java/org/opensearch/search/profile/ContextualProfileBreakdown.java
@@ -8,6 +8,12 @@
 
 package org.opensearch.search.profile;
 
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.Collector;
+
+import java.util.List;
+import java.util.Map;
+
 /**
  * Provide contextual profile breakdowns which are associated with freestyle context. Used when concurrent
  * search over segments is activated and each collector needs own non-shareable profile breakdown instance.
@@ -25,4 +31,8 @@ public abstract class ContextualProfileBreakdown<T extends Enum<T>> extends Abst
      * @return contextual profile breakdown instance
      */
     public abstract AbstractProfileBreakdown<T> context(Object context);
+
+    public void associateCollectorToLeaves(Collector collector, LeafReaderContext leaf) {}
+
+    public void associateCollectorsToLeaves(Map<Collector, List<LeafReaderContext>> collectorToLeaves) {}
 }

--- a/server/src/main/java/org/opensearch/search/profile/aggregation/AggregationProfileBreakdown.java
+++ b/server/src/main/java/org/opensearch/search/profile/aggregation/AggregationProfileBreakdown.java
@@ -34,7 +34,6 @@ package org.opensearch.search.profile.aggregation;
 
 import org.opensearch.search.profile.AbstractProfileBreakdown;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -60,21 +59,7 @@ public class AggregationProfileBreakdown extends AbstractProfileBreakdown<Aggreg
     }
 
     @Override
-    protected Map<String, Object> toDebugMap() {
+    public Map<String, Object> toDebugMap() {
         return unmodifiableMap(extra);
-    }
-
-    /**
-     * Build a timing count startTime breakdown for aggregation timing types
-     */
-    @Override
-    public Map<String, Long> toBreakdownMap() {
-        Map<String, Long> map = new HashMap<>(timings.length * 3);
-        for (AggregationTimingType timingType : timingTypes) {
-            map.put(timingType.toString(), timings[timingType.ordinal()].getApproximateTiming());
-            map.put(timingType + TIMING_TYPE_COUNT_SUFFIX, timings[timingType.ordinal()].getCount());
-            map.put(timingType + TIMING_TYPE_START_TIME_SUFFIX, timings[timingType.ordinal()].getEarliestTimerStartTime());
-        }
-        return Collections.unmodifiableMap(map);
     }
 }

--- a/server/src/main/java/org/opensearch/search/profile/query/AbstractQueryProfileTree.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/AbstractQueryProfileTree.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.profile.query;
+
+import org.apache.lucene.search.Query;
+import org.opensearch.search.profile.AbstractInternalProfileTree;
+import org.opensearch.search.profile.ContextualProfileBreakdown;
+import org.opensearch.search.profile.ProfileResult;
+
+/**
+ * This class tracks the dependency tree for queries (scoring and rewriting) and
+ * generates {@link QueryProfileBreakdown} for each node in the tree.  It also finalizes the tree
+ * and returns a list of {@link ProfileResult} that can be serialized back to the client
+ *
+ * @opensearch.internal
+ */
+public abstract class AbstractQueryProfileTree extends AbstractInternalProfileTree<ContextualProfileBreakdown<QueryTimingType>, Query> {
+
+    /** Rewrite time */
+    private long rewriteTime;
+    private long rewriteScratch;
+
+    @Override
+    protected String getTypeFromElement(Query query) {
+        // Anonymous classes won't have a name,
+        // we need to get the super class
+        if (query.getClass().getSimpleName().isEmpty()) {
+            return query.getClass().getSuperclass().getSimpleName();
+        }
+        return query.getClass().getSimpleName();
+    }
+
+    @Override
+    protected String getDescriptionFromElement(Query query) {
+        return query.toString();
+    }
+
+    /**
+     * Begin timing a query for a specific Timing context
+     */
+    public void startRewriteTime() {
+        assert rewriteScratch == 0;
+        rewriteScratch = System.nanoTime();
+    }
+
+    /**
+     * Halt the timing process and add the elapsed rewriting time.
+     * startRewriteTime() must be called for a particular context prior to calling
+     * stopAndAddRewriteTime(), otherwise the elapsed time will be negative and
+     * nonsensical
+     *
+     * @return          The elapsed time
+     */
+    public long stopAndAddRewriteTime() {
+        long time = Math.max(1, System.nanoTime() - rewriteScratch);
+        rewriteTime += time;
+        rewriteScratch = 0;
+        return time;
+    }
+
+    public long getRewriteTime() {
+        return rewriteTime;
+    }
+}

--- a/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdown.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdown.java
@@ -8,10 +8,15 @@
 
 package org.opensearch.search.profile.query;
 
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.Collector;
 import org.opensearch.search.profile.AbstractProfileBreakdown;
 import org.opensearch.search.profile.ContextualProfileBreakdown;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -23,7 +28,21 @@ import java.util.concurrent.ConcurrentHashMap;
  * @opensearch.internal
  */
 public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBreakdown<QueryTimingType> {
+    static final String SLICE_END_TIME_SUFFIX = "_slice_end_time";
+    static final String SLICE_START_TIME_SUFFIX = "_slice_start_time";
+    static final String MAX_PREFIX = "max_";
+    static final String MIN_PREFIX = "min_";
+    static final String AVG_PREFIX = "avg_";
+    private long queryNodeTime = Long.MIN_VALUE;
+    private long maxSliceNodeTime = Long.MIN_VALUE;
+    private long minSliceNodeTime = Long.MAX_VALUE;
+    private long avgSliceNodeTime = 0L;
+
+    // keep track of all breakdown timings per segment. package-private for testing
     private final Map<Object, AbstractProfileBreakdown<QueryTimingType>> contexts = new ConcurrentHashMap<>();
+
+    // represents slice to leaves mapping as for each slice a unique collector instance is created
+    private final Map<Collector, List<LeafReaderContext>> sliceCollectorsToLeaves = new ConcurrentHashMap<>();
 
     /** Sole constructor. */
     public ConcurrentQueryProfileBreakdown() {
@@ -44,14 +63,268 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
 
     @Override
     public Map<String, Long> toBreakdownMap() {
-        final Map<String, Long> map = new HashMap<>(super.toBreakdownMap());
+        final Map<String, Long> topLevelBreakdownMapWithWeightTime = super.toBreakdownMap();
+        final long createWeightStartTime = topLevelBreakdownMapWithWeightTime.get(
+            QueryTimingType.CREATE_WEIGHT + TIMING_TYPE_START_TIME_SUFFIX
+        );
+        final long createWeightTime = topLevelBreakdownMapWithWeightTime.get(QueryTimingType.CREATE_WEIGHT.toString());
 
-        for (final AbstractProfileBreakdown<QueryTimingType> context : contexts.values()) {
-            for (final Map.Entry<String, Long> entry : context.toBreakdownMap().entrySet()) {
-                map.merge(entry.getKey(), entry.getValue(), Long::sum);
-            }
+        if (sliceCollectorsToLeaves.isEmpty() || contexts.isEmpty()) {
+            // If there are no leaf contexts, then return the default concurrent query level breakdown, which will include the
+            // create_weight time/count
+            queryNodeTime = createWeightTime;
+            maxSliceNodeTime = queryNodeTime;
+            minSliceNodeTime = queryNodeTime;
+            avgSliceNodeTime = queryNodeTime;
+            return buildDefaultQueryBreakdownMap(createWeightTime);
         }
 
-        return map;
+        // first create the slice level breakdowns
+        final Map<Collector, Map<String, Long>> sliceLevelBreakdowns = buildSliceLevelBreakdown(createWeightStartTime);
+        return buildQueryBreakdownMap(sliceLevelBreakdowns, createWeightTime, createWeightStartTime);
+    }
+
+    /**
+     * @param createWeightTime time for creating weight
+     * @return default breakdown map for concurrent query which includes the create weight time and all other timing type stats in the
+     * breakdown has default value of 0. For concurrent search case, the max/min/avg stats for each timing type will also be 0 in this
+     * default breakdown map.
+     */
+    private Map<String, Long> buildDefaultQueryBreakdownMap(long createWeightTime) {
+        final Map<String, Long> concurrentQueryBreakdownMap = new HashMap<>();
+        for (QueryTimingType timingType : QueryTimingType.values()) {
+            final String timingTypeKey = timingType.toString();
+            final String timingTypeCountKey = timingTypeKey + TIMING_TYPE_COUNT_SUFFIX;
+
+            if (timingType.equals(QueryTimingType.CREATE_WEIGHT)) {
+                concurrentQueryBreakdownMap.put(timingTypeKey, createWeightTime);
+                concurrentQueryBreakdownMap.put(timingTypeCountKey, 1L);
+                continue;
+            }
+            final String maxBreakdownTypeTime = MAX_PREFIX + timingTypeKey;
+            final String minBreakdownTypeTime = MIN_PREFIX + timingTypeKey;
+            final String avgBreakdownTypeTime = AVG_PREFIX + timingTypeKey;
+            final String maxBreakdownTypeCount = MAX_PREFIX + timingTypeCountKey;
+            final String minBreakdownTypeCount = MIN_PREFIX + timingTypeCountKey;
+            final String avgBreakdownTypeCount = AVG_PREFIX + timingTypeCountKey;
+            // add time related stats
+            concurrentQueryBreakdownMap.put(timingTypeKey, 0L);
+            concurrentQueryBreakdownMap.put(maxBreakdownTypeTime, 0L);
+            concurrentQueryBreakdownMap.put(minBreakdownTypeTime, 0L);
+            concurrentQueryBreakdownMap.put(avgBreakdownTypeTime, 0L);
+            // add count related stats
+            concurrentQueryBreakdownMap.put(timingTypeCountKey, 0L);
+            concurrentQueryBreakdownMap.put(maxBreakdownTypeCount, 0L);
+            concurrentQueryBreakdownMap.put(minBreakdownTypeCount, 0L);
+            concurrentQueryBreakdownMap.put(avgBreakdownTypeCount, 0L);
+        }
+        return concurrentQueryBreakdownMap;
+    }
+
+    /**
+     * Computes the slice level breakdownMap. It uses sliceCollectorsToLeaves to figure out all the leaves or segments part of a slice.
+     * Then use the breakdown timing stats for each of these leaves to calculate the breakdown stats at slice level.
+     * @param createWeightStartTime start time when createWeight is called
+     * @return map of collector (or slice) to breakdown map
+     */
+    Map<Collector, Map<String, Long>> buildSliceLevelBreakdown(long createWeightStartTime) {
+        final Map<Collector, Map<String, Long>> sliceLevelBreakdowns = new HashMap<>();
+        long totalSliceNodeTime = 0;
+        for (Map.Entry<Collector, List<LeafReaderContext>> slice : sliceCollectorsToLeaves.entrySet()) {
+            final Collector sliceCollector = slice.getKey();
+            // initialize each slice level breakdown
+            final Map<String, Long> currentSliceBreakdown = sliceLevelBreakdowns.computeIfAbsent(sliceCollector, k -> new HashMap<>());
+            // max slice end time across all timing types
+            long sliceMaxEndTime = Long.MIN_VALUE;
+            for (QueryTimingType timingType : QueryTimingType.values()) {
+                if (timingType.equals(QueryTimingType.CREATE_WEIGHT)) {
+                    // do nothing for create weight as that is query level time and not slice level
+                    continue;
+                }
+
+                // for each timing type compute maxSliceEndTime and minSliceStartTime. Also add the counts of timing type to
+                // compute total count at slice level
+                final String timingTypeCountKey = timingType + TIMING_TYPE_COUNT_SUFFIX;
+                final String timingTypeStartKey = timingType + TIMING_TYPE_START_TIME_SUFFIX;
+                final String timingTypeSliceStartTimeKey = timingType + SLICE_START_TIME_SUFFIX;
+                final String timingTypeSliceEndTimeKey = timingType + SLICE_END_TIME_SUFFIX;
+
+                for (LeafReaderContext sliceLeaf : slice.getValue()) {
+                    if (!contexts.containsKey(sliceLeaf)) {
+                        // In case like early termination, the sliceCollectorToLeave association will be added for a
+                        // leaf, but the leaf level breakdown will not be created in the contexts map.
+                        // This is because before updating the contexts map, the query hits earlyTerminationException.
+                        // To handle such case, we will ignore the leaf that is not present.
+                        continue;
+                    }
+                    final Map<String, Long> currentSliceLeafBreakdownMap = contexts.get(sliceLeaf).toBreakdownMap();
+                    // get the count for current leaf timing type
+                    currentSliceBreakdown.compute(
+                        timingTypeCountKey,
+                        (key, value) -> (value == null)
+                            ? currentSliceLeafBreakdownMap.get(timingTypeCountKey)
+                            : value + currentSliceLeafBreakdownMap.get(timingTypeCountKey)
+                    );
+
+                    // compute the sliceEndTime for timingType using max of endTime across slice leaves
+                    final long sliceLeafTimingTypeEndTime = currentSliceLeafBreakdownMap.get(timingTypeStartKey)
+                        + currentSliceLeafBreakdownMap.get(timingType.toString());
+                    currentSliceBreakdown.compute(
+                        timingTypeSliceEndTimeKey,
+                        (key, value) -> (value == null) ? sliceLeafTimingTypeEndTime : Math.max(value, sliceLeafTimingTypeEndTime)
+                    );
+
+                    // compute the sliceStartTime for timingType using min of startTime across slice leaves
+                    final long sliceLeafTimingTypeStartTime = currentSliceLeafBreakdownMap.get(timingTypeStartKey);
+                    currentSliceBreakdown.compute(
+                        timingTypeSliceStartTimeKey,
+                        (key, value) -> (value == null) ? sliceLeafTimingTypeStartTime : Math.min(value, sliceLeafTimingTypeStartTime)
+                    );
+                }
+                // compute sliceMaxEndTime as max of sliceEndTime across all timing types
+                sliceMaxEndTime = Math.max(sliceMaxEndTime, currentSliceBreakdown.get(timingTypeSliceEndTimeKey));
+                // compute total time for each timing type at slice level using sliceEndTime and sliceStartTime
+                currentSliceBreakdown.put(
+                    timingType.toString(),
+                    currentSliceBreakdown.get(timingTypeSliceEndTimeKey) - currentSliceBreakdown.get(timingTypeSliceStartTimeKey)
+                );
+            }
+            // currentSliceNodeTime includes the create weight time as well which will be same for all the slices
+            long currentSliceNodeTime = sliceMaxEndTime - createWeightStartTime;
+            // compute max/min slice times
+            maxSliceNodeTime = Math.max(maxSliceNodeTime, currentSliceNodeTime);
+            minSliceNodeTime = Math.min(minSliceNodeTime, currentSliceNodeTime);
+            // total time at query level
+            totalSliceNodeTime += currentSliceNodeTime;
+        }
+        avgSliceNodeTime = totalSliceNodeTime / sliceCollectorsToLeaves.size();
+        return sliceLevelBreakdowns;
+    }
+
+    /**
+     * Computes the query level breakdownMap using the breakdown maps of all the slices. In query level breakdown map, it has the
+     * time/count stats for each breakdown type. Total time per breakdown type at query level is computed by subtracting the max of slice
+     * end time with min of slice start time for that type. Count for each breakdown type at query level is sum of count of that type
+     * across slices. Other than these, there are max/min/avg stats across slices for each breakdown type
+     *
+     * @param sliceLevelBreakdowns  breakdown map for all the slices
+     * @param createWeightTime      time for create weight
+     * @param createWeightStartTime start time for create weight
+     * @return breakdown map for entire query
+     */
+    public Map<String, Long> buildQueryBreakdownMap(
+        Map<Collector, Map<String, Long>> sliceLevelBreakdowns,
+        long createWeightTime,
+        long createWeightStartTime
+    ) {
+        final Map<String, Long> queryBreakdownMap = new HashMap<>();
+        long queryEndTime = Long.MIN_VALUE;
+        for (QueryTimingType queryTimingType : QueryTimingType.values()) {
+            final String timingTypeKey = queryTimingType.toString();
+            final String timingTypeCountKey = timingTypeKey + TIMING_TYPE_COUNT_SUFFIX;
+            final String sliceEndTimeForTimingType = timingTypeKey + SLICE_END_TIME_SUFFIX;
+            final String sliceStartTimeForTimingType = timingTypeKey + SLICE_START_TIME_SUFFIX;
+
+            final String maxBreakdownTypeTime = MAX_PREFIX + timingTypeKey;
+            final String minBreakdownTypeTime = MIN_PREFIX + timingTypeKey;
+            final String avgBreakdownTypeTime = AVG_PREFIX + timingTypeKey;
+            final String maxBreakdownTypeCount = MAX_PREFIX + timingTypeCountKey;
+            final String minBreakdownTypeCount = MIN_PREFIX + timingTypeCountKey;
+            final String avgBreakdownTypeCount = AVG_PREFIX + timingTypeCountKey;
+
+            long queryTimingTypeEndTime = Long.MIN_VALUE;
+            long queryTimingTypeStartTime = Long.MAX_VALUE;
+            long queryTimingTypeCount = 0L;
+
+            // the create weight time is computed at the query level and is called only once per query
+            if (queryTimingType == QueryTimingType.CREATE_WEIGHT) {
+                queryBreakdownMap.put(timingTypeCountKey, 1L);
+                queryBreakdownMap.put(timingTypeKey, createWeightTime);
+                continue;
+            }
+
+            // for all other timing types, we will compute min/max/avg/total across slices
+            for (Map.Entry<Collector, Map<String, Long>> sliceBreakdown : sliceLevelBreakdowns.entrySet()) {
+                Long sliceBreakdownTypeTime = sliceBreakdown.getValue().get(timingTypeKey);
+                Long sliceBreakdownTypeCount = sliceBreakdown.getValue().get(timingTypeCountKey);
+                // compute max/min/avg TimingType time across slices
+                queryBreakdownMap.compute(
+                    maxBreakdownTypeTime,
+                    (key, value) -> (value == null) ? sliceBreakdownTypeTime : Math.max(sliceBreakdownTypeTime, value)
+                );
+                queryBreakdownMap.compute(
+                    minBreakdownTypeTime,
+                    (key, value) -> (value == null) ? sliceBreakdownTypeTime : Math.min(sliceBreakdownTypeTime, value)
+                );
+                queryBreakdownMap.compute(
+                    avgBreakdownTypeTime,
+                    (key, value) -> (value == null) ? sliceBreakdownTypeTime : sliceBreakdownTypeTime + value
+                );
+
+                // compute max/min/avg TimingType count across slices
+                queryBreakdownMap.compute(
+                    maxBreakdownTypeCount,
+                    (key, value) -> (value == null) ? sliceBreakdownTypeCount : Math.max(sliceBreakdownTypeCount, value)
+                );
+                queryBreakdownMap.compute(
+                    minBreakdownTypeCount,
+                    (key, value) -> (value == null) ? sliceBreakdownTypeCount : Math.min(sliceBreakdownTypeCount, value)
+                );
+                queryBreakdownMap.compute(
+                    avgBreakdownTypeCount,
+                    (key, value) -> (value == null) ? sliceBreakdownTypeCount : sliceBreakdownTypeCount + value
+                );
+
+                // query start/end time for a TimingType is min/max of start/end time across slices for that TimingType
+                queryTimingTypeEndTime = Math.max(queryTimingTypeEndTime, sliceBreakdown.getValue().get(sliceEndTimeForTimingType));
+                queryTimingTypeStartTime = Math.min(queryTimingTypeStartTime, sliceBreakdown.getValue().get(sliceStartTimeForTimingType));
+                queryTimingTypeCount += sliceBreakdownTypeCount;
+            }
+            queryBreakdownMap.put(timingTypeKey, queryTimingTypeEndTime - queryTimingTypeStartTime);
+            queryBreakdownMap.put(timingTypeCountKey, queryTimingTypeCount);
+            queryBreakdownMap.compute(avgBreakdownTypeTime, (key, value) -> (value == null) ? 0 : value / sliceLevelBreakdowns.size());
+            queryBreakdownMap.compute(avgBreakdownTypeCount, (key, value) -> (value == null) ? 0 : value / sliceLevelBreakdowns.size());
+            // compute query end time using max of query end time across all timing types
+            queryEndTime = Math.max(queryEndTime, queryTimingTypeEndTime);
+        }
+        queryNodeTime = queryEndTime - createWeightStartTime;
+        return queryBreakdownMap;
+    }
+
+    @Override
+    public long toNodeTime() {
+        return queryNodeTime;
+    }
+
+    @Override
+    public void associateCollectorToLeaves(Collector collector, LeafReaderContext leaf) {
+        // Each slice (or collector) is executed by single thread. So the list for a key will always be updated by a single thread only
+        sliceCollectorsToLeaves.computeIfAbsent(collector, k -> new ArrayList<>()).add(leaf);
+    }
+
+    @Override
+    public void associateCollectorsToLeaves(Map<Collector, List<LeafReaderContext>> collectorsToLeaves) {
+        sliceCollectorsToLeaves.putAll(collectorsToLeaves);
+    }
+
+    Map<Collector, List<LeafReaderContext>> getSliceCollectorsToLeaves() {
+        return Collections.unmodifiableMap(sliceCollectorsToLeaves);
+    }
+
+    // used by tests
+    Map<Object, AbstractProfileBreakdown<QueryTimingType>> getContexts() {
+        return contexts;
+    }
+
+    long getMaxSliceNodeTime() {
+        return maxSliceNodeTime;
+    }
+
+    long getMinSliceNodeTime() {
+        return minSliceNodeTime;
+    }
+
+    long getAvgSliceNodeTime() {
+        return avgSliceNodeTime;
     }
 }

--- a/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileTree.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileTree.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.profile.query;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.Collector;
+import org.opensearch.search.profile.ContextualProfileBreakdown;
+import org.opensearch.search.profile.ProfileResult;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class returns a list of {@link ProfileResult} that can be serialized back to the client in the concurrent execution.
+ *
+ * @opensearch.internal
+ */
+public class ConcurrentQueryProfileTree extends AbstractQueryProfileTree {
+
+    @Override
+    protected ContextualProfileBreakdown<QueryTimingType> createProfileBreakdown() {
+        return new ConcurrentQueryProfileBreakdown();
+    }
+
+    @Override
+    protected ProfileResult createProfileResult(
+        String type,
+        String description,
+        ContextualProfileBreakdown<QueryTimingType> breakdown,
+        List<ProfileResult> childrenProfileResults
+    ) {
+        assert breakdown instanceof ConcurrentQueryProfileBreakdown;
+        final ConcurrentQueryProfileBreakdown concurrentBreakdown = (ConcurrentQueryProfileBreakdown) breakdown;
+        return new ProfileResult(
+            type,
+            description,
+            concurrentBreakdown.toBreakdownMap(),
+            concurrentBreakdown.toDebugMap(),
+            concurrentBreakdown.toNodeTime(),
+            childrenProfileResults,
+            concurrentBreakdown.getMaxSliceNodeTime(),
+            concurrentBreakdown.getMinSliceNodeTime(),
+            concurrentBreakdown.getAvgSliceNodeTime()
+        );
+    }
+
+    /**
+     * For concurrent query case, when there are nested queries (with children), then the {@link ConcurrentQueryProfileBreakdown} created
+     * for the child queries weight doesn't have the association of collector to leaves. This is because child query weights are not
+     * exposed by the {@link org.apache.lucene.search.Weight} interface. So after all the collection is happened and before the result
+     * tree is created we need to pass the association from parent to the child breakdowns. This will be then used to create the
+     * breakdown map at slice level for the child queries as well
+     *
+     * @return a hierarchical representation of the profiled query tree
+     */
+    @Override
+    public List<ProfileResult> getTree() {
+        for (Integer root : roots) {
+            final ContextualProfileBreakdown<QueryTimingType> parentBreakdown = breakdowns.get(root);
+            assert parentBreakdown instanceof ConcurrentQueryProfileBreakdown;
+            final Map<Collector, List<LeafReaderContext>> parentCollectorToLeaves = ((ConcurrentQueryProfileBreakdown) parentBreakdown)
+                .getSliceCollectorsToLeaves();
+            // update all the children with the parent collectorToLeaves association
+            updateCollectorToLeavesForChildBreakdowns(root, parentCollectorToLeaves);
+        }
+        // once the collector to leaves mapping is updated, get the result
+        return super.getTree();
+    }
+
+    /**
+     * Updates the children with collector to leaves mapping as recorded by parent breakdown
+     * @param parentToken parent token number in the tree
+     * @param collectorToLeaves collector to leaves mapping recorded by parent
+     */
+    private void updateCollectorToLeavesForChildBreakdowns(Integer parentToken, Map<Collector, List<LeafReaderContext>> collectorToLeaves) {
+        final List<Integer> children = tree.get(parentToken);
+        if (children != null) {
+            for (Integer currentChild : children) {
+                final ContextualProfileBreakdown<QueryTimingType> currentChildBreakdown = breakdowns.get(currentChild);
+                currentChildBreakdown.associateCollectorsToLeaves(collectorToLeaves);
+                updateCollectorToLeavesForChildBreakdowns(currentChild, collectorToLeaves);
+            }
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/search/profile/query/InternalQueryProfileTree.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/InternalQueryProfileTree.java
@@ -32,73 +32,18 @@
 
 package org.opensearch.search.profile.query;
 
-import org.apache.lucene.search.Query;
-import org.opensearch.search.profile.AbstractInternalProfileTree;
 import org.opensearch.search.profile.ContextualProfileBreakdown;
 import org.opensearch.search.profile.ProfileResult;
 
 /**
- * This class tracks the dependency tree for queries (scoring and rewriting) and
- * generates {@link QueryProfileBreakdown} for each node in the tree.  It also finalizes the tree
- * and returns a list of {@link ProfileResult} that can be serialized back to the client
+ * This class returns a list of {@link ProfileResult} that can be serialized back to the client in the non-concurrent execution.
  *
  * @opensearch.internal
  */
-final class InternalQueryProfileTree extends AbstractInternalProfileTree<ContextualProfileBreakdown<QueryTimingType>, Query> {
-
-    /** Rewrite time */
-    private long rewriteTime;
-    private long rewriteScratch;
-    private final boolean concurrent;
-
-    InternalQueryProfileTree(boolean concurrent) {
-        this.concurrent = concurrent;
-    }
+public class InternalQueryProfileTree extends AbstractQueryProfileTree {
 
     @Override
     protected ContextualProfileBreakdown<QueryTimingType> createProfileBreakdown() {
-        return (concurrent) ? new ConcurrentQueryProfileBreakdown() : new QueryProfileBreakdown();
-    }
-
-    @Override
-    protected String getTypeFromElement(Query query) {
-        // Anonymous classes won't have a name,
-        // we need to get the super class
-        if (query.getClass().getSimpleName().isEmpty()) {
-            return query.getClass().getSuperclass().getSimpleName();
-        }
-        return query.getClass().getSimpleName();
-    }
-
-    @Override
-    protected String getDescriptionFromElement(Query query) {
-        return query.toString();
-    }
-
-    /**
-     * Begin timing a query for a specific Timing context
-     */
-    public void startRewriteTime() {
-        assert rewriteScratch == 0;
-        rewriteScratch = System.nanoTime();
-    }
-
-    /**
-     * Halt the timing process and add the elapsed rewriting time.
-     * startRewriteTime() must be called for a particular context prior to calling
-     * stopAndAddRewriteTime(), otherwise the elapsed time will be negative and
-     * nonsensical
-     *
-     * @return          The elapsed time
-     */
-    public long stopAndAddRewriteTime() {
-        long time = Math.max(1, System.nanoTime() - rewriteScratch);
-        rewriteTime += time;
-        rewriteScratch = 0;
-        return time;
-    }
-
-    public long getRewriteTime() {
-        return rewriteTime;
+        return new QueryProfileBreakdown();
     }
 }

--- a/server/src/main/java/org/opensearch/search/profile/query/ProfileWeight.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/ProfileWeight.java
@@ -34,6 +34,7 @@ package org.opensearch.search.profile.query;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.BulkScorer;
+import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Scorer;
@@ -137,4 +138,7 @@ public final class ProfileWeight extends Weight {
         return false;
     }
 
+    public void associateCollectorToLeaves(LeafReaderContext leaf, Collector collector) {
+        profile.associateCollectorToLeaves(collector, leaf);
+    }
 }

--- a/server/src/main/java/org/opensearch/search/profile/query/QueryProfiler.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/QueryProfiler.java
@@ -59,7 +59,7 @@ public final class QueryProfiler extends AbstractProfiler<ContextualProfileBreak
     private InternalProfileComponent collector;
 
     public QueryProfiler(boolean concurrent) {
-        super(new InternalQueryProfileTree(concurrent));
+        super(concurrent ? new ConcurrentQueryProfileTree() : new InternalQueryProfileTree());
     }
 
     /** Set the collector that is associated with this profiler. */
@@ -75,7 +75,7 @@ public final class QueryProfiler extends AbstractProfiler<ContextualProfileBreak
      * single metric
      */
     public void startRewriteTime() {
-        ((InternalQueryProfileTree) profileTree).startRewriteTime();
+        ((AbstractQueryProfileTree) profileTree).startRewriteTime();
     }
 
     /**
@@ -85,14 +85,14 @@ public final class QueryProfiler extends AbstractProfiler<ContextualProfileBreak
      * @return cumulative rewrite time
      */
     public long stopAndAddRewriteTime() {
-        return ((InternalQueryProfileTree) profileTree).stopAndAddRewriteTime();
+        return ((AbstractQueryProfileTree) profileTree).stopAndAddRewriteTime();
     }
 
     /**
      * @return total time taken to rewrite all queries in this profile
      */
     public long getRewriteTime() {
-        return ((InternalQueryProfileTree) profileTree).getRewriteTime();
+        return ((AbstractQueryProfileTree) profileTree).getRewriteTime();
     }
 
     /**

--- a/server/src/test/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdownTests.java
+++ b/server/src/test/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdownTests.java
@@ -1,0 +1,323 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.search.profile.query;
+
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.store.Directory;
+import org.opensearch.search.profile.AbstractProfileBreakdown;
+import org.opensearch.search.profile.Timer;
+import org.opensearch.test.OpenSearchTestCase;
+import org.junit.Before;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.opensearch.search.profile.AbstractProfileBreakdown.TIMING_TYPE_COUNT_SUFFIX;
+import static org.opensearch.search.profile.AbstractProfileBreakdown.TIMING_TYPE_START_TIME_SUFFIX;
+import static org.opensearch.search.profile.query.ConcurrentQueryProfileBreakdown.MIN_PREFIX;
+import static org.opensearch.search.profile.query.ConcurrentQueryProfileBreakdown.SLICE_END_TIME_SUFFIX;
+import static org.opensearch.search.profile.query.ConcurrentQueryProfileBreakdown.SLICE_START_TIME_SUFFIX;
+import static org.mockito.Mockito.mock;
+
+public class ConcurrentQueryProfileBreakdownTests extends OpenSearchTestCase {
+    private ConcurrentQueryProfileBreakdown testQueryProfileBreakdown;
+    private Timer createWeightTimer;
+
+    @Before
+    public void setup() {
+        testQueryProfileBreakdown = new ConcurrentQueryProfileBreakdown();
+        createWeightTimer = testQueryProfileBreakdown.getTimer(QueryTimingType.CREATE_WEIGHT);
+        try {
+            createWeightTimer.start();
+            Thread.sleep(10);
+        } catch (InterruptedException ex) {
+            // ignore
+        } finally {
+            createWeightTimer.stop();
+        }
+    }
+
+    public void testBreakdownMapWithNoLeafContext() throws Exception {
+        final Map<String, Long> queryBreakDownMap = testQueryProfileBreakdown.toBreakdownMap();
+        assertFalse(queryBreakDownMap == null || queryBreakDownMap.isEmpty());
+        assertEquals(66, queryBreakDownMap.size());
+        for (QueryTimingType queryTimingType : QueryTimingType.values()) {
+            String timingTypeKey = queryTimingType.toString();
+            String timingTypeCountKey = queryTimingType + TIMING_TYPE_COUNT_SUFFIX;
+
+            if (queryTimingType.equals(QueryTimingType.CREATE_WEIGHT)) {
+                final long createWeightTime = queryBreakDownMap.get(timingTypeKey);
+                assertTrue(createWeightTime > 0);
+                assertEquals(1, (long) queryBreakDownMap.get(timingTypeCountKey));
+                // verify there is no min/max/avg for weight type stats
+                assertFalse(
+                    queryBreakDownMap.containsKey(ConcurrentQueryProfileBreakdown.MAX_PREFIX + timingTypeKey)
+                        || queryBreakDownMap.containsKey(MIN_PREFIX + timingTypeKey)
+                        || queryBreakDownMap.containsKey(ConcurrentQueryProfileBreakdown.AVG_PREFIX + timingTypeKey)
+                        || queryBreakDownMap.containsKey(ConcurrentQueryProfileBreakdown.MAX_PREFIX + timingTypeCountKey)
+                        || queryBreakDownMap.containsKey(MIN_PREFIX + timingTypeCountKey)
+                        || queryBreakDownMap.containsKey(ConcurrentQueryProfileBreakdown.AVG_PREFIX + timingTypeCountKey)
+                );
+                // verify total/min/max/avg node time is same as weight time
+                assertEquals(createWeightTime, testQueryProfileBreakdown.toNodeTime());
+                assertEquals(createWeightTime, testQueryProfileBreakdown.getMaxSliceNodeTime());
+                assertEquals(createWeightTime, testQueryProfileBreakdown.getMinSliceNodeTime());
+                assertEquals(createWeightTime, testQueryProfileBreakdown.getAvgSliceNodeTime());
+                continue;
+            }
+            assertEquals(0, (long) queryBreakDownMap.get(timingTypeKey));
+            assertEquals(0, (long) queryBreakDownMap.get(ConcurrentQueryProfileBreakdown.MAX_PREFIX + timingTypeKey));
+            assertEquals(0, (long) queryBreakDownMap.get(ConcurrentQueryProfileBreakdown.AVG_PREFIX + timingTypeKey));
+            assertEquals(0, (long) queryBreakDownMap.get(MIN_PREFIX + timingTypeKey));
+            assertEquals(0, (long) queryBreakDownMap.get(timingTypeCountKey));
+            assertEquals(0, (long) queryBreakDownMap.get(ConcurrentQueryProfileBreakdown.MAX_PREFIX + timingTypeCountKey));
+            assertEquals(0, (long) queryBreakDownMap.get(MIN_PREFIX + timingTypeCountKey));
+            assertEquals(0, (long) queryBreakDownMap.get(ConcurrentQueryProfileBreakdown.AVG_PREFIX + timingTypeCountKey));
+        }
+    }
+
+    public void testBuildSliceLevelBreakdownWithSingleSlice() throws Exception {
+        final DirectoryReader directoryReader = getDirectoryReader(1);
+        final Directory directory = directoryReader.directory();
+        final LeafReaderContext sliceLeaf = directoryReader.leaves().get(0);
+        final Collector sliceCollector = mock(Collector.class);
+        final long createWeightEarliestStartTime = createWeightTimer.getEarliestTimerStartTime();
+        final Map<String, Long> leafProfileBreakdownMap = getLeafBreakdownMap(createWeightEarliestStartTime + 10, 10, 1);
+        final AbstractProfileBreakdown<QueryTimingType> leafProfileBreakdown = new TestQueryProfileBreakdown(
+            QueryTimingType.class,
+            leafProfileBreakdownMap
+        );
+        testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector, sliceLeaf);
+        testQueryProfileBreakdown.getContexts().put(sliceLeaf, leafProfileBreakdown);
+        final Map<Collector, Map<String, Long>> sliceBreakdownMap = testQueryProfileBreakdown.buildSliceLevelBreakdown(
+            createWeightEarliestStartTime
+        );
+        assertFalse(sliceBreakdownMap == null || sliceBreakdownMap.isEmpty());
+        assertEquals(1, sliceBreakdownMap.size());
+        assertTrue(sliceBreakdownMap.containsKey(sliceCollector));
+
+        final Map<String, Long> sliceBreakdown = sliceBreakdownMap.entrySet().iterator().next().getValue();
+        for (QueryTimingType timingType : QueryTimingType.values()) {
+            String timingTypeKey = timingType.toString();
+            String timingTypeCountKey = timingTypeKey + TIMING_TYPE_COUNT_SUFFIX;
+
+            if (timingType.equals(QueryTimingType.CREATE_WEIGHT)) {
+                // there should be no entry for create weight at slice level breakdown map
+                assertNull(sliceBreakdown.get(timingTypeKey));
+                assertNull(sliceBreakdown.get(timingTypeCountKey));
+                continue;
+            }
+
+            // for other timing type we will have all the value and will be same as leaf breakdown as there is single slice and single leaf
+            assertEquals(leafProfileBreakdownMap.get(timingTypeKey), sliceBreakdown.get(timingTypeKey));
+            assertEquals(leafProfileBreakdownMap.get(timingTypeCountKey), sliceBreakdown.get(timingTypeCountKey));
+            assertEquals(
+                leafProfileBreakdownMap.get(timingTypeKey + TIMING_TYPE_START_TIME_SUFFIX),
+                sliceBreakdown.get(timingTypeKey + SLICE_START_TIME_SUFFIX)
+            );
+            assertEquals(
+                leafProfileBreakdownMap.get(timingTypeKey + TIMING_TYPE_START_TIME_SUFFIX) + leafProfileBreakdownMap.get(timingTypeKey),
+                (long) sliceBreakdown.get(timingTypeKey + SLICE_END_TIME_SUFFIX)
+            );
+        }
+        assertEquals(20, testQueryProfileBreakdown.getMaxSliceNodeTime());
+        assertEquals(20, testQueryProfileBreakdown.getMinSliceNodeTime());
+        assertEquals(20, testQueryProfileBreakdown.getAvgSliceNodeTime());
+        directoryReader.close();
+        directory.close();
+    }
+
+    public void testBuildSliceLevelBreakdownWithMultipleSlices() throws Exception {
+        final DirectoryReader directoryReader = getDirectoryReader(2);
+        final Directory directory = directoryReader.directory();
+        final Collector sliceCollector_1 = mock(Collector.class);
+        final Collector sliceCollector_2 = mock(Collector.class);
+        final long createWeightEarliestStartTime = createWeightTimer.getEarliestTimerStartTime();
+        final Map<String, Long> leafProfileBreakdownMap_1 = getLeafBreakdownMap(createWeightEarliestStartTime + 10, 10, 1);
+        final Map<String, Long> leafProfileBreakdownMap_2 = getLeafBreakdownMap(createWeightEarliestStartTime + 40, 10, 1);
+        final AbstractProfileBreakdown<QueryTimingType> leafProfileBreakdown_1 = new TestQueryProfileBreakdown(
+            QueryTimingType.class,
+            leafProfileBreakdownMap_1
+        );
+        final AbstractProfileBreakdown<QueryTimingType> leafProfileBreakdown_2 = new TestQueryProfileBreakdown(
+            QueryTimingType.class,
+            leafProfileBreakdownMap_2
+        );
+        testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector_1, directoryReader.leaves().get(0));
+        testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector_2, directoryReader.leaves().get(1));
+        testQueryProfileBreakdown.getContexts().put(directoryReader.leaves().get(0), leafProfileBreakdown_1);
+        testQueryProfileBreakdown.getContexts().put(directoryReader.leaves().get(1), leafProfileBreakdown_2);
+        final Map<Collector, Map<String, Long>> sliceBreakdownMap = testQueryProfileBreakdown.buildSliceLevelBreakdown(
+            createWeightEarliestStartTime
+        );
+        assertFalse(sliceBreakdownMap == null || sliceBreakdownMap.isEmpty());
+        assertEquals(2, sliceBreakdownMap.size());
+
+        for (Map.Entry<Collector, Map<String, Long>> sliceBreakdowns : sliceBreakdownMap.entrySet()) {
+            Map<String, Long> sliceBreakdown = sliceBreakdowns.getValue();
+            Map<String, Long> leafProfileBreakdownMap;
+            if (sliceBreakdowns.getKey().equals(sliceCollector_1)) {
+                leafProfileBreakdownMap = leafProfileBreakdownMap_1;
+            } else {
+                leafProfileBreakdownMap = leafProfileBreakdownMap_2;
+            }
+            for (QueryTimingType timingType : QueryTimingType.values()) {
+                String timingTypeKey = timingType.toString();
+                String timingTypeCountKey = timingTypeKey + TIMING_TYPE_COUNT_SUFFIX;
+
+                if (timingType.equals(QueryTimingType.CREATE_WEIGHT)) {
+                    // there should be no entry for create weight at slice level breakdown map
+                    assertNull(sliceBreakdown.get(timingTypeKey));
+                    assertNull(sliceBreakdown.get(timingTypeCountKey));
+                    continue;
+                }
+
+                // for other timing type we will have all the value and will be same as leaf breakdown as there is single slice and single
+                // leaf
+                assertEquals(leafProfileBreakdownMap.get(timingTypeKey), sliceBreakdown.get(timingTypeKey));
+                assertEquals(leafProfileBreakdownMap.get(timingTypeCountKey), sliceBreakdown.get(timingTypeCountKey));
+                assertEquals(
+                    leafProfileBreakdownMap.get(timingTypeKey + TIMING_TYPE_START_TIME_SUFFIX),
+                    sliceBreakdown.get(timingTypeKey + SLICE_START_TIME_SUFFIX)
+                );
+                assertEquals(
+                    leafProfileBreakdownMap.get(timingTypeKey + TIMING_TYPE_START_TIME_SUFFIX) + leafProfileBreakdownMap.get(timingTypeKey),
+                    (long) sliceBreakdown.get(timingTypeKey + SLICE_END_TIME_SUFFIX)
+                );
+            }
+        }
+
+        assertEquals(50, testQueryProfileBreakdown.getMaxSliceNodeTime());
+        assertEquals(20, testQueryProfileBreakdown.getMinSliceNodeTime());
+        assertEquals(35, testQueryProfileBreakdown.getAvgSliceNodeTime());
+        directoryReader.close();
+        directory.close();
+    }
+
+    public void testBreakDownMapWithMultipleSlices() throws Exception {
+        final DirectoryReader directoryReader = getDirectoryReader(2);
+        final Directory directory = directoryReader.directory();
+        final Collector sliceCollector_1 = mock(Collector.class);
+        final Collector sliceCollector_2 = mock(Collector.class);
+        final long createWeightEarliestStartTime = createWeightTimer.getEarliestTimerStartTime();
+        final Map<String, Long> leafProfileBreakdownMap_1 = getLeafBreakdownMap(createWeightEarliestStartTime + 10, 10, 1);
+        final Map<String, Long> leafProfileBreakdownMap_2 = getLeafBreakdownMap(createWeightEarliestStartTime + 40, 20, 1);
+        final AbstractProfileBreakdown<QueryTimingType> leafProfileBreakdown_1 = new TestQueryProfileBreakdown(
+            QueryTimingType.class,
+            leafProfileBreakdownMap_1
+        );
+        final AbstractProfileBreakdown<QueryTimingType> leafProfileBreakdown_2 = new TestQueryProfileBreakdown(
+            QueryTimingType.class,
+            leafProfileBreakdownMap_2
+        );
+        testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector_1, directoryReader.leaves().get(0));
+        testQueryProfileBreakdown.associateCollectorToLeaves(sliceCollector_2, directoryReader.leaves().get(1));
+        testQueryProfileBreakdown.getContexts().put(directoryReader.leaves().get(0), leafProfileBreakdown_1);
+        testQueryProfileBreakdown.getContexts().put(directoryReader.leaves().get(1), leafProfileBreakdown_2);
+
+        Map<String, Long> queryBreakDownMap = testQueryProfileBreakdown.toBreakdownMap();
+        assertFalse(queryBreakDownMap == null || queryBreakDownMap.isEmpty());
+        assertEquals(66, queryBreakDownMap.size());
+
+        for (QueryTimingType queryTimingType : QueryTimingType.values()) {
+            String timingTypeKey = queryTimingType.toString();
+            String timingTypeCountKey = queryTimingType + TIMING_TYPE_COUNT_SUFFIX;
+
+            if (queryTimingType.equals(QueryTimingType.CREATE_WEIGHT)) {
+                final long createWeightTime = queryBreakDownMap.get(timingTypeKey);
+                assertEquals(createWeightTimer.getApproximateTiming(), createWeightTime);
+                assertEquals(1, (long) queryBreakDownMap.get(timingTypeCountKey));
+                // verify there is no min/max/avg for weight type stats
+                assertFalse(
+                    queryBreakDownMap.containsKey(ConcurrentQueryProfileBreakdown.MAX_PREFIX + timingTypeKey)
+                        || queryBreakDownMap.containsKey(MIN_PREFIX + timingTypeKey)
+                        || queryBreakDownMap.containsKey(ConcurrentQueryProfileBreakdown.AVG_PREFIX + timingTypeKey)
+                        || queryBreakDownMap.containsKey(ConcurrentQueryProfileBreakdown.MAX_PREFIX + timingTypeCountKey)
+                        || queryBreakDownMap.containsKey(MIN_PREFIX + timingTypeCountKey)
+                        || queryBreakDownMap.containsKey(ConcurrentQueryProfileBreakdown.AVG_PREFIX + timingTypeCountKey)
+                );
+                continue;
+            }
+            assertEquals(50, (long) queryBreakDownMap.get(timingTypeKey));
+            assertEquals(20, (long) queryBreakDownMap.get(ConcurrentQueryProfileBreakdown.MAX_PREFIX + timingTypeKey));
+            assertEquals(15, (long) queryBreakDownMap.get(ConcurrentQueryProfileBreakdown.AVG_PREFIX + timingTypeKey));
+            assertEquals(10, (long) queryBreakDownMap.get(MIN_PREFIX + timingTypeKey));
+            assertEquals(2, (long) queryBreakDownMap.get(timingTypeCountKey));
+            assertEquals(1, (long) queryBreakDownMap.get(ConcurrentQueryProfileBreakdown.MAX_PREFIX + timingTypeCountKey));
+            assertEquals(1, (long) queryBreakDownMap.get(MIN_PREFIX + timingTypeCountKey));
+            assertEquals(1, (long) queryBreakDownMap.get(ConcurrentQueryProfileBreakdown.AVG_PREFIX + timingTypeCountKey));
+        }
+
+        assertEquals(60, testQueryProfileBreakdown.getMaxSliceNodeTime());
+        assertEquals(20, testQueryProfileBreakdown.getMinSliceNodeTime());
+        assertEquals(40, testQueryProfileBreakdown.getAvgSliceNodeTime());
+        directoryReader.close();
+        directory.close();
+    }
+
+    private Map<String, Long> getLeafBreakdownMap(long startTime, long timeTaken, long count) {
+        Map<String, Long> leafBreakDownMap = new HashMap<>();
+        for (QueryTimingType timingType : QueryTimingType.values()) {
+            if (timingType.equals(QueryTimingType.CREATE_WEIGHT)) {
+                // don't add anything
+                continue;
+            }
+            String timingTypeKey = timingType.toString();
+            leafBreakDownMap.put(timingTypeKey, timeTaken);
+            leafBreakDownMap.put(timingTypeKey + TIMING_TYPE_COUNT_SUFFIX, count);
+            leafBreakDownMap.put(timingTypeKey + TIMING_TYPE_START_TIME_SUFFIX, startTime);
+        }
+        return leafBreakDownMap;
+    }
+
+    private DirectoryReader getDirectoryReader(int numLeaves) throws Exception {
+        final Directory directory = newDirectory();
+        IndexWriter iw = new IndexWriter(directory, new IndexWriterConfig(new StandardAnalyzer()).setMergePolicy(NoMergePolicy.INSTANCE));
+
+        for (int i = 0; i < numLeaves; ++i) {
+            Document document = new Document();
+            document.add(new StringField("field1", "value" + i, Field.Store.NO));
+            document.add(new StringField("field2", "value" + i, Field.Store.NO));
+            iw.addDocument(document);
+            iw.commit();
+        }
+        iw.deleteDocuments(new Term("field1", "value3"));
+        iw.close();
+        return DirectoryReader.open(directory);
+    }
+
+    private static class TestQueryProfileBreakdown extends AbstractProfileBreakdown<QueryTimingType> {
+        private Map<String, Long> breakdownMap;
+
+        public TestQueryProfileBreakdown(Class<QueryTimingType> clazz, Map<String, Long> breakdownMap) {
+            super(clazz);
+            this.breakdownMap = breakdownMap;
+        }
+
+        @Override
+        public Map<String, Long> toBreakdownMap() {
+            return breakdownMap;
+        }
+    }
+}

--- a/server/src/test/java/org/opensearch/search/profile/query/QueryProfilerTests.java
+++ b/server/src/test/java/org/opensearch/search/profile/query/QueryProfilerTests.java
@@ -81,6 +81,9 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -89,6 +92,10 @@ public class QueryProfilerTests extends OpenSearchTestCase {
     private IndexReader reader;
     private ContextIndexSearcher searcher;
     private ExecutorService executor;
+    private static final String MAX_PREFIX = "max_";
+    private static final String MIN_PREFIX = "min_";
+    private static final String AVG_PREFIX = "avg_";
+    private static final String TIMING_TYPE_COUNT_SUFFIX = "_count";
 
     @ParametersFactory
     public static Collection<Object[]> concurrency() {
@@ -160,7 +167,8 @@ public class QueryProfilerTests extends OpenSearchTestCase {
         searcher.search(query, 1);
         List<ProfileResult> results = profiler.getTree();
         assertEquals(1, results.size());
-        Map<String, Long> breakdown = results.get(0).getTimeBreakdown();
+        ProfileResult profileResult = results.get(0);
+        Map<String, Long> breakdown = profileResult.getTimeBreakdown();
         assertThat(breakdown.get(QueryTimingType.CREATE_WEIGHT.toString()), greaterThan(0L));
         assertThat(breakdown.get(QueryTimingType.BUILD_SCORER.toString()), greaterThan(0L));
         assertThat(breakdown.get(QueryTimingType.NEXT_DOC.toString()), greaterThan(0L));
@@ -168,12 +176,52 @@ public class QueryProfilerTests extends OpenSearchTestCase {
         assertThat(breakdown.get(QueryTimingType.SCORE.toString()), greaterThan(0L));
         assertThat(breakdown.get(QueryTimingType.MATCH.toString()), equalTo(0L));
 
-        assertThat(breakdown.get(QueryTimingType.CREATE_WEIGHT.toString() + "_count"), greaterThan(0L));
-        assertThat(breakdown.get(QueryTimingType.BUILD_SCORER.toString() + "_count"), greaterThan(0L));
-        assertThat(breakdown.get(QueryTimingType.NEXT_DOC.toString() + "_count"), greaterThan(0L));
-        assertThat(breakdown.get(QueryTimingType.ADVANCE.toString() + "_count"), equalTo(0L));
-        assertThat(breakdown.get(QueryTimingType.SCORE.toString() + "_count"), greaterThan(0L));
-        assertThat(breakdown.get(QueryTimingType.MATCH.toString() + "_count"), equalTo(0L));
+        assertThat(breakdown.get(QueryTimingType.CREATE_WEIGHT + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+        assertThat(breakdown.get(QueryTimingType.BUILD_SCORER + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+        assertThat(breakdown.get(QueryTimingType.NEXT_DOC + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+        assertThat(breakdown.get(QueryTimingType.ADVANCE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+        assertThat(breakdown.get(QueryTimingType.SCORE + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+        assertThat(breakdown.get(QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+
+        if (executor != null) {
+            assertThat(profileResult.getMaxSliceTime(), is(not(nullValue())));
+            assertThat(profileResult.getMinSliceTime(), is(not(nullValue())));
+            assertThat(profileResult.getAvgSliceTime(), is(not(nullValue())));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.BUILD_SCORER), greaterThan(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.BUILD_SCORER), greaterThan(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.BUILD_SCORER), greaterThan(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.NEXT_DOC), greaterThan(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.NEXT_DOC), greaterThan(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.NEXT_DOC), greaterThan(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.ADVANCE), equalTo(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.ADVANCE), equalTo(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.ADVANCE), equalTo(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.SCORE), greaterThan(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.SCORE), greaterThan(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.SCORE), greaterThan(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.MATCH), equalTo(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.MATCH), equalTo(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.MATCH), equalTo(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.BUILD_SCORER + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.BUILD_SCORER + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.BUILD_SCORER + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.NEXT_DOC + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.NEXT_DOC + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.NEXT_DOC + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.ADVANCE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.ADVANCE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.ADVANCE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.SCORE + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.SCORE + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.SCORE + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+        } else {
+            assertThat(profileResult.getMaxSliceTime(), is(nullValue()));
+            assertThat(profileResult.getMinSliceTime(), is(nullValue()));
+            assertThat(profileResult.getAvgSliceTime(), is(nullValue()));
+        }
 
         long rewriteTime = profiler.getRewriteTime();
         assertThat(rewriteTime, greaterThan(0L));
@@ -186,7 +234,8 @@ public class QueryProfilerTests extends OpenSearchTestCase {
         searcher.search(query, 1, Sort.INDEXORDER); // scores are not needed
         List<ProfileResult> results = profiler.getTree();
         assertEquals(1, results.size());
-        Map<String, Long> breakdown = results.get(0).getTimeBreakdown();
+        ProfileResult profileResult = results.get(0);
+        Map<String, Long> breakdown = profileResult.getTimeBreakdown();
         assertThat(breakdown.get(QueryTimingType.CREATE_WEIGHT.toString()), greaterThan(0L));
         assertThat(breakdown.get(QueryTimingType.BUILD_SCORER.toString()), greaterThan(0L));
         assertThat(breakdown.get(QueryTimingType.NEXT_DOC.toString()), greaterThan(0L));
@@ -194,12 +243,52 @@ public class QueryProfilerTests extends OpenSearchTestCase {
         assertThat(breakdown.get(QueryTimingType.SCORE.toString()), equalTo(0L));
         assertThat(breakdown.get(QueryTimingType.MATCH.toString()), equalTo(0L));
 
-        assertThat(breakdown.get(QueryTimingType.CREATE_WEIGHT.toString() + "_count"), greaterThan(0L));
-        assertThat(breakdown.get(QueryTimingType.BUILD_SCORER.toString() + "_count"), greaterThan(0L));
-        assertThat(breakdown.get(QueryTimingType.NEXT_DOC.toString() + "_count"), greaterThan(0L));
-        assertThat(breakdown.get(QueryTimingType.ADVANCE.toString() + "_count"), equalTo(0L));
-        assertThat(breakdown.get(QueryTimingType.SCORE.toString() + "_count"), equalTo(0L));
-        assertThat(breakdown.get(QueryTimingType.MATCH.toString() + "_count"), equalTo(0L));
+        assertThat(breakdown.get(QueryTimingType.CREATE_WEIGHT + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+        assertThat(breakdown.get(QueryTimingType.BUILD_SCORER + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+        assertThat(breakdown.get(QueryTimingType.NEXT_DOC + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+        assertThat(breakdown.get(QueryTimingType.ADVANCE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+        assertThat(breakdown.get(QueryTimingType.SCORE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+        assertThat(breakdown.get(QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+
+        if (executor != null) {
+            assertThat(profileResult.getMaxSliceTime(), is(not(nullValue())));
+            assertThat(profileResult.getMinSliceTime(), is(not(nullValue())));
+            assertThat(profileResult.getAvgSliceTime(), is(not(nullValue())));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.BUILD_SCORER), greaterThan(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.BUILD_SCORER), greaterThan(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.BUILD_SCORER), greaterThan(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.NEXT_DOC), greaterThan(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.NEXT_DOC), greaterThan(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.NEXT_DOC), greaterThan(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.ADVANCE), equalTo(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.ADVANCE), equalTo(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.ADVANCE), equalTo(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.SCORE), equalTo(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.SCORE), equalTo(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.SCORE), equalTo(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.MATCH), equalTo(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.MATCH), equalTo(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.MATCH), equalTo(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.BUILD_SCORER + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.BUILD_SCORER + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.BUILD_SCORER + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.NEXT_DOC + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.NEXT_DOC + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.NEXT_DOC + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.ADVANCE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.ADVANCE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.ADVANCE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.SCORE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.SCORE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.SCORE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+        } else {
+            assertThat(profileResult.getMaxSliceTime(), is(nullValue()));
+            assertThat(profileResult.getMinSliceTime(), is(nullValue()));
+            assertThat(profileResult.getAvgSliceTime(), is(nullValue()));
+        }
 
         long rewriteTime = profiler.getRewriteTime();
         assertThat(rewriteTime, greaterThan(0L));
@@ -226,7 +315,8 @@ public class QueryProfilerTests extends OpenSearchTestCase {
         searcher.count(query);
         List<ProfileResult> results = profiler.getTree();
         assertEquals(1, results.size());
-        Map<String, Long> breakdown = results.get(0).getTimeBreakdown();
+        ProfileResult profileResult = results.get(0);
+        Map<String, Long> breakdown = profileResult.getTimeBreakdown();
         assertThat(breakdown.get(QueryTimingType.CREATE_WEIGHT.toString()), greaterThan(0L));
         assertThat(breakdown.get(QueryTimingType.BUILD_SCORER.toString()), greaterThan(0L));
         assertThat(breakdown.get(QueryTimingType.NEXT_DOC.toString()), greaterThan(0L));
@@ -234,12 +324,52 @@ public class QueryProfilerTests extends OpenSearchTestCase {
         assertThat(breakdown.get(QueryTimingType.SCORE.toString()), equalTo(0L));
         assertThat(breakdown.get(QueryTimingType.MATCH.toString()), greaterThan(0L));
 
-        assertThat(breakdown.get(QueryTimingType.CREATE_WEIGHT.toString() + "_count"), greaterThan(0L));
-        assertThat(breakdown.get(QueryTimingType.BUILD_SCORER.toString() + "_count"), greaterThan(0L));
-        assertThat(breakdown.get(QueryTimingType.NEXT_DOC.toString() + "_count"), greaterThan(0L));
-        assertThat(breakdown.get(QueryTimingType.ADVANCE.toString() + "_count"), equalTo(0L));
-        assertThat(breakdown.get(QueryTimingType.SCORE.toString() + "_count"), equalTo(0L));
-        assertThat(breakdown.get(QueryTimingType.MATCH.toString() + "_count"), greaterThan(0L));
+        assertThat(breakdown.get(QueryTimingType.CREATE_WEIGHT + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+        assertThat(breakdown.get(QueryTimingType.BUILD_SCORER + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+        assertThat(breakdown.get(QueryTimingType.NEXT_DOC + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+        assertThat(breakdown.get(QueryTimingType.ADVANCE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+        assertThat(breakdown.get(QueryTimingType.SCORE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+        assertThat(breakdown.get(QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+
+        if (executor != null) {
+            assertThat(profileResult.getMaxSliceTime(), is(not(nullValue())));
+            assertThat(profileResult.getMinSliceTime(), is(not(nullValue())));
+            assertThat(profileResult.getAvgSliceTime(), is(not(nullValue())));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.BUILD_SCORER), greaterThan(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.BUILD_SCORER), greaterThan(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.BUILD_SCORER), greaterThan(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.NEXT_DOC), greaterThan(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.NEXT_DOC), greaterThan(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.NEXT_DOC), greaterThan(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.ADVANCE), equalTo(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.ADVANCE), equalTo(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.ADVANCE), equalTo(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.SCORE), equalTo(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.SCORE), equalTo(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.SCORE), equalTo(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.MATCH), greaterThan(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.MATCH), greaterThan(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.MATCH), greaterThan(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.BUILD_SCORER + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.BUILD_SCORER + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.BUILD_SCORER + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.NEXT_DOC + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.NEXT_DOC + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.NEXT_DOC + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.ADVANCE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.ADVANCE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.ADVANCE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.SCORE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.SCORE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.SCORE + TIMING_TYPE_COUNT_SUFFIX), equalTo(0L));
+            assertThat(breakdown.get(MAX_PREFIX + QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(MIN_PREFIX + QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+            assertThat(breakdown.get(AVG_PREFIX + QueryTimingType.MATCH + TIMING_TYPE_COUNT_SUFFIX), greaterThan(0L));
+        } else {
+            assertThat(profileResult.getMaxSliceTime(), is(nullValue()));
+            assertThat(profileResult.getMinSliceTime(), is(nullValue()));
+            assertThat(profileResult.getAvgSliceTime(), is(nullValue()));
+        }
 
         long rewriteTime = profiler.getRewriteTime();
         assertThat(rewriteTime, greaterThan(0L));

--- a/server/src/test/java/org/opensearch/search/query/QueryProfilePhaseTests.java
+++ b/server/src/test/java/org/opensearch/search/query/QueryProfilePhaseTests.java
@@ -338,6 +338,14 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
             assertThat(query.getTimeBreakdown().keySet(), not(empty()));
             assertThat(query.getTimeBreakdown().get("score"), greaterThanOrEqualTo(100L));
             assertThat(query.getTimeBreakdown().get("score_count"), equalTo(1L));
+            if (executor != null) {
+                assertThat(query.getTimeBreakdown().get("max_score"), greaterThanOrEqualTo(100L));
+                assertThat(query.getTimeBreakdown().get("min_score"), greaterThanOrEqualTo(100L));
+                assertThat(query.getTimeBreakdown().get("avg_score"), greaterThanOrEqualTo(100L));
+                assertThat(query.getTimeBreakdown().get("max_score_count"), equalTo(1L));
+                assertThat(query.getTimeBreakdown().get("min_score_count"), equalTo(1L));
+                assertThat(query.getTimeBreakdown().get("avg_score_count"), equalTo(1L));
+            }
             assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
         }, collector -> {
@@ -477,6 +485,14 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
                 assertThat(query.getTimeBreakdown().keySet(), not(empty()));
                 assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("score_count"), greaterThan(0L));
+                if (executor != null) {
+                    assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
+                    assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
+                    assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
+                    assertThat(query.getTimeBreakdown().get("max_score_count"), greaterThan(0L));
+                    assertThat(query.getTimeBreakdown().get("min_score_count"), greaterThan(0L));
+                    assertThat(query.getTimeBreakdown().get("avg_score_count"), greaterThan(0L));
+                }
                 assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
             }, collector -> {
@@ -547,6 +563,14 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
                 assertThat(query.getTimeBreakdown().keySet(), not(empty()));
                 assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("score_count"), greaterThan(0L));
+                if (executor != null) {
+                    assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
+                    assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
+                    assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
+                    assertThat(query.getTimeBreakdown().get("max_score_count"), greaterThan(0L));
+                    assertThat(query.getTimeBreakdown().get("min_score_count"), greaterThan(0L));
+                    assertThat(query.getTimeBreakdown().get("avg_score_count"), greaterThan(0L));
+                }
                 assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
             }, collector -> {
@@ -585,6 +609,14 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
                 assertThat(query.getTimeBreakdown().keySet(), not(empty()));
                 assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("score_count"), greaterThan(0L));
+                if (executor != null) {
+                    assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
+                    assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
+                    assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
+                    assertThat(query.getTimeBreakdown().get("max_score_count"), greaterThan(0L));
+                    assertThat(query.getTimeBreakdown().get("min_score_count"), greaterThan(0L));
+                    assertThat(query.getTimeBreakdown().get("avg_score_count"), greaterThan(0L));
+                }
                 assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
 
@@ -709,6 +741,14 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
                 assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
                 assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("score"), greaterThan(0L));
                 assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("score_count"), greaterThan(0L));
+                if (executor != null) {
+                    assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("max_score"), greaterThan(0L));
+                    assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("min_score"), greaterThan(0L));
+                    assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("avg_score"), greaterThan(0L));
+                    assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("max_score_count"), greaterThan(0L));
+                    assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("min_score_count"), greaterThan(0L));
+                    assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("avg_score_count"), greaterThan(0L));
+                }
 
                 assertThat(query.getProfiledChildren().get(1).getQueryName(), equalTo("TermQuery"));
                 assertThat(query.getProfiledChildren().get(1).getTime(), greaterThan(0L));
@@ -716,6 +756,14 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
                 assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
                 assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("score"), greaterThan(0L));
                 assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("score_count"), greaterThan(0L));
+                if (executor != null) {
+                    assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("max_score"), greaterThan(0L));
+                    assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("min_score"), greaterThan(0L));
+                    assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("avg_score"), greaterThan(0L));
+                    assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("max_score_count"), greaterThan(0L));
+                    assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("min_score_count"), greaterThan(0L));
+                    assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("avg_score_count"), greaterThan(0L));
+                }
             }, collector -> {
                 assertThat(collector.getReason(), equalTo("search_terminate_after_count"));
                 assertThat(collector.getTime(), greaterThan(0L));
@@ -1054,6 +1102,14 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
             assertThat(query.getTimeBreakdown().keySet(), not(empty()));
             assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("score_count"), greaterThan(0L));
+            if (executor != null) {
+                assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("max_score_count"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("min_score_count"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("avg_score_count"), greaterThan(0L));
+            }
             assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
         }, collector -> {
@@ -1133,6 +1189,14 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
             assertThat(query.getTimeBreakdown().keySet(), not(empty()));
             assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("score_count"), equalTo(10L));
+            if (executor != null) {
+                assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("max_score_count"), equalTo(10L));
+                assertThat(query.getTimeBreakdown().get("min_score_count"), equalTo(10L));
+                assertThat(query.getTimeBreakdown().get("avg_score_count"), equalTo(10L));
+            }
             assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
 
@@ -1210,6 +1274,14 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
             assertThat(query.getTimeBreakdown().keySet(), not(empty()));
             assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("score_count"), greaterThanOrEqualTo(6L));
+            if (executor != null) {
+                assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("min_score"), greaterThanOrEqualTo(0L));
+                assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("max_score_count"), greaterThanOrEqualTo(6L));
+                assertThat(query.getTimeBreakdown().get("min_score_count"), greaterThanOrEqualTo(0L));
+                assertThat(query.getTimeBreakdown().get("avg_score_count"), greaterThanOrEqualTo(1L));
+            }
             assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
 
@@ -1245,6 +1317,14 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
             assertThat(query.getTimeBreakdown().keySet(), not(empty()));
             assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("score_count"), greaterThanOrEqualTo(6L));
+            if (executor != null) {
+                assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("max_score_count"), greaterThanOrEqualTo(6L));
+                assertThat(query.getTimeBreakdown().get("min_score_count"), greaterThanOrEqualTo(0L));
+                assertThat(query.getTimeBreakdown().get("avg_score_count"), greaterThanOrEqualTo(1L));
+            }
             assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
 
@@ -1315,6 +1395,14 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
             assertThat(query.getTimeBreakdown().keySet(), not(empty()));
             assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("score_count"), greaterThanOrEqualTo(6L));
+            if (executor != null) {
+                assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("max_score_count"), greaterThanOrEqualTo(6L));
+                assertThat(query.getTimeBreakdown().get("min_score_count"), greaterThanOrEqualTo(6L));
+                assertThat(query.getTimeBreakdown().get("avg_score_count"), greaterThanOrEqualTo(6L));
+            }
             assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
             assertThat(query.getProfiledChildren(), empty());
@@ -1342,6 +1430,14 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
             assertThat(query.getTimeBreakdown().keySet(), not(empty()));
             assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("score_count"), greaterThanOrEqualTo(6L));
+            if (executor != null) {
+                assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("max_score_count"), greaterThanOrEqualTo(6L));
+                assertThat(query.getTimeBreakdown().get("min_score_count"), greaterThanOrEqualTo(6L));
+                assertThat(query.getTimeBreakdown().get("avg_score_count"), greaterThanOrEqualTo(6L));
+            }
             assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
             assertThat(query.getProfiledChildren(), empty());


### PR DESCRIPTION
(cherry picked from commit https://github.com/opensearch-project/OpenSearch/commit/a7374460aa0e91b5af4859458e771e5b2525b9e2)

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
At present, the query profiler is the total timing obtained by summing all segments. However, this does not accurately represent the detailed timing of the query, including queue time and gap time, during concurrent execution. This PR will address the problem.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/8330 https://github.com/opensearch-project/OpenSearch/issues/7354
<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
