### PR TITLE
Fix flaky behavior of RemoteStoreRestoreIT.testRateLimitedRemoteDownloads

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreBaseIntegTestCase.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreBaseIntegTestCase.java
@@ -230,7 +230,7 @@ public class RemoteStoreBaseIntegTestCase extends OpenSearchIntegTestCase {
 
         if (withRateLimiterAttributes) {
             settings.put(segmentRepoSettingsAttributeKeyPrefix + "compress", randomBoolean())
-                .put(segmentRepoSettingsAttributeKeyPrefix + "max_remote_download_bytes_per_sec", "2kb")
+                .put(segmentRepoSettingsAttributeKeyPrefix + "max_remote_download_bytes_per_sec", "4kb")
                 .put(segmentRepoSettingsAttributeKeyPrefix + "chunk_size", 200, ByteSizeUnit.BYTES);
         }
 

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreRestoreIT.java
@@ -406,7 +406,7 @@ public class RemoteStoreRestoreIT extends BaseRemoteStoreRestoreIT {
             for (RepositoriesService repositoriesService : internalCluster().getDataNodeInstances(RepositoriesService.class)) {
                 downloadPauseTime += repositoriesService.repository(REPOSITORY_NAME).getRemoteDownloadThrottleTimeInNanos();
             }
-            assertThat(downloadPauseTime, greaterThan(TimeValue.timeValueSeconds(randomIntBetween(5, 10)).nanos()));
+            assertThat(downloadPauseTime, greaterThan(TimeValue.timeValueSeconds(randomIntBetween(3, 5)).nanos()));
         }, 30, TimeUnit.SECONDS);
         // Waiting for extended period for green state so that rate limit does not cause flakiness
         ensureGreen(TimeValue.timeValueSeconds(120), INDEX_NAME);

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreRestoreIT.java
@@ -408,7 +408,8 @@ public class RemoteStoreRestoreIT extends BaseRemoteStoreRestoreIT {
             }
             assertThat(downloadPauseTime, greaterThan(TimeValue.timeValueSeconds(randomIntBetween(5, 10)).nanos()));
         }, 30, TimeUnit.SECONDS);
-        ensureGreen(INDEX_NAME);
+        // Waiting for extended period for green state so that rate limit does not cause flakiness
+        ensureGreen(TimeValue.timeValueSeconds(120), INDEX_NAME);
         // This is required to get updated number from already active shards which were not restored
         assertEquals(shardCount, getNumShards(INDEX_NAME).totalNumShards);
         assertEquals(0, getNumShards(INDEX_NAME).numReplicas);

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -283,7 +283,6 @@ public class RemoteClusterStateService implements Closeable {
      * @param clusterState current ClusterState
      * @param toUpload list of IndexMetadata to upload
      * @return {@code List<UploadedIndexMetadata>} list of IndexMetadata uploaded to remote
-     * @throws IOException
      */
     private List<UploadedIndexMetadata> writeIndexMetadataParallel(ClusterState clusterState, List<IndexMetadata> toUpload)
         throws IOException {
@@ -358,7 +357,6 @@ public class RemoteClusterStateService implements Closeable {
      * @param clusterState current ClusterState
      * @param indexMetadata {@link IndexMetadata} to upload
      * @param latchedActionListener listener to respond back on after upload finishes
-     * @throws IOException
      */
     private void writeIndexMetadataAsync(
         ClusterState clusterState,

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -283,6 +283,7 @@ public class RemoteClusterStateService implements Closeable {
      * @param clusterState current ClusterState
      * @param toUpload list of IndexMetadata to upload
      * @return {@code List<UploadedIndexMetadata>} list of IndexMetadata uploaded to remote
+     * @throws IOException
      */
     private List<UploadedIndexMetadata> writeIndexMetadataParallel(ClusterState clusterState, List<IndexMetadata> toUpload)
         throws IOException {
@@ -357,6 +358,7 @@ public class RemoteClusterStateService implements Closeable {
      * @param clusterState current ClusterState
      * @param indexMetadata {@link IndexMetadata} to upload
      * @param latchedActionListener listener to respond back on after upload finishes
+     * @throws IOException
      */
     private void writeIndexMetadataAsync(
         ClusterState clusterState,


### PR DESCRIPTION
### Description
- [org.opensearch.remotestore.RemoteStoreRestoreIT.testRateLimitedRemoteDownloads](https://build.ci.opensearch.org/job/gradle-check/24888/testReport/junit/org.opensearch.remotestore/RemoteStoreRestoreIT/testRateLimitedRemoteDownloads/) test slows down restore by adding rate limit in repository settings.
- Due to the rate limit, if the recovery takes more time, `ensureGreen` check fails, making the test flaky.
- In this change, we increase timeout of `ensureGreen` from default 30secs to 120secs
- One of the failed builds: https://build.ci.opensearch.org/job/gradle-check/24888/

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
