### PR TITLE
Fix ReadContextListenerTests to avoid inconsistent WindowsFS file han…

### DIFF
--- a/server/src/test/java/org/opensearch/common/blobstore/stream/read/listener/ReadContextListenerTests.java
+++ b/server/src/test/java/org/opensearch/common/blobstore/stream/read/listener/ReadContextListenerTests.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.common.blobstore.stream.read.listener;
 
+import org.apache.lucene.tests.util.LuceneTestCase.SuppressFileSystems;
 import org.opensearch.action.LatchedActionListener;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.common.blobstore.stream.read.ReadContext;
@@ -32,6 +33,12 @@ import java.util.concurrent.CountDownLatch;
 
 import static org.opensearch.common.blobstore.stream.read.listener.ListenerTestUtils.CountingCompletionListener;
 
+/*
+    WindowsFS tries to simulate file handles in a best case simulation.
+    The deletion for the open file on an actual Windows system will be performed as soon as the last handle
+    is closed, which this simulation does not account for. Preventing use of WindowsFS for these tests.
+ */
+@SuppressFileSystems("WindowsFS")
 public class ReadContextListenerTests extends OpenSearchTestCase {
 
     private Path path;
@@ -70,7 +77,6 @@ public class ReadContextListenerTests extends OpenSearchTestCase {
         assertEquals(NUMBER_OF_PARTS * PART_SIZE, Files.size(fileLocation));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/9776")
     public void testReadContextListenerFailure() throws Exception {
         Path fileLocation = path.resolve(UUID.randomUUID().toString());
         List<InputStreamContainer> blobPartStreams = initializeBlobPartStreams();
@@ -100,7 +106,7 @@ public class ReadContextListenerTests extends OpenSearchTestCase {
         readContextListener.onResponse(readContext);
 
         countDownLatch.await();
-        assertBusy(() -> { assertFalse(Files.exists(fileLocation)); });
+        assertFalse(Files.exists(fileLocation));
     }
 
     public void testReadContextListenerException() {


### PR DESCRIPTION
…dle simulation

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
- Fixes `ReadContextListenerTests` to avoid inconsistent WindowsFS file handle simulation

### Related Issues
Resolves #9776 
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
