### PR TITLE
Parameterize tests with OpenSearchIntegTestCase.SuiteScopeTestCase annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Cleanup Unreferenced file on segment merge failure ([#9503](https://github.com/opensearch-project/OpenSearch/pull/9503))
 - Move ZStd to a plugin ([#9658](https://github.com/opensearch-project/OpenSearch/pull/9658))
 - [Remote Store] Add support for Remote Translog Store upload stats in `_nodes/stats/` API ([#8908](https://github.com/opensearch-project/OpenSearch/pull/8908))
+- Allow parameterization of tests with OpenSearchIntegTestCase.SuiteScopeTestCase annotation ([#9916](https://github.com/opensearch-project/OpenSearch/pull/9916))
 
 ### Deprecated
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/MissingValueIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/MissingValueIT.java
@@ -32,8 +32,12 @@
 
 package org.opensearch.search.aggregations;
 
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.common.geo.GeoPoint;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.opensearch.search.aggregations.bucket.histogram.Histogram;
 import org.opensearch.search.aggregations.bucket.terms.Terms;
@@ -43,7 +47,12 @@ import org.opensearch.search.aggregations.metrics.GeoCentroid;
 import org.opensearch.search.aggregations.metrics.Percentiles;
 import org.opensearch.search.aggregations.metrics.Stats;
 import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
 
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.opensearch.search.SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING;
 import static org.opensearch.search.aggregations.AggregationBuilders.cardinality;
 import static org.opensearch.search.aggregations.AggregationBuilders.dateHistogram;
 import static org.opensearch.search.aggregations.AggregationBuilders.geoCentroid;
@@ -56,7 +65,24 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertSearchResp
 import static org.hamcrest.Matchers.closeTo;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class MissingValueIT extends OpenSearchIntegTestCase {
+public class MissingValueIT extends ParameterizedOpenSearchIntegTestCase {
+
+    public MissingValueIT(Settings dynamicSettings) {
+        super(dynamicSettings);
+    }
+
+    @ParametersFactory
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(
+            new Object[] { Settings.builder().put(CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING.getKey(), false).build() },
+            new Object[] { Settings.builder().put(CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING.getKey(), true).build() }
+        );
+    }
+
+    @Override
+    protected Settings featureFlagSettings() {
+        return Settings.builder().put(super.featureFlagSettings()).put(FeatureFlags.CONCURRENT_SEGMENT_SEARCH, "true").build();
+    }
 
     @Override
     protected int maximumNumberOfShards() {

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
@@ -2316,8 +2316,12 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
          */
         assert INSTANCE == null;
         if (isSuiteScopedTest(targetClass)) {
-            // note we need to do this this way to make sure this is reproducible
-            INSTANCE = (OpenSearchIntegTestCase) targetClass.getConstructor().newInstance();
+            // note we need to do this way to make sure this is reproducible
+            if (isSuiteScopedTestParameterized(targetClass)) {
+                INSTANCE = (OpenSearchIntegTestCase) targetClass.getConstructor(Settings.class).newInstance(Settings.EMPTY);
+            } else {
+                INSTANCE = (OpenSearchIntegTestCase) targetClass.getConstructor().newInstance();
+            }
             boolean success = false;
             try {
                 INSTANCE.printTestMessage("setup");
@@ -2410,6 +2414,16 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
 
     private static boolean isSuiteScopedTest(Class<?> clazz) {
         return clazz.getAnnotation(SuiteScopeTestCase.class) != null;
+    }
+
+    /*
+    * For tests defined with, SuiteScopeTestCase return true if the
+    * class has a constructor that takes a single Settings parameter
+    * */
+    private static boolean isSuiteScopedTestParameterized(Class<?> clazz) {
+        return Arrays.stream(clazz.getConstructors())
+            .filter(x -> x.getParameterTypes().length == 1)
+            .anyMatch(x -> x.getParameterTypes()[0].equals(Settings.class));
     }
 
     /**


### PR DESCRIPTION

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Parameterize tests annotated with @OpenSearchIntegTestCase.SuiteScopeTestCase.
Without this, the parameterization is not working as initializeSuiteScope() expects a default constructor and we have a different constructor with parameterization.
ref: https://build.ci.opensearch.org/job/gradle-check/24979/testReport/junit/org.opensearch.search.aggregations/MissingValueIT/classMethod/
this has many classes failing with this exception: https://build.ci.opensearch.org/job/gradle-check/24979/#showFailuresLink

### Related Issues
Relates #9443 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
