### PR TITLE
Update single comment for check compatibility

### DIFF
--- a/.github/workflows/check-compatibility.yml
+++ b/.github/workflows/check-compatibility.yml
@@ -52,8 +52,18 @@ jobs:
         with:
           name: results.txt
 
+      - name: Find Comment
+        uses: peter-evans/find-comment@v2
+        id: fc
+        with:
+          issue-number: ${{ github.event.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: 'Compatibility status:'
+
       - name: Add comment on the PR
         uses: peter-evans/create-or-update-comment@v3
         with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.number }}
           body-path: results.txt
+          edit-mode: replace


### PR DESCRIPTION
Instead of appending a new comment every time check compatibility runs, this will instead update a single comment with the latest results. The history of previous runs is retained in the comment as GitHub allows you to view the edited revisions of any comment. This matches the behavior of the codecov workflow and should substantially reduce noise in PRs.

Relates #9699

I tested this [on my user fork](https://github.com/andrross/OpenSearch/pull/208#issuecomment-1708952354):

![image](https://github.com/opensearch-project/OpenSearch/assets/9160839/776891ae-0f9a-4255-95f0-d5c8eec65628)

Assuming folks like this approach, I'll do the same thing for the gradle check comment.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
