### PR TITLE
Mute CorrelationCodecTests.testCorrelationVectorIndex

### DIFF
--- a/plugins/events-correlation-engine/src/test/java/org/opensearch/plugin/correlation/core/index/codec/correlation950/CorrelationCodecTests.java
+++ b/plugins/events-correlation-engine/src/test/java/org/opensearch/plugin/correlation/core/index/codec/correlation950/CorrelationCodecTests.java
@@ -51,6 +51,7 @@ public class CorrelationCodecTests extends OpenSearchTestCase {
      * test correlation vector index
      * @throws Exception Exception
      */
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/8329")
     public void testCorrelationVectorIndex() throws Exception {
         Function<MapperService, PerFieldCorrelationVectorsFormat> perFieldCorrelationVectorsProvider =
             mapperService -> new PerFieldCorrelationVectorsFormat(Optional.of(mapperService));


### PR DESCRIPTION
Fix is pending in #7771, but that PR may take some time to land in main so muting for the time being.

Related #8329

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
