### PR TITLE
skip overriding routing table when it already contains entries with remote recovery source

### DIFF
--- a/server/src/main/java/org/opensearch/gateway/ClusterStateUpdaters.java
+++ b/server/src/main/java/org/opensearch/gateway/ClusterStateUpdaters.java
@@ -122,10 +122,12 @@ public class ClusterStateUpdaters {
         final RoutingTable.Builder routingTableBuilder = RoutingTable.builder(state.routingTable());
         for (final IndexMetadata cursor : state.metadata().indices().values()) {
             // Whether IndexMetadata is recovered from local disk or remote it doesn't matter to us at this point.
-            // We are only concerted about index data recovery here. Which is why we only check for remote store enabled and not for remote
+            // We are only concerned about index data recovery here. Which is why we only check for remote store enabled and not for remote
             // cluster state enabled.
             if (cursor.getSettings().getAsBoolean(IndexMetadata.SETTING_REMOTE_STORE_ENABLED, false) == false
+                || state.routingTable().hasIndex(cursor.getIndex()) == false
                 || state.routingTable()
+                    .index(cursor.getIndex())
                     .shardsMatchingPredicateCount(
                         shardRouting -> shardRouting.primary()
                             // We need to ensure atleast one of the primaries is being recovered from remote.

--- a/server/src/main/java/org/opensearch/gateway/ClusterStateUpdaters.java
+++ b/server/src/main/java/org/opensearch/gateway/ClusterStateUpdaters.java
@@ -41,6 +41,7 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.cluster.routing.RecoverySource;
 import org.opensearch.cluster.routing.RoutingTable;
 import org.opensearch.common.settings.ClusterSettings;
 
@@ -120,7 +121,19 @@ public class ClusterStateUpdaters {
         // initialize all index routing tables as empty
         final RoutingTable.Builder routingTableBuilder = RoutingTable.builder(state.routingTable());
         for (final IndexMetadata cursor : state.metadata().indices().values()) {
-            routingTableBuilder.addAsRecovery(cursor);
+            // Whether IndexMetadata is recovered from local disk or remote it doesn't matter to us at this point.
+            // We are only concerted about index data recovery here. Which is why we only check for remote store enabled and not for remote
+            // cluster state enabled.
+            if (cursor.getSettings().getAsBoolean(IndexMetadata.SETTING_REMOTE_STORE_ENABLED, false) == false
+                || state.routingTable()
+                    .shardsMatchingPredicateCount(
+                        shardRouting -> shardRouting.primary()
+                            // We need to ensure atleast one of the primaries is being recovered from remote.
+                            // This ensures we have gone through the RemoteStoreRestoreService and routing table is updated
+                            && shardRouting.recoverySource() instanceof RecoverySource.RemoteStoreRecoverySource
+                    ) == 0) {
+                routingTableBuilder.addAsRecovery(cursor);
+            }
         }
         // start with 0 based versions for routing table
         routingTableBuilder.version(0);

--- a/server/src/main/java/org/opensearch/index/recovery/RemoteStoreRestoreService.java
+++ b/server/src/main/java/org/opensearch/index/recovery/RemoteStoreRestoreService.java
@@ -187,7 +187,7 @@ public class RemoteStoreRestoreService {
             IndexMetadata indexMetadata = indexMetadataEntry.getValue().v2();
             boolean metadataFromRemoteStore = indexMetadataEntry.getValue().v1();
             IndexMetadata updatedIndexMetadata = indexMetadata;
-            if (restoreAllShards || metadataFromRemoteStore) {
+            if (restoreAllShards) {
                 updatedIndexMetadata = IndexMetadata.builder(indexMetadata)
                     .state(IndexMetadata.State.OPEN)
                     .version(1 + indexMetadata.getVersion())

--- a/server/src/main/java/org/opensearch/index/recovery/RemoteStoreRestoreService.java
+++ b/server/src/main/java/org/opensearch/index/recovery/RemoteStoreRestoreService.java
@@ -187,7 +187,7 @@ public class RemoteStoreRestoreService {
             IndexMetadata indexMetadata = indexMetadataEntry.getValue().v2();
             boolean metadataFromRemoteStore = indexMetadataEntry.getValue().v1();
             IndexMetadata updatedIndexMetadata = indexMetadata;
-            if (restoreAllShards) {
+            if (metadataFromRemoteStore == false && restoreAllShards) {
                 updatedIndexMetadata = IndexMetadata.builder(indexMetadata)
                     .state(IndexMetadata.State.OPEN)
                     .version(1 + indexMetadata.getVersion())

--- a/server/src/test/java/org/opensearch/gateway/ClusterStateUpdatersTests.java
+++ b/server/src/test/java/org/opensearch/gateway/ClusterStateUpdatersTests.java
@@ -40,6 +40,10 @@ import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.metadata.MetadataIndexStateService;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodeRole;
+import org.opensearch.cluster.routing.IndexRoutingTable;
+import org.opensearch.cluster.routing.RecoverySource;
+import org.opensearch.cluster.routing.RoutingTable;
+import org.opensearch.cluster.routing.UnassignedInfo;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.settings.ClusterSettings;
@@ -48,10 +52,12 @@ import org.opensearch.common.settings.SettingUpgrader;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.set.Sets;
 import org.opensearch.core.index.Index;
+import org.opensearch.repositories.IndexId;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -266,6 +272,214 @@ public class ClusterStateUpdatersTests extends OpenSearchTestCase {
             assertTrue(newState.routingTable().hasIndex(index));
             assertThat(newState.routingTable().version(), is(0L));
             assertThat(newState.routingTable().allShards(index.getName()).size(), is(numOfShards));
+        }
+    }
+
+    public void testSkipRoutingTableUpdateWhenRemoteRecovery() {
+        final int numOfShards = randomIntBetween(1, 10);
+
+        final IndexMetadata remoteMetadata = createIndexMetadata(
+            "test-remote",
+            Settings.builder()
+                .put(IndexMetadata.SETTING_REMOTE_STORE_ENABLED, true)
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numOfShards)
+                .build()
+        );
+        final IndexMetadata nonRemoteMetadata = createIndexMetadata(
+            "test-nonremote",
+            Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numOfShards).build()
+        );
+        {
+            IndexRoutingTable.Builder remoteBuilderWithoutRemoteRecovery = new IndexRoutingTable.Builder(remoteMetadata.getIndex())
+                .initializeAsNew(remoteMetadata);
+            final Index index = remoteMetadata.getIndex();
+            final ClusterState initialState = ClusterState.builder(ClusterState.EMPTY_STATE)
+                .metadata(Metadata.builder().put(remoteMetadata, false).build())
+                .routingTable(new RoutingTable.Builder().add(remoteBuilderWithoutRemoteRecovery.build()).build())
+                .build();
+            assertTrue(initialState.routingTable().hasIndex(index));
+            final ClusterState newState = updateRoutingTable(initialState);
+            assertTrue(newState.routingTable().hasIndex(index));
+            assertEquals(
+                0,
+                newState.routingTable()
+                    .index("test-remote")
+                    .shardsMatchingPredicateCount(
+                        shardRouting -> shardRouting.unassignedInfo().getReason().equals(UnassignedInfo.Reason.INDEX_CREATED)
+                    )
+            );
+            assertEquals(
+                numOfShards,
+                newState.routingTable()
+                    .index("test-remote")
+                    .shardsMatchingPredicateCount(
+                        shardRouting -> shardRouting.unassignedInfo().getReason().equals(UnassignedInfo.Reason.CLUSTER_RECOVERED)
+                    )
+            );
+            assertEquals(
+                0,
+                newState.routingTable()
+                    .index("test-remote")
+                    .shardsMatchingPredicateCount(
+                        shardRouting -> shardRouting.recoverySource() instanceof RecoverySource.RemoteStoreRecoverySource
+                    )
+            );
+            assertEquals(
+                numOfShards,
+                newState.routingTable()
+                    .index("test-remote")
+                    .shardsMatchingPredicateCount(
+                        shardRouting -> shardRouting.recoverySource() instanceof RecoverySource.EmptyStoreRecoverySource
+                    )
+            );
+
+        }
+        {
+            IndexRoutingTable.Builder remoteBuilderWithRemoteRecovery = new IndexRoutingTable.Builder(remoteMetadata.getIndex())
+                .initializeAsRemoteStoreRestore(
+                    remoteMetadata,
+                    new RecoverySource.RemoteStoreRecoverySource(
+                        UUIDs.randomBase64UUID(),
+                        remoteMetadata.getCreationVersion(),
+                        new IndexId("test-remote", remoteMetadata.getIndexUUID())
+                    ),
+                    new HashMap<>(),
+                    true
+                );
+            final Index index = remoteMetadata.getIndex();
+            final ClusterState initialState = ClusterState.builder(ClusterState.EMPTY_STATE)
+                .metadata(Metadata.builder().put(remoteMetadata, false).build())
+                .routingTable(new RoutingTable.Builder().add(remoteBuilderWithRemoteRecovery.build()).build())
+                .build();
+            assertTrue(initialState.routingTable().hasIndex(index));
+            final ClusterState newState = updateRoutingTable(initialState);
+            assertTrue(newState.routingTable().hasIndex(index));
+            assertEquals(
+                0,
+                newState.routingTable()
+                    .index("test-remote")
+                    .shardsMatchingPredicateCount(
+                        shardRouting -> shardRouting.unassignedInfo().getReason().equals(UnassignedInfo.Reason.CLUSTER_RECOVERED)
+                    )
+            );
+            assertEquals(
+                numOfShards,
+                newState.routingTable()
+                    .index("test-remote")
+                    .shardsMatchingPredicateCount(
+                        shardRouting -> shardRouting.unassignedInfo().getReason().equals(UnassignedInfo.Reason.EXISTING_INDEX_RESTORED)
+                    )
+            );
+            assertEquals(
+                0,
+                newState.routingTable()
+                    .index("test-remote")
+                    .shardsMatchingPredicateCount(
+                        shardRouting -> shardRouting.recoverySource() instanceof RecoverySource.EmptyStoreRecoverySource
+                    )
+            );
+            assertEquals(
+                numOfShards,
+                newState.routingTable()
+                    .index("test-remote")
+                    .shardsMatchingPredicateCount(
+                        shardRouting -> shardRouting.recoverySource() instanceof RecoverySource.RemoteStoreRecoverySource
+                    )
+            );
+
+        }
+        {
+            IndexRoutingTable.Builder remoteBuilderWithRemoteRecovery = new IndexRoutingTable.Builder(remoteMetadata.getIndex())
+                .initializeAsRemoteStoreRestore(
+                    remoteMetadata,
+                    new RecoverySource.RemoteStoreRecoverySource(
+                        UUIDs.randomBase64UUID(),
+                        remoteMetadata.getCreationVersion(),
+                        new IndexId("test-remote", remoteMetadata.getIndexUUID())
+                    ),
+                    new HashMap<>(),
+                    true
+                );
+            IndexRoutingTable.Builder remoteBuilderWithoutRemoteRecovery = new IndexRoutingTable.Builder(nonRemoteMetadata.getIndex())
+                .initializeAsNew(nonRemoteMetadata);
+            final ClusterState initialState = ClusterState.builder(ClusterState.EMPTY_STATE)
+                .metadata(Metadata.builder().put(remoteMetadata, false).build())
+                .metadata(Metadata.builder().put(nonRemoteMetadata, false).build())
+                .routingTable(
+                    new RoutingTable.Builder().add(remoteBuilderWithRemoteRecovery.build())
+                        .add(remoteBuilderWithoutRemoteRecovery.build())
+                        .build()
+                )
+                .build();
+            assertTrue(initialState.routingTable().hasIndex(remoteMetadata.getIndex()));
+            assertTrue(initialState.routingTable().hasIndex(nonRemoteMetadata.getIndex()));
+            final ClusterState newState = updateRoutingTable(initialState);
+            assertTrue(newState.routingTable().hasIndex(remoteMetadata.getIndex()));
+            assertTrue(newState.routingTable().hasIndex(nonRemoteMetadata.getIndex()));
+            assertEquals(
+                0,
+                newState.routingTable()
+                    .index("test-remote")
+                    .shardsMatchingPredicateCount(
+                        shardRouting -> shardRouting.unassignedInfo().getReason().equals(UnassignedInfo.Reason.CLUSTER_RECOVERED)
+                    )
+            );
+            assertEquals(
+                numOfShards,
+                newState.routingTable()
+                    .index("test-remote")
+                    .shardsMatchingPredicateCount(
+                        shardRouting -> shardRouting.unassignedInfo().getReason().equals(UnassignedInfo.Reason.EXISTING_INDEX_RESTORED)
+                    )
+            );
+            assertEquals(
+                0,
+                newState.routingTable()
+                    .index("test-remote")
+                    .shardsMatchingPredicateCount(
+                        shardRouting -> shardRouting.recoverySource() instanceof RecoverySource.EmptyStoreRecoverySource
+                    )
+            );
+            assertEquals(
+                numOfShards,
+                newState.routingTable()
+                    .index("test-remote")
+                    .shardsMatchingPredicateCount(
+                        shardRouting -> shardRouting.recoverySource() instanceof RecoverySource.RemoteStoreRecoverySource
+                    )
+            );
+            assertEquals(
+                0,
+                newState.routingTable()
+                    .index("test-nonremote")
+                    .shardsMatchingPredicateCount(
+                        shardRouting -> shardRouting.unassignedInfo().getReason().equals(UnassignedInfo.Reason.INDEX_CREATED)
+                    )
+            );
+            assertEquals(
+                numOfShards,
+                newState.routingTable()
+                    .index("test-nonremote")
+                    .shardsMatchingPredicateCount(
+                        shardRouting -> shardRouting.unassignedInfo().getReason().equals(UnassignedInfo.Reason.CLUSTER_RECOVERED)
+                    )
+            );
+            assertEquals(
+                0,
+                newState.routingTable()
+                    .index("test-nonremote")
+                    .shardsMatchingPredicateCount(
+                        shardRouting -> shardRouting.recoverySource() instanceof RecoverySource.RemoteStoreRecoverySource
+                    )
+            );
+            assertEquals(
+                numOfShards,
+                newState.routingTable()
+                    .index("test-nonremote")
+                    .shardsMatchingPredicateCount(
+                        shardRouting -> shardRouting.recoverySource() instanceof RecoverySource.EmptyStoreRecoverySource
+                    )
+            );
         }
     }
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
- After Cluster Manager recovery or a fresh cluster bootstrap, we trigger the `GatewayService.RecoverStateUpdateTask` which performs various mutations to the cluster state.
- One of the mutations blindly overrides the routing table in the cluster state. This makes sense as after recovery or new cluster bootstrap, routing table should be generated from scratch.
- But for Remote Store and Remote Cluster State enabled clusters, we auto restore previous valid cluster state from Remote(Only IndexMetadata in 2.10). So routing tables are generated as part of restore flow with remote store recovery source.
- To avoid `GatewayService.RecoverStateUpdateTask` overriding the pre-generated routing table entries for remote store clusters we have skipped the routing table override.
- If we did not skip this, the new routing table would be created with recovery source as ExistingStoreRecoverySource which looks on local disk for recovery. 
 

### Related Issues
Resolves #9921 
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
