### PR TITLE
[Backport 1.3] Force upgrade the vulnerable dependencies of hadoop-minicluster, Enforce up-to-date Guava in buildSrc 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Dependencies
 - Bump `netty` from 4.1.96.Final to 4.1.97.Final ([#9553](https://github.com/opensearch-project/OpenSearch/pull/9553))
+- Bump `org.xerial.snappy:snappy-java` from 1.1.8.2 to 1.1.10.3 ([#9252](https://github.com/opensearch-project/OpenSearch/pull/9252))
+- Bump `com.squareup.okhttp3:okhttp` from 4.9.3 to 4.11.0 ([#9252](https://github.com/opensearch-project/OpenSearch/pull/9252))
+- Bump `com.squareup.okio:okio` from 2.8.0 to 3.5.0 ([#9252](https://github.com/opensearch-project/OpenSearch/pull/9252))
 
 ### Changed
 ### Deprecated

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -156,6 +156,12 @@ dependencies {
   }
 }
 
+configurations.all {
+  resolutionStrategy {
+    force "com.google.guava:guava:${props.getProperty('guava')}"
+  }
+}
+
 /*****************************************************************************
  *                         Bootstrap repositories                            *
  *****************************************************************************/

--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -39,6 +39,9 @@ dependencies {
     exclude module: 'protobuf-java'
     exclude group: 'org.codehaus.jackson'
     exclude group: "org.bouncycastle"
+    exclude group: "com.squareup.okhttp3"
+    exclude group: "org.xerial.snappy"
+    exclude module: "json-io"
   }
 
   api "org.codehaus.jettison:jettison:${versions.jettison}"
@@ -58,4 +61,9 @@ dependencies {
   api "org.eclipse.jetty:jetty-server:${versions.jetty}"
   api "org.eclipse.jetty.websocket:javax-websocket-server-impl:${versions.jetty}"
   runtimeOnly "com.google.guava:guava:${versions.guava}"
+  runtimeOnly("com.squareup.okhttp3:okhttp:4.11.0") {
+    exclude group: "com.squareup.okio"
+  }
+  runtimeOnly "com.squareup.okio:okio:3.5.0"
+  runtimeOnly "org.xerial.snappy:snappy-java:1.1.10.3"
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
- Fixes the following CVEs for `1.3`
- - CVE-2023-34453
- - CVE-2023-2976
- -  CVE-2023-34455
- - CVE-2023-3635
- - CVE-2023-34610


### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
