### PR TITLE
fix stale remote cluster uuid state not purged from remote

### DIFF
--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -742,7 +742,7 @@ public class RemoteClusterStateService implements Closeable {
              */
             return manifestContainer(clusterName, clusterUUID).listBlobsByPrefixInSortedOrder(
                 MANIFEST_FILE_PREFIX + DELIMITER,
-                1,
+                limit,
                 BlobContainer.BlobNameSortOrder.LEXICOGRAPHIC
             );
         } catch (IOException e) {
@@ -809,10 +809,10 @@ public class RemoteClusterStateService implements Closeable {
      * @param clusterState current state of the cluster
      * @param committedManifest last committed ClusterMetadataManifest
      */
-    public void deleteStaleClusterUUID(ClusterState clusterState, ClusterMetadataManifest committedManifest) throws IOException {
+    public void deleteStaleClusterUUID(ClusterState clusterState, ClusterMetadataManifest committedManifest) {
         threadpool.executor(ThreadPool.Names.REMOTE_PURGE).execute(() -> {
             String clusterName = clusterState.getClusterName().value();
-            Set<String> allClustersUUIDsInRemote = null;
+            Set<String> allClustersUUIDsInRemote;
             try {
                 allClustersUUIDsInRemote = new HashSet<>(getAllClusterUUIDs(clusterState.getClusterName().value()));
             } catch (IOException e) {
@@ -830,7 +830,7 @@ public class RemoteClusterStateService implements Closeable {
                         throw new RuntimeException(e);
                     }
                 });
-                // delete all index metdata
+                // delete all index metadata
                 getBlobStoreTransferService().deleteAsync(
                     ThreadPool.Names.REMOTE_PURGE,
                     getCusterMetadataBasePath(clusterName, clusterUUID).add(INDEX_PATH_TOKEN),

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -581,7 +581,7 @@ public class RemoteClusterStateService implements Closeable {
      */
     public String getLastKnownUUIDFromRemote(String clusterName) {
         try {
-            Set<String> clusterUUIDs = Collections.unmodifiableSet(getAllClusterUUIDs(clusterName));
+            Set<String> clusterUUIDs = getAllClusterUUIDs(clusterName);
             Map<String, ClusterMetadataManifest> latestManifests = getLatestManifestForAllClusterUUIDs(clusterName, clusterUUIDs);
             List<String> validChain = createClusterChain(latestManifests, clusterName);
             if (validChain.isEmpty()) {
@@ -600,7 +600,7 @@ public class RemoteClusterStateService implements Closeable {
         if (clusterUUIDMetadata == null) {
             return Collections.emptySet();
         }
-        return clusterUUIDMetadata.keySet();
+        return Collections.unmodifiableSet(clusterUUIDMetadata.keySet());
     }
 
     private Map<String, ClusterMetadataManifest> getLatestManifestForAllClusterUUIDs(String clusterName, Set<String> clusterUUIDs) {
@@ -814,7 +814,7 @@ public class RemoteClusterStateService implements Closeable {
             String clusterName = clusterState.getClusterName().value();
             Set<String> allClustersUUIDsInRemote = null;
             try {
-                allClustersUUIDsInRemote = getAllClusterUUIDs(clusterState.getClusterName().value());
+                allClustersUUIDsInRemote = new HashSet<>(getAllClusterUUIDs(clusterState.getClusterName().value()));
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -103,11 +103,11 @@ public class RemoteClusterStateService implements Closeable {
         Property.Final
     );
 
-    private static final String CLUSTER_STATE_PATH_TOKEN = "cluster-state";
-    private static final String INDEX_PATH_TOKEN = "index";
-    private static final String MANIFEST_PATH_TOKEN = "manifest";
-    private static final String MANIFEST_FILE_PREFIX = "manifest";
-    private static final String INDEX_METADATA_FILE_PREFIX = "metadata";
+    public static final String CLUSTER_STATE_PATH_TOKEN = "cluster-state";
+    public static final String INDEX_PATH_TOKEN = "index";
+    public static final String MANIFEST_PATH_TOKEN = "manifest";
+    public static final String MANIFEST_FILE_PREFIX = "manifest";
+    public static final String INDEX_METADATA_FILE_PREFIX = "metadata";
 
     private final String nodeId;
     private final Supplier<RepositoriesService> repositoriesService;

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
@@ -64,6 +64,9 @@ import java.util.function.Supplier;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 
+import static org.opensearch.gateway.remote.RemoteClusterStateService.DELIMITER;
+import static org.opensearch.gateway.remote.RemoteClusterStateService.INDEX_PATH_TOKEN;
+import static org.opensearch.gateway.remote.RemoteClusterStateService.MANIFEST_FILE_PREFIX;
 import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.REMOTE_STORE_CLUSTER_STATE_REPOSITORY_NAME_ATTRIBUTE_KEY;
 import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_SETTINGS_ATTRIBUTE_KEY_PREFIX;
 import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_TYPE_ATTRIBUTE_KEY_FORMAT;
@@ -76,6 +79,8 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
@@ -334,13 +339,8 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
         final ClusterState clusterState = generateClusterStateWithOneIndex().nodes(nodesWithLocalNodeClusterManager()).build();
 
         BlobContainer blobContainer = mockBlobStoreObjects();
-        when(
-            blobContainer.listBlobsByPrefixInSortedOrder(
-                "manifest" + RemoteClusterStateService.DELIMITER,
-                1,
-                BlobContainer.BlobNameSortOrder.LEXICOGRAPHIC
-            )
-        ).thenThrow(IOException.class);
+        when(blobContainer.listBlobsByPrefixInSortedOrder("manifest" + DELIMITER, 1, BlobContainer.BlobNameSortOrder.LEXICOGRAPHIC))
+            .thenThrow(IOException.class);
 
         remoteClusterStateService.start();
         Exception e = assertThrows(
@@ -357,13 +357,8 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
         final ClusterState clusterState = generateClusterStateWithOneIndex().nodes(nodesWithLocalNodeClusterManager()).build();
 
         BlobContainer blobContainer = mockBlobStoreObjects();
-        when(
-            blobContainer.listBlobsByPrefixInSortedOrder(
-                "manifest" + RemoteClusterStateService.DELIMITER,
-                1,
-                BlobContainer.BlobNameSortOrder.LEXICOGRAPHIC
-            )
-        ).thenReturn(List.of());
+        when(blobContainer.listBlobsByPrefixInSortedOrder("manifest" + DELIMITER, 1, BlobContainer.BlobNameSortOrder.LEXICOGRAPHIC))
+            .thenReturn(List.of());
 
         remoteClusterStateService.start();
         Optional<ClusterMetadataManifest> manifest = remoteClusterStateService.getLatestClusterMetadataManifest(
@@ -378,13 +373,8 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
 
         BlobContainer blobContainer = mockBlobStoreObjects();
         BlobMetadata blobMetadata = new PlainBlobMetadata("manifestFileName", 1);
-        when(
-            blobContainer.listBlobsByPrefixInSortedOrder(
-                "manifest" + RemoteClusterStateService.DELIMITER,
-                1,
-                BlobContainer.BlobNameSortOrder.LEXICOGRAPHIC
-            )
-        ).thenReturn(Arrays.asList(blobMetadata));
+        when(blobContainer.listBlobsByPrefixInSortedOrder("manifest" + DELIMITER, 1, BlobContainer.BlobNameSortOrder.LEXICOGRAPHIC))
+            .thenReturn(Arrays.asList(blobMetadata));
         when(blobContainer.readBlob("manifestFileName")).thenThrow(FileNotFoundException.class);
 
         remoteClusterStateService.start();
@@ -618,6 +608,80 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
         assertThrows(IllegalStateException.class, () -> remoteClusterStateService.getLastKnownUUIDFromRemote("test-cluster"));
     }
 
+    public void testDeleteStaleClusterUUIDs() throws IOException {
+        final ClusterState clusterState = generateClusterStateWithOneIndex().nodes(nodesWithLocalNodeClusterManager()).build();
+        ClusterMetadataManifest clusterMetadataManifest = ClusterMetadataManifest.builder()
+            .indices(List.of())
+            .clusterTerm(1L)
+            .stateVersion(1L)
+            .stateUUID(randomAlphaOfLength(10))
+            .clusterUUID("cluster-uuid1")
+            .nodeId("nodeA")
+            .opensearchVersion(VersionUtils.randomOpenSearchVersion(random()))
+            .previousClusterUUID(ClusterState.UNKNOWN_UUID)
+            .committed(true)
+            .build();
+
+        BlobPath blobPath = new BlobPath().add("random-path");
+        when((blobStoreRepository.basePath())).thenReturn(blobPath);
+        BlobContainer uuidContainerContainer = mock(BlobContainer.class);
+        BlobContainer manifest2Container = mock(BlobContainer.class);
+        BlobContainer manifest2IndexContainer = mock(BlobContainer.class);
+        BlobContainer manifest3Container = mock(BlobContainer.class);
+        BlobContainer manifest3IndexContainer = mock(BlobContainer.class);
+        when(blobStore.blobContainer(any())).then(invocation -> {
+            BlobPath blobPath1 = invocation.getArgument(0);
+            if (blobPath1.buildAsString().endsWith("cluster-state/")) {
+                return uuidContainerContainer;
+            } else if (blobPath1.buildAsString().contains("cluster-state/cluster-uuid2/" + INDEX_PATH_TOKEN)) {
+                return manifest2IndexContainer;
+            } else if (blobPath1.buildAsString().contains("cluster-state/cluster-uuid2/")) {
+                return manifest2Container;
+            } else if (blobPath1.buildAsString().contains("cluster-state/cluster-uuid3/" + INDEX_PATH_TOKEN)) {
+                return manifest3IndexContainer;
+            } else if (blobPath1.buildAsString().contains("cluster-state/cluster-uuid3/")) {
+                return manifest3Container;
+            } else {
+                throw new IllegalArgumentException("Unexpected blob path " + blobPath1);
+            }
+        });
+        Map<String, BlobContainer> blobMetadataMap = Map.of(
+            "cluster-uuid1",
+            mock(BlobContainer.class),
+            "cluster-uuid2",
+            mock(BlobContainer.class),
+            "cluster-uuid3",
+            mock(BlobContainer.class)
+        );
+        when(uuidContainerContainer.children()).thenReturn(blobMetadataMap);
+        when(
+            manifest2Container.listBlobsByPrefixInSortedOrder(
+                MANIFEST_FILE_PREFIX + DELIMITER,
+                Integer.MAX_VALUE,
+                BlobContainer.BlobNameSortOrder.LEXICOGRAPHIC
+            )
+        ).thenReturn(List.of(new PlainBlobMetadata("mainfest2", 1L)));
+        when(
+            manifest3Container.listBlobsByPrefixInSortedOrder(
+                MANIFEST_FILE_PREFIX + DELIMITER,
+                Integer.MAX_VALUE,
+                BlobContainer.BlobNameSortOrder.LEXICOGRAPHIC
+            )
+        ).thenReturn(List.of(new PlainBlobMetadata("mainfest3", 1L)));
+        remoteClusterStateService.start();
+        remoteClusterStateService.deleteStaleClusterUUID(clusterState, clusterMetadataManifest);
+        try {
+            assertBusy(() -> {
+                verify(manifest2Container, times(1)).delete();
+                verify(manifest2IndexContainer, times(1)).delete();
+                verify(manifest3Container, times(1)).delete();
+                verify(manifest3IndexContainer, times(1)).delete();
+            });
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     private void mockObjectsForGettingPreviousClusterUUID(Map<String, String> clusterUUIDsPointers) throws IOException {
         final BlobPath blobPath = mock(BlobPath.class);
         when((blobStoreRepository.basePath())).thenReturn(blobPath);
@@ -760,13 +824,8 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
         Map<String, IndexMetadata> indexMetadataMap
     ) throws IOException {
         BlobMetadata blobMetadata = new PlainBlobMetadata("manifestFileName", 1);
-        when(
-            blobContainer.listBlobsByPrefixInSortedOrder(
-                "manifest" + RemoteClusterStateService.DELIMITER,
-                1,
-                BlobContainer.BlobNameSortOrder.LEXICOGRAPHIC
-            )
-        ).thenReturn(Arrays.asList(blobMetadata));
+        when(blobContainer.listBlobsByPrefixInSortedOrder("manifest" + DELIMITER, 1, BlobContainer.BlobNameSortOrder.LEXICOGRAPHIC))
+            .thenReturn(Arrays.asList(blobMetadata));
 
         BytesReference bytes = RemoteClusterStateService.CLUSTER_METADATA_MANIFEST_FORMAT.serialize(
             clusterMetadataManifest,

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
@@ -633,12 +633,8 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
             BlobPath blobPath1 = invocation.getArgument(0);
             if (blobPath1.buildAsString().endsWith("cluster-state/")) {
                 return uuidContainerContainer;
-            } else if (blobPath1.buildAsString().contains("cluster-state/cluster-uuid2/" + INDEX_PATH_TOKEN)) {
-                return manifest2IndexContainer;
             } else if (blobPath1.buildAsString().contains("cluster-state/cluster-uuid2/")) {
                 return manifest2Container;
-            } else if (blobPath1.buildAsString().contains("cluster-state/cluster-uuid3/" + INDEX_PATH_TOKEN)) {
-                return manifest3IndexContainer;
             } else if (blobPath1.buildAsString().contains("cluster-state/cluster-uuid3/")) {
                 return manifest3Container;
             } else {
@@ -669,13 +665,11 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
             )
         ).thenReturn(List.of(new PlainBlobMetadata("mainfest3", 1L)));
         remoteClusterStateService.start();
-        remoteClusterStateService.deleteStaleClusterUUID(clusterState, clusterMetadataManifest);
+        remoteClusterStateService.deleteStaleClusterUUIDs(clusterState, clusterMetadataManifest);
         try {
             assertBusy(() -> {
                 verify(manifest2Container, times(1)).delete();
-                verify(manifest2IndexContainer, times(1)).delete();
                 verify(manifest3Container, times(1)).delete();
-                verify(manifest3IndexContainer, times(1)).delete();
             });
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
@@ -626,9 +626,7 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
         when((blobStoreRepository.basePath())).thenReturn(blobPath);
         BlobContainer uuidContainerContainer = mock(BlobContainer.class);
         BlobContainer manifest2Container = mock(BlobContainer.class);
-        BlobContainer manifest2IndexContainer = mock(BlobContainer.class);
         BlobContainer manifest3Container = mock(BlobContainer.class);
-        BlobContainer manifest3IndexContainer = mock(BlobContainer.class);
         when(blobStore.blobContainer(any())).then(invocation -> {
             BlobPath blobPath1 = invocation.getArgument(0);
             if (blobPath1.buildAsString().endsWith("cluster-state/")) {

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
@@ -65,7 +65,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 
 import static org.opensearch.gateway.remote.RemoteClusterStateService.DELIMITER;
-import static org.opensearch.gateway.remote.RemoteClusterStateService.INDEX_PATH_TOKEN;
 import static org.opensearch.gateway.remote.RemoteClusterStateService.MANIFEST_FILE_PREFIX;
 import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.REMOTE_STORE_CLUSTER_STATE_REPOSITORY_NAME_ATTRIBUTE_KEY;
 import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_SETTINGS_ATTRIBUTE_KEY_PREFIX;


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
