### PR TITLE
Fix cluster chaining during bootstrap

### DIFF
--- a/server/src/main/java/org/opensearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/opensearch/gateway/GatewayMetaState.java
@@ -684,8 +684,12 @@ public class GatewayMetaState implements Closeable {
                             clusterState.metadata().clusterUUID()
                         );
                         if (latestManifest.isPresent()) {
+                            // The previous UUID should not change for the current UUID. So fetching the latest manifest
+                            // from remote store and getting the previous UUID.
                             previousClusterUUID = latestManifest.get().getPreviousClusterUUID();
                         } else {
+                            // When the user starts the cluster with remote state disabled but later enables the remote state,
+                            // there will not be any manifest for the current cluster UUID.
                             logger.error(
                                 "Latest manifest is not present in remote store for cluster UUID: {}",
                                 clusterState.metadata().clusterUUID()

--- a/server/src/main/java/org/opensearch/gateway/remote/ClusterMetadataManifest.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/ClusterMetadataManifest.java
@@ -79,6 +79,7 @@ public class ClusterMetadataManifest implements Writeable, ToXContentFragment {
     private static String previousClusterUUID(Object[] fields) {
         return (String) fields[8];
     }
+
     private static boolean clusterUUIDCommitted(Object[] fields) {
         return (boolean) fields[9];
     }

--- a/server/src/main/java/org/opensearch/gateway/remote/ClusterMetadataManifest.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/ClusterMetadataManifest.java
@@ -42,6 +42,7 @@ public class ClusterMetadataManifest implements Writeable, ToXContentFragment {
     private static final ParseField COMMITTED_FIELD = new ParseField("committed");
     private static final ParseField INDICES_FIELD = new ParseField("indices");
     private static final ParseField PREVIOUS_CLUSTER_UUID = new ParseField("previous_cluster_uuid");
+    private static final ParseField CLUSTER_UUID_COMMITTED = new ParseField("cluster_uuid_committed");
 
     private static long term(Object[] fields) {
         return (long) fields[0];
@@ -78,6 +79,9 @@ public class ClusterMetadataManifest implements Writeable, ToXContentFragment {
     private static String previousClusterUUID(Object[] fields) {
         return (String) fields[8];
     }
+    private static boolean clusterUUIDCommitted(Object[] fields) {
+        return (boolean) fields[9];
+    }
 
     private static final ConstructingObjectParser<ClusterMetadataManifest, Void> PARSER = new ConstructingObjectParser<>(
         "cluster_metadata_manifest",
@@ -90,7 +94,8 @@ public class ClusterMetadataManifest implements Writeable, ToXContentFragment {
             nodeId(fields),
             committed(fields),
             indices(fields),
-            previousClusterUUID(fields)
+            previousClusterUUID(fields),
+            clusterUUIDCommitted(fields)
         )
     );
 
@@ -108,6 +113,7 @@ public class ClusterMetadataManifest implements Writeable, ToXContentFragment {
             INDICES_FIELD
         );
         PARSER.declareString(ConstructingObjectParser.constructorArg(), PREVIOUS_CLUSTER_UUID);
+        PARSER.declareBoolean(ConstructingObjectParser.constructorArg(), CLUSTER_UUID_COMMITTED);
     }
 
     private final List<UploadedIndexMetadata> indices;
@@ -119,6 +125,7 @@ public class ClusterMetadataManifest implements Writeable, ToXContentFragment {
     private final String nodeId;
     private final boolean committed;
     private final String previousClusterUUID;
+    private final boolean clusterUUIDCommitted;
 
     public List<UploadedIndexMetadata> getIndices() {
         return indices;
@@ -156,6 +163,10 @@ public class ClusterMetadataManifest implements Writeable, ToXContentFragment {
         return previousClusterUUID;
     }
 
+    public boolean isClusterUUIDCommitted() {
+        return clusterUUIDCommitted;
+    }
+
     public ClusterMetadataManifest(
         long clusterTerm,
         long version,
@@ -165,7 +176,8 @@ public class ClusterMetadataManifest implements Writeable, ToXContentFragment {
         String nodeId,
         boolean committed,
         List<UploadedIndexMetadata> indices,
-        String previousClusterUUID
+        String previousClusterUUID,
+        boolean clusterUUIDCommitted
     ) {
         this.clusterTerm = clusterTerm;
         this.stateVersion = version;
@@ -176,6 +188,7 @@ public class ClusterMetadataManifest implements Writeable, ToXContentFragment {
         this.committed = committed;
         this.indices = Collections.unmodifiableList(indices);
         this.previousClusterUUID = previousClusterUUID;
+        this.clusterUUIDCommitted = clusterUUIDCommitted;
     }
 
     public ClusterMetadataManifest(StreamInput in) throws IOException {
@@ -188,6 +201,7 @@ public class ClusterMetadataManifest implements Writeable, ToXContentFragment {
         this.committed = in.readBoolean();
         this.indices = Collections.unmodifiableList(in.readList(UploadedIndexMetadata::new));
         this.previousClusterUUID = in.readString();
+        this.clusterUUIDCommitted = in.readBoolean();
     }
 
     public static Builder builder() {
@@ -215,6 +229,7 @@ public class ClusterMetadataManifest implements Writeable, ToXContentFragment {
         }
         builder.endArray();
         builder.field(PREVIOUS_CLUSTER_UUID.getPreferredName(), getPreviousClusterUUID());
+        builder.field(CLUSTER_UUID_COMMITTED.getPreferredName(), isClusterUUIDCommitted());
         return builder;
     }
 
@@ -229,6 +244,7 @@ public class ClusterMetadataManifest implements Writeable, ToXContentFragment {
         out.writeBoolean(committed);
         out.writeCollection(indices);
         out.writeString(previousClusterUUID);
+        out.writeBoolean(clusterUUIDCommitted);
     }
 
     @Override
@@ -248,7 +264,8 @@ public class ClusterMetadataManifest implements Writeable, ToXContentFragment {
             && Objects.equals(opensearchVersion, that.opensearchVersion)
             && Objects.equals(nodeId, that.nodeId)
             && Objects.equals(committed, that.committed)
-            && Objects.equals(previousClusterUUID, that.previousClusterUUID);
+            && Objects.equals(previousClusterUUID, that.previousClusterUUID)
+            && Objects.equals(clusterUUIDCommitted, that.clusterUUIDCommitted);
     }
 
     @Override
@@ -262,7 +279,8 @@ public class ClusterMetadataManifest implements Writeable, ToXContentFragment {
             opensearchVersion,
             nodeId,
             committed,
-            previousClusterUUID
+            previousClusterUUID,
+            clusterUUIDCommitted
         );
     }
 
@@ -291,6 +309,7 @@ public class ClusterMetadataManifest implements Writeable, ToXContentFragment {
         private String nodeId;
         private String previousClusterUUID;
         private boolean committed;
+        private boolean clusterUUIDCommitted;
 
         public Builder indices(List<UploadedIndexMetadata> indices) {
             this.indices = indices;
@@ -341,6 +360,11 @@ public class ClusterMetadataManifest implements Writeable, ToXContentFragment {
             return this;
         }
 
+        public Builder clusterUUIDCommitted(boolean clusterUUIDCommitted) {
+            this.clusterUUIDCommitted = clusterUUIDCommitted;
+            return this;
+        }
+
         public Builder() {
             indices = new ArrayList<>();
         }
@@ -355,6 +379,7 @@ public class ClusterMetadataManifest implements Writeable, ToXContentFragment {
             this.committed = manifest.committed;
             this.indices = new ArrayList<>(manifest.indices);
             this.previousClusterUUID = manifest.previousClusterUUID;
+            this.clusterUUIDCommitted = manifest.clusterUUIDCommitted;
         }
 
         public ClusterMetadataManifest build() {
@@ -367,7 +392,8 @@ public class ClusterMetadataManifest implements Writeable, ToXContentFragment {
                 nodeId,
                 committed,
                 indices,
-                previousClusterUUID
+                previousClusterUUID,
+                clusterUUIDCommitted
             );
         }
 

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -436,7 +436,8 @@ public class RemoteClusterStateService implements Closeable {
                 nodeId,
                 committed,
                 uploadedIndexMetadata,
-                previousClusterUUID
+                previousClusterUUID,
+                clusterState.metadata().clusterUUIDCommitted()
             );
             writeMetadataManifest(clusterState.getClusterName().value(), clusterState.metadata().clusterUUID(), manifest, manifestFileName);
             return manifest;

--- a/server/src/test/java/org/opensearch/cluster/coordination/CoordinationStateTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/CoordinationStateTests.java
@@ -934,7 +934,8 @@ public class CoordinationStateTests extends OpenSearchTestCase {
             randomAlphaOfLength(10),
             false,
             Collections.emptyList(),
-            randomAlphaOfLength(10)
+            randomAlphaOfLength(10),
+            true
         );
         Mockito.when(remoteClusterStateService.writeFullMetadata(clusterState)).thenReturn(manifest);
 

--- a/server/src/test/java/org/opensearch/gateway/remote/ClusterMetadataManifestTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/ClusterMetadataManifestTests.java
@@ -37,7 +37,8 @@ public class ClusterMetadataManifestTests extends OpenSearchTestCase {
             "test-node-id",
             false,
             Collections.singletonList(uploadedIndexMetadata),
-            "prev-cluster-uuid"
+            "prev-cluster-uuid",
+            true
         );
         final XContentBuilder builder = JsonXContent.contentBuilder();
         builder.startObject();
@@ -60,7 +61,8 @@ public class ClusterMetadataManifestTests extends OpenSearchTestCase {
             "B10RX1f5RJenMQvYccCgSQ",
             true,
             randomUploadedIndexMetadataList(),
-            "yfObdx8KSMKKrXf8UyHhM"
+            "yfObdx8KSMKKrXf8UyHhM",
+            true
         );
         {  // Mutate Cluster Term
             EqualsHashCodeTestUtils.checkEqualsAndHashCode(
@@ -182,6 +184,21 @@ public class ClusterMetadataManifestTests extends OpenSearchTestCase {
                 }
             );
 
+        }
+        { // Mutate cluster uuid committed
+            EqualsHashCodeTestUtils.checkEqualsAndHashCode(
+                initialManifest,
+                orig -> OpenSearchTestCase.copyWriteable(
+                    orig,
+                    new NamedWriteableRegistry(Collections.emptyList()),
+                    ClusterMetadataManifest::new
+                ),
+                manifest -> {
+                    ClusterMetadataManifest.Builder builder = ClusterMetadataManifest.builder(manifest);
+                    builder.clusterUUIDCommitted(false);
+                    return builder.build();
+                }
+            );
         }
     }
 


### PR DESCRIPTION
### Description
This fixes the logic for generating the cluster chain when a new cluster manager node is bootstrapping

### Related Issues
#10019 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
