### PR TITLE
add taskCompletionCount in search_backpressure stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Return 409 Conflict HTTP status instead of 503 on failure to concurrently execute snapshots ([#8986](https://github.com/opensearch-project/OpenSearch/pull/5855))
 - Add task completion count in search backpressure stats API ([#10028](https://github.com/opensearch-project/OpenSearch/pull/10028/))
 - Performance improvement for Datetime field caching ([#4558](https://github.com/opensearch-project/OpenSearch/issues/4558))
-- Add task completionCount in search_backpressure stats API([#10028](https://github.com/opensearch-project/OpenSearch/pull/10028/))
+- Add task completionCount in search backpressure stats API([#10028](https://github.com/opensearch-project/OpenSearch/pull/10028/))
+
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Return 409 Conflict HTTP status instead of 503 on failure to concurrently execute snapshots ([#8986](https://github.com/opensearch-project/OpenSearch/pull/5855))
 - Add task completion count in search backpressure stats API ([#10028](https://github.com/opensearch-project/OpenSearch/pull/10028/))
 - Performance improvement for Datetime field caching ([#4558](https://github.com/opensearch-project/OpenSearch/issues/4558))
+- Add task completionCount in search_backpressure stats API([#10028](https://github.com/opensearch-project/OpenSearch/pull/10028/))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Improve summary error message for invalid setting updates ([#4792](https://github.com/opensearch-project/OpenSearch/pull/4792))
 - Return 409 Conflict HTTP status instead of 503 on failure to concurrently execute snapshots ([#8986](https://github.com/opensearch-project/OpenSearch/pull/5855))
 - Performance improvement for Datetime field caching ([#4558](https://github.com/opensearch-project/OpenSearch/issues/4558))
-- Add task completionCount in search_backpressure stats API
+- Add task completion count in search backpressure stats API
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Improve summary error message for invalid setting updates ([#4792](https://github.com/opensearch-project/OpenSearch/pull/4792))
 - Return 409 Conflict HTTP status instead of 503 on failure to concurrently execute snapshots ([#8986](https://github.com/opensearch-project/OpenSearch/pull/5855))
 - Performance improvement for Datetime field caching ([#4558](https://github.com/opensearch-project/OpenSearch/issues/4558))
+- Add task completionCount in search_backpressure stats API
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,8 +54,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Change http code on create index API with bad input raising NotXContentException from 500 to 400 ([#4773](https://github.com/opensearch-project/OpenSearch/pull/4773))
 - Improve summary error message for invalid setting updates ([#4792](https://github.com/opensearch-project/OpenSearch/pull/4792))
 - Return 409 Conflict HTTP status instead of 503 on failure to concurrently execute snapshots ([#8986](https://github.com/opensearch-project/OpenSearch/pull/5855))
+- Add task completion count in search backpressure stats API ([#10028](https://github.com/opensearch-project/OpenSearch/pull/10028/))
 - Performance improvement for Datetime field caching ([#4558](https://github.com/opensearch-project/OpenSearch/issues/4558))
-- Add task completion count in search backpressure stats API
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Return 409 Conflict HTTP status instead of 503 on failure to concurrently execute snapshots ([#8986](https://github.com/opensearch-project/OpenSearch/pull/5855))
 - Add task completion count in search backpressure stats API ([#10028](https://github.com/opensearch-project/OpenSearch/pull/10028/))
 - Performance improvement for Datetime field caching ([#4558](https://github.com/opensearch-project/OpenSearch/issues/4558))
-- Add task completionCount in search backpressure stats API([#10028](https://github.com/opensearch-project/OpenSearch/pull/10028/))
 
 
 ### Deprecated

--- a/server/src/main/java/org/opensearch/search/backpressure/SearchBackpressureService.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/SearchBackpressureService.java
@@ -399,6 +399,7 @@ public class SearchBackpressureService extends AbstractLifecycleComponent implem
         SearchTaskStats searchTaskStats = new SearchTaskStats(
             searchBackpressureStates.get(SearchTask.class).getCancellationCount(),
             searchBackpressureStates.get(SearchTask.class).getLimitReachedCount(),
+            searchBackpressureStates.get(SearchTask.class).getCompletionCount(),
             taskTrackers.get(SearchTask.class)
                 .stream()
                 .collect(Collectors.toUnmodifiableMap(t -> TaskResourceUsageTrackerType.fromName(t.name()), t -> t.stats(searchTasks)))
@@ -407,6 +408,7 @@ public class SearchBackpressureService extends AbstractLifecycleComponent implem
         SearchShardTaskStats searchShardTaskStats = new SearchShardTaskStats(
             searchBackpressureStates.get(SearchShardTask.class).getCancellationCount(),
             searchBackpressureStates.get(SearchShardTask.class).getLimitReachedCount(),
+            searchBackpressureStates.get(SearchShardTask.class).getCompletionCount(),
             taskTrackers.get(SearchShardTask.class)
                 .stream()
                 .collect(Collectors.toUnmodifiableMap(t -> TaskResourceUsageTrackerType.fromName(t.name()), t -> t.stats(searchShardTasks)))

--- a/server/src/main/java/org/opensearch/search/backpressure/stats/SearchShardTaskStats.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/stats/SearchShardTaskStats.java
@@ -31,7 +31,11 @@ import java.util.Objects;
 public class SearchShardTaskStats implements ToXContentObject, Writeable {
     private final long cancellationCount;
     private final long limitReachedCount;
+<<<<<<< HEAD
     private final long completionCount;
+=======
+    private long completionCount;
+>>>>>>> 3324fa1aaea (add taskCompletionCount in search_backpressure)
     private final Map<TaskResourceUsageTrackerType, TaskResourceUsageTracker.Stats> resourceUsageTrackerStats;
 
     public SearchShardTaskStats(
@@ -103,7 +107,11 @@ public class SearchShardTaskStats implements ToXContentObject, Writeable {
         SearchShardTaskStats that = (SearchShardTaskStats) o;
         return cancellationCount == that.cancellationCount
             && limitReachedCount == that.limitReachedCount
+<<<<<<< HEAD
             && completionCount == completionCount
+=======
+            && completionCount == that.completionCount
+>>>>>>> 3324fa1aaea (add taskCompletionCount in search_backpressure)
             && resourceUsageTrackerStats.equals(that.resourceUsageTrackerStats);
     }
 

--- a/server/src/main/java/org/opensearch/search/backpressure/stats/SearchShardTaskStats.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/stats/SearchShardTaskStats.java
@@ -31,11 +31,7 @@ import java.util.Objects;
 public class SearchShardTaskStats implements ToXContentObject, Writeable {
     private final long cancellationCount;
     private final long limitReachedCount;
-<<<<<<< HEAD
-    private final long completionCount;
-=======
     private long completionCount;
->>>>>>> 3324fa1aaea (add taskCompletionCount in search_backpressure)
     private final Map<TaskResourceUsageTrackerType, TaskResourceUsageTracker.Stats> resourceUsageTrackerStats;
 
     public SearchShardTaskStats(

--- a/server/src/main/java/org/opensearch/search/backpressure/stats/SearchShardTaskStats.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/stats/SearchShardTaskStats.java
@@ -31,7 +31,7 @@ import java.util.Objects;
 public class SearchShardTaskStats implements ToXContentObject, Writeable {
     private final long cancellationCount;
     private final long limitReachedCount;
-    private final Long completionCount;
+    private final long completionCount;
     private final Map<TaskResourceUsageTrackerType, TaskResourceUsageTracker.Stats> resourceUsageTrackerStats;
 
     public SearchShardTaskStats(
@@ -50,9 +50,9 @@ public class SearchShardTaskStats implements ToXContentObject, Writeable {
         this.cancellationCount = in.readVLong();
         this.limitReachedCount = in.readVLong();
         if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
-            completionCount = in.readOptionalVLong();
+            completionCount = in.readVLong();
         } else {
-            completionCount = null;
+            completionCount = -1;
         }
 
         MapBuilder<TaskResourceUsageTrackerType, TaskResourceUsageTracker.Stats> builder = new MapBuilder<>();
@@ -71,7 +71,7 @@ public class SearchShardTaskStats implements ToXContentObject, Writeable {
             builder.field(entry.getKey().getName(), entry.getValue());
         }
         builder.endObject();
-        if (completionCount != null) {
+        if (completionCount != -1) {
             builder.field("completion_count", completionCount);
         }
 
@@ -88,7 +88,7 @@ public class SearchShardTaskStats implements ToXContentObject, Writeable {
         out.writeVLong(cancellationCount);
         out.writeVLong(limitReachedCount);
         if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
-            out.writeOptionalVLong(completionCount);
+            out.writeVLong(completionCount);
         }
 
         out.writeOptionalWriteable(resourceUsageTrackerStats.get(TaskResourceUsageTrackerType.CPU_USAGE_TRACKER));
@@ -103,7 +103,7 @@ public class SearchShardTaskStats implements ToXContentObject, Writeable {
         SearchShardTaskStats that = (SearchShardTaskStats) o;
         return cancellationCount == that.cancellationCount
             && limitReachedCount == that.limitReachedCount
-            && Objects.equals(completionCount, that.completionCount)
+            && completionCount == completionCount
             && resourceUsageTrackerStats.equals(that.resourceUsageTrackerStats);
     }
 

--- a/server/src/main/java/org/opensearch/search/backpressure/stats/SearchShardTaskStats.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/stats/SearchShardTaskStats.java
@@ -103,11 +103,7 @@ public class SearchShardTaskStats implements ToXContentObject, Writeable {
         SearchShardTaskStats that = (SearchShardTaskStats) o;
         return cancellationCount == that.cancellationCount
             && limitReachedCount == that.limitReachedCount
-<<<<<<< HEAD
-            && completionCount == completionCount
-=======
             && completionCount == that.completionCount
->>>>>>> 3324fa1aaea (add taskCompletionCount in search_backpressure)
             && resourceUsageTrackerStats.equals(that.resourceUsageTrackerStats);
     }
 

--- a/server/src/main/java/org/opensearch/search/backpressure/stats/SearchShardTaskStats.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/stats/SearchShardTaskStats.java
@@ -31,7 +31,7 @@ import java.util.Objects;
 public class SearchShardTaskStats implements ToXContentObject, Writeable {
     private final long cancellationCount;
     private final long limitReachedCount;
-    private Long completionCount;
+    private final Long completionCount;
     private final Map<TaskResourceUsageTrackerType, TaskResourceUsageTracker.Stats> resourceUsageTrackerStats;
 
     public SearchShardTaskStats(
@@ -51,6 +51,8 @@ public class SearchShardTaskStats implements ToXContentObject, Writeable {
         this.limitReachedCount = in.readVLong();
         if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
             completionCount = in.readOptionalVLong();
+        } else {
+            completionCount = null;
         }
 
         MapBuilder<TaskResourceUsageTrackerType, TaskResourceUsageTracker.Stats> builder = new MapBuilder<>();

--- a/server/src/main/java/org/opensearch/search/backpressure/stats/SearchShardTaskStats.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/stats/SearchShardTaskStats.java
@@ -31,7 +31,7 @@ import java.util.Objects;
 public class SearchShardTaskStats implements ToXContentObject, Writeable {
     private final long cancellationCount;
     private final long limitReachedCount;
-    private long completionCount;
+    private final long completionCount;
     private final Map<TaskResourceUsageTrackerType, TaskResourceUsageTracker.Stats> resourceUsageTrackerStats;
 
     public SearchShardTaskStats(

--- a/server/src/main/java/org/opensearch/search/backpressure/stats/SearchShardTaskStats.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/stats/SearchShardTaskStats.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.search.backpressure.stats;
 
+import org.opensearch.Version;
 import org.opensearch.common.collect.MapBuilder;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -30,21 +31,27 @@ import java.util.Objects;
 public class SearchShardTaskStats implements ToXContentObject, Writeable {
     private final long cancellationCount;
     private final long limitReachedCount;
+    private Long completionCount;
     private final Map<TaskResourceUsageTrackerType, TaskResourceUsageTracker.Stats> resourceUsageTrackerStats;
 
     public SearchShardTaskStats(
         long cancellationCount,
         long limitReachedCount,
+        long completionCount,
         Map<TaskResourceUsageTrackerType, TaskResourceUsageTracker.Stats> resourceUsageTrackerStats
     ) {
         this.cancellationCount = cancellationCount;
         this.limitReachedCount = limitReachedCount;
+        this.completionCount = completionCount;
         this.resourceUsageTrackerStats = resourceUsageTrackerStats;
     }
 
     public SearchShardTaskStats(StreamInput in) throws IOException {
         this.cancellationCount = in.readVLong();
         this.limitReachedCount = in.readVLong();
+        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+            completionCount = in.readOptionalVLong();
+        }
 
         MapBuilder<TaskResourceUsageTrackerType, TaskResourceUsageTracker.Stats> builder = new MapBuilder<>();
         builder.put(TaskResourceUsageTrackerType.CPU_USAGE_TRACKER, in.readOptionalWriteable(CpuUsageTracker.Stats::new));
@@ -62,6 +69,9 @@ public class SearchShardTaskStats implements ToXContentObject, Writeable {
             builder.field(entry.getKey().getName(), entry.getValue());
         }
         builder.endObject();
+        if (completionCount != null) {
+            builder.field("completion_count", completionCount);
+        }
 
         builder.startObject("cancellation_stats")
             .field("cancellation_count", cancellationCount)
@@ -75,6 +85,9 @@ public class SearchShardTaskStats implements ToXContentObject, Writeable {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVLong(cancellationCount);
         out.writeVLong(limitReachedCount);
+        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+            out.writeOptionalVLong(completionCount);
+        }
 
         out.writeOptionalWriteable(resourceUsageTrackerStats.get(TaskResourceUsageTrackerType.CPU_USAGE_TRACKER));
         out.writeOptionalWriteable(resourceUsageTrackerStats.get(TaskResourceUsageTrackerType.HEAP_USAGE_TRACKER));
@@ -88,11 +101,12 @@ public class SearchShardTaskStats implements ToXContentObject, Writeable {
         SearchShardTaskStats that = (SearchShardTaskStats) o;
         return cancellationCount == that.cancellationCount
             && limitReachedCount == that.limitReachedCount
+            && Objects.equals(completionCount, that.completionCount)
             && resourceUsageTrackerStats.equals(that.resourceUsageTrackerStats);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(cancellationCount, limitReachedCount, resourceUsageTrackerStats);
+        return Objects.hash(cancellationCount, limitReachedCount, resourceUsageTrackerStats, completionCount);
     }
 }

--- a/server/src/main/java/org/opensearch/search/backpressure/stats/SearchTaskStats.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/stats/SearchTaskStats.java
@@ -104,7 +104,7 @@ public class SearchTaskStats implements ToXContentObject, Writeable {
         SearchTaskStats that = (SearchTaskStats) o;
         return cancellationCount == that.cancellationCount
             && limitReachedCount == that.limitReachedCount
-            && completionCount == completionCount
+            && completionCount == that.completionCount
             && resourceUsageTrackerStats.equals(that.resourceUsageTrackerStats);
     }
 

--- a/server/src/main/java/org/opensearch/search/backpressure/stats/SearchTaskStats.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/stats/SearchTaskStats.java
@@ -32,7 +32,7 @@ import java.util.Objects;
 public class SearchTaskStats implements ToXContentObject, Writeable {
     private final long cancellationCount;
     private final long limitReachedCount;
-    private Long completionCount;
+    private final Long completionCount;
     private final Map<TaskResourceUsageTrackerType, TaskResourceUsageTracker.Stats> resourceUsageTrackerStats;
 
     public SearchTaskStats(
@@ -52,6 +52,8 @@ public class SearchTaskStats implements ToXContentObject, Writeable {
         this.limitReachedCount = in.readVLong();
         if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
             this.completionCount = in.readOptionalVLong();
+        } else {
+            this.completionCount = null;
         }
 
 

--- a/server/src/main/java/org/opensearch/search/backpressure/stats/SearchTaskStats.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/stats/SearchTaskStats.java
@@ -32,7 +32,7 @@ import java.util.Objects;
 public class SearchTaskStats implements ToXContentObject, Writeable {
     private final long cancellationCount;
     private final long limitReachedCount;
-    private final Long completionCount;
+    private final long completionCount;
     private final Map<TaskResourceUsageTrackerType, TaskResourceUsageTracker.Stats> resourceUsageTrackerStats;
 
     public SearchTaskStats(
@@ -51,9 +51,9 @@ public class SearchTaskStats implements ToXContentObject, Writeable {
         this.cancellationCount = in.readVLong();
         this.limitReachedCount = in.readVLong();
         if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
-            this.completionCount = in.readOptionalVLong();
+            this.completionCount = in.readVLong();
         } else {
-            this.completionCount = null;
+            this.completionCount = -1;
         }
 
         MapBuilder<TaskResourceUsageTrackerType, TaskResourceUsageTracker.Stats> builder = new MapBuilder<>();
@@ -72,7 +72,7 @@ public class SearchTaskStats implements ToXContentObject, Writeable {
             builder.field(entry.getKey().getName(), entry.getValue());
         }
         builder.endObject();
-        if (completionCount != null) {
+        if (completionCount != -1) {
             builder.field("completion_count", completionCount);
         }
 
@@ -89,7 +89,7 @@ public class SearchTaskStats implements ToXContentObject, Writeable {
         out.writeVLong(cancellationCount);
         out.writeVLong(limitReachedCount);
         if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
-            out.writeOptionalVLong(completionCount);
+            out.writeVLong(completionCount);
         }
 
         out.writeOptionalWriteable(resourceUsageTrackerStats.get(TaskResourceUsageTrackerType.CPU_USAGE_TRACKER));
@@ -104,7 +104,7 @@ public class SearchTaskStats implements ToXContentObject, Writeable {
         SearchTaskStats that = (SearchTaskStats) o;
         return cancellationCount == that.cancellationCount
             && limitReachedCount == that.limitReachedCount
-            && Objects.equals(completionCount, that.completionCount)
+            && completionCount == completionCount
             && resourceUsageTrackerStats.equals(that.resourceUsageTrackerStats);
     }
 

--- a/server/src/main/java/org/opensearch/search/backpressure/stats/SearchTaskStats.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/stats/SearchTaskStats.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.search.backpressure.stats;
 
+import org.opensearch.Version;
 import org.opensearch.common.collect.MapBuilder;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -31,21 +32,28 @@ import java.util.Objects;
 public class SearchTaskStats implements ToXContentObject, Writeable {
     private final long cancellationCount;
     private final long limitReachedCount;
+    private Long completionCount;
     private final Map<TaskResourceUsageTrackerType, TaskResourceUsageTracker.Stats> resourceUsageTrackerStats;
 
     public SearchTaskStats(
         long cancellationCount,
         long limitReachedCount,
+        long completionCount,
         Map<TaskResourceUsageTrackerType, TaskResourceUsageTracker.Stats> resourceUsageTrackerStats
     ) {
         this.cancellationCount = cancellationCount;
         this.limitReachedCount = limitReachedCount;
+        this.completionCount = completionCount;
         this.resourceUsageTrackerStats = resourceUsageTrackerStats;
     }
 
     public SearchTaskStats(StreamInput in) throws IOException {
         this.cancellationCount = in.readVLong();
         this.limitReachedCount = in.readVLong();
+        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+            this.completionCount = in.readOptionalVLong();
+        }
+
 
         MapBuilder<TaskResourceUsageTrackerType, TaskResourceUsageTracker.Stats> builder = new MapBuilder<>();
         builder.put(TaskResourceUsageTrackerType.CPU_USAGE_TRACKER, in.readOptionalWriteable(CpuUsageTracker.Stats::new));
@@ -63,6 +71,9 @@ public class SearchTaskStats implements ToXContentObject, Writeable {
             builder.field(entry.getKey().getName(), entry.getValue());
         }
         builder.endObject();
+        if (completionCount != null) {
+            builder.field("completion_count", completionCount);
+        }
 
         builder.startObject("cancellation_stats")
             .field("cancellation_count", cancellationCount)
@@ -76,6 +87,9 @@ public class SearchTaskStats implements ToXContentObject, Writeable {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVLong(cancellationCount);
         out.writeVLong(limitReachedCount);
+        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+            out.writeOptionalVLong(completionCount);
+        }
 
         out.writeOptionalWriteable(resourceUsageTrackerStats.get(TaskResourceUsageTrackerType.CPU_USAGE_TRACKER));
         out.writeOptionalWriteable(resourceUsageTrackerStats.get(TaskResourceUsageTrackerType.HEAP_USAGE_TRACKER));
@@ -89,11 +103,12 @@ public class SearchTaskStats implements ToXContentObject, Writeable {
         SearchTaskStats that = (SearchTaskStats) o;
         return cancellationCount == that.cancellationCount
             && limitReachedCount == that.limitReachedCount
+            && Objects.equals(completionCount, that.completionCount)
             && resourceUsageTrackerStats.equals(that.resourceUsageTrackerStats);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(cancellationCount, limitReachedCount, resourceUsageTrackerStats);
+        return Objects.hash(cancellationCount, limitReachedCount, resourceUsageTrackerStats, completionCount);
     }
 }

--- a/server/src/main/java/org/opensearch/search/backpressure/stats/SearchTaskStats.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/stats/SearchTaskStats.java
@@ -56,7 +56,6 @@ public class SearchTaskStats implements ToXContentObject, Writeable {
             this.completionCount = null;
         }
 
-
         MapBuilder<TaskResourceUsageTrackerType, TaskResourceUsageTracker.Stats> builder = new MapBuilder<>();
         builder.put(TaskResourceUsageTrackerType.CPU_USAGE_TRACKER, in.readOptionalWriteable(CpuUsageTracker.Stats::new));
         builder.put(TaskResourceUsageTrackerType.HEAP_USAGE_TRACKER, in.readOptionalWriteable(HeapUsageTracker.Stats::new));

--- a/server/src/test/java/org/opensearch/search/backpressure/SearchBackpressureServiceTests.java
+++ b/server/src/test/java/org/opensearch/search/backpressure/SearchBackpressureServiceTests.java
@@ -249,10 +249,11 @@ public class SearchBackpressureServiceTests extends OpenSearchTestCase {
         verify(mockTaskManager, times(10)).cancelTaskAndDescendants(any(), anyString(), anyBoolean(), any());
         assertEquals(3, service.getSearchBackpressureState(SearchTask.class).getLimitReachedCount());
 
-        // Verify search backpressure stats.
+        // Verify search backpressure stats. Since we are not marking any task as completed the completionCount will be 0
+        // for SearchTaskStats here.
         SearchBackpressureStats expectedStats = new SearchBackpressureStats(
-            new SearchTaskStats(10, 3, Map.of(TaskResourceUsageTrackerType.CPU_USAGE_TRACKER, new MockStats(10))),
-            new SearchShardTaskStats(0, 0, Collections.emptyMap()),
+            new SearchTaskStats(10, 3, 0, Map.of(TaskResourceUsageTrackerType.CPU_USAGE_TRACKER, new MockStats(10))),
+            new SearchShardTaskStats(0, 0, 0, Collections.emptyMap()),
             SearchBackpressureMode.ENFORCED
         );
         SearchBackpressureStats actualStats = service.nodeStats();
@@ -323,10 +324,11 @@ public class SearchBackpressureServiceTests extends OpenSearchTestCase {
         verify(mockTaskManager, times(12)).cancelTaskAndDescendants(any(), anyString(), anyBoolean(), any());
         assertEquals(3, service.getSearchBackpressureState(SearchShardTask.class).getLimitReachedCount());
 
-        // Verify search backpressure stats.
+        // Verify search backpressure stats. We are marking 20 SearchShardTasks as completed this should get
+        // reflected in SearchShardTaskStats.
         SearchBackpressureStats expectedStats = new SearchBackpressureStats(
-            new SearchTaskStats(0, 0, Collections.emptyMap()),
-            new SearchShardTaskStats(12, 3, Map.of(TaskResourceUsageTrackerType.CPU_USAGE_TRACKER, new MockStats(12))),
+            new SearchTaskStats(0, 0, 0, Collections.emptyMap()),
+            new SearchShardTaskStats(12, 3, 20, Map.of(TaskResourceUsageTrackerType.CPU_USAGE_TRACKER, new MockStats(12))),
             SearchBackpressureMode.ENFORCED
         );
         SearchBackpressureStats actualStats = service.nodeStats();

--- a/server/src/test/java/org/opensearch/search/backpressure/stats/SearchShardTaskStatsTests.java
+++ b/server/src/test/java/org/opensearch/search/backpressure/stats/SearchShardTaskStatsTests.java
@@ -39,6 +39,11 @@ public class SearchShardTaskStatsTests extends AbstractWireSerializingTestCase<S
             new ElapsedTimeTracker.Stats(randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong())
         );
 
-        return new SearchShardTaskStats(randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong(), resourceUsageTrackerStats);
+        return new SearchShardTaskStats(
+            randomNonNegativeLong(),
+            randomNonNegativeLong(),
+            randomNonNegativeLong(),
+            resourceUsageTrackerStats
+        );
     }
 }

--- a/server/src/test/java/org/opensearch/search/backpressure/stats/SearchShardTaskStatsTests.java
+++ b/server/src/test/java/org/opensearch/search/backpressure/stats/SearchShardTaskStatsTests.java
@@ -39,15 +39,11 @@ public class SearchShardTaskStatsTests extends AbstractWireSerializingTestCase<S
             new ElapsedTimeTracker.Stats(randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong())
         );
 
-<<<<<<< HEAD
         return new SearchShardTaskStats(
             randomNonNegativeLong(),
             randomNonNegativeLong(),
             randomNonNegativeLong(),
             resourceUsageTrackerStats
         );
-=======
-        return new SearchShardTaskStats(randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong(), resourceUsageTrackerStats);
->>>>>>> 3324fa1aaea (add taskCompletionCount in search_backpressure)
     }
 }

--- a/server/src/test/java/org/opensearch/search/backpressure/stats/SearchShardTaskStatsTests.java
+++ b/server/src/test/java/org/opensearch/search/backpressure/stats/SearchShardTaskStatsTests.java
@@ -39,11 +39,15 @@ public class SearchShardTaskStatsTests extends AbstractWireSerializingTestCase<S
             new ElapsedTimeTracker.Stats(randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong())
         );
 
+<<<<<<< HEAD
         return new SearchShardTaskStats(
             randomNonNegativeLong(),
             randomNonNegativeLong(),
             randomNonNegativeLong(),
             resourceUsageTrackerStats
         );
+=======
+        return new SearchShardTaskStats(randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong(), resourceUsageTrackerStats);
+>>>>>>> 3324fa1aaea (add taskCompletionCount in search_backpressure)
     }
 }

--- a/server/src/test/java/org/opensearch/search/backpressure/stats/SearchShardTaskStatsTests.java
+++ b/server/src/test/java/org/opensearch/search/backpressure/stats/SearchShardTaskStatsTests.java
@@ -39,6 +39,6 @@ public class SearchShardTaskStatsTests extends AbstractWireSerializingTestCase<S
             new ElapsedTimeTracker.Stats(randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong())
         );
 
-        return new SearchShardTaskStats(randomNonNegativeLong(), randomNonNegativeLong(), resourceUsageTrackerStats);
+        return new SearchShardTaskStats(randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong(), resourceUsageTrackerStats);
     }
 }

--- a/server/src/test/java/org/opensearch/search/backpressure/stats/SearchTaskStatsTests.java
+++ b/server/src/test/java/org/opensearch/search/backpressure/stats/SearchTaskStatsTests.java
@@ -40,6 +40,6 @@ public class SearchTaskStatsTests extends AbstractWireSerializingTestCase<Search
             new ElapsedTimeTracker.Stats(randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong())
         );
 
-        return new SearchTaskStats(randomNonNegativeLong(), randomNonNegativeLong(), resourceUsageTrackerStats);
+        return new SearchTaskStats(randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong(), resourceUsageTrackerStats);
     }
 }


### PR DESCRIPTION
### Description
With this change the nodeStats API will also return the completionCount of search tasks at shard and coordinator level. Opening this separate PR due to DCO issue in a past commit.
Closed PR : https://github.com/opensearch-project/OpenSearch/pull/8701.

new sample response for an API call like ` curl "localhost:9200/_nodes/stats/search_backpressure?pretty"` will look like the following
```
{
  "_nodes" : {
    "total" : 1,
    "successful" : 1,
    "failed" : 0
  },
  "cluster_name" : "runTask",
  "nodes" : {
    "dPpgbce2STSxlvH7LDaGiA" : {
      "timestamp" : 1693433903192,
      "name" : "runTask-0",
      "transport_address" : "127.0.0.1:9300",
      "host" : "127.0.0.1",
      "ip" : "127.0.0.1:9300",
      "roles" : [
        "cluster_manager",
        "data",
        "ingest",
        "remote_cluster_client"
      ],
      "attributes" : {
        "testattr" : "test",
        "shard_indexing_pressure_enabled" : "true"
      },
      "search_backpressure" : {
        "search_task" : {
          "resource_tracker_stats" : {
            "cpu_usage_tracker" : {
              "cancellation_count" : 0,
              "current_max_millis" : 0,
              "current_avg_millis" : 0
            },
            "elapsed_time_tracker" : {
              "cancellation_count" : 0,
              "current_max_millis" : 0,
              "current_avg_millis" : 0
            },
            "heap_usage_tracker" : {
              "cancellation_count" : 0,
              "current_max_bytes" : 0,
              "current_avg_bytes" : 0,
              "rolling_avg_bytes" : 0
            }
          },
          "completion_count" : 0,
          "cancellation_stats" : {
            "cancellation_count" : 0,
            "cancellation_limit_reached_count" : 0
          }
        },
        "search_shard_task" : {
          "resource_tracker_stats" : {
            "cpu_usage_tracker" : {
              "cancellation_count" : 0,
              "current_max_millis" : 0,
              "current_avg_millis" : 0
            },
            "elapsed_time_tracker" : {
              "cancellation_count" : 0,
              "current_max_millis" : 0,
              "current_avg_millis" : 0
            },
            "heap_usage_tracker" : {
              "cancellation_count" : 0,
              "current_max_bytes" : 0,
              "current_avg_bytes" : 0,
              "rolling_avg_bytes" : 0
            }
          },
          "completion_count" : 0,
          "cancellation_stats" : {
            "cancellation_count" : 0,
            "cancellation_limit_reached_count" : 0
          }
        },
        "mode" : "monitor_only"
      },
      "is_node_under_duress" : false
    }
  }
}
```

### Related Issues
Resolves #[8698](https://github.com/opensearch-project/OpenSearch/issues/8698)
<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).