### PR TITLE
[Backport 1.3] Bump guava dependency to 32.0.1-jre 

### DIFF
--- a/qa/evil-tests/build.gradle
+++ b/qa/evil-tests/build.gradle
@@ -33,7 +33,7 @@
  * integration, change default filesystem impl, mess with arbitrary
  * threads, etc.
  */
- 
+
 import org.opensearch.gradle.info.BuildParams
 
 apply plugin: 'opensearch.testclusters'
@@ -41,6 +41,7 @@ apply plugin: 'opensearch.standalone-test'
 
 dependencies {
   testImplementation 'com.google.jimfs:jimfs:1.2'
+  testRuntimeOnly 'com.google.guava:guava:32.0.1-jre'
 }
 
 // TODO: give each evil test its own fresh JVM for more isolation.


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Potentially fixes CVEs for `1.3`
- CVE-2023-2976

### Related Issues
Resolves CVE-2023-2976

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
