### PR TITLE
Honor max segment size during only_expunge_deletes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add instrumentation in rest and network layer. ([#9415](https://github.com/opensearch-project/OpenSearch/pull/9415))
 - Allow parameterization of tests with OpenSearchIntegTestCase.SuiteScopeTestCase annotation ([#9916](https://github.com/opensearch-project/OpenSearch/pull/9916))
 - Mute the query profile IT with concurrent execution ([#9840](https://github.com/opensearch-project/OpenSearch/pull/9840))
+- Force merge with `only_expunge_deletes` honors max segment size ([#10036](https://github.com/opensearch-project/OpenSearch/pull/10036))
 - Add instrumentation in transport service. ([#10042](https://github.com/opensearch-project/OpenSearch/pull/10042))
 
 ### Deprecated

--- a/server/src/main/java/org/opensearch/index/OpenSearchTieredMergePolicy.java
+++ b/server/src/main/java/org/opensearch/index/OpenSearchTieredMergePolicy.java
@@ -42,7 +42,7 @@ import java.util.Map;
 
 /**
  * Wrapper around {@link TieredMergePolicy} which doesn't respect
- * {@link TieredMergePolicy#setMaxMergedSegmentMB(double)} on forced merges.
+ * {@link TieredMergePolicy#setMaxMergedSegmentMB(double)} on forced merges, but DOES respect it on only_expunge_deletes.
  * See https://issues.apache.org/jira/browse/LUCENE-7976.
  *
  * @opensearch.internal
@@ -71,7 +71,7 @@ final class OpenSearchTieredMergePolicy extends FilterMergePolicy {
 
     @Override
     public MergeSpecification findForcedDeletesMerges(SegmentInfos infos, MergeContext mergeContext) throws IOException {
-        return forcedMergePolicy.findForcedDeletesMerges(infos, mergeContext);
+        return regularMergePolicy.findForcedDeletesMerges(infos, mergeContext);
     }
 
     public void setForceMergeDeletesPctAllowed(double forceMergeDeletesPctAllowed) {
@@ -80,7 +80,7 @@ final class OpenSearchTieredMergePolicy extends FilterMergePolicy {
     }
 
     public double getForceMergeDeletesPctAllowed() {
-        return forcedMergePolicy.getForceMergeDeletesPctAllowed();
+        return regularMergePolicy.getForceMergeDeletesPctAllowed();
     }
 
     public void setFloorSegmentMB(double mbFrac) {

--- a/server/src/test/java/org/opensearch/index/OpenSearchTieredMergePolicyTests.java
+++ b/server/src/test/java/org/opensearch/index/OpenSearchTieredMergePolicyTests.java
@@ -32,8 +32,17 @@
 
 package org.opensearch.index;
 
+import org.apache.lucene.index.MergePolicy;
+import org.apache.lucene.index.SegmentCommitInfo;
+import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.index.TieredMergePolicy;
+import org.apache.lucene.util.InfoStream;
+import org.apache.lucene.util.Version;
 import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
 
 public class OpenSearchTieredMergePolicyTests extends OpenSearchTestCase {
 
@@ -79,5 +88,33 @@ public class OpenSearchTieredMergePolicyTests extends OpenSearchTestCase {
         OpenSearchTieredMergePolicy policy = new OpenSearchTieredMergePolicy();
         policy.setDeletesPctAllowed(42);
         assertEquals(42, policy.regularMergePolicy.getDeletesPctAllowed(), 0);
+    }
+
+    public void testFindDeleteMergesReturnsNullOnEmptySegmentInfos() throws IOException {
+        MergePolicy.MergeSpecification mergeSpecification = new OpenSearchTieredMergePolicy().findForcedDeletesMerges(
+            new SegmentInfos(Version.LATEST.major),
+            new MergePolicy.MergeContext() {
+                @Override
+                public int numDeletesToMerge(SegmentCommitInfo info) {
+                    return 0;
+                }
+
+                @Override
+                public int numDeletedDocs(SegmentCommitInfo info) {
+                    return 0;
+                }
+
+                @Override
+                public InfoStream getInfoStream() {
+                    return InfoStream.NO_OUTPUT;
+                }
+
+                @Override
+                public Set<SegmentCommitInfo> getMergingSegments() {
+                    return Collections.emptySet();
+                }
+            }
+        );
+        assertNull(mergeSpecification);
     }
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
There are latency-sensitive users for whom the default 20% allowable accumulation of deletes is too high, so they force merge with "only_expunge_deletes".

Unfortunately, this has ignored the max segment size, so despite the word "only" in there, they get the terrible side-effect of producing segments larger than the max segment size. These oversized segments are unlikely to participate in future merges, until they have so many deletes that they could drop back below the max segment size, likely making the whole "too many deletes" problem even worse.

This commit fixes that so that "only_expunge_deletes" ONLY EXPUNGES DELETES without creating oversized segments.

### Related Issues
Resolves #7644

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
