### PR TITLE
Fix typo in Precommit and Assemble workflow

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -1,4 +1,4 @@
-name: Gradle Precommit and Asssemble
+name: Gradle Precommit and Assemble
 on: [pull_request]
 
 jobs:


### PR DESCRIPTION
### Description
For a while, I've noticed that one of our workflows has an extra "s" in "Asssemble". I finally decided to fix it.

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
