### PR TITLE
Integ tests for auto restore of cluster metadata

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreBaseIntegTestCase.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreBaseIntegTestCase.java
@@ -312,6 +312,9 @@ public class RemoteStoreBaseIntegTestCase extends OpenSearchIntegTestCase {
     @After
     public void teardown() {
         clusterSettingsSuppliedByTest = false;
+        if (internalCluster().getNodeNames().length == 0) {
+            return;
+        }
         assertRemoteStoreRepositoryOnAllNodes(REPOSITORY_NAME);
         assertRemoteStoreRepositoryOnAllNodes(REPOSITORY_2_NAME);
         assertAcked(clusterAdmin().prepareDeleteRepository(REPOSITORY_NAME));

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreClusterStateRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreClusterStateRestoreIT.java
@@ -10,19 +10,30 @@ package org.opensearch.remotestore;
 
 import org.opensearch.action.admin.cluster.remotestore.restore.RestoreRemoteStoreResponse;
 import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
+import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.opensearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.gateway.remote.ClusterMetadataManifest;
+import org.opensearch.gateway.remote.ClusterMetadataManifest.UploadedIndexMetadata;
 import org.opensearch.gateway.remote.RemoteClusterStateService;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 
 import static org.opensearch.gateway.remote.RemoteClusterStateService.REMOTE_CLUSTER_STATE_ENABLED_SETTING;
+import static org.opensearch.index.IndexSettings.INDEX_REFRESH_INTERVAL_SETTING;
 import static org.opensearch.indices.ShardLimitValidator.SETTING_CLUSTER_MAX_SHARDS_PER_NODE;
 import static org.opensearch.indices.ShardLimitValidator.SETTING_MAX_SHARDS_PER_CLUSTER_KEY;
 
@@ -48,16 +59,11 @@ public class RemoteStoreClusterStateRestoreIT extends BaseRemoteStoreRestoreIT {
 
     private void resetCluster(int dataNodeCount, int clusterManagerNodeCount) {
         internalCluster().stopAllNodes();
-        addNewNodes(dataNodeCount, clusterManagerNodeCount);
+        internalCluster().startClusterManagerOnlyNodes(clusterManagerNodeCount);
+        internalCluster().startDataOnlyNodes(dataNodeCount);
     }
 
-    private void restoreAndValidate(String clusterUUID, Map<String, Long> indexStats) throws Exception {
-        restoreAndValidate(clusterUUID, indexStats, true);
-    }
-
-    private void restoreAndValidate(String clusterUUID, Map<String, Long> indexStats, boolean validate) throws Exception {
-        // TODO once auto restore is merged, the remote cluster state will be restored
-
+    private void validateData(Map<String, Long> indexStats, boolean validate) throws Exception {
         if (validate) {
             // Step - 4 validation restore is successful.
             ensureGreen(INDEX_NAME);
@@ -65,15 +71,14 @@ public class RemoteStoreClusterStateRestoreIT extends BaseRemoteStoreRestoreIT {
         }
     }
 
-    private void restoreAndValidateFails(
-        String clusterUUID,
-        PlainActionFuture<RestoreRemoteStoreResponse> actionListener,
+    private void validateDataFails(
         Class<? extends Throwable> clazz,
         String errorSubString
     ) {
 
         try {
-            restoreAndValidate(clusterUUID, null, false);
+            // TODO Changed argument to true
+            validateData(null, false);
         } catch (Exception e) {
             assertTrue(
                 String.format(Locale.ROOT, "%s %s", clazz, e),
@@ -88,7 +93,6 @@ public class RemoteStoreClusterStateRestoreIT extends BaseRemoteStoreRestoreIT {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/9834")
     public void testFullClusterRestore() throws Exception {
         int shardCount = randomIntBetween(1, 2);
         int replicaCount = 1;
@@ -106,10 +110,10 @@ public class RemoteStoreClusterStateRestoreIT extends BaseRemoteStoreRestoreIT {
         assert !Objects.equals(newClusterUUID, prevClusterUUID) : "cluster restart not successful. cluster uuid is same";
 
         // Step - 3 Trigger full cluster restore and validate
-        restoreAndValidate(prevClusterUUID, indexStats);
+        validateMetadata(List.of(INDEX_NAME));
+        // TODO validate data after #9921 fix
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/9834")
     public void testFullClusterRestoreMultipleIndices() throws Exception {
         int shardCount = randomIntBetween(1, 2);
         int replicaCount = 1;
@@ -134,88 +138,10 @@ public class RemoteStoreClusterStateRestoreIT extends BaseRemoteStoreRestoreIT {
         assert !Objects.equals(newClusterUUID, prevClusterUUID) : "cluster restart not successful. cluster uuid is same";
 
         // Step - 3 Trigger full cluster restore
-        restoreAndValidate(prevClusterUUID, indexStats);
-        ensureGreen(secondIndexName);
-        verifyRestoredData(indexStats2, secondIndexName);
+        validateMetadata(List.of(INDEX_NAME, secondIndexName));
+        // TODO validate data after #9921 fix
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/9834")
-    public void testFullClusterRestoreFailureValidationFailures() throws Exception {
-        int shardCount = randomIntBetween(1, 2);
-        int replicaCount = 1;
-        int dataNodeCount = shardCount * (replicaCount + 1);
-        int clusterManagerNodeCount = 1;
-
-        // index some data to generate files in remote directory
-        Map<String, Long> indexStats = initialTestSetup(shardCount, replicaCount, dataNodeCount, clusterManagerNodeCount);
-        String prevClusterUUID = clusterService().state().metadata().clusterUUID();
-
-        // Start of Test - 1
-        // Test - 1 Trigger full cluster restore and validate it fails due to incorrect cluster UUID
-        PlainActionFuture<RestoreRemoteStoreResponse> future = PlainActionFuture.newFuture();
-        restoreAndValidateFails("randomUUID", future, IllegalStateException.class, "Remote Cluster State not found - randomUUID");
-        // End of Test - 1
-
-        // Start of Test - 3
-        // Test - 2 Trigger full cluster restore and validate it fails due to cluster UUID same as current cluster UUID
-        future = PlainActionFuture.newFuture();
-        restoreAndValidateFails(
-            clusterService().state().metadata().clusterUUID(),
-            future,
-            IllegalArgumentException.class,
-            "clusterUUID to restore from should be different from current cluster UUID"
-        );
-        // End of Test - 2
-
-        // Start of Test - 3
-        // Step - 2 Replace all nodes in the cluster with new nodes. This ensures new cluster state doesn't have previous index metadata
-        // Restarting cluster with just 1 data node helps with applying cluster settings
-        resetCluster(1, clusterManagerNodeCount);
-        String newClusterUUID = clusterService().state().metadata().clusterUUID();
-        assert !Objects.equals(newClusterUUID, prevClusterUUID) : "cluster restart not successful. cluster uuid is same";
-
-        reduceShardLimits(1, 1);
-
-        // Step - 4 Trigger full cluster restore and validate it fails
-        future = PlainActionFuture.newFuture();
-        restoreAndValidateFails(
-            prevClusterUUID,
-            future,
-            IllegalArgumentException.class,
-            "this action would add [2] total shards, but this cluster currently has [0]/[1] maximum shards open"
-        );
-        resetShardLimits();
-        // End of Test - 3
-
-        // Start of Test - 4
-        // Test -4 Reset cluster and trigger full restore with same name index in the cluster
-        // Test -4 Add required nodes for this test after last reset.
-        addNewNodes(dataNodeCount - 1, 0);
-
-        newClusterUUID = clusterService().state().metadata().clusterUUID();
-        assert !Objects.equals(newClusterUUID, prevClusterUUID) : "cluster restart not successful. cluster uuid is same";
-
-        // Test -4 Step - 2 Create a new index with same name
-        createIndex(INDEX_NAME, remoteStoreIndexSettings(0, 1));
-        ensureYellowAndNoInitializingShards(INDEX_NAME);
-        ensureGreen(INDEX_NAME);
-
-        future = PlainActionFuture.newFuture();
-
-        // Test -4 Step - 3 Trigger full cluster restore and validate fails
-        restoreAndValidateFails(
-            prevClusterUUID,
-            future,
-            IllegalStateException.class,
-            "cannot restore index [remote-store-test-idx-1] because an open index with same name/uuid already exists in the cluster"
-        );
-
-        // Test -4 Step - 4 validation restore is successful.
-        ensureGreen(INDEX_NAME);
-        // End of Test - 4
-    }
-
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/9834")
     public void testFullClusterRestoreManifestFilePointsToInvalidIndexMetadataPathThrowsException() throws Exception {
         int shardCount = randomIntBetween(1, 2);
         int replicaCount = 1;
@@ -226,63 +152,169 @@ public class RemoteStoreClusterStateRestoreIT extends BaseRemoteStoreRestoreIT {
         initialTestSetup(shardCount, replicaCount, dataNodeCount, clusterManagerNodeCount);
 
         String prevClusterUUID = clusterService().state().metadata().clusterUUID();
+        String clusterName = clusterService().state().getClusterName().value();
 
         // Step - 2 Replace all nodes in the cluster with new nodes. This ensures new cluster state doesn't have previous index metadata
-        resetCluster(dataNodeCount, clusterManagerNodeCount);
-
-        String newClusterUUID = clusterService().state().metadata().clusterUUID();
-        assert !Objects.equals(newClusterUUID, prevClusterUUID) : "cluster restart not successful. cluster uuid is same";
-
+        internalCluster().stopAllNodes();
         // Step - 4 Delete index metadata file in remote
         try {
             Files.move(
                 segmentRepoPath.resolve(
-                    RemoteClusterStateService.encodeString(clusterService().state().getClusterName().value())
-                        + "/cluster-state/"
-                        + prevClusterUUID
-                        + "/index"
+                    RemoteClusterStateService.encodeString(clusterName) + "/cluster-state/" + prevClusterUUID + "/index"
                 ),
                 segmentRepoPath.resolve("cluster-state/")
             );
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-
-        // Step - 5 Trigger full cluster restore and validate fails
-        PlainActionFuture<RestoreRemoteStoreResponse> future = PlainActionFuture.newFuture();
-        restoreAndValidateFails(prevClusterUUID, future, IllegalStateException.class, "asdsa");
+        assertThrows(IllegalStateException.class, () -> addNewNodes(dataNodeCount, clusterManagerNodeCount));
     }
 
-    private void reduceShardLimits(int maxShardsPerNode, int maxShardsPerCluster) {
-        // Step 3 - Reduce shard limits to hit shard limit with less no of shards
-        try {
-            client().admin()
-                .cluster()
-                .updateSettings(
-                    new ClusterUpdateSettingsRequest().transientSettings(
-                        Settings.builder()
-                            .put(SETTING_CLUSTER_MAX_SHARDS_PER_NODE.getKey(), maxShardsPerNode)
-                            .put(SETTING_MAX_SHARDS_PER_CLUSTER_KEY, maxShardsPerCluster)
-                    )
-                )
-                .get();
-        } catch (InterruptedException | ExecutionException e) {
-            throw new RuntimeException(e);
+    public void testRemoteStateRestoreLongRunning() throws Exception {
+        int shardCount = randomIntBetween(1, 2);
+        int replicaCount = 1;
+        int dataNodeCount = shardCount * (replicaCount + 1);
+        int clusterManagerNodeCount = 3;
+
+        Map<String, Long> indexStats = initialTestSetup(shardCount, replicaCount, dataNodeCount, clusterManagerNodeCount);
+
+        for (int i = 0; i < 100; i++) {
+            logger.info("Current iteration is: {}", i);
+            performOperation(i);
+            validateCurrentMetadata();
+            String prevClusterUUID = clusterService().state().metadata().clusterUUID();
+            Metadata prevMetadata = clusterService().state().metadata();
+            resetCluster(dataNodeCount, clusterManagerNodeCount);
+            String newClusterUUID = clusterService().state().metadata().clusterUUID();
+            assert !Objects.equals(newClusterUUID, prevClusterUUID) : "cluster restart not successful. cluster uuid is same";
+
+            validateMetadataAfterRestore(prevMetadata);
         }
     }
 
-    private void resetShardLimits() {
-        // Step - 5 Reset the cluster settings
-        ClusterUpdateSettingsRequest resetRequest = new ClusterUpdateSettingsRequest();
-        resetRequest.transientSettings(
-            Settings.builder().putNull(SETTING_CLUSTER_MAX_SHARDS_PER_NODE.getKey()).putNull(SETTING_MAX_SHARDS_PER_CLUSTER_KEY)
+    public void testRemoteStateFullRestart() throws Exception {
+        int shardCount = randomIntBetween(1, 2);
+        int replicaCount = 1;
+        int dataNodeCount = shardCount * (replicaCount + 1);
+        int clusterManagerNodeCount = 3;
+
+        Map<String, Long> indexStats = initialTestSetup(shardCount, replicaCount, dataNodeCount, clusterManagerNodeCount);
+        String prevClusterUUID = clusterService().state().metadata().clusterUUID();
+        internalCluster().fullRestart();
+        ensureGreen(INDEX_NAME);
+        String newClusterUUID = clusterService().state().metadata().clusterUUID();
+        assert Objects.equals(newClusterUUID, prevClusterUUID) : "Full restart not successful. cluster uuid has changed";
+        validateCurrentMetadata();
+    }
+
+    private void validateMetadata(List<String> indexNames) {
+        assertEquals(clusterService().state().metadata().indices().size(), indexNames.size());
+        for (String indexName : indexNames) {
+            assertTrue(clusterService().state().metadata().hasIndex(indexName));
+        }
+    }
+
+    private void validateCurrentMetadata() throws Exception {
+        RemoteClusterStateService remoteClusterStateService = internalCluster().getInstance(
+            RemoteClusterStateService.class,
+            internalCluster().getClusterManagerName()
         );
+        assertBusy(() -> {
+            ClusterMetadataManifest manifest = remoteClusterStateService.getLatestClusterMetadataManifest(
+                getClusterState().getClusterName().value(),
+                getClusterState().metadata().clusterUUID()
+            ).get();
+            ClusterState clusterState = getClusterState();
+            Metadata currentMetadata = clusterState.metadata();
+            assertEquals(currentMetadata.indices().size(), manifest.getIndices().size());
+            assertEquals(currentMetadata.coordinationMetadata().term(), manifest.getClusterTerm());
+            assertEquals(clusterState.version(), manifest.getStateVersion());
+            assertEquals(clusterState.stateUUID(), manifest.getStateUUID());
+            assertEquals(currentMetadata.clusterUUIDCommitted(), manifest.isClusterUUIDCommitted());
+            for (UploadedIndexMetadata uploadedIndexMetadata : manifest.getIndices()) {
+                IndexMetadata currentIndexMetadata = currentMetadata.index(uploadedIndexMetadata.getIndexName());
+                assertEquals(currentIndexMetadata.getIndex().getUUID(), uploadedIndexMetadata.getIndexUUID());
+            }
+        });
+    }
 
-        try {
-            client().admin().cluster().updateSettings(resetRequest).get();
-        } catch (InterruptedException | ExecutionException e) {
-            throw new RuntimeException(e);
+    private void validateMetadataAfterRestore(Metadata prevMetadata) throws Exception {
+        assertBusy(() -> {
+            ClusterState clusterState = getClusterState();
+            Metadata currentMetadata = clusterState.metadata();
+            assertEquals(prevMetadata.indices().size(), currentMetadata.indices().size());
+            for (IndexMetadata currentIndexMetadata : currentMetadata.indices().values()) {
+                IndexMetadata prevIndexMetadata = prevMetadata.index(currentIndexMetadata.getIndex().getName());
+                assertEquals(prevIndexMetadata.getIndex().getName(), currentIndexMetadata.getIndex().getName());
+                assertEquals(prevIndexMetadata.getSettings(), currentIndexMetadata.getSettings());
+                assertEquals(prevIndexMetadata.mapping(), currentIndexMetadata.mapping());
+            }
+        });
+    }
+
+    private void performOperation(int iteration) throws Exception {
+        if (randomBoolean()) {
+            // create index
+            createIndex(INDEX_NAME + iteration, remoteStoreIndexSettings(1, 1));
         }
+        if (randomBoolean()) {
+            // update settings
+            randomIndexSettings();
+        }
+        if (randomBoolean()) {
+            // add mappings
+            randomIndexMappings();
+        }
+        if (randomIntBetween(1, 5) == 5) { // Deleting index with 20% probability
+            // delete index
+            deleteRandomIndex();
+        }
+        if (randomBoolean()) {
+            internalCluster().stopCurrentClusterManagerNode();
+            internalCluster().startClusterManagerOnlyNode();
+            internalCluster().validateClusterFormed();
+        }
+    }
+
+    private String randomIndex() {
+        if (clusterService().state().metadata().indices().size() == 0) {
+            return null;
+        }
+        return randomFrom(clusterService().state().metadata().indices().keySet());
+    }
+
+    private void randomIndexSettings() {
+        String indexName = randomIndex();
+        if (indexName == null) {
+            return;
+        }
+        Settings.Builder settingsBuilder = Settings.builder();
+        settingsBuilder.put(INDEX_REFRESH_INTERVAL_SETTING.getKey(), randomTimeValue(1, 60, new String[] { "s" }));
+        client().admin().indices().updateSettings(new UpdateSettingsRequest(indexName).settings(settingsBuilder.build())).actionGet();
+    }
+
+    private void randomIndexMappings() {
+        String indexName = randomIndex();
+        if (indexName == null) {
+            return;
+        }
+        String fieldName = "field-" + randomAlphaOfLength(10);
+
+        // The updated index mapping as a JSON string
+        String updatedMapping = String.format(Locale.ROOT, "{\"properties\": {\"%s\": {\"type\": \"text\"}}}", fieldName);
+
+        PutMappingRequest request = new PutMappingRequest(indexName);
+        request.source(updatedMapping, XContentType.JSON);
+
+        client().admin().indices().putMapping(request).actionGet();
+    }
+
+    private void deleteRandomIndex() {
+        String indexName = randomIndex();
+        if (indexName == null) {
+            return;
+        }
+        client().admin().indices().delete(new DeleteIndexRequest(indexName)).actionGet();
     }
 
 }

--- a/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
@@ -1853,10 +1853,12 @@ public final class InternalTestCluster extends TestCluster {
      */
     public void stopAllNodes() {
         try {
-            int totalDataNodes = numDataNodes();
-            while (totalDataNodes > 0) {
-                stopRandomDataNode();
-                totalDataNodes -= 1;
+            if (numDataAndClusterManagerNodes() != numClusterManagerNodes()) {
+                int totalDataNodes = numDataNodes();
+                while (totalDataNodes > 0) {
+                    stopRandomDataNode();
+                    totalDataNodes -= 1;
+                }
             }
             int totalClusterManagerNodes = numClusterManagerNodes();
             while (totalClusterManagerNodes > 1) {


### PR DESCRIPTION
### Description
Integ test for auto restore of cluster metadata when a new cluster is formed

### Related Issues

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
