### PR TITLE
Integ test fix -> Fix broken backward compatibility from 2.7 for IndexSorted field indices #10045

### DIFF
--- a/server/src/main/java/org/opensearch/index/IndexService.java
+++ b/server/src/main/java/org/opensearch/index/IndexService.java
@@ -240,8 +240,10 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             if (indexSettings.getIndexSortConfig().hasIndexSort()) {
                 // we delay the actual creation of the sort order for this index because the mapping has not been merged yet.
                 // The sort order is validated right after the merge of the mapping later in the process.
+                boolean shouldWidenIndexSortType = this.indexSettings.shouldWidenIndexSortType();
                 this.indexSortSupplier = () -> indexSettings.getIndexSortConfig()
                     .buildIndexSort(
+                        shouldWidenIndexSortType,
                         mapperService::fieldType,
                         (fieldType, searchLookup) -> indexFieldData.getForField(fieldType, indexFieldData.index().getName(), searchLookup)
                     );

--- a/server/src/main/java/org/opensearch/index/IndexSortConfig.java
+++ b/server/src/main/java/org/opensearch/index/IndexSortConfig.java
@@ -143,7 +143,6 @@ public final class IndexSortConfig {
 
     // visible for tests
     final FieldSortSpec[] sortSpecs;
-    final boolean shouldWidenIndexSortType;
 
     public IndexSortConfig(IndexSettings indexSettings) {
         final Settings settings = indexSettings.getSettings();
@@ -183,7 +182,6 @@ public final class IndexSortConfig {
                 sortSpecs[i].missingValue = missingValues.get(i);
             }
         }
-        this.shouldWidenIndexSortType = indexSettings.shouldWidenIndexSortType();
     }
 
     /**
@@ -202,6 +200,7 @@ public final class IndexSortConfig {
      * or returns null if this index has no sort.
      */
     public Sort buildIndexSort(
+        boolean shouldWidenIndexSortType,
         Function<String, MappedFieldType> fieldTypeLookup,
         BiFunction<MappedFieldType, Supplier<SearchLookup>, IndexFieldData<?>> fieldDataLookup
     ) {
@@ -232,7 +231,7 @@ public final class IndexSortConfig {
             if (fieldData == null) {
                 throw new IllegalArgumentException("docvalues not found for index sort field:[" + sortSpec.field + "]");
             }
-            if (this.shouldWidenIndexSortType == true) {
+            if (shouldWidenIndexSortType == true) {
                 sortFields[i] = fieldData.wideSortField(sortSpec.missingValue, mode, null, reverse);
             } else {
                 sortFields[i] = fieldData.sortField(sortSpec.missingValue, mode, null, reverse);


### PR DESCRIPTION
While resolving one of comment, https://github.com/opensearch-project/OpenSearch/pull/10045#discussion_r1326049739
I added `shouldWidenIndexSortTpe` as a class member and initialized from Settting.

But `IndexSortConfig` constructor is always getting called before `IndexSettings` determines the current version and put `shouldWidenIndexSortTpe` in their class. So `shouldWidenIndexSortTpe` always stayed false after that change and lead failuers in integ test `org.opensearch.backwards.IndexingIT.testUpdateSnapshotStatus` in 2.10 branch.

I am going to update this PR as well https://github.com/opensearch-project/OpenSearch/pull/10076