### PR TITLE
Adding stats for unreferenced files cleanup count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Async blob read support for S3 plugin ([#9694](https://github.com/opensearch-project/OpenSearch/pull/9694))
 - [Telemetry-Otel] Added support for OtlpGrpcSpanExporter exporter ([#9666](https://github.com/opensearch-project/OpenSearch/pull/9666))
 - Async blob read support for encrypted containers ([#10131](https://github.com/opensearch-project/OpenSearch/pull/10131))
+- Adding stats for unreferenced cleanup count ([#10157](https://github.com/opensearch-project/OpenSearch/pull/10157))
 
 ### Dependencies
 - Bump `peter-evans/create-or-update-comment` from 2 to 3 ([#9575](https://github.com/opensearch-project/OpenSearch/pull/9575))

--- a/server/src/main/java/org/opensearch/index/merge/UnreferencedFileCleanUpStats.java
+++ b/server/src/main/java/org/opensearch/index/merge/UnreferencedFileCleanUpStats.java
@@ -1,0 +1,71 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.merge;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+/**
+ * Stores stats about unreferenced file cleanup due to segment merge failure.
+ *
+ * @opensearch.internal
+ */
+public class UnreferencedFileCleanUpStats implements Writeable, ToXContentFragment {
+
+    private long totalUnreferencedFileCleanupCount;
+
+    public UnreferencedFileCleanUpStats() {
+
+    }
+
+    public UnreferencedFileCleanUpStats(StreamInput in) throws IOException {
+        totalUnreferencedFileCleanupCount = in.readVLong();
+    }
+
+    public void add(long totalUnreferencedFileCleanupCount) {
+        this.totalUnreferencedFileCleanupCount += totalUnreferencedFileCleanupCount;
+    }
+
+    public void add(UnreferencedFileCleanUpStats cleanUpStats) {
+        if (cleanUpStats == null) {
+            return;
+        }
+
+        this.totalUnreferencedFileCleanupCount += cleanUpStats.totalUnreferencedFileCleanupCount;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(Fields.UNREFERENCED_FILE_CLEANUP);
+        builder.field(Fields.COUNT, totalUnreferencedFileCleanupCount);
+        builder.endObject();
+        return null;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVLong(totalUnreferencedFileCleanupCount);
+    }
+
+    /**
+     * Fields for unreferenced file cleanup statistics
+     *
+     * @opensearch.internal
+     */
+    static final class Fields {
+        static final String UNREFERENCED_FILE_CLEANUP = "unreferenced_file_cleanup";
+        static final String COUNT = "count";
+    }
+
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
