### PR TITLE
Filtering Repeated Wildcards Enhances Regular Expression Performance

### DIFF
--- a/server/src/main/java/org/opensearch/common/regex/Regex.java
+++ b/server/src/main/java/org/opensearch/common/regex/Regex.java
@@ -142,8 +142,12 @@ public class Regex {
                 // str.endsWith(pattern.substring(1)), but avoiding the construction of pattern.substring(1):
                 return str.regionMatches(str.length() - pattern.length() + 1, pattern, 1, pattern.length() - 1);
             } else if (nextIndex == 1) {
-                // Double wildcard "**" - skipping the first "*"
-                return simpleMatchWithNormalizedStrings(pattern.substring(1), str);
+                // Double wildcard "**" detected - skipping all "*"
+                int wildcards = nextIndex + 1;
+                while (wildcards < pattern.length() && pattern.charAt(wildcards) == '*') {
+                    wildcards++;
+                }
+                return simpleMatchWithNormalizedStrings(pattern.substring(wildcards - 1), str);
             }
             final String part = pattern.substring(1, nextIndex);
             int partIndex = str.indexOf(part);

--- a/server/src/test/java/org/opensearch/common/regex/RegexTests.java
+++ b/server/src/test/java/org/opensearch/common/regex/RegexTests.java
@@ -122,4 +122,26 @@ public class RegexTests extends OpenSearchTestCase {
             assertFalse("[" + pattern + "] should not match [" + matchingString + "]", Regex.simpleMatch(pattern, matchingString));
         }
     }
+
+    public void testArbitraryWildcardMatch() {
+        final String prefix = randomAlphaOfLengthBetween(1, 20);
+        final String suffix = randomAlphaOfLengthBetween(1, 20);
+        final String pattern1 = "*".repeat(randomIntBetween(1, 1000));
+        // dd***
+        assertTrue(Regex.simpleMatch(prefix + pattern1, prefix + randomAlphaOfLengthBetween(10, 20), randomBoolean()));
+        // ***dd
+        assertTrue(Regex.simpleMatch(pattern1 + suffix, randomAlphaOfLengthBetween(10, 20) + suffix, randomBoolean()));
+        // dd***dd
+        assertTrue(Regex.simpleMatch(prefix + pattern1 + suffix, prefix + randomAlphaOfLengthBetween(10, 20) + suffix, randomBoolean()));
+        // dd***dd***dd
+        final String middle = randomAlphaOfLengthBetween(1, 20);
+        final String pattern2 = "*".repeat(randomIntBetween(1, 1000));
+        assertTrue(
+            Regex.simpleMatch(
+                prefix + pattern1 + middle + pattern2 + suffix,
+                prefix + randomAlphaOfLengthBetween(10, 20) + middle + randomAlphaOfLengthBetween(10, 20) + suffix,
+                randomBoolean()
+            )
+        );
+    }
 }


### PR DESCRIPTION
### Description
This modification avoids meaningless recursive calls caused by continuous use of the wildcard [\*]. 
Try to skip consecutive wildcards [\*].

### Related Issues

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
