### PR TITLE
Fix circular dependency in Settings initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix broken backward compatibility from 2.7 for IndexSorted field indices ([#10045](https://github.com/opensearch-project/OpenSearch/pull/10045))
 - Fix concurrent search NPE when track_total_hits, terminate_after and size=0 are used ([#10082](https://github.com/opensearch-project/OpenSearch/pull/10082))
 - Fix remove ingest processor handing ignore_missing parameter not correctly ([10089](https://github.com/opensearch-project/OpenSearch/pull/10089))
+- Fix circular dependency in Settings initialization ([10194](https://github.com/opensearch-project/OpenSearch/pull/10194))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/common/settings/Settings.java
+++ b/server/src/main/java/org/opensearch/common/settings/Settings.java
@@ -101,7 +101,7 @@ import static org.opensearch.core.common.unit.ByteSizeValue.parseBytesSizeValue;
 @PublicApi(since = "1.0.0")
 public final class Settings implements ToXContentFragment {
 
-    public static final Settings EMPTY = new Builder().build();
+    public static final Settings EMPTY = new Settings(Collections.emptyMap(), null);
 
     /** The raw settings from the full key to raw string value. */
     private final Map<String, Object> settings;
@@ -757,7 +757,7 @@ public final class Settings implements ToXContentFragment {
     @PublicApi(since = "1.0.0")
     public static class Builder {
 
-        public static final Settings EMPTY_SETTINGS = new Builder().build();
+        public static final Settings EMPTY_SETTINGS = Settings.EMPTY;
 
         // we use a sorted map for consistent serialization when using getAsMap()
         private final Map<String, Object> map = new TreeMap<>();


### PR DESCRIPTION
### Description
There was a weird circular class-loading dependency between Settings and Settings.Builder that could result in ClassLoader deadlock if multiple threads trigger class-loading of Settings at the same time.

### Related Issues
Resolves #10065

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
