### PR TITLE
Script Score Query Builder Visit Method

### DIFF
--- a/server/src/main/java/org/opensearch/index/query/functionscore/ScriptScoreQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/functionscore/ScriptScoreQueryBuilder.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.index.query.functionscore;
 
+import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.Query;
 import org.opensearch.OpenSearchException;
 import org.opensearch.common.lucene.search.function.ScriptScoreQuery;
@@ -45,6 +46,7 @@ import org.opensearch.index.query.AbstractQueryBuilder;
 import org.opensearch.index.query.InnerHitContextBuilder;
 import org.opensearch.index.query.MatchNoneQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilderVisitor;
 import org.opensearch.index.query.QueryRewriteContext;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.script.ScoreScript;
@@ -224,4 +226,12 @@ public class ScriptScoreQueryBuilder extends AbstractQueryBuilder<ScriptScoreQue
         InnerHitContextBuilder.extractInnerHits(query(), innerHits);
     }
 
+    @Override
+    public void visit(QueryBuilderVisitor visitor) {
+        visitor.accept(this);
+        if (query != null) {
+            QueryBuilderVisitor subVisitor = visitor.getChildVisitor(BooleanClause.Occur.MUST);
+            subVisitor.accept(query);
+        }
+    }
 }

--- a/server/src/test/java/org/opensearch/index/query/ScriptQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/ScriptQueryBuilderTests.java
@@ -41,7 +41,9 @@ import org.opensearch.script.ScriptType;
 import org.opensearch.test.AbstractQueryTestCase;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -148,5 +150,12 @@ public class ScriptQueryBuilderTests extends AbstractQueryTestCase<ScriptQueryBu
         ScriptQueryBuilder queryBuilder = doCreateTestQueryBuilder();
         OpenSearchException e = expectThrows(OpenSearchException.class, () -> queryBuilder.toQuery(queryShardContext));
         assertEquals("[script] queries cannot be executed when 'search.allow_expensive_queries' is set to false.", e.getMessage());
+    }
+
+    public void testVisit() {
+        ScriptQueryBuilder scriptQueryBuilder = doCreateTestQueryBuilder();
+        List<QueryBuilder> visitedQueries = new ArrayList<>();
+        scriptQueryBuilder.visit(createTestVisitor(visitedQueries));
+        assertEquals(2, visitedQueries.size());
     }
 }

--- a/server/src/test/java/org/opensearch/index/query/ScriptQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/ScriptQueryBuilderTests.java
@@ -41,9 +41,7 @@ import org.opensearch.script.ScriptType;
 import org.opensearch.test.AbstractQueryTestCase;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -150,12 +148,5 @@ public class ScriptQueryBuilderTests extends AbstractQueryTestCase<ScriptQueryBu
         ScriptQueryBuilder queryBuilder = doCreateTestQueryBuilder();
         OpenSearchException e = expectThrows(OpenSearchException.class, () -> queryBuilder.toQuery(queryShardContext));
         assertEquals("[script] queries cannot be executed when 'search.allow_expensive_queries' is set to false.", e.getMessage());
-    }
-
-    public void testVisit() {
-        ScriptQueryBuilder scriptQueryBuilder = doCreateTestQueryBuilder();
-        List<QueryBuilder> visitedQueries = new ArrayList<>();
-        scriptQueryBuilder.visit(createTestVisitor(visitedQueries));
-        assertEquals(2, visitedQueries.size());
     }
 }

--- a/server/src/test/java/org/opensearch/index/query/ScriptScoreQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/ScriptScoreQueryBuilderTests.java
@@ -32,8 +32,6 @@
 
 package org.opensearch.index.query;
 
-import java.util.ArrayList;
-import java.util.List;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.opensearch.OpenSearchException;
@@ -45,7 +43,9 @@ import org.opensearch.script.ScriptType;
 import org.opensearch.test.AbstractQueryTestCase;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 import static org.opensearch.index.query.QueryBuilders.matchAllQuery;
 import static org.hamcrest.CoreMatchers.instanceOf;

--- a/server/src/test/java/org/opensearch/index/query/ScriptScoreQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/ScriptScoreQueryBuilderTests.java
@@ -32,6 +32,8 @@
 
 package org.opensearch.index.query;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.opensearch.OpenSearchException;
@@ -139,5 +141,12 @@ public class ScriptScoreQueryBuilderTests extends AbstractQueryTestCase<ScriptSc
         ScriptScoreQueryBuilder queryBuilder = doCreateTestQueryBuilder();
         OpenSearchException e = expectThrows(OpenSearchException.class, () -> queryBuilder.toQuery(queryShardContext));
         assertEquals("[script score] queries cannot be executed when 'search.allow_expensive_queries' is set to false.", e.getMessage());
+    }
+
+    public void testVisit() {
+        ScriptScoreQueryBuilder scriptQueryBuilder = doCreateTestQueryBuilder();
+        List<QueryBuilder> visitedQueries = new ArrayList<>();
+        scriptQueryBuilder.visit(createTestVisitor(visitedQueries));
+        assertEquals(2, visitedQueries.size());
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Adding Visit method in Script Score Query Builder. I missed it in my earlier PR [https://github.com/opensearch-project/OpenSearch/pull/10110](https://github.com/opensearch-project/OpenSearch/pull/10110)


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
