### PR TITLE
Add node id to segment and translog metadata

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/index/shard/IndexShardIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/shard/IndexShardIT.java
@@ -650,7 +650,15 @@ public class IndexShardIT extends OpenSearchSingleNodeTestCase {
                 }
             }
         };
-        final IndexShard newShard = newIndexShard(indexService, shard, wrapper, getInstanceFromNode(CircuitBreakerService.class), listener);
+        NodeEnvironment env = getInstanceFromNode(NodeEnvironment.class);
+        final IndexShard newShard = newIndexShard(
+            indexService,
+            shard,
+            wrapper,
+            getInstanceFromNode(CircuitBreakerService.class),
+            env.nodeId(),
+            listener
+        );
         shardRef.set(newShard);
         recoverShard(newShard);
 
@@ -674,6 +682,7 @@ public class IndexShardIT extends OpenSearchSingleNodeTestCase {
         final IndexShard shard,
         CheckedFunction<DirectoryReader, DirectoryReader, IOException> wrapper,
         final CircuitBreakerService cbs,
+        final String nodeId,
         final IndexingOperationListener... listeners
     ) throws IOException {
         ShardRouting initializingShardRouting = getInitializingShardRouting(shard.routingEntry());
@@ -702,7 +711,8 @@ public class IndexShardIT extends OpenSearchSingleNodeTestCase {
             SegmentReplicationCheckpointPublisher.EMPTY,
             null,
             null,
-            () -> IndexSettings.DEFAULT_REMOTE_TRANSLOG_BUFFER_INTERVAL
+            () -> IndexSettings.DEFAULT_REMOTE_TRANSLOG_BUFFER_INTERVAL,
+            nodeId
         );
     }
 

--- a/server/src/main/java/org/opensearch/index/IndexService.java
+++ b/server/src/main/java/org/opensearch/index/IndexService.java
@@ -519,7 +519,8 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                 this.indexSettings.isSegRepEnabled() ? checkpointPublisher : null,
                 remoteStore,
                 remoteStoreStatsTrackerFactory,
-                clusterRemoteTranslogBufferIntervalSupplier
+                clusterRemoteTranslogBufferIntervalSupplier,
+                nodeEnv.nodeId()
             );
             eventListener.indexShardStateChanged(indexShard, null, indexShard.state(), "shard created");
             eventListener.afterIndexShardCreated(indexShard);

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -342,8 +342,6 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
 
     private final List<ReferenceManager.RefreshListener> internalRefreshListener = new ArrayList<>();
 
-    private final String nodeId;
-
     public IndexShard(
         final ShardRouting shardRouting,
         final IndexSettings indexSettings,
@@ -466,7 +464,6 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             ? false
             : mapperService.documentMapper().mappers().containsTimeStampField();
         this.remoteStoreStatsTrackerFactory = remoteStoreStatsTrackerFactory;
-        this.nodeId = nodeId;
     }
 
     public ThreadPool getThreadPool() {
@@ -561,7 +558,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     }
 
     public String getNodeId() {
-        return nodeId;
+        return translogConfig.getNodeId();
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -346,7 +346,8 @@ public final class RemoteStoreRefreshListener extends CloseableRetryableRefreshL
                 segmentInfosSnapshot,
                 storeDirectory,
                 translogFileGeneration,
-                replicationCheckpoint
+                replicationCheckpoint,
+                indexShard.getNodeId()
             );
         }
     }

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -45,6 +45,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -194,7 +194,7 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
             METADATA_FILES_TO_FETCH
         );
 
-        verifyMultipleWriters(metadataFiles);
+        verifyNoMultipleWriters(metadataFiles);
 
         if (metadataFiles.isEmpty() == false) {
             String latestMetadataFile = metadataFiles.get(0);
@@ -208,7 +208,6 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
     }
 
     private RemoteSegmentMetadata readMetadataFile(String metadataFilename) throws IOException {
-
         try (InputStream inputStream = remoteMetadataDirectory.getBlobStream(metadataFilename)) {
             byte[] metadataBytes = inputStream.readAllBytes();
             return metadataStreamWrapper.readStream(new ByteArrayIndexInput(metadataFilename, metadataBytes));
@@ -216,7 +215,7 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
     }
 
     // Visible for testing
-    public static void verifyMultipleWriters(List<String> mdFiles) {
+    public static void verifyNoMultipleWriters(List<String> mdFiles) {
         Map<Tuple<Long, Long>, String> nodesByPrimaryTermAndGeneration = new HashMap<>();
         mdFiles.forEach(mdFile -> {
             Tuple<Tuple<Long, Long>, String> nodeIdByPrimaryTermAndGeneration = MetadataFilenameUtils.getNodeIdByPrimaryTermAndGeneration(
@@ -351,8 +350,7 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
                 RemoteStoreUtils.invertLong(uploadCounter),
                 nodeId,
                 RemoteStoreUtils.invertLong(System.currentTimeMillis()),
-                String.valueOf(metadataVersion),
-                UUIDs.base64UUID()
+                String.valueOf(metadataVersion)
             );
         }
 
@@ -368,7 +366,7 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
 
         public static Tuple<Tuple<Long, Long>, String> getNodeIdByPrimaryTermAndGeneration(String filename) {
             String[] tokens = filename.split(SEPARATOR);
-            if (tokens.length < 9) {
+            if (tokens.length < 8) {
                 // For versions < 2.11, we don't have node id.
                 return null;
             }

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -114,7 +114,7 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
 
     private final AtomicLong metadataUploadCounter = new AtomicLong(0);
 
-    public static final int METADATA_FILES_TO_FETCH = 100;
+    public static final int METADATA_FILES_TO_FETCH = 10;
 
     public RemoteSegmentStoreDirectory(
         RemoteDirectory remoteDataDirectory,

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -341,22 +341,13 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
             return RemoteStoreUtils.invertLong(filenameTokens[2]);
         }
 
-        public static Tuple<Tuple<Long, Long>, String> getNodeIdByPrimaryTermAndGeneration(String filename) {
-            String[] tokens = filename.split(SEPARATOR);
-            if (tokens.length < 8) {
-                // For versions < 2.11, we don't have node id.
-                return null;
-            }
-            return new Tuple<>(new Tuple<>(RemoteStoreUtils.invertLong(tokens[1]), RemoteStoreUtils.invertLong(tokens[2])), tokens[5]);
-        }
-
         public static Tuple<String, String> getNodeIdByPrimaryTermAndGen(String filename) {
             String[] tokens = filename.split(SEPARATOR);
             if (tokens.length < 8) {
                 // For versions < 2.11, we don't have node id.
                 return null;
             }
-            String primaryTermAndGen = String.join(SEPARATOR, tokens[2], tokens[3]);
+            String primaryTermAndGen = String.join(SEPARATOR, tokens[1], tokens[2], tokens[3]);
 
             String nodeId = tokens[5];
             return new Tuple<>(primaryTermAndGen, nodeId);

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -349,10 +349,10 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
                 RemoteStoreUtils.invertLong(generation),
                 RemoteStoreUtils.invertLong(translogGeneration),
                 RemoteStoreUtils.invertLong(uploadCounter),
+                nodeId,
                 RemoteStoreUtils.invertLong(System.currentTimeMillis()),
                 String.valueOf(metadataVersion),
-                UUIDs.base64UUID(),
-                nodeId
+                UUIDs.base64UUID()
             );
         }
 
@@ -372,7 +372,7 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
                 // For versions < 2.11, we don't have node id.
                 return null;
             }
-            return new Tuple<>(new Tuple<>(RemoteStoreUtils.invertLong(tokens[1]), RemoteStoreUtils.invertLong(tokens[2])), tokens[8]);
+            return new Tuple<>(new Tuple<>(RemoteStoreUtils.invertLong(tokens[1]), RemoteStoreUtils.invertLong(tokens[2])), tokens[5]);
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -93,6 +93,7 @@ public class RemoteFsTranslog extends Translog {
         this.primaryModeSupplier = primaryModeSupplier;
         this.remoteTranslogTransferTracker = remoteTranslogTransferTracker;
         fileTransferTracker = new FileTransferTracker(shardId, remoteTranslogTransferTracker);
+
         this.translogTransferManager = buildTranslogTransferManager(
             blobStoreRepository,
             threadPool,
@@ -327,7 +328,8 @@ public class RemoteFsTranslog extends Translog {
                 generation,
                 location,
                 readers,
-                Translog::getCommitCheckpointFileName
+                Translog::getCommitCheckpointFileName,
+                config.getNodeId()
             ).build()
         ) {
             return translogTransferManager.transferSnapshot(

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -93,7 +93,6 @@ public class RemoteFsTranslog extends Translog {
         this.primaryModeSupplier = primaryModeSupplier;
         this.remoteTranslogTransferTracker = remoteTranslogTransferTracker;
         fileTransferTracker = new FileTransferTracker(shardId, remoteTranslogTransferTracker);
-
         this.translogTransferManager = buildTranslogTransferManager(
             blobStoreRepository,
             threadPool,

--- a/server/src/main/java/org/opensearch/index/translog/TranslogConfig.java
+++ b/server/src/main/java/org/opensearch/index/translog/TranslogConfig.java
@@ -57,6 +57,8 @@ public final class TranslogConfig {
     private final Path translogPath;
     private final ByteSizeValue bufferSize;
 
+    private final String nodeId;
+
     /**
      * Creates a new TranslogConfig instance
      * @param shardId the shard ID this translog belongs to
@@ -64,16 +66,24 @@ public final class TranslogConfig {
      * @param indexSettings the index settings used to set internal variables
      * @param bigArrays a bigArrays instance used for temporarily allocating write operations
      */
-    public TranslogConfig(ShardId shardId, Path translogPath, IndexSettings indexSettings, BigArrays bigArrays) {
-        this(shardId, translogPath, indexSettings, bigArrays, DEFAULT_BUFFER_SIZE);
+    public TranslogConfig(ShardId shardId, Path translogPath, IndexSettings indexSettings, BigArrays bigArrays, String nodeId) {
+        this(shardId, translogPath, indexSettings, bigArrays, DEFAULT_BUFFER_SIZE, nodeId);
     }
 
-    TranslogConfig(ShardId shardId, Path translogPath, IndexSettings indexSettings, BigArrays bigArrays, ByteSizeValue bufferSize) {
+    TranslogConfig(
+        ShardId shardId,
+        Path translogPath,
+        IndexSettings indexSettings,
+        BigArrays bigArrays,
+        ByteSizeValue bufferSize,
+        String nodeId
+    ) {
         this.bufferSize = bufferSize;
         this.indexSettings = indexSettings;
         this.shardId = shardId;
         this.translogPath = translogPath;
         this.bigArrays = bigArrays;
+        this.nodeId = nodeId;
     }
 
     /**
@@ -109,5 +119,9 @@ public final class TranslogConfig {
      */
     public ByteSizeValue getBufferSize() {
         return bufferSize;
+    }
+
+    public String getNodeId() {
+        return nodeId;
     }
 }

--- a/server/src/main/java/org/opensearch/index/translog/TranslogConfig.java
+++ b/server/src/main/java/org/opensearch/index/translog/TranslogConfig.java
@@ -56,7 +56,6 @@ public final class TranslogConfig {
     private final ShardId shardId;
     private final Path translogPath;
     private final ByteSizeValue bufferSize;
-
     private final String nodeId;
 
     /**

--- a/server/src/main/java/org/opensearch/index/translog/TruncateTranslogAction.java
+++ b/server/src/main/java/org/opensearch/index/translog/TruncateTranslogAction.java
@@ -194,7 +194,8 @@ public class TruncateTranslogAction {
                 shardPath.getShardId(),
                 translogPath,
                 indexSettings,
-                BigArrays.NON_RECYCLING_INSTANCE
+                BigArrays.NON_RECYCLING_INSTANCE,
+                ""
             );
             long primaryTerm = indexSettings.getIndexMetadata().primaryTerm(shardPath.getShardId().id());
             // We open translog to check for corruption, do not clean anything.

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogCheckpointTransferSnapshot.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogCheckpointTransferSnapshot.java
@@ -40,11 +40,14 @@ public class TranslogCheckpointTransferSnapshot implements TransferSnapshot, Clo
     private final long primaryTerm;
     private long minTranslogGeneration;
 
-    TranslogCheckpointTransferSnapshot(long primaryTerm, long generation, int size) {
+    private String nodeId;
+
+    TranslogCheckpointTransferSnapshot(long primaryTerm, long generation, int size, String nodeId) {
         translogCheckpointFileInfoTupleSet = new HashSet<>(size);
         this.size = size;
         this.generation = generation;
         this.primaryTerm = primaryTerm;
+        this.nodeId = nodeId;
     }
 
     private void add(TranslogFileSnapshot translogFileSnapshot, CheckpointFileSnapshot checkPointFileSnapshot) {
@@ -63,7 +66,13 @@ public class TranslogCheckpointTransferSnapshot implements TransferSnapshot, Clo
 
     @Override
     public TranslogTransferMetadata getTranslogTransferMetadata() {
-        return new TranslogTransferMetadata(primaryTerm, generation, minTranslogGeneration, translogCheckpointFileInfoTupleSet.size() * 2);
+        return new TranslogTransferMetadata(
+            primaryTerm,
+            generation,
+            minTranslogGeneration,
+            translogCheckpointFileInfoTupleSet.size() * 2,
+            nodeId
+        );
     }
 
     @Override
@@ -110,19 +119,22 @@ public class TranslogCheckpointTransferSnapshot implements TransferSnapshot, Clo
         private final List<TranslogReader> readers;
         private final Function<Long, String> checkpointGenFileNameMapper;
         private final Path location;
+        private final String nodeId;
 
         public Builder(
             long primaryTerm,
             long generation,
             Path location,
             List<TranslogReader> readers,
-            Function<Long, String> checkpointGenFileNameMapper
+            Function<Long, String> checkpointGenFileNameMapper,
+            String nodeId
         ) {
             this.primaryTerm = primaryTerm;
             this.generation = generation;
             this.readers = readers;
             this.checkpointGenFileNameMapper = checkpointGenFileNameMapper;
             this.location = location;
+            this.nodeId = nodeId;
         }
 
         public TranslogCheckpointTransferSnapshot build() throws IOException {
@@ -134,7 +146,8 @@ public class TranslogCheckpointTransferSnapshot implements TransferSnapshot, Clo
             TranslogCheckpointTransferSnapshot translogTransferSnapshot = new TranslogCheckpointTransferSnapshot(
                 primaryTerm,
                 generation,
-                readers.size()
+                readers.size(),
+                nodeId
             );
             for (TranslogReader reader : readers) {
                 final long readerGeneration = reader.getGeneration();

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
@@ -65,7 +65,7 @@ public class TranslogTransferManager {
 
     private static final long TRANSFER_TIMEOUT_IN_MILLIS = 30000;
 
-    private static final int METADATA_FILES_TO_FETCH = 100;
+    private static final int METADATA_FILES_TO_FETCH = 10;
 
     private final Logger logger;
     private final static String METADATA_DIR = "metadata";

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
@@ -272,7 +272,7 @@ public class TranslogTransferManager {
         fileTransferTracker.add(fileName, true);
     }
 
-    static public void verifyMultipleWriters(List<BlobMetadata> mdFiles) {
+    static public void verifyNoMultipleWriters(List<BlobMetadata> mdFiles) {
         Map<Tuple<Long, Long>, String> nodesByPrimaryTermAndGeneration = new HashMap<>();
         mdFiles.forEach(blobMetadata -> {
             Tuple<Tuple<Long, Long>, String> nodeIdByPrimaryTermAndGeneration = TranslogTransferMetadata
@@ -298,7 +298,7 @@ public class TranslogTransferManager {
         LatchedActionListener<List<BlobMetadata>> latchedActionListener = new LatchedActionListener<>(
             ActionListener.wrap(blobMetadataList -> {
                 if (blobMetadataList.isEmpty()) return;
-                verifyMultipleWriters(blobMetadataList);
+                verifyNoMultipleWriters(blobMetadataList);
                 String filename = blobMetadataList.get(0).name();
                 boolean downloadStatus = false;
                 long downloadStartTime = System.nanoTime(), bytesToRead = 0;

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
@@ -105,8 +105,8 @@ public class TranslogTransferMetadata {
                 RemoteStoreUtils.invertLong(primaryTerm),
                 RemoteStoreUtils.invertLong(generation),
                 RemoteStoreUtils.invertLong(createdAt),
-                String.valueOf(CURRENT_VERSION),
-                nodeId
+                nodeId,
+                String.valueOf(CURRENT_VERSION)
             )
         );
     }
@@ -117,7 +117,7 @@ public class TranslogTransferMetadata {
             // For versions < 2.11, we don't have node id
             return null;
         }
-        return new Tuple<>(new Tuple<>(RemoteStoreUtils.invertLong(tokens[1]), RemoteStoreUtils.invertLong(tokens[2])), tokens[5]);
+        return new Tuple<>(new Tuple<>(RemoteStoreUtils.invertLong(tokens[1]), RemoteStoreUtils.invertLong(tokens[2])), tokens[4]);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
@@ -113,11 +113,11 @@ public class TranslogTransferMetadata {
 
     public static Tuple<Tuple<Long, Long>, String> getNodeIdByPrimaryTermAndGeneration(String filename) {
         String[] tokens = filename.split(METADATA_SEPARATOR);
-        if (tokens.length < 5) {
+        if (tokens.length < 6) {
             // For versions < 2.11, we don't have node id
             return null;
         }
-        return new Tuple<>(new Tuple<>(RemoteStoreUtils.invertLong(tokens[1]), RemoteStoreUtils.invertLong(tokens[2])), tokens[4]);
+        return new Tuple<>(new Tuple<>(RemoteStoreUtils.invertLong(tokens[1]), RemoteStoreUtils.invertLong(tokens[2])), tokens[5]);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
@@ -62,12 +62,7 @@ public class TranslogTransferMetadata {
     Used only at the time of download . Since details are read from content , nodeId is not available
      */
     public TranslogTransferMetadata(long primaryTerm, long generation, long minTranslogGeneration, int count) {
-        this.primaryTerm = primaryTerm;
-        this.generation = generation;
-        this.minTranslogGeneration = minTranslogGeneration;
-        this.count = count;
-        this.createdAt = System.currentTimeMillis();
-        this.nodeId = "";
+        this(primaryTerm, generation, minTranslogGeneration, count, "");
     }
 
     public long getPrimaryTerm() {

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
@@ -120,6 +120,18 @@ public class TranslogTransferMetadata {
         return new Tuple<>(new Tuple<>(RemoteStoreUtils.invertLong(tokens[1]), RemoteStoreUtils.invertLong(tokens[2])), tokens[4]);
     }
 
+    public static Tuple<String, String> getNodeIdByPrimaryTermAndGen(String filename) {
+        String[] tokens = filename.split(METADATA_SEPARATOR);
+        if (tokens.length < 6) {
+            // For versions < 2.11, we don't have node id.
+            return null;
+        }
+        String primaryTermAndGen = String.join(METADATA_SEPARATOR, tokens[1], tokens[2]);
+
+        String nodeId = tokens[4];
+        return new Tuple<>(primaryTermAndGen, nodeId);
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(primaryTerm, generation);

--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -3997,7 +3997,7 @@ public class InternalEngineTests extends EngineTestCase {
         final Path badTranslogLog = createTempDir();
         final String badUUID = Translog.createEmptyTranslog(badTranslogLog, SequenceNumbers.NO_OPS_PERFORMED, shardId, primaryTerm.get());
         Translog translog = new LocalTranslog(
-            new TranslogConfig(shardId, badTranslogLog, INDEX_SETTINGS, BigArrays.NON_RECYCLING_INSTANCE),
+            new TranslogConfig(shardId, badTranslogLog, INDEX_SETTINGS, BigArrays.NON_RECYCLING_INSTANCE, ""),
             badUUID,
             createTranslogDeletionPolicy(INDEX_SETTINGS),
             () -> SequenceNumbers.NO_OPS_PERFORMED,
@@ -4014,7 +4014,8 @@ public class InternalEngineTests extends EngineTestCase {
             shardId,
             translog.location(),
             config.getIndexSettings(),
-            BigArrays.NON_RECYCLING_INSTANCE
+            BigArrays.NON_RECYCLING_INSTANCE,
+            ""
         );
 
         EngineConfig brokenConfig = new EngineConfig.Builder().shardId(shardId)
@@ -7703,7 +7704,8 @@ public class InternalEngineTests extends EngineTestCase {
                 config.getTranslogConfig().getShardId(),
                 createTempDir(),
                 config.getTranslogConfig().getIndexSettings(),
-                config.getTranslogConfig().getBigArrays()
+                config.getTranslogConfig().getBigArrays(),
+                ""
             );
             EngineConfig configWithWarmer = new EngineConfig.Builder().shardId(config.getShardId())
                 .threadPool(config.getThreadPool())

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStoreUtilsTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStoreUtilsTests.java
@@ -8,9 +8,84 @@
 
 package org.opensearch.index.remote;
 
+import org.opensearch.common.blobstore.BlobMetadata;
+import org.opensearch.common.blobstore.support.PlainBlobMetadata;
+import org.opensearch.index.store.RemoteSegmentStoreDirectory;
+import org.opensearch.index.translog.transfer.TranslogTransferMetadata;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.opensearch.index.remote.RemoteStoreUtils.verifyNoMultipleWriters;
+import static org.opensearch.index.store.RemoteSegmentStoreDirectory.MetadataFilenameUtils.METADATA_PREFIX;
+import static org.opensearch.index.store.RemoteSegmentStoreDirectory.MetadataFilenameUtils.SEPARATOR;
+import static org.opensearch.index.translog.transfer.TranslogTransferMetadata.METADATA_SEPARATOR;
+
 public class RemoteStoreUtilsTests extends OpenSearchTestCase {
+
+    private final String metadataFilename = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(
+        12,
+        23,
+        34,
+        1,
+        1,
+        "node-1"
+    );
+
+    private final String metadataFilenameDup = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(
+        12,
+        23,
+        34,
+        2,
+        1,
+        "node-2"
+    );
+    private final String metadataFilename2 = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(
+        12,
+        13,
+        34,
+        1,
+        1,
+        "node-1"
+    );
+
+    private final String oldMetadataFilename = getOldSegmentMetadataFilename(12, 23, 34, 1, 1);
+
+    /*
+    Gives segment metadata filename for <2.11 version
+     */
+    public static String getOldSegmentMetadataFilename(
+        long primaryTerm,
+        long generation,
+        long translogGeneration,
+        long uploadCounter,
+        int metadataVersion
+    ) {
+        return String.join(
+            SEPARATOR,
+            METADATA_PREFIX,
+            RemoteStoreUtils.invertLong(primaryTerm),
+            RemoteStoreUtils.invertLong(generation),
+            RemoteStoreUtils.invertLong(translogGeneration),
+            RemoteStoreUtils.invertLong(uploadCounter),
+            RemoteStoreUtils.invertLong(System.currentTimeMillis()),
+            String.valueOf(metadataVersion)
+        );
+    }
+
+    public static String getOldTranslogMetadataFilename(long primaryTerm, long generation, int metadataVersion) {
+        return String.join(
+            METADATA_SEPARATOR,
+            METADATA_PREFIX,
+            RemoteStoreUtils.invertLong(primaryTerm),
+            RemoteStoreUtils.invertLong(generation),
+            RemoteStoreUtils.invertLong(System.currentTimeMillis()),
+            String.valueOf(metadataVersion)
+        );
+    }
 
     public void testInvertToStrInvalid() {
         assertThrows(IllegalArgumentException.class, () -> RemoteStoreUtils.invertLong(-1));
@@ -60,4 +135,48 @@ public class RemoteStoreUtilsTests extends OpenSearchTestCase {
     public void testGetSegmentNameException() {
         assertThrows(IllegalArgumentException.class, () -> RemoteStoreUtils.getSegmentName("dvd"));
     }
+
+    public void testVerifyMultipleWriters_Segment() {
+        List<String> mdFiles = new ArrayList<>();
+        mdFiles.add(metadataFilename);
+        mdFiles.add(metadataFilename2);
+        mdFiles.add(oldMetadataFilename);
+        verifyNoMultipleWriters(mdFiles, RemoteSegmentStoreDirectory.MetadataFilenameUtils::getNodeIdByPrimaryTermAndGen);
+
+        mdFiles.add(metadataFilenameDup);
+        assertThrows(
+            IllegalStateException.class,
+            () -> verifyNoMultipleWriters(mdFiles, RemoteSegmentStoreDirectory.MetadataFilenameUtils::getNodeIdByPrimaryTermAndGen)
+        );
+    }
+
+    public void testVerifyMultipleWriters_Translog() throws InterruptedException {
+        TranslogTransferMetadata tm = new TranslogTransferMetadata(1, 1, 1, 2, "node-1");
+        String mdFilename = tm.getFileName();
+        Thread.sleep(1);
+        TranslogTransferMetadata tm2 = new TranslogTransferMetadata(1, 1, 1, 2, "node-1");
+        String mdFilename2 = tm2.getFileName();
+        List<BlobMetadata> bmList = new LinkedList<>();
+        bmList.add(new PlainBlobMetadata(mdFilename, 1));
+        bmList.add(new PlainBlobMetadata(mdFilename2, 1));
+        bmList.add(new PlainBlobMetadata(getOldTranslogMetadataFilename(1, 1, 1), 1));
+        RemoteStoreUtils.verifyNoMultipleWriters(
+            bmList.stream().map(BlobMetadata::name).collect(Collectors.toList()),
+            TranslogTransferMetadata::getNodeIdByPrimaryTermAndGen
+        );
+
+        bmList = new LinkedList<>();
+        bmList.add(new PlainBlobMetadata(mdFilename, 1));
+        TranslogTransferMetadata tm3 = new TranslogTransferMetadata(1, 1, 1, 2, "node-2");
+        bmList.add(new PlainBlobMetadata(tm3.getFileName(), 1));
+        List<BlobMetadata> finalBmList = bmList;
+        assertThrows(
+            IllegalStateException.class,
+            () -> RemoteStoreUtils.verifyNoMultipleWriters(
+                finalBmList.stream().map(BlobMetadata::name).collect(Collectors.toList()),
+                TranslogTransferMetadata::getNodeIdByPrimaryTermAndGen
+            )
+        );
+    }
+
 }

--- a/server/src/test/java/org/opensearch/index/shard/RefreshListenersTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RefreshListenersTests.java
@@ -133,7 +133,8 @@ public class RefreshListenersTests extends OpenSearchTestCase {
             shardId,
             createTempDir("translog"),
             indexSettings,
-            BigArrays.NON_RECYCLING_INSTANCE
+            BigArrays.NON_RECYCLING_INSTANCE,
+            ""
         );
         Engine.EventListener eventListener = new Engine.EventListener() {
             @Override

--- a/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
@@ -579,4 +579,5 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
             }
         }
     }
+
 }

--- a/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
@@ -46,6 +46,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REPLICATION_TYPE;
+import static org.opensearch.index.store.RemoteSegmentStoreDirectory.METADATA_FILES_TO_FETCH;
 import static org.opensearch.test.RemoteStoreTestUtils.createMetadataFileBytes;
 import static org.opensearch.test.RemoteStoreTestUtils.getDummyMetadata;
 import static org.mockito.ArgumentMatchers.any;
@@ -138,7 +139,7 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
                 return Collections.singletonList("dummy string");
             }
             throw new IOException();
-        }).when(remoteMetadataDirectory).listFilesByPrefixInLexicographicOrder(MetadataFilenameUtils.METADATA_PREFIX, 1);
+        }).when(remoteMetadataDirectory).listFilesByPrefixInLexicographicOrder(MetadataFilenameUtils.METADATA_PREFIX, METADATA_FILES_TO_FETCH);
 
         SegmentInfos segmentInfos;
         try (Store indexShardStore = indexShard.store()) {
@@ -166,7 +167,7 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
         // Validate that the stream of metadata file of remoteMetadataDirectory has been opened only once and the
         // listFilesByPrefixInLexicographicOrder has been called twice.
         verify(remoteMetadataDirectory, times(1)).getBlobStream(any());
-        verify(remoteMetadataDirectory, times(2)).listFilesByPrefixInLexicographicOrder(MetadataFilenameUtils.METADATA_PREFIX, 1);
+        verify(remoteMetadataDirectory, times(2)).listFilesByPrefixInLexicographicOrder(MetadataFilenameUtils.METADATA_PREFIX, METADATA_FILES_TO_FETCH);
     }
 
     public void testAfterRefresh() throws IOException {

--- a/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
@@ -139,7 +139,8 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
                 return Collections.singletonList("dummy string");
             }
             throw new IOException();
-        }).when(remoteMetadataDirectory).listFilesByPrefixInLexicographicOrder(MetadataFilenameUtils.METADATA_PREFIX, METADATA_FILES_TO_FETCH);
+        }).when(remoteMetadataDirectory)
+            .listFilesByPrefixInLexicographicOrder(MetadataFilenameUtils.METADATA_PREFIX, METADATA_FILES_TO_FETCH);
 
         SegmentInfos segmentInfos;
         try (Store indexShardStore = indexShard.store()) {
@@ -167,7 +168,10 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
         // Validate that the stream of metadata file of remoteMetadataDirectory has been opened only once and the
         // listFilesByPrefixInLexicographicOrder has been called twice.
         verify(remoteMetadataDirectory, times(1)).getBlobStream(any());
-        verify(remoteMetadataDirectory, times(2)).listFilesByPrefixInLexicographicOrder(MetadataFilenameUtils.METADATA_PREFIX, METADATA_FILES_TO_FETCH);
+        verify(remoteMetadataDirectory, times(2)).listFilesByPrefixInLexicographicOrder(
+            MetadataFilenameUtils.METADATA_PREFIX,
+            METADATA_FILES_TO_FETCH
+        );
     }
 
     public void testAfterRefresh() throws IOException {

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryFactoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryFactoryTests.java
@@ -9,6 +9,8 @@
 package org.opensearch.index.store;
 
 import org.apache.lucene.store.Directory;
+import org.junit.Before;
+import org.mockito.ArgumentCaptor;
 import org.opensearch.action.LatchedActionListener;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.blobstore.BlobContainer;
@@ -26,14 +28,11 @@ import org.opensearch.repositories.blobstore.BlobStoreRepository;
 import org.opensearch.test.IndexSettingsModule;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
-import org.junit.Before;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.function.Supplier;
-
-import org.mockito.ArgumentCaptor;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -42,6 +41,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.index.store.RemoteSegmentStoreDirectory.METADATA_FILES_TO_FETCH;
 
 public class RemoteSegmentStoreDirectoryFactoryTests extends OpenSearchTestCase {
 
@@ -78,7 +78,7 @@ public class RemoteSegmentStoreDirectoryFactoryTests extends OpenSearchTestCase 
             latchedActionListener.onResponse(List.of());
             return null;
         }).when(blobContainer)
-            .listBlobsByPrefixInSortedOrder(any(), eq(1), eq(BlobContainer.BlobNameSortOrder.LEXICOGRAPHIC), any(ActionListener.class));
+            .listBlobsByPrefixInSortedOrder(any(), eq(METADATA_FILES_TO_FETCH), eq(BlobContainer.BlobNameSortOrder.LEXICOGRAPHIC), any(ActionListener.class));
 
         when(repositoriesService.repository("remote_store_repository")).thenReturn(repository);
 
@@ -93,7 +93,7 @@ public class RemoteSegmentStoreDirectoryFactoryTests extends OpenSearchTestCase 
 
             verify(blobContainer).listBlobsByPrefixInSortedOrder(
                 eq(RemoteSegmentStoreDirectory.MetadataFilenameUtils.METADATA_PREFIX),
-                eq(1),
+                eq(METADATA_FILES_TO_FETCH),
                 eq(BlobContainer.BlobNameSortOrder.LEXICOGRAPHIC),
                 any()
             );

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryFactoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryFactoryTests.java
@@ -9,8 +9,6 @@
 package org.opensearch.index.store;
 
 import org.apache.lucene.store.Directory;
-import org.junit.Before;
-import org.mockito.ArgumentCaptor;
 import org.opensearch.action.LatchedActionListener;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.blobstore.BlobContainer;
@@ -28,12 +26,16 @@ import org.opensearch.repositories.blobstore.BlobStoreRepository;
 import org.opensearch.test.IndexSettingsModule;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
+import org.junit.Before;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.function.Supplier;
 
+import org.mockito.ArgumentCaptor;
+
+import static org.opensearch.index.store.RemoteSegmentStoreDirectory.METADATA_FILES_TO_FETCH;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -41,7 +43,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.opensearch.index.store.RemoteSegmentStoreDirectory.METADATA_FILES_TO_FETCH;
 
 public class RemoteSegmentStoreDirectoryFactoryTests extends OpenSearchTestCase {
 
@@ -78,7 +79,12 @@ public class RemoteSegmentStoreDirectoryFactoryTests extends OpenSearchTestCase 
             latchedActionListener.onResponse(List.of());
             return null;
         }).when(blobContainer)
-            .listBlobsByPrefixInSortedOrder(any(), eq(METADATA_FILES_TO_FETCH), eq(BlobContainer.BlobNameSortOrder.LEXICOGRAPHIC), any(ActionListener.class));
+            .listBlobsByPrefixInSortedOrder(
+                any(),
+                eq(METADATA_FILES_TO_FETCH),
+                eq(BlobContainer.BlobNameSortOrder.LEXICOGRAPHIC),
+                any(ActionListener.class)
+            );
 
         when(repositoriesService.repository("remote_store_repository")).thenReturn(repository);
 

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -1145,10 +1145,10 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         List<String> mdFiles = new ArrayList<>();
         mdFiles.add(metadataFilename);
         mdFiles.add(metadataFilename2);
-        RemoteSegmentStoreDirectory.verifyMultipleWriters(mdFiles);
+        RemoteSegmentStoreDirectory.verifyNoMultipleWriters(mdFiles);
 
         mdFiles.add(metadataFilenameDup);
-        assertThrows(IllegalStateException.class, () -> RemoteSegmentStoreDirectory.verifyMultipleWriters(mdFiles));
+        assertThrows(IllegalStateException.class, () -> RemoteSegmentStoreDirectory.verifyNoMultipleWriters(mdFiles));
     }
 
     public void testVerifyOld() {

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -22,9 +22,6 @@ import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.OutputStreamIndexOutput;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.Version;
-import org.junit.After;
-import org.junit.Before;
-import org.mockito.Mockito;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.blobstore.AsyncMultiStreamBlobContainer;
@@ -46,6 +43,8 @@ import org.opensearch.index.store.remote.metadata.RemoteSegmentMetadata;
 import org.opensearch.index.store.remote.metadata.RemoteSegmentMetadataHandler;
 import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.threadpool.ThreadPool;
+import org.junit.After;
+import org.junit.Before;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -61,6 +60,11 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import org.mockito.Mockito;
+
+import static org.opensearch.index.store.RemoteSegmentStoreDirectory.METADATA_FILES_TO_FETCH;
+import static org.opensearch.test.RemoteStoreTestUtils.createMetadataFileBytes;
+import static org.opensearch.test.RemoteStoreTestUtils.getDummyMetadata;
 import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
@@ -74,9 +78,6 @@ import static org.mockito.Mockito.startsWith;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.opensearch.index.store.RemoteSegmentStoreDirectory.METADATA_FILES_TO_FETCH;
-import static org.opensearch.test.RemoteStoreTestUtils.createMetadataFileBytes;
-import static org.opensearch.test.RemoteStoreTestUtils.getDummyMetadata;
 
 public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
     private static final Logger logger = LogManager.getLogger(RemoteSegmentStoreDirectoryTests.class);

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -62,6 +62,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.mockito.Mockito;
 
+import static org.opensearch.index.store.RemoteSegmentStoreDirectory.METADATA_FILES_TO_FETCH;
 import static org.opensearch.test.RemoteStoreTestUtils.createMetadataFileBytes;
 import static org.opensearch.test.RemoteStoreTestUtils.getDummyMetadata;
 import static org.hamcrest.CoreMatchers.is;
@@ -90,9 +91,39 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
     private SegmentInfos segmentInfos;
     private ThreadPool threadPool;
 
-    private final String metadataFilename = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(12, 23, 34, 1, 1);
-    private final String metadataFilename2 = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(12, 13, 34, 1, 1);
-    private final String metadataFilename3 = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(10, 38, 34, 1, 1);
+    private final String metadataFilename = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(
+        12,
+        23,
+        34,
+        1,
+        1,
+        "node-1"
+    );
+
+    private final String metadataFilenameDup = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(
+        12,
+        23,
+        34,
+        2,
+        1,
+        "node-2"
+    );
+    private final String metadataFilename2 = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(
+        12,
+        13,
+        34,
+        1,
+        1,
+        "node-1"
+    );
+    private final String metadataFilename3 = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(
+        10,
+        38,
+        34,
+        1,
+        1,
+        "node-1"
+    );
 
     @Before
     public void setup() throws IOException {
@@ -183,7 +214,7 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
     }
 
     public void testInitException() throws IOException {
-        when(remoteMetadataDirectory.listFilesByPrefixInLexicographicOrder(RemoteSegmentStoreDirectory.MetadataFilenameUtils.METADATA_PREFIX, 1)).thenThrow(
+        when(remoteMetadataDirectory.listFilesByPrefixInLexicographicOrder(RemoteSegmentStoreDirectory.MetadataFilenameUtils.METADATA_PREFIX, METADATA_FILES_TO_FETCH)).thenThrow(
             new IOException("Error")
         );
 
@@ -212,7 +243,7 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         when(
             remoteMetadataDirectory.listFilesByPrefixInLexicographicOrder(
                 RemoteSegmentStoreDirectory.MetadataFilenameUtils.METADATA_PREFIX,
-                1
+                METADATA_FILES_TO_FETCH
             )
         ).thenReturn(List.of(metadataFilename));
         when(
@@ -262,7 +293,7 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         when(
             remoteMetadataDirectory.listFilesByPrefixInLexicographicOrder(
                 RemoteSegmentStoreDirectory.MetadataFilenameUtils.METADATA_PREFIX,
-                1
+                METADATA_FILES_TO_FETCH
             )
         ).thenReturn(List.of(metadataFilename));
 
@@ -318,7 +349,7 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         assertEquals(uploadedSegments.get("_0.si").getLength(), remoteSegmentStoreDirectory.fileLength("_0.si"));
     }
 
-    public void testFileLenghtNoSuchFile() throws IOException {
+    public void testFileLengthNoSuchFile() throws IOException {
         populateMetadata();
         remoteSegmentStoreDirectory.init();
 
@@ -693,7 +724,7 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         when(
             remoteMetadataDirectory.listFilesByPrefixInLexicographicOrder(
                 RemoteSegmentStoreDirectory.MetadataFilenameUtils.METADATA_PREFIX,
-                1
+                METADATA_FILES_TO_FETCH
             )
         ).thenReturn(metadataFiles);
 
@@ -739,7 +770,8 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
                 segmentInfos,
                 storeDirectory,
                 34L,
-                indexShard.getLatestReplicationCheckpoint()
+                indexShard.getLatestReplicationCheckpoint(),
+                ""
             )
         );
     }
@@ -757,7 +789,7 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         when(
             remoteMetadataDirectory.listFilesByPrefixInLexicographicOrder(
                 RemoteSegmentStoreDirectory.MetadataFilenameUtils.METADATA_PREFIX,
-                1
+                METADATA_FILES_TO_FETCH
             )
         ).thenReturn(metadataFiles);
         Map<String, Map<String, String>> metadataFilenameContentMapping = Map.of(
@@ -785,7 +817,8 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
             segInfos,
             storeDirectory,
             generation,
-            indexShard.getLatestReplicationCheckpoint()
+            indexShard.getLatestReplicationCheckpoint(),
+            ""
         );
 
         verify(remoteMetadataDirectory).copyFrom(
@@ -832,7 +865,8 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
                 segmentInfos,
                 storeDirectory,
                 12L,
-                indexShard.getLatestReplicationCheckpoint()
+                indexShard.getLatestReplicationCheckpoint(),
+                ""
             )
         );
         verify(indexOutput).close();
@@ -855,7 +889,7 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         when(
             remoteMetadataDirectory.listFilesByPrefixInLexicographicOrder(
                 RemoteSegmentStoreDirectory.MetadataFilenameUtils.METADATA_PREFIX,
-                1
+                METADATA_FILES_TO_FETCH
             )
         ).thenReturn(metadataFiles);
 
@@ -878,7 +912,7 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         when(
             remoteMetadataDirectory.listFilesByPrefixInLexicographicOrder(
                 RemoteSegmentStoreDirectory.MetadataFilenameUtils.METADATA_PREFIX,
-                1
+                METADATA_FILES_TO_FETCH
             )
         ).thenReturn(metadataFiles);
 
@@ -903,7 +937,7 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         when(
             remoteMetadataDirectory.listFilesByPrefixInLexicographicOrder(
                 RemoteSegmentStoreDirectory.MetadataFilenameUtils.METADATA_PREFIX,
-                1
+                METADATA_FILES_TO_FETCH
             )
         ).thenReturn(metadataFiles);
 
@@ -928,7 +962,7 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         when(
             remoteMetadataDirectory.listFilesByPrefixInLexicographicOrder(
                 RemoteSegmentStoreDirectory.MetadataFilenameUtils.METADATA_PREFIX,
-                1
+                METADATA_FILES_TO_FETCH
             )
         ).thenReturn(metadataFiles);
 
@@ -953,7 +987,7 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         when(
             remoteMetadataDirectory.listFilesByPrefixInLexicographicOrder(
                 RemoteSegmentStoreDirectory.MetadataFilenameUtils.METADATA_PREFIX,
-                1
+                METADATA_FILES_TO_FETCH
             )
         ).thenReturn(metadataFiles);
 
@@ -1107,6 +1141,20 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         assertEquals(RemoteSegmentMetadata.CURRENT_VERSION, 1);
     }
 
+    public void testVerifyMultipleWriters() {
+        List<String> mdFiles = new ArrayList<>();
+        mdFiles.add(metadataFilename);
+        mdFiles.add(metadataFilename2);
+        RemoteSegmentStoreDirectory.verifyMultipleWriters(mdFiles);
+
+        mdFiles.add(metadataFilenameDup);
+        assertThrows(IllegalStateException.class, () -> RemoteSegmentStoreDirectory.verifyMultipleWriters(mdFiles));
+    }
+
+    public void testVerifyOld() {
+
+    }
+
     private void indexDocs(int startDocId, int numberOfDocs) throws IOException {
         for (int i = startDocId; i < startDocId + numberOfDocs; i++) {
             indexDoc(indexShard, "_doc", Integer.toString(i));
@@ -1114,12 +1162,12 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
     }
 
     public void testMetadataFileNameOrder() {
-        String file1 = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(15, 21, 23, 1, 1);
-        String file2 = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(15, 38, 38, 1, 1);
-        String file3 = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(18, 12, 26, 1, 1);
-        String file4 = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(15, 38, 32, 10, 1);
-        String file5 = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(15, 38, 32, 1, 1);
-        String file6 = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(15, 38, 32, 5, 1);
+        String file1 = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(15, 21, 23, 1, 1, "");
+        String file2 = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(15, 38, 38, 1, 1, "");
+        String file3 = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(18, 12, 26, 1, 1, "");
+        String file4 = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(15, 38, 32, 10, 1, "");
+        String file5 = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(15, 38, 32, 1, 1, "");
+        String file6 = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(15, 38, 32, 5, 1, "");
 
         List<String> actualList = new ArrayList<>(List.of(file1, file2, file3, file4, file5, file6));
         actualList.sort(String::compareTo);

--- a/server/src/test/java/org/opensearch/index/translog/InternalTranslogManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/InternalTranslogManagerTests.java
@@ -38,7 +38,7 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
         LocalCheckpointTracker tracker = new LocalCheckpointTracker(NO_OPS_PERFORMED, NO_OPS_PERFORMED);
         try {
             translogManager = new InternalTranslogManager(
-                new TranslogConfig(shardId, primaryTranslogDir, INDEX_SETTINGS, BigArrays.NON_RECYCLING_INSTANCE),
+                new TranslogConfig(shardId, primaryTranslogDir, INDEX_SETTINGS, BigArrays.NON_RECYCLING_INSTANCE, ""),
                 primaryTerm,
                 globalCheckpoint::get,
                 createTranslogDeletionPolicy(INDEX_SETTINGS),
@@ -68,7 +68,7 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
             translogManager.syncTranslog();
             translogManager.close();
             translogManager = new InternalTranslogManager(
-                new TranslogConfig(shardId, primaryTranslogDir, INDEX_SETTINGS, BigArrays.NON_RECYCLING_INSTANCE),
+                new TranslogConfig(shardId, primaryTranslogDir, INDEX_SETTINGS, BigArrays.NON_RECYCLING_INSTANCE, ""),
                 primaryTerm,
                 globalCheckpoint::get,
                 createTranslogDeletionPolicy(INDEX_SETTINGS),
@@ -117,7 +117,7 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
         LocalCheckpointTracker tracker = new LocalCheckpointTracker(NO_OPS_PERFORMED, NO_OPS_PERFORMED);
         try {
             translogManager = new InternalTranslogManager(
-                new TranslogConfig(shardId, primaryTranslogDir, INDEX_SETTINGS, BigArrays.NON_RECYCLING_INSTANCE),
+                new TranslogConfig(shardId, primaryTranslogDir, INDEX_SETTINGS, BigArrays.NON_RECYCLING_INSTANCE, ""),
                 primaryTerm,
                 globalCheckpoint::get,
                 createTranslogDeletionPolicy(INDEX_SETTINGS),
@@ -147,7 +147,7 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
             translogManager.syncTranslog();
             translogManager.close();
             translogManager = new InternalTranslogManager(
-                new TranslogConfig(shardId, primaryTranslogDir, INDEX_SETTINGS, BigArrays.NON_RECYCLING_INSTANCE),
+                new TranslogConfig(shardId, primaryTranslogDir, INDEX_SETTINGS, BigArrays.NON_RECYCLING_INSTANCE, ""),
                 primaryTerm,
                 globalCheckpoint::get,
                 createTranslogDeletionPolicy(INDEX_SETTINGS),
@@ -182,7 +182,7 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
         LocalCheckpointTracker tracker = new LocalCheckpointTracker(NO_OPS_PERFORMED, NO_OPS_PERFORMED);
         try {
             translogManager = new InternalTranslogManager(
-                new TranslogConfig(shardId, primaryTranslogDir, INDEX_SETTINGS, BigArrays.NON_RECYCLING_INSTANCE),
+                new TranslogConfig(shardId, primaryTranslogDir, INDEX_SETTINGS, BigArrays.NON_RECYCLING_INSTANCE, ""),
                 primaryTerm,
                 globalCheckpoint::get,
                 createTranslogDeletionPolicy(INDEX_SETTINGS),
@@ -214,7 +214,7 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
 
             translogManager.close();
             translogManager = new InternalTranslogManager(
-                new TranslogConfig(shardId, primaryTranslogDir, INDEX_SETTINGS, BigArrays.NON_RECYCLING_INSTANCE),
+                new TranslogConfig(shardId, primaryTranslogDir, INDEX_SETTINGS, BigArrays.NON_RECYCLING_INSTANCE, ""),
                 primaryTerm,
                 globalCheckpoint::get,
                 createTranslogDeletionPolicy(INDEX_SETTINGS),
@@ -253,7 +253,7 @@ public class InternalTranslogManagerTests extends TranslogManagerTestCase {
             ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), B_1, null);
             AtomicReference<InternalTranslogManager> translogManagerAtomicReference = new AtomicReference<>();
             translogManager = new InternalTranslogManager(
-                new TranslogConfig(shardId, primaryTranslogDir, INDEX_SETTINGS, BigArrays.NON_RECYCLING_INSTANCE),
+                new TranslogConfig(shardId, primaryTranslogDir, INDEX_SETTINGS, BigArrays.NON_RECYCLING_INSTANCE, ""),
                 primaryTerm,
                 globalCheckpoint::get,
                 createTranslogDeletionPolicy(INDEX_SETTINGS),

--- a/server/src/test/java/org/opensearch/index/translog/LocalTranslogTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/LocalTranslogTests.java
@@ -291,7 +291,7 @@ public class LocalTranslogTests extends OpenSearchTestCase {
         );
 
         final IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(shardId.getIndex(), settings);
-        return new TranslogConfig(shardId, path, indexSettings, NON_RECYCLING_INSTANCE, bufferSize);
+        return new TranslogConfig(shardId, path, indexSettings, NON_RECYCLING_INSTANCE, bufferSize, "");
     }
 
     private Location addToTranslogAndList(Translog translog, List<Translog.Operation> list, Translog.Operation op) throws IOException {
@@ -1452,7 +1452,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
             temp.getTranslogPath(),
             temp.getIndexSettings(),
             temp.getBigArrays(),
-            new ByteSizeValue(1, ByteSizeUnit.KB)
+            new ByteSizeValue(1, ByteSizeUnit.KB),
+            ""
         );
 
         final Set<Long> persistedSeqNos = new HashSet<>();
@@ -1550,7 +1551,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
             temp.getTranslogPath(),
             temp.getIndexSettings(),
             temp.getBigArrays(),
-            new ByteSizeValue(1, ByteSizeUnit.KB)
+            new ByteSizeValue(1, ByteSizeUnit.KB),
+            ""
         );
 
         final Set<Long> persistedSeqNos = new HashSet<>();

--- a/server/src/test/java/org/opensearch/index/translog/RemoteFsTranslogTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/RemoteFsTranslogTests.java
@@ -206,7 +206,7 @@ public class RemoteFsTranslogTests extends OpenSearchTestCase {
         );
 
         final IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(shardId.getIndex(), settings);
-        return new TranslogConfig(shardId, path, indexSettings, NON_RECYCLING_INSTANCE, bufferSize);
+        return new TranslogConfig(shardId, path, indexSettings, NON_RECYCLING_INSTANCE, bufferSize, "");
     }
 
     private BlobStoreRepository createRepository() {
@@ -1258,7 +1258,8 @@ public class RemoteFsTranslogTests extends OpenSearchTestCase {
             temp.getTranslogPath(),
             temp.getIndexSettings(),
             temp.getBigArrays(),
-            new ByteSizeValue(1, ByteSizeUnit.KB)
+            new ByteSizeValue(1, ByteSizeUnit.KB),
+            ""
         );
 
         final Set<Long> persistedSeqNos = new HashSet<>();
@@ -1360,7 +1361,8 @@ public class RemoteFsTranslogTests extends OpenSearchTestCase {
             temp.getTranslogPath(),
             temp.getIndexSettings(),
             temp.getBigArrays(),
-            new ByteSizeValue(1, ByteSizeUnit.KB)
+            new ByteSizeValue(1, ByteSizeUnit.KB),
+            ""
         );
 
         final Set<Long> persistedSeqNos = new HashSet<>();

--- a/server/src/test/java/org/opensearch/index/translog/TranslogManagerTestCase.java
+++ b/server/src/test/java/org/opensearch/index/translog/TranslogManagerTestCase.java
@@ -74,7 +74,7 @@ public abstract class TranslogManagerTestCase extends OpenSearchTestCase {
     }
 
     protected Translog createTranslog(Path translogPath, LongSupplier primaryTermSupplier) throws IOException {
-        TranslogConfig translogConfig = new TranslogConfig(shardId, translogPath, INDEX_SETTINGS, BigArrays.NON_RECYCLING_INSTANCE);
+        TranslogConfig translogConfig = new TranslogConfig(shardId, translogPath, INDEX_SETTINGS, BigArrays.NON_RECYCLING_INSTANCE, "");
         String translogUUID = Translog.createEmptyTranslog(
             translogPath,
             SequenceNumbers.NO_OPS_PERFORMED,

--- a/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
@@ -9,7 +9,6 @@
 package org.opensearch.index.translog.transfer;
 
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.mockito.Mockito;
 import org.opensearch.action.LatchedActionListener;
 import org.opensearch.common.blobstore.BlobContainer;
 import org.opensearch.common.blobstore.BlobMetadata;
@@ -41,6 +40,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import org.mockito.Mockito;
 
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyMap;

--- a/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
@@ -16,6 +16,7 @@ import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.common.blobstore.BlobStore;
 import org.opensearch.common.blobstore.stream.write.WritePriority;
 import org.opensearch.common.blobstore.support.PlainBlobMetadata;
+import org.opensearch.common.collect.Tuple;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
@@ -251,8 +252,8 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
         assertNoDownloadStats(false);
     }
 
-    // This should happen most of the time - Just a single metadata file
-    public void testReadMetadataSingleFile() throws IOException {
+    // This should happen most of the time -
+    public void testReadMetadataFile() throws IOException {
         TranslogTransferManager translogTransferManager = new TranslogTransferManager(
             shardId,
             transferService,
@@ -260,12 +261,16 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
             null,
             remoteTranslogTransferTracker
         );
-        TranslogTransferMetadata tm = new TranslogTransferMetadata(1, 1, 1, 2);
-        String mdFilename = tm.getFileName();
+        TranslogTransferMetadata metadata1 = new TranslogTransferMetadata(1, 1, 1, 2);
+        String mdFilename1 = metadata1.getFileName();
+
+        TranslogTransferMetadata metadata2 = new TranslogTransferMetadata(1, 0, 1, 2);
+        String mdFilename2 = metadata2.getFileName();
         doAnswer(invocation -> {
             LatchedActionListener<List<BlobMetadata>> latchedActionListener = invocation.getArgument(3);
             List<BlobMetadata> bmList = new LinkedList<>();
-            bmList.add(new PlainBlobMetadata(mdFilename, 1));
+            bmList.add(new PlainBlobMetadata(mdFilename1, 1));
+            bmList.add(new PlainBlobMetadata(mdFilename2, 1));
             latchedActionListener.onResponse(bmList);
             return null;
         }).when(transferService)
@@ -273,7 +278,7 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
 
         TranslogTransferMetadata metadata = createTransferSnapshot().getTranslogTransferMetadata();
         long delayForMdDownload = 1;
-        when(transferService.downloadBlob(any(BlobPath.class), eq(mdFilename))).thenAnswer(invocation -> {
+        when(transferService.downloadBlob(any(BlobPath.class), eq(mdFilename1))).thenAnswer(invocation -> {
             Thread.sleep(delayForMdDownload);
             return new ByteArrayInputStream(translogTransferManager.getMetadataBytes(metadata));
         });
@@ -495,5 +500,49 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
         assertEquals(tlogBytes.length + ckpBytes.length, remoteTranslogTransferTracker.getDownloadBytesSucceeded());
         // Expect delay for both tlog and ckp file
         assertTrue(remoteTranslogTransferTracker.getTotalDownloadTimeInMillis() >= 2 * delayForBlobDownload);
+    }
+
+    public void testGetPrimaryTermAndGeneration() {
+        String tm = new TranslogTransferMetadata(1, 2, 1, 2).getFileName();
+        assertEquals(new Tuple<>(1L, 2L), TranslogTransferMetadata.getNodeIdByPrimaryTermAndGeneration(tm));
+    }
+
+    public void testMetadataConflict() throws InterruptedException {
+        TranslogTransferManager translogTransferManager = new TranslogTransferManager(
+            shardId,
+            transferService,
+            remoteBaseTransferPath,
+            null,
+            remoteTranslogTransferTracker
+        );
+        TranslogTransferMetadata tm = new TranslogTransferMetadata(1, 1, 1, 2, "node-1");
+        String mdFilename = tm.getFileName();
+        Thread.sleep(1);
+        TranslogTransferMetadata tm2 = new TranslogTransferMetadata(1, 1, 1, 2, "node-2");
+        String mdFilename2 = tm2.getFileName();
+
+        doAnswer(invocation -> {
+            LatchedActionListener<List<BlobMetadata>> latchedActionListener = invocation.getArgument(3);
+            List<BlobMetadata> bmList = new LinkedList<>();
+            bmList.add(new PlainBlobMetadata(mdFilename, 1));
+            bmList.add(new PlainBlobMetadata(mdFilename2, 1));
+            latchedActionListener.onResponse(bmList);
+            return null;
+        }).when(transferService)
+            .listAllInSortedOrder(any(BlobPath.class), eq(TranslogTransferMetadata.METADATA_PREFIX), anyInt(), any(ActionListener.class));
+
+        assertThrows(RuntimeException.class, translogTransferManager::readMetadata);
+    }
+
+    public void testMetadataNoConflict() throws InterruptedException {
+        TranslogTransferMetadata tm = new TranslogTransferMetadata(1, 1, 1, 2, "node-1");
+        String mdFilename = tm.getFileName();
+        Thread.sleep(1);
+        TranslogTransferMetadata tm2 = new TranslogTransferMetadata(1, 1, 1, 2, "node-1");
+        String mdFilename2 = tm2.getFileName();
+        List<BlobMetadata> bmList = new LinkedList<>();
+        bmList.add(new PlainBlobMetadata(mdFilename, 1));
+        bmList.add(new PlainBlobMetadata(mdFilename2, 1));
+        TranslogTransferManager.verifyMultipleWriters(bmList);
     }
 }

--- a/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
@@ -533,16 +533,4 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
 
         assertThrows(RuntimeException.class, translogTransferManager::readMetadata);
     }
-
-    public void testMetadataNoConflict() throws InterruptedException {
-        TranslogTransferMetadata tm = new TranslogTransferMetadata(1, 1, 1, 2, "node-1");
-        String mdFilename = tm.getFileName();
-        Thread.sleep(1);
-        TranslogTransferMetadata tm2 = new TranslogTransferMetadata(1, 1, 1, 2, "node-1");
-        String mdFilename2 = tm2.getFileName();
-        List<BlobMetadata> bmList = new LinkedList<>();
-        bmList.add(new PlainBlobMetadata(mdFilename, 1));
-        bmList.add(new PlainBlobMetadata(mdFilename2, 1));
-        TranslogTransferManager.verifyNoMultipleWriters(bmList);
-    }
 }

--- a/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
@@ -9,6 +9,7 @@
 package org.opensearch.index.translog.transfer;
 
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.mockito.Mockito;
 import org.opensearch.action.LatchedActionListener;
 import org.opensearch.common.blobstore.BlobContainer;
 import org.opensearch.common.blobstore.BlobMetadata;
@@ -16,7 +17,6 @@ import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.common.blobstore.BlobStore;
 import org.opensearch.common.blobstore.stream.write.WritePriority;
 import org.opensearch.common.blobstore.support.PlainBlobMetadata;
-import org.opensearch.common.collect.Tuple;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
@@ -41,8 +41,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import org.mockito.Mockito;
 
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -504,7 +502,7 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
 
     public void testGetPrimaryTermAndGeneration() {
         String tm = new TranslogTransferMetadata(1, 2, 1, 2).getFileName();
-        assertEquals(new Tuple<>(1L, 2L), TranslogTransferMetadata.getNodeIdByPrimaryTermAndGeneration(tm));
+        assertEquals(null, TranslogTransferMetadata.getNodeIdByPrimaryTermAndGeneration(tm));
     }
 
     public void testMetadataConflict() throws InterruptedException {

--- a/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
@@ -16,6 +16,7 @@ import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.common.blobstore.BlobStore;
 import org.opensearch.common.blobstore.stream.write.WritePriority;
 import org.opensearch.common.blobstore.support.PlainBlobMetadata;
+import org.opensearch.common.collect.Tuple;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
@@ -502,8 +503,8 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
     }
 
     public void testGetPrimaryTermAndGeneration() {
-        String tm = new TranslogTransferMetadata(1, 2, 1, 2).getFileName();
-        assertEquals(null, TranslogTransferMetadata.getNodeIdByPrimaryTermAndGeneration(tm));
+        String tm = new TranslogTransferMetadata(1, 2, 1, 2, "node-1").getFileName();
+        assertEquals(new Tuple<>(new Tuple<>(1L, 2L), "node-1"), TranslogTransferMetadata.getNodeIdByPrimaryTermAndGeneration(tm));
     }
 
     public void testMetadataConflict() throws InterruptedException {

--- a/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
@@ -543,6 +543,6 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
         List<BlobMetadata> bmList = new LinkedList<>();
         bmList.add(new PlainBlobMetadata(mdFilename, 1));
         bmList.add(new PlainBlobMetadata(mdFilename2, 1));
-        TranslogTransferManager.verifyMultipleWriters(bmList);
+        TranslogTransferManager.verifyNoMultipleWriters(bmList);
     }
 }

--- a/test/framework/src/main/java/org/opensearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/engine/EngineTestCase.java
@@ -527,7 +527,7 @@ public abstract class EngineTestCase extends OpenSearchTestCase {
     }
 
     protected Translog createTranslog(Path translogPath, LongSupplier primaryTermSupplier) throws IOException {
-        TranslogConfig translogConfig = new TranslogConfig(shardId, translogPath, INDEX_SETTINGS, BigArrays.NON_RECYCLING_INSTANCE);
+        TranslogConfig translogConfig = new TranslogConfig(shardId, translogPath, INDEX_SETTINGS, BigArrays.NON_RECYCLING_INSTANCE, "");
         String translogUUID = Translog.createEmptyTranslog(
             translogPath,
             SequenceNumbers.NO_OPS_PERFORMED,
@@ -872,7 +872,13 @@ public abstract class EngineTestCase extends OpenSearchTestCase {
         final Engine.EventListener eventListener
     ) {
         final IndexWriterConfig iwc = newIndexWriterConfig();
-        final TranslogConfig translogConfig = new TranslogConfig(shardId, translogPath, indexSettings, BigArrays.NON_RECYCLING_INSTANCE);
+        final TranslogConfig translogConfig = new TranslogConfig(
+            shardId,
+            translogPath,
+            indexSettings,
+            BigArrays.NON_RECYCLING_INSTANCE,
+            ""
+        );
         final List<ReferenceManager.RefreshListener> extRefreshListenerList = externalRefreshListener == null
             ? emptyList()
             : Collections.singletonList(externalRefreshListener);
@@ -939,7 +945,7 @@ public abstract class EngineTestCase extends OpenSearchTestCase {
                 .put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true)
                 .build()
         );
-        TranslogConfig translogConfig = new TranslogConfig(shardId, translogPath, indexSettings, BigArrays.NON_RECYCLING_INSTANCE);
+        TranslogConfig translogConfig = new TranslogConfig(shardId, translogPath, indexSettings, BigArrays.NON_RECYCLING_INSTANCE, "");
         return new EngineConfig.Builder().shardId(config.getShardId())
             .threadPool(config.getThreadPool())
             .indexSettings(indexSettings)

--- a/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
@@ -697,7 +697,8 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
                 checkpointPublisher,
                 remoteStore,
                 remoteStoreStatsTrackerFactory,
-                () -> IndexSettings.DEFAULT_REMOTE_TRANSLOG_BUFFER_INTERVAL
+                () -> IndexSettings.DEFAULT_REMOTE_TRANSLOG_BUFFER_INTERVAL,
+                "dummy-node"
             );
             indexShard.addShardFailureCallback(DEFAULT_SHARD_FAILURE_HANDLER);
             if (remoteStoreStatsTrackerFactory != null) {


### PR DESCRIPTION
Adding validation to identify multiple writers to same primary term and generation in remote store

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

Adding node id to remote segment and translog metadata files . This is to identify if we have concurrent writers to same file , causing consistency issues. 


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
