### PR TITLE
Add TODO for updating public documentation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,6 +19,7 @@ Resolves #[Issue number to be closed when this PR is merged]
   - [ ] New functionality has javadoc added
 - [ ] Commits are signed per the DCO using --signoff
 - [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
+- [ ] GitHub issue/PR created in [OpenSearch documentation repo](https://github.com/opensearch-project/documentation-website) for the required public documentation changes (#[Issue/PR number])
 
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
 For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


### PR DESCRIPTION

### Description
Changes introduced by various PRs are often supposed to be followed with respective updates to the public documentation, maintained in https://github.com/opensearch-project/documentation-website. 

This PR updates the PR template to add a checklist item to ensure we either create a GitHub issue or PR in the documentation repo while reviewing the original code changes PR, to ensure that the public documentation updates to be done are tracked and not missed.

### Related Issues
N/A

### Check List
- [x] ~New functionality includes testing.~
  - [x] All tests pass
- [x] ~New functionality has been documented.~
  - [x] ~New functionality has javadoc added~
- [x] Commits are signed per the DCO using --signoff
- [x] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
