### PR TITLE
Fix: register mulitple extensions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix concurrent search NPE when track_total_hits, terminate_after and size=0 are used ([#10082](https://github.com/opensearch-project/OpenSearch/pull/10082))
 - Fix remove ingest processor handing ignore_missing parameter not correctly ([10089](https://github.com/opensearch-project/OpenSearch/pull/10089))
 - Fix circular dependency in Settings initialization ([10194](https://github.com/opensearch-project/OpenSearch/pull/10194))
+- Fix registration and initialization of multiple extensions ([10256](https://github.com/opensearch-project/OpenSearch/pull/10256))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
@@ -340,7 +340,9 @@ public class ExtensionsManager {
      */
     public void initialize() {
         for (DiscoveryExtensionNode extension : extensionIdMap.values()) {
-            initializeExtension(extension);
+            if (! initializedExtensions.containsKey(extension)) {
+                initializeExtension(extension);
+            }
         }
     }
 
@@ -384,6 +386,7 @@ public class ExtensionsManager {
         transportService.getThreadPool().generic().execute(new AbstractRunnable() {
             @Override
             public void onFailure(Exception e) {
+                logger.warn(String.format("Error registering extension: %s", extension.getId()), e);
                 extensionIdMap.remove(extension.getId());
                 if (e.getCause() instanceof ConnectTransportException) {
                     logger.info("No response from extension to request.", e);

--- a/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
@@ -300,7 +300,7 @@ public class ExtensionsManager {
      * Loads a single extension
      * @param extension The extension to be loaded
      */
-    public void loadExtension(Extension extension) throws IOException {
+    public DiscoveryExtensionNode loadExtension(Extension extension) throws IOException {
         validateExtension(extension);
         DiscoveryExtensionNode discoveryExtensionNode = new DiscoveryExtensionNode(
             extension.getName(),
@@ -314,6 +314,12 @@ public class ExtensionsManager {
         extensionIdMap.put(extension.getUniqueId(), discoveryExtensionNode);
         extensionSettingsMap.put(extension.getUniqueId(), extension);
         logger.info("Loaded extension with uniqueId " + extension.getUniqueId() + ": " + extension);
+        return discoveryExtensionNode;
+    }
+
+    public void initializeExtension(Extension extension) throws IOException {
+        DiscoveryExtensionNode node = loadExtension(extension);
+        initializeExtensionNode(node);
     }
 
     private void validateField(String fieldName, String value) throws IOException {
@@ -340,13 +346,11 @@ public class ExtensionsManager {
      */
     public void initialize() {
         for (DiscoveryExtensionNode extension : extensionIdMap.values()) {
-            if (! initializedExtensions.containsKey(extension)) {
-                initializeExtension(extension);
-            }
+            initializeExtensionNode(extension);
         }
     }
 
-    private void initializeExtension(DiscoveryExtensionNode extension) {
+    public void initializeExtensionNode(DiscoveryExtensionNode extensionNode) {
 
         final CompletableFuture<InitializeExtensionResponse> inProgressFuture = new CompletableFuture<>();
         final TransportResponseHandler<InitializeExtensionResponse> initializeExtensionResponseHandler = new TransportResponseHandler<
@@ -386,8 +390,8 @@ public class ExtensionsManager {
         transportService.getThreadPool().generic().execute(new AbstractRunnable() {
             @Override
             public void onFailure(Exception e) {
-                logger.warn(String.format("Error registering extension: %s", extension.getId()), e);
-                extensionIdMap.remove(extension.getId());
+                logger.warn("Error registering extension: " + extensionNode.getId(), e);
+                extensionIdMap.remove(extensionNode.getId());
                 if (e.getCause() instanceof ConnectTransportException) {
                     logger.info("No response from extension to request.", e);
                     throw (ConnectTransportException) e.getCause();
@@ -402,11 +406,11 @@ public class ExtensionsManager {
 
             @Override
             protected void doRun() throws Exception {
-                transportService.connectToExtensionNode(extension);
+                transportService.connectToExtensionNode(extensionNode);
                 transportService.sendRequest(
-                    extension,
+                    extensionNode,
                     REQUEST_EXTENSION_ACTION_NAME,
-                    new InitializeExtensionRequest(transportService.getLocalNode(), extension, issueServiceAccount(extension)),
+                    new InitializeExtensionRequest(transportService.getLocalNode(), extensionNode, issueServiceAccount(extensionNode)),
                     initializeExtensionResponseHandler
                 );
             }

--- a/server/src/main/java/org/opensearch/extensions/rest/RestActionsRequestHandler.java
+++ b/server/src/main/java/org/opensearch/extensions/rest/RestActionsRequestHandler.java
@@ -62,6 +62,9 @@ public class RestActionsRequestHandler {
         DynamicActionRegistry dynamicActionRegistry
     ) throws Exception {
         DiscoveryExtensionNode discoveryExtensionNode = extensionIdMap.get(restActionsRequest.getUniqueId());
+        if (discoveryExtensionNode == null) {
+            throw new IllegalStateException(String.format("Missing extension node for %s", restActionsRequest.getUniqueId()));
+        }
         RestHandler handler = new RestSendToExtensionAction(
             restActionsRequest,
             discoveryExtensionNode,

--- a/server/src/main/java/org/opensearch/extensions/rest/RestActionsRequestHandler.java
+++ b/server/src/main/java/org/opensearch/extensions/rest/RestActionsRequestHandler.java
@@ -63,7 +63,7 @@ public class RestActionsRequestHandler {
     ) throws Exception {
         DiscoveryExtensionNode discoveryExtensionNode = extensionIdMap.get(restActionsRequest.getUniqueId());
         if (discoveryExtensionNode == null) {
-            throw new IllegalStateException(String.format("Missing extension node for %s", restActionsRequest.getUniqueId()));
+            throw new IllegalStateException("Missing extension node for " + restActionsRequest.getUniqueId());
         }
         RestHandler handler = new RestSendToExtensionAction(
             restActionsRequest,

--- a/server/src/main/java/org/opensearch/extensions/rest/RestInitializeExtensionAction.java
+++ b/server/src/main/java/org/opensearch/extensions/rest/RestInitializeExtensionAction.java
@@ -159,8 +159,7 @@ public class RestInitializeExtensionAction extends BaseRestHandler {
             extAdditionalSettings
         );
         try {
-            extensionsManager.loadExtension(extension);
-            extensionsManager.initialize();
+            extensionsManager.initializeExtension(extension);
         } catch (CompletionException e) {
             Throwable cause = e.getCause();
             if (cause instanceof TimeoutException) {

--- a/server/src/main/java/org/opensearch/extensions/rest/RestSendToExtensionAction.java
+++ b/server/src/main/java/org/opensearch/extensions/rest/RestSendToExtensionAction.java
@@ -150,7 +150,7 @@ public class RestSendToExtensionAction extends BaseRestHandler {
 
     @Override
     public String getName() {
-        return SEND_TO_EXTENSION_ACTION;
+        return this.discoveryExtensionNode.getId() + ":" + SEND_TO_EXTENSION_ACTION;
     }
 
     @Override

--- a/server/src/test/java/org/opensearch/extensions/rest/RestInitializeExtensionActionTests.java
+++ b/server/src/test/java/org/opensearch/extensions/rest/RestInitializeExtensionActionTests.java
@@ -19,8 +19,9 @@ import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.indices.breaker.NoneCircuitBreakerService;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.extensions.DiscoveryExtensionNode;
 import org.opensearch.extensions.ExtensionsManager;
-import org.opensearch.extensions.ExtensionsSettings;
+import org.opensearch.extensions.ExtensionsSettings.Extension;
 import org.opensearch.identity.IdentityService;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.telemetry.tracing.noop.NoopTracer;
@@ -160,8 +161,8 @@ public class RestInitializeExtensionActionTests extends OpenSearchTestCase {
 
         // optionally, you can stub out some methods:
         when(spy.getAdditionalSettings()).thenCallRealMethod();
-        Mockito.doCallRealMethod().when(spy).loadExtension(any(ExtensionsSettings.Extension.class));
-        Mockito.doNothing().when(spy).initialize();
+        Mockito.doCallRealMethod().when(spy).loadExtension(any(Extension.class));
+        Mockito.doNothing().when(spy).initializeExtensionNode(any(DiscoveryExtensionNode.class));
         RestInitializeExtensionAction restInitializeExtensionAction = new RestInitializeExtensionAction(spy);
         final String content = "{\"name\":\"ad-extension\",\"uniqueId\":\"ad-extension\",\"hostAddress\":\"127.0.0.1\","
             + "\"port\":\"4532\",\"version\":\"1.0\",\"opensearchVersion\":\""
@@ -177,10 +178,10 @@ public class RestInitializeExtensionActionTests extends OpenSearchTestCase {
         FakeRestChannel channel = new FakeRestChannel(request, false, 0);
         restInitializeExtensionAction.handleRequest(request, channel, null);
 
-        assertEquals(channel.capturedResponse().status(), RestStatus.ACCEPTED);
+        assertEquals(RestStatus.ACCEPTED, channel.capturedResponse().status());
         assertTrue(channel.capturedResponse().content().utf8ToString().contains("A request to initialize an extension has been sent."));
 
-        Optional<ExtensionsSettings.Extension> extension = spy.lookupExtensionSettingsById("ad-extension");
+        Optional<Extension> extension = spy.lookupExtensionSettingsById("ad-extension");
         assertTrue(extension.isPresent());
         assertEquals(true, extension.get().getAdditionalSettings().get(boolSetting));
         assertEquals("customSetting", extension.get().getAdditionalSettings().get(stringSetting));
@@ -210,8 +211,8 @@ public class RestInitializeExtensionActionTests extends OpenSearchTestCase {
 
         // optionally, you can stub out some methods:
         when(spy.getAdditionalSettings()).thenCallRealMethod();
-        Mockito.doCallRealMethod().when(spy).loadExtension(any(ExtensionsSettings.Extension.class));
-        Mockito.doNothing().when(spy).initialize();
+        Mockito.doCallRealMethod().when(spy).loadExtension(any(Extension.class));
+        Mockito.doNothing().when(spy).initializeExtensionNode(any(DiscoveryExtensionNode.class));
         RestInitializeExtensionAction restInitializeExtensionAction = new RestInitializeExtensionAction(spy);
         final String content = "{\"name\":\"ad-extension\",\"uniqueId\":\"ad-extension\",\"hostAddress\":\"127.0.0.1\","
             + "\"port\":\"4532\",\"version\":\"1.0\",\"opensearchVersion\":\""
@@ -227,10 +228,10 @@ public class RestInitializeExtensionActionTests extends OpenSearchTestCase {
         FakeRestChannel channel = new FakeRestChannel(request, false, 0);
         restInitializeExtensionAction.handleRequest(request, channel, null);
 
-        assertEquals(channel.capturedResponse().status(), RestStatus.ACCEPTED);
+        assertEquals(RestStatus.ACCEPTED, channel.capturedResponse().status());
         assertTrue(channel.capturedResponse().content().utf8ToString().contains("A request to initialize an extension has been sent."));
 
-        Optional<ExtensionsSettings.Extension> extension = spy.lookupExtensionSettingsById("ad-extension");
+        Optional<Extension> extension = spy.lookupExtensionSettingsById("ad-extension");
         assertTrue(extension.isPresent());
         assertEquals(false, extension.get().getAdditionalSettings().get(boolSetting));
         assertEquals("default", extension.get().getAdditionalSettings().get(stringSetting));

--- a/server/src/test/java/org/opensearch/extensions/rest/RestSendToExtensionActionTests.java
+++ b/server/src/test/java/org/opensearch/extensions/rest/RestSendToExtensionActionTests.java
@@ -150,7 +150,7 @@ public class RestSendToExtensionActionTests extends OpenSearchTestCase {
             identityService
         );
 
-        assertEquals("send_to_extension_action", restSendToExtensionAction.getName());
+        assertEquals("uniqueid1:send_to_extension_action", restSendToExtensionAction.getName());
         List<Route> expected = new ArrayList<>();
         String uriPrefix = "/_extensions/_uniqueid1";
         expected.add(new Route(Method.GET, uriPrefix + "/foo"));
@@ -183,7 +183,7 @@ public class RestSendToExtensionActionTests extends OpenSearchTestCase {
             identityService
         );
 
-        assertEquals("send_to_extension_action", restSendToExtensionAction.getName());
+        assertEquals("uniqueid1:send_to_extension_action", restSendToExtensionAction.getName());
         List<NamedRoute> expected = new ArrayList<>();
         String uriPrefix = "/_extensions/_uniqueid1";
         NamedRoute nr1 = new NamedRoute.Builder().method(Method.GET).path(uriPrefix + "/foo").uniqueName("foo").build();
@@ -229,7 +229,7 @@ public class RestSendToExtensionActionTests extends OpenSearchTestCase {
             identityService
         );
 
-        assertEquals("send_to_extension_action", restSendToExtensionAction.getName());
+        assertEquals("uniqueid1:send_to_extension_action", restSendToExtensionAction.getName());
         List<NamedRoute> expected = new ArrayList<>();
         String uriPrefix = "/_extensions/_uniqueid1";
         NamedRoute nr1 = new NamedRoute.Builder().method(Method.GET)


### PR DESCRIPTION
### Description

Fixes registering multiple extensions with OpenSearch.

To reproduce the issue install two extensions, using https://github.com/opensearch-project/opensearch-sdk-java and https://github.com/opensearch-project/opensearch-sdk-py samples.

```
# java extension
cd ~/source/opensearch-project/OpenSearch/dblock-OpenSearch/
git diff

cd ~/source/opensearch-project/opensearch-sdk-java/dblock-opensearch-sdk-java/
./gradlew helloWorld
cat bin/main/org/opensearch/sdk/sample/helloworld/hello.json | jq
curl -s -XPOST "localhost:9200/_extensions/initialize" -H "Content-Type:application/json" --data @bin/main/org/opensearch/sdk/sample/helloworld/hello.json | jq
curl http://localhost:9200/_extensions/_hello-world-java/hello

# python extension
cd ~/source/opensearch-project/opensearch-sdk-py/dblock-opensearch-sdk-py/
cat samples/hello/hello.json | jq
poetry run samples/hello/hello.py
curl -s -XPOST "localhost:9200/_extensions/initialize" -H "Content-Type:application/json" --data @samples/hello/hello.json | jq
curl http://localhost:9200/_extensions/_hello-world-py/hello
```

without the first fix Java extension receives 

```
08:59:01.589 [opensearch[hello-world][generic][T#4]] INFO  org.opensearch.sdk.handlers.AcknowledgedResponseHandler - Extension Request failed
org.opensearch.transport.RemoteTransportException: [runTask-0][127.0.0.1:9300][internal:discovery/registercustomsettings]
Caused by: org.opensearch.common.settings.SettingsException: Could not register setting:custom.validate
        at org.opensearch.common.settings.SettingsModule.registerDynamicSetting(SettingsModule.java:224) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.extensions.settings.CustomSettingsRequestHandler.handleRegisterCustomSettingsRequest(CustomSettingsRequestHandler.java:50) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.extensions.ExtensionsManager.lambda$registerRequestHandler$1(ExtensionsManager.java:233) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.transport.RequestHandlerRegistry.processMessageReceived(RequestHandlerRegistry.java:106) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.transport.InboundHandler$RequestHandler.doRun(InboundHandler.java:454) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:908) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
        at java.lang.Thread.run(Thread.java:833) [?:?]
08:59:01.589 [opensearch[hello-world][generic][T#3]] INFO  org.opensearch.sdk.handlers.AcknowledgedResponseHandler - Extension Request failed
org.opensearch.transport.RemoteTransportException: [runTask-0][127.0.0.1:9300][internal:discovery/registerrestactions]
Caused by: java.lang.IllegalArgumentException: route [NamedRoute [method=GET, path=/_extensions/_hello-world-java/hello, name=greet, actionNames=[cluster:admin/opensearch/hw/greet]]] already registered
        at org.opensearch.action.ActionModule$DynamicActionRegistry.registerDynamicRoute(ActionModule.java:1122) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.extensions.rest.RestSendToExtensionAction.<init>(RestSendToExtensionAction.java:123) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.extensions.rest.RestActionsRequestHandler.handleRegisterRestActionsRequest(RestActionsRequestHandler.java:65) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.extensions.ExtensionsManager.lambda$registerRequestHandler$0(ExtensionsManager.java:224) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.transport.RequestHandlerRegistry.processMessageReceived(RequestHandlerRegistry.java:106) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.transport.InboundHandler$RequestHandler.doRun(InboundHandler.java:454) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:908) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
        at java.lang.Thread.run(Thread.java:833) [?:?]
```

without the second fix, java ext receives

```
09:03:21.793 [opensearch[hello-world][generic][T#2]] INFO  org.opensearch.sdk.handlers.AcknowledgedResponseHandler - Extension Request failed
org.opensearch.transport.RemoteTransportException: [runTask-0][127.0.0.1:9300][internal:discovery/registercustomsettings]
Caused by: org.opensearch.common.settings.SettingsException: Could not register setting:custom.validate
        at org.opensearch.common.settings.SettingsModule.registerDynamicSetting(SettingsModule.java:224) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.extensions.settings.CustomSettingsRequestHandler.handleRegisterCustomSettingsRequest(CustomSettingsRequestHandler.java:50) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.extensions.ExtensionsManager.lambda$registerRequestHandler$1(ExtensionsManager.java:233) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.transport.RequestHandlerRegistry.processMessageReceived(RequestHandlerRegistry.java:106) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.transport.InboundHandler$RequestHandler.doRun(InboundHandler.java:454) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:908) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
        at java.lang.Thread.run(Thread.java:833) [?:?]
09:03:21.793 [opensearch[hello-world][generic][T#1]] INFO  org.opensearch.sdk.handlers.AcknowledgedResponseHandler - Extension Request failed
org.opensearch.transport.RemoteTransportException: [runTask-0][127.0.0.1:9300][internal:discovery/registerrestactions]
Caused by: java.lang.IllegalArgumentException: route [NamedRoute [method=GET, path=/_extensions/_hello-world-java/hello, name=greet, actionNames=[cluster:admin/opensearch/hw/greet]]] already registered
        at org.opensearch.action.ActionModule$DynamicActionRegistry.registerDynamicRoute(ActionModule.java:1122) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.extensions.rest.RestSendToExtensionAction.<init>(RestSendToExtensionAction.java:123) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.extensions.rest.RestActionsRequestHandler.handleRegisterRestActionsRequest(RestActionsRequestHandler.java:65) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.extensions.ExtensionsManager.lambda$registerRequestHandler$0(ExtensionsManager.java:224) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.transport.RequestHandlerRegistry.processMessageReceived(RequestHandlerRegistry.java:106) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.transport.InboundHandler$RequestHandler.doRun(InboundHandler.java:454) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:908) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
        at java.lang.Thread.run(Thread.java:833) [?:?]
```

python ext receives

```
INFO:root:b'ES\x00\x00\x06g\x00\x00\x00\x00\x00\x00\x00\x06\x03\x08 2\x93\x00\x00\x00%\x01\x1c_system_index_access_allowed\x05false\x00\x01\x00g\x01D[runTask-0][127.0.0.1:50617][internal:discovery/registerrestactions]\x01\x06\x01\xdf\x01handler of type [org.opensearch.extensions.rest.RestSendToExtensionAction] conflicts with handler of type [org.opensearch.extensions.rest.RestSendToExtensionAction] as they both have the same name [send_to_extension_action]\x00\x0f!org.opensearch.usage.UsageService\x01\x11UsageService.java\x0eaddRestHandlerc"org.opensearch.rest.RestController\x01\x13RestController.java\x0fregisterHandler\xd8\x01"org.opensearch.rest.RestController\x01\x13RestController.java\x18lambda$registerHandler$3\xea\x01\x13java.util.ArrayList\x01\x0eArrayList.java\x07forEach\xe7\x0b,java.util.Collections$UnmodifiableCollection\x01\x10Collections.java\x07forEach\xc4\x08"org.opensearch.rest.RestController\x01\x13RestController.java\x0fregisterHandler\xea\x018org.opensearch.extensions.rest.RestActionsRequestHandler\x01\x1eRestActionsRequestHandler.java handleRegisterRestActionsRequestH+org.opensearch.extensions.ExtensionsManager\x01\x16ExtensionsManager.java\x1flambda$registerRequestHandler$0\xe0\x01/org.opensearch.transport.RequestHandlerRegistry\x01\x1bRequestHandlerRegistry.java\x16processMessageReceivedj6org.opensearch.transport.InboundHandler$RequestHandler\x01\x13InboundHandler.java\x05doRun\xc6\x03Uorg.opensearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable\x01\x12ThreadContext.java\x05doRun\x8c\x076org.opensearch.common.util.concurrent.AbstractRunnable\x01\x15AbstractRunnable.java\x03run4\'java.util.concurrent.ThreadPoolExecutor\x01\x17ThreadPoolExecutor.java\trunWorker\xf0\x08.java.util.concurrent.ThreadPoolExecutor$Worker\x01\x17ThreadPoolExecutor.java\x03run\xfb\x04\x10java.lang.Thread\x01\x0bThread.java\x03run\xc1\x06\x00\x00\x00\x00\x00\x01\x04\x7f\x00\x00\x01\t127.0.0.1\x00\x00\xc5\xb9\x01&internal:discovery/registerrestactions'
```

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
