### PR TITLE
Refactor read context streams to async streams

### DIFF
--- a/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/S3BlobStoreContainerTests.java
+++ b/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/S3BlobStoreContainerTests.java
@@ -969,7 +969,7 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
         assertEquals(objectSize, readContext.getBlobSize());
 
         for (int partNumber = 1; partNumber < objectPartCount; partNumber++) {
-            InputStreamContainer inputStreamContainer = readContext.getPartStreams().get(partNumber);
+            InputStreamContainer inputStreamContainer = readContext.getPartStreams().get(partNumber).get();
             final int offset = partNumber * partSize;
             assertEquals(partSize, inputStreamContainer.getContentLength());
             assertEquals(offset, inputStreamContainer.getOffset());
@@ -1024,7 +1024,7 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
         assertEquals(checksum, readContext.getBlobChecksum());
         assertEquals(objectSize, readContext.getBlobSize());
 
-        InputStreamContainer inputStreamContainer = readContext.getPartStreams().stream().findFirst().get();
+        InputStreamContainer inputStreamContainer = readContext.getPartStreams().stream().findFirst().get().get();
         assertEquals(objectSize, inputStreamContainer.getContentLength());
         assertEquals(0, inputStreamContainer.getOffset());
         assertEquals(objectSize, inputStreamContainer.getInputStream().readAllBytes().length);

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/multipart/mocks/MockFsAsyncBlobContainer.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/multipart/mocks/MockFsAsyncBlobContainer.java
@@ -27,6 +27,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -124,11 +125,11 @@ public class MockFsAsyncBlobContainer extends FsBlobContainer implements AsyncMu
                 long contentLength = listBlobs().get(blobName).length();
                 long partSize = contentLength / 10;
                 int numberOfParts = (int) ((contentLength % partSize) == 0 ? contentLength / partSize : (contentLength / partSize) + 1);
-                List<InputStreamContainer> blobPartStreams = new ArrayList<>();
+                List<CompletableFuture<InputStreamContainer>> blobPartStreams = new ArrayList<>();
                 for (int partNumber = 0; partNumber < numberOfParts; partNumber++) {
                     long offset = partNumber * partSize;
                     InputStreamContainer blobPartStream = new InputStreamContainer(readBlob(blobName, offset, partSize), partSize, offset);
-                    blobPartStreams.add(blobPartStream);
+                    blobPartStreams.add(CompletableFuture.completedFuture(blobPartStream));
                 }
                 ReadContext blobReadContext = new ReadContext(contentLength, blobPartStreams, null);
                 listener.onResponse(blobReadContext);

--- a/server/src/main/java/org/opensearch/common/blobstore/AsyncMultiStreamBlobContainer.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/AsyncMultiStreamBlobContainer.java
@@ -13,7 +13,6 @@ import org.opensearch.common.blobstore.stream.read.ReadContext;
 import org.opensearch.common.blobstore.stream.read.listener.ReadContextListener;
 import org.opensearch.common.blobstore.stream.write.WriteContext;
 import org.opensearch.core.action.ActionListener;
-import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -49,12 +48,11 @@ public interface AsyncMultiStreamBlobContainer extends BlobContainer {
      * Asynchronously downloads the blob to the specified location using an executor from the thread pool.
      * @param blobName The name of the blob for which needs to be downloaded.
      * @param fileLocation The path on local disk where the blob needs to be downloaded.
-     * @param threadPool The threadpool instance which will provide the executor for performing a multipart download.
      * @param completionListener Listener which will be notified when the download is complete.
      */
     @ExperimentalApi
-    default void asyncBlobDownload(String blobName, Path fileLocation, ThreadPool threadPool, ActionListener<String> completionListener) {
-        ReadContextListener readContextListener = new ReadContextListener(blobName, fileLocation, threadPool, completionListener);
+    default void asyncBlobDownload(String blobName, Path fileLocation, ActionListener<String> completionListener) {
+        ReadContextListener readContextListener = new ReadContextListener(blobName, fileLocation, completionListener);
         readBlobAsync(blobName, readContextListener);
     }
 

--- a/server/src/main/java/org/opensearch/common/blobstore/AsyncMultiStreamEncryptedBlobContainer.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/AsyncMultiStreamEncryptedBlobContainer.java
@@ -19,6 +19,7 @@ import org.opensearch.core.action.ActionListener;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 /**
@@ -144,8 +145,10 @@ public class AsyncMultiStreamEncryptedBlobContainer<T, U> extends EncryptedBlobC
         }
 
         @Override
-        public List<InputStreamContainer> getPartStreams() {
-            return super.getPartStreams().stream().map(this::decryptInputStreamContainer).collect(Collectors.toList());
+        public List<CompletableFuture<InputStreamContainer>> getPartStreams() {
+            return super.getPartStreams().stream()
+                .map(cf -> cf.thenApply(this::decryptInputStreamContainer))
+                .collect(Collectors.toUnmodifiableList());
         }
 
         /**

--- a/server/src/main/java/org/opensearch/common/blobstore/stream/read/ReadContext.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/stream/read/ReadContext.java
@@ -12,6 +12,7 @@ import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.io.InputStreamContainer;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * ReadContext is used to encapsulate all data needed by <code>BlobContainer#readBlobAsync</code>
@@ -19,18 +20,18 @@ import java.util.List;
 @ExperimentalApi
 public class ReadContext {
     private final long blobSize;
-    private final List<InputStreamContainer> partStreams;
+    private final List<CompletableFuture<InputStreamContainer>> asyncPartStreams;
     private final String blobChecksum;
 
-    public ReadContext(long blobSize, List<InputStreamContainer> partStreams, String blobChecksum) {
+    public ReadContext(long blobSize, List<CompletableFuture<InputStreamContainer>> asyncPartStreams, String blobChecksum) {
         this.blobSize = blobSize;
-        this.partStreams = partStreams;
+        this.asyncPartStreams = asyncPartStreams;
         this.blobChecksum = blobChecksum;
     }
 
     public ReadContext(ReadContext readContext) {
         this.blobSize = readContext.blobSize;
-        this.partStreams = readContext.partStreams;
+        this.asyncPartStreams = readContext.asyncPartStreams;
         this.blobChecksum = readContext.blobChecksum;
     }
 
@@ -39,14 +40,14 @@ public class ReadContext {
     }
 
     public int getNumberOfParts() {
-        return partStreams.size();
+        return asyncPartStreams.size();
     }
 
     public long getBlobSize() {
         return blobSize;
     }
 
-    public List<InputStreamContainer> getPartStreams() {
-        return partStreams;
+    public List<CompletableFuture<InputStreamContainer>> getPartStreams() {
+        return asyncPartStreams;
     }
 }

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -62,7 +62,6 @@ import org.opensearch.action.ActionRunnable;
 import org.opensearch.action.admin.indices.flush.FlushRequest;
 import org.opensearch.action.admin.indices.forcemerge.ForceMergeRequest;
 import org.opensearch.action.admin.indices.upgrade.post.UpgradeRequest;
-import org.opensearch.action.support.GroupedActionListener;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.action.support.replication.PendingReplicationActions;
 import org.opensearch.action.support.replication.ReplicationResponse;
@@ -4914,24 +4913,17 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         RemoteSegmentStoreDirectory targetRemoteDirectory,
         Set<String> toDownloadSegments,
         final Runnable onFileSync
-    ) {
-        final PlainActionFuture<Void> completionListener = PlainActionFuture.newFuture();
-        final GroupedActionListener<Void> batchDownloadListener = new GroupedActionListener<>(
-            ActionListener.map(completionListener, v -> null),
-            toDownloadSegments.size()
-        );
-
-        final ActionListener<String> segmentsDownloadListener = ActionListener.map(batchDownloadListener, fileName -> {
+    ) throws IOException {
+        final Path indexPath = store.shardPath() == null ? null : store.shardPath().resolveIndex();
+        for (String segment : toDownloadSegments) {
+            final PlainActionFuture<String> segmentListener = PlainActionFuture.newFuture();
+            sourceRemoteDirectory.copyTo(segment, storeDirectory, indexPath, segmentListener);
+            segmentListener.actionGet();
             onFileSync.run();
             if (targetRemoteDirectory != null) {
-                targetRemoteDirectory.copyFrom(storeDirectory, fileName, fileName, IOContext.DEFAULT);
+                targetRemoteDirectory.copyFrom(storeDirectory, segment, segment, IOContext.DEFAULT);
             }
-            return null;
-        });
-
-        final Path indexPath = store.shardPath() == null ? null : store.shardPath().resolveIndex();
-        toDownloadSegments.forEach(file -> { sourceRemoteDirectory.copyTo(file, storeDirectory, indexPath, segmentsDownloadListener); });
-        completionListener.actionGet();
+        }
     }
 
     private boolean localDirectoryContains(Directory localDirectory, String file, long checksum) {

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -468,7 +468,7 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
         if (destinationPath != null && remoteDataDirectory.getBlobContainer() instanceof AsyncMultiStreamBlobContainer) {
             final AsyncMultiStreamBlobContainer blobContainer = (AsyncMultiStreamBlobContainer) remoteDataDirectory.getBlobContainer();
             final Path destinationFilePath = destinationPath.resolve(source);
-            blobContainer.asyncBlobDownload(blobName, destinationFilePath, threadPool, fileCompletionListener);
+            blobContainer.asyncBlobDownload(blobName, destinationFilePath, fileCompletionListener);
         } else {
             // Fallback to older mechanism of downloading the file
             try {

--- a/server/src/test/java/org/opensearch/common/blobstore/AsyncMultiStreamEncryptedBlobContainerTests.java
+++ b/server/src/test/java/org/opensearch/common/blobstore/AsyncMultiStreamEncryptedBlobContainerTests.java
@@ -20,6 +20,7 @@ import org.opensearch.test.OpenSearchTestCase;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.UnaryOperator;
 
 import org.mockito.Mockito;
@@ -51,10 +52,12 @@ public class AsyncMultiStreamEncryptedBlobContainerTests extends OpenSearchTestC
         // Objects needed for API call
         final byte[] data = new byte[size];
         Randomness.get().nextBytes(data);
+
         final InputStreamContainer inputStreamContainer = new InputStreamContainer(new ByteArrayInputStream(data), data.length, 0);
         final ListenerTestUtils.CountingCompletionListener<ReadContext> completionListener =
             new ListenerTestUtils.CountingCompletionListener<>();
-        final ReadContext readContext = new ReadContext(size, List.of(inputStreamContainer), null);
+        final CompletableFuture<InputStreamContainer> streamContainerFuture = CompletableFuture.completedFuture(inputStreamContainer);
+        final ReadContext readContext = new ReadContext(size, List.of(streamContainerFuture), null);
 
         Mockito.doAnswer(invocation -> {
             ActionListener<ReadContext> readContextActionListener = invocation.getArgument(1);
@@ -76,7 +79,7 @@ public class AsyncMultiStreamEncryptedBlobContainerTests extends OpenSearchTestC
         assertEquals(1, response.getNumberOfParts());
         assertEquals(size, response.getBlobSize());
 
-        InputStreamContainer responseContainer = response.getPartStreams().get(0);
+        InputStreamContainer responseContainer = response.getPartStreams().get(0).get();
         assertEquals(0, responseContainer.getOffset());
         assertEquals(size, responseContainer.getContentLength());
         assertEquals(100, responseContainer.getInputStream().available());
@@ -99,7 +102,8 @@ public class AsyncMultiStreamEncryptedBlobContainerTests extends OpenSearchTestC
         final InputStreamContainer inputStreamContainer = new InputStreamContainer(new ByteArrayInputStream(data), data.length, 0);
         final ListenerTestUtils.CountingCompletionListener<ReadContext> completionListener =
             new ListenerTestUtils.CountingCompletionListener<>();
-        final ReadContext readContext = new ReadContext(size, List.of(inputStreamContainer), null);
+        final CompletableFuture<InputStreamContainer> streamContainerFuture = CompletableFuture.completedFuture(inputStreamContainer);
+        final ReadContext readContext = new ReadContext(size, List.of(streamContainerFuture), null);
 
         Mockito.doAnswer(invocation -> {
             ActionListener<ReadContext> readContextActionListener = invocation.getArgument(1);

--- a/server/src/test/java/org/opensearch/common/blobstore/stream/read/listener/FilePartWriterTests.java
+++ b/server/src/test/java/org/opensearch/common/blobstore/stream/read/listener/FilePartWriterTests.java
@@ -40,14 +40,8 @@ public class FilePartWriterTests extends OpenSearchTestCase {
         AtomicBoolean anyStreamFailed = new AtomicBoolean();
         CountingCompletionListener<Integer> fileCompletionListener = new CountingCompletionListener<>();
 
-        FilePartWriter filePartWriter = new FilePartWriter(
-            partNumber,
-            inputStreamContainer,
-            segmentFilePath,
-            anyStreamFailed,
-            fileCompletionListener
-        );
-        filePartWriter.run();
+        FilePartWriter filePartWriter = new FilePartWriter(partNumber, segmentFilePath, anyStreamFailed, fileCompletionListener);
+        filePartWriter.accept(inputStreamContainer, null);
 
         assertTrue(Files.exists(segmentFilePath));
         assertEquals(contentLength, Files.size(segmentFilePath));
@@ -65,14 +59,8 @@ public class FilePartWriterTests extends OpenSearchTestCase {
         AtomicBoolean anyStreamFailed = new AtomicBoolean();
         CountingCompletionListener<Integer> fileCompletionListener = new CountingCompletionListener<>();
 
-        FilePartWriter filePartWriter = new FilePartWriter(
-            partNumber,
-            inputStreamContainer,
-            segmentFilePath,
-            anyStreamFailed,
-            fileCompletionListener
-        );
-        filePartWriter.run();
+        FilePartWriter filePartWriter = new FilePartWriter(partNumber, segmentFilePath, anyStreamFailed, fileCompletionListener);
+        filePartWriter.accept(inputStreamContainer, null);
 
         assertTrue(Files.exists(segmentFilePath));
         assertEquals(contentLength + offset, Files.size(segmentFilePath));
@@ -89,14 +77,8 @@ public class FilePartWriterTests extends OpenSearchTestCase {
         AtomicBoolean anyStreamFailed = new AtomicBoolean();
         CountingCompletionListener<Integer> fileCompletionListener = new CountingCompletionListener<>();
 
-        FilePartWriter filePartWriter = new FilePartWriter(
-            partNumber,
-            inputStreamContainer,
-            segmentFilePath,
-            anyStreamFailed,
-            fileCompletionListener
-        );
-        filePartWriter.run();
+        FilePartWriter filePartWriter = new FilePartWriter(partNumber, segmentFilePath, anyStreamFailed, fileCompletionListener);
+        filePartWriter.accept(inputStreamContainer, null);
 
         assertTrue(Files.exists(segmentFilePath));
         assertEquals(contentLength, Files.size(segmentFilePath));
@@ -107,21 +89,12 @@ public class FilePartWriterTests extends OpenSearchTestCase {
 
     public void testFilePartWriterException() throws Exception {
         Path segmentFilePath = path.resolve(UUID.randomUUID().toString());
-        int contentLength = 100;
         int partNumber = 1;
-        InputStream inputStream = new ByteArrayInputStream(randomByteArrayOfLength(contentLength));
-        InputStreamContainer inputStreamContainer = new InputStreamContainer(inputStream, contentLength, 0);
         AtomicBoolean anyStreamFailed = new AtomicBoolean();
         CountingCompletionListener<Integer> fileCompletionListener = new CountingCompletionListener<>();
 
         IOException ioException = new IOException();
-        FilePartWriter filePartWriter = new FilePartWriter(
-            partNumber,
-            inputStreamContainer,
-            segmentFilePath,
-            anyStreamFailed,
-            fileCompletionListener
-        );
+        FilePartWriter filePartWriter = new FilePartWriter(partNumber, segmentFilePath, anyStreamFailed, fileCompletionListener);
         assertFalse(anyStreamFailed.get());
         filePartWriter.processFailure(ioException);
 
@@ -148,14 +121,8 @@ public class FilePartWriterTests extends OpenSearchTestCase {
         AtomicBoolean anyStreamFailed = new AtomicBoolean(true);
         CountingCompletionListener<Integer> fileCompletionListener = new CountingCompletionListener<>();
 
-        FilePartWriter filePartWriter = new FilePartWriter(
-            partNumber,
-            inputStreamContainer,
-            segmentFilePath,
-            anyStreamFailed,
-            fileCompletionListener
-        );
-        filePartWriter.run();
+        FilePartWriter filePartWriter = new FilePartWriter(partNumber, segmentFilePath, anyStreamFailed, fileCompletionListener);
+        filePartWriter.accept(inputStreamContainer, null);
 
         assertFalse(Files.exists(segmentFilePath));
         assertEquals(0, fileCompletionListener.getResponseCount());

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -536,10 +536,10 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         when(remoteDataDirectory.getBlobContainer()).thenReturn(blobContainer);
 
         Mockito.doAnswer(invocation -> {
-            ActionListener<String> completionListener = invocation.getArgument(3);
+            ActionListener<String> completionListener = invocation.getArgument(2);
             completionListener.onResponse(invocation.getArgument(0));
             return null;
-        }).when(blobContainer).asyncBlobDownload(any(), any(), any(), any());
+        }).when(blobContainer).asyncBlobDownload(any(), any(), any());
 
         CountDownLatch downloadLatch = new CountDownLatch(1);
         ActionListener<String> completionListener = new ActionListener<String>() {
@@ -554,7 +554,7 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         Path path = createTempDir();
         remoteSegmentStoreDirectory.copyTo(filename, storeDirectory, path, completionListener);
         assertTrue(downloadLatch.await(5000, TimeUnit.SECONDS));
-        verify(blobContainer, times(1)).asyncBlobDownload(contains(filename), eq(path.resolve(filename)), any(), any());
+        verify(blobContainer, times(1)).asyncBlobDownload(contains(filename), eq(path.resolve(filename)), any());
         verify(storeDirectory, times(0)).copyFrom(any(), any(), any(), any());
     }
 


### PR DESCRIPTION
### Description
- Refactor `ReadContext` streams to async streams to prevent joining on all streams causing a blocking `ReadContext`
- Original commit: https://github.com/andrross/OpenSearch/commit/d237c6f113ef865f7bb890652e2025e3f1c88cbc#diff-4eb8a623572c23131b1bc7bb5e75b1ba7d99a3efef0563cf607d35e43f83ac4c

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
