### PR TITLE
Adding stats for unreferenced files cleanup count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Async blob read support for encrypted containers ([#10131](https://github.com/opensearch-project/OpenSearch/pull/10131))
 - Add capability to restrict async durability mode for remote indexes ([#10189](https://github.com/opensearch-project/OpenSearch/pull/10189))
 - Add Doc Status Counter for Indexing Engine ([#4562](https://github.com/opensearch-project/OpenSearch/issues/4562))
+- Add unreferenced file cleanup count to merge stats ([#10204](https://github.com/opensearch-project/OpenSearch/pull/10204))
 
 ### Dependencies
 - Bump `peter-evans/create-or-update-comment` from 2 to 3 ([#9575](https://github.com/opensearch-project/OpenSearch/pull/9575))

--- a/server/src/main/java/org/opensearch/index/engine/Engine.java
+++ b/server/src/main/java/org/opensearch/index/engine/Engine.java
@@ -145,6 +145,7 @@ public abstract class Engine implements LifecycleAware, Closeable {
     protected final EngineConfig engineConfig;
     protected final Store store;
     protected final AtomicBoolean isClosed = new AtomicBoolean(false);
+    private final CounterMetric totalUnreferencedFileCleanUpsPerformed = new CounterMetric();
     private final CountDownLatch closedLatch = new CountDownLatch(1);
     protected final EventListener eventListener;
     protected final ReentrantLock failEngineLock = new ReentrantLock();
@@ -265,6 +266,13 @@ public abstract class Engine implements LifecycleAware, Closeable {
             }
         }
         return new DocsStats(numDocs, numDeletedDocs, sizeInBytes);
+    }
+
+    /**
+     * Returns the unreferenced file cleanup count for this engine
+     */
+    public long unreferencedFileCleanUpsPerformed() {
+        return totalUnreferencedFileCleanUpsPerformed.count();
     }
 
     /**
@@ -1340,7 +1348,9 @@ public abstract class Engine implements LifecycleAware, Closeable {
                     .setOpenMode(IndexWriterConfig.OpenMode.APPEND)
             )
         ) {
-            // do nothing and close this will kick off IndexFileDeleter which will remove all unreferenced files.
+            // do nothing except increasing metric count and close this will kick off IndexFileDeleter which will
+            // remove all unreferenced files.
+            totalUnreferencedFileCleanUpsPerformed.inc();
         } catch (Exception ex) {
             logger.error("Error while deleting unreferenced file ", ex);
         }

--- a/server/src/main/java/org/opensearch/index/merge/MergeStats.java
+++ b/server/src/main/java/org/opensearch/index/merge/MergeStats.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.index.merge;
 
+import org.opensearch.Version;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -64,10 +65,9 @@ public class MergeStats implements Writeable, ToXContentFragment {
     private long totalThrottledTimeInMillis;
 
     private long totalBytesPerSecAutoThrottle;
+    private long unreferencedFileCleanUpsPerformed;
 
-    public MergeStats() {
-
-    }
+    public MergeStats() {}
 
     public MergeStats(StreamInput in) throws IOException {
         total = in.readVLong();
@@ -81,6 +81,9 @@ public class MergeStats implements Writeable, ToXContentFragment {
         totalStoppedTimeInMillis = in.readVLong();
         totalThrottledTimeInMillis = in.readVLong();
         totalBytesPerSecAutoThrottle = in.readVLong();
+        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+            unreferencedFileCleanUpsPerformed = in.readOptionalVLong();
+        }
     }
 
     public void add(
@@ -133,6 +136,7 @@ public class MergeStats implements Writeable, ToXContentFragment {
         this.totalSizeInBytes += mergeStats.totalSizeInBytes;
         this.totalStoppedTimeInMillis += mergeStats.totalStoppedTimeInMillis;
         this.totalThrottledTimeInMillis += mergeStats.totalThrottledTimeInMillis;
+        addUnreferencedFileCleanUpStats(mergeStats.unreferencedFileCleanUpsPerformed);
         if (this.totalBytesPerSecAutoThrottle == Long.MAX_VALUE || mergeStats.totalBytesPerSecAutoThrottle == Long.MAX_VALUE) {
             this.totalBytesPerSecAutoThrottle = Long.MAX_VALUE;
         } else {
@@ -224,6 +228,14 @@ public class MergeStats implements Writeable, ToXContentFragment {
         return new ByteSizeValue(currentSizeInBytes);
     }
 
+    public void addUnreferencedFileCleanUpStats(long unreferencedFileCleanUpsPerformed) {
+        this.unreferencedFileCleanUpsPerformed += unreferencedFileCleanUpsPerformed;
+    }
+
+    public long getUnreferencedFileCleanUpsPerformed() {
+        return this.unreferencedFileCleanUpsPerformed;
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(Fields.MERGES);
@@ -240,6 +252,7 @@ public class MergeStats implements Writeable, ToXContentFragment {
             builder.field(Fields.TOTAL_THROTTLE_BYTES_PER_SEC).value(new ByteSizeValue(totalBytesPerSecAutoThrottle).toString());
         }
         builder.field(Fields.TOTAL_THROTTLE_BYTES_PER_SEC_IN_BYTES, totalBytesPerSecAutoThrottle);
+        builder.field(Fields.UNREFERENCED_FILE_CLEANUPS_PERFORMED, unreferencedFileCleanUpsPerformed);
         builder.endObject();
         return builder;
     }
@@ -267,6 +280,7 @@ public class MergeStats implements Writeable, ToXContentFragment {
         static final String TOTAL_SIZE_IN_BYTES = "total_size_in_bytes";
         static final String TOTAL_THROTTLE_BYTES_PER_SEC_IN_BYTES = "total_auto_throttle_in_bytes";
         static final String TOTAL_THROTTLE_BYTES_PER_SEC = "total_auto_throttle";
+        static final String UNREFERENCED_FILE_CLEANUPS_PERFORMED = "unreferenced_file_cleanups_performed";
     }
 
     @Override
@@ -282,5 +296,8 @@ public class MergeStats implements Writeable, ToXContentFragment {
         out.writeVLong(totalStoppedTimeInMillis);
         out.writeVLong(totalThrottledTimeInMillis);
         out.writeVLong(totalBytesPerSecAutoThrottle);
+        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+            out.writeOptionalVLong(unreferencedFileCleanUpsPerformed);
+        }
     }
 }

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1383,7 +1383,12 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         if (engine == null) {
             return new MergeStats();
         }
-        return engine.getMergeStats();
+        final MergeStats mergeStats = engine.getMergeStats();
+        if (indexSettings.shouldCleanupUnreferencedFiles()) {
+            mergeStats.addUnreferencedFileCleanUpStats(engine.unreferencedFileCleanUpsPerformed());
+        }
+
+        return mergeStats;
     }
 
     public SegmentsStats segmentStats(boolean includeSegmentFileSizes, boolean includeUnloadedSegments) {

--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -233,7 +233,6 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -3334,6 +3333,9 @@ public class InternalEngineTests extends EngineTestCase {
             );
 
             assertTrue(cleanupCompleted.await(10, TimeUnit.SECONDS));
+            // Cleanup count will be incremented whenever cleanup is performed correctly.
+            long unreferencedFileCleanUpsPerformed = engine.unreferencedFileCleanUpsPerformed();
+            assertThat(unreferencedFileCleanUpsPerformed, equalTo(1L));
         } catch (Exception ex) {
             throw new AssertionError(ex);
         }
@@ -3445,6 +3447,9 @@ public class InternalEngineTests extends EngineTestCase {
             );
 
             assertTrue(cleanupCompleted.await(10, TimeUnit.SECONDS));
+            // Cleanup count will not be incremented whenever cleanup is disabled.
+            long unreferencedFileCleanUpsPerformed = engine.unreferencedFileCleanUpsPerformed();
+            assertThat(unreferencedFileCleanUpsPerformed, equalTo(0L));
         } catch (Exception ex) {
             throw new AssertionError(ex);
         }
@@ -3549,6 +3554,9 @@ public class InternalEngineTests extends EngineTestCase {
             );
 
             assertTrue(cleanupCompleted.await(10, TimeUnit.SECONDS));
+            // Cleanup count will not be incremented whenever there is some issue with cleanup.
+            long unreferencedFileCleanUpsPerformed = engine.unreferencedFileCleanUpsPerformed();
+            assertThat(unreferencedFileCleanUpsPerformed, equalTo(0L));
         } catch (Exception ex) {
             throw new AssertionError(ex);
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
