### PR TITLE
Add header verification netty channel handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Async blob read support for encrypted containers ([#10131](https://github.com/opensearch-project/OpenSearch/pull/10131))
 - Add capability to restrict async durability mode for remote indexes ([#10189](https://github.com/opensearch-project/OpenSearch/pull/10189))
 - Add Doc Status Counter for Indexing Engine ([#4562](https://github.com/opensearch-project/OpenSearch/issues/4562))
+- Header verification ([####](https://github.com/opensearch-project/OpenSearch/pull/###))
 
 ### Dependencies
 - Bump `peter-evans/create-or-update-comment` from 2 to 3 ([#9575](https://github.com/opensearch-project/OpenSearch/pull/9575))

--- a/modules/transport-netty4/src/main/java/org/opensearch/http/netty4/Netty4HeaderVerifier.java
+++ b/modules/transport-netty4/src/main/java/org/opensearch/http/netty4/Netty4HeaderVerifier.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.http.netty4;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.ReferenceCountUtil;
+
+/** POC for how an external header verifier would be implemented */
+@ChannelHandler.Sharable
+public class Netty4HeaderVerifier extends ChannelInboundHandlerAdapter {
+
+    final static Logger log = LogManager.getLogger(Netty4HeaderVerifier.class);
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        if (!(msg instanceof HttpRequest)) {
+            ctx.fireChannelRead(msg);
+        }
+
+        HttpRequest request = (HttpRequest) msg;
+        if (!isVerified(request)) {
+            final FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.UNAUTHORIZED);
+            ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
+            ReferenceCountUtil.release(msg);
+        } else {
+            // Lets the request pass to the next channel handler
+            ctx.fireChannelRead(msg);
+        }
+    }
+
+    private boolean isVerified(HttpRequest request) {
+        log.info("Checking if request is authenticated:\n" + request);
+
+        final boolean shouldBlock = request.headers().contains("blockme");
+
+        return !shouldBlock;
+    }
+}


### PR DESCRIPTION
### Description
Adds an entry point for header verification in Netty4HttpServerTransport, using netty channel close allows for fewer downstream changes.

Based off work of @cwperks in https://github.com/opensearch-project/OpenSearch/pull/10261

#### Draft Status
This pull request has a very naïve test strategy, it should be looked into more deeply to be sure there aren't other side effects.  

Note; it is also possible that this approach isn't needed at all if the Netty pipeline construction can be modified by the extensions of the AbstractHttpServerTransport class.  More research is needed in this space.

### Related Issues
- Related https://github.com/opensearch-project/OpenSearch/issues/10260
- Related https://github.com/opensearch-project/security/pull/3430

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
