### PR TITLE
Update multipart download path to first write to temp files

### DIFF
--- a/server/src/main/java/org/opensearch/common/blobstore/stream/read/listener/ReadContextListener.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/stream/read/listener/ReadContextListener.java
@@ -10,7 +10,6 @@ package org.opensearch.common.blobstore.stream.read.listener;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.util.IOUtils;
 import org.opensearch.action.support.GroupedActionListener;
 import org.opensearch.common.SuppressForbidden;

--- a/server/src/main/java/org/opensearch/common/blobstore/stream/read/listener/ReadContextListener.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/stream/read/listener/ReadContextListener.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.util.IOUtils;
 import org.opensearch.action.support.GroupedActionListener;
+import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.annotation.InternalApi;
 import org.opensearch.common.blobstore.stream.read.ReadContext;
@@ -86,6 +87,7 @@ public class ReadContextListener implements ActionListener<ReadContext> {
         }
     }
 
+    @SuppressForbidden(reason = "need to fsync once all parts received")
     private ActionListener<Collection<String>> getFileCompletionListener() {
         return ActionListener.wrap(response -> {
             logger.trace(() -> new ParameterizedMessage("renaming temp file [{}] to [{}]", tmpFileLocation, fileLocation));

--- a/server/src/main/java/org/opensearch/common/blobstore/stream/read/listener/ReadContextListener.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/stream/read/listener/ReadContextListener.java
@@ -94,6 +94,8 @@ public class ReadContextListener implements ActionListener<ReadContext> {
             try {
                 IOUtils.fsync(tmpFileLocation, false);
                 Files.move(tmpFileLocation, fileLocation, StandardCopyOption.ATOMIC_MOVE);
+                // sync parent dir metadata
+                IOUtils.fsync(fileLocation.getParent(), true);
                 completionListener.onResponse(blobName);
             } catch (IOException e) {
                 logger.error("Unable to rename temp file + " + tmpFileLocation, e);

--- a/server/src/main/java/org/opensearch/common/blobstore/stream/read/listener/ReadContextListener.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/stream/read/listener/ReadContextListener.java
@@ -10,7 +10,10 @@ package org.opensearch.common.blobstore.stream.read.listener;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.apache.lucene.util.IOUtils;
 import org.opensearch.action.support.GroupedActionListener;
+import org.opensearch.common.UUIDs;
 import org.opensearch.common.annotation.InternalApi;
 import org.opensearch.common.blobstore.stream.read.ReadContext;
 import org.opensearch.core.action.ActionListener;
@@ -20,6 +23,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Collection;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executor;
@@ -33,9 +38,11 @@ import java.util.function.UnaryOperator;
 @InternalApi
 public class ReadContextListener implements ActionListener<ReadContext> {
     private static final Logger logger = LogManager.getLogger(ReadContextListener.class);
-
+    private static final String DOWNLOAD_PREFIX = "download.";
     private final String blobName;
     private final Path fileLocation;
+    private final String tmpFileName;
+    private final Path tmpFileLocation;
     private final ActionListener<String> completionListener;
     private final ThreadPool threadPool;
     private final UnaryOperator<InputStream> rateLimiter;
@@ -55,6 +62,8 @@ public class ReadContextListener implements ActionListener<ReadContext> {
         this.threadPool = threadPool;
         this.rateLimiter = rateLimiter;
         this.maxConcurrentStreams = maxConcurrentStreams;
+        this.tmpFileName = DOWNLOAD_PREFIX + UUIDs.randomBase64UUID() + "." + blobName;
+        this.tmpFileLocation = fileLocation.getParent().resolve(tmpFileName);
     }
 
     @Override
@@ -62,15 +71,12 @@ public class ReadContextListener implements ActionListener<ReadContext> {
         logger.debug("Received {} parts for blob {}", readContext.getNumberOfParts(), blobName);
         final int numParts = readContext.getNumberOfParts();
         final AtomicBoolean anyPartStreamFailed = new AtomicBoolean(false);
-        final GroupedActionListener<String> groupedListener = new GroupedActionListener<>(
-            ActionListener.wrap(r -> completionListener.onResponse(blobName), completionListener::onFailure),
-            numParts
-        );
+        final GroupedActionListener<String> groupedListener = new GroupedActionListener<>(getFileCompletionListener(), numParts);
         final Queue<ReadContext.StreamPartCreator> queue = new ConcurrentLinkedQueue<>(readContext.getPartStreams());
         final StreamPartProcessor processor = new StreamPartProcessor(
             queue,
             anyPartStreamFailed,
-            fileLocation,
+            tmpFileLocation,
             groupedListener,
             threadPool.executor(ThreadPool.Names.REMOTE_RECOVERY),
             rateLimiter
@@ -78,6 +84,34 @@ public class ReadContextListener implements ActionListener<ReadContext> {
         for (int i = 0; i < Math.min(maxConcurrentStreams, queue.size()); i++) {
             processor.process(queue.poll());
         }
+    }
+
+    private ActionListener<Collection<String>> getFileCompletionListener() {
+        return ActionListener.wrap(response -> {
+            logger.trace(() -> new ParameterizedMessage("renaming temp file [{}] to [{}]", tmpFileLocation, fileLocation));
+            try {
+                IOUtils.fsync(tmpFileLocation, false);
+                Files.move(tmpFileLocation, fileLocation, StandardCopyOption.ATOMIC_MOVE);
+                completionListener.onResponse(blobName);
+            } catch (IOException e) {
+                logger.error("Unable to rename temp file + " + tmpFileLocation, e);
+                completionListener.onFailure(e);
+            }
+        }, e -> {
+            try {
+                Files.deleteIfExists(tmpFileLocation);
+            } catch (IOException ex) {
+                logger.warn("Unable to clean temp file {}", tmpFileLocation);
+            }
+            completionListener.onFailure(e);
+        });
+    }
+
+    /*
+     * For Tests
+     */
+    Path getTmpFileLocation() {
+        return tmpFileLocation;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/common/blobstore/stream/read/listener/ReadContextListener.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/stream/read/listener/ReadContextListener.java
@@ -90,7 +90,7 @@ public class ReadContextListener implements ActionListener<ReadContext> {
     @SuppressForbidden(reason = "need to fsync once all parts received")
     private ActionListener<Collection<String>> getFileCompletionListener() {
         return ActionListener.wrap(response -> {
-            logger.trace(() -> new ParameterizedMessage("renaming temp file [{}] to [{}]", tmpFileLocation, fileLocation));
+            logger.trace("renaming temp file [{}] to [{}]", tmpFileLocation, fileLocation);
             try {
                 IOUtils.fsync(tmpFileLocation, false);
                 Files.move(tmpFileLocation, fileLocation, StandardCopyOption.ATOMIC_MOVE);

--- a/server/src/test/java/org/opensearch/common/blobstore/stream/read/listener/ReadContextListenerTests.java
+++ b/server/src/test/java/org/opensearch/common/blobstore/stream/read/listener/ReadContextListenerTests.java
@@ -17,8 +17,9 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -30,7 +31,6 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.function.UnaryOperator;
 
 import static org.opensearch.common.blobstore.stream.read.listener.ListenerTestUtils.CountingCompletionListener;
@@ -44,19 +44,19 @@ import static org.opensearch.common.blobstore.stream.read.listener.ListenerTestU
 public class ReadContextListenerTests extends OpenSearchTestCase {
 
     private Path path;
-    private ThreadPool threadPool;
+    private static ThreadPool threadPool;
     private static final int NUMBER_OF_PARTS = 5;
     private static final int PART_SIZE = 10;
     private static final String TEST_SEGMENT_FILE = "test_segment_file";
     private static final int MAX_CONCURRENT_STREAMS = 10;
 
-    @Before
-    public void setup() {
+    @BeforeClass
+    public static void setup() {
         threadPool = new TestThreadPool(ReadContextListenerTests.class.getName());
     }
 
-    @After
-    public void cleanup() {
+    @AfterClass
+    public static void cleanup() {
         threadPool.shutdown();
     }
 
@@ -209,46 +209,6 @@ public class ReadContextListenerTests extends OpenSearchTestCase {
         countDownLatch.await();
         assertTrue(Files.exists(fileLocation));
         assertEquals(50, Files.readAllBytes(fileLocation).length);
-        assertFalse(Files.exists(readContextListener.getTmpFileLocation()));
-    }
-
-    /**
-     * Simulate a node drop by invoking shutDownNow on the thread pool while writing a part.
-     */
-    public void testTerminateThreadsWhileWritingParts() throws Exception {
-        final String fileName = UUID.randomUUID().toString();
-        Path fileLocation = path.resolve(fileName);
-        List<ReadContext.StreamPartCreator> blobPartStreams = initializeBlobPartStreams();
-        CountDownLatch countDownLatch = new CountDownLatch(1);
-        ActionListener<String> completionListener = new LatchedActionListener<>(new PlainActionFuture<>(), countDownLatch);
-        ReadContextListener readContextListener = new ReadContextListener(
-            TEST_SEGMENT_FILE,
-            fileLocation,
-            completionListener,
-            threadPool,
-            UnaryOperator.identity(),
-            MAX_CONCURRENT_STREAMS
-        );
-        ByteArrayInputStream assertingStream = new ByteArrayInputStream(randomByteArrayOfLength(PART_SIZE)) {
-            @Override
-            public int read(byte[] b) throws IOException {
-                assertTrue("parts written to temp file location", Files.exists(readContextListener.getTmpFileLocation()));
-                threadPool.shutdownNow();
-                return super.read(b);
-            }
-        };
-        blobPartStreams.add(
-            NUMBER_OF_PARTS,
-            () -> CompletableFuture.supplyAsync(
-                () -> new InputStreamContainer(assertingStream, PART_SIZE, PART_SIZE * NUMBER_OF_PARTS + 1),
-                threadPool.generic()
-            )
-        );
-        ReadContext readContext = new ReadContext((long) (PART_SIZE + 1) * NUMBER_OF_PARTS + 1, blobPartStreams, null);
-        readContextListener.onResponse(readContext);
-        countDownLatch.await(5, TimeUnit.SECONDS);
-        assertTrue(terminate(threadPool));
-        assertFalse(Files.exists(fileLocation));
         assertFalse(Files.exists(readContextListener.getTmpFileLocation()));
     }
 


### PR DESCRIPTION
### Description
This change updates ReadContextListener to first write parts to a temp location until all parts have been received.  This ensures that partially written files do not lead to corruption.  The temp location is prefixed with a random uuid ensuring there is no collision on retries.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/9784

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] GitHub issue/PR created in [OpenSearch documentation repo](https://github.com/opensearch-project/documentation-website) for the required public documentation changes (#[Issue/PR number])

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
