### PR TITLE
Enable remote segment upload backpressure by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Tracing Framework] Add support for SpanKind. ([#10122](https://github.com/opensearch-project/OpenSearch/pull/10122))
 - Pass parent filter to inner query in nested query ([#10246](https://github.com/opensearch-project/OpenSearch/pull/10246))
 - Disable concurrent segment search when terminate_after is used ([#10200](https://github.com/opensearch-project/OpenSearch/pull/10200))
+- Enable remote segment upload backpressure by default ([#10356](https://github.com/opensearch-project/OpenSearch/pull/10356))
 
 ### Deprecated
 

--- a/server/src/main/java/org/opensearch/index/remote/RemoteStorePressureSettings.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStorePressureSettings.java
@@ -30,7 +30,7 @@ public class RemoteStorePressureSettings {
 
     public static final Setting<Boolean> REMOTE_REFRESH_SEGMENT_PRESSURE_ENABLED = Setting.boolSetting(
         "remote_store.segment.pressure.enabled",
-        false,
+        true,
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStorePressureServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStorePressureServiceTests.java
@@ -58,7 +58,7 @@ public class RemoteStorePressureServiceTests extends OpenSearchTestCase {
     public void testIsSegmentsUploadBackpressureEnabled() {
         remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(clusterService, Settings.EMPTY);
         pressureService = new RemoteStorePressureService(clusterService, Settings.EMPTY, remoteStoreStatsTrackerFactory);
-        assertFalse(pressureService.isSegmentsUploadBackpressureEnabled());
+        assertTrue(pressureService.isSegmentsUploadBackpressureEnabled());
 
         Settings newSettings = Settings.builder()
             .put(RemoteStorePressureSettings.REMOTE_REFRESH_SEGMENT_PRESSURE_ENABLED.getKey(), "true")

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStorePressureSettingsTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStorePressureSettingsTests.java
@@ -48,7 +48,7 @@ public class RemoteStorePressureSettingsTests extends OpenSearchTestCase {
         );
 
         // Check remote refresh segment pressure enabled is false
-        assertFalse(pressureSettings.isRemoteRefreshSegmentPressureEnabled());
+        assertTrue(pressureSettings.isRemoteRefreshSegmentPressureEnabled());
 
         // Check bytes lag variance threshold default value
         assertEquals(10.0, pressureSettings.getBytesLagVarianceFactor(), 0.0d);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR makes the change to set the value of `remote_store.segment.pressure.enabled` as true by default. There are tests around remote store backpressure already.

### Related Issues
Resolves #10355
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] GitHub issue/PR created in [OpenSearch documentation repo](https://github.com/opensearch-project/documentation-website/issues/5150)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
