### PR TITLE
Updating the separator for RemoteStoreLockManager since underscore is allowed in base64UUID url charset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,7 +132,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Enable remote segment upload backpressure by default ([#10356](https://github.com/opensearch-project/OpenSearch/pull/10356))
 - [Remote Store] Add support to reload repository metadata inplace ([#9569](https://github.com/opensearch-project/OpenSearch/pull/9569))
 - [Metrics Framework] Add Metrics framework. ([#10241](https://github.com/opensearch-project/OpenSearch/pull/10241))
-- Refactor Remote Store Metadata Lock Manager Utils ([#10379](https://github.com/opensearch-project/OpenSearch/pull/10379))
+- Updating the separator for RemoteLockManager since underscore is allowed in base64UUID url charset ([#10379](https://github.com/opensearch-project/OpenSearch/pull/10379))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,7 +132,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Enable remote segment upload backpressure by default ([#10356](https://github.com/opensearch-project/OpenSearch/pull/10356))
 - [Remote Store] Add support to reload repository metadata inplace ([#9569](https://github.com/opensearch-project/OpenSearch/pull/9569))
 - [Metrics Framework] Add Metrics framework. ([#10241](https://github.com/opensearch-project/OpenSearch/pull/10241))
-- Updating the separator for RemoteLockManager since underscore is allowed in base64UUID url charset ([#10379](https://github.com/opensearch-project/OpenSearch/pull/10379))
+- Updating the separator for RemoteStoreLockManager since underscore is allowed in base64UUID url charset ([#10379](https://github.com/opensearch-project/OpenSearch/pull/10379))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Enable remote segment upload backpressure by default ([#10356](https://github.com/opensearch-project/OpenSearch/pull/10356))
 - [Remote Store] Add support to reload repository metadata inplace ([#9569](https://github.com/opensearch-project/OpenSearch/pull/9569))
 - [Metrics Framework] Add Metrics framework. ([#10241](https://github.com/opensearch-project/OpenSearch/pull/10241))
+- Refactor Remote Store Metadata Lock Manager Utils ([#10379](https://github.com/opensearch-project/OpenSearch/pull/10379))
 
 ### Deprecated
 

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/DeleteSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/DeleteSnapshotIT.java
@@ -64,7 +64,6 @@ public class DeleteSnapshotIT extends AbstractSnapshotIntegTestCase {
         assert (getRepositoryData(snapshotRepoName).getSnapshotIds().size() == 0);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/9115")
     public void testDeleteShallowCopySnapshot() throws Exception {
         disableRepoConsistencyCheck("Remote store repository is being used in the test");
         final Path remoteStoreRepoPath = randomRepoPath();

--- a/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreLockManagerUtils.java
+++ b/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreLockManagerUtils.java
@@ -15,8 +15,11 @@ package org.opensearch.index.store.lockmanager;
  */
 public class RemoteStoreLockManagerUtils {
     static final String FILE_TO_LOCK_NAME = "file_to_lock";
-    static final String SEPARATOR = "___";
-    static final String LOCK_FILE_EXTENSION = ".lock";
+    static final String V1_LOCK_SEPARATOR = "___";
+    static final String SEPARATOR = "...";
+    // for versions <= 2.10, we have lock files with this extension.
+    static final String V1_LOCK_FILE_EXTENSION = ".lock";
+    static final String LOCK_FILE_EXTENSION = ".v2_lock";
     static final String ACQUIRER_ID = "acquirer_id";
     public static final String NO_TTL = "-1";
     static final String LOCK_EXPIRY_TIME = "lock_expiry_time";

--- a/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreLockManagerUtils.java
+++ b/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreLockManagerUtils.java
@@ -15,10 +15,10 @@ package org.opensearch.index.store.lockmanager;
  */
 public class RemoteStoreLockManagerUtils {
     static final String FILE_TO_LOCK_NAME = "file_to_lock";
-    static final String V1_LOCK_SEPARATOR = "___";
+    static final String PRE_OS210_LOCK_SEPARATOR = "___";
     static final String SEPARATOR = "...";
     // for versions <= 2.10, we have lock files with this extension.
-    static final String V1_LOCK_FILE_EXTENSION = ".lock";
+    static final String PRE_OS210_LOCK_FILE_EXTENSION = ".lock";
     static final String LOCK_FILE_EXTENSION = ".v2_lock";
     static final String ACQUIRER_ID = "acquirer_id";
     public static final String NO_TTL = "-1";

--- a/server/src/test/java/org/opensearch/index/store/lockmanager/FileLockInfoTests.java
+++ b/server/src/test/java/org/opensearch/index/store/lockmanager/FileLockInfoTests.java
@@ -20,8 +20,8 @@ public class FileLockInfoTests extends OpenSearchTestCase {
     String testMetadata1 = "metadata__9223372036854775806__9223372036854775803__9223372036854775790"
         + "__9223372036854775800___Hf3Dbw2QQagfGLlVBOUrg__9223370340398865071__1";
 
-    String oldLock = testMetadata1 + RemoteStoreLockManagerUtils.V1_LOCK_SEPARATOR + testAcquirerId2
-        + RemoteStoreLockManagerUtils.V1_LOCK_FILE_EXTENSION;
+    String oldLock = testMetadata1 + RemoteStoreLockManagerUtils.PRE_OS210_LOCK_SEPARATOR + testAcquirerId2
+        + RemoteStoreLockManagerUtils.PRE_OS210_LOCK_FILE_EXTENSION;
     String newLock = testMetadata1 + RemoteStoreLockManagerUtils.SEPARATOR + testAcquirerId3
         + RemoteStoreLockManagerUtils.LOCK_FILE_EXTENSION;
 
@@ -53,6 +53,16 @@ public class FileLockInfoTests extends OpenSearchTestCase {
     public void testGetLockPrefixFailureCase() {
         FileLockInfo fileLockInfo = FileLockInfo.getLockInfoBuilder().withAcquirerId(testAcquirerId).build();
         assertThrows(IllegalArgumentException.class, fileLockInfo::getLockPrefix);
+    }
+
+    public void testGetFileToLockNameFromLock() {
+        assertEquals(testMetadata1, FileLockInfo.LockFileUtils.getFileToLockNameFromLock(oldLock));
+        assertEquals(testMetadata1, FileLockInfo.LockFileUtils.getFileToLockNameFromLock(newLock));
+    }
+
+    public void testGetAcquirerIdFromLock() {
+        assertEquals(testAcquirerId2, FileLockInfo.LockFileUtils.getAcquirerIdFromLock(oldLock));
+        assertEquals(testAcquirerId3, FileLockInfo.LockFileUtils.getAcquirerIdFromLock(newLock));
     }
 
     public void testGetLocksForAcquirer() throws NoSuchFileException {

--- a/server/src/test/java/org/opensearch/index/store/lockmanager/FileLockInfoTests.java
+++ b/server/src/test/java/org/opensearch/index/store/lockmanager/FileLockInfoTests.java
@@ -15,10 +15,24 @@ import java.nio.file.NoSuchFileException;
 public class FileLockInfoTests extends OpenSearchTestCase {
     String testMetadata = "testMetadata";
     String testAcquirerId = "testAcquirerId";
+    String testAcquirerId2 = "ZxZ4Wh89SXyEPmSYAHrIrQ";
+    String testAcquirerId3 = "ZxZ4Wh89SXyEPmSYAHrItS";
+    String testMetadata1 = "metadata__9223372036854775806__9223372036854775803__9223372036854775790"
+        + "__9223372036854775800___Hf3Dbw2QQagfGLlVBOUrg__9223370340398865071__1";
+
+    String oldLock = testMetadata1 + RemoteStoreLockManagerUtils.V1_LOCK_SEPARATOR + testAcquirerId2
+        + RemoteStoreLockManagerUtils.V1_LOCK_FILE_EXTENSION;
+    String newLock = testMetadata1 + RemoteStoreLockManagerUtils.SEPARATOR + testAcquirerId3
+        + RemoteStoreLockManagerUtils.LOCK_FILE_EXTENSION;
 
     public void testGenerateLockName() {
         FileLockInfo fileLockInfo = FileLockInfo.getLockInfoBuilder().withFileToLock(testMetadata).withAcquirerId(testAcquirerId).build();
         assertEquals(fileLockInfo.generateLockName(), FileLockInfo.LockFileUtils.generateLockName(testMetadata, testAcquirerId));
+
+        // validate that lock generated will be the new version lock
+        fileLockInfo = FileLockInfo.getLockInfoBuilder().withFileToLock(testMetadata1).withAcquirerId(testAcquirerId3).build();
+        assertEquals(fileLockInfo.generateLockName(), newLock);
+
     }
 
     public void testGenerateLockNameFailureCase1() {
@@ -42,12 +56,22 @@ public class FileLockInfoTests extends OpenSearchTestCase {
     }
 
     public void testGetLocksForAcquirer() throws NoSuchFileException {
+
         String[] locks = new String[] {
             FileLockInfo.LockFileUtils.generateLockName(testMetadata, testAcquirerId),
-            FileLockInfo.LockFileUtils.generateLockName(testMetadata, "acquirerId2") };
+            FileLockInfo.LockFileUtils.generateLockName(testMetadata, "acquirerId2"),
+            oldLock,
+            newLock };
         FileLockInfo fileLockInfo = FileLockInfo.getLockInfoBuilder().withAcquirerId(testAcquirerId).build();
-
         assertEquals(fileLockInfo.getLockForAcquirer(locks), FileLockInfo.LockFileUtils.generateLockName(testMetadata, testAcquirerId));
+
+        // validate old lock
+        fileLockInfo = FileLockInfo.getLockInfoBuilder().withAcquirerId(testAcquirerId2).build();
+        assertEquals(fileLockInfo.getLockForAcquirer(locks), oldLock);
+
+        // validate new lock
+        fileLockInfo = FileLockInfo.getLockInfoBuilder().withAcquirerId(testAcquirerId3).build();
+        assertEquals(fileLockInfo.getLockForAcquirer(locks), newLock);
     }
 
 }

--- a/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryHelperTests.java
+++ b/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryHelperTests.java
@@ -66,7 +66,9 @@ public class BlobStoreRepositoryHelperTests extends OpenSearchSingleNodeTestCase
         BlobPath shardLevelBlobPath = remoteStorerepository.basePath().add(indexUUID).add("0").add("segments").add("lock_files");
         BlobContainer blobContainer = remoteStorerepository.blobStore().blobContainer(shardLevelBlobPath);
         try (RemoteBufferedOutputDirectory lockDirectory = new RemoteBufferedOutputDirectory(blobContainer)) {
-            return Arrays.stream(lockDirectory.listAll()).filter(lock -> lock.endsWith(".lock")).toArray(String[]::new);
+            return Arrays.stream(lockDirectory.listAll())
+                .filter(lock -> lock.endsWith(".lock") || lock.endsWith(".v2_lock"))
+                .toArray(String[]::new);
         }
     }
 

--- a/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryRemoteIndexTests.java
+++ b/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryRemoteIndexTests.java
@@ -145,7 +145,7 @@ public class BlobStoreRepositoryRemoteIndexTests extends BlobStoreRepositoryHelp
         final SnapshotId snapshotId1 = snapshotInfo.snapshotId();
 
         String[] lockFiles = getLockFilesInRemoteStore(remoteStoreIndexName, remoteStoreRepositoryName);
-        assert (lockFiles.length == 0) : "there should be no lock files present in directory, but found " + Arrays.toString(lockFiles);
+        assertEquals("there should be no lock files present in directory, but found " + Arrays.toString(lockFiles), 0, lockFiles.length);
         logger.info("--> create remote index shallow snapshot");
         Settings snapshotRepoSettingsForShallowCopy = Settings.builder()
             .put(snapshotRepoSettings)
@@ -161,8 +161,8 @@ public class BlobStoreRepositoryRemoteIndexTests extends BlobStoreRepositoryHelp
         final SnapshotId snapshotId2 = snapshotInfo.snapshotId();
 
         lockFiles = getLockFilesInRemoteStore(remoteStoreIndexName, remoteStoreRepositoryName);
-        assert (lockFiles.length == 1) : "there should be only one lock file, but found " + Arrays.toString(lockFiles);
-        assert lockFiles[0].endsWith(snapshotId2.getUUID() + ".v2_lock");
+        assertEquals("there should be only one lock file, but found " + Arrays.toString(lockFiles), 1, lockFiles.length);
+        assertTrue(lockFiles[0].endsWith(snapshotId2.getUUID() + ".v2_lock"));
 
         logger.info("--> create another normal snapshot");
         updateRepository(client, snapshotRepositoryName, snapshotRepoSettings);
@@ -174,8 +174,8 @@ public class BlobStoreRepositoryRemoteIndexTests extends BlobStoreRepositoryHelp
         final SnapshotId snapshotId3 = snapshotInfo.snapshotId();
 
         lockFiles = getLockFilesInRemoteStore(remoteStoreIndexName, remoteStoreRepositoryName);
-        assert (lockFiles.length == 1) : "there should be only one lock file, but found " + Arrays.toString(lockFiles);
-        assert lockFiles[0].endsWith(snapshotId2.getUUID() + ".v2_lock");
+        assertEquals("there should be only one lock file, but found " + Arrays.toString(lockFiles), 1, lockFiles.length);
+        assertTrue(lockFiles[0].endsWith(snapshotId2.getUUID() + ".v2_lock"));
 
         logger.info("--> make sure the node's repository can resolve the snapshots");
         final List<SnapshotId> originalSnapshots = Arrays.asList(snapshotId1, snapshotId2, snapshotId3);
@@ -230,8 +230,8 @@ public class BlobStoreRepositoryRemoteIndexTests extends BlobStoreRepositoryHelp
         final SnapshotId snapshotId = snapshotInfo.snapshotId();
 
         String[] lockFiles = getLockFilesInRemoteStore(remoteStoreIndexName, remoteStoreRepositoryName);
-        assert (lockFiles.length == 1) : "there should be only one lock file, but found " + Arrays.toString(lockFiles);
-        assert lockFiles[0].endsWith(snapshotId.getUUID() + ".v2_lock");
+        assertEquals("there should be only one lock file, but found " + Arrays.toString(lockFiles), 1, lockFiles.length);
+        assertTrue(lockFiles[0].endsWith(snapshotId.getUUID() + ".v2_lock"));
 
         final RepositoriesService repositoriesService = getInstanceFromNode(RepositoriesService.class);
         final BlobStoreRepository repository = (BlobStoreRepository) repositoriesService.repository(snapshotRepositoryName);
@@ -305,8 +305,8 @@ public class BlobStoreRepositoryRemoteIndexTests extends BlobStoreRepositoryHelp
         final SnapshotId snapshotId1 = snapshotInfo.snapshotId();
 
         String[] lockFiles = getLockFilesInRemoteStore(remoteStoreIndexName, remoteStoreRepositoryName);
-        assert (lockFiles.length == 1) : "lock files are " + Arrays.toString(lockFiles);
-        assert lockFiles[0].endsWith(snapshotId1.getUUID() + ".v2_lock");
+        assertEquals("lock files are " + Arrays.toString(lockFiles), 1, lockFiles.length);
+        assertTrue(lockFiles[0].endsWith(snapshotId1.getUUID() + ".v2_lock"));
 
         logger.info("--> create second remote index shallow snapshot");
         snapshotInfo = createSnapshot(
@@ -317,10 +317,10 @@ public class BlobStoreRepositoryRemoteIndexTests extends BlobStoreRepositoryHelp
         final SnapshotId snapshotId2 = snapshotInfo.snapshotId();
 
         lockFiles = getLockFilesInRemoteStore(remoteStoreIndexName, remoteStoreRepositoryName);
-        assert (lockFiles.length == 2) : "lock files are " + Arrays.toString(lockFiles);
+        assertEquals("lock files are " + Arrays.toString(lockFiles), 2, lockFiles.length);
         List<SnapshotId> shallowCopySnapshotIDs = Arrays.asList(snapshotId1, snapshotId2);
         for (SnapshotId snapshotId : shallowCopySnapshotIDs) {
-            assert lockFiles[0].contains(snapshotId.getUUID()) || lockFiles[1].contains(snapshotId.getUUID());
+            assertTrue(lockFiles[0].contains(snapshotId.getUUID()) || lockFiles[1].contains(snapshotId.getUUID()));
         }
         logger.info("--> create third remote index shallow snapshot");
         snapshotInfo = createSnapshot(
@@ -331,12 +331,14 @@ public class BlobStoreRepositoryRemoteIndexTests extends BlobStoreRepositoryHelp
         final SnapshotId snapshotId3 = snapshotInfo.snapshotId();
 
         lockFiles = getLockFilesInRemoteStore(remoteStoreIndexName, remoteStoreRepositoryName);
-        assert (lockFiles.length == 3);
+        assertEquals(3, lockFiles.length);
         shallowCopySnapshotIDs = Arrays.asList(snapshotId1, snapshotId2, snapshotId3);
         for (SnapshotId snapshotId : shallowCopySnapshotIDs) {
-            assert lockFiles[0].contains(snapshotId.getUUID())
-                || lockFiles[1].contains(snapshotId.getUUID())
-                || lockFiles[2].contains(snapshotId.getUUID());
+            assertTrue(
+                lockFiles[0].contains(snapshotId.getUUID())
+                    || lockFiles[1].contains(snapshotId.getUUID())
+                    || lockFiles[2].contains(snapshotId.getUUID())
+            );
         }
         logger.info("--> create normal snapshot");
         createRepository(client, snapshotRepositoryName, snapshotRepoSettings);
@@ -348,12 +350,14 @@ public class BlobStoreRepositoryRemoteIndexTests extends BlobStoreRepositoryHelp
         final SnapshotId snapshotId4 = snapshotInfo.snapshotId();
 
         lockFiles = getLockFilesInRemoteStore(remoteStoreIndexName, remoteStoreRepositoryName);
-        assert (lockFiles.length == 3) : "lock files are " + Arrays.toString(lockFiles);
+        assertEquals("lock files are " + Arrays.toString(lockFiles), 3, lockFiles.length);
         shallowCopySnapshotIDs = Arrays.asList(snapshotId1, snapshotId2, snapshotId3);
         for (SnapshotId snapshotId : shallowCopySnapshotIDs) {
-            assert lockFiles[0].contains(snapshotId.getUUID())
-                || lockFiles[1].contains(snapshotId.getUUID())
-                || lockFiles[2].contains(snapshotId.getUUID());
+            assertTrue(
+                lockFiles[0].contains(snapshotId.getUUID())
+                    || lockFiles[1].contains(snapshotId.getUUID())
+                    || lockFiles[2].contains(snapshotId.getUUID())
+            );
         }
 
         logger.info("--> make sure the node's repository can resolve the snapshots");

--- a/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryRemoteIndexTests.java
+++ b/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryRemoteIndexTests.java
@@ -162,7 +162,7 @@ public class BlobStoreRepositoryRemoteIndexTests extends BlobStoreRepositoryHelp
 
         lockFiles = getLockFilesInRemoteStore(remoteStoreIndexName, remoteStoreRepositoryName);
         assert (lockFiles.length == 1) : "there should be only one lock file, but found " + Arrays.toString(lockFiles);
-        assert lockFiles[0].endsWith(snapshotId2.getUUID() + ".lock");
+        assert lockFiles[0].endsWith(snapshotId2.getUUID() + ".v2_lock");
 
         logger.info("--> create another normal snapshot");
         updateRepository(client, snapshotRepositoryName, snapshotRepoSettings);
@@ -175,7 +175,7 @@ public class BlobStoreRepositoryRemoteIndexTests extends BlobStoreRepositoryHelp
 
         lockFiles = getLockFilesInRemoteStore(remoteStoreIndexName, remoteStoreRepositoryName);
         assert (lockFiles.length == 1) : "there should be only one lock file, but found " + Arrays.toString(lockFiles);
-        assert lockFiles[0].endsWith(snapshotId2.getUUID() + ".lock");
+        assert lockFiles[0].endsWith(snapshotId2.getUUID() + ".v2_lock");
 
         logger.info("--> make sure the node's repository can resolve the snapshots");
         final List<SnapshotId> originalSnapshots = Arrays.asList(snapshotId1, snapshotId2, snapshotId3);
@@ -231,7 +231,7 @@ public class BlobStoreRepositoryRemoteIndexTests extends BlobStoreRepositoryHelp
 
         String[] lockFiles = getLockFilesInRemoteStore(remoteStoreIndexName, remoteStoreRepositoryName);
         assert (lockFiles.length == 1) : "there should be only one lock file, but found " + Arrays.toString(lockFiles);
-        assert lockFiles[0].endsWith(snapshotId.getUUID() + ".lock");
+        assert lockFiles[0].endsWith(snapshotId.getUUID() + ".v2_lock");
 
         final RepositoriesService repositoriesService = getInstanceFromNode(RepositoriesService.class);
         final BlobStoreRepository repository = (BlobStoreRepository) repositoriesService.repository(snapshotRepositoryName);
@@ -306,7 +306,7 @@ public class BlobStoreRepositoryRemoteIndexTests extends BlobStoreRepositoryHelp
 
         String[] lockFiles = getLockFilesInRemoteStore(remoteStoreIndexName, remoteStoreRepositoryName);
         assert (lockFiles.length == 1) : "lock files are " + Arrays.toString(lockFiles);
-        assert lockFiles[0].endsWith(snapshotId1.getUUID() + ".lock");
+        assert lockFiles[0].endsWith(snapshotId1.getUUID() + ".v2_lock");
 
         logger.info("--> create second remote index shallow snapshot");
         snapshotInfo = createSnapshot(


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
We are using URL Safe Base64UUID in most of the places in code which can have '__' as one of the characters. For Remote Store Metadata Lock files, Keeping '____' (triple underscores) as separator to separate out snapshot UUID and remote store metadata name would not work because if either the Metadata or the Snapshot UUID starts or ends will '_', we cannot use our separator to separate out the fields.

To Fix this, as part of this PR I am updating the separator to "..." for new lock files. We will still support reading older lock files  for backward compatibility, but we will do best effort by pulling out the snapshotID from the end first and then getting the md file.

### Related Issues
Resolves #9115
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] GitHub issue/PR created in [OpenSearch documentation repo](https://github.com/opensearch-project/documentation-website) for the required public documentation changes (#[Issue/PR number])

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
