### PR TITLE
[Remote Store] Fix stats reporting for multistream downloads.

### DIFF
--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -4930,10 +4930,10 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         final Runnable onFileSync
     ) throws IOException {
         final Path indexPath = store.shardPath() == null ? null : store.shardPath().resolveIndex();
-        final DirectoryFileTransferTracker tracker = store.getDirectoryFileTransferTracker();
+        final DirectoryFileTransferTracker fileTransferTracker = store.getDirectoryFileTransferTracker();
         for (String segment : toDownloadSegments) {
             final PlainActionFuture<String> segmentListener = PlainActionFuture.newFuture();
-            sourceRemoteDirectory.copyTo(segment, storeDirectory, indexPath, tracker, segmentListener);
+            sourceRemoteDirectory.copyTo(segment, storeDirectory, indexPath, fileTransferTracker, segmentListener);
             segmentListener.actionGet();
             onFileSync.run();
             if (targetRemoteDirectory != null) {

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -160,6 +160,7 @@ import org.opensearch.index.seqno.SeqNoStats;
 import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.index.shard.PrimaryReplicaSyncer.ResyncTask;
 import org.opensearch.index.similarity.SimilarityService;
+import org.opensearch.index.store.DirectoryFileTransferTracker;
 import org.opensearch.index.store.RemoteSegmentStoreDirectory;
 import org.opensearch.index.store.RemoteSegmentStoreDirectoryFactory;
 import org.opensearch.index.store.Store;
@@ -4929,9 +4930,10 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         final Runnable onFileSync
     ) throws IOException {
         final Path indexPath = store.shardPath() == null ? null : store.shardPath().resolveIndex();
+        final DirectoryFileTransferTracker tracker = store.getDirectoryFileTransferTracker();
         for (String segment : toDownloadSegments) {
             final PlainActionFuture<String> segmentListener = PlainActionFuture.newFuture();
-            sourceRemoteDirectory.copyTo(segment, storeDirectory, indexPath, segmentListener);
+            sourceRemoteDirectory.copyTo(segment, storeDirectory, indexPath, tracker, segmentListener);
             segmentListener.actionGet();
             onFileSync.run();
             if (targetRemoteDirectory != null) {

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -489,15 +489,37 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
      * @param destinationPath The destination path (if multipart is supported)
      * @param fileCompletionListener The listener to notify of completion
      */
-    public void copyTo(String source, Directory destinationDirectory, Path destinationPath, ActionListener<String> fileCompletionListener) {
+    public void copyTo(
+        String source,
+        Directory destinationDirectory,
+        Path destinationPath,
+        DirectoryFileTransferTracker tracker,
+        ActionListener<String> fileCompletionListener
+    ) {
         final String blobName = getExistingRemoteFilename(source);
         if (destinationPath != null && remoteDataDirectory.getBlobContainer() instanceof AsyncMultiStreamBlobContainer) {
+            long length = 0L;
+            try {
+                length = fileLength(source);
+            } catch (IOException ex) {
+                logger.error("Unable to fetch segment length for stats tracking", ex);
+            }
+            final long fileLength = length;
+            final long startTime = System.currentTimeMillis();
+            tracker.addTransferredBytesStarted(fileLength);
             final AsyncMultiStreamBlobContainer blobContainer = (AsyncMultiStreamBlobContainer) remoteDataDirectory.getBlobContainer();
             final Path destinationFilePath = destinationPath.resolve(source);
+            final ActionListener<String> completionListener = ActionListener.wrap(response -> {
+                tracker.addTransferredBytesSucceeded(fileLength, startTime);
+                fileCompletionListener.onResponse(response);
+            }, e -> {
+                tracker.addTransferredBytesFailed(fileLength, startTime);
+                fileCompletionListener.onFailure(e);
+            });
             final ReadContextListener readContextListener = new ReadContextListener(
                 blobName,
                 destinationFilePath,
-                fileCompletionListener,
+                completionListener,
                 threadPool,
                 remoteDataDirectory.getDownloadRateLimiter(),
                 recoverySettings.getMaxConcurrentRemoteStoreStreams()
@@ -505,12 +527,10 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
             blobContainer.readBlobAsync(blobName, readContextListener);
         } else {
             // Fallback to older mechanism of downloading the file
-            try {
+            ActionListener.completeWith(fileCompletionListener, () -> {
                 destinationDirectory.copyFrom(this, source, source, IOContext.DEFAULT);
-                fileCompletionListener.onResponse(source);
-            } catch (IOException e) {
-                fileCompletionListener.onFailure(e);
-            }
+                return source;
+            });
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -487,13 +487,14 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
      * @param source The source file name
      * @param destinationDirectory The destination directory (if multipart is not supported)
      * @param destinationPath The destination path (if multipart is supported)
+     * @param fileTransferTracker Tracker used for file transfer stats
      * @param fileCompletionListener The listener to notify of completion
      */
     public void copyTo(
         String source,
         Directory destinationDirectory,
         Path destinationPath,
-        DirectoryFileTransferTracker tracker,
+        DirectoryFileTransferTracker fileTransferTracker,
         ActionListener<String> fileCompletionListener
     ) {
         final String blobName = getExistingRemoteFilename(source);
@@ -506,14 +507,14 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
             }
             final long fileLength = length;
             final long startTime = System.currentTimeMillis();
-            tracker.addTransferredBytesStarted(fileLength);
+            fileTransferTracker.addTransferredBytesStarted(fileLength);
             final AsyncMultiStreamBlobContainer blobContainer = (AsyncMultiStreamBlobContainer) remoteDataDirectory.getBlobContainer();
             final Path destinationFilePath = destinationPath.resolve(source);
             final ActionListener<String> completionListener = ActionListener.wrap(response -> {
-                tracker.addTransferredBytesSucceeded(fileLength, startTime);
+                fileTransferTracker.addTransferredBytesSucceeded(fileLength, startTime);
                 fileCompletionListener.onResponse(response);
             }, e -> {
-                tracker.addTransferredBytesFailed(fileLength, startTime);
+                fileTransferTracker.addTransferredBytesFailed(fileLength, startTime);
                 fileCompletionListener.onFailure(e);
             });
             final ReadContextListener readContextListener = new ReadContextListener(

--- a/server/src/main/java/org/opensearch/indices/replication/RemoteStoreReplicationSource.java
+++ b/server/src/main/java/org/opensearch/indices/replication/RemoteStoreReplicationSource.java
@@ -122,8 +122,8 @@ public class RemoteStoreReplicationSource implements SegmentReplicationSource {
                         assert directoryFiles.contains(file) == false : "Local store already contains the file " + file;
                         toDownloadSegments.add(fileMetadata);
                     }
-                    final DirectoryFileTransferTracker transferTracker = indexShard.store().getDirectoryFileTransferTracker();
-                    downloadSegments(storeDirectory, remoteDirectory, toDownloadSegments, shardPath, transferTracker, listener);
+                    final DirectoryFileTransferTracker fileTransferTracker = indexShard.store().getDirectoryFileTransferTracker();
+                    downloadSegments(storeDirectory, remoteDirectory, toDownloadSegments, shardPath, fileTransferTracker, listener);
                     logger.debug("Downloaded segment files from remote store {}", toDownloadSegments);
                 } finally {
                     indexShard.store().decRef();
@@ -140,13 +140,13 @@ public class RemoteStoreReplicationSource implements SegmentReplicationSource {
         RemoteSegmentStoreDirectory remoteStoreDirectory,
         List<StoreFileMetadata> toDownloadSegments,
         ShardPath shardPath,
-        DirectoryFileTransferTracker tracker,
+        DirectoryFileTransferTracker fileTransferTracker,
         ActionListener<GetSegmentFilesResponse> completionListener
     ) {
         final Path indexPath = shardPath == null ? null : shardPath.resolveIndex();
         for (StoreFileMetadata storeFileMetadata : toDownloadSegments) {
             final PlainActionFuture<String> segmentListener = PlainActionFuture.newFuture();
-            remoteStoreDirectory.copyTo(storeFileMetadata.name(), storeDirectory, indexPath, tracker, segmentListener);
+            remoteStoreDirectory.copyTo(storeFileMetadata.name(), storeDirectory, indexPath, fileTransferTracker, segmentListener);
             segmentListener.actionGet();
         }
         completionListener.onResponse(new GetSegmentFilesResponse(toDownloadSegments));

--- a/server/src/main/java/org/opensearch/indices/replication/RemoteStoreReplicationSource.java
+++ b/server/src/main/java/org/opensearch/indices/replication/RemoteStoreReplicationSource.java
@@ -20,6 +20,7 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.shard.IndexShardState;
 import org.opensearch.index.shard.ShardPath;
+import org.opensearch.index.store.DirectoryFileTransferTracker;
 import org.opensearch.index.store.RemoteSegmentStoreDirectory;
 import org.opensearch.index.store.Store;
 import org.opensearch.index.store.StoreFileMetadata;
@@ -121,7 +122,8 @@ public class RemoteStoreReplicationSource implements SegmentReplicationSource {
                         assert directoryFiles.contains(file) == false : "Local store already contains the file " + file;
                         toDownloadSegments.add(fileMetadata);
                     }
-                    downloadSegments(storeDirectory, remoteDirectory, toDownloadSegments, shardPath, listener);
+                    final DirectoryFileTransferTracker transferTracker = indexShard.store().getDirectoryFileTransferTracker();
+                    downloadSegments(storeDirectory, remoteDirectory, toDownloadSegments, shardPath, transferTracker, listener);
                     logger.debug("Downloaded segment files from remote store {}", toDownloadSegments);
                 } finally {
                     indexShard.store().decRef();
@@ -138,12 +140,13 @@ public class RemoteStoreReplicationSource implements SegmentReplicationSource {
         RemoteSegmentStoreDirectory remoteStoreDirectory,
         List<StoreFileMetadata> toDownloadSegments,
         ShardPath shardPath,
+        DirectoryFileTransferTracker tracker,
         ActionListener<GetSegmentFilesResponse> completionListener
     ) {
         final Path indexPath = shardPath == null ? null : shardPath.resolveIndex();
         for (StoreFileMetadata storeFileMetadata : toDownloadSegments) {
             final PlainActionFuture<String> segmentListener = PlainActionFuture.newFuture();
-            remoteStoreDirectory.copyTo(storeFileMetadata.name(), storeDirectory, indexPath, segmentListener);
+            remoteStoreDirectory.copyTo(storeFileMetadata.name(), storeDirectory, indexPath, tracker, segmentListener);
             segmentListener.actionGet();
         }
         completionListener.onResponse(new GetSegmentFilesResponse(toDownloadSegments));

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -596,10 +596,15 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
             public void onFailure(Exception e) {}
         };
         Path path = createTempDir();
-        remoteSegmentStoreDirectory.copyTo(filename, storeDirectory, path, completionListener);
+        DirectoryFileTransferTracker directoryFileTransferTracker = new DirectoryFileTransferTracker();
+        long sourceFileLengthInBytes = remoteSegmentStoreDirectory.fileLength(filename);
+        remoteSegmentStoreDirectory.copyTo(filename, storeDirectory, path, directoryFileTransferTracker, completionListener);
         assertTrue(downloadLatch.await(5000, TimeUnit.SECONDS));
         verify(blobContainer, times(1)).readBlobAsync(contains(filename), any());
         verify(storeDirectory, times(0)).copyFrom(any(), any(), any(), any());
+
+        // Verify stats are updated to DirectoryFileTransferTracker
+        assertEquals(sourceFileLengthInBytes, directoryFileTransferTracker.getTransferredBytesSucceeded());
     }
 
     public void testCopyFilesTo() throws Exception {
@@ -619,7 +624,7 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
             public void onFailure(Exception e) {}
         };
         Path path = createTempDir();
-        remoteSegmentStoreDirectory.copyTo(filename, storeDirectory, path, completionListener);
+        remoteSegmentStoreDirectory.copyTo(filename, storeDirectory, path, new DirectoryFileTransferTracker(), completionListener);
         assertTrue(downloadLatch.await(5000, TimeUnit.MILLISECONDS));
         verify(storeDirectory, times(1)).copyFrom(any(), eq(filename), eq(filename), eq(IOContext.DEFAULT));
     }
@@ -643,7 +648,7 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
             @Override
             public void onFailure(Exception e) {}
         };
-        remoteSegmentStoreDirectory.copyTo(filename, storeDirectory, null, completionListener);
+        remoteSegmentStoreDirectory.copyTo(filename, storeDirectory, null, new DirectoryFileTransferTracker(), completionListener);
         assertTrue(downloadLatch.await(5000, TimeUnit.MILLISECONDS));
         verify(storeDirectory, times(1)).copyFrom(any(), eq(filename), eq(filename), eq(IOContext.DEFAULT));
     }
@@ -670,7 +675,7 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
             }
         };
         Path path = createTempDir();
-        remoteSegmentStoreDirectory.copyTo(filename, storeDirectory, path, completionListener);
+        remoteSegmentStoreDirectory.copyTo(filename, storeDirectory, path, new DirectoryFileTransferTracker(), completionListener);
         assertTrue(downloadLatch.await(5000, TimeUnit.MILLISECONDS));
         verify(storeDirectory, times(1)).copyFrom(any(), eq(filename), eq(filename), eq(IOContext.DEFAULT));
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR reports stats for multistream downloads. With addition of copyTo() in [PR](https://github.com/opensearch-project/OpenSearch/pull/9710/files#diff-f57628264c235a133d2d6db458404e07a43f18026e40ed5e956536c03add9925) proper stats are no longer reported. This PR fixes the issue and reports proper stats.

### Related Issues
Resolves #10283
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] GitHub issue/PR created in [OpenSearch documentation repo](https://github.com/opensearch-project/documentation-website) for the required public documentation changes (#[Issue/PR number])

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
