### PR TITLE
[Tracing Instrumentation] Fix for null connection test cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix remove ingest processor handing ignore_missing parameter not correctly ([10089](https://github.com/opensearch-project/OpenSearch/pull/10089))
 - Fix circular dependency in Settings initialization ([10194](https://github.com/opensearch-project/OpenSearch/pull/10194))
 - Fix registration and initialization of multiple extensions ([10256](https://github.com/opensearch-project/OpenSearch/pull/10256))
+- [Tracing Instrumentation] Fix for null connection test cases ([10410](https://github.com/opensearch-project/OpenSearch/pull/10410))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/telemetry/tracing/SpanBuilder.java
+++ b/server/src/main/java/org/opensearch/telemetry/tracing/SpanBuilder.java
@@ -117,7 +117,7 @@ public final class SpanBuilder {
     }
 
     private static String createSpanName(String action, Transport.Connection connection) {
-        return action + SEPARATOR + (connection.getNode() != null ? connection.getNode().getHostAddress() : null);
+        return action + SEPARATOR + ((connection != null && connection.getNode() != null) ? connection.getNode().getHostAddress() : null);
     }
 
     private static Attributes buildSpanAttributes(String action, Transport.Connection connection) {


### PR DESCRIPTION
### Description
Anomaly-detection has some test cases which passes null connection and those are getting NullPointerException which was earlier handled by the listener. Adding the null connection check in the SpanName builder.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] GitHub issue/PR created in [OpenSearch documentation repo](https://github.com/opensearch-project/documentation-website) for the required public documentation changes (#[Issue/PR number])

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
