### PR TITLE
Remove S3 cooldown period setting

### DIFF
--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3Repository.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3Repository.java
@@ -37,9 +37,7 @@ import software.amazon.awssdk.services.s3.model.StorageClass;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
-import org.opensearch.action.ActionRunnable;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.metadata.RepositoryMetadata;
@@ -51,7 +49,6 @@ import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.settings.SecureSetting;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.settings.SecureString;
@@ -68,9 +65,7 @@ import org.opensearch.repositories.s3.async.AsyncExecutorContainer;
 import org.opensearch.repositories.s3.async.AsyncTransferManager;
 import org.opensearch.snapshots.SnapshotId;
 import org.opensearch.snapshots.SnapshotInfo;
-import org.opensearch.snapshots.SnapshotsService;
 import org.opensearch.threadpool.Scheduler;
-import org.opensearch.threadpool.ThreadPool;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -78,7 +73,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
@@ -211,24 +205,6 @@ class S3Repository extends MeteredBlobStoreRepository {
     static final Setting<String> CLIENT_NAME = new Setting<>("client", "default", Function.identity());
 
     /**
-     * Artificial delay to introduce after a snapshot finalization or delete has finished so long as the repository is still using the
-     * backwards compatible snapshot format from before
-     * {@link org.opensearch.snapshots.SnapshotsService#SHARD_GEN_IN_REPO_DATA_VERSION} ({@link LegacyESVersion#V_7_6_0}).
-     * This delay is necessary so that the eventually consistent nature of AWS S3 does not randomly result in repository corruption when
-     * doing repository operations in rapid succession on a repository in the old metadata format.
-     * This setting should not be adjusted in production when working with an AWS S3 backed repository. Doing so risks the repository
-     * becoming silently corrupted. To get rid of this waiting period, either create a new S3 repository or remove all snapshots older than
-     * {@link LegacyESVersion#V_7_6_0} from the repository which will trigger an upgrade of the repository metadata to the new
-     * format and disable the cooldown period.
-     */
-    static final Setting<TimeValue> COOLDOWN_PERIOD = Setting.timeSetting(
-        "cooldown_period",
-        new TimeValue(3, TimeUnit.MINUTES),
-        new TimeValue(0, TimeUnit.MILLISECONDS),
-        Setting.Property.Dynamic
-    );
-
-    /**
      * Specifies the path within bucket to repository data. Defaults to root directory.
      */
     static final Setting<String> BASE_PATH_SETTING = Setting.simpleString("base_path");
@@ -248,12 +224,6 @@ class S3Repository extends MeteredBlobStoreRepository {
     private volatile String storageClass;
 
     private volatile String cannedACL;
-
-    /**
-     * Time period to delay repository operations by after finalizing or deleting a snapshot.
-     * See {@link #COOLDOWN_PERIOD} for details.
-     */
-    private final TimeValue coolDown;
 
     private final AsyncTransferManager asyncUploadUtils;
     private final S3AsyncService s3AsyncService;
@@ -317,8 +287,6 @@ class S3Repository extends MeteredBlobStoreRepository {
 
         validateRepositoryMetadata(metadata);
         readRepositoryMetadata();
-
-        coolDown = COOLDOWN_PERIOD.get(metadata.settings());
     }
 
     private static Map<String, String> buildLocation(RepositoryMetadata metadata) {
@@ -341,9 +309,6 @@ class S3Repository extends MeteredBlobStoreRepository {
         Function<ClusterState, ClusterState> stateTransformer,
         ActionListener<RepositoryData> listener
     ) {
-        if (SnapshotsService.useShardGenerations(repositoryMetaVersion) == false) {
-            listener = delayedListener(listener);
-        }
         super.finalizeSnapshot(
             shardGenerations,
             repositoryStateId,
@@ -362,57 +327,7 @@ class S3Repository extends MeteredBlobStoreRepository {
         Version repositoryMetaVersion,
         ActionListener<RepositoryData> listener
     ) {
-        if (SnapshotsService.useShardGenerations(repositoryMetaVersion) == false) {
-            listener = delayedListener(listener);
-        }
         super.deleteSnapshots(snapshotIds, repositoryStateId, repositoryMetaVersion, listener);
-    }
-
-    /**
-     * Wraps given listener such that it is executed with a delay of {@link #coolDown} on the snapshot thread-pool after being invoked.
-     * See {@link #COOLDOWN_PERIOD} for details.
-     */
-    private <T> ActionListener<T> delayedListener(ActionListener<T> listener) {
-        final ActionListener<T> wrappedListener = ActionListener.runBefore(listener, () -> {
-            final Scheduler.Cancellable cancellable = finalizationFuture.getAndSet(null);
-            assert cancellable != null;
-        });
-        return new ActionListener<T>() {
-            @Override
-            public void onResponse(T response) {
-                logCooldownInfo();
-                final Scheduler.Cancellable existing = finalizationFuture.getAndSet(
-                    threadPool.schedule(
-                        ActionRunnable.wrap(wrappedListener, l -> l.onResponse(response)),
-                        coolDown,
-                        ThreadPool.Names.SNAPSHOT
-                    )
-                );
-                assert existing == null : "Already have an ongoing finalization " + finalizationFuture;
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                logCooldownInfo();
-                final Scheduler.Cancellable existing = finalizationFuture.getAndSet(
-                    threadPool.schedule(ActionRunnable.wrap(wrappedListener, l -> l.onFailure(e)), coolDown, ThreadPool.Names.SNAPSHOT)
-                );
-                assert existing == null : "Already have an ongoing finalization " + finalizationFuture;
-            }
-        };
-    }
-
-    private void logCooldownInfo() {
-        logger.info(
-            "Sleeping for [{}] after modifying repository [{}] because it contains snapshots older than version [{}]"
-                + " and therefore is using a backwards compatible metadata format that requires this cooldown period to avoid "
-                + "repository corruption. To get rid of this message and move to the new repository metadata format, either remove "
-                + "all snapshots older than version [{}] from the repository or create a new repository at an empty location.",
-            coolDown,
-            metadata.name(),
-            SnapshotsService.SHARD_GEN_IN_REPO_DATA_VERSION,
-            SnapshotsService.SHARD_GEN_IN_REPO_DATA_VERSION
-        );
     }
 
     @Override


### PR DESCRIPTION

### Description
This PR removes the `COOLDOWN_PERIOD` setting for `S3Repository`. This does not exist in `main` but still exists in `2.x`.

### Related Issues
N/A

### Check List
- [x] ~New functionality includes testing.~
  - [ ] All tests pass
- [x] ~New functionality has been documented.~
  - [x] ~New functionality has javadoc added~
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] ~GitHub issue/PR created in [OpenSearch documentation repo](https://github.com/opensearch-project/documentation-website) for the required public documentation changes (#[Issue/PR number])~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
