### PR TITLE
Fix ScalingThreadPoolTest to handle new pool

### DIFF
--- a/server/src/test/java/org/opensearch/threadpool/ScalingThreadPoolTests.java
+++ b/server/src/test/java/org/opensearch/threadpool/ScalingThreadPoolTests.java
@@ -32,10 +32,13 @@
 
 package org.opensearch.threadpool;
 
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.OpenSearchThreadPoolExecutor;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -43,14 +46,29 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.equalTo;
 
 public class ScalingThreadPoolTests extends OpenSearchThreadPoolTestCase {
 
+    @ParametersFactory
+    public static Collection<Object[]> scalingThreadPools() {
+        return ThreadPool.THREAD_POOL_TYPES.entrySet()
+            .stream()
+            .filter(t -> t.getValue().equals(ThreadPool.ThreadPoolType.SCALING))
+            .map(e -> new String[] { e.getKey() })
+            .collect(Collectors.toList());
+    }
+
+    private final String threadPoolName;
+
+    public ScalingThreadPoolTests(String threadPoolName) {
+        this.threadPoolName = threadPoolName;
+    }
+
     public void testScalingThreadPoolConfiguration() throws InterruptedException {
-        final String threadPoolName = randomThreadPool(ThreadPool.ThreadPoolType.SCALING);
         final Settings.Builder builder = Settings.builder();
 
         final int core;
@@ -136,11 +154,11 @@ public class ScalingThreadPoolTests extends OpenSearchThreadPoolTestCase {
         sizes.put(ThreadPool.Names.TRANSLOG_SYNC, n -> 4 * n);
         sizes.put(ThreadPool.Names.REMOTE_PURGE, ThreadPool::halfAllocatedProcessorsMaxFive);
         sizes.put(ThreadPool.Names.REMOTE_REFRESH_RETRY, ThreadPool::halfAllocatedProcessorsMaxTen);
+        sizes.put(ThreadPool.Names.REMOTE_RECOVERY, ThreadPool::halfAllocatedProcessorsMaxTen);
         return sizes.get(threadPoolName).apply(numberOfProcessors);
     }
 
     public void testScalingThreadPoolIsBounded() throws InterruptedException {
-        final String threadPoolName = randomThreadPool(ThreadPool.ThreadPoolType.SCALING);
         final int size = randomIntBetween(32, 512);
         final Settings settings = Settings.builder().put("thread_pool." + threadPoolName + ".max", size).build();
         runScalingThreadPoolTest(settings, (clusterSettings, threadPool) -> {
@@ -170,7 +188,6 @@ public class ScalingThreadPoolTests extends OpenSearchThreadPoolTestCase {
     }
 
     public void testScalingThreadPoolThreadsAreTerminatedAfterKeepAlive() throws InterruptedException {
-        final String threadPoolName = randomThreadPool(ThreadPool.ThreadPoolType.SCALING);
         final int min = "generic".equals(threadPoolName) ? 4 : 1;
         final Settings settings = Settings.builder()
             .put("thread_pool." + threadPoolName + ".max", 128)


### PR DESCRIPTION
This was a bad use of randomization. The test is super fast so it can be run against every scaling thread pool every time.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
