### PR TITLE
[Backport 2.x] Performance Improvement for Datetime formats to 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Remote Store] Add Remote Store backpressure rejection stats to `_nodes/stats` ([#10524](https://github.com/opensearch-project/OpenSearch/pull/10524))
 - [BUG] Fix java.lang.SecurityException in repository-gcs plugin ([#10642](https://github.com/opensearch-project/OpenSearch/pull/10642))
 - Add telemetry tracer/metric enable flag and integ test. ([#10395](https://github.com/opensearch-project/OpenSearch/pull/10395))
+- Performance improvement for Datetime field caching ([#4558](https://github.com/opensearch-project/OpenSearch/issues/4558))
 
 ### Deprecated
 

--- a/distribution/src/config/opensearch.yml
+++ b/distribution/src/config/opensearch.yml
@@ -121,3 +121,9 @@ ${path.logs}
 # index searcher threadpool.
 #
 #opensearch.experimental.feature.concurrent_segment_search.enabled: false
+#
+#
+# Gates the optimization of datetime formatters caching along with change in default datetime formatter
+# Once there is no observed impact on performance, this feature flag can be removed.
+#
+#opensearch.experimental.optimization.datetime_formatter_caching.enabled: false

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DateHistogramIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DateHistogramIT.java
@@ -124,7 +124,7 @@ public class DateHistogramIT extends ParameterizedOpenSearchIntegTestCase {
     }
 
     private ZonedDateTime date(String date) {
-        return DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(date));
+        return DateFormatters.from(DateFieldMapper.getDefaultDateTimeFormatter().parse(date));
     }
 
     private static String format(ZonedDateTime date, String pattern) {
@@ -1624,8 +1624,8 @@ public class DateHistogramIT extends ParameterizedOpenSearchIntegTestCase {
                 .setSettings(Settings.builder().put("requests.cache.enable", true).put("number_of_shards", 1).put("number_of_replicas", 1))
                 .get()
         );
-        String date = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.format(date(1, 1));
-        String date2 = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.format(date(2, 1));
+        String date = DateFieldMapper.getDefaultDateTimeFormatter().format(date(1, 1));
+        String date2 = DateFieldMapper.getDefaultDateTimeFormatter().format(date(2, 1));
         indexRandom(
             true,
             client().prepareIndex("cache_test_idx").setId("1").setSource("d", date),

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DateHistogramOffsetIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DateHistogramOffsetIT.java
@@ -92,7 +92,7 @@ public class DateHistogramOffsetIT extends ParameterizedOpenSearchIntegTestCase 
     }
 
     private ZonedDateTime date(String date) {
-        return DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(date));
+        return DateFormatters.from(DateFieldMapper.getDefaultDateTimeFormatter().parse(date));
     }
 
     @Before

--- a/server/src/main/java/org/opensearch/common/joda/JodaDateFormatter.java
+++ b/server/src/main/java/org/opensearch/common/joda/JodaDateFormatter.java
@@ -126,6 +126,11 @@ public class JodaDateFormatter implements DateFormatter {
     }
 
     @Override
+    public String printPattern() {
+        throw new UnsupportedOperationException("JodaDateFormatter does not have a print pattern");
+    }
+
+    @Override
     public Locale locale() {
         return printer.getLocale();
     }

--- a/server/src/main/java/org/opensearch/common/settings/FeatureFlagSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/FeatureFlagSettings.java
@@ -39,7 +39,8 @@ public class FeatureFlagSettings extends AbstractScopedSettings {
                 FeatureFlags.EXTENSIONS_SETTING,
                 FeatureFlags.IDENTITY_SETTING,
                 FeatureFlags.CONCURRENT_SEGMENT_SEARCH_SETTING,
-                FeatureFlags.TELEMETRY_SETTING
+                FeatureFlags.TELEMETRY_SETTING,
+                FeatureFlags.DATETIME_FORMATTER_CACHING_SETTING
             )
         )
     );

--- a/server/src/main/java/org/opensearch/common/time/DateFormatter.java
+++ b/server/src/main/java/org/opensearch/common/time/DateFormatter.java
@@ -127,6 +127,14 @@ public interface DateFormatter {
     String pattern();
 
     /**
+     * A name based format for this formatter. Can be one of the registered formatters like <code>epoch_millis</code> or
+     * a configured format like <code>HH:mm:ss</code>
+     *
+     * @return The name of this formatter
+     */
+    String printPattern();
+
+    /**
      * Returns the configured locale of the date formatter
      *
      * @return The locale of this formatter
@@ -147,7 +155,7 @@ public interface DateFormatter {
      */
     DateMathParser toDateMathParser();
 
-    static DateFormatter forPattern(String input) {
+    static DateFormatter forPattern(String input, String printPattern, Boolean canCacheFormatter) {
 
         if (Strings.hasLength(input) == false) {
             throw new IllegalArgumentException("No date pattern provided");
@@ -158,7 +166,28 @@ public interface DateFormatter {
         List<String> patterns = splitCombinedPatterns(format);
         List<DateFormatter> formatters = patterns.stream().map(DateFormatters::forPattern).collect(Collectors.toList());
 
-        return JavaDateFormatter.combined(input, formatters);
+        DateFormatter printFormatter = formatters.get(0);
+        if (Strings.hasLength(printPattern)) {
+            String printFormat = strip8Prefix(printPattern);
+            try {
+                printFormatter = DateFormatters.forPattern(printFormat);
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("Invalid print format: " + e.getMessage(), e);
+            }
+        }
+        return JavaDateFormatter.combined(input, formatters, printFormatter, canCacheFormatter);
+    }
+
+    static DateFormatter forPattern(String input) {
+        return forPattern(input, null, false);
+    }
+
+    static DateFormatter forPattern(String input, String printPattern) {
+        return forPattern(input, printPattern, false);
+    }
+
+    static DateFormatter forPattern(String input, Boolean canCacheFormatter) {
+        return forPattern(input, null, canCacheFormatter);
     }
 
     static String strip8Prefix(String input) {

--- a/server/src/main/java/org/opensearch/common/time/JavaDateFormatter.java
+++ b/server/src/main/java/org/opensearch/common/time/JavaDateFormatter.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.common.time;
 
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.common.Strings;
 
 import java.text.ParsePosition;
@@ -51,6 +52,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
@@ -67,9 +69,11 @@ class JavaDateFormatter implements DateFormatter {
     }
 
     private final String format;
+    private final String printFormat;
     private final DateTimeFormatter printer;
     private final List<DateTimeFormatter> parsers;
     private final JavaDateFormatter roundupParser;
+    private final Boolean canCacheLastParsedFormatter;
 
     /**
      * A round up formatter
@@ -93,8 +97,18 @@ class JavaDateFormatter implements DateFormatter {
     }
 
     // named formatters use default roundUpParser
+    JavaDateFormatter(
+        String format,
+        String printFormat,
+        DateTimeFormatter printer,
+        Boolean canCacheLastParsedFormatter,
+        DateTimeFormatter... parsers
+    ) {
+        this(format, printFormat, printer, ROUND_UP_BASE_FIELDS, canCacheLastParsedFormatter, parsers);
+    }
+
     JavaDateFormatter(String format, DateTimeFormatter printer, DateTimeFormatter... parsers) {
-        this(format, printer, ROUND_UP_BASE_FIELDS, parsers);
+        this(format, format, printer, false, parsers);
     }
 
     private static final BiConsumer<DateTimeFormatterBuilder, DateTimeFormatter> ROUND_UP_BASE_FIELDS = (builder, parser) -> {
@@ -111,8 +125,10 @@ class JavaDateFormatter implements DateFormatter {
     // subclasses override roundUpParser
     JavaDateFormatter(
         String format,
+        String printFormat,
         DateTimeFormatter printer,
         BiConsumer<DateTimeFormatterBuilder, DateTimeFormatter> roundupParserConsumer,
+        Boolean canCacheLastParsedFormatter,
         DateTimeFormatter... parsers
     ) {
         if (printer == null) {
@@ -128,14 +144,25 @@ class JavaDateFormatter implements DateFormatter {
         }
         this.printer = printer;
         this.format = format;
+        this.printFormat = printFormat;
+        this.canCacheLastParsedFormatter = canCacheLastParsedFormatter;
 
         if (parsers.length == 0) {
             this.parsers = Collections.singletonList(printer);
         } else {
-            this.parsers = Arrays.asList(parsers);
+            this.parsers = new CopyOnWriteArrayList<>(parsers);
         }
         List<DateTimeFormatter> roundUp = createRoundUpParser(format, roundupParserConsumer);
         this.roundupParser = new RoundUpFormatter(format, roundUp);
+    }
+
+    JavaDateFormatter(
+        String format,
+        DateTimeFormatter printer,
+        BiConsumer<DateTimeFormatterBuilder, DateTimeFormatter> roundupParserConsumer,
+        DateTimeFormatter... parsers
+    ) {
+        this(format, format, printer, roundupParserConsumer, false, parsers);
     }
 
     /**
@@ -164,24 +191,52 @@ class JavaDateFormatter implements DateFormatter {
         return null;
     }
 
-    public static DateFormatter combined(String input, List<DateFormatter> formatters) {
+    public static DateFormatter combined(
+        String input,
+        List<DateFormatter> formatters,
+        DateFormatter printFormatter,
+        Boolean canCacheLastParsedFormatter
+    ) {
         assert formatters.size() > 0;
+        assert printFormatter != null;
 
         List<DateTimeFormatter> parsers = new ArrayList<>(formatters.size());
         List<DateTimeFormatter> roundUpParsers = new ArrayList<>(formatters.size());
 
-        DateTimeFormatter printer = null;
+        assert printFormatter instanceof JavaDateFormatter;
+        JavaDateFormatter javaPrintFormatter = (JavaDateFormatter) printFormatter;
+        DateTimeFormatter printer = javaPrintFormatter.getPrinter();
         for (DateFormatter formatter : formatters) {
             assert formatter instanceof JavaDateFormatter;
             JavaDateFormatter javaDateFormatter = (JavaDateFormatter) formatter;
-            if (printer == null) {
-                printer = javaDateFormatter.getPrinter();
-            }
             parsers.addAll(javaDateFormatter.getParsers());
             roundUpParsers.addAll(javaDateFormatter.getRoundupParser().getParsers());
         }
 
-        return new JavaDateFormatter(input, printer, roundUpParsers, parsers);
+        return new JavaDateFormatter(
+            input,
+            javaPrintFormatter.format,
+            printer,
+            roundUpParsers,
+            parsers,
+            canCacheLastParsedFormatter & FeatureFlags.isEnabled(FeatureFlags.DATETIME_FORMATTER_CACHING_SETTING)
+        ); // check if caching is enabled
+    }
+
+    private JavaDateFormatter(
+        String format,
+        String printFormat,
+        DateTimeFormatter printer,
+        List<DateTimeFormatter> roundUpParsers,
+        List<DateTimeFormatter> parsers,
+        Boolean canCacheLastParsedFormatter
+    ) {
+        this.format = format;
+        this.printFormat = printFormat;
+        this.printer = printer;
+        this.roundupParser = roundUpParsers != null ? new RoundUpFormatter(format, roundUpParsers) : null;
+        this.parsers = new CopyOnWriteArrayList<>(parsers);
+        this.canCacheLastParsedFormatter = canCacheLastParsedFormatter;
     }
 
     private JavaDateFormatter(
@@ -190,10 +245,7 @@ class JavaDateFormatter implements DateFormatter {
         List<DateTimeFormatter> roundUpParsers,
         List<DateTimeFormatter> parsers
     ) {
-        this.format = format;
-        this.printer = printer;
-        this.roundupParser = roundUpParsers != null ? new RoundUpFormatter(format, roundUpParsers) : null;
-        this.parsers = parsers;
+        this(format, format, printer, roundUpParsers, parsers, false);
     }
 
     JavaDateFormatter getRoundupParser() {
@@ -233,12 +285,24 @@ class JavaDateFormatter implements DateFormatter {
      */
     private TemporalAccessor doParse(String input) {
         if (parsers.size() > 1) {
+            Object object = null;
+            DateTimeFormatter lastParsedformatter = null;
             for (DateTimeFormatter formatter : parsers) {
                 ParsePosition pos = new ParsePosition(0);
-                Object object = formatter.toFormat().parseObject(input, pos);
+                object = formatter.toFormat().parseObject(input, pos);
                 if (parsingSucceeded(object, input, pos)) {
-                    return (TemporalAccessor) object;
+                    lastParsedformatter = formatter;
+                    break;
                 }
+            }
+            if (lastParsedformatter != null) {
+                if (canCacheLastParsedFormatter && lastParsedformatter != parsers.get(0)) {
+                    synchronized (parsers) {
+                        parsers.remove(lastParsedformatter);
+                        parsers.add(0, lastParsedformatter);
+                    }
+                }
+                return (TemporalAccessor) object;
             }
             throw new DateTimeParseException("Failed to parse with all enclosed parsers", input, 0);
         }
@@ -255,12 +319,14 @@ class JavaDateFormatter implements DateFormatter {
         if (zoneId.equals(zone())) {
             return this;
         }
-        List<DateTimeFormatter> parsers = this.parsers.stream().map(p -> p.withZone(zoneId)).collect(Collectors.toList());
+        List<DateTimeFormatter> parsers = new CopyOnWriteArrayList<>(
+            this.parsers.stream().map(p -> p.withZone(zoneId)).collect(Collectors.toList())
+        );
         List<DateTimeFormatter> roundUpParsers = this.roundupParser.getParsers()
             .stream()
             .map(p -> p.withZone(zoneId))
             .collect(Collectors.toList());
-        return new JavaDateFormatter(format, printer.withZone(zoneId), roundUpParsers, parsers);
+        return new JavaDateFormatter(format, printFormat, printer.withZone(zoneId), roundUpParsers, parsers, canCacheLastParsedFormatter);
     }
 
     @Override
@@ -269,12 +335,14 @@ class JavaDateFormatter implements DateFormatter {
         if (locale.equals(locale())) {
             return this;
         }
-        List<DateTimeFormatter> parsers = this.parsers.stream().map(p -> p.withLocale(locale)).collect(Collectors.toList());
+        List<DateTimeFormatter> parsers = new CopyOnWriteArrayList<>(
+            this.parsers.stream().map(p -> p.withLocale(locale)).collect(Collectors.toList())
+        );
         List<DateTimeFormatter> roundUpParsers = this.roundupParser.getParsers()
             .stream()
             .map(p -> p.withLocale(locale))
             .collect(Collectors.toList());
-        return new JavaDateFormatter(format, printer.withLocale(locale), roundUpParsers, parsers);
+        return new JavaDateFormatter(format, printFormat, printer.withLocale(locale), roundUpParsers, parsers, canCacheLastParsedFormatter);
     }
 
     @Override
@@ -285,6 +353,11 @@ class JavaDateFormatter implements DateFormatter {
     @Override
     public String pattern() {
         return format;
+    }
+
+    @Override
+    public String printPattern() {
+        return printFormat;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
+++ b/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
@@ -56,6 +56,11 @@ public class FeatureFlags {
     public static final String TELEMETRY = "opensearch.experimental.feature.telemetry.enabled";
 
     /**
+     * Gates the optimization of datetime formatters caching along with change in default datetime formatter.
+     */
+    public static final String DATETIME_FORMATTER_CACHING = "opensearch.experimental.optimization.datetime_formatter_caching.enabled";
+
+    /**
      * Should store the settings from opensearch.yml.
      */
     private static Settings settings;
@@ -83,6 +88,17 @@ public class FeatureFlags {
         return settings != null && settings.getAsBoolean(featureFlagName, false);
     }
 
+    public static boolean isEnabled(Setting<Boolean> featureFlag) {
+        if ("true".equalsIgnoreCase(System.getProperty(featureFlag.getKey()))) {
+            // TODO: Remove the if condition once FeatureFlags are only supported via opensearch.yml
+            return true;
+        } else if (settings != null) {
+            return featureFlag.get(settings);
+        } else {
+            return featureFlag.getDefault(Settings.EMPTY);
+        }
+    }
+
     public static final Setting<Boolean> SEGMENT_REPLICATION_EXPERIMENTAL_SETTING = Setting.boolSetting(
         SEGMENT_REPLICATION_EXPERIMENTAL,
         false,
@@ -98,6 +114,12 @@ public class FeatureFlags {
     public static final Setting<Boolean> CONCURRENT_SEGMENT_SEARCH_SETTING = Setting.boolSetting(
         CONCURRENT_SEGMENT_SEARCH,
         false,
+        Property.NodeScope
+    );
+
+    public static final Setting<Boolean> DATETIME_FORMATTER_CACHING_SETTING = Setting.boolSetting(
+        DATETIME_FORMATTER_CACHING,
+        true,
         Property.NodeScope
     );
 }

--- a/server/src/main/java/org/opensearch/index/mapper/RangeFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/RangeFieldMapper.java
@@ -96,7 +96,7 @@ public class RangeFieldMapper extends ParametrizedFieldMapper {
      */
     public static class Defaults {
         public static final Explicit<Boolean> COERCE = new Explicit<>(true, false);
-        public static final DateFormatter DATE_FORMATTER = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER;
+        public static final DateFormatter DATE_FORMATTER = DateFieldMapper.getDefaultDateTimeFormatter();
     }
 
     // this is private since it has a different default

--- a/server/src/main/java/org/opensearch/index/mapper/RangeType.java
+++ b/server/src/main/java/org/opensearch/index/mapper/RangeType.java
@@ -313,7 +313,7 @@ public enum RangeType {
         ) {
             ZoneId zone = (timeZone == null) ? ZoneOffset.UTC : timeZone;
 
-            DateMathParser dateMathParser = (parser == null) ? DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.toDateMathParser() : parser;
+            DateMathParser dateMathParser = (parser == null) ? DateFieldMapper.getDefaultDateTimeFormatter().toDateMathParser() : parser;
             boolean roundUp = includeLower == false; // using "gt" should round lower bound up
             Long low = lowerTerm == null
                 ? minValue()

--- a/server/src/main/java/org/opensearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/RootObjectMapper.java
@@ -73,7 +73,7 @@ public class RootObjectMapper extends ObjectMapper {
      */
     public static class Defaults {
         public static final DateFormatter[] DYNAMIC_DATE_TIME_FORMATTERS = new DateFormatter[] {
-            DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER,
+            DateFieldMapper.getDefaultDateTimeFormatter(),
             DateFormatter.forPattern("yyyy/MM/dd HH:mm:ss||yyyy/MM/dd||epoch_millis") };
         public static final boolean DATE_DETECTION = true;
         public static final boolean NUMERIC_DETECTION = false;

--- a/server/src/main/java/org/opensearch/script/ScoreScriptUtils.java
+++ b/server/src/main/java/org/opensearch/script/ScoreScriptUtils.java
@@ -342,11 +342,14 @@ public final class ScoreScriptUtils {
     /**
      * Limitations: since script functions don't have access to DateFieldMapper,
      * decay functions on dates are limited to dates in the default format and default time zone,
+     * Further, since script module gets initialized before the featureflags are loaded,
+     * we cannot use the feature flag to gate the usage of the new default date format.
      * Also, using calculations with <code>now</code> are not allowed.
      *
      */
     private static final ZoneId defaultZoneId = ZoneId.of("UTC");
-    private static final DateMathParser dateParser = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.toDateMathParser();
+    // ToDo: use new default date formatter once feature flag is removed
+    private static final DateMathParser dateParser = DateFieldMapper.LEGACY_DEFAULT_DATE_TIME_FORMATTER.toDateMathParser();
 
     /**
      * Linear date decay

--- a/server/src/main/java/org/opensearch/search/DocValueFormat.java
+++ b/server/src/main/java/org/opensearch/search/DocValueFormat.java
@@ -247,6 +247,9 @@ public interface DocValueFormat extends NamedWriteable {
 
         public DateTime(StreamInput in) throws IOException {
             String datePattern = in.readString();
+            String printPattern = null;
+            if (in.getVersion().onOrAfter(Version.V_2_1_1)) {
+                printPattern = in.readOptionalString();
 
             String zoneId = in.readString();
             if (in.getVersion().before(LegacyESVersion.V_7_0_0)) {
@@ -271,7 +274,7 @@ public interface DocValueFormat extends NamedWriteable {
                  */
                 isJoda = Joda.isJodaPattern(in.getVersion(), datePattern);
             }
-            this.formatter = isJoda ? Joda.forPattern(datePattern) : DateFormatter.forPattern(datePattern);
+            this.formatter = isJoda ? Joda.forPattern(datePattern) : DateFormatter.forPattern(datePattern, printPattern);
 
             this.parser = formatter.toDateMathParser();
 
@@ -284,7 +287,14 @@ public interface DocValueFormat extends NamedWriteable {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeString(formatter.pattern());
+            if(out.getVersion().before(Version.V_2_1_1) && formatter.equals(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER)) {
+                out.writeString(DateFieldMapper.LEGACY_DEFAULT_DATE_TIME_FORMATTER.pattern()); // required for backwards compatibility
+            } else {
+                out.writeString(formatter.pattern());
+            }
+            if (out.getVersion().onOrAfter(Version.V_2_1_1)) {
+                out.writeOptionalString(formatter.printPattern());
+            }
             if (out.getVersion().before(LegacyESVersion.V_7_0_0)) {
                 out.writeString(DateUtils.zoneIdToDateTimeZone(timeZone).getID());
             } else {

--- a/server/src/main/java/org/opensearch/search/DocValueFormat.java
+++ b/server/src/main/java/org/opensearch/search/DocValueFormat.java
@@ -35,6 +35,7 @@ package org.opensearch.search;
 import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.LegacyESVersion;
+import org.opensearch.Version;
 import org.opensearch.common.Numbers;
 import org.opensearch.common.joda.Joda;
 import org.opensearch.common.joda.JodaDateFormatter;
@@ -248,9 +249,9 @@ public interface DocValueFormat extends NamedWriteable {
         public DateTime(StreamInput in) throws IOException {
             String datePattern = in.readString();
             String printPattern = null;
-            if (in.getVersion().onOrAfter(Version.V_2_1_1)) {
+            if (in.getVersion().onOrAfter(Version.V_2_12_0)) {
                 printPattern = in.readOptionalString();
-
+            }
             String zoneId = in.readString();
             if (in.getVersion().before(LegacyESVersion.V_7_0_0)) {
                 this.timeZone = DateUtils.of(zoneId);
@@ -287,12 +288,12 @@ public interface DocValueFormat extends NamedWriteable {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            if(out.getVersion().before(Version.V_2_1_1) && formatter.equals(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER)) {
+            if (out.getVersion().before(Version.V_2_12_0) && formatter.equals(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER)) {
                 out.writeString(DateFieldMapper.LEGACY_DEFAULT_DATE_TIME_FORMATTER.pattern()); // required for backwards compatibility
             } else {
                 out.writeString(formatter.pattern());
             }
-            if (out.getVersion().onOrAfter(Version.V_2_1_1)) {
+            if (out.getVersion().onOrAfter(Version.V_2_12_0)) {
                 out.writeOptionalString(formatter.printPattern());
             }
             if (out.getVersion().before(LegacyESVersion.V_7_0_0)) {

--- a/server/src/main/java/org/opensearch/search/aggregations/support/CoreValuesSourceType.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/support/CoreValuesSourceType.java
@@ -411,7 +411,7 @@ public enum CoreValuesSourceType implements ValuesSourceType {
         @Override
         public DocValueFormat getFormatter(String format, ZoneId tz) {
             return new DocValueFormat.DateTime(
-                format == null ? DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER : DateFormatter.forPattern(format),
+                format == null ? DateFieldMapper.getDefaultDateTimeFormatter() : DateFormatter.forPattern(format),
                 tz == null ? ZoneOffset.UTC : tz,
                 // If we were just looking at fields, we could read the resolution from the field settings, but we need to deal with script
                 // output, which has no way to indicate the resolution, so we need to default to something. Milliseconds is the standard.

--- a/server/src/main/java/org/opensearch/search/aggregations/support/ValueType.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/support/ValueType.java
@@ -61,7 +61,7 @@ public enum ValueType implements Writeable {
         "date",
         "date",
         CoreValuesSourceType.DATE,
-        new DocValueFormat.DateTime(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER, ZoneOffset.UTC, DateFieldMapper.Resolution.MILLISECONDS)
+        new DocValueFormat.DateTime(DateFieldMapper.getDefaultDateTimeFormatter(), ZoneOffset.UTC, DateFieldMapper.Resolution.MILLISECONDS)
     ),
     IP((byte) 6, "ip", "ip", CoreValuesSourceType.IP, DocValueFormat.IP),
     // TODO: what is the difference between "number" and "numeric"?

--- a/server/src/test/java/org/opensearch/action/search/BottomSortValuesCollectorTests.java
+++ b/server/src/test/java/org/opensearch/action/search/BottomSortValuesCollectorTests.java
@@ -46,7 +46,6 @@ import org.opensearch.test.OpenSearchTestCase;
 import java.time.ZoneId;
 import java.util.Arrays;
 
-import static org.opensearch.index.mapper.DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.apache.lucene.search.TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO;
@@ -136,7 +135,11 @@ public class BottomSortValuesCollectorTests extends OpenSearchTestCase {
         for (boolean reverse : new boolean[] { true, false }) {
             SortField[] sortFields = new SortField[] { new SortField("foo", SortField.Type.LONG, reverse) };
             DocValueFormat[] sortFormats = new DocValueFormat[] {
-                new DocValueFormat.DateTime(DEFAULT_DATE_TIME_FORMATTER, ZoneId.of("UTC"), DateFieldMapper.Resolution.MILLISECONDS) };
+                new DocValueFormat.DateTime(
+                    DateFieldMapper.getDefaultDateTimeFormatter(),
+                    ZoneId.of("UTC"),
+                    DateFieldMapper.Resolution.MILLISECONDS
+                ) };
             BottomSortValuesCollector collector = new BottomSortValuesCollector(3, sortFields);
             collector.consumeTopDocs(
                 createTopDocs(sortFields[0], 100, newDateArray("2017-06-01T12:18:20Z", "2018-04-03T15:10:27Z", "2013-06-01T13:10:20Z")),
@@ -170,7 +173,11 @@ public class BottomSortValuesCollectorTests extends OpenSearchTestCase {
         for (boolean reverse : new boolean[] { true, false }) {
             SortField[] sortFields = new SortField[] { new SortField("foo", SortField.Type.LONG, reverse) };
             DocValueFormat[] sortFormats = new DocValueFormat[] {
-                new DocValueFormat.DateTime(DEFAULT_DATE_TIME_FORMATTER, ZoneId.of("UTC"), DateFieldMapper.Resolution.NANOSECONDS) };
+                new DocValueFormat.DateTime(
+                    DateFieldMapper.getDefaultDateTimeFormatter(),
+                    ZoneId.of("UTC"),
+                    DateFieldMapper.Resolution.NANOSECONDS
+                ) };
             BottomSortValuesCollector collector = new BottomSortValuesCollector(3, sortFields);
             collector.consumeTopDocs(
                 createTopDocs(sortFields[0], 100, newDateNanoArray("2017-06-01T12:18:20Z", "2018-04-03T15:10:27Z", "2013-06-01T13:10:20Z")),
@@ -242,7 +249,7 @@ public class BottomSortValuesCollectorTests extends OpenSearchTestCase {
     private Object[] newDateArray(String... values) {
         Long[] longs = new Long[values.length];
         for (int i = 0; i < values.length; i++) {
-            longs[i] = DEFAULT_DATE_TIME_FORMATTER.parseMillis(values[i]);
+            longs[i] = DateFieldMapper.getDefaultDateTimeFormatter().parseMillis(values[i]);
         }
         return longs;
     }
@@ -250,7 +257,7 @@ public class BottomSortValuesCollectorTests extends OpenSearchTestCase {
     private Object[] newDateNanoArray(String... values) {
         Long[] longs = new Long[values.length];
         for (int i = 0; i < values.length; i++) {
-            longs[i] = DateUtils.toNanoSeconds(DEFAULT_DATE_TIME_FORMATTER.parseMillis(values[i]));
+            longs[i] = DateUtils.toNanoSeconds(DateFieldMapper.getDefaultDateTimeFormatter().parseMillis(values[i]));
         }
         return longs;
     }

--- a/server/src/test/java/org/opensearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/DateFieldMapperTests.java
@@ -66,6 +66,7 @@ public class DateFieldMapperTests extends MapperTestCase {
         checker.registerConflictCheck("index", b -> b.field("index", false));
         checker.registerConflictCheck("store", b -> b.field("store", true));
         checker.registerConflictCheck("format", b -> b.field("format", "yyyy-MM-dd"));
+        checker.registerConflictCheck("print_format", b -> b.field("print_format", "yyyy-MM-dd"));
         checker.registerConflictCheck("locale", b -> b.field("locale", "es"));
         checker.registerConflictCheck("null_value", b -> b.field("null_value", "34500000"));
         checker.registerUpdateCheck(b -> b.field("ignore_malformed", true), m -> assertTrue(((DateFieldMapper) m).getIgnoreMalformed()));
@@ -148,7 +149,7 @@ public class DateFieldMapperTests extends MapperTestCase {
     public void testIgnoreMalformed() throws IOException {
         testIgnoreMalformedForValue(
             "2016-03-99",
-            "failed to parse date field [2016-03-99] with format [strict_date_optional_time||epoch_millis]"
+            "failed to parse date field [2016-03-99] with format [strict_date_time_no_millis||strict_date_optional_time||epoch_millis]"
         );
         testIgnoreMalformedForValue("-2147483648", "Invalid value for Year (valid values -999999999 - 999999999): -2147483648");
         testIgnoreMalformedForValue("-522000000", "long overflow");

--- a/server/src/test/java/org/opensearch/index/mapper/DateFieldTypeTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/DateFieldTypeTests.java
@@ -108,7 +108,7 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
         w.addDocument(doc);
         DirectoryReader reader = DirectoryReader.open(w);
 
-        DateMathParser alternateFormat = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.toDateMathParser();
+        DateMathParser alternateFormat = DateFieldMapper.getDefaultDateTimeFormatter().toDateMathParser();
         doTestIsFieldWithinQuery(ft, reader, null, null);
         doTestIsFieldWithinQuery(ft, reader, null, alternateFormat);
         doTestIsFieldWithinQuery(ft, reader, DateTimeZone.UTC, null);
@@ -159,7 +159,7 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
 
     public void testValueFormat() {
         MappedFieldType ft = new DateFieldType("field");
-        long instant = DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse("2015-10-12T14:10:55"))
+        long instant = DateFormatters.from(DateFieldMapper.getDefaultDateTimeFormatter().parse("2015-10-12T14:10:55"))
             .toInstant()
             .toEpochMilli();
 
@@ -168,14 +168,14 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
         assertEquals("2015", new DateFieldType("field").docValueFormat("YYYY", ZoneOffset.UTC).format(instant));
         assertEquals(instant, ft.docValueFormat(null, ZoneOffset.UTC).parseLong("2015-10-12T14:10:55", false, null));
         assertEquals(instant + 999, ft.docValueFormat(null, ZoneOffset.UTC).parseLong("2015-10-12T14:10:55", true, null));
-        long i = DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse("2015-10-13")).toInstant().toEpochMilli();
+        long i = DateFormatters.from(DateFieldMapper.getDefaultDateTimeFormatter().parse("2015-10-13")).toInstant().toEpochMilli();
         assertEquals(i - 1, ft.docValueFormat(null, ZoneOffset.UTC).parseLong("2015-10-12||/d", true, null));
     }
 
     public void testValueForSearch() {
         MappedFieldType ft = new DateFieldType("field");
         String date = "2015-10-12T12:09:55.000Z";
-        long instant = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseMillis(date);
+        long instant = DateFieldMapper.getDefaultDateTimeFormatter().parseMillis(date);
         assertEquals(date, ft.valueForDisplay(instant));
     }
 
@@ -206,7 +206,7 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
         );
         MappedFieldType ft = new DateFieldType("field");
         String date = "2015-10-12T14:10:55";
-        long instant = DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(date)).toInstant().toEpochMilli();
+        long instant = DateFormatters.from(DateFieldMapper.getDefaultDateTimeFormatter().parse(date)).toInstant().toEpochMilli();
         Query expected = new IndexOrDocValuesQuery(
             LongPoint.newRangeQuery("field", instant, instant + 999),
             SortedNumericDocValuesField.newSlowRangeQuery("field", instant, instant + 999)
@@ -218,7 +218,7 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
             false,
             false,
             true,
-            DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER,
+            DateFieldMapper.getDefaultDateTimeFormatter(),
             Resolution.MILLISECONDS,
             null,
             Collections.emptyMap()
@@ -255,8 +255,8 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
         MappedFieldType ft = new DateFieldType("field");
         String date1 = "2015-10-12T14:10:55";
         String date2 = "2016-04-28T11:33:52";
-        long instant1 = DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(date1)).toInstant().toEpochMilli();
-        long instant2 = DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(date2)).toInstant().toEpochMilli() + 999;
+        long instant1 = DateFormatters.from(DateFieldMapper.getDefaultDateTimeFormatter().parse(date1)).toInstant().toEpochMilli();
+        long instant2 = DateFormatters.from(DateFieldMapper.getDefaultDateTimeFormatter().parse(date2)).toInstant().toEpochMilli() + 999;
         Query expected = new IndexOrDocValuesQuery(
             LongPoint.newRangeQuery("field", instant1, instant2),
             SortedNumericDocValuesField.newSlowRangeQuery("field", instant1, instant2)
@@ -281,7 +281,7 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
             false,
             false,
             true,
-            DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER,
+            DateFieldMapper.getDefaultDateTimeFormatter(),
             Resolution.MILLISECONDS,
             null,
             Collections.emptyMap()
@@ -327,8 +327,8 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
         MappedFieldType ft = new DateFieldType("field");
         String date1 = "2015-10-12T14:10:55";
         String date2 = "2016-04-28T11:33:52";
-        long instant1 = DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(date1)).toInstant().toEpochMilli();
-        long instant2 = DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(date2)).toInstant().toEpochMilli() + 999;
+        long instant1 = DateFormatters.from(DateFieldMapper.getDefaultDateTimeFormatter().parse(date1)).toInstant().toEpochMilli();
+        long instant2 = DateFormatters.from(DateFieldMapper.getDefaultDateTimeFormatter().parse(date2)).toInstant().toEpochMilli() + 999;
 
         Query pointQuery = LongPoint.newRangeQuery("field", instant1, instant2);
         Query dvQuery = SortedNumericDocValuesField.newSlowRangeQuery("field", instant1, instant2);

--- a/server/src/test/java/org/opensearch/index/mapper/RangeFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/RangeFieldMapperTests.java
@@ -361,7 +361,12 @@ public class RangeFieldMapperTests extends AbstractNumericFieldMapperTestCase {
 
             // if type is date_range we check that the mapper contains the default format and locale
             // otherwise it should not contain a locale or format
-            assertTrue(got, got.contains("\"format\":\"strict_date_optional_time||epoch_millis\"") == type.equals("date_range"));
+            assertTrue(
+                got,
+                got.contains("\"format\":\"strict_date_time_no_millis||strict_date_optional_time||epoch_millis\"") == type.equals(
+                    "date_range"
+                )
+            );
             assertTrue(got, got.contains("\"locale\":" + "\"" + Locale.ROOT + "\"") == type.equals("date_range"));
         }
     }

--- a/server/src/test/java/org/opensearch/index/mapper/RangeFieldTypeTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/RangeFieldTypeTests.java
@@ -265,7 +265,9 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
         );
         assertThat(
             ex.getMessage(),
-            containsString("failed to parse date field [2016-15-06T15:29:50+08:00] with format [strict_date_optional_time||epoch_millis]")
+            containsString(
+                "failed to parse date field [2016-15-06T15:29:50+08:00] with format [strict_date_time_no_millis||strict_date_optional_time||epoch_millis]"
+            )
         );
 
         // setting mapping format which is compatible with those dates

--- a/server/src/test/java/org/opensearch/index/query/RangeQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/RangeQueryBuilderTests.java
@@ -87,8 +87,8 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
                 ZonedDateTime start = now.minusMillis(randomIntBetween(0, 1000000)).atZone(ZoneOffset.UTC);
                 ZonedDateTime end = now.plusMillis(randomIntBetween(0, 1000000)).atZone(ZoneOffset.UTC);
                 query = new RangeQueryBuilder(randomFrom(DATE_FIELD_NAME, DATE_RANGE_FIELD_NAME, DATE_ALIAS_FIELD_NAME));
-                query.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.format(start));
-                query.to(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.format(end));
+                query.from(DateFieldMapper.getDefaultDateTimeFormatter().format(start));
+                query.to(DateFieldMapper.getDefaultDateTimeFormatter().format(end));
                 // Create timestamp option only then we have a date mapper,
                 // otherwise we could trigger exception.
                 if (createShardContext().getMapperService().fieldType(DATE_FIELD_NAME) != null) {

--- a/server/src/test/java/org/opensearch/search/aggregations/AggregatorBaseTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/AggregatorBaseTests.java
@@ -135,7 +135,7 @@ public class AggregatorBaseTests extends OpenSearchSingleNodeTestCase {
             indexed,
             false,
             true,
-            DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER,
+            DateFieldMapper.getDefaultDateTimeFormatter(),
             resolution,
             null,
             Collections.emptyMap()
@@ -184,7 +184,7 @@ public class AggregatorBaseTests extends OpenSearchSingleNodeTestCase {
                 assertNull(pointReaderShim(mockSearchContext(null), null, getVSConfig("number", resolution, false, context)));
             }
             // Check that we decode a dates "just like" the doc values instance.
-            Instant expected = Instant.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse("2020-01-01T00:00:00Z"));
+            Instant expected = Instant.from(DateFieldMapper.getDefaultDateTimeFormatter().parse("2020-01-01T00:00:00Z"));
             byte[] scratch = new byte[8];
             LongPoint.encodeDimension(DateFieldMapper.Resolution.MILLISECONDS.convert(expected), scratch, 0);
             assertThat(

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTestCase.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTestCase.java
@@ -125,7 +125,7 @@ public abstract class DateHistogramAggregatorTestCase extends AggregatorTestCase
             isSearchable,
             false,
             true,
-            DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER,
+            DateFieldMapper.getDefaultDateTimeFormatter(),
             useNanosecondResolution ? DateFieldMapper.Resolution.NANOSECONDS : DateFieldMapper.Resolution.MILLISECONDS,
             null,
             Collections.emptyMap()

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTests.java
@@ -1245,7 +1245,7 @@ public class DateHistogramAggregatorTests extends DateHistogramAggregatorTestCas
     }
 
     private static long asLong(String dateTime) {
-        return DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(dateTime)).toInstant().toEpochMilli();
+        return DateFormatters.from(DateFieldMapper.getDefaultDateTimeFormatter().parse(dateTime)).toInstant().toEpochMilli();
     }
 
     private static long asLong(String dateTime, DateFieldMapper.DateFieldType fieldType) {

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/histogram/DateRangeHistogramAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/histogram/DateRangeHistogramAggregatorTests.java
@@ -1086,7 +1086,7 @@ public class DateRangeHistogramAggregatorTests extends AggregatorTestCase {
     }
 
     private static long asLong(String dateTime) {
-        return DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(dateTime)).toInstant().toEpochMilli();
+        return DateFormatters.from(DateFieldMapper.getDefaultDateTimeFormatter().parse(dateTime)).toInstant().toEpochMilli();
     }
 
     private static ZonedDateTime asZDT(String dateTime) {

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/range/DateRangeAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/range/DateRangeAggregatorTests.java
@@ -273,7 +273,7 @@ public class DateRangeAggregatorTests extends AggregatorTestCase {
             true,
             false,
             true,
-            DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER,
+            DateFieldMapper.getDefaultDateTimeFormatter(),
             resolution,
             null,
             Collections.emptyMap()

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/range/RangeAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/range/RangeAggregatorTests.java
@@ -136,7 +136,7 @@ public class RangeAggregatorTests extends AggregatorTestCase {
             true,
             false,
             true,
-            DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER,
+            DateFieldMapper.getDefaultDateTimeFormatter(),
             DateFieldMapper.Resolution.NANOSECONDS,
             null,
             Collections.emptyMap()
@@ -167,7 +167,7 @@ public class RangeAggregatorTests extends AggregatorTestCase {
             true,
             false,
             true,
-            DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER,
+            DateFieldMapper.getDefaultDateTimeFormatter(),
             DateFieldMapper.Resolution.NANOSECONDS,
             null,
             Collections.emptyMap()

--- a/server/src/test/java/org/opensearch/search/aggregations/pipeline/AvgBucketAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/pipeline/AvgBucketAggregatorTests.java
@@ -144,6 +144,6 @@ public class AvgBucketAggregatorTests extends AggregatorTestCase {
     }
 
     private static long asLong(String dateTime) {
-        return DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(dateTime)).toInstant().toEpochMilli();
+        return DateFormatters.from(DateFieldMapper.getDefaultDateTimeFormatter().parse(dateTime)).toInstant().toEpochMilli();
     }
 }

--- a/server/src/test/java/org/opensearch/search/aggregations/pipeline/CumulativeSumAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/pipeline/CumulativeSumAggregatorTests.java
@@ -344,6 +344,6 @@ public class CumulativeSumAggregatorTests extends AggregatorTestCase {
     }
 
     private static long asLong(String dateTime) {
-        return DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(dateTime)).toInstant().toEpochMilli();
+        return DateFormatters.from(DateFieldMapper.getDefaultDateTimeFormatter().parse(dateTime)).toInstant().toEpochMilli();
     }
 }

--- a/server/src/test/java/org/opensearch/search/aggregations/pipeline/MovFnAggrgatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/pipeline/MovFnAggrgatorTests.java
@@ -169,6 +169,6 @@ public class MovFnAggrgatorTests extends AggregatorTestCase {
     }
 
     private static long asLong(String dateTime) {
-        return DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(dateTime)).toInstant().toEpochMilli();
+        return DateFormatters.from(DateFieldMapper.getDefaultDateTimeFormatter().parse(dateTime)).toInstant().toEpochMilli();
     }
 }

--- a/test/framework/src/main/java/org/opensearch/search/aggregations/composite/BaseCompositeAggregatorTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/search/aggregations/composite/BaseCompositeAggregatorTestCase.java
@@ -305,6 +305,6 @@ public class BaseCompositeAggregatorTestCase extends AggregatorTestCase {
     }
 
     protected static long asLong(String dateTime) {
-        return DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(dateTime)).toInstant().toEpochMilli();
+        return DateFormatters.from(DateFieldMapper.getDefaultDateTimeFormatter().parse(dateTime)).toInstant().toEpochMilli();
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Backport changes #9567 and #10385

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/4558

Public doc: https://github.com/opensearch-project/documentation-website/pull/5163

<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
