### PR TITLE
[Backport 2.x] [Remote Store] Using hash of node id in metadata file names

### DIFF
--- a/server/src/main/java/org/opensearch/index/remote/RemoteStoreUtils.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStoreUtils.java
@@ -82,7 +82,7 @@ public class RemoteStoreUtils {
      * @param fn Function to extract PrimaryTerm_Generation and Node Id from metadata file name .
      *          fn returns null if node id is not part of the file name
      */
-    static public void verifyNoMultipleWriters(List<String> mdFiles, Function<String, Tuple<String, String>> fn) {
+    public static void verifyNoMultipleWriters(List<String> mdFiles, Function<String, Tuple<String, String>> fn) {
         Map<String, String> nodesByPrimaryTermAndGen = new HashMap<>();
         mdFiles.forEach(mdFile -> {
             Tuple<String, String> nodeIdByPrimaryTermAndGen = fn.apply(mdFile);
@@ -91,10 +91,9 @@ public class RemoteStoreUtils {
                     && (!nodesByPrimaryTermAndGen.get(nodeIdByPrimaryTermAndGen.v1()).equals(nodeIdByPrimaryTermAndGen.v2()))) {
                     throw new IllegalStateException(
                         "Multiple metadata files from different nodes"
+                            + "having same primary term and generations "
                             + nodeIdByPrimaryTermAndGen.v1()
-                            + " and "
-                            + nodeIdByPrimaryTermAndGen.v2()
-                            + "having same primary term and generations detected"
+                            + " detected "
                     );
                 }
                 nodesByPrimaryTermAndGen.put(nodeIdByPrimaryTermAndGen.v1(), nodeIdByPrimaryTermAndGen.v2());

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -54,6 +54,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -332,7 +333,7 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
                 RemoteStoreUtils.invertLong(generation),
                 RemoteStoreUtils.invertLong(translogGeneration),
                 RemoteStoreUtils.invertLong(uploadCounter),
-                nodeId,
+                String.valueOf(Objects.hash(nodeId)),
                 RemoteStoreUtils.invertLong(System.currentTimeMillis()),
                 String.valueOf(metadataVersion)
             );

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
@@ -100,7 +100,7 @@ public class TranslogTransferMetadata {
                 RemoteStoreUtils.invertLong(primaryTerm),
                 RemoteStoreUtils.invertLong(generation),
                 RemoteStoreUtils.invertLong(createdAt),
-                nodeId,
+                String.valueOf(Objects.hash(nodeId)),
                 String.valueOf(CURRENT_VERSION)
             )
         );

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStoreUtilsTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStoreUtilsTests.java
@@ -151,10 +151,10 @@ public class RemoteStoreUtilsTests extends OpenSearchTestCase {
     }
 
     public void testVerifyMultipleWriters_Translog() throws InterruptedException {
-        TranslogTransferMetadata tm = new TranslogTransferMetadata(1, 1, 1, 2, "node-1");
+        TranslogTransferMetadata tm = new TranslogTransferMetadata(1, 1, 1, 2, "node--1");
         String mdFilename = tm.getFileName();
         Thread.sleep(1);
-        TranslogTransferMetadata tm2 = new TranslogTransferMetadata(1, 1, 1, 2, "node-1");
+        TranslogTransferMetadata tm2 = new TranslogTransferMetadata(1, 1, 1, 2, "node--1");
         String mdFilename2 = tm2.getFileName();
         List<BlobMetadata> bmList = new LinkedList<>();
         bmList.add(new PlainBlobMetadata(mdFilename, 1));
@@ -167,7 +167,7 @@ public class RemoteStoreUtilsTests extends OpenSearchTestCase {
 
         bmList = new LinkedList<>();
         bmList.add(new PlainBlobMetadata(mdFilename, 1));
-        TranslogTransferMetadata tm3 = new TranslogTransferMetadata(1, 1, 1, 2, "node-2");
+        TranslogTransferMetadata tm3 = new TranslogTransferMetadata(1, 1, 1, 2, "node--2");
         bmList.add(new PlainBlobMetadata(tm3.getFileName(), 1));
         List<BlobMetadata> finalBmList = bmList;
         assertThrows(

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -67,6 +67,7 @@ import java.util.function.UnaryOperator;
 import org.mockito.Mockito;
 
 import static org.opensearch.index.store.RemoteSegmentStoreDirectory.METADATA_FILES_TO_FETCH;
+import static org.opensearch.index.store.RemoteSegmentStoreDirectory.MetadataFilenameUtils.SEPARATOR;
 import static org.opensearch.test.RemoteStoreTestUtils.createMetadataFileBytes;
 import static org.opensearch.test.RemoteStoreTestUtils.getDummyMetadata;
 import static org.hamcrest.CoreMatchers.is;
@@ -213,9 +214,7 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
     }
 
     public void testGetPrimaryTermGenerationUuid() {
-        String[] filenameTokens = "abc__9223372036854775795__9223372036854775784__uuid_xyz".split(
-            RemoteSegmentStoreDirectory.MetadataFilenameUtils.SEPARATOR
-        );
+        String[] filenameTokens = "abc__9223372036854775795__9223372036854775784__uuid_xyz".split(SEPARATOR);
         assertEquals(12, RemoteSegmentStoreDirectory.MetadataFilenameUtils.getPrimaryTerm(filenameTokens));
         assertEquals(23, RemoteSegmentStoreDirectory.MetadataFilenameUtils.getGeneration(filenameTokens));
     }
@@ -1178,6 +1177,10 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         actualList.sort(String::compareTo);
 
         assertEquals(List.of(file3, file2, file4, file6, file5, file1), actualList);
+
+        long count = file1.chars().filter(ch -> ch == SEPARATOR.charAt(0)).count();
+        // There should not be any `_` in mdFile name as it is used a separator .
+        assertEquals(14, count);
     }
 
     private static class WrapperIndexOutput extends IndexOutput {

--- a/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
@@ -44,6 +44,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.mockito.Mockito;
 
+import static org.opensearch.index.translog.transfer.TranslogTransferMetadata.METADATA_SEPARATOR;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anySet;
@@ -515,10 +516,13 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
             null,
             remoteTranslogTransferTracker
         );
-        TranslogTransferMetadata tm = new TranslogTransferMetadata(1, 1, 1, 2, "node-1");
+        TranslogTransferMetadata tm = new TranslogTransferMetadata(1, 1, 1, 2, "node--1");
         String mdFilename = tm.getFileName();
+        long count = mdFilename.chars().filter(ch -> ch == METADATA_SEPARATOR.charAt(0)).count();
+        // There should not be any `_` in mdFile name as it is used a separator .
+        assertEquals(10, count);
         Thread.sleep(1);
-        TranslogTransferMetadata tm2 = new TranslogTransferMetadata(1, 1, 1, 2, "node-2");
+        TranslogTransferMetadata tm2 = new TranslogTransferMetadata(1, 1, 1, 2, "node--2");
         String mdFilename2 = tm2.getFileName();
 
         doAnswer(invocation -> {

--- a/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
@@ -39,7 +39,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.mockito.Mockito;
@@ -504,8 +506,12 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
     }
 
     public void testGetPrimaryTermAndGeneration() {
-        String tm = new TranslogTransferMetadata(1, 2, 1, 2, "node-1").getFileName();
-        assertEquals(new Tuple<>(new Tuple<>(1L, 2L), "node-1"), TranslogTransferMetadata.getNodeIdByPrimaryTermAndGeneration(tm));
+        String nodeId = UUID.randomUUID().toString();
+        String tm = new TranslogTransferMetadata(1, 2, 1, 2, nodeId).getFileName();
+        Tuple<Tuple<Long, Long>, String> actualOutput = TranslogTransferMetadata.getNodeIdByPrimaryTermAndGeneration(tm);
+        assertEquals(1L, (long) (actualOutput.v1().v1()));
+        assertEquals(2L, (long) (actualOutput.v1().v2()));
+        assertEquals(String.valueOf(Objects.hash(nodeId)), actualOutput.v2());
     }
 
     public void testMetadataConflict() throws InterruptedException {


### PR DESCRIPTION
 - Backports https://github.com/opensearch-project/OpenSearch/commit/98defa595cc83369fa863d50057d518133b81540 from https://github.com/opensearch-project/OpenSearch/pull/10480.
 - Backports https://github.com/opensearch-project/OpenSearch/commit/22ddcf19c7a0ceb8998cdc6344ba132b547cef1c from https://github.com/opensearch-project/OpenSearch/pull/10490