### PR TITLE
Fix some test methods in SimulatePipelineRequestParsingTests never run and fix test failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix circular dependency in Settings initialization ([10194](https://github.com/opensearch-project/OpenSearch/pull/10194))
 - Fix registration and initialization of multiple extensions ([10256](https://github.com/opensearch-project/OpenSearch/pull/10256))
 - Fix Segment Replication ShardLockObtainFailedException bug during index corruption ([10370](https://github.com/opensearch-project/OpenSearch/pull/10370))
+- Fix some test methods in SimulatePipelineRequestParsingTests never run and fix test failure
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,7 +149,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix circular dependency in Settings initialization ([10194](https://github.com/opensearch-project/OpenSearch/pull/10194))
 - Fix registration and initialization of multiple extensions ([10256](https://github.com/opensearch-project/OpenSearch/pull/10256))
 - Fix Segment Replication ShardLockObtainFailedException bug during index corruption ([10370](https://github.com/opensearch-project/OpenSearch/pull/10370))
-- Fix some test methods in SimulatePipelineRequestParsingTests never run and fix test failure
+- Fix some test methods in SimulatePipelineRequestParsingTests never run and fix test failure ([#10496](https://github.com/opensearch-project/OpenSearch/pull/10496))
 
 ### Security
 

--- a/server/src/test/java/org/opensearch/action/ingest/SimulatePipelineRequestParsingTests.java
+++ b/server/src/test/java/org/opensearch/action/ingest/SimulatePipelineRequestParsingTests.java
@@ -85,7 +85,7 @@ public class SimulatePipelineRequestParsingTests extends OpenSearchTestCase {
         when(ingestService.getProcessorFactories()).thenReturn(registry);
     }
 
-    public void testParseUsingPipelineStore(boolean useExplicitType) throws Exception {
+    public void testParseUsingPipelineStore() throws Exception {
         int numDocs = randomIntBetween(1, 10);
 
         Map<String, Object> requestContent = new HashMap<>();
@@ -131,7 +131,7 @@ public class SimulatePipelineRequestParsingTests extends OpenSearchTestCase {
         assertThat(actualRequest.getPipeline().getProcessors().size(), equalTo(1));
     }
 
-    public void innerTestParseWithProvidedPipeline() throws Exception {
+    public void testParseWithProvidedPipeline() throws Exception {
         int numDocs = randomIntBetween(1, 10);
 
         Map<String, Object> requestContent = new HashMap<>();
@@ -149,9 +149,9 @@ public class SimulatePipelineRequestParsingTests extends OpenSearchTestCase {
                         doc.put(field.getFieldName(), value);
                         expectedDoc.put(field.getFieldName(), value);
                     } else {
-                        Integer value = randomIntBetween(1, 1000000);
+                        int value = randomIntBetween(1, 1000000);
                         doc.put(field.getFieldName(), value);
-                        expectedDoc.put(field.getFieldName(), value);
+                        expectedDoc.put(field.getFieldName(), (long) value);
                     }
                 } else if (field == VERSION_TYPE) {
                     String value = VersionType.toString(randomFrom(VersionType.INTERNAL, VersionType.EXTERNAL, VersionType.EXTERNAL_GTE));
@@ -163,9 +163,9 @@ public class SimulatePipelineRequestParsingTests extends OpenSearchTestCase {
                         doc.put(field.getFieldName(), value);
                         expectedDoc.put(field.getFieldName(), value);
                     } else {
-                        Integer value = randomIntBetween(1, 1000000);
+                        int value = randomIntBetween(1, 1000000);
                         doc.put(field.getFieldName(), value);
-                        expectedDoc.put(field.getFieldName(), value);
+                        expectedDoc.put(field.getFieldName(), (long) value);
                     }
                 } else {
                     if (randomBoolean()) {


### PR DESCRIPTION
### Description

The two methods `testParseUsingPipelineStore` and `innerTestParseWithProvidedPipeline` in SimulatePipelineRequestParsingTests never run, that's because `testParseUsingPipelineStore` has unused input parameter and `innerTestParseWithProvidedPipeline` doesn't start with `test`,  this PR fix the bug and fix the test failure when running `innerTestParseWithProvidedPipeline`.

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/10493

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
