### PR TITLE
[Tiered Caching] Adding took time for QuerySearchResult

### DIFF
--- a/server/src/main/java/org/opensearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/opensearch/search/query/QueryPhase.java
@@ -131,7 +131,7 @@ public class QueryPhase {
     }
 
     public void execute(SearchContext searchContext) throws QueryPhaseExecutionException {
-        long startTime = System.nanoTime();
+        final long startTime = System.nanoTime();
         if (searchContext.hasOnlySuggest()) {
             suggestProcessor.process(searchContext);
             searchContext.queryResult()

--- a/server/src/main/java/org/opensearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/opensearch/search/query/QueryPhase.java
@@ -131,6 +131,7 @@ public class QueryPhase {
     }
 
     public void execute(SearchContext searchContext) throws QueryPhaseExecutionException {
+        long startTime = System.nanoTime();
         if (searchContext.hasOnlySuggest()) {
             suggestProcessor.process(searchContext);
             searchContext.queryResult()
@@ -138,6 +139,7 @@ public class QueryPhase {
                     new TopDocsAndMaxScore(new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), Lucene.EMPTY_SCORE_DOCS), Float.NaN),
                     new DocValueFormat[0]
                 );
+            searchContext.queryResult().setTookTimeNanos(System.nanoTime() - startTime);
             return;
         }
 
@@ -165,6 +167,7 @@ public class QueryPhase {
             );
             searchContext.queryResult().profileResults(shardResults);
         }
+        searchContext.queryResult().setTookTimeNanos(System.nanoTime() - startTime);
     }
 
     // making public for testing
@@ -292,7 +295,6 @@ public class QueryPhase {
                     queryResult.nodeQueueSize(rExecutor.getCurrentQueueSize());
                     queryResult.serviceTimeEWMA((long) rExecutor.getTaskExecutionEWMA());
                 }
-
                 return shouldRescore;
             } finally {
                 // Search phase has finished, no longer need to check for timeout

--- a/server/src/main/java/org/opensearch/search/query/QuerySearchResult.java
+++ b/server/src/main/java/org/opensearch/search/query/QuerySearchResult.java
@@ -88,7 +88,7 @@ public final class QuerySearchResult extends SearchPhaseResult {
     private int nodeQueueSize = -1;
 
     private final boolean isNull;
-    private long tookTimeNanos;
+    private Long tookTimeNanos = null;
 
     public QuerySearchResult() {
         this(false);
@@ -367,9 +367,9 @@ public final class QuerySearchResult extends SearchPhaseResult {
         setShardSearchRequest(in.readOptionalWriteable(ShardSearchRequest::new));
         setRescoreDocIds(new RescoreDocIds(in));
         if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
-            tookTimeNanos = in.readVLong();
+            tookTimeNanos = in.readOptionalLong();
         } else {
-            tookTimeNanos = -1L;
+            tookTimeNanos = null;
         }
     }
 
@@ -414,7 +414,7 @@ public final class QuerySearchResult extends SearchPhaseResult {
         out.writeOptionalWriteable(getShardSearchRequest());
         getRescoreDocIds().writeTo(out);
         if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
-            out.writeVLong(tookTimeNanos); // VLong as took time should always be positive
+            out.writeOptionalLong(tookTimeNanos);
         }
     }
 
@@ -426,7 +426,7 @@ public final class QuerySearchResult extends SearchPhaseResult {
         return maxScore;
     }
 
-    public long getTookTimeNanos() {
+    public Long getTookTimeNanos() {
         return tookTimeNanos;
     }
 

--- a/server/src/main/java/org/opensearch/search/query/QuerySearchResult.java
+++ b/server/src/main/java/org/opensearch/search/query/QuerySearchResult.java
@@ -87,6 +87,7 @@ public final class QuerySearchResult extends SearchPhaseResult {
     private int nodeQueueSize = -1;
 
     private final boolean isNull;
+    private long tookTimeNanos;
 
     public QuerySearchResult() {
         this(false);
@@ -364,6 +365,7 @@ public final class QuerySearchResult extends SearchPhaseResult {
         nodeQueueSize = in.readInt();
         setShardSearchRequest(in.readOptionalWriteable(ShardSearchRequest::new));
         setRescoreDocIds(new RescoreDocIds(in));
+        tookTimeNanos = in.readVLong();
     }
 
     @Override
@@ -406,6 +408,7 @@ public final class QuerySearchResult extends SearchPhaseResult {
         out.writeInt(nodeQueueSize);
         out.writeOptionalWriteable(getShardSearchRequest());
         getRescoreDocIds().writeTo(out);
+        out.writeVLong(tookTimeNanos); // VLong as took time should always be positive
     }
 
     public TotalHits getTotalHits() {
@@ -414,5 +417,13 @@ public final class QuerySearchResult extends SearchPhaseResult {
 
     public float getMaxScore() {
         return maxScore;
+    }
+
+    public long getTookTimeNanos() {
+        return tookTimeNanos;
+    }
+
+    public void setTookTimeNanos(long tookTime) {
+        tookTimeNanos = tookTime;
     }
 }

--- a/server/src/main/java/org/opensearch/search/query/QuerySearchResult.java
+++ b/server/src/main/java/org/opensearch/search/query/QuerySearchResult.java
@@ -89,7 +89,6 @@ public final class QuerySearchResult extends SearchPhaseResult {
 
     private final boolean isNull;
     private long tookTimeNanos;
-    private final static Version minimumTookTimeVersion = Version.V_3_0_0;
 
     public QuerySearchResult() {
         this(false);
@@ -367,7 +366,7 @@ public final class QuerySearchResult extends SearchPhaseResult {
         nodeQueueSize = in.readInt();
         setShardSearchRequest(in.readOptionalWriteable(ShardSearchRequest::new));
         setRescoreDocIds(new RescoreDocIds(in));
-        if (in.getVersion().onOrAfter(minimumTookTimeVersion)) {
+        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
             tookTimeNanos = in.readVLong();
         } else {
             tookTimeNanos = -1L;
@@ -414,7 +413,7 @@ public final class QuerySearchResult extends SearchPhaseResult {
         out.writeInt(nodeQueueSize);
         out.writeOptionalWriteable(getShardSearchRequest());
         getRescoreDocIds().writeTo(out);
-        if (out.getVersion().onOrAfter(minimumTookTimeVersion)) {
+        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
             out.writeVLong(tookTimeNanos); // VLong as took time should always be positive
         }
     }

--- a/server/src/test/java/org/opensearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/opensearch/search/query/QueryPhaseTests.java
@@ -1204,7 +1204,7 @@ public class QueryPhaseTests extends IndexShardTestCase {
 
         QueryPhase queryPhase = new QueryPhase(delayedQueryPhaseSearcher);
         queryPhase.execute(searchContext);
-        long tookTime = searchContext.queryResult().getTookTimeNanos();
+        Long tookTime = searchContext.queryResult().getTookTimeNanos();
         assertTrue(tookTime >= (long) sleepMillis * 1000000);
         reader.close();
         dir.close();

--- a/server/src/test/java/org/opensearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/opensearch/search/query/QueryPhaseTests.java
@@ -1154,7 +1154,7 @@ public class QueryPhaseTests extends IndexShardTestCase {
     }
 
     public void testQuerySearchResultTookTime() throws IOException {
-        int sleepMillis = randomIntBetween(500, 4000); // between 0.5 and 4 sec
+        int sleepMillis = randomIntBetween(10, 100); // between 0.01 and 0.1 sec
         DelayedQueryPhaseSearcher delayedQueryPhaseSearcher = new DelayedQueryPhaseSearcher(sleepMillis);
 
         // we need to test queryPhase.execute(), not executeInternal(), since that's what the timer wraps around

--- a/server/src/test/java/org/opensearch/search/query/QuerySearchResultTests.java
+++ b/server/src/test/java/org/opensearch/search/query/QuerySearchResultTests.java
@@ -99,6 +99,7 @@ public class QuerySearchResultTests extends OpenSearchTestCase {
         if (randomBoolean()) {
             result.aggregations(InternalAggregationsTests.createTestInstance());
         }
+        assertEquals(0, result.getTookTimeNanos());
         return result;
     }
 
@@ -118,6 +119,7 @@ public class QuerySearchResultTests extends OpenSearchTestCase {
             assertEquals(aggs.asList(), deserializedAggs.asList());
         }
         assertEquals(querySearchResult.terminatedEarly(), deserialized.terminatedEarly());
+        assertEquals(querySearchResult.getTookTimeNanos(), deserialized.getTookTimeNanos());
     }
 
     public void testNullResponse() throws Exception {

--- a/server/src/test/java/org/opensearch/search/query/QuerySearchResultTests.java
+++ b/server/src/test/java/org/opensearch/search/query/QuerySearchResultTests.java
@@ -56,6 +56,8 @@ import org.opensearch.search.internal.ShardSearchRequest;
 import org.opensearch.search.suggest.SuggestTests;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.util.HashMap;
+
 import static java.util.Collections.emptyList;
 
 public class QuerySearchResultTests extends OpenSearchTestCase {
@@ -104,10 +106,13 @@ public class QuerySearchResultTests extends OpenSearchTestCase {
     }
 
     public void testSerialization() throws Exception {
-        for (int i = 0; i < 2; i++) {
+        HashMap<Boolean, Long> expectedValues = new HashMap<>(); // map contains whether to set took time, and if so, to what value
+        expectedValues.put(false, null);
+        expectedValues.put(true, 1000L);
+        for (Boolean doSetTookTime : expectedValues.keySet()) {
             QuerySearchResult querySearchResult = createTestInstance();
-            if (i == 0) {
-                querySearchResult.setTookTimeNanos(1000L); // test both an initialized and an uninitialized null value
+            if (doSetTookTime) {
+                querySearchResult.setTookTimeNanos(expectedValues.get(doSetTookTime));
             }
             QuerySearchResult deserialized = copyWriteable(querySearchResult, namedWriteableRegistry, QuerySearchResult::new);
             assertEquals(querySearchResult.getContextId().getId(), deserialized.getContextId().getId());
@@ -124,9 +129,7 @@ public class QuerySearchResultTests extends OpenSearchTestCase {
             }
             assertEquals(querySearchResult.terminatedEarly(), deserialized.terminatedEarly());
             assertEquals(querySearchResult.getTookTimeNanos(), deserialized.getTookTimeNanos());
-            if (i == 1) {
-                assertNull(deserialized.getTookTimeNanos());
-            }
+            assertEquals(expectedValues.get(doSetTookTime), querySearchResult.getTookTimeNanos());
         }
     }
 

--- a/server/src/test/java/org/opensearch/search/query/QuerySearchResultTests.java
+++ b/server/src/test/java/org/opensearch/search/query/QuerySearchResultTests.java
@@ -99,27 +99,35 @@ public class QuerySearchResultTests extends OpenSearchTestCase {
         if (randomBoolean()) {
             result.aggregations(InternalAggregationsTests.createTestInstance());
         }
-        assertEquals(0, result.getTookTimeNanos());
+        assertNull(result.getTookTimeNanos());
         return result;
     }
 
     public void testSerialization() throws Exception {
-        QuerySearchResult querySearchResult = createTestInstance();
-        QuerySearchResult deserialized = copyWriteable(querySearchResult, namedWriteableRegistry, QuerySearchResult::new);
-        assertEquals(querySearchResult.getContextId().getId(), deserialized.getContextId().getId());
-        assertNull(deserialized.getSearchShardTarget());
-        assertEquals(querySearchResult.topDocs().maxScore, deserialized.topDocs().maxScore, 0f);
-        assertEquals(querySearchResult.topDocs().topDocs.totalHits, deserialized.topDocs().topDocs.totalHits);
-        assertEquals(querySearchResult.from(), deserialized.from());
-        assertEquals(querySearchResult.size(), deserialized.size());
-        assertEquals(querySearchResult.hasAggs(), deserialized.hasAggs());
-        if (deserialized.hasAggs()) {
-            Aggregations aggs = querySearchResult.consumeAggs().expand();
-            Aggregations deserializedAggs = deserialized.consumeAggs().expand();
-            assertEquals(aggs.asList(), deserializedAggs.asList());
+        for (int i = 0; i < 2; i++) {
+            QuerySearchResult querySearchResult = createTestInstance();
+            if (i == 0) {
+                querySearchResult.setTookTimeNanos(1000L); // test both an initialized and an uninitialized null value
+            }
+            QuerySearchResult deserialized = copyWriteable(querySearchResult, namedWriteableRegistry, QuerySearchResult::new);
+            assertEquals(querySearchResult.getContextId().getId(), deserialized.getContextId().getId());
+            assertNull(deserialized.getSearchShardTarget());
+            assertEquals(querySearchResult.topDocs().maxScore, deserialized.topDocs().maxScore, 0f);
+            assertEquals(querySearchResult.topDocs().topDocs.totalHits, deserialized.topDocs().topDocs.totalHits);
+            assertEquals(querySearchResult.from(), deserialized.from());
+            assertEquals(querySearchResult.size(), deserialized.size());
+            assertEquals(querySearchResult.hasAggs(), deserialized.hasAggs());
+            if (deserialized.hasAggs()) {
+                Aggregations aggs = querySearchResult.consumeAggs().expand();
+                Aggregations deserializedAggs = deserialized.consumeAggs().expand();
+                assertEquals(aggs.asList(), deserializedAggs.asList());
+            }
+            assertEquals(querySearchResult.terminatedEarly(), deserialized.terminatedEarly());
+            assertEquals(querySearchResult.getTookTimeNanos(), deserialized.getTookTimeNanos());
+            if (i == 1) {
+                assertNull(deserialized.getTookTimeNanos());
+            }
         }
-        assertEquals(querySearchResult.terminatedEarly(), deserialized.terminatedEarly());
-        assertEquals(querySearchResult.getTookTimeNanos(), deserialized.getTookTimeNanos());
     }
 
     public void testNullResponse() throws Exception {


### PR DESCRIPTION
### Description
Adds time taken in nanoseconds to QuerySearchResult in the query phase, part of the shard-level query response. This will be used as part of tiered caching, to decide whether or not to move cached entries to the disk tier based on how long it would take to recompute them.

Unit tested in QuerySearchResultTests.java. The tests add a random delay to QueryPhase::execute() and assert the took time in the result is greater than or equal to this delay. 

### Related Issues
Resolves #10411 
Milestone of larger tiered caching feature. 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [N/A] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [N/A] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
