### PR TITLE
Point deprecated settings to the new location.

### DIFF
--- a/server/src/main/java/org/opensearch/search/backpressure/settings/SearchBackpressureSettings.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/settings/SearchBackpressureSettings.java
@@ -55,7 +55,7 @@ public class SearchBackpressureSettings {
      * Defines the percentage of tasks to cancel relative to the number of successful task completions.
      * In other words, it is the number of tokens added to the bucket on each successful task completion.
      * <p>
-     * The setting below is deprecated.
+     * The setting below is deprecated. The new setting is in {@link SearchShardTaskSettings}.
      * To keep backwards compatibility, the old usage is remained, and it's also used as the fallback for the new usage.
      */
     public static final Setting<Double> SETTING_CANCELLATION_RATIO = Setting.doubleSetting(
@@ -72,7 +72,7 @@ public class SearchBackpressureSettings {
      * Defines the number of tasks to cancel per unit time (in millis).
      * In other words, it is the number of tokens added to the bucket each millisecond.
      * <p>
-     * The setting below is deprecated.
+     * The setting below is deprecated. The new setting is in {@link SearchShardTaskSettings}.
      * To keep backwards compatibility, the old usage is remained, and it's also used as the fallback for the new usage.
      */
     public static final Setting<Double> SETTING_CANCELLATION_RATE = Setting.doubleSetting(
@@ -87,7 +87,7 @@ public class SearchBackpressureSettings {
     /**
      * Defines the maximum number of tasks that can be cancelled before being rate-limited.
      * <p>
-     * The setting below is deprecated.
+     * The setting below is deprecated. The new setting is in {@link SearchShardTaskSettings}.
      * To keep backwards compatibility, the old usage is remained, and it's also used as the fallback for the new usage.
      */
     public static final Setting<Double> SETTING_CANCELLATION_BURST = Setting.doubleSetting(


### PR DESCRIPTION
### Description
I was looking through some cluster settings, stumbled across the search back-pressure settings, saw they were deprecated, and the Javadoc alluded to some myserious new settings.

I'm adding links to the class with the new settings to help future developers.

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
