### PR TITLE
Fixes ByteArrayIndexInput::validatePos and adds UT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Fix for deserilization bug in weighted round-robin metadata ([#11679](https://github.com/opensearch-project/OpenSearch/pull/11679))
 - Add a system property to configure YamlParser codepoint limits ([#12298](https://github.com/opensearch-project/OpenSearch/pull/12298))
+- Prevent read beyond slice boundary in ByteArrayIndexInput ([#10481](https://github.com/opensearch-project/OpenSearch/issues/10481))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/common/lucene/store/ByteArrayIndexInput.java
+++ b/server/src/main/java/org/opensearch/common/lucene/store/ByteArrayIndexInput.java
@@ -144,7 +144,7 @@ public class ByteArrayIndexInput extends IndexInput implements RandomAccessInput
     }
 
     private void validatePos(long pos, int len) throws EOFException {
-        if (pos < 0 || pos + len > length + offset) {
+        if (pos < 0 || pos + len > length) {
             throw new EOFException("seek past EOF");
         }
     }

--- a/server/src/test/java/org/opensearch/common/lucene/store/ByteArrayIndexInputTests.java
+++ b/server/src/test/java/org/opensearch/common/lucene/store/ByteArrayIndexInputTests.java
@@ -32,6 +32,8 @@
 
 package org.opensearch.common.lucene.store;
 
+import org.apache.lucene.store.IndexInput;
+
 import java.io.EOFException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -153,4 +155,37 @@ public class ByteArrayIndexInputTests extends OpenSearchIndexInputTestCase {
         // 10001001 00100101 10001001 00110000 11100111 00100100 10110001 00101110
         assertEquals(-8564288273245753042L, indexInput.readLong(1));
     }
+
+
+    public void testReadBytesWithSlice() throws IOException {
+        int inputLength = randomIntBetween(100, 1000);
+
+        byte[] input = randomUnicodeOfLength(inputLength).getBytes(StandardCharsets.UTF_8);
+        ByteArrayIndexInput indexInput = new ByteArrayIndexInput("test", input);
+
+        int sliceOffset = randomIntBetween(1, inputLength - 10);
+        int sliceLength = randomIntBetween(2, inputLength - sliceOffset);
+        IndexInput slice = indexInput.slice("slice", sliceOffset, sliceLength);
+
+        // read a byte from sliced index input and verify if the read value is correct
+        assertEquals(input[sliceOffset], slice.readByte());
+
+        // read few more bytes into a byte array
+        int bytesToRead = randomIntBetween(1, sliceLength - 1);
+        slice.readBytes(new byte[bytesToRead], 0, bytesToRead);
+
+        // now try to read beyond the boundary of the slice, but within the
+        // boundary of the original IndexInput. We've already read few bytes
+        // so this is expected to fail
+        assertThrows(EOFException.class, () -> slice.readBytes(new byte[sliceLength], 0, sliceLength));
+
+        // seek to EOF and then try to read
+        slice.seek(sliceLength);
+        assertThrows(EOFException.class, () -> slice.readBytes(new byte[1], 0, 1));
+
+        slice.close();
+        indexInput.close();
+
+    }
+
 }

--- a/server/src/test/java/org/opensearch/common/lucene/store/ByteArrayIndexInputTests.java
+++ b/server/src/test/java/org/opensearch/common/lucene/store/ByteArrayIndexInputTests.java
@@ -156,7 +156,6 @@ public class ByteArrayIndexInputTests extends OpenSearchIndexInputTestCase {
         assertEquals(-8564288273245753042L, indexInput.readLong(1));
     }
 
-
     public void testReadBytesWithSlice() throws IOException {
         int inputLength = randomIntBetween(100, 1000);
 
@@ -185,7 +184,5 @@ public class ByteArrayIndexInputTests extends OpenSearchIndexInputTestCase {
 
         slice.close();
         indexInput.close();
-
     }
-
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fixes `ByteArrayIndexInput::validatePos` and adds UT

### Related Issues
Resolves #10481 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
