### PR TITLE
Add the means to extract the contextual properties from HttpChannel, TcpChannel and TrasportChannel without excessive typecasting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Remote Store] Add support to reload repository metadata inplace ([#9569](https://github.com/opensearch-project/OpenSearch/pull/9569))
 - [Metrics Framework] Add Metrics framework. ([#10241](https://github.com/opensearch-project/OpenSearch/pull/10241))
 - Updating the separator for RemoteStoreLockManager since underscore is allowed in base64UUID url charset ([#10379](https://github.com/opensearch-project/OpenSearch/pull/10379))
+- Add the means to extract the contextual properties from HttpChannel, TcpCChannel and TrasportChannel without excessive typecasting ([#10562](https://github.com/opensearch-project/OpenSearch/pull/10562))
 
 ### Deprecated
 

--- a/modules/transport-netty4/src/main/java/org/opensearch/http/netty4/Netty4HttpChannel.java
+++ b/modules/transport-netty4/src/main/java/org/opensearch/http/netty4/Netty4HttpChannel.java
@@ -98,6 +98,22 @@ public class Netty4HttpChannel implements HttpChannel {
         return channel;
     }
 
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T get(String name, Class<T> clazz) {
+        Object handler = getNettyChannel().pipeline().get(name);
+
+        if (handler == null && inboundPipeline() != null) {
+            handler = inboundPipeline().get(name);
+        }
+
+        if (handler != null && clazz.isInstance(handler) == true) {
+            return (T) handler;
+        }
+
+        return null;
+    }
+
     @Override
     public String toString() {
         return "Netty4HttpChannel{" + "localAddress=" + getLocalAddress() + ", remoteAddress=" + getRemoteAddress() + '}';

--- a/modules/transport-netty4/src/main/java/org/opensearch/http/netty4/Netty4HttpChannel.java
+++ b/modules/transport-netty4/src/main/java/org/opensearch/http/netty4/Netty4HttpChannel.java
@@ -40,6 +40,7 @@ import org.opensearch.http.HttpResponse;
 import org.opensearch.transport.netty4.Netty4TcpChannel;
 
 import java.net.InetSocketAddress;
+import java.util.Optional;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelPipeline;
@@ -100,7 +101,7 @@ public class Netty4HttpChannel implements HttpChannel {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T> T get(String name, Class<T> clazz) {
+    public <T> Optional<T> get(String name, Class<T> clazz) {
         Object handler = getNettyChannel().pipeline().get(name);
 
         if (handler == null && inboundPipeline() != null) {
@@ -108,10 +109,10 @@ public class Netty4HttpChannel implements HttpChannel {
         }
 
         if (handler != null && clazz.isInstance(handler) == true) {
-            return (T) handler;
+            return Optional.of((T) handler);
         }
 
-        return null;
+        return Optional.empty();
     }
 
     @Override

--- a/modules/transport-netty4/src/main/java/org/opensearch/transport/netty4/Netty4TcpChannel.java
+++ b/modules/transport-netty4/src/main/java/org/opensearch/transport/netty4/Netty4TcpChannel.java
@@ -41,6 +41,7 @@ import org.opensearch.transport.TcpChannel;
 import org.opensearch.transport.TransportException;
 
 import java.net.InetSocketAddress;
+import java.util.Optional;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -166,14 +167,14 @@ public class Netty4TcpChannel implements TcpChannel {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T> T get(String name, Class<T> clazz) {
+    public <T> Optional<T> get(String name, Class<T> clazz) {
         final Object handler = getNettyChannel().pipeline().get(name);
 
         if (handler != null && clazz.isInstance(handler) == true) {
-            return (T) handler;
+            return Optional.of((T) handler);
         }
 
-        return null;
+        return Optional.empty();
     }
 
     public Channel getNettyChannel() {

--- a/modules/transport-netty4/src/main/java/org/opensearch/transport/netty4/Netty4TcpChannel.java
+++ b/modules/transport-netty4/src/main/java/org/opensearch/transport/netty4/Netty4TcpChannel.java
@@ -164,6 +164,18 @@ public class Netty4TcpChannel implements TcpChannel {
         }
     }
 
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T get(String name, Class<T> clazz) {
+        final Object handler = getNettyChannel().pipeline().get(name);
+
+        if (handler != null && clazz.isInstance(handler) == true) {
+            return (T) handler;
+        }
+
+        return null;
+    }
+
     public Channel getNettyChannel() {
         return channel;
     }

--- a/server/src/main/java/org/opensearch/http/HttpChannel.java
+++ b/server/src/main/java/org/opensearch/http/HttpChannel.java
@@ -36,6 +36,7 @@ import org.opensearch.common.network.CloseableChannel;
 import org.opensearch.core.action.ActionListener;
 
 import java.net.InetSocketAddress;
+import java.util.Optional;
 
 /**
  * Represents an HTTP comms channel
@@ -80,10 +81,9 @@ public interface HttpChannel extends CloseableChannel {
      * @param name the name of the property
      * @param clazz the expected type of the property
      *
-     * @return the value of the property.
-     *         {@code null} if there's no such property or the expected type is not compatible.
+     * @return the value of the property
      */
-    default <T> T get(String name, Class<T> clazz) {
-        return null;
+    default <T> Optional<T> get(String name, Class<T> clazz) {
+        return Optional.empty();
     }
 }

--- a/server/src/main/java/org/opensearch/http/HttpChannel.java
+++ b/server/src/main/java/org/opensearch/http/HttpChannel.java
@@ -72,4 +72,18 @@ public interface HttpChannel extends CloseableChannel {
      */
     InetSocketAddress getRemoteAddress();
 
+    /**
+     * Returns the contextual property associated with this specific HTTP channel (the
+     * implementation of how such properties are managed depends on the the particular
+     * transport engine).
+     *
+     * @param name the name of the property
+     * @param clazz the expected type of the property
+     *
+     * @return the value of the property.
+     *         {@code null} if there's no such property or the expected type is not compatible.
+     */
+    default <T> T get(String name, Class<T> clazz) {
+        return null;
+    }
 }

--- a/server/src/main/java/org/opensearch/telemetry/tracing/channels/TraceableHttpChannel.java
+++ b/server/src/main/java/org/opensearch/telemetry/tracing/channels/TraceableHttpChannel.java
@@ -92,4 +92,9 @@ public class TraceableHttpChannel implements HttpChannel {
     public InetSocketAddress getRemoteAddress() {
         return delegate.getRemoteAddress();
     }
+
+    @Override
+    public <T> T get(String name, Class<T> clazz) {
+        return delegate.get(name, clazz);
+    }
 }

--- a/server/src/main/java/org/opensearch/telemetry/tracing/channels/TraceableHttpChannel.java
+++ b/server/src/main/java/org/opensearch/telemetry/tracing/channels/TraceableHttpChannel.java
@@ -18,6 +18,7 @@ import org.opensearch.telemetry.tracing.listener.TraceableActionListener;
 
 import java.net.InetSocketAddress;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Tracer wrapped {@link HttpChannel}
@@ -94,7 +95,7 @@ public class TraceableHttpChannel implements HttpChannel {
     }
 
     @Override
-    public <T> T get(String name, Class<T> clazz) {
+    public <T> Optional<T> get(String name, Class<T> clazz) {
         return delegate.get(name, clazz);
     }
 }

--- a/server/src/main/java/org/opensearch/telemetry/tracing/channels/TraceableTcpTransportChannel.java
+++ b/server/src/main/java/org/opensearch/telemetry/tracing/channels/TraceableTcpTransportChannel.java
@@ -109,4 +109,9 @@ public class TraceableTcpTransportChannel extends BaseTcpTransportChannel {
     public Version getVersion() {
         return delegate.getVersion();
     }
+
+    @Override
+    public <T> T get(String name, Class<T> clazz) {
+        return delegate.get(name, clazz);
+    }
 }

--- a/server/src/main/java/org/opensearch/telemetry/tracing/channels/TraceableTcpTransportChannel.java
+++ b/server/src/main/java/org/opensearch/telemetry/tracing/channels/TraceableTcpTransportChannel.java
@@ -20,6 +20,7 @@ import org.opensearch.transport.TcpTransportChannel;
 import org.opensearch.transport.TransportChannel;
 
 import java.io.IOException;
+import java.util.Optional;
 
 /**
  * Tracer wrapped {@link TransportChannel}
@@ -111,7 +112,7 @@ public class TraceableTcpTransportChannel extends BaseTcpTransportChannel {
     }
 
     @Override
-    public <T> T get(String name, Class<T> clazz) {
+    public <T> Optional<T> get(String name, Class<T> clazz) {
         return delegate.get(name, clazz);
     }
 }

--- a/server/src/main/java/org/opensearch/transport/TaskTransportChannel.java
+++ b/server/src/main/java/org/opensearch/transport/TaskTransportChannel.java
@@ -89,4 +89,9 @@ public class TaskTransportChannel implements TransportChannel {
     public TransportChannel getChannel() {
         return channel;
     }
+
+    @Override
+    public <T> T get(String name, Class<T> clazz) {
+        return getChannel().get(name, clazz);
+    }
 }

--- a/server/src/main/java/org/opensearch/transport/TaskTransportChannel.java
+++ b/server/src/main/java/org/opensearch/transport/TaskTransportChannel.java
@@ -37,6 +37,7 @@ import org.opensearch.common.lease.Releasable;
 import org.opensearch.core.transport.TransportResponse;
 
 import java.io.IOException;
+import java.util.Optional;
 
 /**
  * Transport channel for tasks
@@ -91,7 +92,7 @@ public class TaskTransportChannel implements TransportChannel {
     }
 
     @Override
-    public <T> T get(String name, Class<T> clazz) {
+    public <T> Optional<T> get(String name, Class<T> clazz) {
         return getChannel().get(name, clazz);
     }
 }

--- a/server/src/main/java/org/opensearch/transport/TcpChannel.java
+++ b/server/src/main/java/org/opensearch/transport/TcpChannel.java
@@ -97,6 +97,21 @@ public interface TcpChannel extends CloseableChannel {
     ChannelStats getChannelStats();
 
     /**
+     * Returns the contextual property associated with this specific TCP channel (the
+     * implementation of how such properties are managed depends on the the particular
+     * transport engine).
+     *
+     * @param name the name of the property
+     * @param clazz the expected type of the property
+     *
+     * @return the value of the property.
+     *         {@code null} if there's no such property or the expected type is not compatible.
+     */
+    default <T> T get(String name, Class<T> clazz) {
+        return null;
+    }
+
+    /**
      * Channel statistics
      *
      * @opensearch.internal

--- a/server/src/main/java/org/opensearch/transport/TcpChannel.java
+++ b/server/src/main/java/org/opensearch/transport/TcpChannel.java
@@ -38,6 +38,7 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesReference;
 
 import java.net.InetSocketAddress;
+import java.util.Optional;
 
 /**
  * This is a tcp channel representing a single channel connection to another node. It is the base channel
@@ -104,11 +105,10 @@ public interface TcpChannel extends CloseableChannel {
      * @param name the name of the property
      * @param clazz the expected type of the property
      *
-     * @return the value of the property.
-     *         {@code null} if there's no such property or the expected type is not compatible.
+     * @return the value of the property
      */
-    default <T> T get(String name, Class<T> clazz) {
-        return null;
+    default <T> Optional<T> get(String name, Class<T> clazz) {
+        return Optional.empty();
     }
 
     /**

--- a/server/src/main/java/org/opensearch/transport/TcpTransportChannel.java
+++ b/server/src/main/java/org/opensearch/transport/TcpTransportChannel.java
@@ -38,6 +38,7 @@ import org.opensearch.core.transport.TransportResponse;
 import org.opensearch.search.query.QuerySearchResult;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -131,7 +132,7 @@ public final class TcpTransportChannel extends BaseTcpTransportChannel {
     }
 
     @Override
-    public <T> T get(String name, Class<T> clazz) {
+    public <T> Optional<T> get(String name, Class<T> clazz) {
         return getChannel().get(name, clazz);
     }
 }

--- a/server/src/main/java/org/opensearch/transport/TcpTransportChannel.java
+++ b/server/src/main/java/org/opensearch/transport/TcpTransportChannel.java
@@ -130,4 +130,8 @@ public final class TcpTransportChannel extends BaseTcpTransportChannel {
         return version;
     }
 
+    @Override
+    public <T> T get(String name, Class<T> clazz) {
+        return getChannel().get(name, clazz);
+    }
 }

--- a/server/src/main/java/org/opensearch/transport/TransportChannel.java
+++ b/server/src/main/java/org/opensearch/transport/TransportChannel.java
@@ -78,4 +78,19 @@ public interface TransportChannel {
             );
         }
     }
+
+    /**
+     * Returns the contextual property associated with this specific transport channel (the
+     * implementation of how such properties are managed depends on the the particular
+     * transport engine).
+     *
+     * @param name the name of the property
+     * @param clazz the expected type of the property
+     *
+     * @return the value of the property.
+     *         {@code null} if there's no such property or the expected type is not compatible.
+     */
+    default <T> T get(String name, Class<T> clazz) {
+        return null;
+    }
 }

--- a/server/src/main/java/org/opensearch/transport/TransportChannel.java
+++ b/server/src/main/java/org/opensearch/transport/TransportChannel.java
@@ -39,6 +39,7 @@ import org.opensearch.Version;
 import org.opensearch.core.transport.TransportResponse;
 
 import java.io.IOException;
+import java.util.Optional;
 
 /**
  * A transport channel allows to send a response to a request on the channel.
@@ -88,9 +89,8 @@ public interface TransportChannel {
      * @param clazz the expected type of the property
      *
      * @return the value of the property.
-     *         {@code null} if there's no such property or the expected type is not compatible.
      */
-    default <T> T get(String name, Class<T> clazz) {
-        return null;
+    default <T> Optional<T> get(String name, Class<T> clazz) {
+        return Optional.empty();
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
While instrumenting the transports (both TCP and HTTP), we found out that `security` plugin heavily depends on `netty` transport (in fact, it does not support anything else) but it is excessive typecasting the different transport object to their `Netty4Xxx` equivalents for accessing handlers and attributes. It significantly complicates any instrumentation efforts and needs general mechanism to access contextual information without typecasting.

### Related Issues
Related to https://github.com/opensearch-project/security/issues/3515

<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
