### PR TITLE
[Backport 2.x] Honor max segment size during only_expunge_deletes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `org.apache.logging.log4j:log4j-core` from 2.20.0 to 2.21.0 ([#10858](https://github.com/opensearch-project/OpenSearch/pull/10858))
 
 ### Changed
+- Force merge with `only_expunge_deletes` honors max segment size ([#10036](https://github.com/opensearch-project/OpenSearch/pull/10036))
 - Add the means to extract the contextual properties from HttpChannel, TcpCChannel and TrasportChannel without excessive typecasting ([#10562](https://github.com/opensearch-project/OpenSearch/pull/10562))
 - Backport the PR #9107 for updating CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_KEY setting to a dynamic setting ([#10606](https://github.com/opensearch-project/OpenSearch/pull/10606))
 - [Remote Store] Add Remote Store backpressure rejection stats to `_nodes/stats` ([#10524](https://github.com/opensearch-project/OpenSearch/pull/10524))

--- a/server/src/main/java/org/opensearch/index/OpenSearchTieredMergePolicy.java
+++ b/server/src/main/java/org/opensearch/index/OpenSearchTieredMergePolicy.java
@@ -42,7 +42,7 @@ import java.util.Map;
 
 /**
  * Wrapper around {@link TieredMergePolicy} which doesn't respect
- * {@link TieredMergePolicy#setMaxMergedSegmentMB(double)} on forced merges.
+ * {@link TieredMergePolicy#setMaxMergedSegmentMB(double)} on forced merges, but DOES respect it on only_expunge_deletes.
  * See https://issues.apache.org/jira/browse/LUCENE-7976.
  *
  * @opensearch.internal
@@ -71,7 +71,7 @@ final class OpenSearchTieredMergePolicy extends FilterMergePolicy {
 
     @Override
     public MergeSpecification findForcedDeletesMerges(SegmentInfos infos, MergeContext mergeContext) throws IOException {
-        return forcedMergePolicy.findForcedDeletesMerges(infos, mergeContext);
+        return regularMergePolicy.findForcedDeletesMerges(infos, mergeContext);
     }
 
     public void setForceMergeDeletesPctAllowed(double forceMergeDeletesPctAllowed) {
@@ -80,7 +80,7 @@ final class OpenSearchTieredMergePolicy extends FilterMergePolicy {
     }
 
     public double getForceMergeDeletesPctAllowed() {
-        return forcedMergePolicy.getForceMergeDeletesPctAllowed();
+        return regularMergePolicy.getForceMergeDeletesPctAllowed();
     }
 
     public void setFloorSegmentMB(double mbFrac) {

--- a/server/src/test/java/org/opensearch/index/OpenSearchTieredMergePolicyTests.java
+++ b/server/src/test/java/org/opensearch/index/OpenSearchTieredMergePolicyTests.java
@@ -32,8 +32,17 @@
 
 package org.opensearch.index;
 
+import org.apache.lucene.index.MergePolicy;
+import org.apache.lucene.index.SegmentCommitInfo;
+import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.index.TieredMergePolicy;
+import org.apache.lucene.util.InfoStream;
+import org.apache.lucene.util.Version;
 import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
 
 public class OpenSearchTieredMergePolicyTests extends OpenSearchTestCase {
 
@@ -79,5 +88,33 @@ public class OpenSearchTieredMergePolicyTests extends OpenSearchTestCase {
         OpenSearchTieredMergePolicy policy = new OpenSearchTieredMergePolicy();
         policy.setDeletesPctAllowed(42);
         assertEquals(42, policy.regularMergePolicy.getDeletesPctAllowed(), 0);
+    }
+
+    public void testFindDeleteMergesReturnsNullOnEmptySegmentInfos() throws IOException {
+        MergePolicy.MergeSpecification mergeSpecification = new OpenSearchTieredMergePolicy().findForcedDeletesMerges(
+            new SegmentInfos(Version.LATEST.major),
+            new MergePolicy.MergeContext() {
+                @Override
+                public int numDeletesToMerge(SegmentCommitInfo info) {
+                    return 0;
+                }
+
+                @Override
+                public int numDeletedDocs(SegmentCommitInfo info) {
+                    return 0;
+                }
+
+                @Override
+                public InfoStream getInfoStream() {
+                    return InfoStream.NO_OUTPUT;
+                }
+
+                @Override
+                public Set<SegmentCommitInfo> getMergingSegments() {
+                    return Collections.emptySet();
+                }
+            }
+        );
+        assertNull(mergeSpecification);
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

Manual backport of https://github.com/opensearch-project/OpenSearch/pull/10036

There are latency-sensitive users for whom the default 20% allowable accumulation of deletes is too high, so they force merge with "only_expunge_deletes".

Unfortunately, this has ignored the max segment size, so despite the word "only" in there, they get the terrible side-effect of producing segments larger than the max segment size. These oversized segments are unlikely to participate in future merges, until they have so many deletes that they could drop back below the max segment size, likely making the whole "too many deletes" problem even worse.

This commit fixes that so that "only_expunge_deletes" ONLY EXPUNGES DELETES without creating oversized segments.


### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
