### PR TITLE
Fix assertion failure while closing remoteStore

### DIFF
--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1975,7 +1975,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     /*
     ToDo : Fix this https://github.com/opensearch-project/OpenSearch/issues/8003
      */
-    private RemoteSegmentStoreDirectory getRemoteDirectory() {
+    public RemoteSegmentStoreDirectory getRemoteDirectory() {
         assert indexSettings.isRemoteStoreEnabled();
         assert remoteStore.directory() instanceof FilterDirectory : "Store.directory is not an instance of FilterDirectory";
         FilterDirectory remoteStoreDirectory = (FilterDirectory) remoteStore.directory();


### PR DESCRIPTION
### Description
- When an instance of Store is created, a shardlock is created which is released on closing the instance of store.
- Currently, we create 2 instances of store for remote store backed indices: store and remoteStore.
- As there can be only one shardlock acquired for a given shard, the lock is shared between store and remoteStore.
- This creates an issue when we are deleting the index as it results in closing both store and remoteStore. At the time of closure of second Store instance, we get the assertion error saying shard is not locked.
- Ideally, we should be closing the remoteStore but until we work on CompositeStore (https://github.com/opensearch-project/OpenSearch/issues/3719), we mitigate the test failures by closing the remoteDirectory.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
