### PR TITLE
Request level coordinator slow logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 2.x]
 ### Added
 - Per request phase latency ([#10351](https://github.com/opensearch-project/OpenSearch/issues/10351))
+- Request level coordinator slow logs ([#10650](https://github.com/opensearch-project/OpenSearch/pull/10650))
 - [Remote Store] Add repository stats for remote store([#10567](https://github.com/opensearch-project/OpenSearch/pull/10567))
 - Add search query categorizer ([#10255](https://github.com/opensearch-project/OpenSearch/pull/10255))
 - Introduce ConcurrentQueryProfiler to profile query using concurrent segment search path and support concurrency during rewrite and create weight ([10352](https://github.com/opensearch-project/OpenSearch/pull/10352))

--- a/distribution/docker/src/docker/config/log4j2.properties
+++ b/distribution/docker/src/docker/config/log4j2.properties
@@ -34,6 +34,16 @@ logger.deprecation.appenderRef.deprecation_rolling.ref = deprecation_rolling
 logger.deprecation.appenderRef.header_warning.ref = header_warning
 logger.deprecation.additivity = false
 
+appender.search_request_slowlog_json_appender.type = Console
+appender.search_request_slowlog_json_appender.name = search_request_slowlog_json_appender
+appender.search_request_slowlog_json_appender.layout.type = OpenSearchJsonLayout
+appender.search_request_slowlog_json_appender.layout.type_name = search_request_slowlog
+
+logger.search_request_slowlog_logger.name = cluster.search.request.slowlog
+logger.search_request_slowlog_logger.level = trace
+logger.search_request_slowlog_logger.appenderRef.search_request_slowlog_json_appender.ref = search_request_slowlog_json_appender
+logger.search_request_slowlog_logger.additivity = false
+
 appender.index_search_slowlog_rolling.type = Console
 appender.index_search_slowlog_rolling.name = index_search_slowlog_rolling
 appender.index_search_slowlog_rolling.layout.type = OpenSearchJsonLayout

--- a/distribution/src/config/log4j2.properties
+++ b/distribution/src/config/log4j2.properties
@@ -113,6 +113,47 @@ logger.deprecation.appenderRef.deprecation_rolling_old.ref = deprecation_rolling
 logger.deprecation.appenderRef.header_warning.ref = header_warning
 logger.deprecation.additivity = false
 
+######## Search Request Slowlog JSON ####################
+appender.search_request_slowlog_json_appender.type = RollingFile
+appender.search_request_slowlog_json_appender.name = search_request_slowlog_json_appender
+appender.search_request_slowlog_json_appender.fileName = ${sys:opensearch.logs.base_path}${sys:file.separator}${sys:opensearch.logs\
+  .cluster_name}_index_search_slowlog.json
+appender.search_request_slowlog_json_appender.filePermissions = rw-r-----
+appender.search_request_slowlog_json_appender.layout.type = OpenSearchJsonLayout
+appender.search_request_slowlog_json_appender.layout.type_name = search_request_slowlog
+appender.search_request_slowlog_json_appender.layout.opensearchmessagefields=message,took,took_millis,phase_took,total_hits,search_type,shards,source,id
+
+appender.search_request_slowlog_json_appender.filePattern = ${sys:opensearch.logs.base_path}${sys:file.separator}${sys:opensearch.logs\
+  .cluster_name}_index_search_slowlog-%i.json.gz
+appender.search_request_slowlog_json_appender.policies.type = Policies
+appender.search_request_slowlog_json_appender.policies.size.type = SizeBasedTriggeringPolicy
+appender.search_request_slowlog_json_appender.policies.size.size = 1GB
+appender.search_request_slowlog_json_appender.strategy.type = DefaultRolloverStrategy
+appender.search_request_slowlog_json_appender.strategy.max = 4
+#################################################
+######## Search Request Slowlog Log File -  old style pattern ####
+appender.search_request_slowlog_log_appender.type = RollingFile
+appender.search_request_slowlog_log_appender.name = search_request_slowlog_log_appender
+appender.search_request_slowlog_log_appender.fileName = ${sys:opensearch.logs.base_path}${sys:file.separator}${sys:opensearch.logs.cluster_name}\
+  _index_search_slowlog.log
+appender.search_request_slowlog_log_appender.filePermissions = rw-r-----
+appender.search_request_slowlog_log_appender.layout.type = PatternLayout
+appender.search_request_slowlog_log_appender.layout.pattern = [%d{ISO8601}][%-5p][%c{1.}] [%node_name]%marker %m%n
+
+appender.search_request_slowlog_log_appender.filePattern = ${sys:opensearch.logs.base_path}${sys:file.separator}${sys:opensearch.logs.cluster_name}\
+  _index_search_slowlog-%i.log.gz
+appender.search_request_slowlog_log_appender.policies.type = Policies
+appender.search_request_slowlog_log_appender.policies.size.type = SizeBasedTriggeringPolicy
+appender.search_request_slowlog_log_appender.policies.size.size = 1GB
+appender.search_request_slowlog_log_appender.strategy.type = DefaultRolloverStrategy
+appender.search_request_slowlog_log_appender.strategy.max = 4
+#################################################
+logger.search_request_slowlog_logger.name = cluster.search.request.slowlog
+logger.search_request_slowlog_logger.level = trace
+logger.search_request_slowlog_logger.appenderRef.search_request_slowlog_json_appender.ref = search_request_slowlog_json_appender
+logger.search_request_slowlog_logger.appenderRef.search_request_slowlog_log_appender.ref = search_request_slowlog_log_appender
+logger.search_request_slowlog_logger.additivity = false
+
 ######## Search slowlog JSON ####################
 appender.index_search_slowlog_rolling.type = RollingFile
 appender.index_search_slowlog_rolling.name = index_search_slowlog_rolling

--- a/server/src/main/java/org/opensearch/action/search/CanMatchPreFilterSearchPhase.java
+++ b/server/src/main/java/org/opensearch/action/search/CanMatchPreFilterSearchPhase.java
@@ -91,7 +91,7 @@ final class CanMatchPreFilterSearchPhase extends AbstractSearchAsyncAction<CanMa
         SearchTask task,
         Function<GroupShardsIterator<SearchShardIterator>, SearchPhase> phaseFactory,
         SearchResponse.Clusters clusters,
-        SearchRequestOperationsListener searchRequestOperationsListener
+        SearchRequestContext searchRequestContext
     ) {
         // We set max concurrent shard requests to the number of shards so no throttling happens for can_match requests
         super(
@@ -112,7 +112,7 @@ final class CanMatchPreFilterSearchPhase extends AbstractSearchAsyncAction<CanMa
             new CanMatchSearchPhaseResults(shardsIts.size()),
             shardsIts.size(),
             clusters,
-            searchRequestOperationsListener
+            searchRequestContext
         );
         this.phaseFactory = phaseFactory;
         this.shardsIts = shardsIts;

--- a/server/src/main/java/org/opensearch/action/search/SearchDfsQueryThenFetchAsyncAction.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchDfsQueryThenFetchAsyncAction.java
@@ -77,7 +77,7 @@ final class SearchDfsQueryThenFetchAsyncAction extends AbstractSearchAsyncAction
         final ClusterState clusterState,
         final SearchTask task,
         SearchResponse.Clusters clusters,
-        SearchRequestOperationsListener searchRequestOperationsListener
+        SearchRequestContext searchRequestContext
     ) {
         super(
             SearchPhaseName.DFS_PRE_QUERY.getName(),
@@ -97,7 +97,7 @@ final class SearchDfsQueryThenFetchAsyncAction extends AbstractSearchAsyncAction
             new ArraySearchPhaseResults<>(shardsIts.size()),
             request.getMaxConcurrentShardRequests(),
             clusters,
-            searchRequestOperationsListener
+            searchRequestContext
         );
         this.queryPhaseResultConsumer = queryPhaseResultConsumer;
         this.searchPhaseController = searchPhaseController;

--- a/server/src/main/java/org/opensearch/action/search/SearchQueryThenFetchAsyncAction.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchQueryThenFetchAsyncAction.java
@@ -82,7 +82,7 @@ class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<SearchPh
         ClusterState clusterState,
         SearchTask task,
         SearchResponse.Clusters clusters,
-        SearchRequestOperationsListener searchRequestOperationsListener
+        SearchRequestContext searchRequestContext
     ) {
         super(
             SearchPhaseName.QUERY.getName(),
@@ -102,7 +102,7 @@ class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<SearchPh
             resultConsumer,
             request.getMaxConcurrentShardRequests(),
             clusters,
-            searchRequestOperationsListener
+            searchRequestContext
         );
         this.topDocsSize = SearchPhaseController.getTopDocsSize(request);
         this.trackTotalHitsUpTo = request.resolveTrackTotalHitsUpTo();

--- a/server/src/main/java/org/opensearch/action/search/SearchRequestContext.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequestContext.java
@@ -1,0 +1,124 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.search;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.lucene.search.TotalHits;
+
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * This class holds request-level context for search queries at the coordinator node
+ *
+ * @opensearch.internal
+ */
+public class SearchRequestContext {
+    private final SearchRequestOperationsListener searchRequestOperationsListener;
+    private long absoluteStartNanos;
+    private final Map<String, Long> phaseTookMap;
+    private TotalHits totalHits;
+    private final EnumMap<ShardStatsFieldNames, Integer> shardStats;
+
+    /**
+     * This constructor is for testing only
+     */
+    public SearchRequestContext() {
+        this(new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()));
+    }
+
+    public SearchRequestContext(SearchRequestOperationsListener searchRequestOperationsListener) {
+        this.searchRequestOperationsListener = searchRequestOperationsListener;
+        this.absoluteStartNanos = System.nanoTime();
+        this.phaseTookMap = new HashMap<>();
+        this.shardStats = new EnumMap<>(ShardStatsFieldNames.class);
+    }
+
+    SearchRequestOperationsListener getSearchRequestOperationsListener() {
+        return searchRequestOperationsListener;
+    }
+
+    void updatePhaseTookMap(String phaseName, Long tookTime) {
+        this.phaseTookMap.put(phaseName, tookTime);
+    }
+
+    Map<String, Long> phaseTookMap() {
+        return phaseTookMap;
+    }
+
+    /**
+     * Override absoluteStartNanos set in constructor.
+     * For testing only
+     */
+    void setAbsoluteStartNanos(long absoluteStartNanos) {
+        this.absoluteStartNanos = absoluteStartNanos;
+    }
+
+    /**
+     * Request start time in nanos
+     */
+    long getAbsoluteStartNanos() {
+        return absoluteStartNanos;
+    }
+
+    void setTotalHits(TotalHits totalHits) {
+        this.totalHits = totalHits;
+    }
+
+    TotalHits totalHits() {
+        return totalHits;
+    }
+
+    void setShardStats(int total, int successful, int skipped, int failed) {
+        this.shardStats.put(ShardStatsFieldNames.SEARCH_REQUEST_SLOWLOG_SHARD_TOTAL, total);
+        this.shardStats.put(ShardStatsFieldNames.SEARCH_REQUEST_SLOWLOG_SHARD_SUCCESSFUL, successful);
+        this.shardStats.put(ShardStatsFieldNames.SEARCH_REQUEST_SLOWLOG_SHARD_SKIPPED, skipped);
+        this.shardStats.put(ShardStatsFieldNames.SEARCH_REQUEST_SLOWLOG_SHARD_FAILED, failed);
+    }
+
+    String formattedShardStats() {
+        if (shardStats.isEmpty()) {
+            return "";
+        } else {
+            return String.format(
+                Locale.ROOT,
+                "{%s:%s, %s:%s, %s:%s, %s:%s}",
+                ShardStatsFieldNames.SEARCH_REQUEST_SLOWLOG_SHARD_TOTAL.toString(),
+                shardStats.get(ShardStatsFieldNames.SEARCH_REQUEST_SLOWLOG_SHARD_TOTAL),
+                ShardStatsFieldNames.SEARCH_REQUEST_SLOWLOG_SHARD_SUCCESSFUL.toString(),
+                shardStats.get(ShardStatsFieldNames.SEARCH_REQUEST_SLOWLOG_SHARD_SUCCESSFUL),
+                ShardStatsFieldNames.SEARCH_REQUEST_SLOWLOG_SHARD_SKIPPED.toString(),
+                shardStats.get(ShardStatsFieldNames.SEARCH_REQUEST_SLOWLOG_SHARD_SKIPPED),
+                ShardStatsFieldNames.SEARCH_REQUEST_SLOWLOG_SHARD_FAILED.toString(),
+                shardStats.get(ShardStatsFieldNames.SEARCH_REQUEST_SLOWLOG_SHARD_FAILED)
+            );
+        }
+    }
+}
+
+enum ShardStatsFieldNames {
+    SEARCH_REQUEST_SLOWLOG_SHARD_TOTAL("total"),
+    SEARCH_REQUEST_SLOWLOG_SHARD_SUCCESSFUL("successful"),
+    SEARCH_REQUEST_SLOWLOG_SHARD_SKIPPED("skipped"),
+    SEARCH_REQUEST_SLOWLOG_SHARD_FAILED("failed");
+
+    private final String name;
+
+    ShardStatsFieldNames(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return this.name;
+    }
+}

--- a/server/src/main/java/org/opensearch/action/search/SearchRequestOperationsListener.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequestOperationsListener.java
@@ -22,9 +22,13 @@ public interface SearchRequestOperationsListener {
 
     void onPhaseStart(SearchPhaseContext context);
 
-    void onPhaseEnd(SearchPhaseContext context);
+    void onPhaseEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext);
 
     void onPhaseFailure(SearchPhaseContext context);
+
+    default void onRequestStart(SearchRequestContext searchRequestContext) {}
+
+    default void onRequestEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext) {}
 
     /**
      * Holder of Composite Listeners
@@ -53,10 +57,10 @@ public interface SearchRequestOperationsListener {
         }
 
         @Override
-        public void onPhaseEnd(SearchPhaseContext context) {
+        public void onPhaseEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
             for (SearchRequestOperationsListener listener : listeners) {
                 try {
-                    listener.onPhaseEnd(context);
+                    listener.onPhaseEnd(context, searchRequestContext);
                 } catch (Exception e) {
                     logger.warn(() -> new ParameterizedMessage("onPhaseEnd listener [{}] failed", listener), e);
                 }
@@ -70,6 +74,28 @@ public interface SearchRequestOperationsListener {
                     listener.onPhaseFailure(context);
                 } catch (Exception e) {
                     logger.warn(() -> new ParameterizedMessage("onPhaseFailure listener [{}] failed", listener), e);
+                }
+            }
+        }
+
+        @Override
+        public void onRequestStart(SearchRequestContext searchRequestContext) {
+            for (SearchRequestOperationsListener listener : listeners) {
+                try {
+                    listener.onRequestStart(searchRequestContext);
+                } catch (Exception e) {
+                    logger.warn(() -> new ParameterizedMessage("onRequestStart listener [{}] failed", listener), e);
+                }
+            }
+        }
+
+        @Override
+        public void onRequestEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
+            for (SearchRequestOperationsListener listener : listeners) {
+                try {
+                    listener.onRequestEnd(context, searchRequestContext);
+                } catch (Exception e) {
+                    logger.warn(() -> new ParameterizedMessage("onRequestEnd listener [{}] failed", listener), e);
                 }
             }
         }

--- a/server/src/main/java/org/opensearch/action/search/SearchRequestSlowLog.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequestSlowLog.java
@@ -1,0 +1,273 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.action.search;
+
+import com.fasterxml.jackson.core.io.JsonStringEncoder;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.logging.Loggers;
+import org.opensearch.common.logging.OpenSearchLogMessage;
+import org.opensearch.common.logging.SlowLogLevel;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.tasks.Task;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * The request-level search slow log implementation
+ *
+ * @opensearch.internal
+ */
+public final class SearchRequestSlowLog implements SearchRequestOperationsListener {
+    private static final Charset UTF_8 = StandardCharsets.UTF_8;
+
+    private long warnThreshold;
+    private long infoThreshold;
+    private long debugThreshold;
+    private long traceThreshold;
+    private SlowLogLevel level;
+
+    private final Logger logger;
+
+    static final String CLUSTER_SEARCH_REQUEST_SLOWLOG_PREFIX = "cluster.search.request.slowlog";
+
+    public static final Setting<TimeValue> CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_WARN_SETTING = Setting.timeSetting(
+        CLUSTER_SEARCH_REQUEST_SLOWLOG_PREFIX + ".threshold.warn",
+        TimeValue.timeValueNanos(-1),
+        TimeValue.timeValueMillis(-1),
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+    public static final Setting<TimeValue> CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_INFO_SETTING = Setting.timeSetting(
+        CLUSTER_SEARCH_REQUEST_SLOWLOG_PREFIX + ".threshold.info",
+        TimeValue.timeValueNanos(-1),
+        TimeValue.timeValueMillis(-1),
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+    public static final Setting<TimeValue> CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_DEBUG_SETTING = Setting.timeSetting(
+        CLUSTER_SEARCH_REQUEST_SLOWLOG_PREFIX + ".threshold.debug",
+        TimeValue.timeValueNanos(-1),
+        TimeValue.timeValueMillis(-1),
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+    public static final Setting<TimeValue> CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_TRACE_SETTING = Setting.timeSetting(
+        CLUSTER_SEARCH_REQUEST_SLOWLOG_PREFIX + ".threshold.trace",
+        TimeValue.timeValueNanos(-1),
+        TimeValue.timeValueMillis(-1),
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+    public static final Setting<SlowLogLevel> CLUSTER_SEARCH_REQUEST_SLOWLOG_LEVEL = new Setting<>(
+        CLUSTER_SEARCH_REQUEST_SLOWLOG_PREFIX + ".level",
+        SlowLogLevel.TRACE.name(),
+        SlowLogLevel::parse,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    private static final ToXContent.Params FORMAT_PARAMS = new ToXContent.MapParams(Collections.singletonMap("pretty", "false"));
+
+    public SearchRequestSlowLog(ClusterService clusterService) {
+        this(clusterService, LogManager.getLogger(CLUSTER_SEARCH_REQUEST_SLOWLOG_PREFIX)); // logger configured in log4j2.properties
+    }
+
+    SearchRequestSlowLog(ClusterService clusterService, Logger logger) {
+        this.logger = logger;
+        Loggers.setLevel(this.logger, SlowLogLevel.TRACE.name());
+
+        this.warnThreshold = clusterService.getClusterSettings().get(CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_WARN_SETTING).nanos();
+        this.infoThreshold = clusterService.getClusterSettings().get(CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_INFO_SETTING).nanos();
+        this.debugThreshold = clusterService.getClusterSettings().get(CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_DEBUG_SETTING).nanos();
+        this.traceThreshold = clusterService.getClusterSettings().get(CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_TRACE_SETTING).nanos();
+        this.level = clusterService.getClusterSettings().get(CLUSTER_SEARCH_REQUEST_SLOWLOG_LEVEL);
+
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_WARN_SETTING, this::setWarnThreshold);
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_INFO_SETTING, this::setInfoThreshold);
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_DEBUG_SETTING, this::setDebugThreshold);
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_TRACE_SETTING, this::setTraceThreshold);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(CLUSTER_SEARCH_REQUEST_SLOWLOG_LEVEL, this::setLevel);
+    }
+
+    @Override
+    public void onPhaseStart(SearchPhaseContext context) {}
+
+    @Override
+    public void onPhaseEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext) {}
+
+    @Override
+    public void onPhaseFailure(SearchPhaseContext context) {}
+
+    @Override
+    public void onRequestStart(SearchRequestContext searchRequestContext) {}
+
+    @Override
+    public void onRequestEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
+        long tookInNanos = System.nanoTime() - searchRequestContext.getAbsoluteStartNanos();
+
+        if (warnThreshold >= 0 && tookInNanos > warnThreshold && level.isLevelEnabledFor(SlowLogLevel.WARN)) {
+            logger.warn(new SearchRequestSlowLogMessage(context, tookInNanos, searchRequestContext));
+        } else if (infoThreshold >= 0 && tookInNanos > infoThreshold && level.isLevelEnabledFor(SlowLogLevel.INFO)) {
+            logger.info(new SearchRequestSlowLogMessage(context, tookInNanos, searchRequestContext));
+        } else if (debugThreshold >= 0 && tookInNanos > debugThreshold && level.isLevelEnabledFor(SlowLogLevel.DEBUG)) {
+            logger.debug(new SearchRequestSlowLogMessage(context, tookInNanos, searchRequestContext));
+        } else if (traceThreshold >= 0 && tookInNanos > traceThreshold && level.isLevelEnabledFor(SlowLogLevel.TRACE)) {
+            logger.trace(new SearchRequestSlowLogMessage(context, tookInNanos, searchRequestContext));
+        }
+    }
+
+    /**
+     * Search request slow log message
+     *
+     * @opensearch.internal
+     */
+    static final class SearchRequestSlowLogMessage extends OpenSearchLogMessage {
+
+        SearchRequestSlowLogMessage(SearchPhaseContext context, long tookInNanos, SearchRequestContext searchRequestContext) {
+            super(prepareMap(context, tookInNanos, searchRequestContext), message(context, tookInNanos, searchRequestContext));
+        }
+
+        private static Map<String, Object> prepareMap(
+            SearchPhaseContext context,
+            long tookInNanos,
+            SearchRequestContext searchRequestContext
+        ) {
+            final Map<String, Object> messageFields = new HashMap<>();
+            messageFields.put("took", TimeValue.timeValueNanos(tookInNanos));
+            messageFields.put("took_millis", TimeUnit.NANOSECONDS.toMillis(tookInNanos));
+            messageFields.put("phase_took", searchRequestContext.phaseTookMap().toString());
+            if (searchRequestContext.totalHits() != null) {
+                messageFields.put("total_hits", searchRequestContext.totalHits());
+            } else {
+                messageFields.put("total_hits", "-1");
+            }
+            messageFields.put("search_type", context.getRequest().searchType());
+            messageFields.put("shards", searchRequestContext.formattedShardStats());
+
+            if (context.getRequest().source() != null) {
+                String source = escapeJson(context.getRequest().source().toString(FORMAT_PARAMS));
+                messageFields.put("source", source);
+            } else {
+                messageFields.put("source", "{}");
+            }
+
+            messageFields.put("id", context.getTask().getHeader(Task.X_OPAQUE_ID));
+            return messageFields;
+        }
+
+        // Message will be used in plaintext logs
+        private static String message(SearchPhaseContext context, long tookInNanos, SearchRequestContext searchRequestContext) {
+            final StringBuilder sb = new StringBuilder();
+            sb.append("took[").append(TimeValue.timeValueNanos(tookInNanos)).append("], ");
+            sb.append("took_millis[").append(TimeUnit.NANOSECONDS.toMillis(tookInNanos)).append("], ");
+            sb.append("phase_took_millis[").append(searchRequestContext.phaseTookMap().toString()).append("], ");
+            if (searchRequestContext.totalHits() != null) {
+                sb.append("total_hits[").append(searchRequestContext.totalHits()).append("], ");
+            } else {
+                sb.append("total_hits[-1]");
+            }
+            sb.append("search_type[").append(context.getRequest().searchType()).append("], ");
+            sb.append("shards[").append(searchRequestContext.formattedShardStats()).append("], ");
+            if (context.getRequest().source() != null) {
+                sb.append("source[").append(context.getRequest().source().toString(FORMAT_PARAMS)).append("], ");
+            } else {
+                sb.append("source[], ");
+            }
+            if (context.getTask().getHeader(Task.X_OPAQUE_ID) != null) {
+                sb.append("id[").append(context.getTask().getHeader(Task.X_OPAQUE_ID)).append("]");
+            } else {
+                sb.append("id[]");
+            }
+            return sb.toString();
+        }
+
+        private static String escapeJson(String text) {
+            byte[] sourceEscaped = JsonStringEncoder.getInstance().quoteAsUTF8(text);
+            return new String(sourceEscaped, UTF_8);
+        }
+    }
+
+    void setWarnThreshold(TimeValue warnThreshold) {
+        this.warnThreshold = warnThreshold.nanos();
+    }
+
+    void setInfoThreshold(TimeValue infoThreshold) {
+        this.infoThreshold = infoThreshold.nanos();
+    }
+
+    void setDebugThreshold(TimeValue debugThreshold) {
+        this.debugThreshold = debugThreshold.nanos();
+    }
+
+    void setTraceThreshold(TimeValue traceThreshold) {
+        this.traceThreshold = traceThreshold.nanos();
+    }
+
+    void setLevel(SlowLogLevel level) {
+        this.level = level;
+    }
+
+    protected long getWarnThreshold() {
+        return warnThreshold;
+    }
+
+    protected long getInfoThreshold() {
+        return infoThreshold;
+    }
+
+    protected long getDebugThreshold() {
+        return debugThreshold;
+    }
+
+    protected long getTraceThreshold() {
+        return traceThreshold;
+    }
+
+    SlowLogLevel getLevel() {
+        return level;
+    }
+}

--- a/server/src/main/java/org/opensearch/action/search/SearchRequestStats.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequestStats.java
@@ -51,7 +51,7 @@ public final class SearchRequestStats implements SearchRequestOperationsListener
     }
 
     @Override
-    public void onPhaseEnd(SearchPhaseContext context) {
+    public void onPhaseEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
         StatsHolder phaseStats = phaseStatsMap.get(context.getCurrentPhase().getSearchPhaseName());
         phaseStats.current.dec();
         phaseStats.total.inc();

--- a/server/src/main/java/org/opensearch/common/logging/SlowLogLevel.java
+++ b/server/src/main/java/org/opensearch/common/logging/SlowLogLevel.java
@@ -29,7 +29,7 @@
  * GitHub history for details.
  */
 
-package org.opensearch.index;
+package org.opensearch.common.logging;
 
 import java.util.Locale;
 
@@ -54,7 +54,7 @@ public enum SlowLogLevel {
         return valueOf(level.toUpperCase(Locale.ROOT));
     }
 
-    boolean isLevelEnabledFor(SlowLogLevel levelToBeUsed) {
+    public boolean isLevelEnabledFor(SlowLogLevel levelToBeUsed) {
         // example: this.info(2) tries to log with levelToBeUsed.warn(3) - should allow
         return this.specificity <= levelToBeUsed.specificity;
     }

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -35,6 +35,7 @@ import org.apache.logging.log4j.LogManager;
 import org.opensearch.action.admin.cluster.configuration.TransportAddVotingConfigExclusionsAction;
 import org.opensearch.action.admin.indices.close.TransportCloseIndexAction;
 import org.opensearch.action.search.CreatePitController;
+import org.opensearch.action.search.SearchRequestSlowLog;
 import org.opensearch.action.search.TransportSearchAction;
 import org.opensearch.action.support.AutoCreateIndex;
 import org.opensearch.action.support.DestructiveOperations;
@@ -680,6 +681,13 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 // Related to monitoring of task cancellation
                 TaskCancellationMonitoringSettings.IS_ENABLED_SETTING,
                 TaskCancellationMonitoringSettings.DURATION_MILLIS_SETTING,
+
+                // Search request slow log settings
+                SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_WARN_SETTING,
+                SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_INFO_SETTING,
+                SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_DEBUG_SETTING,
+                SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_TRACE_SETTING,
+                SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_LEVEL,
 
                 // Remote cluster state settings
                 RemoteClusterStateService.REMOTE_CLUSTER_STATE_ENABLED_SETTING,

--- a/server/src/main/java/org/opensearch/index/IndexingSlowLog.java
+++ b/server/src/main/java/org/opensearch/index/IndexingSlowLog.java
@@ -38,6 +38,7 @@ import org.apache.logging.log4j.util.StringBuilders;
 import org.opensearch.common.Booleans;
 import org.opensearch.common.logging.Loggers;
 import org.opensearch.common.logging.OpenSearchLogMessage;
+import org.opensearch.common.logging.SlowLogLevel;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.common.unit.TimeValue;

--- a/server/src/main/java/org/opensearch/index/SearchSlowLog.java
+++ b/server/src/main/java/org/opensearch/index/SearchSlowLog.java
@@ -38,6 +38,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.common.logging.Loggers;
 import org.opensearch.common.logging.OpenSearchLogMessage;
+import org.opensearch.common.logging.SlowLogLevel;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.common.unit.TimeValue;

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -46,6 +46,7 @@ import org.opensearch.action.ActionType;
 import org.opensearch.action.admin.cluster.snapshots.status.TransportNodesSnapshotsStatus;
 import org.opensearch.action.search.SearchExecutionStatsCollector;
 import org.opensearch.action.search.SearchPhaseController;
+import org.opensearch.action.search.SearchRequestSlowLog;
 import org.opensearch.action.search.SearchRequestStats;
 import org.opensearch.action.search.SearchTransportService;
 import org.opensearch.action.support.TransportAction;
@@ -792,6 +793,7 @@ public class Node implements Closeable {
             );
 
             final SearchRequestStats searchRequestStats = new SearchRequestStats();
+            final SearchRequestSlowLog searchRequestSlowLog = new SearchRequestSlowLog(clusterService);
 
             remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(clusterService, settings);
             final IndicesService indicesService = new IndicesService(
@@ -1263,6 +1265,7 @@ public class Node implements Closeable {
                 b.bind(IdentityService.class).toInstance(identityService);
                 b.bind(Tracer.class).toInstance(tracer);
                 b.bind(SearchRequestStats.class).toInstance(searchRequestStats);
+                b.bind(SearchRequestSlowLog.class).toInstance(searchRequestSlowLog);
                 b.bind(MetricsRegistry.class).toInstance(metricsRegistry);
                 b.bind(RemoteClusterStateService.class).toProvider(() -> remoteClusterStateService);
                 b.bind(PersistedStateRegistry.class).toInstance(persistedStateRegistry);

--- a/server/src/test/java/org/opensearch/action/search/AbstractSearchAsyncActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/AbstractSearchAsyncActionTests.java
@@ -175,7 +175,7 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
             results,
             request.getMaxConcurrentShardRequests(),
             SearchResponse.Clusters.EMPTY,
-            null
+            new SearchRequestContext()
         ) {
             @Override
             protected SearchPhase getNextPhase(final SearchPhaseResults<SearchPhaseResult> results, SearchPhaseContext context) {
@@ -710,7 +710,7 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
             null,
             task,
             SearchResponse.Clusters.EMPTY,
-            new SearchRequestOperationsListener.CompositeListener(searchRequestOperationsListeners, logger)
+            new SearchRequestContext(new SearchRequestOperationsListener.CompositeListener(searchRequestOperationsListeners, logger))
         );
     }
 
@@ -760,7 +760,7 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
             null,
             task,
             SearchResponse.Clusters.EMPTY,
-            new SearchRequestOperationsListener.CompositeListener(searchRequestOperationsListeners, logger)
+            new SearchRequestContext(new SearchRequestOperationsListener.CompositeListener(searchRequestOperationsListeners, logger))
         ) {
             @Override
             ShardSearchFailure[] buildShardFailures() {

--- a/server/src/test/java/org/opensearch/action/search/CanMatchPreFilterSearchPhaseTests.java
+++ b/server/src/test/java/org/opensearch/action/search/CanMatchPreFilterSearchPhaseTests.java
@@ -137,7 +137,7 @@ public class CanMatchPreFilterSearchPhaseTests extends OpenSearchTestCase {
                 }
             },
             SearchResponse.Clusters.EMPTY,
-            null
+            new SearchRequestContext()
         );
 
         canMatchPhase.start();
@@ -229,7 +229,7 @@ public class CanMatchPreFilterSearchPhaseTests extends OpenSearchTestCase {
                 }
             },
             SearchResponse.Clusters.EMPTY,
-            null
+            new SearchRequestContext()
         );
 
         canMatchPhase.start();
@@ -320,7 +320,7 @@ public class CanMatchPreFilterSearchPhaseTests extends OpenSearchTestCase {
                 new ArraySearchPhaseResults<>(iter.size()),
                 randomIntBetween(1, 32),
                 SearchResponse.Clusters.EMPTY,
-                null
+                new SearchRequestContext()
             ) {
 
                 @Override
@@ -348,7 +348,7 @@ public class CanMatchPreFilterSearchPhaseTests extends OpenSearchTestCase {
                 }
             },
             SearchResponse.Clusters.EMPTY,
-            null
+            new SearchRequestContext()
         );
 
         canMatchPhase.start();
@@ -433,7 +433,7 @@ public class CanMatchPreFilterSearchPhaseTests extends OpenSearchTestCase {
                     }
                 },
                 SearchResponse.Clusters.EMPTY,
-                null
+                new SearchRequestContext()
             );
 
             canMatchPhase.start();
@@ -533,7 +533,7 @@ public class CanMatchPreFilterSearchPhaseTests extends OpenSearchTestCase {
                     }
                 },
                 SearchResponse.Clusters.EMPTY,
-                null
+                new SearchRequestContext()
             );
 
             canMatchPhase.start();

--- a/server/src/test/java/org/opensearch/action/search/MockSearchPhaseContext.java
+++ b/server/src/test/java/org/opensearch/action/search/MockSearchPhaseContext.java
@@ -65,11 +65,16 @@ public final class MockSearchPhaseContext implements SearchPhaseContext {
     final List<ShardSearchFailure> failures = Collections.synchronizedList(new ArrayList<>());
     SearchTransportService searchTransport;
     final Set<ShardSearchContextId> releasedSearchContexts = new HashSet<>();
-    final SearchRequest searchRequest = new SearchRequest();
+    final SearchRequest searchRequest;
     final AtomicReference<SearchResponse> searchResponse = new AtomicReference<>();
 
     public MockSearchPhaseContext(int numShards) {
+        this(numShards, new SearchRequest());
+    }
+
+    public MockSearchPhaseContext(int numShards, SearchRequest searchRequest) {
         this.numShards = numShards;
+        this.searchRequest = searchRequest;
         numSuccess = new AtomicInteger(numShards);
     }
 

--- a/server/src/test/java/org/opensearch/action/search/SearchAsyncActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchAsyncActionTests.java
@@ -136,7 +136,7 @@ public class SearchAsyncActionTests extends OpenSearchTestCase {
             new ArraySearchPhaseResults<>(shardsIter.size()),
             request.getMaxConcurrentShardRequests(),
             SearchResponse.Clusters.EMPTY,
-            null
+            new SearchRequestContext()
         ) {
 
             @Override
@@ -255,7 +255,7 @@ public class SearchAsyncActionTests extends OpenSearchTestCase {
             new ArraySearchPhaseResults<>(shardsIter.size()),
             request.getMaxConcurrentShardRequests(),
             SearchResponse.Clusters.EMPTY,
-            null
+            new SearchRequestContext()
         ) {
 
             @Override
@@ -373,7 +373,7 @@ public class SearchAsyncActionTests extends OpenSearchTestCase {
             new ArraySearchPhaseResults<>(shardsIter.size()),
             request.getMaxConcurrentShardRequests(),
             SearchResponse.Clusters.EMPTY,
-            null
+            new SearchRequestContext()
         ) {
             TestSearchResponse response = new TestSearchResponse();
 
@@ -496,7 +496,7 @@ public class SearchAsyncActionTests extends OpenSearchTestCase {
             new ArraySearchPhaseResults<>(shardsIter.size()),
             request.getMaxConcurrentShardRequests(),
             SearchResponse.Clusters.EMPTY,
-            null
+            new SearchRequestContext()
         ) {
             TestSearchResponse response = new TestSearchResponse();
 
@@ -610,7 +610,7 @@ public class SearchAsyncActionTests extends OpenSearchTestCase {
             new ArraySearchPhaseResults<>(shardsIter.size()),
             request.getMaxConcurrentShardRequests(),
             SearchResponse.Clusters.EMPTY,
-            null
+            new SearchRequestContext()
         ) {
             @Override
             protected void executePhaseOnShard(

--- a/server/src/test/java/org/opensearch/action/search/SearchQueryThenFetchAsyncActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchQueryThenFetchAsyncActionTests.java
@@ -215,7 +215,7 @@ public class SearchQueryThenFetchAsyncActionTests extends OpenSearchTestCase {
             null,
             task,
             SearchResponse.Clusters.EMPTY,
-            null
+            new SearchRequestContext()
         ) {
             @Override
             protected SearchPhase getNextPhase(SearchPhaseResults<SearchPhaseResult> results, SearchPhaseContext context) {

--- a/server/src/test/java/org/opensearch/action/search/SearchRequestOperationsListenerTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchRequestOperationsListenerTests.java
@@ -34,7 +34,7 @@ public class SearchRequestOperationsListenerTests extends OpenSearchTestCase {
             }
 
             @Override
-            public void onPhaseEnd(SearchPhaseContext context) {
+            public void onPhaseEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
                 searchPhaseMap.get(context.getCurrentPhase().getSearchPhaseName()).current.dec();
                 searchPhaseMap.get(context.getCurrentPhase().getSearchPhaseName()).total.inc();
             }

--- a/server/src/test/java/org/opensearch/action/search/SearchRequestSlowLogTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchRequestSlowLogTests.java
@@ -1,0 +1,410 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.action.search;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.lucene.search.TotalHits;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.logging.Loggers;
+import org.opensearch.common.logging.MockAppender;
+import org.opensearch.common.logging.SlowLogLevel;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Phaser;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasToString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SearchRequestSlowLogTests extends OpenSearchTestCase {
+    static MockAppender appender;
+    static Logger logger = LogManager.getLogger(SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_PREFIX + ".SearchRequestSlowLog");
+
+    @BeforeClass
+    public static void init() throws IllegalAccessException {
+        appender = new MockAppender("trace_appender");
+        appender.start();
+        Loggers.addAppender(logger, appender);
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        Loggers.removeAppender(logger, appender);
+        appender.stop();
+    }
+
+    public void testMultipleSlowLoggersUseSingleLog4jLogger() {
+        LoggerContext context = (LoggerContext) LogManager.getContext(false);
+
+        SearchPhaseContext searchPhaseContext1 = new MockSearchPhaseContext(1);
+        ClusterService clusterService1 = new ClusterService(
+            Settings.EMPTY,
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+            null
+        );
+        SearchRequestSlowLog searchRequestSlowLog1 = new SearchRequestSlowLog(clusterService1);
+        int numberOfLoggersBefore = context.getLoggers().size();
+
+        SearchPhaseContext searchPhaseContext2 = new MockSearchPhaseContext(1);
+        ClusterService clusterService2 = new ClusterService(
+            Settings.EMPTY,
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+            null
+        );
+        SearchRequestSlowLog searchRequestSlowLog2 = new SearchRequestSlowLog(clusterService2);
+
+        int numberOfLoggersAfter = context.getLoggers().size();
+        assertThat(numberOfLoggersAfter, equalTo(numberOfLoggersBefore));
+    }
+
+    public void testOnRequestEnd() throws InterruptedException {
+        final Logger logger = mock(Logger.class);
+        final SearchRequestContext searchRequestContext = mock(SearchRequestContext.class);
+        final SearchPhaseContext searchPhaseContext = mock(SearchPhaseContext.class);
+        final SearchRequest searchRequest = mock(SearchRequest.class);
+        final SearchTask searchTask = mock(SearchTask.class);
+
+        Settings.Builder settingsBuilder = Settings.builder();
+        settingsBuilder.put(SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_INFO_SETTING.getKey(), "0ms");
+        settingsBuilder.put(SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_DEBUG_SETTING.getKey(), "0ms");
+        settingsBuilder.put(SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_TRACE_SETTING.getKey(), "0ms");
+        Settings settings = settingsBuilder.build();
+        ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        ClusterService clusterService = new ClusterService(settings, clusterSettings, null);
+        SearchRequestSlowLog searchRequestSlowLog = new SearchRequestSlowLog(clusterService, logger);
+        final List<SearchRequestOperationsListener> searchListenersList = new ArrayList<>(List.of(searchRequestSlowLog));
+
+        when(searchRequestContext.getSearchRequestOperationsListener()).thenReturn(
+            new SearchRequestOperationsListener.CompositeListener(searchListenersList, logger)
+        );
+        when(searchRequestContext.getAbsoluteStartNanos()).thenReturn(System.nanoTime() - 1L);
+        when(searchPhaseContext.getRequest()).thenReturn(searchRequest);
+        when(searchPhaseContext.getTask()).thenReturn(searchTask);
+        when(searchRequest.searchType()).thenReturn(SearchType.QUERY_THEN_FETCH);
+
+        searchRequestContext.getSearchRequestOperationsListener().onRequestEnd(searchPhaseContext, searchRequestContext);
+
+        verify(logger, never()).warn(any(SearchRequestSlowLog.SearchRequestSlowLogMessage.class));
+        verify(logger, times(1)).info(any(SearchRequestSlowLog.SearchRequestSlowLogMessage.class));
+        verify(logger, never()).debug(any(SearchRequestSlowLog.SearchRequestSlowLogMessage.class));
+        verify(logger, never()).trace(any(SearchRequestSlowLog.SearchRequestSlowLogMessage.class));
+    }
+
+    public void testConcurrentOnRequestEnd() throws InterruptedException {
+        final Logger logger = mock(Logger.class);
+        final SearchPhaseContext searchPhaseContext = mock(SearchPhaseContext.class);
+        final SearchRequest searchRequest = mock(SearchRequest.class);
+        final SearchTask searchTask = mock(SearchTask.class);
+
+        Settings.Builder settingsBuilder = Settings.builder();
+        settingsBuilder.put(SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_WARN_SETTING.getKey(), "-1");
+        settingsBuilder.put(SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_INFO_SETTING.getKey(), "10s");
+        settingsBuilder.put(SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_DEBUG_SETTING.getKey(), "-1");
+        settingsBuilder.put(SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_TRACE_SETTING.getKey(), "-1");
+        Settings settings = settingsBuilder.build();
+        ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        ClusterService clusterService = new ClusterService(settings, clusterSettings, null);
+        SearchRequestSlowLog searchRequestSlowLog = new SearchRequestSlowLog(clusterService, logger);
+        final List<SearchRequestOperationsListener> searchListenersList = new ArrayList<>(List.of(searchRequestSlowLog));
+
+        when(searchPhaseContext.getRequest()).thenReturn(searchRequest);
+        when(searchPhaseContext.getTask()).thenReturn(searchTask);
+        when(searchRequest.searchType()).thenReturn(SearchType.QUERY_THEN_FETCH);
+
+        int numRequests = 50;
+        int numRequestsLogged = randomIntBetween(0, 50);
+        Thread[] threads = new Thread[numRequests];
+        Phaser phaser = new Phaser(numRequests + 1);
+        CountDownLatch countDownLatch = new CountDownLatch(numRequests);
+
+        // create a list of SearchRequestContexts
+        // each SearchRequestContext contains unique composite SearchRequestOperationsListener
+        ArrayList<SearchRequestContext> searchRequestContexts = new ArrayList<>();
+        for (int i = 0; i < numRequests; i++) {
+            SearchRequestContext searchRequestContext = new SearchRequestContext(
+                new SearchRequestOperationsListener.CompositeListener(searchListenersList, logger)
+            );
+            searchRequestContext.setAbsoluteStartNanos((i < numRequestsLogged) ? 0 : System.nanoTime());
+            searchRequestContexts.add(searchRequestContext);
+        }
+
+        for (int i = 0; i < numRequests; i++) {
+            int finalI = i;
+            threads[i] = new Thread(() -> {
+                phaser.arriveAndAwaitAdvance();
+                SearchRequestContext thisContext = searchRequestContexts.get(finalI);
+                thisContext.getSearchRequestOperationsListener().onRequestEnd(searchPhaseContext, thisContext);
+                countDownLatch.countDown();
+            });
+            threads[i].start();
+        }
+        phaser.arriveAndAwaitAdvance();
+        countDownLatch.await();
+
+        verify(logger, never()).warn(any(SearchRequestSlowLog.SearchRequestSlowLogMessage.class));
+        verify(logger, times(numRequestsLogged)).info(any(SearchRequestSlowLog.SearchRequestSlowLogMessage.class));
+        verify(logger, never()).debug(any(SearchRequestSlowLog.SearchRequestSlowLogMessage.class));
+        verify(logger, never()).trace(any(SearchRequestSlowLog.SearchRequestSlowLogMessage.class));
+    }
+
+    public void testSearchRequestSlowLogHasJsonFields_EmptySearchRequestContext() throws IOException {
+        SearchSourceBuilder source = SearchSourceBuilder.searchSource().query(QueryBuilders.matchAllQuery());
+        SearchRequest searchRequest = new SearchRequest().source(source);
+        SearchPhaseContext searchPhaseContext = new MockSearchPhaseContext(1, searchRequest);
+        SearchRequestContext searchRequestContext = new SearchRequestContext();
+        SearchRequestSlowLog.SearchRequestSlowLogMessage p = new SearchRequestSlowLog.SearchRequestSlowLogMessage(
+            searchPhaseContext,
+            10,
+            searchRequestContext
+        );
+
+        assertThat(p.getValueFor("took"), equalTo("10nanos"));
+        assertThat(p.getValueFor("took_millis"), equalTo("0"));
+        assertThat(p.getValueFor("phase_took"), equalTo("{}"));
+        assertThat(p.getValueFor("total_hits"), equalTo("-1"));
+        assertThat(p.getValueFor("search_type"), equalTo("QUERY_THEN_FETCH"));
+        assertThat(p.getValueFor("shards"), equalTo(""));
+        assertThat(p.getValueFor("source"), equalTo("{\\\"query\\\":{\\\"match_all\\\":{\\\"boost\\\":1.0}}}"));
+        assertThat(p.getValueFor("id"), equalTo(null));
+    }
+
+    public void testSearchRequestSlowLogHasJsonFields_NotEmptySearchRequestContext() throws IOException {
+        SearchSourceBuilder source = SearchSourceBuilder.searchSource().query(QueryBuilders.matchAllQuery());
+        SearchRequest searchRequest = new SearchRequest().source(source);
+        SearchPhaseContext searchPhaseContext = new MockSearchPhaseContext(1, searchRequest);
+        SearchRequestContext searchRequestContext = new SearchRequestContext();
+        searchRequestContext.updatePhaseTookMap(SearchPhaseName.FETCH.getName(), 10L);
+        searchRequestContext.updatePhaseTookMap(SearchPhaseName.QUERY.getName(), 50L);
+        searchRequestContext.updatePhaseTookMap(SearchPhaseName.EXPAND.getName(), 5L);
+        searchRequestContext.setTotalHits(new TotalHits(3L, TotalHits.Relation.EQUAL_TO));
+        searchRequestContext.setShardStats(10, 8, 1, 1);
+        SearchRequestSlowLog.SearchRequestSlowLogMessage p = new SearchRequestSlowLog.SearchRequestSlowLogMessage(
+            searchPhaseContext,
+            10,
+            searchRequestContext
+        );
+
+        assertThat(p.getValueFor("took"), equalTo("10nanos"));
+        assertThat(p.getValueFor("took_millis"), equalTo("0"));
+        assertThat(p.getValueFor("phase_took"), equalTo("{expand=5, fetch=10, query=50}"));
+        assertThat(p.getValueFor("total_hits"), equalTo("3 hits"));
+        assertThat(p.getValueFor("search_type"), equalTo("QUERY_THEN_FETCH"));
+        assertThat(p.getValueFor("shards"), equalTo("{total:10, successful:8, skipped:1, failed:1}"));
+        assertThat(p.getValueFor("source"), equalTo("{\\\"query\\\":{\\\"match_all\\\":{\\\"boost\\\":1.0}}}"));
+        assertThat(p.getValueFor("id"), equalTo(null));
+    }
+
+    public void testSearchRequestSlowLogHasJsonFields_PartialContext() throws IOException {
+        SearchSourceBuilder source = SearchSourceBuilder.searchSource().query(QueryBuilders.matchAllQuery());
+        SearchRequest searchRequest = new SearchRequest().source(source);
+        SearchPhaseContext searchPhaseContext = new MockSearchPhaseContext(1, searchRequest);
+        SearchRequestContext searchRequestContext = new SearchRequestContext();
+        searchRequestContext.updatePhaseTookMap(SearchPhaseName.FETCH.getName(), 10L);
+        searchRequestContext.updatePhaseTookMap(SearchPhaseName.QUERY.getName(), 50L);
+        searchRequestContext.updatePhaseTookMap(SearchPhaseName.EXPAND.getName(), 5L);
+        searchRequestContext.setTotalHits(new TotalHits(3L, TotalHits.Relation.EQUAL_TO));
+        searchRequestContext.setShardStats(5, 3, 1, 1);
+        SearchRequestSlowLog.SearchRequestSlowLogMessage p = new SearchRequestSlowLog.SearchRequestSlowLogMessage(
+            searchPhaseContext,
+            10000000000L,
+            searchRequestContext
+        );
+
+        assertThat(p.getValueFor("took"), equalTo("10s"));
+        assertThat(p.getValueFor("took_millis"), equalTo("10000"));
+        assertThat(p.getValueFor("phase_took"), equalTo("{expand=5, fetch=10, query=50}"));
+        assertThat(p.getValueFor("total_hits"), equalTo("3 hits"));
+        assertThat(p.getValueFor("search_type"), equalTo("QUERY_THEN_FETCH"));
+        assertThat(p.getValueFor("shards"), equalTo("{total:5, successful:3, skipped:1, failed:1}"));
+        assertThat(p.getValueFor("source"), equalTo("{\\\"query\\\":{\\\"match_all\\\":{\\\"boost\\\":1.0}}}"));
+        assertThat(p.getValueFor("id"), equalTo(null));
+    }
+
+    public void testSearchRequestSlowLogSearchContextPrinterToLog() throws IOException {
+        SearchSourceBuilder source = SearchSourceBuilder.searchSource().query(QueryBuilders.matchAllQuery());
+        SearchRequest searchRequest = new SearchRequest().source(source);
+        SearchPhaseContext searchPhaseContext = new MockSearchPhaseContext(1, searchRequest);
+        SearchRequestContext searchRequestContext = new SearchRequestContext();
+        searchRequestContext.updatePhaseTookMap(SearchPhaseName.FETCH.getName(), 10L);
+        searchRequestContext.updatePhaseTookMap(SearchPhaseName.QUERY.getName(), 50L);
+        searchRequestContext.updatePhaseTookMap(SearchPhaseName.EXPAND.getName(), 5L);
+        searchRequestContext.setTotalHits(new TotalHits(3L, TotalHits.Relation.EQUAL_TO));
+        searchRequestContext.setShardStats(10, 8, 1, 1);
+        SearchRequestSlowLog.SearchRequestSlowLogMessage p = new SearchRequestSlowLog.SearchRequestSlowLogMessage(
+            searchPhaseContext,
+            100000,
+            searchRequestContext
+        );
+
+        assertThat(p.getFormattedMessage(), startsWith("took[100micros]"));
+        assertThat(p.getFormattedMessage(), containsString("took_millis[0]"));
+        assertThat(p.getFormattedMessage(), containsString("phase_took_millis[{expand=5, fetch=10, query=50}]"));
+        assertThat(p.getFormattedMessage(), containsString("total_hits[3 hits]"));
+        assertThat(p.getFormattedMessage(), containsString("search_type[QUERY_THEN_FETCH]"));
+        assertThat(p.getFormattedMessage(), containsString("shards[{total:10, successful:8, skipped:1, failed:1}]"));
+        assertThat(p.getFormattedMessage(), containsString("source[{\"query\":{\"match_all\":{\"boost\":1.0}}}]"));
+        // Makes sure that output doesn't contain any new lines
+        assertThat(p.getFormattedMessage(), not(containsString("\n")));
+        assertThat(p.getFormattedMessage(), endsWith("id[]"));
+    }
+
+    public void testLevelSettingWarn() {
+        SlowLogLevel level = SlowLogLevel.WARN;
+        Settings.Builder settingsBuilder = Settings.builder();
+        settingsBuilder.put(SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_LEVEL.getKey(), level);
+        Settings settings = settingsBuilder.build();
+        ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        ClusterService clusterService = new ClusterService(settings, clusterSettings, null);
+        SearchRequestSlowLog searchRequestSlowLog = new SearchRequestSlowLog(clusterService);
+        assertEquals(level, searchRequestSlowLog.getLevel());
+    }
+
+    public void testLevelSettingDebug() {
+        String level = "DEBUG";
+        Settings.Builder settingsBuilder = Settings.builder();
+        settingsBuilder.put(SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_LEVEL.getKey(), level);
+        Settings settings = settingsBuilder.build();
+        ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        ClusterService clusterService = new ClusterService(settings, clusterSettings, null);
+        SearchRequestSlowLog searchRequestSlowLog = new SearchRequestSlowLog(clusterService);
+        assertEquals(level, searchRequestSlowLog.getLevel().toString());
+    }
+
+    public void testLevelSettingFail() {
+        String level = "NOT A LEVEL";
+        Settings.Builder settingsBuilder = Settings.builder();
+        settingsBuilder.put(SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_LEVEL.getKey(), level);
+        Settings settings = settingsBuilder.build();
+        ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        ClusterService clusterService = new ClusterService(settings, clusterSettings, null);
+
+        try {
+            new SearchRequestSlowLog(clusterService);
+            fail();
+        } catch (IllegalArgumentException ex) {
+            final String expected = "No enum constant org.opensearch.common.logging.SlowLogLevel.NOT A LEVEL";
+            assertThat(ex, hasToString(containsString(expected)));
+            assertThat(ex, instanceOf(IllegalArgumentException.class));
+        }
+    }
+
+    public void testSetThresholds() {
+        Settings.Builder settingsBuilder = Settings.builder();
+        settingsBuilder.put(SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_WARN_SETTING.getKey(), "400ms");
+        settingsBuilder.put(SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_INFO_SETTING.getKey(), "300ms");
+        settingsBuilder.put(SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_DEBUG_SETTING.getKey(), "200ms");
+        settingsBuilder.put(SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_TRACE_SETTING.getKey(), "100ms");
+        Settings settings = settingsBuilder.build();
+        ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        ClusterService clusterService = new ClusterService(settings, clusterSettings, null);
+        SearchRequestSlowLog searchRequestSlowLog = new SearchRequestSlowLog(clusterService);
+        assertEquals(TimeValue.timeValueMillis(400).nanos(), searchRequestSlowLog.getWarnThreshold());
+        assertEquals(TimeValue.timeValueMillis(300).nanos(), searchRequestSlowLog.getInfoThreshold());
+        assertEquals(TimeValue.timeValueMillis(200).nanos(), searchRequestSlowLog.getDebugThreshold());
+        assertEquals(TimeValue.timeValueMillis(100).nanos(), searchRequestSlowLog.getTraceThreshold());
+        assertEquals(SlowLogLevel.TRACE, searchRequestSlowLog.getLevel());
+    }
+
+    public void testSetThresholdsUnits() {
+        Settings.Builder settingsBuilder = Settings.builder();
+        settingsBuilder.put(SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_WARN_SETTING.getKey(), "400s");
+        settingsBuilder.put(SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_INFO_SETTING.getKey(), "300ms");
+        settingsBuilder.put(SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_DEBUG_SETTING.getKey(), "200micros");
+        settingsBuilder.put(SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_TRACE_SETTING.getKey(), "100nanos");
+        Settings settings = settingsBuilder.build();
+        ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        ClusterService clusterService = new ClusterService(settings, clusterSettings, null);
+        SearchRequestSlowLog searchRequestSlowLog = new SearchRequestSlowLog(clusterService);
+        assertEquals(TimeValue.timeValueSeconds(400).nanos(), searchRequestSlowLog.getWarnThreshold());
+        assertEquals(TimeValue.timeValueMillis(300).nanos(), searchRequestSlowLog.getInfoThreshold());
+        assertEquals(TimeValue.timeValueNanos(200000).nanos(), searchRequestSlowLog.getDebugThreshold());
+        assertEquals(TimeValue.timeValueNanos(100).nanos(), searchRequestSlowLog.getTraceThreshold());
+        assertEquals(SlowLogLevel.TRACE, searchRequestSlowLog.getLevel());
+    }
+
+    public void testSetThresholdsDefaults() {
+        Settings.Builder settingsBuilder = Settings.builder();
+        settingsBuilder.put(SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_WARN_SETTING.getKey(), "400ms");
+        settingsBuilder.put(SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_DEBUG_SETTING.getKey(), "200ms");
+        Settings settings = settingsBuilder.build();
+        ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        ClusterService clusterService = new ClusterService(settings, clusterSettings, null);
+        SearchRequestSlowLog searchRequestSlowLog = new SearchRequestSlowLog(clusterService);
+        assertEquals(TimeValue.timeValueMillis(400).nanos(), searchRequestSlowLog.getWarnThreshold());
+        assertEquals(TimeValue.timeValueMillis(-1).nanos(), searchRequestSlowLog.getInfoThreshold());
+        assertEquals(TimeValue.timeValueMillis(200).nanos(), searchRequestSlowLog.getDebugThreshold());
+        assertEquals(TimeValue.timeValueMillis(-1).nanos(), searchRequestSlowLog.getTraceThreshold());
+        assertEquals(SlowLogLevel.TRACE, searchRequestSlowLog.getLevel());
+    }
+
+    public void testSetThresholdsError() {
+        Settings.Builder settingsBuilder = Settings.builder();
+        settingsBuilder.put(SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_THRESHOLD_WARN_SETTING.getKey(), "NOT A TIME VALUE");
+        Settings settings = settingsBuilder.build();
+        ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        ClusterService clusterService = new ClusterService(settings, clusterSettings, null);
+
+        try {
+            new SearchRequestSlowLog(clusterService);
+            fail();
+        } catch (IllegalArgumentException ex) {
+            final String expected =
+                "failed to parse setting [cluster.search.request.slowlog.threshold.warn] with value [NOT A TIME VALUE] as a time value";
+            assertThat(ex, hasToString(containsString(expected)));
+            assertThat(ex, instanceOf(IllegalArgumentException.class));
+        }
+    }
+}

--- a/server/src/test/java/org/opensearch/action/search/SearchRequestStatsTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchRequestStatsTests.java
@@ -50,7 +50,7 @@ public class SearchRequestStatsTests extends OpenSearchTestCase {
             long startTime = System.nanoTime() - TimeUnit.MILLISECONDS.toNanos(tookTimeInMillis);
             when(mockSearchPhase.getStartTimeInNanos()).thenReturn(startTime);
             assertEquals(1, testRequestStats.getPhaseCurrent(searchPhaseName));
-            testRequestStats.onPhaseEnd(ctx);
+            testRequestStats.onPhaseEnd(ctx, new SearchRequestContext());
             assertEquals(0, testRequestStats.getPhaseCurrent(searchPhaseName));
             assertEquals(1, testRequestStats.getPhaseTotal(searchPhaseName));
             assertThat(testRequestStats.getPhaseMetric(searchPhaseName), greaterThanOrEqualTo(tookTimeInMillis));
@@ -102,7 +102,7 @@ public class SearchRequestStatsTests extends OpenSearchTestCase {
             for (int i = 0; i < numTasks; i++) {
                 threads[i] = new Thread(() -> {
                     phaser.arriveAndAwaitAdvance();
-                    testRequestStats.onPhaseEnd(ctx);
+                    testRequestStats.onPhaseEnd(ctx, new SearchRequestContext());
                     countDownLatch.countDown();
                 });
                 threads[i].start();

--- a/server/src/test/java/org/opensearch/action/search/SearchTimeProviderTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchTimeProviderTests.java
@@ -47,7 +47,7 @@ public class SearchTimeProviderTests extends OpenSearchTestCase {
             long startTime = System.nanoTime() - TimeUnit.MILLISECONDS.toNanos(tookTimeInMillis);
             when(mockSearchPhase.getStartTimeInNanos()).thenReturn(startTime);
             assertNull(testTimeProvider.getPhaseTookTime(searchPhaseName));
-            testTimeProvider.onPhaseEnd(ctx);
+            testTimeProvider.onPhaseEnd(ctx, new SearchRequestContext());
             assertThat(testTimeProvider.getPhaseTookTime(searchPhaseName), greaterThanOrEqualTo(tookTimeInMillis));
         }
     }

--- a/server/src/test/java/org/opensearch/index/IndexingSlowLogTests.java
+++ b/server/src/test/java/org/opensearch/index/IndexingSlowLogTests.java
@@ -44,6 +44,7 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.logging.Loggers;
 import org.opensearch.common.logging.MockAppender;
+import org.opensearch.common.logging.SlowLogLevel;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.json.JsonXContent;
@@ -412,7 +413,7 @@ public class IndexingSlowLogTests extends OpenSearchTestCase {
             assertNotNull(ex.getCause());
             assertThat(ex.getCause(), instanceOf(IllegalArgumentException.class));
             final IllegalArgumentException cause = (IllegalArgumentException) ex.getCause();
-            assertThat(cause, hasToString(containsString("No enum constant org.opensearch.index.SlowLogLevel.NOT A LEVEL")));
+            assertThat(cause, hasToString(containsString("No enum constant org.opensearch.common.logging.SlowLogLevel.NOT A LEVEL")));
         }
         assertEquals(SlowLogLevel.TRACE, log.getLevel());
 

--- a/server/src/test/java/org/opensearch/index/SearchSlowLogTests.java
+++ b/server/src/test/java/org/opensearch/index/SearchSlowLogTests.java
@@ -41,6 +41,7 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.logging.Loggers;
 import org.opensearch.common.logging.MockAppender;
+import org.opensearch.common.logging.SlowLogLevel;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.BigArrays;
@@ -337,7 +338,7 @@ public class SearchSlowLogTests extends OpenSearchSingleNodeTestCase {
             assertNotNull(ex.getCause());
             assertThat(ex.getCause(), instanceOf(IllegalArgumentException.class));
             final IllegalArgumentException cause = (IllegalArgumentException) ex.getCause();
-            assertThat(cause, hasToString(containsString("No enum constant org.opensearch.index.SlowLogLevel.NOT A LEVEL")));
+            assertThat(cause, hasToString(containsString("No enum constant org.opensearch.common.logging.SlowLogLevel.NOT A LEVEL")));
         }
         assertEquals(SlowLogLevel.TRACE, log.getLevel());
 

--- a/server/src/test/java/org/opensearch/index/SlowLogLevelTests.java
+++ b/server/src/test/java/org/opensearch/index/SlowLogLevelTests.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.index;
 
+import org.opensearch.common.logging.SlowLogLevel;
 import org.opensearch.test.OpenSearchTestCase;
 
 public class SlowLogLevelTests extends OpenSearchTestCase {

--- a/server/src/test/java/org/opensearch/index/search/stats/SearchStatsTests.java
+++ b/server/src/test/java/org/opensearch/index/search/stats/SearchStatsTests.java
@@ -35,6 +35,7 @@ package org.opensearch.index.search.stats;
 import org.opensearch.action.search.SearchPhase;
 import org.opensearch.action.search.SearchPhaseContext;
 import org.opensearch.action.search.SearchPhaseName;
+import org.opensearch.action.search.SearchRequestContext;
 import org.opensearch.action.search.SearchRequestStats;
 import org.opensearch.index.search.stats.SearchStats.Stats;
 import org.opensearch.test.OpenSearchTestCase;
@@ -85,7 +86,7 @@ public class SearchStatsTests extends OpenSearchTestCase {
             when(mockSearchPhase.getSearchPhaseName()).thenReturn(searchPhaseName);
             for (int iterator = 0; iterator < paramValue; iterator++) {
                 testRequestStats.onPhaseStart(ctx);
-                testRequestStats.onPhaseEnd(ctx);
+                testRequestStats.onPhaseEnd(ctx, new SearchRequestContext());
             }
         }
         searchStats1.setSearchRequestStats(testRequestStats);

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -90,6 +90,7 @@ import org.opensearch.action.search.SearchAction;
 import org.opensearch.action.search.SearchExecutionStatsCollector;
 import org.opensearch.action.search.SearchPhaseController;
 import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchRequestSlowLog;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchTransportService;
 import org.opensearch.action.search.TransportSearchAction;
@@ -2309,6 +2310,7 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                             client
                         ),
                         null,
+                        new SearchRequestSlowLog(clusterService),
                         NoopMetricsRegistry.INSTANCE
                     )
                 );


### PR DESCRIPTION
### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/9642
Documentation PR: https://github.com/opensearch-project/documentation-website/pull/5298

### Description
Slow logs at coordinator level: As of now, we only have the capability to enable slow logs at a shard level for desired search phase(query and fetch). See [this](https://opensearch.org/docs/1.2/opensearch/logs/#slow-logs). Setting this threshold is tricky when customer usually sees latency spikes at a request level. Plus shard level slow logs doesn't offer a holistic view. So as part of this, we will also add capabilities to capture slow logs at a request level along with different search phases from coordinator node perspective.

Coordinator slow logs are governed by cluster settings.
```
// Setting on a whole request level
cluster.search.request.slowlog.threshold.warn: 10s
cluster.search.request.slowlog.threshold.info: 5s
cluster.search.request.slowlog.threshold.debug: 2s
cluster.search.request.slowlog.threshold.trace: 500ms

// Minimum level to print
cluster.search.request.slowlog.level: "trace"
```

Sample SearchRequestSlowLog:
```
% cat runTask_index_search_slowlog.log
[2023-10-27T11:38:06,741][TRACE][c.s.r.slowlog] [runTask-0] took[119.5ms], took_millis[119], phase_took_millis[{expand=0, query=76, fetch=24}], total_hits[1 hits], search_type[QUERY_THEN_FETCH], shards[{total: 10, successful: 10, skipped: 0, failed: 0}], source[{"query":{"query_string":{"query":"value1","fields":[],"type":"best_fields","default_operator":"or","max_determinized_states":10000,"enable_position_increments":true,"fuzziness":"AUTO","fuzzy_prefix_length":0,"fuzzy_max_expansions":50,"phrase_slop":0,"escape":false,"auto_generate_synonyms_phrase_query":true,"fuzzy_transpositions":true,"boost":1.0}}}], id[]
```
```
% cat runTask_index_search_slowlog.json | jq
{
  "type": "search_request_slowlog",
  "timestamp": "2023-10-27T11:38:06,741-07:00",
  "level": "TRACE",
  "component": "c.s.r.slowlog",
  "cluster.name": "runTask",
  "node.name": "runTask-0",
  "took": "119.5ms",
  "took_millis": "119",
  "phase_took": "{expand=0, query=76, fetch=24}",
  "total_hits": "1 hits",
  "search_type": "QUERY_THEN_FETCH",
  "shards": "{total: 10, successful: 10, skipped: 0, failed: 0}",
  "source": "{\"query\":{\"query_string\":{\"query\":\"value1\",\"fields\":[],\"type\":\"best_fields\",\"default_operator\":\"or\",\"max_determinized_states\":10000,\"enable_position_increments\":true,\"fuzziness\":\"AUTO\",\"fuzzy_prefix_length\":0,\"fuzzy_max_expansions\":50,\"phrase_slop\":0,\"escape\":false,\"auto_generate_synonyms_phrase_query\":true,\"fuzzy_transpositions\":true,\"boost\":1.0}}}",
  "cluster.uuid": "iH0dDisEQFar-1ZyfD_vjw",
  "node.id": "AR_pfXWRSm-di2Ru8aaruQ"
}
```

Thresholds are set based on total search duration, but logs include phase-level breakdown.

### Testing
1. Launch local OpenSearch server with debugger
https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md#launching-and-debugging-from-an-ide
```
./gradlew run --debug-jvm
```

2. Create an index and ingest some data
```
curl -X PUT "localhost:9200/test2?pretty" -H 'Content-Type: application/json' -d' 
{                                                
  "settings": {
    "number_of_shards": 10
  }
}'

curl -X POST "localhost:9200/_bulk?pretty" -H 'Content-Type: application/json' -d'
{ "index" : { "_index" : "test2", "_id" : "1" } }
{ "field1" : "value1" }                          
{ "index" : { "_index" : "test2", "_id" : "2" } }
{ "field2" : "value2" }
{ "index" : { "_index" : "test2", "_id" : "3" } }
{ "field3" : "value3" }
{ "index" : { "_index" : "test2", "_id" : "4" } }
{ "field4" : "value4" }
'
```

3. Update and verify cluster setting
```
curl -X PUT "localhost:9200/_cluster/settings" -H 'Content-Type: application/json' -d '{"transient" : {"cluster.search.request.slowlog.threshold.trace" : "0ms"}}'
curl -X GET "localhost:9200/_cluster/settings?pretty&flat_settings"
```

4. Search request
```
curl -XGET 'localhost:9200/_search?pretty' -H 'Content-Type: application/json' -d'
{
 "query": { "query_string": { "query": "abc" } }
}'
```

5. Check output in OpenSearch server tab

### Performance Tests
x% increase in P50, P90, P99 latency observed when logging **all requests**.
No significant impact to P50, P90, P99 latency observed when logging **no requests** (all searches under log threshold).

Procedure:
1. Spin up localhost OpenSearch cluster
```
./gradlew run
```
2. Update slowlog threshold cluster setting
```
curl -X PUT "localhost:9200/_cluster/settings" -H 'Content-Type: application/json' -d '{"transient" : {"cluster.search.request.slowlog.threshold.trace" : "0ms"}}'
curl -X GET "localhost:9200/_cluster/settings?pretty&flat_settings"
```
3. Run opensearch-benchmark nyc_taxis workload
```
opensearch-benchmark execute-test --workload-path=./nyc_taxis --pipeline=benchmark-only --client-options="basic_auth_user:'admin',basic_auth_password:'Admin_123'" --results-file=/tmp/output.txt
```

**Results**
Main | 50th percentile latency | 90th percentile latency | 99th percentile latency
-- | -- | -- | --
1 | 6.45966 | 7.16774 | 12.2049
2 | 7.14608 | 8.80989 | 14.7602
3 | 6.23131 | 9.04382 | 15.4128
4 | 6.7432 | 8.19057 | 11.8496
5 | 6.92057 | 8.19506 | 9.92856
6 | 6.01713 | 7.73637 | 10.7374
7 | 6.21754 | 7.18561 | 8.82464
8 | 7.15195 | 8.22125 | 12.5205
9 | 5.51498 | 7.36984 | 9.75166
10 | 7.6733 | 8.25051 | 11.0328
Mean | 6.60757 | 8.01707 | 11.70231
St Dev | 0.64087 | 0.64559 | 2.12586

Slowlog Off (-1 threshold) | 50th percentile latency | 90th percentile latency | 99th percentile latency
-- | -- | -- | --
1 | 7.14947 | 8.37281 | 12.2798
2 | 7.52558 | 8.81152 | 15.9566
3 | 6.53822 | 7.56006 | 10.7598
4 | 8.16498 | 8.82595 | 11.5625
5 | 7.20736 | 8.58643 | 10.4346
6 | 6.43303 | 8.07587 | 8.72964
7 | 6.73321 | 8.41968 | 9.49111
8 | 6.72711 | 8.32944 | 14.8351
9 | 6.53244 | 7.71201 | 16.0138
10 | 6.46849 | 7.6002 | 9.50796
Mean | 6.94799 | 8.2294 | 11.95709
St Dev | 0.56304 | 0.47424 | 2.73339

Slowlog On (0ms thresold) | 50th percentile latency | 90th percentile latency | 99th percentile latency
-- | -- | -- | --
1 | 7.69207 | 9.87628 | 13.73330
2 | 6.76473 | 7.63000 | 9.31518
3 | 6.28997 | 9.05151 | 16.19130
4 | 6.81525 | 8.31300 | 17.52860
5 | 7.74137 | 8.48340 | 10.63630
6 | 6.77349 | 8.65474 | 11.93540
7 | 7.31905 | 8.94366 | 15.39660
8 | 7.78096 | 8.90685 | 11.84000
9 | 6.36214 | 8.52370 | 15.33980
10 | 6.56414 | 8.96694 | 12.39780
Mean | 7.01032 | 8.73501 | 13.43143
St Dev | 0.57552 | 0.58148 | 2.63721

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
