### PR TITLE
OnBehalfOf claims take second duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Allow mmap to use new JDK-19 preview APIs in Apache Lucene 9.4+ ([#5151](https://github.com/opensearch-project/OpenSearch/pull/5151))
 - Add events correlation engine plugin ([#6854](https://github.com/opensearch-project/OpenSearch/issues/6854))
 - Introduce new dynamic cluster setting to control slice computation for concurrent segment search ([#9107](https://github.com/opensearch-project/OpenSearch/pull/9107))
-- Implement on behalf of token passing for extensions ([#8679](https://github.com/opensearch-project/OpenSearch/pull/8679))
+- Implement on behalf of token passing for extensions ([#8679](https://github.com/opensearch-project/OpenSearch/pull/8679), [#10664](https://github.com/opensearch-project/OpenSearch/pull/10664))
 - Provide service accounts tokens to extensions ([#9618](https://github.com/opensearch-project/OpenSearch/pull/9618))
 - [Admission control] Add enhancements to FS stats to include read/write time, queue size and IO time ([#10541](https://github.com/opensearch-project/OpenSearch/pull/10541))
 - [Admission control] Add Resource usage collector service and resource usage tracker  ([#9890](https://github.com/opensearch-project/OpenSearch/pull/9890))

--- a/server/src/main/java/org/opensearch/identity/tokens/AuthToken.java
+++ b/server/src/main/java/org/opensearch/identity/tokens/AuthToken.java
@@ -16,4 +16,5 @@ package org.opensearch.identity.tokens;
 public interface AuthToken {
 
     String asAuthHeaderValue();
+
 }

--- a/server/src/main/java/org/opensearch/identity/tokens/OnBehalfOfClaims.java
+++ b/server/src/main/java/org/opensearch/identity/tokens/OnBehalfOfClaims.java
@@ -23,7 +23,7 @@ public class OnBehalfOfClaims {
      * Constructor for OnBehalfOfClaims
      * @param aud the Audience for the token
      * @param subject the subject of the token
-     * @param expiration the expiration time in seconds for the token
+     * @param expiration the length of time in seconds the token is valid
      * @param not_before the not_before time in seconds for the token
      * @param issued_at the issued_at time in seconds for the token
      */
@@ -62,7 +62,7 @@ public class OnBehalfOfClaims {
      * @param subject the subject of the token
      */
     public OnBehalfOfClaims(String aud, String subject) {
-        this(aud, subject, System.currentTimeMillis() / 1000 + 300);
+        this(aud, subject, 300L);
     }
 
     public String getAudience() {

--- a/server/src/main/java/org/opensearch/identity/tokens/OnBehalfOfClaims.java
+++ b/server/src/main/java/org/opensearch/identity/tokens/OnBehalfOfClaims.java
@@ -40,7 +40,6 @@ public class OnBehalfOfClaims {
         return audience;
     }
 
-
     public Long getExpiration() {
         return expiration_seconds;
     }

--- a/server/src/main/java/org/opensearch/identity/tokens/OnBehalfOfClaims.java
+++ b/server/src/main/java/org/opensearch/identity/tokens/OnBehalfOfClaims.java
@@ -14,46 +14,17 @@ package org.opensearch.identity.tokens;
 public class OnBehalfOfClaims {
 
     private final String audience;
-    private final String subject;
-    private final Long expiration;
-    private final Long not_before;
-    private final Long issued_at;
+    private final Long expiration_seconds;
 
     /**
      * Constructor for OnBehalfOfClaims
      * @param aud the Audience for the token
-     * @param subject the subject of the token
-     * @param expiration the length of time in seconds the token is valid
-     * @param not_before the not_before time in seconds for the token
-     * @param issued_at the issued_at time in seconds for the token
+     * @param expiration_seconds the length of time in seconds the token is valid
+
      */
-    public OnBehalfOfClaims(String aud, String subject, Long expiration, Long not_before, Long issued_at) {
+    public OnBehalfOfClaims(String aud, Long expiration_seconds) {
         this.audience = aud;
-        this.subject = subject;
-        this.expiration = expiration;
-        this.not_before = not_before;
-        this.issued_at = issued_at;
-    }
-
-    /**
-     * A constructor that sets a default issued at time of the current time
-     * @param aud the Audience for the token
-     * @param subject the subject of the token
-     * @param expiration the expiration time in seconds for the token
-     * @param not_before the not_before time in seconds for the token
-     */
-    public OnBehalfOfClaims(String aud, String subject, Long expiration, Long not_before) {
-        this(aud, subject, expiration, not_before, System.currentTimeMillis() / 1000);
-    }
-
-    /**
-     * A constructor which sets a default not before time of the current time
-     * @param aud the Audience for the token
-     * @param subject the subject of the token
-     * @param expiration the expiration time in seconds for the token
-     */
-    public OnBehalfOfClaims(String aud, String subject, Long expiration) {
-        this(aud, subject, expiration, System.currentTimeMillis() / 1000);
+        this.expiration_seconds = expiration_seconds;
     }
 
     /**
@@ -62,26 +33,15 @@ public class OnBehalfOfClaims {
      * @param subject the subject of the token
      */
     public OnBehalfOfClaims(String aud, String subject) {
-        this(aud, subject, 300L);
+        this(aud, 300L);
     }
 
     public String getAudience() {
         return audience;
     }
 
-    public String getSubject() {
-        return subject;
-    }
 
     public Long getExpiration() {
-        return expiration;
-    }
-
-    public Long getNot_before() {
-        return not_before;
-    }
-
-    public Long getIssued_at() {
-        return issued_at;
+        return expiration_seconds;
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This change swaps the OnBehalfOf claims provider in core in order to work with external token providers. Without this change, implementing the TokenManager class is not straightforward. We would force users to to provide an expiration _time_ (i.e. system time) when we want them to be able to provide a value in seconds and do the math for them. 


### Check List
- [ ] ~New functionality includes testing.~
  - [x] All tests pass
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
