### PR TITLE
Return unformatted Segment Replication metrics that take upload time into account for replication lag

### DIFF
--- a/server/src/main/java/org/opensearch/index/ReplicationStats.java
+++ b/server/src/main/java/org/opensearch/index/ReplicationStats.java
@@ -91,11 +91,5 @@ public class ReplicationStats implements ToXContentFragment, Writeable {
         static final String MAX_BYTES_BEHIND = "max_bytes_behind";
         static final String TOTAL_BYTES_BEHIND = "total_bytes_behind";
         static final String MAX_REPLICATION_LAG = "max_replication_lag";
-        static final String MAX_DATA_LAG = "max_data_lag";
-        static final String TOTAL_DATA_LAG = "total_data_lag";
-        static final String MAX_TIME_LAG = "max_time_lag";
-        static final String MAX_DATA_LAG_BYTES = "max_data_lag_in_bytes";
-        static final String TOTAL_DATA_LAG_BYTES = "total_data_lag_in_bytes";
-        static final String MAX_TIME_LAG_MILLIS = "max_time_lag_in_millis";
     }
 }

--- a/server/src/main/java/org/opensearch/index/ReplicationStats.java
+++ b/server/src/main/java/org/opensearch/index/ReplicationStats.java
@@ -79,6 +79,9 @@ public class ReplicationStats implements ToXContentFragment, Writeable {
         builder.field(Fields.MAX_BYTES_BEHIND, new ByteSizeValue(maxBytesBehind).toString());
         builder.field(Fields.TOTAL_BYTES_BEHIND, new ByteSizeValue(totalBytesBehind).toString());
         builder.field(Fields.MAX_REPLICATION_LAG, new TimeValue(maxReplicationLag));
+        builder.humanReadableField(Fields.MAX_DATA_LAG_BYTES, Fields.MAX_DATA_LAG, new ByteSizeValue(maxBytesBehind));
+        builder.humanReadableField(Fields.TOTAL_DATA_LAG_BYTES, Fields.TOTAL_DATA_LAG, new ByteSizeValue(totalBytesBehind));
+        builder.humanReadableField(Fields.MAX_TIME_LAG_MILLIS, Fields.MAX_TIME_LAG, new TimeValue(maxReplicationLag));
         builder.endObject();
         return builder;
     }
@@ -93,5 +96,11 @@ public class ReplicationStats implements ToXContentFragment, Writeable {
         static final String MAX_BYTES_BEHIND = "max_bytes_behind";
         static final String TOTAL_BYTES_BEHIND = "total_bytes_behind";
         static final String MAX_REPLICATION_LAG = "max_replication_lag";
+        static final String MAX_DATA_LAG = "max_data_lag";
+        static final String TOTAL_DATA_LAG = "total_data_lag";
+        static final String MAX_TIME_LAG = "max_time_lag";
+        static final String MAX_DATA_LAG_BYTES = "max_data_lag_in_bytes";
+        static final String TOTAL_DATA_LAG_BYTES = "total_data_lag_in_bytes";
+        static final String MAX_TIME_LAG_MILLIS = "max_time_lag_in_millis";
     }
 }

--- a/server/src/main/java/org/opensearch/index/ReplicationStats.java
+++ b/server/src/main/java/org/opensearch/index/ReplicationStats.java
@@ -8,11 +8,9 @@
 
 package org.opensearch.index;
 
-import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
-import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.core.xcontent.ToXContentFragment;
 import org.opensearch.core.xcontent.XContentBuilder;
 
@@ -76,12 +74,9 @@ public class ReplicationStats implements ToXContentFragment, Writeable {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(Fields.SEGMENT_REPLICATION);
-        builder.field(Fields.MAX_BYTES_BEHIND, new ByteSizeValue(maxBytesBehind).toString());
-        builder.field(Fields.TOTAL_BYTES_BEHIND, new ByteSizeValue(totalBytesBehind).toString());
-        builder.field(Fields.MAX_REPLICATION_LAG, new TimeValue(maxReplicationLag));
-        builder.humanReadableField(Fields.MAX_DATA_LAG_BYTES, Fields.MAX_DATA_LAG, new ByteSizeValue(maxBytesBehind));
-        builder.humanReadableField(Fields.TOTAL_DATA_LAG_BYTES, Fields.TOTAL_DATA_LAG, new ByteSizeValue(totalBytesBehind));
-        builder.humanReadableField(Fields.MAX_TIME_LAG_MILLIS, Fields.MAX_TIME_LAG, new TimeValue(maxReplicationLag));
+        builder.field(Fields.MAX_BYTES_BEHIND, maxBytesBehind);
+        builder.field(Fields.TOTAL_BYTES_BEHIND, totalBytesBehind);
+        builder.field(Fields.MAX_REPLICATION_LAG, maxReplicationLag);
         builder.endObject();
         return builder;
     }

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -3010,7 +3010,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             long maxBytesBehind = stats.stream().mapToLong(SegmentReplicationShardStats::getBytesBehindCount).max().orElse(0L);
             long totalBytesBehind = stats.stream().mapToLong(SegmentReplicationShardStats::getBytesBehindCount).sum();
             long maxReplicationLag = stats.stream()
-                .mapToLong(SegmentReplicationShardStats::getCurrentReplicationTimeMillis)
+                .mapToLong(SegmentReplicationShardStats::getCurrentReplicationLagMillis)
                 .max()
                 .orElse(0L);
             return new ReplicationStats(maxBytesBehind, totalBytesBehind, maxReplicationLag);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This change does 2 things: 

1. Returns segment replication stats metrics in an unformatted raw format unless requested in a human readable format (query parameter of human=true) 
2. The replication lag metric being returned `MAX_REPLICATION_LAG` now takes into account the total replication lag i.e., it now includes the time taken to upload data to the remote store. 

### Related Issues
Resolves #10666
Resolves #10722 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
