### PR TITLE
Override local disk state if we are able to restore from remote

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreClusterStateRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreClusterStateRestoreIT.java
@@ -88,43 +88,69 @@ public class RemoteStoreClusterStateRestoreIT extends BaseRemoteStoreRestoreIT {
         verifyRestoredData(indexStats, INDEX_NAME);
     }
 
+    /**
+     * This test scenario covers the case where right after remote state restore and persisting it to disk via LucenePersistedState, full cluster restarts.
+     * This is a special case for remote state as at this point cluster uuid in the restored state is still ClusterState.UNKNOWN_UUID as we persist it disk.
+     * After restart the local disk state will be read but should be again overridden with remote state.
+     *
+     * 1. Form a cluster and index few docs
+     * 2. Replace all nodes to remove all local disk state
+     * 3. Start cluster manager node without correct seeding to ensure local disk state is written with cluster uuid ClusterState.UNKNOWN_UUID but with remote restored Metadata
+     * 4. Restart the cluster manager node with correct seeding.
+     * 5. After restart the cluster manager picks up the local disk state with has same Metadata as remote but cluster uuid is still ClusterState.UNKNOWN_UUID
+     * 6. The cluster manager will try to restore from remote again.
+     * 7. Metadata loaded from local disk state will be overridden with remote Metadata and no conflict should arise.
+     * 8. Add data nodes to recover index data
+     * 9. Verify Metadata and index data is restored.
+     */
     public void testFullClusterStateRestore() throws Exception {
         int shardCount = randomIntBetween(1, 2);
         int replicaCount = 1;
         int dataNodeCount = shardCount * (replicaCount + 1);
         int clusterManagerNodeCount = 1;
 
-        // Step - 1 index some data to generate files in remote directory
+        // index some data to generate files in remote directory
         Map<String, Long> indexStats = initialTestSetup(shardCount, replicaCount, dataNodeCount, 1);
         String prevClusterUUID = clusterService().state().metadata().clusterUUID();
 
+        // stop all nodes
         internalCluster().stopAllNodes();
-        internalCluster().setAutoManageClusterManagerNodes(false);
-        internalCluster().startClusterManagerOnlyNodes(
-            clusterManagerNodeCount,
-            Settings.builder()
-                .putList(INITIAL_CLUSTER_MANAGER_NODES_SETTING.getKey()) // disable seeding during bootstrapping
-                .build()
-        );
-        String newClusterUUID = clusterService().state().metadata().clusterUUID();
-        assert Objects.equals(newClusterUUID, ClusterState.UNKNOWN_UUID) : "cluster restart not successful. cluster uuid is not _na_";
 
-        internalCluster().setAutoManageClusterManagerNodes(true);
+        // start a cluster manager node with no cluster manager seeding.
+        // This should fail with IllegalStateException as cluster manager fails to form without any initial seed
+        assertThrows(
+            IllegalStateException.class,
+            () -> internalCluster().startClusterManagerOnlyNodes(
+                clusterManagerNodeCount,
+                Settings.builder()
+                    .putList(INITIAL_CLUSTER_MANAGER_NODES_SETTING.getKey()) // disable seeding during bootstrapping
+                    .build()
+            )
+        );
+
+        // verify cluster manager not elected
+        String newClusterUUID = clusterService().state().metadata().clusterUUID();
+        assert Objects.equals(newClusterUUID, ClusterState.UNKNOWN_UUID)
+            : "Disabling Cluster manager seeding failed. cluster uuid is not unknown";
+
+        // restart cluster manager with correct seed
         internalCluster().fullRestart(new InternalTestCluster.RestartCallback() {
             @Override
             public Settings onNodeStopped(String nodeName) {
                 return Settings.builder()
-                    .putList(INITIAL_CLUSTER_MANAGER_NODES_SETTING.getKey(), nodeName)  // disable seeding
+                    .putList(INITIAL_CLUSTER_MANAGER_NODES_SETTING.getKey(), nodeName)  // Seed with correct Cluster Manager node
                     .build();
             }
         });
-        internalCluster().startDataOnlyNodes(dataNodeCount);
-        newClusterUUID = clusterService().state().metadata().clusterUUID();
-        assert !Objects.equals(newClusterUUID, ClusterState.UNKNOWN_UUID) : "cluster restart not successful. cluster uuid is still _na_";
-        assert !Objects.equals(newClusterUUID, prevClusterUUID) : "cluster restart not successful. cluster uuid is same";
 
-        // Step - 3 Trigger full cluster restore and validate
+        // validate new cluster state formed
+        newClusterUUID = clusterService().state().metadata().clusterUUID();
+        assert !Objects.equals(newClusterUUID, ClusterState.UNKNOWN_UUID) : "cluster restart not successful. cluster uuid is still unknown";
+        assert !Objects.equals(newClusterUUID, prevClusterUUID) : "cluster restart not successful. cluster uuid is same";
         validateMetadata(List.of(INDEX_NAME));
+
+        // start data nodes to trigger index data recovery
+        internalCluster().startDataOnlyNodes(dataNodeCount);
         verifyRestoredData(indexStats, INDEX_NAME);
     }
 

--- a/server/src/main/java/org/opensearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/opensearch/gateway/GatewayMetaState.java
@@ -160,15 +160,15 @@ public class GatewayMetaState implements Closeable {
                 try {
                     ClusterState clusterState = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.get(settings))
                         .version(lastAcceptedVersion)
-                        .metadata(metadata)
                         .build();
 
+                    boolean isRemoteStateRestored = false;
                     if (DiscoveryNode.isClusterManagerNode(settings) && isRemoteStoreClusterStateEnabled(settings)) {
+                        String lastKnownClusterUUID = ClusterState.UNKNOWN_UUID;
                         // If the cluster UUID loaded from local is unknown (_na_) then fetch the best state from remote
                         // If there is no valid state on remote, continue with initial empty state
                         // If there is a valid state, then restore index metadata using this state
-                        String lastKnownClusterUUID = ClusterState.UNKNOWN_UUID;
-                        if (ClusterState.UNKNOWN_UUID.equals(clusterState.metadata().clusterUUID())) {
+                        if (ClusterState.UNKNOWN_UUID.equals(metadata.clusterUUID())) {
                             lastKnownClusterUUID = remoteClusterStateService.getLastKnownUUIDFromRemote(
                                 clusterState.getClusterName().value()
                             );
@@ -181,9 +181,15 @@ public class GatewayMetaState implements Closeable {
                                     new String[] {}
                                 );
                                 clusterState = remoteRestoreResult.getClusterState();
+                                isRemoteStateRestored = true;
                             }
                         }
                         remotePersistedState = new RemotePersistedState(remoteClusterStateService, lastKnownClusterUUID);
+                    }
+
+                    if (isRemoteStateRestored == false) {
+                        // if we did not restore from remote, apply the local disk state.
+                        clusterState = ClusterState.builder(clusterState).metadata(metadata).build();
                     }
 
                     // Recovers Cluster and Index level blocks

--- a/server/src/main/java/org/opensearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/opensearch/gateway/GatewayMetaState.java
@@ -175,7 +175,6 @@ public class GatewayMetaState implements Closeable {
                             if (ClusterState.UNKNOWN_UUID.equals(lastKnownClusterUUID) == false) {
                                 // Load state from remote
                                 final RemoteRestoreResult remoteRestoreResult = remoteStoreRestoreService.restore(
-                                    // Override Metadata restored from local disk during remote state restore.
                                     // Remote Metadata should always override local disk Metadata
                                     // if local disk Metadata's cluster uuid is UNKNOWN_UUID
                                     ClusterState.builder(clusterState).metadata(Metadata.EMPTY_METADATA).build(),
@@ -553,7 +552,9 @@ public class GatewayMetaState implements Closeable {
             // out by this version of OpenSearch. TODO TBD should we avoid indexing when possible?
             final PersistedClusterStateService.Writer writer = persistedClusterStateService.createWriter();
             try {
-                // With Remote State we can write cluster state with non empty Metadata but UNKNOWN_UUID cluster uuid
+                // During remote state restore, there will be non empty metadata getting persisted with cluster UUID as
+                // ClusterState.UNKOWN_UUID . The valid UUID will be generated and persisted along with the first cluster state getting
+                // published.
                 writer.writeFullStateAndCommit(currentTerm, lastAcceptedState);
             } catch (Exception e) {
                 try {

--- a/server/src/main/java/org/opensearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/opensearch/gateway/GatewayMetaState.java
@@ -164,11 +164,11 @@ public class GatewayMetaState implements Closeable {
                         .build();
 
                     if (DiscoveryNode.isClusterManagerNode(settings) && isRemoteStoreClusterStateEnabled(settings)) {
-                        String lastKnownClusterUUID = ClusterState.UNKNOWN_UUID;
                         // If the cluster UUID loaded from local is unknown (_na_) then fetch the best state from remote
                         // If there is no valid state on remote, continue with initial empty state
                         // If there is a valid state, then restore index metadata using this state
-                        if (ClusterState.UNKNOWN_UUID.equals(metadata.clusterUUID())) {
+                        String lastKnownClusterUUID = ClusterState.UNKNOWN_UUID;
+                        if (ClusterState.UNKNOWN_UUID.equals(clusterState.metadata().clusterUUID())) {
                             lastKnownClusterUUID = remoteClusterStateService.getLastKnownUUIDFromRemote(
                                 clusterState.getClusterName().value()
                             );
@@ -553,6 +553,7 @@ public class GatewayMetaState implements Closeable {
             // out by this version of OpenSearch. TODO TBD should we avoid indexing when possible?
             final PersistedClusterStateService.Writer writer = persistedClusterStateService.createWriter();
             try {
+                // With Remote State we can write cluster state with non empty Metadata but UNKNOWN_UUID cluster uuid
                 writer.writeFullStateAndCommit(currentTerm, lastAcceptedState);
             } catch (Exception e) {
                 try {

--- a/server/src/main/java/org/opensearch/index/recovery/RemoteStoreRestoreService.java
+++ b/server/src/main/java/org/opensearch/index/recovery/RemoteStoreRestoreService.java
@@ -161,7 +161,7 @@ public class RemoteStoreRestoreService {
                 IndexMetadata indexMetadata = currentState.metadata().index(indexName);
                 if (indexMetadata == null) {
                     logger.warn("Index restore is not supported for non-existent index. Skipping: {}", indexName);
-                } else if (indexMetadata.getSettings().getAsBoolean(SETTING_REMOTE_STORE_ENABLED, false)) {
+                } else if (indexMetadata.getSettings().getAsBoolean(SETTING_REMOTE_STORE_ENABLED, false) == false) {
                     logger.warn("Remote store is not enabled for index: {}", indexName);
                 } else if (restoreAllShards && IndexMetadata.State.CLOSE.equals(indexMetadata.getState()) == false) {
                     throw new IllegalStateException(

--- a/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
@@ -266,7 +266,7 @@ public final class InternalTestCluster extends TestCluster {
 
     private final ExecutorService executor;
 
-    private final boolean autoManageClusterManagerNodes;
+    private boolean autoManageClusterManagerNodes;
 
     private final Collection<Class<? extends Plugin>> mockPlugins;
 
@@ -475,6 +475,10 @@ public final class InternalTestCluster extends TestCluster {
             : "bootstrapClusterManagerNodeIndex should be -1 if autoManageClusterManagerNodes is true, but was "
                 + bootstrapClusterManagerNodeIndex;
         this.bootstrapClusterManagerNodeIndex = bootstrapClusterManagerNodeIndex;
+    }
+
+    public void setAutoManageClusterManagerNodes(boolean autoManageClusterManagerNodes) {
+        this.autoManageClusterManagerNodes = autoManageClusterManagerNodes;
     }
 
     @Override

--- a/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
@@ -266,7 +266,7 @@ public final class InternalTestCluster extends TestCluster {
 
     private final ExecutorService executor;
 
-    private boolean autoManageClusterManagerNodes;
+    private final boolean autoManageClusterManagerNodes;
 
     private final Collection<Class<? extends Plugin>> mockPlugins;
 
@@ -475,10 +475,6 @@ public final class InternalTestCluster extends TestCluster {
             : "bootstrapClusterManagerNodeIndex should be -1 if autoManageClusterManagerNodes is true, but was "
                 + bootstrapClusterManagerNodeIndex;
         this.bootstrapClusterManagerNodeIndex = bootstrapClusterManagerNodeIndex;
-    }
-
-    public void setAutoManageClusterManagerNodes(boolean autoManageClusterManagerNodes) {
-        this.autoManageClusterManagerNodes = autoManageClusterManagerNodes;
     }
 
     @Override


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
- Immediately after remote state restore, we write restored state to disk with UNKNOWN_UUID cluster uuid. 
- This leads to issues if process restarts before committing newly generated state with valid uuid to disk
- Now, If restart happens before performing a new write to disk with valid cluster uuid, the auto restore fails with conflicting states in remote and local disk. 
- Please find more details in the linked issue

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/10776

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
