### PR TITLE
Removed unnecessary catch statement

### DIFF
--- a/server/src/main/java/org/opensearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/opensearch/gateway/GatewayMetaState.java
@@ -67,7 +67,6 @@ import org.opensearch.index.recovery.RemoteStoreRestoreService;
 import org.opensearch.index.recovery.RemoteStoreRestoreService.RemoteRestoreResult;
 import org.opensearch.node.Node;
 import org.opensearch.plugins.MetadataUpgrader;
-import org.opensearch.repositories.RepositoryMissingException;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 

--- a/server/src/main/java/org/opensearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/opensearch/gateway/GatewayMetaState.java
@@ -712,12 +712,6 @@ public class GatewayMetaState implements Closeable {
                 assert verifyManifestAndClusterState(manifest, clusterState) == true : "Manifest and ClusterState are not in sync";
                 lastAcceptedManifest = manifest;
                 lastAcceptedState = clusterState;
-            } catch (RepositoryMissingException e) {
-                // TODO This logic needs to be modified once PR for repo registration during bootstrap is pushed
-                // https://github.com/opensearch-project/OpenSearch/pull/9105/
-                // After the above PR is pushed, we can remove this silent failure and throw the exception instead.
-                logger.error("Remote repository is not yet registered");
-                lastAcceptedState = clusterState;
             } catch (Exception e) {
                 handleExceptionOnWrite(e);
             }


### PR DESCRIPTION
### Description
Removed the catch statement which will never be invoked, as with remote store the remote state repository is registered at the time of bootstrap.

### Related Issues
No tracking issue for this

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
