### PR TITLE
[Backport 2.x] Fix flaky remote cluster state UT

### DIFF
--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
@@ -454,7 +454,7 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
         mockBlobStoreObjects();
         final CoordinationMetadata coordinationMetadata = CoordinationMetadata.builder().term(1L).build();
         final ClusterState initialClusterState = ClusterState.builder(ClusterName.DEFAULT)
-            .metadata(Metadata.builder().coordinationMetadata(coordinationMetadata))
+            .metadata(Metadata.builder().coordinationMetadata(coordinationMetadata).version(randomNonNegativeLong()))
             .build();
         final ClusterMetadataManifest initialManifest = ClusterMetadataManifest.builder()
             .codecVersion(2)
@@ -475,6 +475,7 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
         // new cluster state where only global metadata is different
         Metadata newMetadata = Metadata.builder(clusterState.metadata())
             .persistentSettings(Settings.builder().put("cluster.blocks.read_only", true).build())
+            .version(randomNonNegativeLong())
             .build();
         ClusterState newClusterState = ClusterState.builder(clusterState).metadata(newMetadata).build();
 
@@ -1247,7 +1248,12 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
             .version(1L)
             .stateUUID("state-uuid")
             .metadata(
-                Metadata.builder().put(indexMetadata, true).clusterUUID("cluster-uuid").coordinationMetadata(coordinationMetadata).build()
+                Metadata.builder()
+                    .version(randomNonNegativeLong())
+                    .put(indexMetadata, true)
+                    .clusterUUID("cluster-uuid")
+                    .coordinationMetadata(coordinationMetadata)
+                    .build()
             );
     }
 


### PR DESCRIPTION
### Description
Backport flaky test fix to 2.x: https://github.com/opensearch-project/OpenSearch/pull/10780

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
