### PR TITLE
[Remote Store] Use time elapsed since last successful local refresh for refresh lag

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreBackpressureAndResiliencyIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreBackpressureAndResiliencyIT.java
@@ -56,7 +56,7 @@ public class RemoteStoreBackpressureAndResiliencyIT extends AbstractRemoteStoreM
     public void testWritesRejectedDueToTimeLagBreach() throws Exception {
         // Initially indexing happens with doc size of 1KB, then all remote store interactions start failing. Now, the
         // indexing happens with doc size of 1 byte leading to time lag limit getting exceeded and leading to rejections.
-        validateBackpressure(ByteSizeUnit.KB.toIntBytes(1), 20, ByteSizeUnit.BYTES.toIntBytes(1), 15, "time_lag");
+        validateBackpressure(ByteSizeUnit.KB.toIntBytes(1), 20, ByteSizeUnit.BYTES.toIntBytes(1), 3, "time_lag");
     }
 
     private void validateBackpressure(
@@ -133,11 +133,13 @@ public class RemoteStoreBackpressureAndResiliencyIT extends AbstractRemoteStoreM
         return matches.get(0).getSegmentStats();
     }
 
-    private void indexDocAndRefresh(BytesReference source, int iterations) {
+    private void indexDocAndRefresh(BytesReference source, int iterations) throws InterruptedException {
         for (int i = 0; i < iterations; i++) {
             client().prepareIndex(INDEX_NAME).setSource(source, MediaTypeRegistry.JSON).get();
             refresh(INDEX_NAME);
         }
+        Thread.sleep(100);
+        client().prepareIndex(INDEX_NAME).setSource(source, MediaTypeRegistry.JSON).get();
     }
 
     /**

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreBackpressureAndResiliencyIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreBackpressureAndResiliencyIT.java
@@ -138,7 +138,7 @@ public class RemoteStoreBackpressureAndResiliencyIT extends AbstractRemoteStoreM
             client().prepareIndex(INDEX_NAME).setSource(source, MediaTypeRegistry.JSON).get();
             refresh(INDEX_NAME);
         }
-        Thread.sleep(100);
+        Thread.sleep(250);
         client().prepareIndex(INDEX_NAME).setSource(source, MediaTypeRegistry.JSON).get();
     }
 

--- a/server/src/main/java/org/opensearch/index/remote/RemoteStorePressureService.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStorePressureService.java
@@ -177,17 +177,14 @@ public class RemoteStorePressureService {
         @Override
         public boolean validate(RemoteSegmentTransferTracker pressureTracker, ShardId shardId) {
             if (pressureTracker.getRefreshSeqNoLag() <= 1) {
-                logger.info("not ready");
                 return true;
             }
             if (pressureTracker.isUploadTimeMovingAverageReady() == false) {
-                logger.info("upload time moving average is not ready");
                 return true;
             }
             long timeLag = pressureTracker.getTimeMsLag();
             double dynamicTimeLagThreshold = pressureTracker.getUploadTimeMovingAverage() * pressureSettings
                 .getUploadTimeLagVarianceFactor();
-            logger.info("timeLag={} dynamicTimeLagThreshold={}", timeLag, dynamicTimeLagThreshold);
             return timeLag <= dynamicTimeLagThreshold;
         }
 

--- a/server/src/main/java/org/opensearch/index/remote/RemoteStorePressureService.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStorePressureService.java
@@ -177,15 +177,17 @@ public class RemoteStorePressureService {
         @Override
         public boolean validate(RemoteSegmentTransferTracker pressureTracker, ShardId shardId) {
             if (pressureTracker.getRefreshSeqNoLag() <= 1) {
+                logger.info("not ready");
                 return true;
             }
             if (pressureTracker.isUploadTimeMovingAverageReady() == false) {
-                logger.trace("upload time moving average is not ready");
+                logger.info("upload time moving average is not ready");
                 return true;
             }
             long timeLag = pressureTracker.getTimeMsLag();
             double dynamicTimeLagThreshold = pressureTracker.getUploadTimeMovingAverage() * pressureSettings
                 .getUploadTimeLagVarianceFactor();
+            logger.info("timeLag={} dynamicTimeLagThreshold={}", timeLag, dynamicTimeLagThreshold);
             return timeLag <= dynamicTimeLagThreshold;
         }
 

--- a/server/src/test/java/org/opensearch/index/remote/RemoteSegmentTransferTrackerTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteSegmentTransferTrackerTests.java
@@ -23,6 +23,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.opensearch.index.remote.RemoteSegmentTransferTracker.currentTimeMsUsingSystemNanos;
+
 public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
     private RemoteStoreStatsTrackerFactory remoteStoreStatsTrackerFactory;
     private ClusterService clusterService;
@@ -92,7 +94,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
             directoryFileTransferTracker,
             remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
         );
-        long refreshTimeMs = System.nanoTime() / 1_000_000L + randomIntBetween(10, 100);
+        long refreshTimeMs = currentTimeMsUsingSystemNanos() + randomIntBetween(10, 100);
         transferTracker.updateLocalRefreshTimeMs(refreshTimeMs);
         assertEquals(refreshTimeMs, transferTracker.getLocalRefreshTimeMs());
     }
@@ -103,7 +105,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
             directoryFileTransferTracker,
             remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
         );
-        long refreshTimeMs = System.nanoTime() / 1_000_000 + randomIntBetween(10, 100);
+        long refreshTimeMs = currentTimeMsUsingSystemNanos() + randomIntBetween(10, 100);
         transferTracker.updateRemoteRefreshTimeMs(refreshTimeMs);
         assertEquals(refreshTimeMs, transferTracker.getRemoteRefreshTimeMs());
     }
@@ -133,20 +135,28 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         assertEquals(localRefreshSeqNo - remoteRefreshSeqNo, transferTracker.getRefreshSeqNoLag());
     }
 
-    public void testComputeTimeLagOnUpdate() {
+    public void testComputeTimeLagOnUpdate() throws InterruptedException {
         transferTracker = new RemoteSegmentTransferTracker(
             shardId,
             directoryFileTransferTracker,
             remoteStoreStatsTrackerFactory.getMovingAverageWindowSize()
         );
-        long currentLocalRefreshTimeMs = transferTracker.getLocalRefreshTimeMs();
-        long currentTimeMs = System.nanoTime() / 1_000_000L;
-        long localRefreshTimeMs = currentTimeMs + randomIntBetween(100, 500);
-        long remoteRefreshTimeMs = currentTimeMs + randomIntBetween(50, 99);
-        transferTracker.updateLocalRefreshTimeMs(localRefreshTimeMs);
-        assertEquals(localRefreshTimeMs - currentLocalRefreshTimeMs, transferTracker.getTimeMsLag());
-        transferTracker.updateRemoteRefreshTimeMs(remoteRefreshTimeMs);
-        assertEquals(localRefreshTimeMs - remoteRefreshTimeMs, transferTracker.getTimeMsLag());
+
+        // No lag if there is a remote upload corresponding to a local refresh
+        assertEquals(0, transferTracker.getTimeMsLag());
+
+        // Set a local refresh time that is higher than remote refresh time
+        Thread.sleep(1);
+        transferTracker.updateLocalRefreshTimeMs(currentTimeMsUsingSystemNanos());
+
+        // Sleep for 100ms and then the lag should be within 100ms +/- 20ms
+        Thread.sleep(100);
+        assertTrue(Math.abs(transferTracker.getTimeMsLag() - 100) <= 20);
+
+        transferTracker.updateLocalRefreshTimeMs(currentTimeMsUsingSystemNanos());
+        long random = randomIntBetween(50, 200);
+        Thread.sleep(random);
+        assertTrue(Math.abs(transferTracker.getTimeMsLag() - random) <= 20);
     }
 
     public void testAddUploadBytesStarted() {
@@ -519,7 +529,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         transferTracker = constructTracker();
         RemoteSegmentTransferTracker.Stats transferTrackerStats = transferTracker.stats();
         assertEquals(transferTracker.getShardId(), transferTrackerStats.shardId);
-        assertEquals(transferTracker.getTimeMsLag(), (int) transferTrackerStats.refreshTimeLagMs);
+        assertTrue(Math.abs(transferTracker.getTimeMsLag() - transferTrackerStats.refreshTimeLagMs) <= 20);
         assertEquals(transferTracker.getLocalRefreshSeqNo(), (int) transferTrackerStats.localRefreshNumber);
         assertEquals(transferTracker.getRemoteRefreshSeqNo(), (int) transferTrackerStats.remoteRefreshNumber);
         assertEquals(transferTracker.getBytesLag(), (int) transferTrackerStats.bytesLag);
@@ -591,9 +601,9 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         );
         transferTracker.incrementTotalUploadsStarted();
         transferTracker.incrementTotalUploadsFailed();
-        transferTracker.updateUploadTimeMovingAverage(System.nanoTime() / 1_000_000L + randomIntBetween(10, 100));
+        transferTracker.updateUploadTimeMovingAverage(currentTimeMsUsingSystemNanos() + randomIntBetween(10, 100));
         transferTracker.updateUploadBytesMovingAverage(99);
-        transferTracker.updateRemoteRefreshTimeMs(System.nanoTime() / 1_000_000L + randomIntBetween(10, 100));
+        transferTracker.updateRemoteRefreshTimeMs(currentTimeMsUsingSystemNanos() + randomIntBetween(10, 100));
         transferTracker.incrementRejectionCount();
         transferTracker.getDirectoryFileTransferTracker().addTransferredBytesStarted(10);
         transferTracker.getDirectoryFileTransferTracker().addTransferredBytesSucceeded(10, System.currentTimeMillis());

--- a/server/src/test/java/org/opensearch/index/remote/RemoteSegmentTransferTrackerTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteSegmentTransferTrackerTests.java
@@ -153,6 +153,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         Thread.sleep(100);
         assertTrue(Math.abs(transferTracker.getTimeMsLag() - 100) <= 20);
 
+        transferTracker.updateRemoteRefreshTimeMs(transferTracker.getLocalRefreshTimeMs());
         transferTracker.updateLocalRefreshTimeMs(currentTimeMsUsingSystemNanos());
         long random = randomIntBetween(50, 200);
         Thread.sleep(random);

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStorePressureServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStorePressureServiceTests.java
@@ -21,8 +21,11 @@ import org.opensearch.threadpool.ThreadPool;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 
+import static org.opensearch.index.remote.RemoteSegmentTransferTracker.currentTimeMsUsingSystemNanos;
 import static org.opensearch.index.remote.RemoteStoreTestsHelper.createIndexShard;
 
 public class RemoteStorePressureServiceTests extends OpenSearchTestCase {
@@ -68,7 +71,7 @@ public class RemoteStorePressureServiceTests extends OpenSearchTestCase {
         assertTrue(pressureService.isSegmentsUploadBackpressureEnabled());
     }
 
-    public void testValidateSegmentUploadLag() {
+    public void testValidateSegmentUploadLag() throws InterruptedException {
         // Create the pressure tracker
         IndexShard indexShard = createIndexShard(shardId, true);
         remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(clusterService, Settings.EMPTY);
@@ -86,14 +89,27 @@ public class RemoteStorePressureServiceTests extends OpenSearchTestCase {
             sum.addAndGet(i);
         });
         double avg = (double) sum.get() / 20;
-        long currentMs = System.nanoTime() / 1_000_000;
-        pressureTracker.updateLocalRefreshTimeMs((long) (currentMs + 12 * avg));
-        pressureTracker.updateRemoteRefreshTimeMs(currentMs);
-        Exception e = assertThrows(OpenSearchRejectedExecutionException.class, () -> pressureService.validateSegmentsUploadLag(shardId));
-        assertTrue(e.getMessage().contains("due to remote segments lagging behind local segments"));
-        assertTrue(e.getMessage().contains("time_lag:114 ms dynamic_time_lag_threshold:95.0 ms"));
+        logger.info("avg={}", avg);
 
-        pressureTracker.updateRemoteRefreshTimeMs((long) (currentMs + 2 * avg));
+        // We run this to ensure that the local and remote refresh time are not same anymore
+        while (pressureTracker.getLocalRefreshTimeMs() == currentTimeMsUsingSystemNanos()) {
+            Thread.sleep(10);
+        }
+        long localRefreshTimeMs = currentTimeMsUsingSystemNanos();
+        pressureTracker.updateLocalRefreshTimeMs(localRefreshTimeMs);
+
+        while (currentTimeMsUsingSystemNanos() - localRefreshTimeMs <= 20 * avg) {
+            Thread.sleep((long) (4 * avg));
+        }
+        Exception e = assertThrows(OpenSearchRejectedExecutionException.class, () -> pressureService.validateSegmentsUploadLag(shardId));
+        String regex = "^rejected execution on primary shard:\\[index]\\[0] due to remote segments lagging behind "
+            + "local segments.time_lag:[0-9]{2,3} ms dynamic_time_lag_threshold:95\\.0 ms$";
+        Pattern pattern = Pattern.compile(regex);
+        Matcher matcher = pattern.matcher(e.getMessage());
+        assertTrue(matcher.matches());
+
+        pressureTracker.updateLocalRefreshTimeMs(currentTimeMsUsingSystemNanos());
+        Thread.sleep((long) (2 * avg));
         pressureService.validateSegmentsUploadLag(shardId);
 
         // 2. bytes lag more than dynamic threshold

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStorePressureServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStorePressureServiceTests.java
@@ -89,7 +89,6 @@ public class RemoteStorePressureServiceTests extends OpenSearchTestCase {
             sum.addAndGet(i);
         });
         double avg = (double) sum.get() / 20;
-        logger.info("avg={}", avg);
 
         // We run this to ensure that the local and remote refresh time are not same anymore
         while (pressureTracker.getLocalRefreshTimeMs() == currentTimeMsUsingSystemNanos()) {
@@ -108,6 +107,7 @@ public class RemoteStorePressureServiceTests extends OpenSearchTestCase {
         Matcher matcher = pattern.matcher(e.getMessage());
         assertTrue(matcher.matches());
 
+        pressureTracker.updateRemoteRefreshTimeMs(pressureTracker.getLocalRefreshTimeMs());
         pressureTracker.updateLocalRefreshTimeMs(currentTimeMsUsingSystemNanos());
         Thread.sleep((long) (2 * avg));
         pressureService.validateSegmentsUploadLag(shardId);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
For remote store, we track refresh lag in node stats api and it is as well used for remote segments upload backpressure. Until now, we were using the time difference of the most recent successful remote upload and local refresh. This conveys the lag in terms of freshness of data. While it works for cases where the refresh interval is default and low, it shows huge spikes when the user has configured refresh interval of -1 and the flushes are governed by the translog flush size breach. In this PR, we make the change to determine lag by only comparing the time when the local refresh succeeded versus the time elapsed since the refresh until remote upload finishes. This simplifies the mental model of perceiving the lag as it would always grow gradually from 0 to a higher number in contrast to the existing state where if lets say refresh has happened after a day in which case the lag can spike to a day from 0. The backpressure logic continues to stay same, just that we have change the time lag calculation.


### Related Issues
No issue created.
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
