### PR TITLE
Remove remote store attributes from DiscoveryNode toString()

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
@@ -553,7 +553,13 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
             sb.append('}');
         }
         if (!attributes.isEmpty()) {
-            sb.append(attributes);
+            sb.append(
+                attributes.entrySet()
+                    .stream()
+                    .filter(entry -> !entry.getKey().startsWith(REMOTE_STORE_NODE_ATTRIBUTE_KEY_PREFIX)) // filter remote_store attributes
+                                                                                                         // from logging to reduce noise.
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
+            );
         }
         return sb.toString();
     }

--- a/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodeTests.java
+++ b/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodeTests.java
@@ -38,13 +38,16 @@ import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.transport.TransportAddress;
+import org.opensearch.node.remotestore.RemoteStoreNodeAttribute;
 import org.opensearch.test.NodeRoles;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.net.InetAddress;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -79,6 +82,22 @@ public class DiscoveryNodeTests extends OpenSearchTestCase {
             previous = current;
         }
 
+    }
+
+    public void testRemoteStoreRedactionInToString() {
+        final Set<DiscoveryNodeRole> roles = new HashSet<>(randomSubsetOf(DiscoveryNodeRole.BUILT_IN_ROLES));
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(RemoteStoreNodeAttribute.REMOTE_STORE_SEGMENT_REPOSITORY_NAME_ATTRIBUTE_KEY, "test-repo");
+        attributes.put(RemoteStoreNodeAttribute.REMOTE_STORE_CLUSTER_STATE_REPOSITORY_NAME_ATTRIBUTE_KEY, "test-repo");
+        final DiscoveryNode node = new DiscoveryNode(
+            "name",
+            "id",
+            new TransportAddress(TransportAddress.META_ADDRESS, 9200),
+            attributes,
+            roles,
+            Version.CURRENT
+        );
+        assertFalse(node.toString().contains(RemoteStoreNodeAttribute.REMOTE_STORE_NODE_ATTRIBUTE_KEY_PREFIX));
     }
 
     public void testDiscoveryNodeIsCreatedWithHostFromInetAddress() throws Exception {


### PR DESCRIPTION
### Description
Remove remote store attributes from discovery node toString method to reduce the noise in logs. With this change, it will not log the remote store attributes when it logs the node's information.

**Log before fix:**

`
[2023-10-21T11:59:37,563][INFO ][o.o.c.s.MasterService    ] [a483e760c3eb.ant.amazon.com] elected-as-cluster-manager ([1] nodes joined)[{a483e760c3eb.ant.amazon.com}{h32zPMOiSdi2-bPknzppAg}{-TZ4rc9URAqRxMMrQ7urhQ}{127.0.0.1}{127.0.0.1:9300}{dimr}{remote_store.repository.my-repo-1.settings.region=XXXXX, remote_store.repository.my-repo-1.settings.bucket=XXXXXX, remote_store.repository.my-repo-1.type=XXXX, remote_store.state.repository=my-repo-1, remote_store.repository.my-repo-1.settings.base_path=XXXXX, shard_indexing_pressure_enabled=true, remote_store.segment.repository=my-repo-1, remote_store.translog.repository=my-repo-1} elect leader, _BECOME_CLUSTER_MANAGER_TASK_, _FINISH_ELECTION_], term: 6, version: 20, delta: cluster-manager node changed {previous [], current [{a483e760c3eb.ant.amazon.com}{h32zPMOiSdi2-bPknzppAg}{-TZ4rc9URAqRxMMrQ7urhQ}{127.0.0.1}{127.0.0.1:9300}{dimr}{remote_store.repository.my-repo-1.settings.region=XXXX, remote_store.repository.my-repo-1.settings.bucket=XXXXX, remote_store.repository.my-repo-1.type=XXXX, remote_store.state.repository=my-repo-1, remote_store.repository.my-repo-1.settings.base_path=XXXXXXX, shard_indexing_pressure_enabled=true, remote_store.segment.repository=my-repo-1, remote_store.translog.repository=my-repo-1}]}
`

**Log after fix:**

`
[2023-10-21T12:28:24,448][INFO ][o.o.c.s.MasterService    ] [a483e760c3eb.ant.amazon.com] elected-as-cluster-manager ([1] nodes joined)[{a483e760c3eb.ant.amazon.com}{h32zPMOiSdi2-bPknzppAg}{HrkFLotDS1KSN6EeQdBK0Q}{127.0.0.1}{127.0.0.1:9300}{dimr}{shard_indexing_pressure_enabled=true} elect leader, _BECOME_CLUSTER_MANAGER_TASK_, _FINISH_ELECTION_], term: 8, version: 28, delta: cluster-manager node changed {previous [], current [{a483e760c3eb.ant.amazon.com}{h32zPMOiSdi2-bPknzppAg}{HrkFLotDS1KSN6EeQdBK0Q}{127.0.0.1}{127.0.0.1:9300}{dimr}{shard_indexing_pressure_enabled=true}]}
`

### Related Issues
#10809 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
