### PR TITLE
Make index and global metadata upload timeout dynamic cluster settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Remote Store] Add repository stats for remote store([#10567](https://github.com/opensearch-project/OpenSearch/pull/10567))
 - Add search query categorizer ([#10255](https://github.com/opensearch-project/OpenSearch/pull/10255))
 - Introduce ConcurrentQueryProfiler to profile query using concurrent segment search path and support concurrency during rewrite and create weight ([10352](https://github.com/opensearch-project/OpenSearch/pull/10352))
+- [Remote cluster state] Make index and global metadata upload timeout dynamic cluster settings ([#10814](https://github.com/opensearch-project/OpenSearch/pull/10814))
 
 ### Dependencies
 - Bump `com.google.api.grpc:proto-google-common-protos` from 2.10.0 to 2.25.1 ([#10208](https://github.com/opensearch-project/OpenSearch/pull/10208), [#10298](https://github.com/opensearch-project/OpenSearch/pull/10298))

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -682,8 +682,8 @@ public final class ClusterSettings extends AbstractScopedSettings {
 
                 // Remote cluster state settings
                 RemoteClusterStateService.REMOTE_CLUSTER_STATE_ENABLED_SETTING,
-                RemoteClusterStateService.INDEX_METADATA_UPLOAD_WAIT_TIME_SETTING,
-                RemoteClusterStateService.GLOBAL_METADATA_UPLOAD_WAIT_TIME_SETTING,
+                RemoteClusterStateService.INDEX_METADATA_UPLOAD_TIMEOUT_SETTING,
+                RemoteClusterStateService.GLOBAL_METADATA_UPLOAD_TIMEOUT_SETTING,
                 RemoteStoreNodeService.REMOTE_STORE_COMPATIBILITY_MODE_SETTING,
                 IndicesService.CLUSTER_REMOTE_TRANSLOG_BUFFER_INTERVAL_SETTING,
                 IndicesService.CLUSTER_REMOTE_INDEX_RESTRICT_ASYNC_DURABILITY_SETTING,

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -682,6 +682,8 @@ public final class ClusterSettings extends AbstractScopedSettings {
 
                 // Remote cluster state settings
                 RemoteClusterStateService.REMOTE_CLUSTER_STATE_ENABLED_SETTING,
+                RemoteClusterStateService.INDEX_METADATA_UPLOAD_WAIT_TIME_SETTINGS,
+                RemoteClusterStateService.GLOBAL_METADATA_UPLOAD_WAIT_TIME_SETTINGS,
                 RemoteStoreNodeService.REMOTE_STORE_COMPATIBILITY_MODE_SETTING,
                 IndicesService.CLUSTER_REMOTE_TRANSLOG_BUFFER_INTERVAL_SETTING,
                 IndicesService.CLUSTER_REMOTE_INDEX_RESTRICT_ASYNC_DURABILITY_SETTING,

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -682,8 +682,8 @@ public final class ClusterSettings extends AbstractScopedSettings {
 
                 // Remote cluster state settings
                 RemoteClusterStateService.REMOTE_CLUSTER_STATE_ENABLED_SETTING,
-                RemoteClusterStateService.INDEX_METADATA_UPLOAD_WAIT_TIME_SETTINGS,
-                RemoteClusterStateService.GLOBAL_METADATA_UPLOAD_WAIT_TIME_SETTINGS,
+                RemoteClusterStateService.INDEX_METADATA_UPLOAD_WAIT_TIME_SETTING,
+                RemoteClusterStateService.GLOBAL_METADATA_UPLOAD_WAIT_TIME_SETTING,
                 RemoteStoreNodeService.REMOTE_STORE_COMPATIBILITY_MODE_SETTING,
                 IndicesService.CLUSTER_REMOTE_TRANSLOG_BUFFER_INTERVAL_SETTING,
                 IndicesService.CLUSTER_REMOTE_INDEX_RESTRICT_ASYNC_DURABILITY_SETTING,

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -85,7 +85,7 @@ public class RemoteClusterStateService implements Closeable {
 
     // default value for index metadata upload wait is 20s
     static volatile TimeValue indexMetadataUploadWaitTime = TimeValue.timeValueMillis(20000);
-    // default value for index metadata upload wait is 20s
+    // default value for global metadata upload wait is 20s
     static volatile TimeValue globalMetadataUploadWaitTime = TimeValue.timeValueMillis(20000);
 
     public static final Setting<TimeValue> INDEX_METADATA_UPLOAD_WAIT_TIME_SETTING = Setting.timeSetting(

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -83,23 +83,19 @@ public class RemoteClusterStateService implements Closeable {
 
     private static final Logger logger = LogManager.getLogger(RemoteClusterStateService.class);
 
-    // TODO make this two variable as dynamic setting [issue: #10688]
-    // public static final int INDEX_METADATA_UPLOAD_WAIT_MILLIS = 20000;
-    // public static final int GLOBAL_METADATA_UPLOAD_WAIT_MILLIS = 20000;
-
     // default value for index metadata upload wait is 20s
     static volatile TimeValue indexMetadataUploadWaitTime = TimeValue.timeValueMillis(20000);
     // default value for index metadata upload wait is 20s
     static volatile TimeValue globalMetadataUploadWaitTime = TimeValue.timeValueMillis(20000);
 
-    public static final Setting<TimeValue> INDEX_METADATA_UPLOAD_WAIT_TIME_SETTINGS = Setting.timeSetting(
+    public static final Setting<TimeValue> INDEX_METADATA_UPLOAD_WAIT_TIME_SETTING = Setting.timeSetting(
         "cluster.remote_store.index_metadata.upload_wait_time",
         indexMetadataUploadWaitTime,
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
 
-    public static final Setting<TimeValue> GLOBAL_METADATA_UPLOAD_WAIT_TIME_SETTINGS = Setting.timeSetting(
+    public static final Setting<TimeValue> GLOBAL_METADATA_UPLOAD_WAIT_TIME_SETTING = Setting.timeSetting(
         "cluster.remote_store.global_metadata.upload_wait_time",
         globalMetadataUploadWaitTime,
         Setting.Property.Dynamic,
@@ -191,10 +187,10 @@ public class RemoteClusterStateService implements Closeable {
         this.threadpool = threadPool;
         this.slowWriteLoggingThreshold = clusterSettings.get(SLOW_WRITE_LOGGING_THRESHOLD);
         clusterSettings.addSettingsUpdateConsumer(SLOW_WRITE_LOGGING_THRESHOLD, this::setSlowWriteLoggingThreshold);
-        clusterSettings.addSettingsUpdateConsumer(INDEX_METADATA_UPLOAD_WAIT_TIME_SETTINGS, this::setIndexMetadataUploadWaitTime);
-        clusterSettings.addSettingsUpdateConsumer(GLOBAL_METADATA_UPLOAD_WAIT_TIME_SETTINGS, this::setGlobalMetadataUploadWaitTime);
-        setIndexMetadataUploadWaitTime(INDEX_METADATA_UPLOAD_WAIT_TIME_SETTINGS.get(settings));
-        setGlobalMetadataUploadWaitTime(GLOBAL_METADATA_UPLOAD_WAIT_TIME_SETTINGS.get(settings));
+        clusterSettings.addSettingsUpdateConsumer(INDEX_METADATA_UPLOAD_WAIT_TIME_SETTING, this::setIndexMetadataUploadWaitTime);
+        clusterSettings.addSettingsUpdateConsumer(GLOBAL_METADATA_UPLOAD_WAIT_TIME_SETTING, this::setGlobalMetadataUploadWaitTime);
+        setIndexMetadataUploadWaitTime(INDEX_METADATA_UPLOAD_WAIT_TIME_SETTING.get(settings));
+        setGlobalMetadataUploadWaitTime(GLOBAL_METADATA_UPLOAD_WAIT_TIME_SETTING.get(settings));
     }
 
     private BlobStoreTransferService getBlobStoreTransferService() {

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
@@ -1043,29 +1043,34 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
 
     public void testIndexMetadataUploadWaitTimeSetting() {
         // verify default value
-        assertEquals(RemoteClusterStateService.INDEX_METADATA_UPLOAD_TIMEOUT, RemoteClusterStateService.getIndexMetadataUploadTimeout());
+        assertEquals(
+            RemoteClusterStateService.INDEX_METADATA_UPLOAD_TIMEOUT_DEFAULT,
+            remoteClusterStateService.getIndexMetadataUploadTimeout()
+        );
 
         // verify update index metadata upload timeout
         int indexMetadataUploadTimeout = randomIntBetween(1, 10);
         Settings newSettings = Settings.builder()
-            .put("cluster.remote_store.index_metadata.upload_timeout", indexMetadataUploadTimeout + "s")
+            .put("cluster.remote_store.state.index_metadata.upload_timeout", indexMetadataUploadTimeout + "s")
             .build();
         clusterSettings.applySettings(newSettings);
-        assertEquals(indexMetadataUploadTimeout, RemoteClusterStateService.getIndexMetadataUploadTimeout().seconds());
-
+        assertEquals(indexMetadataUploadTimeout, remoteClusterStateService.getIndexMetadataUploadTimeout().seconds());
     }
 
     public void testGlobalMetadataUploadWaitTimeSetting() {
         // verify default value
-        assertEquals(RemoteClusterStateService.GLOBAL_METADATA_UPLOAD_TIMEOUT, RemoteClusterStateService.getGlobalMetadataUploadTimeout());
+        assertEquals(
+            RemoteClusterStateService.GLOBAL_METADATA_UPLOAD_TIMEOUT_DEFAULT,
+            remoteClusterStateService.getGlobalMetadataUploadTimeout()
+        );
 
         // verify update global metadata upload timeout
         int globalMetadataUploadTimeout = randomIntBetween(1, 10);
         Settings newSettings = Settings.builder()
-            .put("cluster.remote_store.global_metadata.upload_timeout", globalMetadataUploadTimeout + "s")
+            .put("cluster.remote_store.state.global_metadata.upload_timeout", globalMetadataUploadTimeout + "s")
             .build();
         clusterSettings.applySettings(newSettings);
-        assertEquals(globalMetadataUploadTimeout, RemoteClusterStateService.getGlobalMetadataUploadTimeout().seconds());
+        assertEquals(globalMetadataUploadTimeout, remoteClusterStateService.getGlobalMetadataUploadTimeout().seconds());
     }
 
     private void mockObjectsForGettingPreviousClusterUUID(Map<String, String> clusterUUIDsPointers) throws IOException {

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
@@ -1039,6 +1039,52 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
         assertBusy(() -> assertEquals(1, callCount.get()));
     }
 
+    public void testIndexMetadataUploadWaitTimeSetting() {
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.builder().build(), ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        // verify defaults
+        assertEquals(remoteClusterStateService.indexMetadataUploadWaitTime, RemoteClusterStateService.getIndexMetadataUploadWaitTime());
+        assertEquals(remoteClusterStateService.globalMetadataUploadWaitTime, RemoteClusterStateService.getGlobalMetadataUploadWaitTime());
+
+        // verify update index metadata upload wait time
+        int indexMetadataUploadWaitTime = randomIntBetween(1, 10);
+        Settings newSettings = Settings.builder()
+            .put("cluster.remote_store.index_metadata.upload_wait_time", indexMetadataUploadWaitTime + "s")
+            .build();
+        clusterSettings.applySettings(newSettings);
+        assertEquals(indexMetadataUploadWaitTime, RemoteClusterStateService.getIndexMetadataUploadWaitTime().seconds());
+
+        // verify update global metadata upload wait time
+        int globalMetadataUploadWaitTime = randomIntBetween(1, 10);
+        newSettings = Settings.builder()
+            .put("cluster.remote_store.global_metadata.upload_wait_time", globalMetadataUploadWaitTime + "s")
+            .build();
+        clusterSettings.applySettings(newSettings);
+        assertEquals(globalMetadataUploadWaitTime, RemoteClusterStateService.getGlobalMetadataUploadWaitTime().seconds());
+    }
+
+    public void testIndexMetadataUploadWaitTimeSetting() {
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.builder().build(), ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        // verify defaults
+        assertEquals(remoteClusterStateService.indexMetadataUploadWaitTime, RemoteClusterStateService.getIndexMetadataUploadWaitTime());
+        assertEquals(remoteClusterStateService.globalMetadataUploadWaitTime, RemoteClusterStateService.getGlobalMetadataUploadWaitTime());
+
+        // verify update index metadata upload wait time
+        int indexMetadataUploadWaitTime = randomIntBetween(1, 10);
+        Settings newSettings = Settings.builder()
+            .put("cluster.remote_store.index_metadata.upload_wait_time", indexMetadataUploadWaitTime + "s")
+            .build();
+        clusterSettings.applySettings(newSettings);
+        assertEquals(indexMetadataUploadWaitTime, RemoteClusterStateService.getIndexMetadataUploadWaitTime().seconds());
+
+        // verify update global metadata upload wait time
+        int globalMetadataUploadWaitTime = randomIntBetween(1, 10);
+        newSettings = Settings.builder()
+            .put("cluster.remote_store.global_metadata.upload_wait_time", globalMetadataUploadWaitTime + "s")
+            .build();
+        clusterSettings.applySettings(newSettings);
+        assertEquals(globalMetadataUploadWaitTime, RemoteClusterStateService.getGlobalMetadataUploadWaitTime().seconds());
+    }
+
     private void mockObjectsForGettingPreviousClusterUUID(Map<String, String> clusterUUIDsPointers) throws IOException {
         final BlobPath blobPath = mock(BlobPath.class);
         when((blobStoreRepository.basePath())).thenReturn(blobPath);

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
@@ -1043,29 +1043,29 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
 
     public void testIndexMetadataUploadWaitTimeSetting() {
         // verify default value
-        assertEquals(RemoteClusterStateService.indexMetadataUploadWaitTime, RemoteClusterStateService.getIndexMetadataUploadWaitTime());
+        assertEquals(RemoteClusterStateService.INDEX_METADATA_UPLOAD_TIMEOUT, RemoteClusterStateService.getIndexMetadataUploadTimeout());
 
-        // verify update index metadata upload wait time
-        int indexMetadataUploadWaitTime = randomIntBetween(1, 10);
+        // verify update index metadata upload timeout
+        int indexMetadataUploadTimeout = randomIntBetween(1, 10);
         Settings newSettings = Settings.builder()
-            .put("cluster.remote_store.index_metadata.upload_wait_time", indexMetadataUploadWaitTime + "s")
+            .put("cluster.remote_store.index_metadata.upload_timeout", indexMetadataUploadTimeout + "s")
             .build();
         clusterSettings.applySettings(newSettings);
-        assertEquals(indexMetadataUploadWaitTime, RemoteClusterStateService.getIndexMetadataUploadWaitTime().seconds());
+        assertEquals(indexMetadataUploadTimeout, RemoteClusterStateService.getIndexMetadataUploadTimeout().seconds());
 
     }
 
     public void testGlobalMetadataUploadWaitTimeSetting() {
         // verify default value
-        assertEquals(RemoteClusterStateService.globalMetadataUploadWaitTime, RemoteClusterStateService.getGlobalMetadataUploadWaitTime());
+        assertEquals(RemoteClusterStateService.GLOBAL_METADATA_UPLOAD_TIMEOUT, RemoteClusterStateService.getGlobalMetadataUploadTimeout());
 
-        // verify update global metadata upload wait time
-        int globalMetadataUploadWaitTime = randomIntBetween(1, 10);
+        // verify update global metadata upload timeout
+        int globalMetadataUploadTimeout = randomIntBetween(1, 10);
         Settings newSettings = Settings.builder()
-            .put("cluster.remote_store.global_metadata.upload_wait_time", globalMetadataUploadWaitTime + "s")
+            .put("cluster.remote_store.global_metadata.upload_timeout", globalMetadataUploadTimeout + "s")
             .build();
         clusterSettings.applySettings(newSettings);
-        assertEquals(globalMetadataUploadWaitTime, RemoteClusterStateService.getGlobalMetadataUploadWaitTime().seconds());
+        assertEquals(globalMetadataUploadTimeout, RemoteClusterStateService.getGlobalMetadataUploadTimeout().seconds());
     }
 
     private void mockObjectsForGettingPreviousClusterUUID(Map<String, String> clusterUUIDsPointers) throws IOException {

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
@@ -96,6 +96,7 @@ import static org.mockito.Mockito.when;
 public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
 
     private RemoteClusterStateService remoteClusterStateService;
+    private ClusterSettings clusterSettings;
     private Supplier<RepositoriesService> repositoriesServiceSupplier;
     private RepositoriesService repositoriesService;
     private BlobStoreRepository blobStoreRepository;
@@ -126,6 +127,7 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
             .put(RemoteClusterStateService.REMOTE_CLUSTER_STATE_ENABLED_SETTING.getKey(), true)
             .build();
 
+        clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         blobStoreRepository = mock(BlobStoreRepository.class);
         blobStore = mock(BlobStore.class);
         when(blobStoreRepository.blobStore()).thenReturn(blobStore);
@@ -135,7 +137,7 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
             "test-node-id",
             repositoriesServiceSupplier,
             settings,
-            new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+            clusterSettings,
             () -> 0L,
             threadPool
         );
@@ -1040,10 +1042,8 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
     }
 
     public void testIndexMetadataUploadWaitTimeSetting() {
-        ClusterSettings clusterSettings = new ClusterSettings(Settings.builder().build(), ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        // verify defaults
-        assertEquals(remoteClusterStateService.indexMetadataUploadWaitTime, RemoteClusterStateService.getIndexMetadataUploadWaitTime());
-        assertEquals(remoteClusterStateService.globalMetadataUploadWaitTime, RemoteClusterStateService.getGlobalMetadataUploadWaitTime());
+        // verify default value
+        assertEquals(RemoteClusterStateService.indexMetadataUploadWaitTime, RemoteClusterStateService.getIndexMetadataUploadWaitTime());
 
         // verify update index metadata upload wait time
         int indexMetadataUploadWaitTime = randomIntBetween(1, 10);
@@ -1053,32 +1053,15 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
         clusterSettings.applySettings(newSettings);
         assertEquals(indexMetadataUploadWaitTime, RemoteClusterStateService.getIndexMetadataUploadWaitTime().seconds());
 
-        // verify update global metadata upload wait time
-        int globalMetadataUploadWaitTime = randomIntBetween(1, 10);
-        newSettings = Settings.builder()
-            .put("cluster.remote_store.global_metadata.upload_wait_time", globalMetadataUploadWaitTime + "s")
-            .build();
-        clusterSettings.applySettings(newSettings);
-        assertEquals(globalMetadataUploadWaitTime, RemoteClusterStateService.getGlobalMetadataUploadWaitTime().seconds());
     }
 
-    public void testIndexMetadataUploadWaitTimeSetting() {
-        ClusterSettings clusterSettings = new ClusterSettings(Settings.builder().build(), ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        // verify defaults
-        assertEquals(remoteClusterStateService.indexMetadataUploadWaitTime, RemoteClusterStateService.getIndexMetadataUploadWaitTime());
-        assertEquals(remoteClusterStateService.globalMetadataUploadWaitTime, RemoteClusterStateService.getGlobalMetadataUploadWaitTime());
-
-        // verify update index metadata upload wait time
-        int indexMetadataUploadWaitTime = randomIntBetween(1, 10);
-        Settings newSettings = Settings.builder()
-            .put("cluster.remote_store.index_metadata.upload_wait_time", indexMetadataUploadWaitTime + "s")
-            .build();
-        clusterSettings.applySettings(newSettings);
-        assertEquals(indexMetadataUploadWaitTime, RemoteClusterStateService.getIndexMetadataUploadWaitTime().seconds());
+    public void testGlobalMetadataUploadWaitTimeSetting() {
+        // verify default value
+        assertEquals(RemoteClusterStateService.globalMetadataUploadWaitTime, RemoteClusterStateService.getGlobalMetadataUploadWaitTime());
 
         // verify update global metadata upload wait time
         int globalMetadataUploadWaitTime = randomIntBetween(1, 10);
-        newSettings = Settings.builder()
+        Settings newSettings = Settings.builder()
             .put("cluster.remote_store.global_metadata.upload_wait_time", globalMetadataUploadWaitTime + "s")
             .build();
         clusterSettings.applySettings(newSettings);


### PR DESCRIPTION
### Description

- Make remote store index and global metadata upload timeout dynamic
- Adds 2 new dynamically configurable settings, with default value 20s:
    - `cluster.remote_store.index_metadata.upload_timeout`
    - `cluster.remote_store.global_metadata.upload_timeout`

### Related Issues
Resolves #10688 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

