### PR TITLE
link previous cluster uuid to current cluster uuid even if current cluster uuid is not committed

### DIFF
--- a/server/src/main/java/org/opensearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/opensearch/gateway/GatewayMetaState.java
@@ -699,8 +699,6 @@ public class GatewayMetaState implements Closeable {
                             "Latest manifest is not present in remote store for cluster UUID: {}",
                             clusterState.metadata().clusterUUID()
                         );
-                        // we dont need this as previousClusterUUID would always be unknown in this case
-                        // previousClusterUUID = ClusterState.UNKNOWN_UUID;
                     }
                     manifest = remoteClusterStateService.writeFullMetadata(clusterState, previousClusterUUID);
                 } else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Cluster chaining can break if there is consecutive node replace and restart

This change removes the check for `clusterUUIDCommitted` for current state when fetch previousClusterUUID from remote. But since we already have a check on `clusterUUIDCommitted` while constructing cluster chain, we should be good

https://github.com/opensearch-project/OpenSearch/blob/ef4b327ab48a6a674b657049e440418fe427cb0c/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java#L829-L833

** It might be beneficial to make previousClusterUUID part of `Metadata` itself in future **

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/10841

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
