### PR TITLE
Add support to create empty local translog if remote translog is empty

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreRestoreIT.java
@@ -19,14 +19,12 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.core.common.unit.ByteSizeUnit;
-import org.opensearch.core.util.FileSystemUtils;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.repositories.Repository;
 import org.opensearch.test.InternalTestCluster;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Locale;
@@ -34,7 +32,6 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_SETTINGS_ATTRIBUTE_KEY_PREFIX;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
@@ -269,7 +266,6 @@ public class RemoteStoreRestoreIT extends BaseRemoteStoreRestoreIT {
             TimeUnit.SECONDS
         );
     }
-
 
     public void testRestoreFlowWithForceEmptyTranslog() throws Exception {
         prepareCluster(1, 3, INDEX_NAME, 0, 1);

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreRestoreIT.java
@@ -38,7 +38,7 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.greaterThan;
 
-@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, numDataNodes = 0)
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
 public class RemoteStoreRestoreIT extends BaseRemoteStoreRestoreIT {
 
     /**
@@ -236,7 +236,7 @@ public class RemoteStoreRestoreIT extends BaseRemoteStoreRestoreIT {
         verifyRestoredData(indexStats, INDEX_NAME);
     }
 
-    public void testRestoreFlowWithForceEmptyTranslogNoOp() throws Exception {
+    public void testRestoreFlowWithForceAllocateNoOp() throws Exception {
         prepareCluster(1, 3, INDEX_NAME, 0, 1);
         Map<String, Long> indexStats = indexData(randomIntBetween(2, 3), randomBoolean(), INDEX_NAME);
 
@@ -252,7 +252,7 @@ public class RemoteStoreRestoreIT extends BaseRemoteStoreRestoreIT {
         client().admin()
             .cluster()
             .restoreRemoteStore(
-                new RestoreRemoteStoreRequest().indices(INDEX_NAME).restoreAllShards(true).forceEmptyTranslog(true),
+                new RestoreRemoteStoreRequest().indices(INDEX_NAME).restoreAllShards(true).forceAllocate(true),
                 PlainActionFuture.newFuture()
             );
         ensureGreen(INDEX_NAME);
@@ -267,7 +267,7 @@ public class RemoteStoreRestoreIT extends BaseRemoteStoreRestoreIT {
         );
     }
 
-    public void testRestoreFlowWithForceEmptyTranslog() throws Exception {
+    public void testRestoreFlowWithForceAllocate() throws Exception {
         prepareCluster(1, 3, INDEX_NAME, 0, 1);
         Map<String, Long> indexStats = indexData(randomIntBetween(2, 3), randomBoolean(), INDEX_NAME);
 
@@ -292,7 +292,7 @@ public class RemoteStoreRestoreIT extends BaseRemoteStoreRestoreIT {
         client().admin()
             .cluster()
             .restoreRemoteStore(
-                new RestoreRemoteStoreRequest().indices(INDEX_NAME).restoreAllShards(true).forceEmptyTranslog(true),
+                new RestoreRemoteStoreRequest().indices(INDEX_NAME).restoreAllShards(true).forceAllocate(true),
                 PlainActionFuture.newFuture()
             );
         ensureGreen(INDEX_NAME);

--- a/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/restore/RestoreRemoteStoreRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/restore/RestoreRemoteStoreRequest.java
@@ -38,7 +38,7 @@ public class RestoreRemoteStoreRequest extends ClusterManagerNodeRequest<Restore
     private String[] indices = Strings.EMPTY_ARRAY;
     private Boolean waitForCompletion = false;
     private Boolean restoreAllShards = false;
-    private Boolean forceEmptyTranslog = false;
+    private Boolean forceAllocate = false;
 
     public RestoreRemoteStoreRequest() {}
 
@@ -48,7 +48,7 @@ public class RestoreRemoteStoreRequest extends ClusterManagerNodeRequest<Restore
         waitForCompletion = in.readOptionalBoolean();
         restoreAllShards = in.readOptionalBoolean();
         if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
-            forceEmptyTranslog = in.readOptionalBoolean();
+            forceAllocate = in.readOptionalBoolean();
         }
     }
 
@@ -59,7 +59,7 @@ public class RestoreRemoteStoreRequest extends ClusterManagerNodeRequest<Restore
         out.writeOptionalBoolean(waitForCompletion);
         out.writeOptionalBoolean(restoreAllShards);
         if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
-            out.writeOptionalBoolean(forceEmptyTranslog);
+            out.writeOptionalBoolean(forceAllocate);
         }
     }
 
@@ -151,24 +151,24 @@ public class RestoreRemoteStoreRequest extends ClusterManagerNodeRequest<Restore
     }
 
     /**
-     * Set the value for forceEmptyTranslog, denoting whether to create empty translog if remote translog does not have any data.
+     * Set the value for forceAllocate, denoting whether to create empty store/translog if remote segment store/translog does not have any data.
      *
-     * @param forceEmptyTranslog If true and if remote translog does not have any data, the operation will create empty translog on local
-     *                           If false, the operation will always try to fetch data from remote translog and will fail if remote translog is empty.
+     * @param forceAllocate If true and if remote segment store/translog does not have any data, the operation will create empty store/translog on local
+     *                      If false, the operation will always try to fetch data from remote segment store/translog and will fail if either one is empty.
      * @return this request
      */
-    public RestoreRemoteStoreRequest forceEmptyTranslog(boolean forceEmptyTranslog) {
-        this.forceEmptyTranslog = forceEmptyTranslog;
+    public RestoreRemoteStoreRequest forceAllocate(boolean forceAllocate) {
+        this.forceAllocate = forceAllocate;
         return this;
     }
 
     /**
-     * Returns forceEmptyTranslog setting
+     * Returns forceAllocate setting
      *
-     * @return true if the operation will create empty translog on local when remote translog is empty
+     * @return true if the operation will create empty store/translog on local when remote segment store/translog is empty
      */
-    public boolean forceEmptyTranslog() {
-        return forceEmptyTranslog;
+    public boolean forceAllocate() {
+        return forceAllocate;
     }
 
     /**
@@ -222,13 +222,13 @@ public class RestoreRemoteStoreRequest extends ClusterManagerNodeRequest<Restore
         RestoreRemoteStoreRequest that = (RestoreRemoteStoreRequest) o;
         return waitForCompletion == that.waitForCompletion
             && restoreAllShards == that.restoreAllShards
-            && forceEmptyTranslog == that.forceEmptyTranslog
+            && forceAllocate == that.forceAllocate
             && Arrays.equals(indices, that.indices);
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(waitForCompletion, restoreAllShards, forceEmptyTranslog);
+        int result = Objects.hash(waitForCompletion, restoreAllShards, forceAllocate);
         result = 31 * result + Arrays.hashCode(indices);
         return result;
     }

--- a/server/src/main/java/org/opensearch/cluster/routing/RecoverySource.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RecoverySource.java
@@ -419,17 +419,17 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
         private final String restoreUUID;
         private final IndexId index;
         private final Version version;
-        private final boolean forceEmptyTranslog;
+        private final boolean forceAllocate;
 
         public RemoteStoreRecoverySource(String restoreUUID, Version version, IndexId indexId) {
             this(restoreUUID, version, indexId, false);
         }
 
-        public RemoteStoreRecoverySource(String restoreUUID, Version version, IndexId indexId, boolean forceEmptyTranslog) {
+        public RemoteStoreRecoverySource(String restoreUUID, Version version, IndexId indexId, boolean forceAllocate) {
             this.restoreUUID = restoreUUID;
             this.version = Objects.requireNonNull(version);
             this.index = Objects.requireNonNull(indexId);
-            this.forceEmptyTranslog = forceEmptyTranslog;
+            this.forceAllocate = forceAllocate;
         }
 
         RemoteStoreRecoverySource(StreamInput in) throws IOException {
@@ -437,9 +437,9 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
             version = in.readVersion();
             index = new IndexId(in);
             if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
-                forceEmptyTranslog = in.readBoolean();
+                forceAllocate = in.readBoolean();
             } else {
-                forceEmptyTranslog = false;
+                forceAllocate = false;
             }
         }
 
@@ -461,8 +461,8 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
             return version;
         }
 
-        public boolean forceEmptyTranslog() {
-            return forceEmptyTranslog;
+        public boolean forceAllocate() {
+            return forceAllocate;
         }
 
         @Override
@@ -471,7 +471,7 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
             out.writeVersion(version);
             index.writeTo(out);
             if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
-                out.writeBoolean(forceEmptyTranslog);
+                out.writeBoolean(forceAllocate);
             }
         }
 
@@ -485,7 +485,7 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
             builder.field("version", version.toString())
                 .field("index", index.getName())
                 .field("restoreUUID", restoreUUID)
-                .field("forceEmptyTranslog", forceEmptyTranslog);
+                .field("forceAllocate", forceAllocate);
         }
 
         @Override
@@ -506,12 +506,12 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
             return restoreUUID.equals(that.restoreUUID)
                 && index.equals(that.index)
                 && version.equals(that.version)
-                && forceEmptyTranslog == that.forceEmptyTranslog;
+                && forceAllocate == that.forceAllocate;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(restoreUUID, index, version, forceEmptyTranslog);
+            return Objects.hash(restoreUUID, index, version, forceAllocate);
         }
 
         // TODO: This override should be removed/be updated to return "true",

--- a/server/src/main/java/org/opensearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/opensearch/gateway/GatewayMetaState.java
@@ -179,6 +179,7 @@ public class GatewayMetaState implements Closeable {
                                     ClusterState.builder(clusterState).metadata(Metadata.EMPTY_METADATA).build(),
                                     lastKnownClusterUUID,
                                     false,
+                                    false,
                                     new String[] {}
                                 );
                                 clusterState = remoteRestoreResult.getClusterState();

--- a/server/src/main/java/org/opensearch/index/recovery/RemoteStoreRestoreService.java
+++ b/server/src/main/java/org/opensearch/index/recovery/RemoteStoreRestoreService.java
@@ -103,7 +103,7 @@ public class RemoteStoreRestoreService {
                     currentState,
                     null,
                     request.restoreAllShards(),
-                    request.forceEmptyTranslog(),
+                    request.forceAllocate(),
                     request.indices()
                 );
                 restoreUUID = remoteRestoreResult.getRestoreUUID();
@@ -141,7 +141,7 @@ public class RemoteStoreRestoreService {
         ClusterState currentState,
         @Nullable String restoreClusterUUID,
         boolean restoreAllShards,
-        boolean forceEmptyTranslog,
+        boolean forceAllocate,
         String[] indexNames
     ) {
         Map<String, Tuple<Boolean, IndexMetadata>> indexMetadataMap = new HashMap<>();
@@ -183,7 +183,7 @@ public class RemoteStoreRestoreService {
                 }
             }
         }
-        return executeRestore(currentState, indexMetadataMap, restoreAllShards, remoteMetadata, forceEmptyTranslog);
+        return executeRestore(currentState, indexMetadataMap, restoreAllShards, remoteMetadata, forceAllocate);
     }
 
     /**
@@ -198,7 +198,7 @@ public class RemoteStoreRestoreService {
         Map<String, Tuple<Boolean, IndexMetadata>> indexMetadataMap,
         boolean restoreAllShards,
         Metadata remoteMetadata,
-        boolean forceEmptyTranslog
+        boolean forceAllocate
     ) {
         final String restoreUUID = UUIDs.randomBase64UUID();
         List<String> indicesToBeRestored = new ArrayList<>();
@@ -237,7 +237,7 @@ public class RemoteStoreRestoreService {
                     restoreUUID,
                     updatedIndexMetadata.getCreationVersion(),
                     indexId,
-                    forceEmptyTranslog
+                    forceAllocate
                 );
 
                 rtBuilder.addAsRemoteStoreRestore(updatedIndexMetadata, recoverySource, indexShardRoutingTableMap, restoreAllShards);

--- a/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
@@ -407,7 +407,7 @@ final class StoreRecovery {
                 if (indexShard.indexSettings.isRemoteTranslogStoreEnabled() == false) {
                     bootstrap(indexShard, store);
                 } else {
-                    bootstrapForSnapshot(indexShard, store);
+                    bootstrapFromLastCommit(indexShard, store);
                 }
                 assert indexShard.shardRouting.primary() : "only primary shards can recover from store";
                 writeEmptyRetentionLeasesFile(indexShard);
@@ -555,7 +555,7 @@ final class StoreRecovery {
                 }
             } else if (remoteSegmentEmpty == false && remoteTranslogEmpty) {
                 if (((RecoverySource.RemoteStoreRecoverySource) indexShard.shardRouting.recoverySource()).forceEmptyTranslog()) {
-                    bootstrap(indexShard, store);
+                    bootstrapFromLastCommit(indexShard, store);
                 }
             }
 
@@ -695,7 +695,7 @@ final class StoreRecovery {
             if (indexShard.indexSettings.isRemoteTranslogStoreEnabled() == false) {
                 bootstrap(indexShard, store);
             } else {
-                bootstrapForSnapshot(indexShard, store);
+                bootstrapFromLastCommit(indexShard, store);
             }
             assert indexShard.shardRouting.primary() : "only primary shards can recover from store";
             writeEmptyRetentionLeasesFile(indexShard);
@@ -747,7 +747,7 @@ final class StoreRecovery {
         }
     }
 
-    private void bootstrapForSnapshot(final IndexShard indexShard, final Store store) throws IOException {
+    private void bootstrapFromLastCommit(final IndexShard indexShard, final Store store) throws IOException {
         store.bootstrapNewHistory();
         final SegmentInfos segmentInfos = store.readLastCommittedSegmentsInfo();
         final long localCheckpoint = Long.parseLong(segmentInfos.userData.get(SequenceNumbers.LOCAL_CHECKPOINT_KEY));

--- a/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
@@ -554,7 +554,7 @@ final class StoreRecovery {
                     store.createEmpty(indexShard.indexSettings().getIndexVersionCreated().luceneVersion, translogHeader.getTranslogUUID());
                 }
             } else if (remoteSegmentEmpty == false && remoteTranslogEmpty) {
-                if (((RecoverySource.RemoteStoreRecoverySource) indexShard.shardRouting.recoverySource()).forceEmptyTranslog()) {
+                if (((RecoverySource.RemoteStoreRecoverySource) indexShard.shardRouting.recoverySource()).forceAllocate()) {
                     bootstrapFromLastCommit(indexShard, store);
                 }
             }

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestRestoreRemoteStoreAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestRestoreRemoteStoreAction.java
@@ -45,7 +45,7 @@ public final class RestRestoreRemoteStoreAction extends BaseRestHandler {
         );
         restoreRemoteStoreRequest.waitForCompletion(request.paramAsBoolean("wait_for_completion", false));
         restoreRemoteStoreRequest.restoreAllShards(request.paramAsBoolean("restore_all_shards", false));
-        restoreRemoteStoreRequest.forceEmptyTranslog(request.paramAsBoolean("force_empty_translog", false));
+        restoreRemoteStoreRequest.forceAllocate(request.paramAsBoolean("force_allocate", false));
         request.applyContentParser(p -> restoreRemoteStoreRequest.source(p.mapOrdered()));
         return channel -> client.admin().cluster().restoreRemoteStore(restoreRemoteStoreRequest, new RestToXContentListener<>(channel));
     }

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestRestoreRemoteStoreAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestRestoreRemoteStoreAction.java
@@ -45,6 +45,7 @@ public final class RestRestoreRemoteStoreAction extends BaseRestHandler {
         );
         restoreRemoteStoreRequest.waitForCompletion(request.paramAsBoolean("wait_for_completion", false));
         restoreRemoteStoreRequest.restoreAllShards(request.paramAsBoolean("restore_all_shards", false));
+        restoreRemoteStoreRequest.forceEmptyTranslog(request.paramAsBoolean("force_empty_translog", false));
         request.applyContentParser(p -> restoreRemoteStoreRequest.source(p.mapOrdered()));
         return channel -> client.admin().cluster().restoreRemoteStore(restoreRemoteStoreRequest, new RestToXContentListener<>(channel));
     }

--- a/server/src/test/java/org/opensearch/gateway/GatewayMetaStatePersistedStateTests.java
+++ b/server/src/test/java/org/opensearch/gateway/GatewayMetaStatePersistedStateTests.java
@@ -785,7 +785,7 @@ public class GatewayMetaStatePersistedStateTests extends OpenSearchTestCase {
             RemoteClusterStateService remoteClusterStateService = mock(RemoteClusterStateService.class);
             when(remoteClusterStateService.getLastKnownUUIDFromRemote("test-cluster")).thenReturn("test-cluster-uuid");
             RemoteStoreRestoreService remoteStoreRestoreService = mock(RemoteStoreRestoreService.class);
-            when(remoteStoreRestoreService.restore(any(), any(), anyBoolean(), any())).thenReturn(
+            when(remoteStoreRestoreService.restore(any(), any(), anyBoolean(), anyBoolean(), any())).thenReturn(
                 RemoteRestoreResult.build("test-cluster-uuid", null, ClusterState.EMPTY_STATE)
             );
             gateway = new MockGatewayMetaState(localNode, bigArrays, remoteClusterStateService, remoteStoreRestoreService);
@@ -832,7 +832,7 @@ public class GatewayMetaStatePersistedStateTests extends OpenSearchTestCase {
             when(remoteClusterStateService.getLastKnownUUIDFromRemote(clusterName.value())).thenReturn(ClusterState.UNKNOWN_UUID);
 
             final RemoteStoreRestoreService remoteStoreRestoreService = mock(RemoteStoreRestoreService.class);
-            when(remoteStoreRestoreService.restore(any(), any(), anyBoolean(), any())).thenReturn(
+            when(remoteStoreRestoreService.restore(any(), any(), anyBoolean(), anyBoolean(), any())).thenReturn(
                 RemoteRestoreResult.build("test-cluster-uuid", null, ClusterState.EMPTY_STATE)
             );
             final PersistedStateRegistry persistedStateRegistry = persistedStateRegistry();
@@ -879,7 +879,7 @@ public class GatewayMetaStatePersistedStateTests extends OpenSearchTestCase {
             );
 
             final RemoteStoreRestoreService remoteStoreRestoreService = mock(RemoteStoreRestoreService.class);
-            when(remoteStoreRestoreService.restore(any(), any(), anyBoolean(), any())).thenReturn(
+            when(remoteStoreRestoreService.restore(any(), any(), anyBoolean(), anyBoolean(), any())).thenReturn(
                 RemoteRestoreResult.build("test-cluster-uuid", null, previousState)
             );
             final PersistedStateRegistry persistedStateRegistry = persistedStateRegistry();
@@ -893,7 +893,7 @@ public class GatewayMetaStatePersistedStateTests extends OpenSearchTestCase {
             final CoordinationState.PersistedState lucenePersistedState = gateway.getPersistedState();
             PersistedState remotePersistedState = persistedStateRegistry.getPersistedState(PersistedStateType.REMOTE);
             verify(remoteClusterStateService).getLastKnownUUIDFromRemote(Mockito.any());
-            verify(remoteStoreRestoreService).restore(any(), any(), anyBoolean(), any());
+            verify(remoteStoreRestoreService).restore(any(), any(), anyBoolean(), anyBoolean(), any());
             assertThat(remotePersistedState.getLastAcceptedState(), nullValue());
             assertThat(lucenePersistedState.getLastAcceptedState().metadata(), equalTo(previousState.metadata()));
         } finally {
@@ -969,7 +969,7 @@ public class GatewayMetaStatePersistedStateTests extends OpenSearchTestCase {
             ).nodes(DiscoveryNodes.EMPTY_NODES).build();
 
             final RemoteStoreRestoreService remoteStoreRestoreService = mock(RemoteStoreRestoreService.class);
-            when(remoteStoreRestoreService.restore(any(), any(), anyBoolean(), any())).thenReturn(
+            when(remoteStoreRestoreService.restore(any(), any(), anyBoolean(), anyBoolean(), any())).thenReturn(
                 RemoteRestoreResult.build("test-cluster-uuid", null, clusterState)
             );
             final PersistedStateRegistry persistedStateRegistry = persistedStateRegistry();
@@ -983,7 +983,13 @@ public class GatewayMetaStatePersistedStateTests extends OpenSearchTestCase {
             PersistedState remotePersistedState = persistedStateRegistry.getPersistedState(PersistedStateType.REMOTE);
             PersistedState lucenePersistedState = persistedStateRegistry.getPersistedState(PersistedStateType.LOCAL);
             verify(remoteClusterStateService).getLastKnownUUIDFromRemote(clusterName.value()); // change this
-            verify(remoteStoreRestoreService).restore(any(ClusterState.class), any(String.class), anyBoolean(), any(String[].class));
+            verify(remoteStoreRestoreService).restore(
+                any(ClusterState.class),
+                any(String.class),
+                anyBoolean(),
+                anyBoolean(),
+                any(String[].class)
+            );
             assertThat(remotePersistedState.getLastAcceptedState(), nullValue());
             assertThat(
                 Metadata.isGlobalStateEquals(lucenePersistedState.getLastAcceptedState().metadata(), clusterState.metadata()),


### PR DESCRIPTION
### Description
- In this change, we add a support to create empty translog on local if there is no data in remote translog.
- Remote store restore fails if remote translog is empty. As most of the data is part of segments, the new query parameter added in this PR, `force_empty_translog`, ignores remote translog and creates empty translog on local.
- But this is not ideal solution. We made sure each time primary shard is created, remote translog is populated here: https://github.com/opensearch-project/OpenSearch/pull/10839 but it is not guaranteed to succeed always (e.g. if remote store calls are failing at the time of shard creation)

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
