### PR TITLE
[BUG] The thread context is not properly cleared and messes up the traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix 'org.apache.hc.core5.http.ParseException: Invalid protocol version' under JDK 16+ ([#4827](https://github.com/opensearch-project/OpenSearch/pull/4827))
 - Fix compression support for h2c protocol ([#4944](https://github.com/opensearch-project/OpenSearch/pull/4944))
 - Don't over-allocate in HeapBufferedAsyncEntityConsumer in order to consume the response ([#9993](https://github.com/opensearch-project/OpenSearch/pull/9993))
-- [BUG] The thread context is not properly cleared and messes up the traces ([#10873](https://github.com/opensearch-project/OpenSearch/pull/10873))
+- [BUG] Fix the thread context that is not properly cleared and messes up the traces ([#10873](https://github.com/opensearch-project/OpenSearch/pull/10873))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix 'org.apache.hc.core5.http.ParseException: Invalid protocol version' under JDK 16+ ([#4827](https://github.com/opensearch-project/OpenSearch/pull/4827))
 - Fix compression support for h2c protocol ([#4944](https://github.com/opensearch-project/OpenSearch/pull/4944))
 - Don't over-allocate in HeapBufferedAsyncEntityConsumer in order to consume the response ([#9993](https://github.com/opensearch-project/OpenSearch/pull/9993))
+- [BUG] The thread context is not properly cleared and messes up the traces ([#10873](https://github.com/opensearch-project/OpenSearch/pull/10873))
 
 ### Security
 

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/DefaultSpanScope.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/DefaultSpanScope.java
@@ -44,23 +44,23 @@ class DefaultSpanScope implements SpanScope {
     public static SpanScope create(Span span, TracerContextStorage<String, Span> tracerContextStorage) {
         final SpanScope beforeSpanScope = spanScopeThreadLocal.get();
         SpanScope newSpanScope = new DefaultSpanScope(span, beforeSpanScope, tracerContextStorage);
-        spanScopeThreadLocal.set(newSpanScope);
         return newSpanScope;
     }
 
     @Override
     public void close() {
         detach();
-        spanScopeThreadLocal.set(previousSpanScope);
     }
 
     @Override
     public SpanScope attach() {
+        spanScopeThreadLocal.set(this);
         tracerContextStorage.put(TracerContextStorage.CURRENT_SPAN, this.span);
         return this;
     }
 
     private void detach() {
+        spanScopeThreadLocal.set(previousSpanScope);
         if (previousSpanScope != null) {
             tracerContextStorage.put(TracerContextStorage.CURRENT_SPAN, previousSpanScope.getSpan());
         } else {

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/DefaultTracer.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/DefaultTracer.java
@@ -12,7 +12,7 @@ import org.opensearch.common.annotation.InternalApi;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.List;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 
@@ -53,7 +53,6 @@ class DefaultTracer implements Tracer {
             parentSpan = getCurrentSpanInternal();
         }
         Span span = createSpan(context, parentSpan);
-        setCurrentSpanInContext(span);
         addDefaultAttributes(span);
         return span;
     }
@@ -94,10 +93,6 @@ class DefaultTracer implements Tracer {
         return tracingTelemetry.createSpan(spanCreationContext, parentSpan);
     }
 
-    private void setCurrentSpanInContext(Span span) {
-        tracerContextStorage.put(TracerContextStorage.CURRENT_SPAN, span);
-    }
-
     /**
      * Adds default attributes in the span
      * @param span the current active span
@@ -107,7 +102,7 @@ class DefaultTracer implements Tracer {
     }
 
     @Override
-    public Span startSpan(SpanCreationContext spanCreationContext, Map<String, List<String>> headers) {
+    public Span startSpan(SpanCreationContext spanCreationContext, Map<String, Collection<String>> headers) {
         Optional<Span> propagatedSpan = tracingTelemetry.getContextPropagator().extractFromHeaders(headers);
         return startSpan(spanCreationContext.parent(propagatedSpan.map(SpanContext::new).orElse(null)));
     }

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/SpanReference.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/SpanReference.java
@@ -17,6 +17,7 @@ import org.opensearch.common.annotation.InternalApi;
  */
 @InternalApi
 final class SpanReference {
+
     private Span span;
 
     /**

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/SpanReference.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/SpanReference.java
@@ -17,7 +17,6 @@ import org.opensearch.common.annotation.InternalApi;
  */
 @InternalApi
 final class SpanReference {
-
     private Span span;
 
     /**

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/Tracer.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/Tracer.java
@@ -9,7 +9,7 @@
 package org.opensearch.telemetry.tracing;
 
 import org.opensearch.common.annotation.ExperimentalApi;
-import org.opensearch.telemetry.tracing.http.HttpTracer;
+import org.opensearch.telemetry.tracing.transport.TransportTracer;
 
 import java.io.Closeable;
 
@@ -22,7 +22,7 @@ import java.io.Closeable;
  * @opensearch.experimental
  */
 @ExperimentalApi
-public interface Tracer extends HttpTracer, Closeable {
+public interface Tracer extends TransportTracer, Closeable {
     /**
      * Starts the {@link Span} with given {@link SpanCreationContext}
      *

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/TracingContextPropagator.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/TracingContextPropagator.java
@@ -10,7 +10,7 @@ package org.opensearch.telemetry.tracing;
 
 import org.opensearch.common.annotation.ExperimentalApi;
 
-import java.util.List;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
@@ -36,7 +36,7 @@ public interface TracingContextPropagator {
      * @param headers request headers to extract the context from
      * @return current span
      */
-    Optional<Span> extractFromHeaders(Map<String, List<String>> headers);
+    Optional<Span> extractFromHeaders(Map<String, Collection<String>> headers);
 
     /**
      * Injects tracing context

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/noop/NoopTracer.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/noop/NoopTracer.java
@@ -16,7 +16,7 @@ import org.opensearch.telemetry.tracing.SpanCreationContext;
 import org.opensearch.telemetry.tracing.SpanScope;
 import org.opensearch.telemetry.tracing.Tracer;
 
-import java.util.List;
+import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -65,7 +65,7 @@ public class NoopTracer implements Tracer {
     }
 
     @Override
-    public Span startSpan(SpanCreationContext spanCreationContext, Map<String, List<String>> header) {
+    public Span startSpan(SpanCreationContext spanCreationContext, Map<String, Collection<String>> header) {
         return NoopSpan.INSTANCE;
     }
 }

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/transport/TransportTracer.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/transport/TransportTracer.java
@@ -6,31 +6,31 @@
  * compatible open source license.
  */
 
-package org.opensearch.telemetry.tracing.http;
+package org.opensearch.telemetry.tracing.transport;
 
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.telemetry.tracing.Span;
 import org.opensearch.telemetry.tracing.SpanCreationContext;
 
-import java.util.List;
+import java.util.Collection;
 import java.util.Map;
 
 /**
- * HttpTracer helps in creating a {@link Span} which reads the incoming tracing information
- * from the HttpRequest header and propagate the span accordingly.
+ * TransportTracer helps in creating a {@link Span} which reads the incoming tracing information
+ * from the HTTP or TCP transport headers and propagate the span accordingly.
  * <p>
  * All methods on the Tracer object are multi-thread safe.
  *
  * @opensearch.experimental
  */
 @ExperimentalApi
-public interface HttpTracer {
+public interface TransportTracer {
     /**
      * Start the span with propagating the tracing info from the HttpRequest header.
      *
      * @param spanCreationContext span name.
-     * @param header http request header.
-     * @return span.
+     * @param headers transport headers
+     * @return the span instance
      */
-    Span startSpan(SpanCreationContext spanCreationContext, Map<String, List<String>> header);
+    Span startSpan(SpanCreationContext spanCreationContext, Map<String, Collection<String>> headers);
 }

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/transport/package-info.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/transport/package-info.java
@@ -7,6 +7,6 @@
  */
 
 /**
- * Contains No-op implementations
+ * Contains HTTP or TCP transport related tracer capabilities
  */
-package org.opensearch.telemetry.tracing.http;
+package org.opensearch.telemetry.tracing.transport;

--- a/plugins/telemetry-otel/src/main/java/org/opensearch/telemetry/tracing/OTelTracingContextPropagator.java
+++ b/plugins/telemetry-otel/src/main/java/org/opensearch/telemetry/tracing/OTelTracingContextPropagator.java
@@ -10,8 +10,8 @@ package org.opensearch.telemetry.tracing;
 
 import org.opensearch.core.common.Strings;
 
+import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
@@ -51,7 +51,7 @@ public class OTelTracingContextPropagator implements TracingContextPropagator {
     }
 
     @Override
-    public Optional<Span> extractFromHeaders(Map<String, List<String>> headers) {
+    public Optional<Span> extractFromHeaders(Map<String, Collection<String>> headers) {
         Context context = openTelemetry.getPropagators().getTextMapPropagator().extract(Context.current(), headers, HEADER_TEXT_MAP_GETTER);
         return Optional.ofNullable(getPropagatedSpan(context));
     }
@@ -87,9 +87,9 @@ public class OTelTracingContextPropagator implements TracingContextPropagator {
         }
     };
 
-    private static final TextMapGetter<Map<String, List<String>>> HEADER_TEXT_MAP_GETTER = new TextMapGetter<>() {
+    private static final TextMapGetter<Map<String, Collection<String>>> HEADER_TEXT_MAP_GETTER = new TextMapGetter<>() {
         @Override
-        public Iterable<String> keys(Map<String, List<String>> headers) {
+        public Iterable<String> keys(Map<String, Collection<String>> headers) {
             if (headers != null) {
                 return headers.keySet();
             } else {
@@ -98,7 +98,7 @@ public class OTelTracingContextPropagator implements TracingContextPropagator {
         }
 
         @Override
-        public String get(Map<String, List<String>> headers, String key) {
+        public String get(Map<String, Collection<String>> headers, String key) {
             if (headers != null && headers.containsKey(key)) {
                 return Strings.collectionToCommaDelimitedString(headers.get(key));
             }

--- a/plugins/telemetry-otel/src/test/java/org/opensearch/telemetry/tracing/OTelTracingContextPropagatorTests.java
+++ b/plugins/telemetry-otel/src/test/java/org/opensearch/telemetry/tracing/OTelTracingContextPropagatorTests.java
@@ -11,8 +11,8 @@ package org.opensearch.telemetry.tracing;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import io.opentelemetry.api.OpenTelemetry;
@@ -57,7 +57,7 @@ public class OTelTracingContextPropagatorTests extends OpenSearchTestCase {
     }
 
     public void testExtractTracerContextFromHttpHeader() {
-        Map<String, List<String>> requestHeaders = new HashMap<>();
+        Map<String, Collection<String>> requestHeaders = new HashMap<>();
         requestHeaders.put("traceparent", Arrays.asList("00-" + TRACE_ID + "-" + SPAN_ID + "-00"));
         OpenTelemetry mockOpenTelemetry = mock(OpenTelemetry.class);
         when(mockOpenTelemetry.getPropagators()).thenReturn(ContextPropagators.create(W3CTraceContextPropagator.getInstance()));

--- a/server/src/main/java/org/opensearch/http/AbstractHttpServerTransport.java
+++ b/server/src/main/java/org/opensearch/http/AbstractHttpServerTransport.java
@@ -69,9 +69,11 @@ import java.net.InetSocketAddress;
 import java.nio.channels.CancelledKeyException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -362,7 +364,7 @@ public abstract class AbstractHttpServerTransport extends AbstractLifecycleCompo
      * @param httpChannel that received the http request
      */
     public void incomingRequest(final HttpRequest httpRequest, final HttpChannel httpChannel) {
-        final Span span = tracer.startSpan(SpanBuilder.from(httpRequest), httpRequest.getHeaders());
+        final Span span = tracer.startSpan(SpanBuilder.from(httpRequest), extractHeaders(httpRequest.getHeaders()));
         try (final SpanScope httpRequestSpanScope = tracer.withSpanInScope(span)) {
             HttpChannel traceableHttpChannel = TraceableHttpChannel.create(httpChannel, span, tracer);
             handleIncomingRequest(httpRequest, traceableHttpChannel, httpRequest.getInboundException());
@@ -482,5 +484,10 @@ public abstract class AbstractHttpServerTransport extends AbstractLifecycleCompo
         } else {
             return NO_OP;
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <Values extends Collection<String>> Map<String, Collection<String>> extractHeaders(Map<String, Values> headers) {
+        return (Map<String, Collection<String>>) headers;
     }
 }

--- a/server/src/main/java/org/opensearch/telemetry/tracing/ThreadContextBasedTracerContextStorage.java
+++ b/server/src/main/java/org/opensearch/telemetry/tracing/ThreadContextBasedTracerContextStorage.java
@@ -15,7 +15,6 @@ import org.opensearch.common.util.concurrent.ThreadContextStatePropagator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 
 /**
  * Core's ThreadContext based TracerContextStorage implementation
@@ -79,17 +78,7 @@ public class ThreadContextBasedTracerContextStorage implements TracerContextStor
     }
 
     Span getCurrentSpan(String key) {
-        Optional<Span> optionalSpanFromContext = spanFromThreadContext(key);
-        return optionalSpanFromContext.orElse(spanFromHeader());
-    }
-
-    private Optional<Span> spanFromThreadContext(String key) {
         SpanReference currentSpanRef = threadContext.getTransient(key);
-        return (currentSpanRef == null) ? Optional.empty() : Optional.ofNullable(currentSpanRef.getSpan());
-    }
-
-    private Span spanFromHeader() {
-        Optional<Span> span = tracingTelemetry.getContextPropagator().extract(threadContext.getHeaders());
-        return span.orElse(null);
+        return (currentSpanRef == null) ? null : currentSpanRef.getSpan();
     }
 }

--- a/server/src/main/java/org/opensearch/telemetry/tracing/TracerFactory.java
+++ b/server/src/main/java/org/opensearch/telemetry/tracing/TracerFactory.java
@@ -62,6 +62,13 @@ public class TracerFactory implements Closeable {
         }
     }
 
+    protected TracerContextStorage<String, Span> createTracerContextStorage(
+        TracingTelemetry tracingTelemetry,
+        ThreadContext threadContext
+    ) {
+        return new ThreadContextBasedTracerContextStorage(threadContext, tracingTelemetry);
+    }
+
     private Tracer tracer(Optional<Telemetry> telemetry, ThreadContext threadContext) {
         return telemetry.map(Telemetry::getTracingTelemetry)
             .map(tracingTelemetry -> createDefaultTracer(tracingTelemetry, threadContext))
@@ -70,10 +77,7 @@ public class TracerFactory implements Closeable {
     }
 
     private Tracer createDefaultTracer(TracingTelemetry tracingTelemetry, ThreadContext threadContext) {
-        TracerContextStorage<String, Span> tracerContextStorage = new ThreadContextBasedTracerContextStorage(
-            threadContext,
-            tracingTelemetry
-        );
+        TracerContextStorage<String, Span> tracerContextStorage = createTracerContextStorage(tracingTelemetry, threadContext);
         return new DefaultTracer(tracingTelemetry, tracerContextStorage);
     }
 

--- a/server/src/main/java/org/opensearch/telemetry/tracing/WrappedTracer.java
+++ b/server/src/main/java/org/opensearch/telemetry/tracing/WrappedTracer.java
@@ -13,7 +13,7 @@ import org.opensearch.telemetry.TelemetrySettings;
 import org.opensearch.telemetry.tracing.noop.NoopTracer;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -75,7 +75,7 @@ final class WrappedTracer implements Tracer {
     }
 
     @Override
-    public Span startSpan(SpanCreationContext spanCreationContext, Map<String, List<String>> headers) {
+    public Span startSpan(SpanCreationContext spanCreationContext, Map<String, Collection<String>> headers) {
         return defaultTracer.startSpan(spanCreationContext, headers);
     }
 }

--- a/server/src/main/java/org/opensearch/transport/TransportService.java
+++ b/server/src/main/java/org/opensearch/transport/TransportService.java
@@ -867,59 +867,18 @@ public class TransportService extends AbstractLifecycleComponent
         final TransportRequestOptions options,
         final TransportResponseHandler<T> handler
     ) {
-        final Span span = tracer.startSpan(SpanBuilder.from(action, connection));
-        try (SpanScope spanScope = tracer.withSpanInScope(span)) {
-            TransportResponseHandler<T> traceableTransportResponseHandler = TraceableTransportResponseHandler.create(handler, span, tracer);
-            try {
-                logger.debug("Action: " + action);
-                final TransportResponseHandler<T> delegate;
-                if (request.getParentTask().isSet()) {
-                    // TODO: capture the connection instead so that we can cancel child tasks on the remote connections.
-                    final Releasable unregisterChildNode = taskManager.registerChildNode(
-                        request.getParentTask().getId(),
-                        connection.getNode()
-                    );
-                    delegate = new TransportResponseHandler<T>() {
-                        @Override
-                        public void handleResponse(T response) {
-                            unregisterChildNode.close();
-                            traceableTransportResponseHandler.handleResponse(response);
-                        }
-
-                        @Override
-                        public void handleException(TransportException exp) {
-                            unregisterChildNode.close();
-                            traceableTransportResponseHandler.handleException(exp);
-                        }
-
-                        @Override
-                        public String executor() {
-                            return traceableTransportResponseHandler.executor();
-                        }
-
-                        @Override
-                        public T read(StreamInput in) throws IOException {
-                            return traceableTransportResponseHandler.read(in);
-                        }
-
-                        @Override
-                        public String toString() {
-                            return getClass().getName() + "/[" + action + "]:" + handler.toString();
-                        }
-                    };
-                } else {
-                    delegate = traceableTransportResponseHandler;
-                }
-                asyncSender.sendRequest(connection, action, request, options, delegate);
-            } catch (final Exception ex) {
-                // the caller might not handle this so we invoke the handler
-                final TransportException te;
-                if (ex instanceof TransportException) {
-                    te = (TransportException) ex;
-                } else {
-                    te = new TransportException("failure to send", ex);
-                }
-                traceableTransportResponseHandler.handleException(te);
+        if (connection == localNodeConnection) {
+            // See please https://github.com/opensearch-project/OpenSearch/issues/10291
+            sendRequestAsync(connection, action, request, options, handler);
+        } else {
+            final Span span = tracer.startSpan(SpanBuilder.from(action, connection));
+            try (SpanScope spanScope = tracer.withSpanInScope(span)) {
+                TransportResponseHandler<T> traceableTransportResponseHandler = TraceableTransportResponseHandler.create(
+                    handler,
+                    span,
+                    tracer
+                );
+                sendRequestAsync(connection, action, request, options, traceableTransportResponseHandler);
             }
         }
     }
@@ -1688,6 +1647,63 @@ public class TransportService extends AbstractLifecycleComponent
             for (TransportMessageListener listener : listeners) {
                 listener.onResponseReceived(requestId, holder);
             }
+        }
+    }
+
+    private <T extends TransportResponse> void sendRequestAsync(
+        final Transport.Connection connection,
+        final String action,
+        final TransportRequest request,
+        final TransportRequestOptions options,
+        final TransportResponseHandler<T> handler
+    ) {
+        try {
+            logger.debug("Action: " + action);
+            final TransportResponseHandler<T> delegate;
+            if (request.getParentTask().isSet()) {
+                // TODO: capture the connection instead so that we can cancel child tasks on the remote connections.
+                final Releasable unregisterChildNode = taskManager.registerChildNode(request.getParentTask().getId(), connection.getNode());
+                delegate = new TransportResponseHandler<T>() {
+                    @Override
+                    public void handleResponse(T response) {
+                        unregisterChildNode.close();
+                        handler.handleResponse(response);
+                    }
+
+                    @Override
+                    public void handleException(TransportException exp) {
+                        unregisterChildNode.close();
+                        handler.handleException(exp);
+                    }
+
+                    @Override
+                    public String executor() {
+                        return handler.executor();
+                    }
+
+                    @Override
+                    public T read(StreamInput in) throws IOException {
+                        return handler.read(in);
+                    }
+
+                    @Override
+                    public String toString() {
+                        return getClass().getName() + "/[" + action + "]:" + handler.toString();
+                    }
+                };
+            } else {
+                delegate = handler;
+            }
+            asyncSender.sendRequest(connection, action, request, options, delegate);
+        } catch (final Exception ex) {
+            // the caller might not handle this so we invoke the handler
+            final TransportException te;
+            if (ex instanceof TransportException) {
+                te = (TransportException) ex;
+            } else {
+                te = new TransportException("failure to send", ex);
+            }
+            handler.handleException(te);
         }
     }
 }

--- a/server/src/test/java/org/opensearch/telemetry/tracing/ThreadContextBasedTracerContextStorageTests.java
+++ b/server/src/test/java/org/opensearch/telemetry/tracing/ThreadContextBasedTracerContextStorageTests.java
@@ -1,0 +1,174 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.telemetry.tracing;
+
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.common.util.concurrent.ThreadContext.StoredContext;
+import org.opensearch.telemetry.Telemetry;
+import org.opensearch.telemetry.TelemetrySettings;
+import org.opensearch.telemetry.metrics.MetricsTelemetry;
+import org.opensearch.telemetry.tracing.noop.NoopTracer;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.telemetry.tracing.MockTracingTelemetry;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.opensearch.telemetry.TelemetrySettings.TRACER_ENABLED_SETTING;
+import static org.opensearch.telemetry.TelemetrySettings.TRACER_FEATURE_ENABLED_SETTING;
+import static org.opensearch.telemetry.TelemetrySettings.TRACER_SAMPLER_PROBABILITY;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+
+public class ThreadContextBasedTracerContextStorageTests extends OpenSearchTestCase {
+    private Tracer tracer;
+    private ThreadContext threadContext;
+    private TracerContextStorage<String, Span> threadContextStorage;
+    private ExecutorService executorService;
+
+    @SuppressWarnings("resource")
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        final Settings settings = Settings.builder()
+            .put(TRACER_ENABLED_SETTING.getKey(), true)
+            .put(TRACER_SAMPLER_PROBABILITY.getKey(), 1d)
+            .put(TRACER_FEATURE_ENABLED_SETTING.getKey(), true)
+            .build();
+
+        final TelemetrySettings telemetrySettings = new TelemetrySettings(
+            settings,
+            new ClusterSettings(Settings.EMPTY, Set.of(TRACER_ENABLED_SETTING, TRACER_SAMPLER_PROBABILITY))
+        );
+
+        final TracingTelemetry tracingTelemetry = new MockTracingTelemetry();
+
+        threadContext = new ThreadContext(Settings.EMPTY);
+        threadContextStorage = new ThreadContextBasedTracerContextStorage(threadContext, tracingTelemetry);
+
+        tracer = new TracerFactory(telemetrySettings, Optional.of(new Telemetry() {
+            @Override
+            public MetricsTelemetry getMetricsTelemetry() {
+                return null;
+            }
+
+            @Override
+            public TracingTelemetry getTracingTelemetry() {
+                return tracingTelemetry;
+            }
+        }), threadContext) {
+            @Override
+            protected TracerContextStorage<String, Span> createTracerContextStorage(
+                TracingTelemetry tracingTelemetry,
+                ThreadContext threadContext
+            ) {
+                return threadContextStorage;
+            }
+        }.getTracer();
+
+        executorService = Executors.newSingleThreadExecutor();
+        assertThat(tracer, not(instanceOf(NoopTracer.class)));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+        executorService.shutdown();
+        tracer.close();
+    }
+
+    public void testStartingSpanDoesNotChangeThreadContext() {
+        final Span span = tracer.startSpan(SpanCreationContext.internal().name("test"));
+        assertThat(threadContext.getTransient(ThreadContextBasedTracerContextStorage.CURRENT_SPAN), is(nullValue()));
+    }
+
+    public void testSpanInScopeChangesThreadContext() {
+        final Span span = tracer.startSpan(SpanCreationContext.internal().name("test"));
+
+        try (SpanScope scope = tracer.withSpanInScope(span)) {
+            assertThat(threadContext.getTransient(ThreadContextBasedTracerContextStorage.CURRENT_SPAN), is(not(nullValue())));
+            assertThat(threadContextStorage.get(ThreadContextBasedTracerContextStorage.CURRENT_SPAN), is(span));
+        }
+
+        assertThat(threadContext.getTransient(ThreadContextBasedTracerContextStorage.CURRENT_SPAN), is(not(nullValue())));
+        assertThat(threadContextStorage.get(ThreadContextBasedTracerContextStorage.CURRENT_SPAN), is(nullValue()));
+    }
+
+    public void testStashingPropagatesThreadContext() {
+        final Span span = tracer.startSpan(SpanCreationContext.internal().name("test"));
+
+        try (SpanScope scope = tracer.withSpanInScope(span)) {
+            try (StoredContext ignored = threadContext.stashContext()) {
+                assertThat(threadContext.getTransient(ThreadContextBasedTracerContextStorage.CURRENT_SPAN), is(not(nullValue())));
+                assertThat(threadContextStorage.get(ThreadContextBasedTracerContextStorage.CURRENT_SPAN), is(span));
+            }
+        }
+
+        assertThat(threadContext.getTransient(ThreadContextBasedTracerContextStorage.CURRENT_SPAN), is(not(nullValue())));
+        assertThat(threadContextStorage.get(ThreadContextBasedTracerContextStorage.CURRENT_SPAN), is(nullValue()));
+    }
+
+    public void testPreservingContextThreadContext() throws InterruptedException, ExecutionException, TimeoutException {
+        final Span span = tracer.startSpan(SpanCreationContext.internal().name("test"));
+
+        try (SpanScope scope = tracer.withSpanInScope(span)) {
+            final Runnable r = new Runnable() {
+                @Override
+                public void run() {
+                    assertThat(threadContext.getTransient(ThreadContextBasedTracerContextStorage.CURRENT_SPAN), is(not(nullValue())));
+                    assertThat(threadContextStorage.get(ThreadContextBasedTracerContextStorage.CURRENT_SPAN), is(span));
+                }
+            };
+
+            executorService.submit(threadContext.preserveContext(r)).get(1, TimeUnit.SECONDS);
+        }
+
+        assertThat(threadContext.getTransient(ThreadContextBasedTracerContextStorage.CURRENT_SPAN), is(not(nullValue())));
+        assertThat(threadContextStorage.get(ThreadContextBasedTracerContextStorage.CURRENT_SPAN), is(nullValue()));
+    }
+
+    public void testPreservingContextAndStashingThreadContext() throws InterruptedException, ExecutionException, TimeoutException {
+        final Span span = tracer.startSpan(SpanCreationContext.internal().name("test"));
+
+        try (SpanScope scope = tracer.withSpanInScope(span)) {
+            final Runnable r = new Runnable() {
+                @Override
+                public void run() {
+                    final Span local = tracer.startSpan(SpanCreationContext.internal().name("test-local"));
+                    try (SpanScope localScope = tracer.withSpanInScope(local)) {
+                        try (StoredContext ignored = threadContext.stashContext()) {
+                            assertThat(
+                                threadContext.getTransient(ThreadContextBasedTracerContextStorage.CURRENT_SPAN),
+                                is(not(nullValue()))
+                            );
+                            assertThat(threadContextStorage.get(ThreadContextBasedTracerContextStorage.CURRENT_SPAN), is(local));
+                        }
+                    }
+                }
+            };
+
+            executorService.submit(threadContext.preserveContext(r)).get(1, TimeUnit.SECONDS);
+        }
+
+        assertThat(threadContext.getTransient(ThreadContextBasedTracerContextStorage.CURRENT_SPAN), is(not(nullValue())));
+        assertThat(threadContextStorage.get(ThreadContextBasedTracerContextStorage.CURRENT_SPAN), is(nullValue()));
+    }
+}

--- a/test/telemetry/src/main/java/org/opensearch/test/telemetry/tracing/MockTracingContextPropagator.java
+++ b/test/telemetry/src/main/java/org/opensearch/test/telemetry/tracing/MockTracingContextPropagator.java
@@ -14,7 +14,7 @@ import org.opensearch.telemetry.tracing.SpanKind;
 import org.opensearch.telemetry.tracing.TracingContextPropagator;
 import org.opensearch.telemetry.tracing.attributes.Attributes;
 
-import java.util.List;
+import java.util.Collection;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -52,7 +52,7 @@ public class MockTracingContextPropagator implements TracingContextPropagator {
     }
 
     @Override
-    public Optional<Span> extractFromHeaders(Map<String, List<String>> headers) {
+    public Optional<Span> extractFromHeaders(Map<String, Collection<String>> headers) {
         if (headers != null) {
             Map<String, String> convertedHeader = headers.entrySet()
                 .stream()

--- a/test/telemetry/src/main/java/org/opensearch/test/telemetry/tracing/TelemetryValidators.java
+++ b/test/telemetry/src/main/java/org/opensearch/test/telemetry/tracing/TelemetryValidators.java
@@ -49,7 +49,7 @@ public class TelemetryValidators {
         StringBuilder sb = new StringBuilder();
         for (var entry : spanMap.entrySet()) {
             sb.append("SpanData validation failed for validator " + entry.getKey());
-            sb.append("/n");
+            sb.append("\n");
             for (MockSpanData span : entry.getValue()) {
                 sb.append(span.toString());
             }

--- a/test/telemetry/src/main/java/org/opensearch/test/telemetry/tracing/validators/NumberOfTraceIDsEqualToRequests.java
+++ b/test/telemetry/src/main/java/org/opensearch/test/telemetry/tracing/validators/NumberOfTraceIDsEqualToRequests.java
@@ -13,9 +13,9 @@ import org.opensearch.test.telemetry.tracing.MockSpanData;
 import org.opensearch.test.telemetry.tracing.TracingValidator;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -41,13 +41,10 @@ public class NumberOfTraceIDsEqualToRequests implements TracingValidator {
      */
     @Override
     public List<MockSpanData> validate(List<MockSpanData> spans, int requests) {
-        Set<String> totalTraceIDs = spans.stream()
-            .filter(span -> isMatchingSpan(span))
-            .map(MockSpanData::getTraceID)
-            .collect(Collectors.toSet());
+        final Collection<MockSpanData> totalTraceIDs = spans.stream().filter(span -> isMatchingSpan(span)).collect(Collectors.toList());
         List<MockSpanData> problematicSpans = new ArrayList<>();
-        if (totalTraceIDs.size() != requests) {
-            problematicSpans.addAll(spans);
+        if (totalTraceIDs.stream().map(MockSpanData::getTraceID).distinct().count() != requests) {
+            problematicSpans.addAll(totalTraceIDs);
         }
         return problematicSpans;
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The thread context stashing messes up the propagation of the current span across thread boundaries (and even same thread boundary). It leads to split brain situation when some state is stored in `ThreadContext` and in the thread local scope, which is difficult (if possible at all) to reconcile. 

### Related Issues

Closes https://github.com/opensearch-project/OpenSearch/issues/10789

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
