### PR TITLE
Fix flaky testClusterStateBatchedUpdates test

### DIFF
--- a/server/src/test/java/org/opensearch/cluster/service/MasterServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/service/MasterServiceTests.java
@@ -487,6 +487,9 @@ public class MasterServiceTests extends OpenSearchTestCase {
                     }
                 });
                 assertBusy(mockAppender::assertAllExpectationsMatched);
+                // verify stats values after state is published
+                assertEquals(1, clusterManagerService.getClusterStateStats().getUpdateSuccess());
+                assertEquals(0, clusterManagerService.getClusterStateStats().getUpdateFailed());
             }
         }
     }
@@ -691,9 +694,6 @@ public class MasterServiceTests extends OpenSearchTestCase {
                     submittedTasksPerThread.get(entry.getKey()).get()
                 );
             }
-            // verify stats values after state is published
-            assertEquals(1, clusterManagerService.getClusterStateStats().getUpdateSuccess());
-            assertEquals(0, clusterManagerService.getClusterStateStats().getUpdateFailed());
         }
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Move the assertion to more deterministic test where cluster state update will happen for sure. Executed the test 1000 time locally in a loop to verify it's not going to be flaky anymore.

### Related Issues
Resolves #10899 

### Check List
- [x] New functionality includes testing.
 - [x] All tests pass
~- [x] New functionality has been documented.~
 ~- [x] New functionality has javadoc added~
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
~- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
