### PR TITLE
Add statsName field on stream while constructing PersistedStateStats

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/gateway/remote/RemoteClusterStateServiceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/gateway/remote/RemoteClusterStateServiceIT.java
@@ -115,16 +115,7 @@ public class RemoteClusterStateServiceIT extends RemoteStoreBaseIntegTestCase {
             .get();
 
         // assert cluster state stats
-        DiscoveryStats discoveryStats = nodesStatsResponse.getNodes().get(0).getDiscoveryStats();
-
-        assertNotNull(discoveryStats.getClusterStateStats());
-        assertTrue(discoveryStats.getClusterStateStats().getUpdateSuccess() > 1);
-        assertEquals(0, discoveryStats.getClusterStateStats().getUpdateFailed());
-        assertTrue(discoveryStats.getClusterStateStats().getUpdateTotalTimeInMillis() > 0);
-        // assert remote state stats
-        assertTrue(discoveryStats.getClusterStateStats().getPersistenceStats().get(0).getSuccessCount() > 1);
-        assertEquals(0, discoveryStats.getClusterStateStats().getPersistenceStats().get(0).getFailedCount());
-        assertTrue(discoveryStats.getClusterStateStats().getPersistenceStats().get(0).getTotalTimeInMillis() > 0);
+        assertClusterManagerClusterStateStats(nodesStatsResponse);
 
         NodesStatsResponse nodesStatsResponseDataNode = client().admin()
             .cluster()
@@ -135,6 +126,67 @@ public class RemoteClusterStateServiceIT extends RemoteStoreBaseIntegTestCase {
         DiscoveryStats dataNodeDiscoveryStats = nodesStatsResponseDataNode.getNodes().get(0).getDiscoveryStats();
         assertNotNull(dataNodeDiscoveryStats.getClusterStateStats());
         assertEquals(0, dataNodeDiscoveryStats.getClusterStateStats().getUpdateSuccess());
+
+        // call nodes/stats with nodeId filter
+        NodesStatsResponse nodesStatsNodeIdFilterResponse = client().admin()
+            .cluster()
+            .prepareNodesStats(dataNode)
+            .addMetric(NodesStatsRequest.Metric.DISCOVERY.metricName())
+            .setNodesIds(clusterManagerNode)
+            .get();
+
+        assertClusterManagerClusterStateStats(nodesStatsNodeIdFilterResponse);
+    }
+
+    private void assertClusterManagerClusterStateStats(NodesStatsResponse nodesStatsResponse) {
+        // assert cluster state stats
+        DiscoveryStats discoveryStats = nodesStatsResponse.getNodes().get(0).getDiscoveryStats();
+
+        assertNotNull(discoveryStats.getClusterStateStats());
+        assertTrue(discoveryStats.getClusterStateStats().getUpdateSuccess() > 1);
+        assertEquals(0, discoveryStats.getClusterStateStats().getUpdateFailed());
+        assertTrue(discoveryStats.getClusterStateStats().getUpdateTotalTimeInMillis() > 0);
+        // assert remote state stats
+        assertTrue(discoveryStats.getClusterStateStats().getPersistenceStats().get(0).getSuccessCount() > 1);
+        assertEquals(0, discoveryStats.getClusterStateStats().getPersistenceStats().get(0).getFailedCount());
+        assertTrue(discoveryStats.getClusterStateStats().getPersistenceStats().get(0).getTotalTimeInMillis() > 0);
+    }
+
+    public void testRemoteStateStatsFromAllNodes() {
+        int shardCount = randomIntBetween(1, 5);
+        int replicaCount = 1;
+        int dataNodeCount = shardCount * (replicaCount + 1);
+        int clusterManagerNodeCount = 3;
+        prepareCluster(clusterManagerNodeCount, dataNodeCount, INDEX_NAME, replicaCount, shardCount);
+        String[] allNodes = internalCluster().getNodeNames();
+        // call _nodes/stats/discovery from all the nodes
+        for (String node : allNodes) {
+            NodesStatsResponse nodesStatsResponse = client().admin()
+                .cluster()
+                .prepareNodesStats(node)
+                .addMetric(NodesStatsRequest.Metric.DISCOVERY.metricName())
+                .get();
+            validateNodesStatsResponse(nodesStatsResponse);
+        }
+
+        // call _nodes/stats/discovery from all the nodes with random nodeId filter
+        for (String node : allNodes) {
+            NodesStatsResponse nodesStatsResponse = client().admin()
+                .cluster()
+                .prepareNodesStats(node)
+                .addMetric(NodesStatsRequest.Metric.DISCOVERY.metricName())
+                .setNodesIds(allNodes[randomIntBetween(0, allNodes.length - 1)])
+                .get();
+            validateNodesStatsResponse(nodesStatsResponse);
+        }
+    }
+
+    private void validateNodesStatsResponse(NodesStatsResponse nodesStatsResponse) {
+        // _nodes/stats/discovery must never fail due to any exception
+        assertFalse(nodesStatsResponse.toString().contains("exception"));
+        assertNotNull(nodesStatsResponse.getNodes());
+        assertNotNull(nodesStatsResponse.getNodes().get(0));
+        assertNotNull(nodesStatsResponse.getNodes().get(0).getDiscoveryStats());
     }
 
     private void setReplicaCount(int replicaCount) {

--- a/server/src/main/java/org/opensearch/cluster/coordination/PersistedStateStats.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/PersistedStateStats.java
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * @opensearch.internal
  */
 public class PersistedStateStats implements Writeable, ToXContentObject {
-    private String statsName;
+    private final String statsName;
     private AtomicLong totalTimeInMillis = new AtomicLong(0);
     private AtomicLong failedCount = new AtomicLong(0);
     private AtomicLong successCount = new AtomicLong(0);
@@ -37,6 +37,7 @@ public class PersistedStateStats implements Writeable, ToXContentObject {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(statsName);
         out.writeVLong(successCount.get());
         out.writeVLong(failedCount.get());
         out.writeVLong(totalTimeInMillis.get());
@@ -53,6 +54,7 @@ public class PersistedStateStats implements Writeable, ToXContentObject {
     }
 
     public PersistedStateStats(StreamInput in) throws IOException {
+        this.statsName = in.readString();
         this.successCount = new AtomicLong(in.readVLong());
         this.failedCount = new AtomicLong(in.readVLong());
         this.totalTimeInMillis = new AtomicLong(in.readVLong());
@@ -111,6 +113,10 @@ public class PersistedStateStats implements Writeable, ToXContentObject {
 
     protected void addToExtendedFields(String extendedField, AtomicLong extendedFieldValue) {
         this.extendedFields.put(extendedField, extendedFieldValue);
+    }
+
+    public String getStatsName() {
+        return statsName;
     }
 
     /**

--- a/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -368,6 +368,7 @@ public class NodeStatsTests extends OpenSearchTestCase {
                             .getPersistenceStats()
                             .get(0);
                         PersistedStateStats remoteStateStats = stateStats.getPersistenceStats().get(0);
+                        assertEquals(remoteStateStats.getStatsName(), deserializedRemoteStateStats.getStatsName());
                         assertEquals(remoteStateStats.getFailedCount(), deserializedRemoteStateStats.getFailedCount());
                         assertEquals(remoteStateStats.getSuccessCount(), deserializedRemoteStateStats.getSuccessCount());
                         assertEquals(remoteStateStats.getTotalTimeInMillis(), deserializedRemoteStateStats.getTotalTimeInMillis());


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
_nodes/stats is failing due to recently added cluster state stats. This PR fixes that issue by writing **statsName** field on the stream and reads from it to properly create the PersistedStateStats object. 

### Related Issues
Resolves #10961 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
~- [ ] New functionality has been documented.~
~- [ ] New functionality has javadoc added~
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
~- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
