### PR TITLE
Add validation to shallow copy snapshot

### DIFF
--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1998,7 +1998,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     /*
     ToDo : Fix this https://github.com/opensearch-project/OpenSearch/issues/8003
      */
-    private RemoteSegmentStoreDirectory getRemoteDirectory() {
+    public RemoteSegmentStoreDirectory getRemoteDirectory() {
         assert indexSettings.isRemoteStoreEnabled();
         assert remoteStore.directory() instanceof FilterDirectory : "Store.directory is not an instance of FilterDirectory";
         FilterDirectory remoteStoreDirectory = (FilterDirectory) remoteStore.directory();

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -205,7 +205,7 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
         return remoteSegmentMetadata;
     }
 
-    private RemoteSegmentMetadata readMetadataFile(String metadataFilename) throws IOException {
+    public RemoteSegmentMetadata readMetadataFile(String metadataFilename) throws IOException {
         try (InputStream inputStream = remoteMetadataDirectory.getBlobStream(metadataFilename)) {
             byte[] metadataBytes = inputStream.readAllBytes();
             return metadataStreamWrapper.readStream(new ByteArrayIndexInput(metadataFilename, metadataBytes));
@@ -515,8 +515,7 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
         return mdLockManager.isAcquired(FileLockInfo.getLockInfoBuilder().withFileToLock(metadataFile).build());
     }
 
-    // Visible for testing
-    String getMetadataFileForCommit(long primaryTerm, long generation) throws IOException {
+    public String getMetadataFileForCommit(long primaryTerm, long generation) throws IOException {
         List<String> metadataFiles = remoteMetadataDirectory.listFilesByPrefixInLexicographicOrder(
             MetadataFilenameUtils.getMetadataFilePrefixForCommit(primaryTerm, generation),
             1


### PR DESCRIPTION
### Description
- Currently, shallow copy snapshot (which references data in remote store) takes a lock on remote store metadata file based on primary term and generation.
- But as we upload a metadata file each refresh, there are multiple files that get created for the same primary term and generation.
- Following is the example that creates issues in the snapshot flow:
  - Snapshot triggers flush, generation is increased to 4 and snapshot has taken lock on primary term and generation 4. Assume metadata file name was `md_1_4_1`
  - As indexing proceeded, multiple metadata files are uploaded for the same primary term and generation. Let's say last file uploaded was `md_1_4_24`.
  - While restoring snapshot, we only provide primary term and generation and ask to get the metadata file where the latest metadata file is fetched (as we fetch the files in lexicographic order).
  - (Ideally, we should use the complete metadata file name while fetching but currently we use only primary term and generation)
  - Snapshot restore works fine most of the times even with the latest metadata file as it restores only from the `segments_N` file which remains constant for the given generation.
  - But the problem occurs when the segments that are referred by the `segments_N` file gets merged and not part of the latest metadata file anymore.
- To mitigate this issue, in this PR, we have introduced following:
  - After acquiring lock on primary term and generation, trigger `flush`. This will make sure generation is increased and there are no more metadata files for the PT and Gen on which snapshot was taken. But there can still be more than 1 files be created as indexing can still happen during snapshot creation.
  - We have added another validation which checks if the latest metadata file's `segments_N` has all the referenced files as part of metadata. If not, we flush and retry again. If retry fails, we fail the snapshot.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
