### PR TITLE
[Remote Store] Add log on seq number gap between segments and translog

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreRestoreIT.java
@@ -12,6 +12,7 @@ import org.opensearch.action.admin.cluster.remotestore.restore.RestoreRemoteStor
 import org.opensearch.action.admin.cluster.remotestore.restore.RestoreRemoteStoreResponse;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.cluster.health.ClusterHealthStatus;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
@@ -23,13 +24,17 @@ import org.opensearch.test.InternalTestCluster;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_SETTINGS_ATTRIBUTE_KEY_PREFIX;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
@@ -459,6 +464,85 @@ public class RemoteStoreRestoreIT extends BaseRemoteStoreRestoreIT {
             Repository segmentRepo = repositoriesService.repository(REPOSITORY_NAME);
             assertNull(segmentRepo.getMetadata().settings().get("max_remote_download_bytes_per_sec"));
         }
+    }
+
+    @AwaitsFix(bugUrl = "this test asserts on truncation of translog data")
+    public void testRestoreIncompleteTranslog() throws IOException {
+        // Create cluster and index
+        prepareCluster(1, 3, INDEX_NAME, 0, 1);
+
+        // Ingest 20 docs, as refresh interval is 300 secs, all these docs should be in translog only.
+        for (int i = 0; i < 20; i++) {
+            indexSingleDoc(INDEX_NAME);
+        }
+
+        // Stop primary to make the cluster red
+        internalCluster().stopRandomNode(InternalTestCluster.nameFilter(primaryNodeName(INDEX_NAME)));
+        ensureRed(INDEX_NAME);
+
+        // Delete latest 3 translog metadata files from remote
+        // This is to simulate partial translog scenario
+        String indexUUID = client().admin()
+            .indices()
+            .prepareGetSettings(INDEX_NAME)
+            .get()
+            .getSetting(INDEX_NAME, IndexMetadata.SETTING_INDEX_UUID);
+        Path indexPath = Path.of(String.valueOf(translogRepoPath), indexUUID, "/0/translog/metadata");
+        try (Stream<Path> files = Files.list(indexPath)) {
+            List<Path> allMetadataFiles = files.collect(Collectors.toList());
+            allMetadataFiles.sort(Comparator.comparing(Path::getFileName));
+
+            for (int i = 0; i < 3; i++) {
+                Files.delete(allMetadataFiles.get(i));
+            }
+        }
+
+        // On restore, index will turn green but the doc count will be less
+        restore(INDEX_NAME);
+        ensureGreen(INDEX_NAME);
+        assertHitCount(client().prepareSearch(INDEX_NAME).setSize(0).get(), 20);
+    }
+
+    public void testRestoreSeqNoGapBetweenSegmentAndTranslog() throws Exception {
+        // Create cluster and index
+        prepareCluster(1, 3, INDEX_NAME, 0, 1);
+
+        // Ingest 20 docs, as refresh interval is 300 secs, all these docs should be in translog only.
+        Map<String, Long> indexStats = indexData(5, true, INDEX_NAME);
+        for (int i = 0; i < 20; i++) {
+            indexSingleDoc(INDEX_NAME);
+        }
+
+        // Stop primary to make the cluster red
+        internalCluster().stopRandomNode(InternalTestCluster.nameFilter(primaryNodeName(INDEX_NAME)));
+        ensureRed(INDEX_NAME);
+
+        // Delete latest 3 segment metadata files from remote
+        // This is to simulate seq number gap between segments and translog
+        String indexUUID = client().admin()
+            .indices()
+            .prepareGetSettings(INDEX_NAME)
+            .get()
+            .getSetting(INDEX_NAME, IndexMetadata.SETTING_INDEX_UUID);
+        Path indexPath = Path.of(String.valueOf(segmentRepoPath), indexUUID, "/0/segments/metadata");
+        try (Stream<Path> files = Files.list(indexPath)) {
+            List<Path> allMetadataFiles = files.collect(Collectors.toList());
+            allMetadataFiles.sort(Comparator.comparing(Path::getFileName));
+
+            for (int i = 0; i < 2; i++) {
+                Files.delete(allMetadataFiles.get(i));
+            }
+        }
+
+        // On restore, index will turn green but the doc count will be less
+        restore(INDEX_NAME);
+
+        // Added ensureRed to assertBusy to make sure none of the recovery attempts succeed.
+        assertBusy(() -> ensureRed(INDEX_NAME));
+
+        // Without the validation added to Translog.newSnapshot(), we get green index but following count fails
+        // ensureGreen(INDEX_NAME);
+        // assertHitCount(client().prepareSearch(INDEX_NAME).setSize(0).get(), indexStats.get(TOTAL_OPERATIONS) + 20);
     }
 
     // TODO: Restore flow - index aliases

--- a/server/src/main/java/org/opensearch/index/translog/Translog.java
+++ b/server/src/main/java/org/opensearch/index/translog/Translog.java
@@ -652,8 +652,11 @@ public abstract class Translog extends AbstractIndexShardComponent implements In
                 .toArray(TranslogSnapshot[]::new);
             if (this instanceof RemoteFsTranslog
                 && fromSeqNo != 0
-                && Arrays.stream(snapshots).noneMatch(snapshot -> snapshot.getCheckpoint().minSeqNo == fromSeqNo)) {
-                throw new MissingHistoryOperationsException("No operation from from_seqno [" + fromSeqNo + "] found");
+                && Arrays.stream(snapshots)
+                    .noneMatch(
+                        snapshot -> snapshot.getCheckpoint().minSeqNo <= fromSeqNo || snapshot.getCheckpoint().maxSeqNo >= fromSeqNo
+                    )) {
+                logger.warn("No operation from from_seqno {} found", fromSeqNo);
             }
             final Snapshot snapshot = newMultiSnapshot(snapshots);
             return new SeqNoFilterSnapshot(snapshot, fromSeqNo, toSeqNo, requiredFullRange);


### PR DESCRIPTION
### Description
- Add logger when there is a gap between starting sequence number from remote translog and sequence number from segments.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
