### PR TITLE
Disable sort optimization for HALF_FLOAT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [BUG] Fix java.lang.SecurityException in repository-gcs plugin ([#10642](https://github.com/opensearch-project/OpenSearch/pull/10642))
 - Add telemetry tracer/metric enable flag and integ test. ([#10395](https://github.com/opensearch-project/OpenSearch/pull/10395))
 - Add instrumentation for indexing in transport bulk action and transport shard bulk action. ([#10273](https://github.com/opensearch-project/OpenSearch/pull/10273))
+- [BUG] Disable sort optimization for HALF_FLOAT ([#10999](https://github.com/opensearch-project/OpenSearch/pull/10999))
 
 ### Deprecated
 

--- a/server/src/main/java/org/opensearch/index/fielddata/IndexNumericFieldData.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/IndexNumericFieldData.java
@@ -242,7 +242,7 @@ public abstract class IndexNumericFieldData implements IndexFieldData<LeafNumeri
                 assert !targetNumericType.isFloatingPoint();
                 source = new IntValuesComparatorSource(this, missingValue, sortMode, nested);
         }
-        if (targetNumericType != getNumericType()) {
+        if (targetNumericType != getNumericType() || getNumericType() == NumericType.HALF_FLOAT) {
             source.disableSkipping(); // disable skipping logic for cast of sort field
         }
         return source;


### PR DESCRIPTION
Fixing - > #10997.
Disable point based sort optimization for half_flaot.
There is a way we can enable it back but it needs bigger code change and I will send out shortly. We will have to create HalfFloatNumericSourceComparator as well HafFloatComparator same as we did for `unsigned_long` for that.
Created follow up issue here to make it back.
https://github.com/opensearch-project/OpenSearch/issues/10998

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)