### PR TITLE
[Backport] [2.11] Disable sort optimization for HALF_FLOAT (#10999)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 ### Fixed
+- [BUG] Disable sort optimization for HALF_FLOAT ([#10999](https://github.com/opensearch-project/OpenSearch/pull/10999))
 
 ### Security
 
 [Unreleased 2.11]: https://github.com/opensearch-project/OpenSearch/compare/2.11...2.11
+

--- a/server/src/main/java/org/opensearch/index/fielddata/IndexNumericFieldData.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/IndexNumericFieldData.java
@@ -242,7 +242,7 @@ public abstract class IndexNumericFieldData implements IndexFieldData<LeafNumeri
                 assert !targetNumericType.isFloatingPoint();
                 source = new IntValuesComparatorSource(this, missingValue, sortMode, nested);
         }
-        if (targetNumericType != getNumericType()) {
+        if (targetNumericType != getNumericType() || getNumericType() == NumericType.HALF_FLOAT) {
             source.disableSkipping(); // disable skipping logic for cast of sort field
         }
         return source;


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/10999

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
