### PR TITLE
Enable Fuzzy codec for doc id fields using a bloom filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Remote cluster state] Make index and global metadata upload timeout dynamic cluster settings ([#10814](https://github.com/opensearch-project/OpenSearch/pull/10814))
 - Added cluster setting cluster.restrict.index.replication_type to restrict setting of index setting replication type ([#10866](https://github.com/opensearch-project/OpenSearch/pull/10866))
 - Add cluster state stats ([#10670](https://github.com/opensearch-project/OpenSearch/pull/10670))
+- Enable Fuzzy codec for doc id fields using a bloom filter ([#11022](https://github.com/opensearch-project/OpenSearch/pull/11022))
 
 ### Dependencies
 - Bump `com.google.api.grpc:proto-google-common-protos` from 2.10.0 to 2.25.1 ([#10208](https://github.com/opensearch-project/OpenSearch/pull/10208), [#10298](https://github.com/opensearch-project/OpenSearch/pull/10298))

--- a/benchmarks/src/main/java/org/opensearch/benchmark/index/codec/fuzzy/FilterConstructionBenchmark.java
+++ b/benchmarks/src/main/java/org/opensearch/benchmark/index/codec/fuzzy/FilterConstructionBenchmark.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.benchmark.index.codec.fuzzy;
+
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.common.UUIDs;
+import org.opensearch.index.codec.fuzzy.FuzzySet;
+import org.opensearch.index.codec.fuzzy.FuzzySetFactory;
+import org.opensearch.index.codec.fuzzy.FuzzySetParameters;
+import org.opensearch.index.mapper.IdFieldMapper;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Fork(3)
+@Warmup(iterations = 2)
+@Measurement(iterations = 5, time = 60, timeUnit = TimeUnit.SECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class FilterConstructionBenchmark {
+
+    private List<BytesRef> items;
+
+    @Param({ "1000000", "10000000", "50000000" })
+    private int numIds;
+
+    @Param({ "0.0511", "0.1023", "0.2047" })
+    private double fpp;
+
+    private FuzzySetFactory fuzzySetFactory;
+    private String fieldName;
+
+    @Setup
+    public void setupIds() {
+        this.fieldName = IdFieldMapper.NAME;
+        this.items = IntStream.range(0, numIds).mapToObj(i -> new BytesRef(UUIDs.base64UUID())).collect(Collectors.toList());
+        FuzzySetParameters parameters = new FuzzySetParameters(() -> fpp);
+        this.fuzzySetFactory = new FuzzySetFactory(Map.of(fieldName, parameters));
+    }
+
+    @Benchmark
+    public FuzzySet buildFilter() throws IOException {
+        return fuzzySetFactory.createFuzzySet(items.size(), fieldName, () -> items.iterator());
+    }
+}

--- a/benchmarks/src/main/java/org/opensearch/benchmark/index/codec/fuzzy/FilterLookupBenchmark.java
+++ b/benchmarks/src/main/java/org/opensearch/benchmark/index/codec/fuzzy/FilterLookupBenchmark.java
@@ -1,0 +1,80 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.benchmark.index.codec.fuzzy;
+
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.common.UUIDs;
+import org.opensearch.index.codec.fuzzy.FuzzySet;
+import org.opensearch.index.codec.fuzzy.FuzzySetFactory;
+import org.opensearch.index.codec.fuzzy.FuzzySetParameters;
+import org.opensearch.index.mapper.IdFieldMapper;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Fork(3)
+@Warmup(iterations = 2)
+@Measurement(iterations = 5, time = 60, timeUnit = TimeUnit.SECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class FilterLookupBenchmark {
+
+    @Param({ "50000000", "1000000" })
+    private int numItems;
+
+    @Param({ "1000000" })
+    private int searchKeyCount;
+
+    @Param({ "0.0511", "0.1023", "0.2047" })
+    private double fpp;
+
+    private FuzzySet fuzzySet;
+    private List<BytesRef> items;
+    private Random random = new Random();
+
+    @Setup
+    public void setupFilter() throws IOException {
+        String fieldName = IdFieldMapper.NAME;
+        items = IntStream.range(0, numItems).mapToObj(i -> new BytesRef(UUIDs.base64UUID())).collect(Collectors.toList());
+        FuzzySetParameters parameters = new FuzzySetParameters(() -> fpp);
+        fuzzySet = new FuzzySetFactory(Map.of(fieldName, parameters)).createFuzzySet(numItems, fieldName, () -> items.iterator());
+    }
+
+    @Benchmark
+    public void contains_withExistingKeys(Blackhole blackhole) throws IOException {
+        for (int i = 0; i < searchKeyCount; i++) {
+            blackhole.consume(fuzzySet.contains(items.get(random.nextInt(items.size()))) == FuzzySet.Result.MAYBE);
+        }
+    }
+
+    @Benchmark
+    public void contains_withRandomKeys(Blackhole blackhole) throws IOException {
+        for (int i = 0; i < searchKeyCount; i++) {
+            blackhole.consume(fuzzySet.contains(new BytesRef(UUIDs.base64UUID())));
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -228,6 +228,9 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 IndexMetadata.INDEX_REMOTE_SEGMENT_STORE_REPOSITORY_SETTING,
                 IndexMetadata.INDEX_REMOTE_TRANSLOG_REPOSITORY_SETTING,
 
+                IndexSettings.INDEX_DOC_ID_FUZZY_SET_ENABLED_SETTING,
+                IndexSettings.INDEX_DOC_ID_FUZZY_SET_FALSE_POSITIVE_PROBABILITY_SETTING,
+
                 // validate that built-in similarities don't get redefined
                 Setting.groupSetting("index.similarity.", (s) -> {
                     Map<String, Settings> groups = s.getAsGroups();

--- a/server/src/main/java/org/opensearch/index/codec/PerFieldMappingPostingFormatCodec.java
+++ b/server/src/main/java/org/opensearch/index/codec/PerFieldMappingPostingFormatCodec.java
@@ -39,9 +39,15 @@ import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.codecs.lucene90.Lucene90DocValuesFormat;
 import org.apache.lucene.codecs.lucene95.Lucene95Codec;
 import org.opensearch.common.lucene.Lucene;
+import org.opensearch.index.codec.fuzzy.FuzzyFilterPostingsFormat;
+import org.opensearch.index.codec.fuzzy.FuzzySetFactory;
+import org.opensearch.index.codec.fuzzy.FuzzySetParameters;
 import org.opensearch.index.mapper.CompletionFieldMapper;
+import org.opensearch.index.mapper.IdFieldMapper;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.MapperService;
+
+import java.util.Map;
 
 /**
  * {@link PerFieldMappingPostingFormatCodec This postings format} is the default
@@ -57,6 +63,8 @@ public class PerFieldMappingPostingFormatCodec extends Lucene95Codec {
     private final Logger logger;
     private final MapperService mapperService;
     private final DocValuesFormat dvFormat = new Lucene90DocValuesFormat();
+    private FuzzySetFactory fuzzySetFactory;
+    private FuzzyFilterPostingsFormat docIdPostingsFormat;
 
     static {
         assert Codec.forName(Lucene.LATEST_CODEC).getClass().isAssignableFrom(PerFieldMappingPostingFormatCodec.class)
@@ -67,6 +75,12 @@ public class PerFieldMappingPostingFormatCodec extends Lucene95Codec {
         super(compressionMode);
         this.mapperService = mapperService;
         this.logger = logger;
+        fuzzySetFactory = new FuzzySetFactory(
+            Map.of(
+                IdFieldMapper.NAME,
+                new FuzzySetParameters(() -> mapperService.getIndexSettings().getDocIdFuzzySetFalsePositiveProbability())
+            )
+        );
     }
 
     @Override
@@ -76,6 +90,11 @@ public class PerFieldMappingPostingFormatCodec extends Lucene95Codec {
             logger.warn("no index mapper found for field: [{}] returning default postings format", field);
         } else if (fieldType instanceof CompletionFieldMapper.CompletionFieldType) {
             return CompletionFieldMapper.CompletionFieldType.postingsFormat();
+        } else if (IdFieldMapper.NAME.equals(field) && mapperService.getIndexSettings().isEnableFuzzySetForDocId()) {
+            if (docIdPostingsFormat == null) {
+                docIdPostingsFormat = new FuzzyFilterPostingsFormat(super.getPostingsFormatForField(field), fuzzySetFactory);
+            }
+            return docIdPostingsFormat;
         }
         return super.getPostingsFormatForField(field);
     }

--- a/server/src/main/java/org/opensearch/index/codec/fuzzy/AbstractFuzzySet.java
+++ b/server/src/main/java/org/opensearch/index/codec/fuzzy/AbstractFuzzySet.java
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.codec.fuzzy;
+
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.common.CheckedSupplier;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+/**
+ * Encapsulates common behaviour implementation for a fuzzy set.
+ */
+public abstract class AbstractFuzzySet implements FuzzySet {
+
+    /**
+     * Add an item to this fuzzy set.
+     * @param value The value to be added
+     */
+    protected abstract void add(BytesRef value);
+
+    /**
+     * Add all items to the underlying set.
+     * Implementations can choose to perform this using an optimized strategy based on the type of set.
+     * @param valuesIteratorProvider Supplier for an iterator over All values which should be added to the set.
+     */
+    protected void addAll(CheckedSupplier<Iterator<BytesRef>, IOException> valuesIteratorProvider) throws IOException {
+        Iterator<BytesRef> values = valuesIteratorProvider.get();
+        while (values.hasNext()) {
+            add(values.next());
+        }
+    }
+
+    protected long generateKey(BytesRef value) {
+        return MurmurHash64.INSTANCE.hash(value);
+    }
+
+    protected void assertAllElementsExist(CheckedSupplier<Iterator<BytesRef>, IOException> iteratorProvider) throws IOException {
+        Iterator<BytesRef> iter = iteratorProvider.get();
+        int cnt = 0;
+        while (iter.hasNext()) {
+            BytesRef item = iter.next();
+            assert contains(item) == Result.MAYBE
+                : "Expected Filter to return positive response for elements added to it. Elements matched: " + cnt;
+            cnt++;
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/index/codec/fuzzy/BloomFilter.java
+++ b/server/src/main/java/org/opensearch/index/codec/fuzzy/BloomFilter.java
@@ -1,0 +1,142 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.codec.fuzzy;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.store.DataOutput;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.opensearch.common.CheckedSupplier;
+import org.opensearch.common.util.io.IOUtils;
+import org.opensearch.core.Assertions;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+/**
+ * The code is based on Lucene's implementation of Bloom Filter.
+ * It represents a subset of the Lucene implementation needed for OpenSearch use cases.
+ * Since the Lucene implementation is marked experimental,
+ * this aims to ensure we can provide a bwc implementation during upgrades.
+ */
+public class BloomFilter extends AbstractFuzzySet {
+
+    private static final Logger logger = LogManager.getLogger(BloomFilter.class);
+
+    // The sizes of BitSet used are all numbers that, when expressed in binary form,
+    // are all ones. This is to enable fast downsizing from one bitset to another
+    // by simply ANDing each set index in one bitset with the size of the target bitset
+    // - this provides a fast modulo of the number. Values previously accumulated in
+    // a large bitset and then mapped to a smaller set can be looked up using a single
+    // AND operation of the query term's hash rather than needing to perform a 2-step
+    // translation of the query term that mirrors the stored content's reprojections.
+    static final int[] usableBitSetSizes;
+
+    static {
+        usableBitSetSizes = new int[26];
+        for (int i = 0; i < usableBitSetSizes.length; i++) {
+            usableBitSetSizes[i] = (1 << (i + 6)) - 1;
+        }
+    }
+
+    private final LongArrayBackedBitSet bitset;
+    private final int setSize;
+    private final int hashCount;
+
+    BloomFilter(long maxDocs, double maxFpp, CheckedSupplier<Iterator<BytesRef>, IOException> fieldIteratorProvider) throws IOException {
+        int setSize = (int) Math.ceil((maxDocs * Math.log(maxFpp)) / Math.log(1 / Math.pow(2, Math.log(2))));
+        setSize = getNearestSetSize(2 * setSize);
+        int optimalK = (int) Math.round(((double) setSize / maxDocs) * Math.log(2));
+        this.bitset = new LongArrayBackedBitSet(setSize + 1);
+        this.setSize = setSize;
+        this.hashCount = optimalK;
+        addAll(fieldIteratorProvider);
+        if (Assertions.ENABLED) {
+            assertAllElementsExist(fieldIteratorProvider);
+        }
+        logger.trace("Bloom filter created with fpp: {}, setSize: {}, hashCount: {}", maxFpp, setSize, hashCount);
+    }
+
+    BloomFilter(IndexInput in) throws IOException {
+        hashCount = in.readInt();
+        setSize = in.readInt();
+        this.bitset = new LongArrayBackedBitSet(in);
+    }
+
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
+        out.writeInt(hashCount);
+        out.writeInt(setSize);
+        bitset.writeTo(out);
+    }
+
+    static int getNearestSetSize(int maxNumberOfBits) {
+        int result = usableBitSetSizes[0];
+        for (int i = 0; i < usableBitSetSizes.length; i++) {
+            if (usableBitSetSizes[i] <= maxNumberOfBits) {
+                result = usableBitSetSizes[i];
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public SetType setType() {
+        return SetType.BLOOM_FILTER_V1;
+    }
+
+    @Override
+    public Result contains(BytesRef value) {
+        long hash = generateKey(value);
+        int msb = (int) (hash >>> Integer.SIZE);
+        int lsb = (int) hash;
+        for (int i = 0; i < hashCount; i++) {
+            int bloomPos = (lsb + i * msb);
+            if (!mayContainValue(bloomPos)) {
+                return Result.NO;
+            }
+        }
+        return Result.MAYBE;
+    }
+
+    protected void add(BytesRef value) {
+        long hash = generateKey(value);
+        int msb = (int) (hash >>> Integer.SIZE);
+        int lsb = (int) hash;
+        for (int i = 0; i < hashCount; i++) {
+            // Bitmasking using bloomSize is effectively a modulo operation since set sizes are always power of 2
+            int bloomPos = (lsb + i * msb) & setSize;
+            bitset.set(bloomPos);
+        }
+    }
+
+    @Override
+    public boolean isSaturated() {
+        long numBitsSet = bitset.cardinality();
+        return (float) numBitsSet / (float) setSize > 0.9f;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return RamUsageEstimator.sizeOf(bitset.ramBytesUsed());
+    }
+
+    private boolean mayContainValue(int aHash) {
+        // Bloom sizes are always base 2 and so can be ANDed for a fast modulo
+        int pos = aHash & setSize;
+        return bitset.isSet(pos);
+    }
+
+    @Override
+    public void close() throws IOException {
+        IOUtils.close(bitset);
+    }
+}

--- a/server/src/main/java/org/opensearch/index/codec/fuzzy/FuzzyFilterPostingsFormat.java
+++ b/server/src/main/java/org/opensearch/index/codec/fuzzy/FuzzyFilterPostingsFormat.java
@@ -1,0 +1,470 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.codec.fuzzy;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.FieldsConsumer;
+import org.apache.lucene.codecs.FieldsProducer;
+import org.apache.lucene.codecs.NormsProducer;
+import org.apache.lucene.codecs.PostingsFormat;
+import org.apache.lucene.index.BaseTermsEnum;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.Fields;
+import org.apache.lucene.index.ImpactsEnum;
+import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.index.PostingsEnum;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.CompiledAutomaton;
+import org.opensearch.common.util.io.IOUtils;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Based on Lucene's BloomFilterPostingsFormat.
+ */
+public final class FuzzyFilterPostingsFormat extends PostingsFormat {
+
+    private static final Logger logger = LogManager.getLogger(FuzzyFilterPostingsFormat.class);
+
+    public static final String FUZZY_SET_CODEC_NAME = "FuzzySetCodec";
+    public static final int VERSION_START = 0;
+    public static final int VERSION_CURRENT = VERSION_START;
+
+    /** Extension of Fuzzy Filters file */
+    public static final String FUZZY_FILTER_FILE_EXTENSION = "fzd";
+
+    private final PostingsFormat delegatePostingsFormat;
+    private final FuzzySetFactory fuzzySetFactory;
+
+    public FuzzyFilterPostingsFormat(PostingsFormat delegatePostingsFormat, FuzzySetFactory fuzzySetFactory) {
+        super(FUZZY_SET_CODEC_NAME);
+        this.delegatePostingsFormat = delegatePostingsFormat;
+        this.fuzzySetFactory = fuzzySetFactory;
+    }
+
+    // Needed for SPI
+    public FuzzyFilterPostingsFormat() {
+        this(null, null);
+    }
+
+    @Override
+    public FieldsConsumer fieldsConsumer(SegmentWriteState state) throws IOException {
+        if (delegatePostingsFormat == null) {
+            throw new UnsupportedOperationException(
+                "Error - " + getClass().getName() + " has been constructed without a choice of PostingsFormat"
+            );
+        }
+        FieldsConsumer fieldsConsumer = delegatePostingsFormat.fieldsConsumer(state);
+        return new FuzzySetFieldsConsumer(fieldsConsumer, state);
+    }
+
+    @Override
+    public FieldsProducer fieldsProducer(SegmentReadState state) throws IOException {
+        return new FuzzySetFieldsProducer(state);
+    }
+
+    static class FuzzySetFieldsProducer extends FieldsProducer {
+        private FieldsProducer delegateFieldsProducer;
+        HashMap<String, FuzzySet> fuzzySetsByFieldName = new HashMap<>();
+        private List<Closeable> closeables = new ArrayList<>();
+
+        public FuzzySetFieldsProducer(SegmentReadState state) throws IOException {
+            String fuzzySetFileName = IndexFileNames.segmentFileName(
+                state.segmentInfo.name,
+                state.segmentSuffix,
+                FUZZY_FILTER_FILE_EXTENSION
+            );
+            IndexInput filterIn = null;
+            boolean success = false;
+            try {
+                filterIn = state.directory.openInput(fuzzySetFileName, IOContext.READONCE);
+                CodecUtil.checkIndexHeader(
+                    filterIn,
+                    FUZZY_SET_CODEC_NAME,
+                    VERSION_START,
+                    VERSION_CURRENT,
+                    state.segmentInfo.getId(),
+                    state.segmentSuffix
+                );
+                // // Load the hash function used in the Fuzzy filter
+                // hashFunction = HashFunction.forName(filterIn.readString());
+                // Load the delegate postings format
+                PostingsFormat delegatePostingsFormat = PostingsFormat.forName(filterIn.readString());
+                this.delegateFieldsProducer = delegatePostingsFormat.fieldsProducer(state);
+                int numFilters = filterIn.readInt();
+                for (int i = 0; i < numFilters; i++) {
+                    int fieldNum = filterIn.readInt();
+                    FuzzySet set = FuzzySetFactory.deserializeFuzzySet(filterIn);
+                    closeables.add(set);
+                    FieldInfo fieldInfo = state.fieldInfos.fieldInfo(fieldNum);
+                    fuzzySetsByFieldName.put(fieldInfo.name, set);
+                }
+                CodecUtil.retrieveChecksum(filterIn);
+                CodecUtil.checksumEntireFile(filterIn);
+                success = true;
+                closeables.add(filterIn);
+            } finally {
+                if (!success) {
+                    IOUtils.closeWhileHandlingException(filterIn, delegateFieldsProducer);
+                }
+            }
+        }
+
+        @Override
+        public Iterator<String> iterator() {
+            return delegateFieldsProducer.iterator();
+        }
+
+        @Override
+        public void close() throws IOException {
+            IOUtils.closeWhileHandlingException(closeables);
+            delegateFieldsProducer.close();
+        }
+
+        @Override
+        public Terms terms(String field) throws IOException {
+            FuzzySet filter = fuzzySetsByFieldName.get(field);
+            if (filter == null) {
+                return delegateFieldsProducer.terms(field);
+            } else {
+                Terms result = delegateFieldsProducer.terms(field);
+                if (result == null) {
+                    return null;
+                }
+                return new FuzzySetFieldsProducer.FuzzyFilterFrontedTerms(result, filter);
+            }
+        }
+
+        @Override
+        public int size() {
+            return delegateFieldsProducer.size();
+        }
+
+        static class FuzzyFilterFrontedTerms extends Terms {
+            private Terms delegateTerms;
+            private FuzzySet filter;
+
+            public FuzzyFilterFrontedTerms(Terms terms, FuzzySet filter) {
+                this.delegateTerms = terms;
+                this.filter = filter;
+            }
+
+            @Override
+            public TermsEnum intersect(CompiledAutomaton compiled, final BytesRef startTerm) throws IOException {
+                return delegateTerms.intersect(compiled, startTerm);
+            }
+
+            @Override
+            public TermsEnum iterator() throws IOException {
+                return new FilterAppliedTermsEnum(delegateTerms, filter);
+            }
+
+            @Override
+            public long size() throws IOException {
+                return delegateTerms.size();
+            }
+
+            @Override
+            public long getSumTotalTermFreq() throws IOException {
+                return delegateTerms.getSumTotalTermFreq();
+            }
+
+            @Override
+            public long getSumDocFreq() throws IOException {
+                return delegateTerms.getSumDocFreq();
+            }
+
+            @Override
+            public int getDocCount() throws IOException {
+                return delegateTerms.getDocCount();
+            }
+
+            @Override
+            public boolean hasFreqs() {
+                return delegateTerms.hasFreqs();
+            }
+
+            @Override
+            public boolean hasOffsets() {
+                return delegateTerms.hasOffsets();
+            }
+
+            @Override
+            public boolean hasPositions() {
+                return delegateTerms.hasPositions();
+            }
+
+            @Override
+            public boolean hasPayloads() {
+                return delegateTerms.hasPayloads();
+            }
+
+            @Override
+            public BytesRef getMin() throws IOException {
+                return delegateTerms.getMin();
+            }
+
+            @Override
+            public BytesRef getMax() throws IOException {
+                return delegateTerms.getMax();
+            }
+        }
+
+        static final class FilterAppliedTermsEnum extends BaseTermsEnum {
+            private Terms delegateTerms;
+            private TermsEnum delegateTermsEnum;
+            private final FuzzySet filter;
+
+            public FilterAppliedTermsEnum(Terms delegateTerms, FuzzySet filter) throws IOException {
+                this.delegateTerms = delegateTerms;
+                this.filter = filter;
+            }
+
+            void reset(Terms delegateTerms) throws IOException {
+                this.delegateTerms = delegateTerms;
+                this.delegateTermsEnum = null;
+            }
+
+            private TermsEnum delegate() throws IOException {
+                if (delegateTermsEnum == null) {
+                    /* pull the iterator only if we really need it -
+                     * this can be a relativly heavy operation depending on the
+                     * delegate postings format and they underlying directory
+                     * (clone IndexInput) */
+                    delegateTermsEnum = delegateTerms.iterator();
+                }
+                return delegateTermsEnum;
+            }
+
+            @Override
+            public BytesRef next() throws IOException {
+                return delegate().next();
+            }
+
+            @Override
+            public boolean seekExact(BytesRef text) throws IOException {
+                // The magical fail-fast speed up that is the entire point of all of
+                // this code - save a disk seek if there is a match on an in-memory
+                // structure
+                // that may occasionally give a false positive but guaranteed no false
+                // negatives
+                if (filter.contains(text) == FuzzySet.Result.NO) {
+                    return false;
+                }
+                return delegate().seekExact(text);
+            }
+
+            @Override
+            public SeekStatus seekCeil(BytesRef text) throws IOException {
+                return delegate().seekCeil(text);
+            }
+
+            @Override
+            public void seekExact(long ord) throws IOException {
+                delegate().seekExact(ord);
+            }
+
+            @Override
+            public BytesRef term() throws IOException {
+                return delegate().term();
+            }
+
+            @Override
+            public long ord() throws IOException {
+                return delegate().ord();
+            }
+
+            @Override
+            public int docFreq() throws IOException {
+                return delegate().docFreq();
+            }
+
+            @Override
+            public long totalTermFreq() throws IOException {
+                return delegate().totalTermFreq();
+            }
+
+            @Override
+            public PostingsEnum postings(PostingsEnum reuse, int flags) throws IOException {
+                return delegate().postings(reuse, flags);
+            }
+
+            @Override
+            public ImpactsEnum impacts(int flags) throws IOException {
+                return delegate().impacts(flags);
+            }
+
+            @Override
+            public String toString() {
+                return getClass().getSimpleName() + "(filter=" + filter.toString() + ")";
+            }
+        }
+
+        @Override
+        public void checkIntegrity() throws IOException {
+            delegateFieldsProducer.checkIntegrity();
+        }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() + "(fields=" + fuzzySetsByFieldName.size() + ",delegate=" + delegateFieldsProducer + ")";
+        }
+    }
+
+    class FuzzySetFieldsConsumer extends FieldsConsumer {
+        private FieldsConsumer delegateFieldsConsumer;
+        private Map<FieldInfo, FuzzySet> fuzzySets = new HashMap<>();
+        private SegmentWriteState state;
+        private List<Closeable> closeables = new ArrayList<>();
+
+        public FuzzySetFieldsConsumer(FieldsConsumer fieldsConsumer, SegmentWriteState state) {
+            this.delegateFieldsConsumer = fieldsConsumer;
+            this.state = state;
+        }
+
+        @Override
+        public void write(Fields fields, NormsProducer norms) throws IOException {
+
+            // Delegate must write first: it may have opened files
+            // on creating the class
+            // (e.g. Lucene41PostingsConsumer), and write() will
+            // close them; alternatively, if we delayed pulling
+            // the fields consumer until here, we could do it
+            // afterwards:
+            delegateFieldsConsumer.write(fields, norms);
+
+            for (String field : fields) {
+                Terms terms = fields.terms(field);
+                if (terms == null) {
+                    continue;
+                }
+                FieldInfo fieldInfo = state.fieldInfos.fieldInfo(field);
+                FuzzySet fuzzySet = fuzzySetFactory.createFuzzySet(state.segmentInfo.maxDoc(), fieldInfo.name, () -> iterator(terms));
+                if (fuzzySet == null) {
+                    break;
+                }
+                assert fuzzySets.containsKey(fieldInfo) == false;
+                closeables.add(fuzzySet);
+                fuzzySets.put(fieldInfo, fuzzySet);
+            }
+        }
+
+        private Iterator<BytesRef> iterator(Terms terms) throws IOException {
+            TermsEnum termIterator = terms.iterator();
+            return new Iterator<>() {
+
+                private BytesRef currentTerm;
+                private PostingsEnum postingsEnum;
+
+                @Override
+                public boolean hasNext() {
+                    try {
+                        do {
+                            currentTerm = termIterator.next();
+                            if (currentTerm == null) {
+                                return false;
+                            }
+                            postingsEnum = termIterator.postings(postingsEnum, 0);
+                            if (postingsEnum.nextDoc() != PostingsEnum.NO_MORE_DOCS) {
+                                return true;
+                            }
+                        } while (true);
+                    } catch (IOException ex) {
+                        throw new IllegalStateException("Cannot read terms: " + termIterator.attributes());
+                    }
+                }
+
+                @Override
+                public BytesRef next() {
+                    return currentTerm;
+                }
+            };
+        }
+
+        private boolean closed;
+
+        @Override
+        public void close() throws IOException {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            delegateFieldsConsumer.close();
+
+            // Now we are done accumulating values for these fields
+            List<Map.Entry<FieldInfo, FuzzySet>> nonSaturatedSets = new ArrayList<>();
+
+            for (Map.Entry<FieldInfo, FuzzySet> entry : fuzzySets.entrySet()) {
+                FuzzySet fuzzySet = entry.getValue();
+                if (!fuzzySet.isSaturated()) {
+                    nonSaturatedSets.add(entry);
+                }
+            }
+            String fuzzyFilterFileName = IndexFileNames.segmentFileName(
+                state.segmentInfo.name,
+                state.segmentSuffix,
+                FUZZY_FILTER_FILE_EXTENSION
+            );
+            try (IndexOutput fuzzyFilterFileOutput = state.directory.createOutput(fuzzyFilterFileName, state.context)) {
+                logger.trace(
+                    "Writing fuzzy filter postings with version: {} for segment: {}",
+                    VERSION_CURRENT,
+                    state.segmentInfo.toString()
+                );
+                CodecUtil.writeIndexHeader(
+                    fuzzyFilterFileOutput,
+                    FUZZY_SET_CODEC_NAME,
+                    VERSION_CURRENT,
+                    state.segmentInfo.getId(),
+                    state.segmentSuffix
+                );
+                // remember the name of the postings format we will delegate to
+                fuzzyFilterFileOutput.writeString(delegatePostingsFormat.getName());
+
+                // First field in the output file is the number of fields+sets saved
+                fuzzyFilterFileOutput.writeInt(nonSaturatedSets.size());
+                for (Map.Entry<FieldInfo, FuzzySet> entry : nonSaturatedSets) {
+                    FieldInfo fieldInfo = entry.getKey();
+                    FuzzySet fuzzySet = entry.getValue();
+                    fuzzyFilterFileOutput.writeInt(fieldInfo.number);
+                    saveAppropriatelySizedFuzzySet(fuzzyFilterFileOutput, fuzzySet, fieldInfo);
+                }
+                CodecUtil.writeFooter(fuzzyFilterFileOutput);
+            }
+            // We are done with large bitsets so no need to keep them hanging around
+            fuzzySets.clear();
+            IOUtils.closeWhileHandlingException(closeables);
+        }
+
+        private void saveAppropriatelySizedFuzzySet(IndexOutput fileOutput, FuzzySet fuzzySet, FieldInfo fieldInfo) throws IOException {
+            fileOutput.writeString(fuzzySet.setType().getSetName());
+            fuzzySet.writeTo(fileOutput);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "FuzzyFilterPostingsFormat(" + delegatePostingsFormat + ")";
+    }
+}

--- a/server/src/main/java/org/opensearch/index/codec/fuzzy/FuzzySet.java
+++ b/server/src/main/java/org/opensearch/index/codec/fuzzy/FuzzySet.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.codec.fuzzy;
+
+import org.apache.lucene.store.DataOutput;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.common.CheckedFunction;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Fuzzy Filter interface
+ */
+public interface FuzzySet extends Accountable, Closeable {
+
+    /**
+     * Name used for a codec to be aware of what fuzzy set has been used.
+     */
+    SetType setType();
+
+    /**
+     * @param value the item whose membership needs to be checked.
+     */
+    Result contains(BytesRef value);
+
+    boolean isSaturated();
+
+    void writeTo(DataOutput out) throws IOException;
+
+    /**
+     * Enum to represent result of membership check on a fuzzy set.
+     */
+    enum Result {
+        /**
+         * A definite no for the set membership of an item.
+         */
+        NO,
+
+        /**
+         * Fuzzy sets cannot guarantee that a given item is present in the set or not due the data being stored in
+         * a lossy format (e.g. fingerprint, hash).
+         * Hence, we return a response denoting that the item maybe present.
+         */
+        MAYBE
+    }
+
+    /**
+     * Enum to declare supported properties and mappings for a fuzzy set implementation.
+     */
+    enum SetType {
+        BLOOM_FILTER_V1("bloom_filter_v1", BloomFilter::new, List.of("bloom_filter"));
+
+        private final String setName;
+        private final CheckedFunction<IndexInput, ? extends FuzzySet, IOException> deserializer;
+
+        SetType(String setName, CheckedFunction<IndexInput, ? extends FuzzySet, IOException> deserializer, List<String> aliases) {
+            if (aliases.size() < 1) {
+                throw new IllegalArgumentException("Alias list is empty. Could not create Set Type: " + setName);
+            }
+            this.setName = setName;
+            this.deserializer = deserializer;
+        }
+
+        public String getSetName() {
+            return setName;
+        }
+
+        public CheckedFunction<IndexInput, ? extends FuzzySet, IOException> getDeserializer() {
+            return deserializer;
+        }
+
+        public static SetType from(String name) {
+            for (SetType type : SetType.values()) {
+                if (type.setName.equals(name)) {
+                    return type;
+                }
+            }
+            throw new IllegalArgumentException("There is no implementation for fuzzy set: " + name);
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/index/codec/fuzzy/FuzzySetFactory.java
+++ b/server/src/main/java/org/opensearch/index/codec/fuzzy/FuzzySetFactory.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.codec.fuzzy;
+
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.common.CheckedSupplier;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Factory class to create fuzzy set.
+ * Supports bloom filters for now. More sets can be added as required.
+ */
+public class FuzzySetFactory {
+
+    private final Map<String, FuzzySetParameters> setTypeForField;
+
+    public FuzzySetFactory(Map<String, FuzzySetParameters> setTypeForField) {
+        this.setTypeForField = setTypeForField;
+    }
+
+    public FuzzySet createFuzzySet(int maxDocs, String fieldName, CheckedSupplier<Iterator<BytesRef>, IOException> iteratorProvider)
+        throws IOException {
+        FuzzySetParameters params = setTypeForField.get(fieldName);
+        if (params == null) {
+            throw new IllegalArgumentException("No fuzzy set defined for field: " + fieldName);
+        }
+        switch (params.getSetType()) {
+            case BLOOM_FILTER_V1:
+                return new BloomFilter(maxDocs, params.getFalsePositiveProbability(), iteratorProvider);
+            default:
+                throw new IllegalArgumentException("No Implementation for set type: " + params.getSetType());
+        }
+    }
+
+    public static FuzzySet deserializeFuzzySet(IndexInput in) throws IOException {
+        FuzzySet.SetType setType = FuzzySet.SetType.from(in.readString());
+        return setType.getDeserializer().apply(in);
+    }
+}

--- a/server/src/main/java/org/opensearch/index/codec/fuzzy/FuzzySetParameters.java
+++ b/server/src/main/java/org/opensearch/index/codec/fuzzy/FuzzySetParameters.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.codec.fuzzy;
+
+import java.util.function.Supplier;
+
+/**
+ * Wrapper for params to create a fuzzy set.
+ */
+public class FuzzySetParameters {
+    private final Supplier<Double> falsePositiveProbabilityProvider;
+    private final FuzzySet.SetType setType;
+
+    public static final double DEFAULT_FALSE_POSITIVE_PROBABILITY = 0.2047d;
+
+    public FuzzySetParameters(Supplier<Double> falsePositiveProbabilityProvider) {
+        this.falsePositiveProbabilityProvider = falsePositiveProbabilityProvider;
+        this.setType = FuzzySet.SetType.BLOOM_FILTER_V1;
+    }
+
+    public double getFalsePositiveProbability() {
+        return falsePositiveProbabilityProvider.get();
+    }
+
+    public FuzzySet.SetType getSetType() {
+        return setType;
+    }
+}

--- a/server/src/main/java/org/opensearch/index/codec/fuzzy/IndexInputLongArray.java
+++ b/server/src/main/java/org/opensearch/index/codec/fuzzy/IndexInputLongArray.java
@@ -1,0 +1,71 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.codec.fuzzy;
+
+import org.apache.lucene.store.RandomAccessInput;
+import org.opensearch.OpenSearchException;
+import org.opensearch.common.CheckedSupplier;
+import org.opensearch.common.util.LongArray;
+
+import java.io.IOException;
+
+/**
+ * A Long array backed by RandomAccessInput.
+ */
+public class IndexInputLongArray implements LongArray {
+
+    public RandomAccessInput input;
+    private long size;
+
+    public IndexInputLongArray(long size, RandomAccessInput input) {
+        this.size = size;
+        this.input = input;
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public long size() {
+        return size;
+    }
+
+    @Override
+    public long get(long index) {
+        return wrapException(() -> input.readLong(index << 3));
+    }
+
+    @Override
+    public long set(long index, long value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long increment(long index, long inc) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void fill(long fromIndex, long toIndex, long value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return 128;
+    }
+
+    private <T> T wrapException(CheckedSupplier<T, IOException> supplier) {
+        try {
+            return supplier.get();
+        } catch (IOException ex) {
+            throw new OpenSearchException(ex);
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/index/codec/fuzzy/LongArrayBackedBitSet.java
+++ b/server/src/main/java/org/opensearch/index/codec/fuzzy/LongArrayBackedBitSet.java
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.codec.fuzzy;
+
+import org.apache.lucene.store.DataOutput;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.Accountable;
+import org.opensearch.common.util.BigArrays;
+import org.opensearch.common.util.LongArray;
+import org.opensearch.common.util.io.IOUtils;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * A bitset backed by a long-indexed array.
+ */
+public class LongArrayBackedBitSet implements Accountable, Closeable {
+
+    private long underlyingArrayLength = 0L;
+    private LongArray longArray;
+
+    LongArrayBackedBitSet(long capacity) {
+        underlyingArrayLength = ((capacity - 1L) >> 6) + 1;
+        this.longArray = BigArrays.NON_RECYCLING_INSTANCE.withCircuitBreaking().newLongArray(underlyingArrayLength);
+    }
+
+    LongArrayBackedBitSet(IndexInput in) throws IOException {
+        underlyingArrayLength = in.readLong();
+        long streamLength = underlyingArrayLength << 3;
+        this.longArray = new IndexInputLongArray(underlyingArrayLength, in.randomAccessSlice(in.getFilePointer(), streamLength));
+        in.skipBytes(streamLength);
+    }
+
+    public void writeTo(DataOutput out) throws IOException {
+        out.writeLong(underlyingArrayLength);
+        for (int idx = 0; idx < underlyingArrayLength; idx++) {
+            out.writeLong(longArray.get(idx));
+        }
+    }
+
+    public long cardinality() {
+        long tot = 0;
+        for (int i = 0; i < underlyingArrayLength; ++i) {
+            tot += Long.bitCount(longArray.get(i));
+        }
+        return tot;
+    }
+
+    public boolean isSet(long index) {
+        long i = index >> 6; // div 64
+        long val = longArray.get(i);
+        // signed shift will keep a negative index and force an
+        // array-index-out-of-bounds-exception, removing the need for an explicit check.
+        long bitmask = 1L << index;
+        return (val & bitmask) != 0;
+    }
+
+    public void set(long index) {
+        long wordNum = index >> 6; // div 64
+        long bitmask = 1L << index;
+        long val = longArray.get(wordNum);
+        longArray.set(wordNum, val | bitmask);
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return 128L + longArray.ramBytesUsed();
+    }
+
+    @Override
+    public void close() throws IOException {
+        IOUtils.close(longArray);
+    }
+}

--- a/server/src/main/java/org/opensearch/index/codec/fuzzy/MurmurHash64.java
+++ b/server/src/main/java/org/opensearch/index/codec/fuzzy/MurmurHash64.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.codec.fuzzy;
+
+import org.apache.lucene.util.BitUtil;
+import org.apache.lucene.util.BytesRef;
+
+/**
+ * Utility to calculate hash for incoming bytes.
+ */
+public class MurmurHash64 {
+    private static final long M64 = 0xc6a4a7935bd1e995L;
+    private static final int R64 = 47;
+    public static final MurmurHash64 INSTANCE = new MurmurHash64();
+
+    /**
+     * Generates a 64-bit hash from byte array of the given length and seed.
+     *
+     * @param data The input byte array
+     * @param seed The initial seed value
+     * @param length The length of the array
+     * @return The 64-bit hash of the given array
+     */
+    public static long hash64(byte[] data, int seed, int offset, int length) {
+        long h = (seed & 0xffffffffL) ^ (length * M64);
+
+        final int nblocks = length >> 3;
+
+        // body
+        for (int i = 0; i < nblocks; i++) {
+
+            long k = (long) BitUtil.VH_LE_LONG.get(data, offset);
+            k *= M64;
+            k ^= k >>> R64;
+            k *= M64;
+
+            h ^= k;
+            h *= M64;
+
+            offset += Long.BYTES;
+        }
+
+        int remaining = length & 0x07;
+        if (0 < remaining) {
+            for (int i = 0; i < remaining; i++) {
+                h ^= ((long) data[offset + i] & 0xff) << (Byte.SIZE * i);
+            }
+            h *= M64;
+        }
+
+        h ^= h >>> R64;
+        h *= M64;
+        h ^= h >>> R64;
+
+        return h;
+    }
+
+    public final long hash(BytesRef br) {
+        return hash64(br.bytes, 0xe17a1465, br.offset, br.length);
+    }
+}

--- a/server/src/main/java/org/opensearch/index/codec/fuzzy/package-info.java
+++ b/server/src/main/java/org/opensearch/index/codec/fuzzy/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/** classes responsible for handling all fuzzy codecs and operations */
+package org.opensearch.index.codec.fuzzy;

--- a/server/src/main/java/org/opensearch/index/engine/SegmentsStats.java
+++ b/server/src/main/java/org/opensearch/index/engine/SegmentsStats.java
@@ -40,6 +40,7 @@ import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.core.xcontent.ToXContentFragment;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.ReplicationStats;
+import org.opensearch.index.codec.fuzzy.FuzzyFilterPostingsFormat;
 import org.opensearch.index.remote.RemoteSegmentStats;
 
 import java.io.IOException;
@@ -93,7 +94,8 @@ public class SegmentsStats implements Writeable, ToXContentFragment {
         Map.entry("tvx", "Term Vector Index"),
         Map.entry("tvd", "Term Vector Documents"),
         Map.entry("tvf", "Term Vector Fields"),
-        Map.entry("liv", "Live Documents")
+        Map.entry("liv", "Live Documents"),
+        Map.entry(FuzzyFilterPostingsFormat.FUZZY_FILTER_FILE_EXTENSION, "Fuzzy Filter")
     );
 
     public SegmentsStats() {

--- a/server/src/main/resources/META-INF/services/org.apache.lucene.codecs.PostingsFormat
+++ b/server/src/main/resources/META-INF/services/org.apache.lucene.codecs.PostingsFormat
@@ -1,1 +1,2 @@
 org.apache.lucene.search.suggest.document.Completion50PostingsFormat
+org.opensearch.index.codec.fuzzy.FuzzyFilterPostingsFormat

--- a/server/src/test/java/org/opensearch/index/codec/fuzzy/BloomFilterTests.java
+++ b/server/src/test/java/org/opensearch/index/codec/fuzzy/BloomFilterTests.java
@@ -1,0 +1,82 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.codec.fuzzy;
+
+import org.apache.lucene.store.ByteArrayDataOutput;
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.common.lucene.store.ByteArrayIndexInput;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+
+public class BloomFilterTests extends OpenSearchTestCase {
+
+    public void testBloomFilterSerializationDeserialization() throws IOException {
+        int elementCount = randomIntBetween(1, 100);
+        long maxDocs = elementCount * 10L; // Keeping this high so that it ensures some bits are not set.
+        BloomFilter filter = new BloomFilter(maxDocs, getFpp(), () -> idIterator(elementCount));
+        byte[] buffer = new byte[(int) maxDocs * 5];
+        ByteArrayDataOutput out = new ByteArrayDataOutput(buffer);
+
+        // Write in the format readable through factory
+        out.writeString(filter.setType().getSetName());
+        filter.writeTo(out);
+
+        FuzzySet reconstructedFilter = FuzzySetFactory.deserializeFuzzySet(new ByteArrayIndexInput("filter", buffer));
+        assertEquals(FuzzySet.SetType.BLOOM_FILTER_V1, reconstructedFilter.setType());
+
+        Iterator<BytesRef> idIterator = idIterator(elementCount);
+        while (idIterator.hasNext()) {
+            BytesRef element = idIterator.next();
+            assertEquals(FuzzySet.Result.MAYBE, reconstructedFilter.contains(element));
+            assertEquals(FuzzySet.Result.MAYBE, filter.contains(element));
+        }
+    }
+
+    public void testBloomFilterIsSaturated_returnsTrue() throws IOException {
+        BloomFilter bloomFilter = new BloomFilter(1L, getFpp(), () -> idIterator(1000));
+        assertEquals(FuzzySet.SetType.BLOOM_FILTER_V1, bloomFilter.setType());
+        assertEquals(true, bloomFilter.isSaturated());
+    }
+
+    public void testBloomFilterIsSaturated_returnsFalse() throws IOException {
+        int elementCount = randomIntBetween(1, 100);
+        BloomFilter bloomFilter = new BloomFilter(20000, getFpp(), () -> idIterator(elementCount));
+        assertEquals(FuzzySet.SetType.BLOOM_FILTER_V1, bloomFilter.setType());
+        assertEquals(false, bloomFilter.isSaturated());
+    }
+
+    public void testBloomFilterWithLargeCapacity() throws IOException {
+        long maxDocs = randomLongBetween(Integer.MAX_VALUE, 5L * Integer.MAX_VALUE);
+        BloomFilter bloomFilter = new BloomFilter(maxDocs, getFpp(), () -> List.of(new BytesRef("bar")).iterator());
+        assertEquals(FuzzySet.SetType.BLOOM_FILTER_V1, bloomFilter.setType());
+    }
+
+    private double getFpp() {
+        return randomDoubleBetween(0.01, 0.50, true);
+    }
+
+    private Iterator<BytesRef> idIterator(int count) {
+        return new Iterator<BytesRef>() {
+            int cnt = count;
+
+            @Override
+            public boolean hasNext() {
+                return cnt-- > 0;
+            }
+
+            @Override
+            public BytesRef next() {
+                return new BytesRef(Integer.toString(cnt));
+            }
+        };
+    }
+}

--- a/server/src/test/java/org/opensearch/index/codec/fuzzy/FuzzyFilterPostingsFormatTests.java
+++ b/server/src/test/java/org/opensearch/index/codec/fuzzy/FuzzyFilterPostingsFormatTests.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.codec.fuzzy;
+
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.tests.index.BasePostingsFormatTestCase;
+import org.apache.lucene.tests.util.TestUtil;
+
+import java.util.TreeMap;
+
+public class FuzzyFilterPostingsFormatTests extends BasePostingsFormatTestCase {
+
+    private TreeMap<String, FuzzySetParameters> params = new TreeMap<>() {
+        @Override
+        public FuzzySetParameters get(Object k) {
+            return new FuzzySetParameters(() -> 0.2047);
+        }
+    };
+
+    private Codec fuzzyFilterCodec = TestUtil.alwaysPostingsFormat(
+        new FuzzyFilterPostingsFormat(TestUtil.getDefaultPostingsFormat(), new FuzzySetFactory(params))
+    );
+
+    @Override
+    protected Codec getCodec() {
+        return fuzzyFilterCodec;
+    }
+}

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
@@ -208,6 +208,8 @@ import static org.opensearch.common.unit.TimeValue.timeValueMillis;
 import static org.opensearch.core.common.util.CollectionUtils.eagerPartition;
 import static org.opensearch.discovery.DiscoveryModule.DISCOVERY_SEED_PROVIDERS_SETTING;
 import static org.opensearch.discovery.SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
+import static org.opensearch.index.IndexSettings.INDEX_DOC_ID_FUZZY_SET_ENABLED_SETTING;
+import static org.opensearch.index.IndexSettings.INDEX_DOC_ID_FUZZY_SET_FALSE_POSITIVE_PROBABILITY_SETTING;
 import static org.opensearch.index.IndexSettings.INDEX_SOFT_DELETES_RETENTION_LEASE_PERIOD_SETTING;
 import static org.opensearch.index.query.QueryBuilders.matchAllQuery;
 import static org.opensearch.test.XContentTestUtils.convertToMap;
@@ -768,6 +770,11 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
                     )
                 ).getStringRep()
             );
+        }
+
+        if (randomBoolean()) {
+            builder.put(INDEX_DOC_ID_FUZZY_SET_ENABLED_SETTING.getKey(), true);
+            builder.put(INDEX_DOC_ID_FUZZY_SET_FALSE_POSITIVE_PROBABILITY_SETTING.getKey(), randomDoubleBetween(0.00, 0.50, true));
         }
 
         return builder.build();


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/4489
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
