### PR TITLE
Support allow_duplicate_keys for json processor

### DIFF
--- a/libs/core/src/main/java/org/opensearch/core/xcontent/MapXContentParser.java
+++ b/libs/core/src/main/java/org/opensearch/core/xcontent/MapXContentParser.java
@@ -109,6 +109,11 @@ public class MapXContentParser extends AbstractXContentParser {
     }
 
     @Override
+    public void allowDuplicateKeys(boolean allowDuplicateKeys) {
+        throw new UnsupportedOperationException("Allowing duplicate keys is not possible for maps");
+    }
+
+    @Override
     public Token nextToken() throws IOException {
         if (iterator == null) {
             return null;

--- a/libs/core/src/main/java/org/opensearch/core/xcontent/XContentParser.java
+++ b/libs/core/src/main/java/org/opensearch/core/xcontent/XContentParser.java
@@ -153,6 +153,8 @@ public interface XContentParser extends Closeable {
 
     MediaType contentType();
 
+    void allowDuplicateKeys(boolean allowDuplicateKeys);
+
     Token nextToken() throws IOException;
 
     void skipChildren() throws IOException;

--- a/libs/core/src/main/java/org/opensearch/core/xcontent/XContentSubParser.java
+++ b/libs/core/src/main/java/org/opensearch/core/xcontent/XContentSubParser.java
@@ -68,6 +68,11 @@ public class XContentSubParser implements XContentParser {
     }
 
     @Override
+    public void allowDuplicateKeys(boolean allowDuplicateKeys) {
+        parser.allowDuplicateKeys(allowDuplicateKeys);
+    }
+
+    @Override
     public Token nextToken() throws IOException {
         if (level > 0) {
             Token token = parser.nextToken();

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/cbor/CborXContentParser.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/cbor/CborXContentParser.java
@@ -49,4 +49,9 @@ public class CborXContentParser extends JsonXContentParser {
     public XContentType contentType() {
         return XContentType.CBOR;
     }
+
+    @Override
+    public void allowDuplicateKeys(boolean allowDuplicateKeys) {
+        throw new UnsupportedOperationException("Allowing duplicate keys after the parser has been created is not possible for CBOR");
+    }
 }

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/json/JsonXContentParser.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/json/JsonXContentParser.java
@@ -62,6 +62,11 @@ public class JsonXContentParser extends AbstractXContentParser {
     }
 
     @Override
+    public void allowDuplicateKeys(boolean allowDuplicateKeys) {
+        parser.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, allowDuplicateKeys == false);
+    }
+
+    @Override
     public Token nextToken() throws IOException {
         return convertToken(parser.nextToken());
     }

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/smile/SmileXContentParser.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/smile/SmileXContentParser.java
@@ -49,4 +49,9 @@ public class SmileXContentParser extends JsonXContentParser {
     public XContentType contentType() {
         return XContentType.SMILE;
     }
+
+    @Override
+    public void allowDuplicateKeys(boolean allowDuplicateKeys) {
+        throw new UnsupportedOperationException("Allowing duplicate keys after the parser has been created is not possible for Smile");
+    }
 }

--- a/modules/ingest-common/src/main/java/org/opensearch/ingest/common/Processors.java
+++ b/modules/ingest-common/src/main/java/org/opensearch/ingest/common/Processors.java
@@ -49,11 +49,11 @@ public final class Processors {
     }
 
     public static Object json(Object fieldValue) {
-        return JsonProcessor.apply(fieldValue);
+        return JsonProcessor.apply(fieldValue, false);
     }
 
     public static void json(Map<String, Object> ctx, String field) {
-        JsonProcessor.apply(ctx, field);
+        JsonProcessor.apply(ctx, field, false);
     }
 
     public static String urlDecode(String value) {

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/140_json.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/140_json.yml
@@ -4,6 +4,10 @@ teardown:
       ingest.delete_pipeline:
         id: "1"
         ignore: 404
+  - do:
+      ingest.delete_pipeline:
+        id: "2"
+        ignore: 404
 
 ---
 "Test JSON Processor":
@@ -71,3 +75,36 @@ teardown:
   - match: { _source.foo_number: 3 }
   - is_true:  _source.foo_boolean
   - is_false: _source.foo_null
+
+---
+"Test JSON Processor duplicate keys":
+  - do:
+      ingest.put_pipeline:
+        id: "2"
+        body: {
+            "processors": [
+              {
+                "json" : {
+                  "field" : "json",
+                  "add_to_root": true,
+                  "allow_duplicate_keys": true
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test
+        id: 2
+        pipeline: "2"
+        body: {
+          json: "{\"dupe\": 1, \"dupe\": 2}",
+        }
+
+  - do:
+      get:
+        index: test
+        id: 2
+  - match: { _source.dupe: 2 }

--- a/server/src/main/java/org/opensearch/common/xcontent/JsonToStringXContentParser.java
+++ b/server/src/main/java/org/opensearch/common/xcontent/JsonToStringXContentParser.java
@@ -140,6 +140,11 @@ public class JsonToStringXContentParser extends AbstractXContentParser {
     }
 
     @Override
+    public void allowDuplicateKeys(boolean allowDuplicateKeys) {
+        throw new UnsupportedOperationException("Allowing duplicate keys is not possible for JsonToString");
+    }
+
+    @Override
     public Token nextToken() throws IOException {
         return this.parser.nextToken();
     }

--- a/server/src/test/java/org/opensearch/common/xcontent/BaseXContentTestCase.java
+++ b/server/src/test/java/org/opensearch/common/xcontent/BaseXContentTestCase.java
@@ -111,7 +111,7 @@ public abstract class BaseXContentTestCase extends OpenSearchTestCase {
 
     protected abstract XContentType xcontentType();
 
-    private XContentBuilder builder() throws IOException {
+    protected XContentBuilder builder() throws IOException {
         return XContentBuilder.builder(xcontentType().xContent());
     }
 
@@ -1103,6 +1103,14 @@ public abstract class BaseXContentTestCase extends OpenSearchTestCase {
         try (XContentParser xParser = createParser(builder)) {
             JsonParseException pex = expectThrows(JsonParseException.class, () -> xParser.map());
             assertThat(pex.getMessage(), startsWith("Duplicate field 'key'"));
+        }
+    }
+
+    public void testAllowsDuplicates() throws Exception {
+        XContentBuilder builder = builder().startObject().field("key", 1).field("key", 2).endObject();
+        try (XContentParser xParser = createParser(builder)) {
+            xParser.allowDuplicateKeys(true);
+            assertThat(xParser.map(), equalTo(Map.of("key", 2)));
         }
     }
 

--- a/server/src/test/java/org/opensearch/common/xcontent/cbor/CborXContentTests.java
+++ b/server/src/test/java/org/opensearch/common/xcontent/cbor/CborXContentTests.java
@@ -37,6 +37,7 @@ import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
 
 import org.opensearch.common.xcontent.BaseXContentTestCase;
 import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.XContentParser;
 
 import java.io.ByteArrayOutputStream;
 
@@ -51,5 +52,11 @@ public class CborXContentTests extends BaseXContentTestCase {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         JsonGenerator generator = new CBORFactory().createGenerator(os);
         doTestBigInteger(generator, os);
+    }
+
+    public void testAllowsDuplicates() throws Exception {
+        try (XContentParser xParser = createParser(builder().startObject().endObject())) {
+            expectThrows(UnsupportedOperationException.class, () -> xParser.allowDuplicateKeys(true));
+        }
     }
 }

--- a/server/src/test/java/org/opensearch/common/xcontent/smile/SmileXContentTests.java
+++ b/server/src/test/java/org/opensearch/common/xcontent/smile/SmileXContentTests.java
@@ -37,6 +37,7 @@ import com.fasterxml.jackson.dataformat.smile.SmileFactory;
 
 import org.opensearch.common.xcontent.BaseXContentTestCase;
 import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.XContentParser;
 
 import java.io.ByteArrayOutputStream;
 
@@ -51,5 +52,11 @@ public class SmileXContentTests extends BaseXContentTestCase {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         JsonGenerator generator = new SmileFactory().createGenerator(os);
         doTestBigInteger(generator, os);
+    }
+
+    public void testAllowsDuplicates() throws Exception {
+        try (XContentParser xParser = createParser(builder().startObject().endObject())) {
+            expectThrows(UnsupportedOperationException.class, () -> xParser.allowDuplicateKeys(true));
+        }
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

This is to support creating an ingest pipeline for ECS JSON logs.
Due to how some logging frameworks work, ECS JSON logs may contain duplicate keys. Instead of failing, the JSON parser should be more lenient and prefer the last value.

Ported from https://github.com/elastic/elasticsearch/pull/74956

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
