### PR TITLE
Fix dynamic date detection parsing failure bug

### DIFF
--- a/server/src/main/java/org/opensearch/common/time/DateFormatter.java
+++ b/server/src/main/java/org/opensearch/common/time/DateFormatter.java
@@ -39,7 +39,6 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
 import java.util.List;
@@ -56,7 +55,7 @@ public interface DateFormatter {
     /**
      * Try to parse input to a java time TemporalAccessor
      * @param input                   An arbitrary string resembling the string representation of a date or time
-     * @throws DateTimeParseException If parsing fails, this exception will be thrown.
+     * @throws IllegalArgumentException If parsing fails, this exception will be thrown.
      *                                Note that it can contained suppressed exceptions when several formatters failed parse this value
      * @return                        The java time object containing the parsed input
      */

--- a/server/src/test/java/org/opensearch/common/time/DateFormattersTests.java
+++ b/server/src/test/java/org/opensearch/common/time/DateFormattersTests.java
@@ -683,4 +683,15 @@ public class DateFormattersTests extends OpenSearchTestCase {
             }
         }
     }
+
+    public void testToVerifyFixForDateTimeException() {
+        DateFormatter formatter = DateFormatter.forPattern("strict_date_optional_time||epoch_millis");
+        assertEquals(1522431028842L, Instant.from(formatter.parse("2018-03-30T17:30:28.842Z")).toEpochMilli());
+        assertEquals(1522431028842L, Instant.from(formatter.parse("1522431028842")).toEpochMilli());
+        assertThrows(IllegalArgumentException.class, () -> formatter.parse(""));
+        // text causes DateTimeException from DateTimeFormatter#parseObject for the pattern in this test,
+        // and causes parse failure.
+        assertThrows(IllegalArgumentException.class, () -> formatter.parse("2018-03-30T17-30-28.842Z"));
+    }
+
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
JavaDateFormatter is introduced during Joda-Datetime deprecation, it supports composition of multiple parsers/formatter and return the first one succeeded to parse the input.

DateTimeException from new Java DataTime APIs is not handled at all causing the bug in date time auto-detection in some corner case.

Meanwhile there are also some other issue in current implementation:
1. The behavior when there is one parser is different from the behavior when there are more than one parsers.
2. Cache implementation is not optimal.

These two issue are also fixed in the change.


### Related Issues
Resolves #4055 
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
