### PR TITLE
Fix tests for concurrent Search: SamplerIT and TermsDocCountErrorIT

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/SamplerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/SamplerIT.java
@@ -145,6 +145,7 @@ public class SamplerIT extends ParameterizedOpenSearchIntegTestCase {
         // Tests that we can refer to nested elements under a sample in a path
         // statement
         boolean asc = randomBoolean();
+        indexRandomForConcurrentSearch("test");
         SearchResponse response = client().prepareSearch("test")
             .setSearchType(SearchType.QUERY_THEN_FETCH)
             .addAggregation(
@@ -176,6 +177,7 @@ public class SamplerIT extends ParameterizedOpenSearchIntegTestCase {
     public void testSimpleSampler() throws Exception {
         SamplerAggregationBuilder sampleAgg = sampler("sample").shardSize(100);
         sampleAgg.subAggregation(terms("authors").field("author"));
+        indexRandomForConcurrentSearch("test");
         SearchResponse response = client().prepareSearch("test")
             .setSearchType(SearchType.QUERY_THEN_FETCH)
             .setQuery(new TermQueryBuilder("genre", "fantasy"))
@@ -233,6 +235,7 @@ public class SamplerIT extends ParameterizedOpenSearchIntegTestCase {
     public void testRidiculousShardSizeSampler() throws Exception {
         SamplerAggregationBuilder sampleAgg = sampler("sample").shardSize(Integer.MAX_VALUE);
         sampleAgg.subAggregation(terms("authors").field("author"));
+        indexRandomForConcurrentSearch("test");
         SearchResponse response = client().prepareSearch("test")
             .setSearchType(SearchType.QUERY_THEN_FETCH)
             .setQuery(new TermQueryBuilder("genre", "fantasy"))

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/TermsDocCountErrorIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/TermsDocCountErrorIT.java
@@ -325,6 +325,7 @@ public class TermsDocCountErrorIT extends ParameterizedOpenSearchIntegTestCase {
     public void testStringValueField() throws Exception {
         int size = randomIntBetween(1, 20);
         int shardSize = randomIntBetween(size, size * 2);
+        indexRandomForConcurrentSearch("idx");
         SearchResponse accurateResponse = client().prepareSearch("idx")
             .addAggregation(
                 terms("terms").executionHint(randomExecutionHint())
@@ -584,6 +585,7 @@ public class TermsDocCountErrorIT extends ParameterizedOpenSearchIntegTestCase {
     public void testLongValueField() throws Exception {
         int size = randomIntBetween(1, 20);
         int shardSize = randomIntBetween(size, size * 2);
+        indexRandomForConcurrentSearch("idx");
         SearchResponse accurateResponse = client().prepareSearch("idx")
             .addAggregation(
                 terms("terms").executionHint(randomExecutionHint())


### PR DESCRIPTION
### Description
This PR is to make sure that the index random function which is used in multiple classes has creation of multiple segments to test the concurrent search code path in the following IT:
```
SamplerIT
TermsDocCountErrorIT
```
This change will fix 7 concurrent search tests.

### Related Issues

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
