### PR TITLE
Fix tests for concurrent Search: TermsDocCountErrorIT

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/TermsDocCountErrorIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/TermsDocCountErrorIT.java
@@ -225,6 +225,7 @@ public class TermsDocCountErrorIT extends ParameterizedOpenSearchIntegTestCase {
         }
 
         indexRandom(true, builders);
+        indexRandomForMultipleSlices("idx");
         ensureSearchable();
     }
 

--- a/test/framework/src/main/java/org/opensearch/test/ParameterizedOpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/ParameterizedOpenSearchIntegTestCase.java
@@ -47,6 +47,7 @@ public abstract class ParameterizedOpenSearchIntegTestCase extends OpenSearchInt
         client().admin().cluster().prepareUpdateSettings().setPersistentSettings(settingsToUnset).get();
     }
 
+    // This method shouldn't be called in setupSuiteScopeCluster(). Only call this method inside single test.
     public void indexRandomForConcurrentSearch(String... indices) throws InterruptedException {
         if (dynamicSettings.get(CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING.getKey()).equals("true")) {
             indexRandomForMultipleSlices(indices);


### PR DESCRIPTION
### Description
This PR is to make sure that the index random function which is used in multiple classes has creation of multiple segments to test the concurrent search code path in the following IT:
```
TermsDocCountErrorIT
```
This change will fix 2 concurrent search tests.

### Related Issues

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] ~New functionality has been documented.~
- [ ] ~New functionality has javadoc added~
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [ ] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
