### PR TITLE
Fix flaky testMinScoreDisablesCountOptimization in query profile phase tests

### DIFF
--- a/server/src/test/java/org/opensearch/search/query/QueryProfilePhaseTests.java
+++ b/server/src/test/java/org/opensearch/search/query/QueryProfilePhaseTests.java
@@ -336,12 +336,17 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
         assertEquals(TotalHits.Relation.EQUAL_TO, context.queryResult().topDocs().topDocs.totalHits.relation);
         assertProfileData(context, "MatchAllDocsQuery", query -> {
             assertThat(query.getTimeBreakdown().keySet(), not(empty()));
-            assertThat(query.getTimeBreakdown().get("score"), greaterThanOrEqualTo(100L));
+            assertThat(query.getTimeBreakdown().get("score"), greaterThanOrEqualTo(1L));
             assertThat(query.getTimeBreakdown().get("score_count"), equalTo(1L));
             if (executor != null) {
-                assertThat(query.getTimeBreakdown().get("max_score"), greaterThanOrEqualTo(100L));
-                assertThat(query.getTimeBreakdown().get("min_score"), greaterThanOrEqualTo(100L));
-                assertThat(query.getTimeBreakdown().get("avg_score"), greaterThanOrEqualTo(100L));
+                long maxScore = query.getTimeBreakdown().get("max_score");
+                long minScore = query.getTimeBreakdown().get("min_score");
+                long avgScore = query.getTimeBreakdown().get("avg_score");
+                assertThat(maxScore, greaterThanOrEqualTo(1L));
+                assertThat(minScore, greaterThanOrEqualTo(1L));
+                assertThat(avgScore, greaterThanOrEqualTo(1L));
+                assertThat(maxScore, greaterThanOrEqualTo(avgScore));
+                assertThat(avgScore, greaterThanOrEqualTo(minScore));
                 assertThat(query.getTimeBreakdown().get("max_score_count"), equalTo(1L));
                 assertThat(query.getTimeBreakdown().get("min_score_count"), equalTo(1L));
                 assertThat(query.getTimeBreakdown().get("avg_score_count"), equalTo(1L));


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This flaky test uses [min_score](https://opensearch.org/docs/latest/query-dsl/compound/function-score/#filtering-documents-that-dont-meet-a-threshold) to filter documents. Documents with lower score are excluded from the search results, but it still makes sense to include the actual score time and count in the profile response. As a result, the score time_in_nanos should not always be greater than or equal to `100`, and we need to revise the test accordingly. I run the new changes 1000+ times to make sure that they all passed.

### Related Issues
Resolves #10518
<!-- List any other related issues here -->

### Check List
- [ ] ~New functionality includes testing.~
  - [X] All tests pass
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [ ] ~Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))~
- [X] Commits are signed per the DCO using --signoff
- [ ] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
