### PR TITLE
Fix slice collectors to leaves association with post filter

### DIFF
--- a/server/src/main/java/org/opensearch/common/lucene/search/FilteredCollector.java
+++ b/server/src/main/java/org/opensearch/common/lucene/search/FilteredCollector.java
@@ -40,6 +40,7 @@ import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.Bits;
 import org.opensearch.common.lucene.Lucene;
+import org.opensearch.search.profile.query.ProfileWeight;
 
 import java.io.IOException;
 
@@ -64,6 +65,9 @@ public class FilteredCollector implements Collector {
 
     @Override
     public LeafCollector getLeafCollector(LeafReaderContext context) throws IOException {
+        if (filter instanceof ProfileWeight) {
+            ((ProfileWeight) filter).associateCollectorToLeaves(context, collector);
+        }
         final ScorerSupplier filterScorerSupplier = filter.scorerSupplier(context);
         final LeafCollector in = collector.getLeafCollector(context);
         final Bits bits = Lucene.asSequentialAccessBits(context.reader().maxDoc(), filterScorerSupplier);

--- a/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdown.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdown.java
@@ -83,7 +83,12 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
             // creates a new weight and breakdown map for each rewritten query. This new breakdown map captures the timing information for
             // the new rewritten query. The sliceCollectorsToLeaves is empty because this breakdown for rewritten query gets created later
             // in search leaf path which doesn't have collector. Also, this is not needed since this breakdown is per leaf and there is no
-            // concurrency involved. An empty sliceCollectorsToLeaves could also happen in the case of early termination.
+            // concurrency involved.
+            assert contexts.size() == 1 : new OpenSearchException(
+                "Unexpected size: "
+                    + contexts.size()
+                    + " of leaves breakdown in ConcurrentQueryProfileBreakdown of rewritten query for a leaf."
+            );
             AbstractProfileBreakdown<QueryTimingType> breakdown = contexts.values().iterator().next();
             queryNodeTime = breakdown.toNodeTime() + createWeightTime;
             maxSliceNodeTime = 0L;

--- a/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdown.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfileBreakdown.java
@@ -84,11 +84,9 @@ public final class ConcurrentQueryProfileBreakdown extends ContextualProfileBrea
             // the new rewritten query. The sliceCollectorsToLeaves is empty because this breakdown for rewritten query gets created later
             // in search leaf path which doesn't have collector. Also, this is not needed since this breakdown is per leaf and there is no
             // concurrency involved.
-            assert contexts.size() == 1 : new OpenSearchException(
-                "Unexpected size: "
-                    + contexts.size()
-                    + " of leaves breakdown in ConcurrentQueryProfileBreakdown of rewritten query for a leaf."
-            );
+            assert contexts.size() == 1 : "Unexpected size: "
+                + contexts.size()
+                + " of leaves breakdown in ConcurrentQueryProfileBreakdown of rewritten query for a leaf.";
             AbstractProfileBreakdown<QueryTimingType> breakdown = contexts.values().iterator().next();
             queryNodeTime = breakdown.toNodeTime() + createWeightTime;
             maxSliceNodeTime = 0L;


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
In the post filter query, a profile node is created during the creation of the filtered collector context, which occurred before the concurrent path in `ContextIndexSearcher::search()`. However, there is no association call for the filtered collector to leaves. Consequently, this led to an unexpected context size when generating the profile results.

This PR adds the association for the collector to leaves before building the scorer on the post-filter profile node. Following this modification, we can identify the missing association call for `sliceCollectorsToLeave@739870973`, and we can also confirm that the leaf counts in the `contexts` map match those in `sliceCollectorsToLeaves` when we invoke `toBreakdownMap() `to build the result.

``` ruby
------------ post filter query with 2 slices and 1 leaf/slice -------------
-- query rewrite --
-- query rewrite --
[T#21] ConcurrentQueryProfileBreakdown.sliceCollectorsToLeaves@2013178468
[T#21] searcher.search(query, collectorManager)
-- query rewrite --
[T#21] ConcurrentQueryProfileBreakdown.sliceCollectorsToLeaves@739870973
[T#21] ConcurrentQueryProfileBreakdown.sliceCollectorsToLeaves@208094559
[T#26] == search ===
[T#27] == search ===
[T#26] = searchLeaf() =
[T#27] = searchLeaf() =
[T#27] ConcurrentQueryProfileBreakdown.associateCollectorToLeaves() | sliceCollectorsToLeaves@739870973
[T#26] ConcurrentQueryProfileBreakdown.associateCollectorToLeaves() | sliceCollectorsToLeaves@739870973
[T#27] FilteredCollector.getLeafCollector() called
[T#26] FilteredCollector.getLeafCollector() called
[T#27] ConcurrentQueryProfileBreakdown.associateCollectorToLeaves() | sliceCollectorsToLeaves@2013178468
[T#26] ConcurrentQueryProfileBreakdown.associateCollectorToLeaves() | sliceCollectorsToLeaves@2013178468
[T#27] ConcurrentQueryProfileBreakdown.context() context=LeafReaderContext(FilterLeafReader(_1(9.8.0):C76 | sliceCollectorsToLeaves@2013178468
[T#26] ConcurrentQueryProfileBreakdown.context() context=LeafReaderContext(FilterLeafReader(_0(9.8.0):C524 | sliceCollectorsToLeaves@2013178468
[T#27] ConcurrentQueryProfileBreakdown.context() context=LeafReaderContext(FilterLeafReader(_1(9.8.0):C76 | sliceCollectorsToLeaves@2013178468
[T#26] ConcurrentQueryProfileBreakdown.context() context=LeafReaderContext(FilterLeafReader(_0(9.8.0):C524 | sliceCollectorsToLeaves@2013178468
[T#27] ConcurrentQueryProfileBreakdown.context() context=LeafReaderContext(FilterLeafReader(_1(9.8.0):C76 | sliceCollectorsToLeaves@739870973
[T#26] ConcurrentQueryProfileBreakdown.context() context=LeafReaderContext(FilterLeafReader(_0(9.8.0):C524 | sliceCollectorsToLeaves@739870973
[T#27] ConcurrentQueryProfileBreakdown.context() context=LeafReaderContext(FilterLeafReader(_1(9.8.0):C76 | sliceCollectorsToLeaves@208094559
[T#26] ConcurrentQueryProfileBreakdown.context() context=LeafReaderContext(FilterLeafReader(_0(9.8.0):C524 | sliceCollectorsToLeaves@208094559
[T#27] ConcurrentQueryProfileBreakdown.context() context=LeafReaderContext(FilterLeafReader(_1(9.8.0):C76 | sliceCollectorsToLeaves@208094559
[T#26] ConcurrentQueryProfileBreakdown.context() context=LeafReaderContext(FilterLeafReader(_0(9.8.0):C524 | sliceCollectorsToLeaves@208094559
[T#27] ConcurrentQueryProfileBreakdown.context() context=LeafReaderContext(FilterLeafReader(_1(9.8.0):C76 | sliceCollectorsToLeaves@739870973
[T#26] ConcurrentQueryProfileBreakdown.context() context=LeafReaderContext(FilterLeafReader(_0(9.8.0):C524 | sliceCollectorsToLeaves@739870973
[T#21] ConcurrentQueryProfileBreakdown.associateCollectorsToLeaves() | sliceCollectorsToLeaves@208094559
[T#21] toBreakdownMap() contexts=2 | sliceCollectorsToLeaves@2013178468=2
...
[T#21] toBreakdownMap() contexts=2 | sliceCollectorsToLeaves@208094559=2
...
[T#21] toBreakdownMap() contexts=2 | sliceCollectorsToLeaves@739870973=2
...
```

### Related Issues
Resolves #10767
<!-- List any other related issues here -->

### Check List
- [ ] ~New functionality includes testing.~
  - [X] All tests pass
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [X] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [X] Commits are signed per the DCO using --signoff
- [ ] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
