### PR TITLE
[Backport 2.x] Fix SuggestSearch.testSkipDuplicates by forceing refresh when indexing its test documents (#11068)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Fix class_cast_exception when passing int to _version and other metadata fields in ingest simulate API ([#10101](https://github.com/opensearch-project/OpenSearch/pull/10101))
+- Fix SuggestSearch.testSkipDuplicates by forcing refresh when indexing its test documents ([#11068](https://github.com/opensearch-project/OpenSearch/pull/11068))
 
 ### Security
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/suggest/CompletionSuggestSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/suggest/CompletionSuggestSearchIT.java
@@ -79,6 +79,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
+import static org.opensearch.action.support.WriteRequest.RefreshPolicy.WAIT_UNTIL;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
 import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
@@ -1171,6 +1172,7 @@ public class CompletionSuggestSearchIT extends ParameterizedOpenSearchIntegTestC
         createIndexAndMapping(mapping);
         int numDocs = randomIntBetween(10, 100);
         int numUnique = randomIntBetween(1, numDocs);
+        logger.info("Suggestion duplicate parameters: numDocs {} numUnique {}", numDocs, numUnique);
         List<IndexRequestBuilder> indexRequestBuilders = new ArrayList<>();
         int[] weights = new int[numUnique];
         Integer[] termIds = new Integer[numUnique];
@@ -1180,8 +1182,10 @@ public class CompletionSuggestSearchIT extends ParameterizedOpenSearchIntegTestC
             int weight = randomIntBetween(0, 100);
             weights[id] = Math.max(weight, weights[id]);
             String suggestion = "suggestion-" + String.format(Locale.ENGLISH, "%03d", id);
+            logger.info("Creating {}, id {}, weight {}", suggestion, i, id, weight);
             indexRequestBuilders.add(
                 client().prepareIndex(INDEX)
+                    .setRefreshPolicy(WAIT_UNTIL)
                     .setSource(
                         jsonBuilder().startObject()
                             .startObject(FIELD)
@@ -1195,10 +1199,12 @@ public class CompletionSuggestSearchIT extends ParameterizedOpenSearchIntegTestC
         indexRandom(true, indexRequestBuilders);
 
         Arrays.sort(termIds, Comparator.comparingInt(o -> weights[(int) o]).reversed().thenComparingInt(a -> (int) a));
+        logger.info("Expected terms id ordered {}", (Object[]) termIds);
         String[] expected = new String[numUnique];
         for (int i = 0; i < termIds.length; i++) {
             expected[i] = "suggestion-" + String.format(Locale.ENGLISH, "%03d", termIds[i]);
         }
+        logger.info("Expected suggestions field values {}", (Object[]) expected);
         CompletionSuggestionBuilder completionSuggestionBuilder = SuggestBuilders.completionSuggestion(FIELD)
             .prefix("sugg")
             .skipDuplicates(true)
@@ -1207,6 +1213,7 @@ public class CompletionSuggestSearchIT extends ParameterizedOpenSearchIntegTestC
         SearchResponse searchResponse = client().prepareSearch(INDEX)
             .suggest(new SuggestBuilder().addSuggestion("suggestions", completionSuggestionBuilder))
             .get();
+        logger.info("Search Response with Suggestions {}", searchResponse);
         assertSuggestions(searchResponse, true, "suggestions", expected);
     }
 


### PR DESCRIPTION
### Description

During the testSkipDuplicates its possible that not all documents were fully indexed by the time the search with suggestions was created, updating the indexing operations to refresh the index before returning.

As its possible that did not fix the issue, I've added logging around the test case to capture the state when the error occurred that can assist in future troubleshooting.

Signed-off-by: Peter Nied <petern@amazon.com>
(cherry picked from commit 0ba5d5807860a799c76f0fb6e063e8c5bd458492)

### Related Issues
- Related #10798

### Check List
- [ ] ~New functionality includes testing.~
  - [X] All tests pass
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
