### PR TITLE
Fix remote shards balancer and remove unused variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix per request latency last phase not tracked ([#10934](https://github.com/opensearch-project/OpenSearch/pull/10934))
 - Fix for stuck update action in a bulk with `retry_on_conflict` property ([#11152](https://github.com/opensearch-project/OpenSearch/issues/11152))
 - Remove shadowJar from `lang-painless` module publication ([#11369](https://github.com/opensearch-project/OpenSearch/issues/11369))
+- Fix remote shards balancer and remove unused variables ([#11167](https://github.com/opensearch-project/OpenSearch/pull/11167))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancer.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancer.java
@@ -65,7 +65,6 @@ public class LocalShardsBalancer extends ShardsBalancer {
 
     private final float threshold;
     private final Metadata metadata;
-    private final float avgShardsPerNode;
 
     private final float avgPrimaryShardsPerNode;
     private final BalancedShardsAllocator.NodeSorter sorter;
@@ -85,7 +84,6 @@ public class LocalShardsBalancer extends ShardsBalancer {
         this.threshold = threshold;
         this.routingNodes = allocation.routingNodes();
         this.metadata = allocation.metadata();
-        avgShardsPerNode = ((float) metadata.getTotalNumberOfShards()) / routingNodes.size();
         avgPrimaryShardsPerNode = (float) (StreamSupport.stream(metadata.spliterator(), false)
             .mapToInt(IndexMetadata::getNumberOfShards)
             .sum()) / routingNodes.size();
@@ -663,7 +661,6 @@ public class LocalShardsBalancer extends ShardsBalancer {
         RoutingNode targetNode = null;
         final List<NodeAllocationResult> nodeExplanationMap = explain ? new ArrayList<>() : null;
         int weightRanking = 0;
-        int targetNodeProcessed = 0;
         for (BalancedShardsAllocator.ModelNode currentNode : sorter.modelNodes) {
             if (currentNode != sourceNode) {
                 RoutingNode target = currentNode.getRoutingNode();
@@ -677,7 +674,6 @@ public class LocalShardsBalancer extends ShardsBalancer {
                         continue;
                     }
                 }
-                targetNodeProcessed++;
                 // don't use canRebalance as we want hard filtering rules to apply. See #17698
                 Decision allocationDecision = allocation.deciders().canAllocate(shardRouting, target, allocation);
                 if (explain) {

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/RemoteShardsBalancer.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/RemoteShardsBalancer.java
@@ -406,7 +406,7 @@ public final class RemoteShardsBalancer extends ShardsBalancer {
                     allocation.metadata(),
                     allocation.routingTable()
                 );
-                ShardRouting initShard = routingNodes.initializeShard(shard, node.nodeId(), null, shardSize, allocation.changes());
+                routingNodes.initializeShard(shard, node.nodeId(), null, shardSize, allocation.changes());
                 nodeQueue.offer(node);
                 allocated = true;
                 break;

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/RemoteShardsBalancer.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/RemoteShardsBalancer.java
@@ -444,7 +444,6 @@ public final class RemoteShardsBalancer extends ShardsBalancer {
 
                 // Break out if all nodes in the queue have been checked for this shard
                 if (nodeQueue.stream().allMatch(rn -> nodesCheckedForShard.contains(rn.nodeId()))) {
-                    throttled = true;
                     break;
                 }
             }

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/AllocationDeciders.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/AllocationDeciders.java
@@ -257,7 +257,7 @@ public class AllocationDeciders extends AllocationDecider {
         Decision.Multi ret = new Decision.Multi();
         for (AllocationDecider decider : allocations) {
             Decision decision = decider.canAllocateAnyShardToNode(node, allocation);
-            if (decision.type().canPremptivelyReturn()) {
+            if (decision.type().canPreemptivelyReturn()) {
                 if (logger.isTraceEnabled()) {
                     logger.trace("Shard can not be allocated on node [{}] due to [{}]", node.nodeId(), decider.getClass().getSimpleName());
                 }
@@ -279,7 +279,7 @@ public class AllocationDeciders extends AllocationDecider {
         for (AllocationDecider decider : allocations) {
             Decision decision = decider.canMoveAway(shardRouting, allocation);
             // short track if a NO is returned.
-            if (decision.type().canPremptivelyReturn()) {
+            if (decision.type().canPreemptivelyReturn()) {
                 if (logger.isTraceEnabled()) {
                     logger.trace("Shard [{}] can not be moved away due to [{}]", shardRouting, decider.getClass().getSimpleName());
                 }
@@ -301,7 +301,7 @@ public class AllocationDeciders extends AllocationDecider {
         for (AllocationDecider decider : allocations) {
             Decision decision = decider.canMoveAnyShard(allocation);
             // short track if a NO is returned.
-            if (decision.type().canPremptivelyReturn()) {
+            if (decision.type().canPreemptivelyReturn()) {
                 if (allocation.debugDecision() == false) {
                     return decision;
                 } else {

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/Decision.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/Decision.java
@@ -144,7 +144,7 @@ public abstract class Decision implements ToXContent, Writeable {
             return false;
         }
 
-        public boolean canPremptivelyReturn() {
+        public boolean canPreemptivelyReturn() {
             return this == THROTTLE || this == NO;
         }
 

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/RemoteShardsAllocateUnassignedTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/RemoteShardsAllocateUnassignedTests.java
@@ -13,10 +13,15 @@ import org.opensearch.cluster.routing.RoutingNode;
 import org.opensearch.cluster.routing.RoutingNodes;
 import org.opensearch.cluster.routing.RoutingPool;
 import org.opensearch.cluster.routing.ShardRouting;
+import org.opensearch.cluster.routing.UnassignedInfo;
 import org.opensearch.cluster.routing.allocation.allocator.RemoteShardsBalancer;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.opensearch.cluster.routing.UnassignedInfo.AllocationStatus.DECIDERS_NO;
+import static org.opensearch.cluster.routing.UnassignedInfo.AllocationStatus.DECIDERS_THROTTLED;
+import static org.opensearch.cluster.routing.UnassignedInfo.AllocationStatus.NO_ATTEMPT;
 
 public class RemoteShardsAllocateUnassignedTests extends RemoteShardsBalancerBaseTestCase {
 
@@ -86,6 +91,38 @@ public class RemoteShardsAllocateUnassignedTests extends RemoteShardsBalancerBas
         final int indexShardLimit = (int) Math.ceil(totalPrimaries(remoteIndices) / (float) remoteCapableNodes);
         for (int primaries : nodePrimariesCounter.values()) {
             assertTrue(primaries <= indexShardLimit);
+        }
+    }
+
+    /**
+     * Test remote unassigned shard allocation when deciders decide no.
+     */
+    public void testNoRemoteAllocation() {
+        final int localOnlyNodes = 10;
+        final int remoteCapableNodes = 5;
+        final int localIndices = 2;
+        final int remoteIndices = 1;
+        final ClusterState oldState = createInitialCluster(localOnlyNodes, remoteCapableNodes, localIndices, remoteIndices);
+        final boolean throttle = randomBoolean();
+        final AllocationService service = this.createRejectRemoteAllocationService(throttle);
+        final ClusterState newState = allocateShardsAndBalance(oldState, service);
+        final RoutingNodes routingNodes = newState.getRoutingNodes();
+        final RoutingAllocation allocation = getRoutingAllocation(newState, routingNodes);
+
+        assertEquals(totalShards(remoteIndices), routingNodes.unassigned().size());
+
+        for (ShardRouting shard : newState.getRoutingTable().allShards()) {
+            if (RoutingPool.getShardPool(shard, allocation) == RoutingPool.REMOTE_CAPABLE) {
+                assertTrue(shard.unassigned());
+                if (shard.primary()) {
+                    final UnassignedInfo.AllocationStatus expect = throttle ? DECIDERS_THROTTLED : DECIDERS_NO;
+                    assertEquals(expect, shard.unassignedInfo().getLastAllocationStatus());
+                } else {
+                    assertEquals(NO_ATTEMPT, shard.unassignedInfo().getLastAllocationStatus());
+                }
+            } else {
+                assertFalse(shard.unassigned());
+            }
         }
     }
 

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/RemoteShardsAllocateUnassignedTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/RemoteShardsAllocateUnassignedTests.java
@@ -95,7 +95,7 @@ public class RemoteShardsAllocateUnassignedTests extends RemoteShardsBalancerBas
     }
 
     /**
-     * Test remote unassigned shard allocation when deciders decide no.
+     * Test remote unassigned shard allocation when deciders make NO or THROTTLED decision.
      */
     public void testNoRemoteAllocation() {
         final int localOnlyNodes = 10;

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/RemoteShardsBalancerBaseTestCase.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/RemoteShardsBalancerBaseTestCase.java
@@ -224,7 +224,7 @@ public abstract class RemoteShardsBalancerBaseTestCase extends OpenSearchAllocat
             @Override
             public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
                 if (RoutingPool.REMOTE_CAPABLE.equals(RoutingPool.getShardPool(shardRouting, allocation))) {
-                    return throttle? Decision.THROTTLE : Decision.NO;
+                    return throttle ? Decision.THROTTLE : Decision.NO;
                 } else {
                     return Decision.ALWAYS;
                 }

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/RemoteShardsBalancerBaseTestCase.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/RemoteShardsBalancerBaseTestCase.java
@@ -20,7 +20,9 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.node.DiscoveryNodeRole;
 import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.cluster.routing.RoutingNode;
 import org.opensearch.cluster.routing.RoutingNodes;
+import org.opensearch.cluster.routing.RoutingPool;
 import org.opensearch.cluster.routing.RoutingTable;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.UnassignedInfo;
@@ -28,6 +30,7 @@ import org.opensearch.cluster.routing.allocation.allocator.BalancedShardsAllocat
 import org.opensearch.cluster.routing.allocation.allocator.ShardsAllocator;
 import org.opensearch.cluster.routing.allocation.decider.AllocationDecider;
 import org.opensearch.cluster.routing.allocation.decider.AllocationDeciders;
+import org.opensearch.cluster.routing.allocation.decider.Decision;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
@@ -199,6 +202,36 @@ public abstract class RemoteShardsBalancerBaseTestCase extends OpenSearchAllocat
             EmptyClusterInfoService.INSTANCE,
             SNAPSHOT_INFO_SERVICE_WITH_NO_SHARD_SIZES
         );
+    }
+
+    public AllocationService createRejectRemoteAllocationService(boolean throttle) {
+        Settings settings = Settings.Builder.EMPTY_SETTINGS;
+        return new OpenSearchAllocationTestCase.MockAllocationService(
+            createRejectRemoteAllocationDeciders(throttle),
+            new TestGatewayAllocator(),
+            createShardAllocator(settings),
+            EmptyClusterInfoService.INSTANCE,
+            SNAPSHOT_INFO_SERVICE_WITH_NO_SHARD_SIZES
+        );
+    }
+
+    public AllocationDeciders createRejectRemoteAllocationDeciders(boolean throttle) {
+        Settings settings = Settings.Builder.EMPTY_SETTINGS;
+        List<AllocationDecider> deciders = new ArrayList<>(
+            ClusterModule.createAllocationDeciders(settings, EMPTY_CLUSTER_SETTINGS, Collections.emptyList())
+        );
+        deciders.add(new AllocationDecider() {
+            @Override
+            public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+                if (RoutingPool.REMOTE_CAPABLE.equals(RoutingPool.getShardPool(shardRouting, allocation))) {
+                    return throttle? Decision.THROTTLE : Decision.NO;
+                } else {
+                    return Decision.ALWAYS;
+                }
+            }
+        });
+        Collections.shuffle(deciders, random());
+        return new AllocationDeciders(deciders);
     }
 
     public AllocationDeciders createAllocationDeciders() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Two changes here:
- make sure the primary shard's `AllocationStatus` be set to `DECIDERS_NO` when it cannot be allocated to any nodes;
- remove unused variables

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
