### PR TITLE
Fixed flaky and failing test cases for concurrent search

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/fetch/FetchSubPhasePluginIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/fetch/FetchSubPhasePluginIT.java
@@ -100,10 +100,6 @@ public class FetchSubPhasePluginIT extends ParameterizedOpenSearchIntegTestCase 
 
     @SuppressWarnings("unchecked")
     public void testPlugin() throws Exception {
-        assumeFalse(
-            "Concurrent search case muted pending fix: https://github.com/opensearch-project/OpenSearch/issues/11112",
-            internalCluster().clusterService().getClusterSettings().get(CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING)
-        );
         client().admin()
             .indices()
             .prepareCreate("test")

--- a/server/src/internalClusterTest/java/org/opensearch/search/functionscore/RandomScoreFunctionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/functionscore/RandomScoreFunctionIT.java
@@ -135,6 +135,7 @@ public class RandomScoreFunctionIT extends ParameterizedOpenSearchIntegTestCase 
         }
         flush();
         refresh();
+        indexRandomForConcurrentSearch("test");
         int outerIters = scaledRandomIntBetween(10, 20);
         for (int o = 0; o < outerIters; o++) {
             final int seed = randomInt();
@@ -299,6 +300,7 @@ public class RandomScoreFunctionIT extends ParameterizedOpenSearchIntegTestCase 
         index("test", "type", "1", jsonBuilder().startObject().endObject());
         flush();
         refresh();
+        indexRandomForConcurrentSearch("test");
 
         int seed = 12345678;
 
@@ -318,6 +320,7 @@ public class RandomScoreFunctionIT extends ParameterizedOpenSearchIntegTestCase 
         index("test", "type", "1", jsonBuilder().startObject().endObject());
         flush();
         refresh();
+        indexRandomForConcurrentSearch("test");
 
         int seed = 12345678;
 


### PR DESCRIPTION
### Description
This makes use of the indexRandomForConcurrentSearch function, which creates more segments for concurrent search tests, in several test cases for their concurrent search use-cases. The following test suites are affected by this change:

- RandomScoreFunctionIT.java
- FetchSubPhasePluginIT.java
- ~SearchWhileRelocatingIT.java~

### Related Issues
Resolves #11112 
Resolves #11106 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [ ] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
