### PR TITLE
[Backport 2.11]  [Refactor] Use iterative approach to evaluate Regex.simpleMatch (#11060)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Dependencies
 
 ### Changed
+- Use iterative approach to evaluate Regex.simpleMatch ([#11060](https://github.com/opensearch-project/OpenSearch/pull/11060))
 
 ### Deprecated
 

--- a/server/src/test/java/org/opensearch/common/regex/RegexTests.java
+++ b/server/src/test/java/org/opensearch/common/regex/RegexTests.java
@@ -97,6 +97,21 @@ public class RegexTests extends OpenSearchTestCase {
         assertTrue(Regex.simpleMatch("fff*******ddd", "fffabcddd"));
         assertTrue(Regex.simpleMatch("fff*******ddd", "FffAbcdDd", true));
         assertFalse(Regex.simpleMatch("fff******ddd", "fffabcdd"));
+        assertFalse(Regex.simpleMatch("fff*******ddd", "FffAbcdDd", false));
+        assertTrue(Regex.simpleMatch("abCDefGH******ddd", "abCDefGHddd", false));
+        assertTrue(Regex.simpleMatch("******", "a"));
+        assertTrue(Regex.simpleMatch("***WILDcard***", "aaaaaaaaWILDcardZZZZZZ", false));
+        assertFalse(Regex.simpleMatch("***xxxxx123456789xxxxxx***", "xxxxxabcdxxxxx", false));
+        assertFalse(Regex.simpleMatch("***xxxxxabcdxxxxx***", "xxxxxABCDxxxxx", false));
+        assertTrue(Regex.simpleMatch("***xxxxxabcdxxxxx***", "xxxxxABCDxxxxx", true));
+        assertTrue(Regex.simpleMatch("**stephenIsSuperCool**", "ItIsTrueThatStephenIsSuperCoolSoYouShouldLetThisIn", true));
+        assertTrue(
+            Regex.simpleMatch(
+                "**w**X**y**Z**",
+                "abcdeFGHIJKLMNOPqrstuvwabcdeFGHIJKLMNOPqrstuvwXabcdeFGHIJKLMNOPqrstuvwXyabcdeFGHIJKLMNOPqrstuvwXyZ",
+                false
+            )
+        );
     }
 
     public void testSimpleMatch() {


### PR DESCRIPTION
Manual backport of #11060 to 2.11.