### PR TITLE
Fixing the tests for concurrent search

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/query/SearchQueryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/query/SearchQueryIT.java
@@ -196,7 +196,7 @@ public class SearchQueryIT extends ParameterizedOpenSearchIntegTestCase {
     }
 
     // see https://github.com/elastic/elasticsearch/issues/3177
-    public void testIssue3177() {
+    public void testIssue3177() throws InterruptedException {
         createIndex("test");
         client().prepareIndex("test").setId("1").setSource("field1", "value1").get();
         client().prepareIndex("test").setId("2").setSource("field1", "value2").get();
@@ -205,6 +205,7 @@ public class SearchQueryIT extends ParameterizedOpenSearchIntegTestCase {
         waitForRelocation();
         forceMerge();
         refresh();
+        indexRandomForConcurrentSearch("test");
         assertHitCount(
             client().prepareSearch()
                 .setQuery(matchAllQuery())
@@ -876,11 +877,12 @@ public class SearchQueryIT extends ParameterizedOpenSearchIntegTestCase {
         assertFirstHit(searchResponse, hasId("1"));
     }
 
-    public void testMatchQueryZeroTermsQuery() {
+    public void testMatchQueryZeroTermsQuery() throws InterruptedException {
         assertAcked(prepareCreate("test").setMapping("field1", "type=text,analyzer=classic", "field2", "type=text,analyzer=classic"));
         client().prepareIndex("test").setId("1").setSource("field1", "value1").get();
         client().prepareIndex("test").setId("2").setSource("field1", "value2").get();
         refresh();
+        indexRandomForConcurrentSearch("test");
 
         BoolQueryBuilder boolQuery = boolQuery().must(matchQuery("field1", "a").zeroTermsQuery(MatchQuery.ZeroTermsQuery.NONE))
             .must(matchQuery("field1", "value1").zeroTermsQuery(MatchQuery.ZeroTermsQuery.NONE));
@@ -897,11 +899,12 @@ public class SearchQueryIT extends ParameterizedOpenSearchIntegTestCase {
         assertHitCount(searchResponse, 2L);
     }
 
-    public void testMultiMatchQueryZeroTermsQuery() {
+    public void testMultiMatchQueryZeroTermsQuery() throws InterruptedException {
         assertAcked(prepareCreate("test").setMapping("field1", "type=text,analyzer=classic", "field2", "type=text,analyzer=classic"));
         client().prepareIndex("test").setId("1").setSource("field1", "value1", "field2", "value2").get();
         client().prepareIndex("test").setId("2").setSource("field1", "value3", "field2", "value4").get();
         refresh();
+        indexRandomForConcurrentSearch("test");
 
         BoolQueryBuilder boolQuery = boolQuery().must(
             multiMatchQuery("a", "field1", "field2").zeroTermsQuery(MatchQuery.ZeroTermsQuery.NONE)
@@ -1944,11 +1947,12 @@ public class SearchQueryIT extends ParameterizedOpenSearchIntegTestCase {
         assertHitCount(searchResponse, 2L);
     }
 
-    public void testSearchEmptyDoc() {
+    public void testSearchEmptyDoc() throws InterruptedException {
         assertAcked(prepareCreate("test").setSettings("{\"index.analysis.analyzer.default.type\":\"keyword\"}", MediaTypeRegistry.JSON));
         client().prepareIndex("test").setId("1").setSource("{}", MediaTypeRegistry.JSON).get();
 
         refresh();
+        indexRandomForConcurrentSearch("test");
         assertHitCount(client().prepareSearch().setQuery(matchAllQuery()).get(), 1L);
     }
 


### PR DESCRIPTION
### Description
Follow-up to https://github.com/opensearch-project/OpenSearch/pull/11076.
Added indexRandomForConcurrentSearch method to the tests that were failing earlier for concurrent search case.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/11074

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [X] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [X] Commits are signed per the DCO using --signoff
- [ ] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
