### PR TITLE
Skipping half_float sort tests for 2.11.0 as well

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/260_sort_mixed.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/260_sort_mixed.yml
@@ -124,8 +124,8 @@
 ---
 "search across indices with mixed long and double and float numeric types":
   - skip:
-      version: " - 2.10.99"
-      reason: half float was broken before 2.11
+      version: " - 2.11.0"
+      reason: half float was broken before 2.11.1
 
   - do:
       indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/90_search_after.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/90_search_after.yml
@@ -324,8 +324,8 @@
 ---
 "half float":
   - skip:
-        version: " - 2.10.99"
-        reason: half_float was broken for 2.10 and earlier
+        version: " - 2.11.0"
+        reason: half_float was broken for 2.11.0 and earlier
 
   - do:
       indices.create:


### PR DESCRIPTION
### Description
Skipping half_float sort tests for 2.11.0 as well

### Related Issues
https://github.com/opensearch-project/opensearch-py/issues/582

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
