### PR TITLE
Fix SearchQueryIT to not depend on percentage

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/query/SearchQueryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/query/SearchQueryIT.java
@@ -394,7 +394,19 @@ public class SearchQueryIT extends ParameterizedOpenSearchIntegTestCase {
         assertSecondHit(searchResponse, hasId("2"));
         assertThirdHit(searchResponse, hasId("3"));
 
-        searchResponse = client().prepareSearch().setQuery(commonTermsQuery("field1", "the huge fox").lowFreqMinimumShouldMatch("2")).get();
+        // cutoff frequency of 1 makes all terms high frequency so the query gets rewritten as a
+        // conjunction of all terms (the lowFreqMinimumShouldMatch parameter is effectively ignored)
+        searchResponse = client().prepareSearch()
+            .setQuery(commonTermsQuery("field1", "the huge fox").cutoffFrequency(1).lowFreqMinimumShouldMatch("2"))
+            .get();
+        assertHitCount(searchResponse, 1L);
+        assertFirstHit(searchResponse, hasId("2"));
+
+        // cutoff frequency of 100 makes all terms low frequency, so lowFreqMinimumShouldMatch=3
+        // means all terms must match
+        searchResponse = client().prepareSearch()
+            .setQuery(commonTermsQuery("field1", "the huge fox").cutoffFrequency(100).lowFreqMinimumShouldMatch("3"))
+            .get();
         assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("2"));
 


### PR DESCRIPTION
The CommonTermsQuery tests in SearchQueryIT had one case that depended on the default cutoff frequency percentage. A recent change for concurrent search increased the number of deleted documents that could be indexed in the "indexRandom" helper method, and it turns out the cutoff percentage is calculated from a max docs value that includes deleted docs. This change replaces the default percentage with an absolute value (number of documents that must match) so it is no longer susceptible to behavior change due to number of deleted documents.

### Related Issues
Resolves #11208

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
