### PR TITLE
Handle canMatchSearchAfter for frozen context scenario

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix 'org.apache.hc.core5.http.ParseException: Invalid protocol version' under JDK 16+ ([#4827](https://github.com/opensearch-project/OpenSearch/pull/4827))
 - Fix compression support for h2c protocol ([#4944](https://github.com/opensearch-project/OpenSearch/pull/4944))
 - Don't over-allocate in HeapBufferedAsyncEntityConsumer in order to consume the response ([#9993](https://github.com/opensearch-project/OpenSearch/pull/9993))
+- Handle canMatchSearchAfter for frozen context scenario ([#11249](https://github.com/opensearch-project/OpenSearch/pull/11249))
 
 ### Security
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/240_date_nanos.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/240_date_nanos.yml
@@ -164,3 +164,99 @@ setup:
   - match: { aggregations.date.buckets.1.key: 1540857600000 }
   - match: { aggregations.date.buckets.1.key_as_string: "2018-10-30T00:00:00.000Z" }
   - match: { aggregations.date.buckets.1.doc_count: 2 }
+
+
+---
+"date with nested sort now":
+  - skip:
+      version: " - 2.12.99"
+      reason: fixed in 3.0.0
+
+  # This tests cover scenario where nested sort have now() in date field type.
+  # For this test, we have date field as nested field and we trigger asc/desc sort
+  # on that nested field. `filter` clause is needed when we sort any nested field,
+  # like in this case, "gte": "now/h" says sort nested field date_field only where
+  # document is having value greater than current time now().
+  # Nested field sort query doesn't sort documents if it is not qualified through
+  # `filter` clause.
+  # Only adding tests for `gte` as `lte` would be same behaviour
+
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            properties:
+              nested_field:
+                type: nested
+                properties:
+                  date_field:
+                    type: date
+                    format: date_optional_time
+  - do:
+      bulk:
+        refresh: true
+        index: test
+        body: |
+          {"index":{}}
+          {"nested_field": [{"date_field": "3023-10-26T12:00:00+09:00"}]}
+          {"index":{}}
+          {"nested_field": [{"date_field": "3024-10-26T12:00:00+09:00"}]}
+          {"index":{}}
+          {"nested_field": [{"date_field": "3025-10-26T12:00:00+09:00"}]}
+          {"index":{}}
+          {"nested_field": [{"date_field": "3026-10-26T12:00:00+09:00"}]}
+          {"index":{}}
+          {"nested_field": [{"date_field": "3027-10-26T12:00:00+09:00"}]}
+          {"index":{}}
+          {"nested_field": [{"date_field": "2022-10-26T12:00:00+09:00"}]}
+          {"index":{}}
+          {"nested_field": [{"date_field": "2023-10-26T12:00:00+09:00"}]}
+          {"index":{}}
+          {"nested_field": [{"date_field": "2021-10-26T12:00:00+09:00"}]}
+          {"index":{}}
+          {"nested_field": [{"date_field": "2020-10-26T12:00:00+09:00"}]}
+          {"index":{}}
+          {"nested_field": [{"date_field": "2019-10-26T12:00:00+09:00"}]}
+
+  # gte: now/h with the desc sort
+  - do:
+      search:
+        index: test
+        body:
+          size: 5
+          sort: [{ nested_field.date_field: { mode: max, order: desc, nested: { path: nested_field, filter: { bool: { filter : [{ range : { nested_field.date_field: { gte: now/h, time_zone: +09:00} } }] } } } } } ]
+  - match: {hits.total.value: 10 }
+  - length: {hits.hits: 5 }
+  - match: { hits.hits.0._index: test }
+  - match: { hits.hits.0._source.nested_field.0.date_field: "3027-10-26T12:00:00+09:00" }
+  - match: { hits.hits.0.sort: [33381428400000] }
+  - match: { hits.hits.1._source.nested_field.0.date_field: "3026-10-26T12:00:00+09:00" }
+  - match: { hits.hits.1.sort: [ 33349892400000 ] }
+  - match: { hits.hits.2._source.nested_field.0.date_field: "3025-10-26T12:00:00+09:00" }
+  - match: { hits.hits.2.sort: [ 33318356400000 ] }
+  - match: { hits.hits.3._source.nested_field.0.date_field: "3024-10-26T12:00:00+09:00" }
+  - match: { hits.hits.3.sort: [ 33286820400000 ] }
+  - match: { hits.hits.4._source.nested_field.0.date_field: "3023-10-26T12:00:00+09:00" }
+  - match: { hits.hits.4.sort: [ 33255198000000 ] }
+
+  # gte: now/h with the asc sort
+  - do:
+      search:
+        index: test
+        body:
+          size: 5
+          sort: [ { nested_field.date_field: { mode: max, order: asc, nested: { path: nested_field, filter: { bool: { filter: [ { range: { nested_field.date_field: { gte: now/h, time_zone: +09:00 } } } ] } } } } } ]
+  - match: { hits.total.value: 10 }
+  - length: { hits.hits: 5 }
+  - match: { hits.hits.0._index: test }
+  - match: { hits.hits.0._source.nested_field.0.date_field: "3023-10-26T12:00:00+09:00" }
+  - match: { hits.hits.0.sort: [ 33255198000000 ] }
+  - match: { hits.hits.1._source.nested_field.0.date_field: "3024-10-26T12:00:00+09:00" }
+  - match: { hits.hits.1.sort: [ 33286820400000 ] }
+  - match: { hits.hits.2._source.nested_field.0.date_field: "3025-10-26T12:00:00+09:00" }
+  - match: { hits.hits.2.sort: [ 33318356400000 ] }
+  - match: { hits.hits.3._source.nested_field.0.date_field: "3026-10-26T12:00:00+09:00" }
+  - match: { hits.hits.3.sort: [ 33349892400000 ] }
+  - match: { hits.hits.4._source.nested_field.0.date_field: "3027-10-26T12:00:00+09:00" }
+  - match: { hits.hits.4.sort: [ 33381428400000 ] }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/240_date_nanos.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/240_date_nanos.yml
@@ -169,8 +169,8 @@ setup:
 ---
 "date with nested sort now":
   - skip:
-      version: " - 2.12.99"
-      reason: fixed in 3.0.0
+      version: " - 2.11.99"
+      reason: fixed in 2.12.0
 
   # This tests cover scenario where nested sort have now() in date field type.
   # For this test, we have date field as nested field and we trigger asc/desc sort

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/90_search_after.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/90_search_after.yml
@@ -219,7 +219,7 @@
   - match: {hits.hits.0._source.timestamp: "2019-10-21 08:30:04.828733" }
   - match: {hits.hits.0.sort: [1571646604828733000] }
 
-  # search_after with the sort
+  # search_after with the asc sort
   - do:
       search:
         index: test

--- a/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
@@ -507,10 +507,7 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
     }
 
     private boolean canMatchSearchAfter(LeafReaderContext ctx) throws IOException {
-        if (searchContext.searchAfter() != null
-            && searchContext.sort() != null
-            && searchContext.request() != null
-            && searchContext.request().source() != null) {
+        if (searchContext.searchAfter() != null && searchContext.request() != null && searchContext.request().source() != null) {
             // Only applied on primary sort field and primary search_after.
             FieldSortBuilder primarySortField = FieldSortBuilder.getPrimaryFieldSortOrNull(searchContext.request().source());
             if (primarySortField != null) {

--- a/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
@@ -507,14 +507,18 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
     }
 
     private boolean canMatchSearchAfter(LeafReaderContext ctx) throws IOException {
-        if (searchContext.request() != null && searchContext.request().source() != null) {
+        if (searchContext.searchAfter() != null
+            && searchContext.sort() != null
+            && searchContext.request() != null
+            && searchContext.request().source() != null) {
             // Only applied on primary sort field and primary search_after.
             FieldSortBuilder primarySortField = FieldSortBuilder.getPrimaryFieldSortOrNull(searchContext.request().source());
             if (primarySortField != null) {
                 MinAndMax<?> minMax = FieldSortBuilder.getMinMaxOrNullForSegment(
                     this.searchContext.getQueryShardContext(),
                     ctx,
-                    primarySortField
+                    primarySortField,
+                    searchContext.sort()
                 );
                 return SearchService.canMatchSearchAfter(
                     searchContext.searchAfter(),

--- a/server/src/main/java/org/opensearch/search/sort/FieldSortBuilder.java
+++ b/server/src/main/java/org/opensearch/search/sort/FieldSortBuilder.java
@@ -611,7 +611,8 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
      * and configurations return <code>null</code>.
      */
     public static MinAndMax<?> getMinMaxOrNull(QueryShardContext context, FieldSortBuilder sortBuilder) throws IOException {
-        return getMinMaxOrNullInternal(context.getIndexReader(), context, sortBuilder, null);
+        final SortAndFormats sort = SortBuilder.buildSort(Collections.singletonList(sortBuilder), context).get();
+        return getMinMaxOrNullInternal(context.getIndexReader(), context, sortBuilder, sort);
     }
 
     /**
@@ -634,9 +635,6 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
         FieldSortBuilder sortBuilder,
         SortAndFormats sort
     ) throws IOException {
-        if (sort == null) {
-            sort = SortBuilder.buildSort(Collections.singletonList(sortBuilder), context).get();
-        }
         SortField sortField = sort.sort.getSort()[0];
         if (sortField.getField() == null) {
             return null;

--- a/server/src/main/java/org/opensearch/search/sort/FieldSortBuilder.java
+++ b/server/src/main/java/org/opensearch/search/sort/FieldSortBuilder.java
@@ -611,7 +611,7 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
      * and configurations return <code>null</code>.
      */
     public static MinAndMax<?> getMinMaxOrNull(QueryShardContext context, FieldSortBuilder sortBuilder) throws IOException {
-        return getMinMaxOrNullInternal(context.getIndexReader(), context, sortBuilder);
+        return getMinMaxOrNullInternal(context.getIndexReader(), context, sortBuilder, null);
     }
 
     /**
@@ -619,14 +619,24 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
      * The value can be extracted on non-nested indexed mapped fields of type keyword, numeric or date, other fields
      * and configurations return <code>null</code>.
      */
-    public static MinAndMax<?> getMinMaxOrNullForSegment(QueryShardContext context, LeafReaderContext ctx, FieldSortBuilder sortBuilder)
-        throws IOException {
-        return getMinMaxOrNullInternal(ctx.reader(), context, sortBuilder);
+    public static MinAndMax<?> getMinMaxOrNullForSegment(
+        QueryShardContext context,
+        LeafReaderContext ctx,
+        FieldSortBuilder sortBuilder,
+        SortAndFormats sort
+    ) throws IOException {
+        return getMinMaxOrNullInternal(ctx.reader(), context, sortBuilder, sort);
     }
 
-    private static MinAndMax<?> getMinMaxOrNullInternal(IndexReader reader, QueryShardContext context, FieldSortBuilder sortBuilder)
-        throws IOException {
-        SortAndFormats sort = SortBuilder.buildSort(Collections.singletonList(sortBuilder), context).get();
+    private static MinAndMax<?> getMinMaxOrNullInternal(
+        IndexReader reader,
+        QueryShardContext context,
+        FieldSortBuilder sortBuilder,
+        SortAndFormats sort
+    ) throws IOException {
+        if (sort == null) {
+            sort = SortBuilder.buildSort(Collections.singletonList(sortBuilder), context).get();
+        }
         SortField sortField = sort.sort.getSort()[0];
         if (sortField.getField() == null) {
             return null;


### PR DESCRIPTION
### Description
There is a corner case where sort is failing on nested field after this PR https://github.com/opensearch-project/OpenSearch/pull/7453. When nested field is `date` type and have `filter` in nested field has `now()` function call.
OpenSearch prevents SortFields' initialization in such cases more then one time.
This is very corner scenario but I added integ tests for that as we didn't have any integ test.
As a mitigation, I am pssing already initialized `SortAndFormats` in ContextIndexSearcher in this PR. In fact I also made change to invoke that `if clause` only if SearchContext contains searchAfter.

This happens only when nested_sort is having date field type and filter is having range along with now(). Culprit is the now() call that Opensearch is trying to avoid since now() should get called only once.

### How to repro the issue
```
PUT test_sort_nested_date2
{
  "settings" : {
      "number_of_shards" : 1,
      "number_of_replicas" : 0
  },
  "mappings": {
    "properties": {
      "nested_field": {
        "type": "nested",
        "properties": {
          "date_field": {
            "type": "date",
            "format": "date_optional_time"
          }
        }
      }
    }
  }
}
```

```
POST test_sort_nested_date2/_bulk
{"index": {"_id": "1"}}
{"nested_field": [{"date_field": "2023-10-26T12:00:00+09:00"}, {"date_field": "2025-10-01T12:00:00+09:00"}]}
```

```
GET test_sort_nested_date2/_search
{
  "sort": [
    {
      "nested_field.date_field": {
      "mode": "max",
        "order": "desc",
        "nested": {
          "path": "nested_field",
          "filter": {
            "bool": {
              "filter": [
                {
                  "range": {
                    "nested_field.date_field": {
                      "gte": "now/h",
                      "time_zone": "+09:00"
                    }
                  }
                }
              ]
            }
          }
        }
      }
    }
  ]
}
```

This search query failes with below Exception,
```
{
  "error": {
    "root_cause": [
      {
        "type": "parse_exception",
        "reason": "could not read the current timestamp"
      }
    ],
    "type": "search_phase_execution_exception",
    "reason": "all shards failed",
    "phase": "query",
    "grouped": true,
    "failed_shards": [
      {
        "shard": 0,
        "index": "test_sort_nested_date2",
        "node": "WT1VH4gyTVGVZyi_tNMO-Q",
        "reason": {
          "type": "parse_exception",
          "reason": "could not read the current timestamp",
          "caused_by": {
            "type": "illegal_argument_exception",
            "reason": "features that prevent cachability are disabled on this context"
          }
        }
      }
    ]
  },
  "status": 400
}
```

Server side traces are corelated with canMatchSearchAfter where we are trying to initialize SortAndFormats again to get MinMax values.

```
[2023-10-21T12:21:59,877][DEBUG][o.o.a.s.TransportSearchAction] [bc908df47a785e9192f108cf1282c4e4] All shards failed for phase: [query]
OpenSearchParseException[could not read the current timestamp]; nested: IllegalArgumentException[features that prevent cachability are disabled on this context];
    at org.opensearch.common.time.JavaDateMathParser.parse(JavaDateMathParser.java:83)
    at org.opensearch.index.mapper.DateFieldMapper$DateFieldType.parseToLong(DateFieldMapper.java:510)
    at org.opensearch.index.mapper.DateFieldMapper$DateFieldType.lambda$dateRangeQuery$1(DateFieldMapper.java:464)
    at org.opensearch.index.mapper.DateFieldMapper$DateFieldType.handleNow(DateFieldMapper.java:493)
    at org.opensearch.index.mapper.DateFieldMapper$DateFieldType.dateRangeQuery(DateFieldMapper.java:459)
    at org.opensearch.index.mapper.DateFieldMapper$DateFieldType.rangeQuery(DateFieldMapper.java:434)
    at org.opensearch.index.query.RangeQueryBuilder.doToQuery(RangeQueryBuilder.java:527)
    at org.opensearch.index.query.AbstractQueryBuilder.toQuery(AbstractQueryBuilder.java:117)
    at org.opensearch.index.query.BoolQueryBuilder.addBooleanClauses(BoolQueryBuilder.java:346)
    at org.opensearch.index.query.BoolQueryBuilder.doToQuery(BoolQueryBuilder.java:329)
    at org.opensearch.index.query.AbstractQueryBuilder.toQuery(AbstractQueryBuilder.java:117)
    at org.opensearch.search.sort.SortBuilder.resolveNestedQuery(SortBuilder.java:245)
    at org.opensearch.search.sort.SortBuilder.resolveNested(SortBuilder.java:203)
    at org.opensearch.search.sort.FieldSortBuilder.nested(FieldSortBuilder.java:588)
    at org.opensearch.search.sort.FieldSortBuilder.build(FieldSortBuilder.java:411)
    at org.opensearch.search.sort.SortBuilder.buildSort(SortBuilder.java:166)
    at org.opensearch.search.sort.FieldSortBuilder.getMinMaxOrNullInternal(FieldSortBuilder.java:631)
    at org.opensearch.search.sort.FieldSortBuilder.getMinMaxOrNullForSegment(FieldSortBuilder.java:626)
    at org.opensearch.search.internal.ContextIndexSearcher.canMatchSearchAfter(ContextIndexSearcher.java:499)
    at org.opensearch.search.internal.ContextIndexSearcher.canMatch(ContextIndexSearcher.java:491)
    at org.opensearch.search.internal.ContextIndexSearcher.searchLeaf(ContextIndexSearcher.java:309)
    at org.opensearch.search.internal.ContextIndexSearcher.search(ContextIndexSearcher.java:295)
    at org.apache.lucene.search.IndexSearcher.search(IndexSearcher.java:551)
    at org.opensearch.search.query.QueryPhase.searchWithCollector(QueryPhase.java:341)
    at org.opensearch.search.query.QueryPhase$DefaultQueryPhaseSearcher.searchWithCollector(QueryPhase.java:419)
    at org.opensearch.search.query.QueryPhase$DefaultQueryPhaseSearcher.searchWith(QueryPhase.java:408)
    at org.opensearch.search.query.QueryPhase.executeInternal(QueryPhase.java:263)
    at org.opensearch.search.query.QueryPhase.execute(QueryPhase.java:150)
    at org.opensearch.search.SearchService.loadOrExecuteQueryPhase(SearchService.java:527)
    at org.opensearch.search.SearchService.executeQueryPhase(SearchService.java:591)
    at org.opensearch.search.SearchService$2.lambda$onResponse$0(SearchService.java:560)
    at org.opensearch.action.ActionRunnable.lambda$supply$0(ActionRunnable.java:73)
    at org.opensearch.action.ActionRunnable$2.doRun(ActionRunnable.java:88)
    at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52)
    at org.opensearch.threadpool.TaskAwareRunnable.doRun(TaskAwareRunnable.java:78)
    at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52)
    at org.opensearch.common.util.concurrent.TimedRunnable.doRun(TimedRunnable.java:59)
    at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:815)
    at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
    at java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.IllegalArgumentException: features that prevent cachability are disabled on this context
    at org.opensearch.index.query.QueryShardContext.failIfFrozen(QueryShardContext.java:521)
    at org.opensearch.index.query.QueryShardContext.nowInMillis(QueryShardContext.java:555)
    at org.opensearch.index.mapper.DateFieldMapper$DateFieldType.lambda$handleNow$2(DateFieldMapper.java:491)
    at org.opensearch.common.time.JavaDateMathParser.parse(JavaDateMathParser.java:81)
    ... 41 more
```

### Related Issues
Resolves #11248

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).