### PR TITLE
Fix maxScore check in reduce phase when some scores are NaN

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/sort/FieldSortIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/sort/FieldSortIT.java
@@ -268,10 +268,6 @@ public class FieldSortIT extends ParameterizedOpenSearchIntegTestCase {
     }
 
     public void testTrackScores() throws Exception {
-        assumeFalse(
-            "Concurrent search case muted pending fix: https://github.com/opensearch-project/OpenSearch/issues/11189",
-            internalCluster().clusterService().getClusterSettings().get(CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING)
-        );
         assertAcked(client().admin().indices().prepareCreate("test").setMapping("svalue", "type=keyword").get());
         ensureGreen();
         index(

--- a/server/src/main/java/org/opensearch/search/query/TopDocsCollectorContext.java
+++ b/server/src/main/java/org/opensearch/search/query/TopDocsCollectorContext.java
@@ -532,7 +532,7 @@ public abstract class TopDocsCollectorContext extends QueryCollectorContext {
                     float score = collector.getMaxScore();
                     if (Float.isNaN(maxScore)) {
                         maxScore = score;
-                    } else {
+                    } else if (!Float.isNaN(score)) {
                         maxScore = Math.max(maxScore, score);
                     }
                 }


### PR DESCRIPTION
### Description
`Math.max(float, float` will return NaN if either parameter is `NaN`, so there's a small bug here where `max_score` might end up as `NaN` even if one of the collector scores is not `NaN`.

I ran `FieldSortIT.testTrackScores` 200x after this change and saw no more flakiness whereas before it was failing around 40% of the time (https://github.com/opensearch-project/OpenSearch/issues/11189#issuecomment-1817206936)

### Related Issues
Resolves #11189

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
