### PR TITLE
Update error message when lucene max document limit is breached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Disable concurrent aggs for Diversified Sampler and Sampler aggs ([#11087](https://github.com/opensearch-project/OpenSearch/issues/11087))
 - Made leader/follower check timeout setting dynamic ([#10528](https://github.com/opensearch-project/OpenSearch/pull/10528))
 - Improve boolean parsing performance ([#11308](https://github.com/opensearch-project/OpenSearch/pull/11308))
+- Change error message when per shard document limit is breached ([#11312](https://github.com/opensearch-project/OpenSearch/pull/11312))
 
 ### Deprecated
 

--- a/server/src/internalClusterTest/java/org/opensearch/index/engine/MaxDocsLimitIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/engine/MaxDocsLimitIT.java
@@ -127,7 +127,7 @@ public class MaxDocsLimitIT extends OpenSearchIntegTestCase {
         );
         assertThat(
             deleteError.getMessage(),
-            containsString("Number of documents in shard " + shardId + " can't exceed [" + maxDocs.get() + "]")
+            containsString("Number of documents in shard " + shardId + " exceeds the limit of [" + maxDocs.get() + "] documents per shard")
         );
         client().admin().indices().prepareRefresh("test").get();
         SearchResponse searchResponse = client().prepareSearch("test")
@@ -216,7 +216,13 @@ public class MaxDocsLimitIT extends OpenSearchIntegTestCase {
                         numFailure.incrementAndGet();
                         assertThat(
                             e.getMessage(),
-                            containsString("Number of documents in shard " + shardId + " can't exceed [" + maxDocs.get() + "]")
+                            containsString(
+                                "Number of documents in shard "
+                                    + shardId
+                                    + " exceeds the limit of ["
+                                    + maxDocs.get()
+                                    + "] documents per shard"
+                            )
                         );
                     }
                 }

--- a/server/src/internalClusterTest/java/org/opensearch/index/engine/MaxDocsLimitIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/engine/MaxDocsLimitIT.java
@@ -36,6 +36,8 @@ import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.core.index.Index;
+import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.index.IndexSettings;
@@ -65,6 +67,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 public class MaxDocsLimitIT extends OpenSearchIntegTestCase {
 
     private static final AtomicInteger maxDocs = new AtomicInteger();
+    private static final ShardId shardId = new ShardId(new Index("test", "_na_"), 0);
 
     public static class TestEnginePlugin extends Plugin implements EnginePlugin {
         @Override
@@ -122,7 +125,10 @@ public class MaxDocsLimitIT extends OpenSearchIntegTestCase {
             IllegalArgumentException.class,
             () -> client().prepareDelete("test", "any-id").get()
         );
-        assertThat(deleteError.getMessage(), containsString("Number of documents in the index can't exceed [" + maxDocs.get() + "]"));
+        assertThat(
+            deleteError.getMessage(),
+            containsString("Number of documents in shard " + shardId + " can't exceed [" + maxDocs.get() + "]")
+        );
         client().admin().indices().prepareRefresh("test").get();
         SearchResponse searchResponse = client().prepareSearch("test")
             .setQuery(new MatchAllQueryBuilder())
@@ -208,7 +214,10 @@ public class MaxDocsLimitIT extends OpenSearchIntegTestCase {
                         assertThat(resp.status(), equalTo(RestStatus.CREATED));
                     } catch (IllegalArgumentException e) {
                         numFailure.incrementAndGet();
-                        assertThat(e.getMessage(), containsString("Number of documents in the index can't exceed [" + maxDocs.get() + "]"));
+                        assertThat(
+                            e.getMessage(),
+                            containsString("Number of documents in shard " + shardId + " can't exceed [" + maxDocs.get() + "]")
+                        );
                     }
                 }
             });

--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -1412,7 +1412,9 @@ public class InternalEngine extends Engine {
         final long totalDocs = indexWriter.getPendingNumDocs() + inFlightDocCount.addAndGet(addingDocs);
         if (totalDocs > maxDocs) {
             releaseInFlightDocs(addingDocs);
-            return new IllegalArgumentException("Number of documents in shard " + shardId + " can't exceed [" + maxDocs + "]");
+            return new IllegalArgumentException(
+                "Number of documents in shard " + shardId + " exceeds the limit of [" + maxDocs + "] documents per shard"
+            );
         } else {
             return null;
         }

--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -1412,7 +1412,7 @@ public class InternalEngine extends Engine {
         final long totalDocs = indexWriter.getPendingNumDocs() + inFlightDocCount.addAndGet(addingDocs);
         if (totalDocs > maxDocs) {
             releaseInFlightDocs(addingDocs);
-            return new IllegalArgumentException("Number of documents in the index can't exceed [" + maxDocs + "]");
+            return new IllegalArgumentException("Number of documents in shard " + shardId + " can't exceed [" + maxDocs + "]");
         } else {
             return null;
         }

--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -7801,7 +7801,9 @@ public class InternalEngineTests extends EngineTestCase {
                     assertNotNull(result.getFailure());
                     assertThat(
                         result.getFailure().getMessage(),
-                        containsString("Number of documents in shard " + shardId + " can't exceed [" + maxDocs + "]")
+                        containsString(
+                            "Number of documents in shard " + shardId + " exceeds the limit of [" + maxDocs + "] documents per shard"
+                        )
                     );
                     assertThat(result.getSeqNo(), equalTo(UNASSIGNED_SEQ_NO));
                     assertThat(engine.getLocalCheckpointTracker().getMaxSeqNo(), equalTo(maxSeqNo));

--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -7801,7 +7801,7 @@ public class InternalEngineTests extends EngineTestCase {
                     assertNotNull(result.getFailure());
                     assertThat(
                         result.getFailure().getMessage(),
-                        containsString("Number of documents in the index can't exceed [" + maxDocs + "]")
+                        containsString("Number of documents in shard " + shardId + " can't exceed [" + maxDocs + "]")
                     );
                     assertThat(result.getSeqNo(), equalTo(UNASSIGNED_SEQ_NO));
                     assertThat(engine.getLocalCheckpointTracker().getMaxSeqNo(), equalTo(maxSeqNo));


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Whenever lucene document limit(which is currently INT_MAX) is breached for any shard, the error message that is shown currently indicates that the limit is on an index level whereas actually the limit is on a shard level.

Updating the error message in this PR to indicate the same. Also including the Shard Id as well in the message.

Previous message
```
Number of documents in the index can't exceed [2147483647]
```

Updated message
```
Number of documents in shard <index_name>[<shardId>] exceeds the limit of [2147483647] documents per shard
```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List

- [ ] ~New functionality includes testing.~
  - [ ] ~All tests pass~
- [ ] ~New functionality has been documented.~
 - [ ] ~New functionality has javadoc added~
- [ ] ~Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))~
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
