### PR TITLE
[Remote Store] Handoff refreshes, translog uploads during relocation from old to new primary

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/BaseRemoteStoreRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/BaseRemoteStoreRestoreIT.java
@@ -8,9 +8,7 @@
 
 package org.opensearch.remotestore;
 
-import org.opensearch.action.admin.cluster.remotestore.restore.RestoreRemoteStoreRequest;
 import org.opensearch.action.index.IndexResponse;
-import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.test.transport.MockTransportService;
@@ -20,7 +18,6 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
 
 public class BaseRemoteStoreRestoreIT extends RemoteStoreBaseIntegTestCase {
@@ -47,18 +44,6 @@ public class BaseRemoteStoreRestoreIT extends RemoteStoreBaseIntegTestCase {
 
     protected void restore(String... indices) {
         restore(randomBoolean(), indices);
-    }
-
-    protected void restore(boolean restoreAllShards, String... indices) {
-        if (restoreAllShards) {
-            assertAcked(client().admin().indices().prepareClose(indices));
-        }
-        client().admin()
-            .cluster()
-            .restoreRemoteStore(
-                new RestoreRemoteStoreRequest().indices(indices).restoreAllShards(restoreAllShards),
-                PlainActionFuture.newFuture()
-            );
     }
 
     protected void verifyRestoredData(Map<String, Long> indexStats, String indexName, boolean indexMoreData) throws Exception {

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.remotestore;
 
+import org.opensearch.OpenSearchException;
 import org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
@@ -16,6 +17,7 @@ import org.opensearch.action.admin.indices.flush.FlushRequest;
 import org.opensearch.action.admin.indices.recovery.RecoveryResponse;
 import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.search.SearchPhaseExecutionException;
 import org.opensearch.cluster.health.ClusterHealthStatus;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.routing.RecoverySource;
@@ -701,5 +703,62 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
             .execute()
             .actionGet();
         assertFalse(clusterHealthResponse.isTimedOut());
+    }
+
+    public void testResumeUploadAfterFailedPrimaryRelocation() throws ExecutionException, InterruptedException {
+        // In this test, we fail the hand off during the primary relocation. This will undo the drainRefreshes and
+        // drainSync performed as part of relocation handoff (before performing the handoff transport action).
+        // We validate the same here by failing the peer recovery and ensuring we can index afterward as well.
+
+        internalCluster().startClusterManagerOnlyNode();
+        String oldPrimary = internalCluster().startDataOnlyNodes(1).get(0);
+        createIndex(INDEX_NAME, remoteStoreIndexSettings(0));
+        ensureGreen(INDEX_NAME);
+        int docs = randomIntBetween(5, 10);
+        indexBulk(INDEX_NAME, docs);
+        flushAndRefresh(INDEX_NAME);
+        assertHitCount(client(oldPrimary).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), docs);
+        String newPrimary = internalCluster().startDataOnlyNodes(1).get(0);
+        ensureStableCluster(3);
+
+        IndexShard oldPrimaryIndexShard = getIndexShard(oldPrimary, INDEX_NAME);
+        CountDownLatch handOffLatch = new CountDownLatch(1);
+
+        MockTransportService mockTargetTransportService = ((MockTransportService) internalCluster().getInstance(
+            TransportService.class,
+            oldPrimary
+        ));
+        mockTargetTransportService.addSendBehavior((connection, requestId, action, request, options) -> {
+            if (PeerRecoveryTargetService.Actions.HANDOFF_PRIMARY_CONTEXT.equals(action)) {
+                handOffLatch.countDown();
+                throw new OpenSearchException("failing recovery for test purposes");
+            }
+            connection.sendRequest(requestId, action, request, options);
+        });
+
+        logger.info("--> relocate the shard");
+        client().admin()
+            .cluster()
+            .prepareReroute()
+            .add(new MoveAllocationCommand(INDEX_NAME, 0, oldPrimary, newPrimary))
+            .execute()
+            .actionGet();
+
+        handOffLatch.await(30, TimeUnit.SECONDS);
+
+        assertTrue(oldPrimaryIndexShard.isStartedPrimary());
+        assertEquals(oldPrimary, primaryNodeName(INDEX_NAME));
+        assertHitCount(client(oldPrimary).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), docs);
+
+        SearchPhaseExecutionException ex = assertThrows(
+            SearchPhaseExecutionException.class,
+            () -> client(newPrimary).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get()
+        );
+        assertEquals("all shards failed", ex.getMessage());
+
+        int moreDocs = randomIntBetween(5, 10);
+        indexBulk(INDEX_NAME, moreDocs);
+        flushAndRefresh(INDEX_NAME);
+        assertHitCount(client(oldPrimary).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), docs + moreDocs);
     }
 }

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
@@ -8,30 +8,34 @@
 
 package org.opensearch.remotestore;
 
+import org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
-import org.opensearch.action.admin.indices.get.GetIndexRequest;
-import org.opensearch.action.admin.indices.get.GetIndexResponse;
+import org.opensearch.action.admin.indices.flush.FlushRequest;
 import org.opensearch.action.admin.indices.recovery.RecoveryResponse;
 import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.opensearch.action.index.IndexResponse;
+import org.opensearch.cluster.health.ClusterHealthStatus;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.routing.RecoverySource;
+import org.opensearch.cluster.routing.allocation.command.MoveAllocationCommand;
+import org.opensearch.common.Priority;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.BufferedAsyncIOProcessor;
-import org.opensearch.core.index.Index;
-import org.opensearch.index.IndexService;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.shard.IndexShard;
+import org.opensearch.index.shard.IndexShardClosedException;
 import org.opensearch.index.translog.Translog.Durability;
 import org.opensearch.indices.IndicesService;
+import org.opensearch.indices.recovery.PeerRecoveryTargetService;
 import org.opensearch.indices.recovery.RecoverySettings;
 import org.opensearch.indices.recovery.RecoveryState;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.transport.MockTransportService;
+import org.opensearch.transport.TransportService;
 import org.hamcrest.MatcherAssert;
 
 import java.io.IOException;
@@ -42,6 +46,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -180,7 +185,7 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
             .getSetting(INDEX_NAME, IndexMetadata.SETTING_INDEX_UUID);
         Path indexPath = Path.of(String.valueOf(segmentRepoPath), indexUUID, "/0/segments/metadata");
 
-        IndexShard indexShard = getIndexShard(dataNode);
+        IndexShard indexShard = getIndexShard(dataNode, INDEX_NAME);
         int lastNMetadataFilesToKeep = indexShard.getRecoverySettings().getMinRemoteSegmentMetadataFiles();
         // Delete is async.
         assertBusy(() -> {
@@ -265,7 +270,7 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
         ensureGreen(INDEX_NAME);
         assertClusterRemoteBufferInterval(IndexSettings.DEFAULT_REMOTE_TRANSLOG_BUFFER_INTERVAL, dataNode);
 
-        IndexShard indexShard = getIndexShard(dataNode);
+        IndexShard indexShard = getIndexShard(dataNode, INDEX_NAME);
         assertTrue(indexShard.getTranslogSyncProcessor() instanceof BufferedAsyncIOProcessor);
         assertBufferInterval(IndexSettings.DEFAULT_REMOTE_TRANSLOG_BUFFER_INTERVAL, indexShard);
 
@@ -298,7 +303,7 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
         ensureYellowAndNoInitializingShards(INDEX_NAME);
         ensureGreen(INDEX_NAME);
 
-        IndexShard indexShard = getIndexShard(dataNode);
+        IndexShard indexShard = getIndexShard(dataNode, INDEX_NAME);
         assertTrue(indexShard.getTranslogSyncProcessor() instanceof BufferedAsyncIOProcessor);
         assertBufferInterval(bufferInterval, indexShard);
 
@@ -414,7 +419,7 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
             .put(IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING.getKey(), durability)
             .build();
         createIndex(INDEX_NAME, indexSettings);
-        IndexShard indexShard = getIndexShard(dataNode);
+        IndexShard indexShard = getIndexShard(dataNode, INDEX_NAME);
         assertEquals(durability, indexShard.indexSettings().getTranslogDurability());
 
         durability = randomFrom(Durability.values());
@@ -447,7 +452,7 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
 
         // Case 2 - Test update index fails
         createIndex(INDEX_NAME);
-        IndexShard indexShard = getIndexShard(dataNode);
+        IndexShard indexShard = getIndexShard(dataNode, INDEX_NAME);
         assertEquals(Durability.REQUEST, indexShard.indexSettings().getTranslogDurability());
         exception = assertThrows(
             IllegalArgumentException.class,
@@ -457,15 +462,6 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
                 .actionGet()
         );
         assertEquals(expectedExceptionMsg, exception.getMessage());
-    }
-
-    private IndexShard getIndexShard(String dataNode) throws ExecutionException, InterruptedException {
-        String clusterManagerName = internalCluster().getClusterManagerName();
-        IndicesService indicesService = internalCluster().getInstance(IndicesService.class, dataNode);
-        GetIndexResponse getIndexResponse = client(clusterManagerName).admin().indices().getIndex(new GetIndexRequest()).get();
-        String uuid = getIndexResponse.getSettings().get(INDEX_NAME).get(IndexMetadata.SETTING_INDEX_UUID);
-        IndexService indexService = indicesService.indexService(new Index(INDEX_NAME, uuid));
-        return indexService.getShard(0);
     }
 
     private void assertClusterRemoteBufferInterval(TimeValue expectedBufferInterval, String dataNode) {
@@ -559,7 +555,7 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
 
         createIndex(INDEX_NAME, remoteStoreIndexSettings(0));
         ensureGreen(INDEX_NAME);
-        IndexShard indexShard = getIndexShard(primaryShardNode);
+        IndexShard indexShard = getIndexShard(primaryShardNode, INDEX_NAME);
         assertFalse(indexShard.isSearchIdleSupported());
 
         String replicaShardNode = internalCluster().startDataOnlyNodes(1).get(0);
@@ -572,7 +568,7 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
         ensureGreen(INDEX_NAME);
         assertFalse(indexShard.isSearchIdleSupported());
 
-        indexShard = getIndexShard(replicaShardNode);
+        indexShard = getIndexShard(replicaShardNode, INDEX_NAME);
         assertFalse(indexShard.isSearchIdleSupported());
     }
 
@@ -620,5 +616,90 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
             assertHitCount(client(dataNodes.get(0)).prepareSearch(INDEX_NAME).setSize(0).get(), 50);
             assertHitCount(client(dataNodes.get(1)).prepareSearch(INDEX_NAME).setSize(0).get(), 50);
         });
+    }
+
+    public void testNoMultipleWriterDuringPrimaryRelocation() throws ExecutionException, InterruptedException {
+        // In this test, we trigger a force flush on existing primary while the primary mode on new primary has been
+        // activated. There was a bug in primary relocation of remote store enabled indexes where the new primary
+        // starts uploading translog and segments even before the cluster manager has started this shard. With this test,
+        // we check that we do not overwrite any file on remote store. Here we will also increase the replica count to
+        // check that there are no duplicate metadata files for translog or upload.
+
+        internalCluster().startClusterManagerOnlyNode();
+        String oldPrimary = internalCluster().startDataOnlyNodes(1).get(0);
+        createIndex(INDEX_NAME, remoteStoreIndexSettings(0));
+        ensureGreen(INDEX_NAME);
+        indexBulk(INDEX_NAME, randomIntBetween(5, 10));
+        String newPrimary = internalCluster().startDataOnlyNodes(1).get(0);
+        ensureStableCluster(3);
+
+        IndexShard oldPrimaryIndexShard = getIndexShard(oldPrimary, INDEX_NAME);
+        CountDownLatch flushLatch = new CountDownLatch(1);
+
+        MockTransportService mockTargetTransportService = ((MockTransportService) internalCluster().getInstance(
+            TransportService.class,
+            oldPrimary
+        ));
+        mockTargetTransportService.addSendBehavior((connection, requestId, action, request, options) -> {
+            if (PeerRecoveryTargetService.Actions.HANDOFF_PRIMARY_CONTEXT.equals(action)) {
+                flushLatch.countDown();
+            }
+            connection.sendRequest(requestId, action, request, options);
+        });
+
+        logger.info("--> relocate the shard");
+        client().admin()
+            .cluster()
+            .prepareReroute()
+            .add(new MoveAllocationCommand(INDEX_NAME, 0, oldPrimary, newPrimary))
+            .execute()
+            .actionGet();
+
+        CountDownLatch flushDone = new CountDownLatch(1);
+        Thread flushThread = new Thread(() -> {
+            try {
+                flushLatch.await(2, TimeUnit.SECONDS);
+                oldPrimaryIndexShard.flush(new FlushRequest().waitIfOngoing(true).force(true));
+                // newPrimaryTranslogRepo.setSleepSeconds(0);
+            } catch (IndexShardClosedException e) {
+                // this is fine
+            } catch (InterruptedException e) {
+                throw new AssertionError(e);
+            } finally {
+                flushDone.countDown();
+            }
+        });
+        flushThread.start();
+        flushDone.await(5, TimeUnit.SECONDS);
+        flushThread.join();
+
+        ClusterHealthResponse clusterHealthResponse = client().admin()
+            .cluster()
+            .prepareHealth()
+            .setWaitForStatus(ClusterHealthStatus.GREEN)
+            .setWaitForEvents(Priority.LANGUID)
+            .setWaitForNoRelocatingShards(true)
+            .setTimeout(TimeValue.timeValueSeconds(5))
+            .execute()
+            .actionGet();
+        assertFalse(clusterHealthResponse.isTimedOut());
+
+        client().admin()
+            .indices()
+            .updateSettings(
+                new UpdateSettingsRequest(INDEX_NAME).settings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1))
+            )
+            .get();
+
+        clusterHealthResponse = client().admin()
+            .cluster()
+            .prepareHealth()
+            .setWaitForStatus(ClusterHealthStatus.GREEN)
+            .setWaitForEvents(Priority.LANGUID)
+            .setWaitForNoRelocatingShards(true)
+            .setTimeout(TimeValue.timeValueSeconds(5))
+            .execute()
+            .actionGet();
+        assertFalse(clusterHealthResponse.isTimedOut());
     }
 }

--- a/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
+++ b/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
@@ -108,7 +108,7 @@ public final class EngineConfig {
     private final LongSupplier globalCheckpointSupplier;
     private final Supplier<RetentionLeases> retentionLeasesSupplier;
     private final boolean isReadOnlyReplica;
-    private final BooleanSupplier primaryModeSupplier;
+    private final BooleanSupplier startedPrimarySupplier;
     private final Comparator<LeafReader> leafSorter;
 
     /**
@@ -287,7 +287,7 @@ public final class EngineConfig {
         this.primaryTermSupplier = builder.primaryTermSupplier;
         this.tombstoneDocSupplier = builder.tombstoneDocSupplier;
         this.isReadOnlyReplica = builder.isReadOnlyReplica;
-        this.primaryModeSupplier = builder.primaryModeSupplier;
+        this.startedPrimarySupplier = builder.startedPrimarySupplier;
         this.translogFactory = builder.translogFactory;
         this.leafSorter = builder.leafSorter;
     }
@@ -495,11 +495,11 @@ public final class EngineConfig {
     }
 
     /**
-     * Returns the underlying primaryModeSupplier.
+     * Returns the underlying startedPrimarySupplier.
      * @return the primary mode supplier.
      */
-    public BooleanSupplier getPrimaryModeSupplier() {
-        return primaryModeSupplier;
+    public BooleanSupplier getStartedPrimarySupplier() {
+        return startedPrimarySupplier;
     }
 
     /**
@@ -577,7 +577,7 @@ public final class EngineConfig {
         private TombstoneDocSupplier tombstoneDocSupplier;
         private TranslogDeletionPolicyFactory translogDeletionPolicyFactory;
         private boolean isReadOnlyReplica;
-        private BooleanSupplier primaryModeSupplier;
+        private BooleanSupplier startedPrimarySupplier;
         private TranslogFactory translogFactory = new InternalTranslogFactory();
         Comparator<LeafReader> leafSorter;
 
@@ -701,8 +701,8 @@ public final class EngineConfig {
             return this;
         }
 
-        public Builder primaryModeSupplier(BooleanSupplier primaryModeSupplier) {
-            this.primaryModeSupplier = primaryModeSupplier;
+        public Builder startedPrimarySupplier(BooleanSupplier startedPrimarySupplier) {
+            this.startedPrimarySupplier = startedPrimarySupplier;
             return this;
         }
 

--- a/server/src/main/java/org/opensearch/index/engine/EngineConfigFactory.java
+++ b/server/src/main/java/org/opensearch/index/engine/EngineConfigFactory.java
@@ -152,7 +152,7 @@ public class EngineConfigFactory {
         LongSupplier primaryTermSupplier,
         EngineConfig.TombstoneDocSupplier tombstoneDocSupplier,
         boolean isReadOnlyReplica,
-        BooleanSupplier primaryModeSupplier,
+        BooleanSupplier startedPrimarySupplier,
         TranslogFactory translogFactory,
         Comparator<LeafReader> leafSorter
     ) {
@@ -185,7 +185,7 @@ public class EngineConfigFactory {
             .primaryTermSupplier(primaryTermSupplier)
             .tombstoneDocSupplier(tombstoneDocSupplier)
             .readOnlyReplica(isReadOnlyReplica)
-            .primaryModeSupplier(primaryModeSupplier)
+            .startedPrimarySupplier(startedPrimarySupplier)
             .translogFactory(translogFactory)
             .leafSorter(leafSorter)
             .build();

--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -292,7 +292,7 @@ public class InternalEngine extends Engine {
                     new CompositeTranslogEventListener(Arrays.asList(internalTranslogEventListener, translogEventListener), shardId),
                     this::ensureOpen,
                     engineConfig.getTranslogFactory(),
-                    engineConfig.getPrimaryModeSupplier()
+                    engineConfig.getStartedPrimarySupplier()
                 );
                 this.translogManager = translogManagerRef;
                 this.softDeletesPolicy = newSoftDeletesPolicy();

--- a/server/src/main/java/org/opensearch/index/engine/NRTReplicationEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/NRTReplicationEngine.java
@@ -125,7 +125,7 @@ public class NRTReplicationEngine extends Engine {
                 },
                 this,
                 engineConfig.getTranslogFactory(),
-                engineConfig.getPrimaryModeSupplier()
+                engineConfig.getStartedPrimarySupplier()
             );
             this.translogManager = translogManagerRef;
             success = true;

--- a/server/src/main/java/org/opensearch/index/engine/NoOpEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/NoOpEngine.java
@@ -203,7 +203,7 @@ public final class NoOpEngine extends ReadOnlyEngine {
                                         engineConfig.getGlobalCheckpointSupplier(),
                                         engineConfig.getPrimaryTermSupplier(),
                                         seqNo -> {},
-                                        engineConfig.getPrimaryModeSupplier()
+                                        engineConfig.getStartedPrimarySupplier()
                                     )
                             ) {
                                 translog.trimUnreferencedReaders();

--- a/server/src/main/java/org/opensearch/index/engine/ReadOnlyEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/ReadOnlyEngine.java
@@ -278,7 +278,7 @@ public class ReadOnlyEngine extends Engine {
                     config.getGlobalCheckpointSupplier(),
                     config.getPrimaryTermSupplier(),
                     seqNo -> {},
-                    config.getPrimaryModeSupplier()
+                    config.getStartedPrimarySupplier()
                 )
         ) {
             return translog.stats();

--- a/server/src/main/java/org/opensearch/index/shard/CheckpointRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/CheckpointRefreshListener.java
@@ -21,7 +21,7 @@ import java.io.IOException;
  *
  * @opensearch.internal
  */
-public class CheckpointRefreshListener extends CloseableRetryableRefreshListener {
+public class CheckpointRefreshListener extends ReleasableRetryableRefreshListener {
 
     protected static Logger logger = LogManager.getLogger(CheckpointRefreshListener.class);
 

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -910,7 +910,6 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             failShard("timed out waiting for relocation hand-off to complete", null);
             throw new IndexShardClosedException(shardId(), "timed out waiting for relocation hand-off to complete");
         } catch (Exception ex) {
-            logger.warn("exception occurred during relocation hand-off to complete errorMsg={}", ex.getMessage());
             assert replicationTracker.isPrimaryMode();
             // If the primary mode is still true after the end of handoff attempt, it basically means that the relocation
             // failed. The existing primary will continue to be the primary, so we need to allow the segments and translog

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -912,14 +912,11 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         } catch (Exception ex) {
             logger.warn("exception occurred during relocation hand-off to complete errorMsg={}", ex.getMessage());
             assert replicationTracker.isPrimaryMode();
-            throw ex;
-        } finally {
             // If the primary mode is still true after the end of handoff attempt, it basically means that the relocation
             // failed. The existing primary will continue to be the primary, so we need to allow the segments and translog
             // upload to resume.
-            if (replicationTracker.isPrimaryMode()) {
-                Releasables.close(releasablesOnHandoffFailures);
-            }
+            Releasables.close(releasablesOnHandoffFailures);
+            throw ex;
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -851,6 +851,9 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         final Runnable performSegRep
     ) throws IllegalIndexShardStateException, IllegalStateException, InterruptedException {
         assert shardRouting.primary() : "only primaries can be marked as relocated: " + shardRouting;
+        // The below list of releasable ensures that if the relocation does not happen, we undo the activity of close and
+        // acquire all permits. This will ensure that the remote store uploads can still be done by the existing primary shard.
+        List<Releasable> releasablesOnNoHandoff = new ArrayList<>();
         try (Releasable forceRefreshes = refreshListeners.forceRefreshes()) {
             indexShardOperationPermits.blockOperations(30, TimeUnit.MINUTES, () -> {
                 forceRefreshes.close();
@@ -863,11 +866,15 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                     maybeSync();
                 }
 
-                // Ensures all in-flight remote store operations drain, before we perform the handoff.
-                internalRefreshListener.stream()
-                    .filter(refreshListener -> refreshListener instanceof Closeable)
-                    .map(refreshListener -> (Closeable) refreshListener)
-                    .close();
+                // Ensures all in-flight remote store refreshes drain, before we perform the performSegRep.
+                for (ReferenceManager.RefreshListener refreshListener : internalRefreshListener) {
+                    if (refreshListener instanceof CloseableRetryableRefreshListener) {
+                        releasablesOnNoHandoff.add(((CloseableRetryableRefreshListener) refreshListener).drainRefreshes());
+                    }
+                }
+
+                // Ensure all in-flight remote store translog upload drains, before we perform the performSegRep.
+                releasablesOnNoHandoff.add(getEngineOrNull().translogManager().drainSyncToStore());
 
                 // no shard operation permits are being held here, move state from started to relocated
                 assert indexShardOperationPermits.getActiveOperationsCount() == OPERATIONS_BLOCKED
@@ -902,6 +909,15 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             // Fail primary relocation source and target shards.
             failShard("timed out waiting for relocation hand-off to complete", null);
             throw new IndexShardClosedException(shardId(), "timed out waiting for relocation hand-off to complete");
+        } finally {
+            // If the primary mode is still true after the end of handoff attempt, it basically means that the relocation
+            // failed. The existing primary will continue to be the primary, so we need to allow the segments and translog
+            // upload to resume.
+            if (replicationTracker.isPrimaryMode()) {
+                for (Releasable releasable : releasablesOnNoHandoff) {
+                    releasable.close();
+                }
+            }
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -874,7 +874,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                 }
 
                 // Ensure all in-flight remote store translog upload drains, before we perform the performSegRep.
-                releasablesOnNoHandoff.add(getEngineOrNull().translogManager().drainSyncToStore());
+                releasablesOnNoHandoff.add(getEngineOrNull().translogManager().drainSync());
 
                 // no shard operation permits are being held here, move state from started to relocated
                 assert indexShardOperationPermits.getActiveOperationsCount() == OPERATIONS_BLOCKED

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -853,7 +853,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         assert shardRouting.primary() : "only primaries can be marked as relocated: " + shardRouting;
         // The below list of releasable ensures that if the relocation does not happen, we undo the activity of close and
         // acquire all permits. This will ensure that the remote store uploads can still be done by the existing primary shard.
-        List<Releasable> releasablesOnNoHandoff = new ArrayList<>();
+        List<Releasable> releasablesOnHandoffFailures = new ArrayList<>(2);
         try (Releasable forceRefreshes = refreshListeners.forceRefreshes()) {
             indexShardOperationPermits.blockOperations(30, TimeUnit.MINUTES, () -> {
                 forceRefreshes.close();
@@ -868,13 +868,13 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
 
                 // Ensures all in-flight remote store refreshes drain, before we perform the performSegRep.
                 for (ReferenceManager.RefreshListener refreshListener : internalRefreshListener) {
-                    if (refreshListener instanceof CloseableRetryableRefreshListener) {
-                        releasablesOnNoHandoff.add(((CloseableRetryableRefreshListener) refreshListener).drainRefreshes());
+                    if (refreshListener instanceof ReleasableRetryableRefreshListener) {
+                        releasablesOnHandoffFailures.add(((ReleasableRetryableRefreshListener) refreshListener).drainRefreshes());
                     }
                 }
 
                 // Ensure all in-flight remote store translog upload drains, before we perform the performSegRep.
-                releasablesOnNoHandoff.add(getEngineOrNull().translogManager().drainSync());
+                releasablesOnHandoffFailures.add(getEngine().translogManager().drainSync());
 
                 // no shard operation permits are being held here, move state from started to relocated
                 assert indexShardOperationPermits.getActiveOperationsCount() == OPERATIONS_BLOCKED
@@ -909,14 +909,16 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             // Fail primary relocation source and target shards.
             failShard("timed out waiting for relocation hand-off to complete", null);
             throw new IndexShardClosedException(shardId(), "timed out waiting for relocation hand-off to complete");
+        } catch (Exception ex) {
+            logger.warn("exception occurred during relocation hand-off to complete errorMsg={}", ex.getMessage());
+            assert replicationTracker.isPrimaryMode();
+            throw ex;
         } finally {
             // If the primary mode is still true after the end of handoff attempt, it basically means that the relocation
             // failed. The existing primary will continue to be the primary, so we need to allow the segments and translog
             // upload to resume.
             if (replicationTracker.isPrimaryMode()) {
-                for (Releasable releasable : releasablesOnNoHandoff) {
-                    releasable.close();
-                }
+                Releasables.close(releasablesOnHandoffFailures);
             }
         }
     }

--- a/server/src/main/java/org/opensearch/index/shard/ReleasableRetryableRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/ReleasableRetryableRefreshListener.java
@@ -23,11 +23,11 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * RefreshListener that runs afterRefresh method if and only if there is a permit available. Once the listener
- * is closed, all the permits are acquired and there are no available permits to afterRefresh. This abstract class provides
+ * RefreshListener that runs afterRefresh method if and only if there is a permit available. Once the {@code drainRefreshes()}
+ * is called, all the permits are acquired and there are no available permits to afterRefresh. This abstract class provides
  * necessary abstract methods to schedule retry.
  */
-public abstract class CloseableRetryableRefreshListener implements ReferenceManager.RefreshListener {
+public abstract class ReleasableRetryableRefreshListener implements ReferenceManager.RefreshListener {
 
     /**
      * Total permits = 1 ensures that there is only single instance of runAfterRefreshWithPermit that is running at a time.
@@ -48,11 +48,11 @@ public abstract class CloseableRetryableRefreshListener implements ReferenceMana
      */
     private final AtomicBoolean retryScheduled = new AtomicBoolean(false);
 
-    public CloseableRetryableRefreshListener() {
+    public ReleasableRetryableRefreshListener() {
         this.threadPool = null;
     }
 
-    public CloseableRetryableRefreshListener(ThreadPool threadPool) {
+    public ReleasableRetryableRefreshListener(ThreadPool threadPool) {
         assert Objects.nonNull(threadPool);
         this.threadPool = threadPool;
     }
@@ -215,7 +215,7 @@ public abstract class CloseableRetryableRefreshListener implements ReferenceMana
     /**
      * Returns the timeout which is used while draining refreshes.
      */
-    protected TimeValue getDrainTimeout() {
+    TimeValue getDrainTimeout() {
         return DRAIN_TIMEOUT;
     }
 

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -484,7 +484,7 @@ public final class RemoteStoreRefreshListener extends ReleasableRetryableRefresh
     /**
      * This checks for readiness of the index shard and primary mode. This has separated from shouldSync since we use the
      * returned value of this method for scheduling retries in syncSegments method.
-     * @return true iff primaryMode is true and index shard is not in closed state.
+     * @return true iff the shard is a started with primary mode true or it is local or snapshot recovery.
      */
     private boolean isReadyForUpload() {
         boolean isReady = indexShard.isStartedPrimary() || isLocalOrSnapshotRecovery();

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -487,8 +487,7 @@ public final class RemoteStoreRefreshListener extends CloseableRetryableRefreshL
      * @return true iff primaryMode is true and index shard is not in closed state.
      */
     private boolean isReadyForUpload() {
-        boolean isReady = (indexShard.getReplicationTracker().isPrimaryMode() && indexShard.state() != IndexShardState.CLOSED)
-            || isLocalOrSnapshotRecovery();
+        boolean isReady = indexShard.isStartedPrimary() || isLocalOrSnapshotRecovery();
 
         if (isReady == false) {
             StringBuilder sb = new StringBuilder("Skipped syncing segments with");
@@ -501,11 +500,11 @@ public final class RemoteStoreRefreshListener extends CloseableRetryableRefreshL
             if (indexShard.getEngineOrNull() != null) {
                 sb.append(" engineType=").append(indexShard.getEngine().getClass().getSimpleName());
             }
-            if (isLocalOrSnapshotRecovery() == false) {
+            if (indexShard.recoveryState() != null) {
                 sb.append(" recoverySourceType=").append(indexShard.recoveryState().getRecoverySource().getType());
                 sb.append(" primary=").append(indexShard.shardRouting.primary());
             }
-            logger.trace(sb.toString());
+            logger.info(sb.toString());
         }
         return isReady;
     }
@@ -514,8 +513,8 @@ public final class RemoteStoreRefreshListener extends CloseableRetryableRefreshL
         // In this case when the primary mode is false, we need to upload segments to Remote Store
         // This is required in case of snapshots/shrink/ split/clone where we need to durable persist
         // all segments to remote before completing the recovery to ensure durability.
-
         return (indexShard.state() == IndexShardState.RECOVERING && indexShard.shardRouting.primary())
+            && indexShard.recoveryState() != null
             && (indexShard.recoveryState().getRecoverySource().getType() == RecoverySource.Type.LOCAL_SHARDS
                 || indexShard.recoveryState().getRecoverySource().getType() == RecoverySource.Type.SNAPSHOT);
     }

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -54,7 +54,7 @@ import static org.opensearch.index.seqno.SequenceNumbers.LOCAL_CHECKPOINT_KEY;
  *
  * @opensearch.internal
  */
-public final class RemoteStoreRefreshListener extends CloseableRetryableRefreshListener {
+public final class RemoteStoreRefreshListener extends ReleasableRetryableRefreshListener {
 
     private final Logger logger;
 

--- a/server/src/main/java/org/opensearch/index/translog/InternalTranslogFactory.java
+++ b/server/src/main/java/org/opensearch/index/translog/InternalTranslogFactory.java
@@ -28,7 +28,7 @@ public class InternalTranslogFactory implements TranslogFactory {
         LongSupplier globalCheckpointSupplier,
         LongSupplier primaryTermSupplier,
         LongConsumer persistedSequenceNumberConsumer,
-        BooleanSupplier primaryModeSupplier
+        BooleanSupplier startedPrimarySupplier
     ) throws IOException {
 
         return new LocalTranslog(

--- a/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
@@ -308,8 +308,8 @@ public class InternalTranslogManager implements TranslogManager, Closeable {
     }
 
     @Override
-    public Releasable drainSyncToStore() {
-        return translog.drainSyncToStore();
+    public Releasable drainSync() {
+        return translog.drainSync();
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
@@ -59,7 +59,7 @@ public class InternalTranslogManager implements TranslogManager, Closeable {
         TranslogEventListener translogEventListener,
         LifecycleAware engineLifeCycleAware,
         TranslogFactory translogFactory,
-        BooleanSupplier primaryModeSupplier
+        BooleanSupplier startedPrimarySupplier
     ) throws IOException {
         this.shardId = shardId;
         this.readLock = readLock;
@@ -72,7 +72,7 @@ public class InternalTranslogManager implements TranslogManager, Closeable {
             if (tracker != null) {
                 tracker.markSeqNoAsPersisted(seqNo);
             }
-        }, translogUUID, translogFactory, primaryModeSupplier);
+        }, translogUUID, translogFactory, startedPrimarySupplier);
         assert translog.getGeneration() != null;
         this.translog = translog;
         assert pendingTranslogRecovery.get() == false : "translog recovery can't be pending before we set it";
@@ -369,7 +369,7 @@ public class InternalTranslogManager implements TranslogManager, Closeable {
         LongConsumer persistedSequenceNumberConsumer,
         String translogUUID,
         TranslogFactory translogFactory,
-        BooleanSupplier primaryModeSupplier
+        BooleanSupplier startedPrimarySupplier
     ) throws IOException {
         return translogFactory.newTranslog(
             translogConfig,
@@ -378,7 +378,7 @@ public class InternalTranslogManager implements TranslogManager, Closeable {
             globalCheckpointSupplier,
             primaryTermSupplier,
             persistedSequenceNumberConsumer,
-            primaryModeSupplier
+            startedPrimarySupplier
         );
     }
 

--- a/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
@@ -11,6 +11,7 @@ package org.opensearch.index.translog;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.store.AlreadyClosedException;
+import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.logging.Loggers;
 import org.opensearch.common.util.concurrent.ReleasableLock;
 import org.opensearch.common.util.io.IOUtils;
@@ -301,8 +302,14 @@ public class InternalTranslogManager implements TranslogManager, Closeable {
         translog.setMinSeqNoToKeep(seqNo);
     }
 
+    @Override
     public void onDelete() {
         translog.onDelete();
+    }
+
+    @Override
+    public Releasable drainSyncToStore() {
+        return translog.drainSyncToStore();
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/translog/LocalTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/LocalTranslog.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.index.translog;
 
+import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.util.concurrent.ReleasableLock;
 import org.opensearch.common.util.io.IOUtils;
 
@@ -138,6 +139,11 @@ public class LocalTranslog extends Translog {
                 earliestLastModifiedAge()
             );
         }
+    }
+
+    @Override
+    Releasable drainSync() {
+        return () -> {}; // noop
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/translog/NoOpTranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/NoOpTranslogManager.java
@@ -126,7 +126,7 @@ public class NoOpTranslogManager implements TranslogManager {
     public void onDelete() {}
 
     @Override
-    public Releasable drainSyncToStore() {
+    public Releasable drainSync() {
         return () -> {};
     }
 

--- a/server/src/main/java/org/opensearch/index/translog/NoOpTranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/NoOpTranslogManager.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.index.translog;
 
+import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.util.concurrent.ReleasableLock;
 import org.opensearch.core.index.shard.ShardId;
 
@@ -121,7 +122,13 @@ public class NoOpTranslogManager implements TranslogManager {
         throw new UnsupportedOperationException("Translog snapshot unsupported with no-op translogs");
     }
 
+    @Override
     public void onDelete() {}
+
+    @Override
+    public Releasable drainSyncToStore() {
+        return () -> {};
+    }
 
     @Override
     public Translog.TranslogGeneration getTranslogGeneration() {

--- a/server/src/main/java/org/opensearch/index/translog/RemoteBlobStoreInternalTranslogFactory.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteBlobStoreInternalTranslogFactory.java
@@ -59,7 +59,7 @@ public class RemoteBlobStoreInternalTranslogFactory implements TranslogFactory {
         LongSupplier globalCheckpointSupplier,
         LongSupplier primaryTermSupplier,
         LongConsumer persistedSequenceNumberConsumer,
-        BooleanSupplier primaryModeSupplier
+        BooleanSupplier startedPrimarySupplier
     ) throws IOException {
 
         assert repository instanceof BlobStoreRepository : "repository should be instance of BlobStoreRepository";
@@ -73,7 +73,7 @@ public class RemoteBlobStoreInternalTranslogFactory implements TranslogFactory {
             persistedSequenceNumberConsumer,
             blobStoreRepository,
             threadPool,
-            primaryModeSupplier,
+            startedPrimarySupplier,
             remoteTranslogTransferTracker
         );
     }

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -333,7 +333,6 @@ public class RemoteFsTranslog extends Translog {
             return true;
         }
         logger.trace("uploading translog for {} {}", primaryTerm, generation);
-        induceDelayForTest();
         try (
             TranslogCheckpointTransferSnapshot transferSnapshotProvider = new TranslogCheckpointTransferSnapshot.Builder(
                 primaryTerm,
@@ -351,11 +350,6 @@ public class RemoteFsTranslog extends Translog {
         } finally {
             syncPermit.release(SYNC_PERMIT);
         }
-
-    }
-
-    // Made available for testing only
-    void induceDelayForTest() {
 
     }
 

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -275,6 +275,16 @@ public class RemoteFsTranslog extends Translog {
     }
 
     private boolean prepareAndUpload(Long primaryTerm, Long generation) throws IOException {
+        // During primary relocation, both the old and new primary have engine created with RemoteFsTranslog and having
+        // ReplicationTracker.primaryMode() as true. However, before we perform the `internal:index/shard/replication/segments_sync`
+        // action which re-downloads the segments and translog on the new primary. We are ensuring 2 things here -
+        // 1. Using startedPrimarySupplier, we prevent the new primary to do pre-emptive syncs
+        // 2. Using syncPermits, we prevent syncs at the desired time during primary relocation.
+        if (startedPrimarySupplier.getAsBoolean() == false || syncPermit.tryAcquire(SYNC_PERMIT) == false) {
+            logger.debug("skipped uploading translog for {} {} syncPermits={}", primaryTerm, generation, syncPermit.availablePermits());
+            // NO-OP
+            return false;
+        }
         long maxSeqNo = -1;
         try (Releasable ignored = writeLock.acquire()) {
             if (generation == null || generation == current.getGeneration()) {
@@ -324,16 +334,6 @@ public class RemoteFsTranslog extends Translog {
     }
 
     private boolean upload(long primaryTerm, long generation, long maxSeqNo) throws IOException {
-        // During primary relocation, both the old and new primary have engine created with RemoteFsTranslog and having
-        // ReplicationTracker.primaryMode() as true. However, before we perform the `internal:index/shard/replication/segments_sync`
-        // action which re-downloads the segments and translog on the new primary. We are ensuring 2 things here -
-        // 1. Using startedPrimarySupplier, we prevent the new primary to do pre-emptive syncs
-        // 2. Using syncPermits, we prevent syncs at the desired time during primary relocation.
-        if (startedPrimarySupplier.getAsBoolean() == false || syncPermit.tryAcquire(SYNC_PERMIT) == false) {
-            logger.debug("skipped uploading translog for {} {} syncPermits={}", primaryTerm, generation, syncPermit.availablePermits());
-            // NO-OP
-            return true;
-        }
         logger.trace("uploading translog for {} {}", primaryTerm, generation);
         try (
             TranslogCheckpointTransferSnapshot transferSnapshotProvider = new TranslogCheckpointTransferSnapshot.Builder(
@@ -462,7 +462,7 @@ public class RemoteFsTranslog extends Translog {
 
         // This is to ensure that after the permits are acquired during primary relocation, there are no further modification on remote
         // store.
-        if (pauseSync.get()) {
+        if (startedPrimarySupplier.getAsBoolean() == false || pauseSync.get()) {
             return;
         }
 

--- a/server/src/main/java/org/opensearch/index/translog/Translog.java
+++ b/server/src/main/java/org/opensearch/index/translog/Translog.java
@@ -1820,9 +1820,7 @@ public abstract class Translog extends AbstractIndexShardComponent implements In
     /**
      * Drains ongoing syncs to the underlying store. It returns a releasable which can be closed to resume the syncs back.
      */
-    protected Releasable drainSync() {
-        return () -> {}; // noop
-    }
+    abstract Releasable drainSync();
 
     /**
      * deletes all files associated with a reader. package-private to be able to simulate node failures at this point

--- a/server/src/main/java/org/opensearch/index/translog/Translog.java
+++ b/server/src/main/java/org/opensearch/index/translog/Translog.java
@@ -1820,8 +1820,8 @@ public abstract class Translog extends AbstractIndexShardComponent implements In
     /**
      * Drains ongoing syncs to the underlying store. It returns a releasable which can be closed to resume the syncs back.
      */
-    protected Releasable drainSyncToStore() {
-        return () -> {};
+    protected Releasable drainSync() {
+        return () -> {}; // noop
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/translog/Translog.java
+++ b/server/src/main/java/org/opensearch/index/translog/Translog.java
@@ -1818,6 +1818,13 @@ public abstract class Translog extends AbstractIndexShardComponent implements In
     protected void onDelete() {}
 
     /**
+     * Drains ongoing syncs to the underlying store. It returns a releasable which can be closed to resume the syncs back.
+     */
+    protected Releasable drainSyncToStore() {
+        return () -> {};
+    }
+
+    /**
      * deletes all files associated with a reader. package-private to be able to simulate node failures at this point
      */
     void deleteReaderFiles(TranslogReader reader) {

--- a/server/src/main/java/org/opensearch/index/translog/TranslogFactory.java
+++ b/server/src/main/java/org/opensearch/index/translog/TranslogFactory.java
@@ -32,6 +32,6 @@ public interface TranslogFactory {
         final LongSupplier globalCheckpointSupplier,
         final LongSupplier primaryTermSupplier,
         final LongConsumer persistedSequenceNumberConsumer,
-        final BooleanSupplier primaryModeSupplier
+        final BooleanSupplier startedPrimarySupplier
     ) throws IOException;
 }

--- a/server/src/main/java/org/opensearch/index/translog/TranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/TranslogManager.java
@@ -139,7 +139,7 @@ public interface TranslogManager {
     /**
      * Drains ongoing syncs to the underlying store. It returns a releasable which can be closed to resume the syncs back.
      */
-    Releasable drainSyncToStore();
+    Releasable drainSync();
 
     Translog.TranslogGeneration getTranslogGeneration();
 }

--- a/server/src/main/java/org/opensearch/index/translog/TranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/TranslogManager.java
@@ -9,6 +9,7 @@
 package org.opensearch.index.translog;
 
 import org.opensearch.common.annotation.PublicApi;
+import org.opensearch.common.lease.Releasable;
 
 import java.io.IOException;
 import java.util.stream.Stream;
@@ -134,6 +135,11 @@ public interface TranslogManager {
     Clean up if any needed on deletion of index
      */
     void onDelete();
+
+    /**
+     * Drains ongoing syncs to the underlying store. It returns a releasable which can be closed to resume the syncs back.
+     */
+    Releasable drainSyncToStore();
 
     Translog.TranslogGeneration getTranslogGeneration();
 }

--- a/server/src/main/java/org/opensearch/index/translog/WriteOnlyTranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/WriteOnlyTranslogManager.java
@@ -38,7 +38,7 @@ public class WriteOnlyTranslogManager extends InternalTranslogManager {
         TranslogEventListener translogEventListener,
         LifecycleAware engineLifecycleAware,
         TranslogFactory translogFactory,
-        BooleanSupplier primaryModeSupplier
+        BooleanSupplier startedPrimarySupplier
     ) throws IOException {
         super(
             translogConfig,
@@ -52,7 +52,7 @@ public class WriteOnlyTranslogManager extends InternalTranslogManager {
             translogEventListener,
             engineLifecycleAware,
             translogFactory,
-            primaryModeSupplier
+            startedPrimarySupplier
         );
     }
 

--- a/server/src/test/java/org/opensearch/index/shard/CloseableRetryableRefreshListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/CloseableRetryableRefreshListenerTests.java
@@ -66,7 +66,7 @@ public class CloseableRetryableRefreshListenerTests extends OpenSearchTestCase {
         // Second invocation of afterRefresh method
         testRefreshListener.afterRefresh(true);
         assertEquals(0, countDownLatch.getCount());
-        testRefreshListener.close();
+        testRefreshListener.drainRefreshes();
     }
 
     /**
@@ -98,7 +98,7 @@ public class CloseableRetryableRefreshListenerTests extends OpenSearchTestCase {
         assertEquals(initialCount - refreshCount, countDownLatch.getCount());
 
         // Closing the refresh listener so that no further afterRefreshes are executed going forward
-        testRefreshListener.close();
+        testRefreshListener.drainRefreshes();
 
         for (int i = 0; i < initialCount - refreshCount; i++) {
             testRefreshListener.afterRefresh(true);
@@ -129,7 +129,7 @@ public class CloseableRetryableRefreshListenerTests extends OpenSearchTestCase {
         };
         testRefreshListener.afterRefresh(true);
         assertEquals(initialCount - 1, countDownLatch.getCount());
-        testRefreshListener.close();
+        testRefreshListener.drainRefreshes();
 
         testRefreshListener = new CloseableRetryableRefreshListener(threadPool) {
             @Override
@@ -148,7 +148,7 @@ public class CloseableRetryableRefreshListenerTests extends OpenSearchTestCase {
         };
         testRefreshListener.afterRefresh(true);
         assertEquals(initialCount - 2, countDownLatch.getCount());
-        testRefreshListener.close();
+        testRefreshListener.drainRefreshes();
 
         testRefreshListener = new CloseableRetryableRefreshListener(threadPool) {
             @Override
@@ -172,7 +172,7 @@ public class CloseableRetryableRefreshListenerTests extends OpenSearchTestCase {
         };
         testRefreshListener.afterRefresh(true);
         assertEquals(initialCount - 3, countDownLatch.getCount());
-        testRefreshListener.close();
+        testRefreshListener.drainRefreshes();
 
         testRefreshListener = new CloseableRetryableRefreshListener(threadPool) {
             @Override
@@ -196,7 +196,7 @@ public class CloseableRetryableRefreshListenerTests extends OpenSearchTestCase {
         };
         testRefreshListener.afterRefresh(true);
         assertEquals(initialCount - 4, countDownLatch.getCount());
-        testRefreshListener.close();
+        testRefreshListener.drainRefreshes();
     }
 
     /**
@@ -237,7 +237,7 @@ public class CloseableRetryableRefreshListenerTests extends OpenSearchTestCase {
         };
         testRefreshListener.afterRefresh(true);
         assertBusy(() -> assertEquals(0, countDownLatch.getCount()));
-        testRefreshListener.close();
+        testRefreshListener.drainRefreshes();
     }
 
     /**
@@ -272,7 +272,7 @@ public class CloseableRetryableRefreshListenerTests extends OpenSearchTestCase {
             }
         };
         testRefreshListener.afterRefresh(randomBoolean());
-        testRefreshListener.close();
+        testRefreshListener.drainRefreshes();
         assertNotEquals(0, countDownLatch.getCount());
     }
 
@@ -307,7 +307,7 @@ public class CloseableRetryableRefreshListenerTests extends OpenSearchTestCase {
         });
         thread.start();
         assertBusy(() -> assertEquals(0, countDownLatch.getCount()));
-        testRefreshListener.close();
+        testRefreshListener.drainRefreshes();
     }
 
     public void testScheduleRetryAfterClose() throws Exception {
@@ -358,8 +358,8 @@ public class CloseableRetryableRefreshListenerTests extends OpenSearchTestCase {
         Thread thread2 = new Thread(() -> {
             try {
                 Thread.sleep(500);
-                testRefreshListener.close();
-            } catch (IOException | InterruptedException e) {
+                testRefreshListener.drainRefreshes();
+            } catch (InterruptedException e) {
                 throw new AssertionError(e);
             }
         });
@@ -408,7 +408,7 @@ public class CloseableRetryableRefreshListenerTests extends OpenSearchTestCase {
         testRefreshListener.afterRefresh(true);
         testRefreshListener.afterRefresh(true);
         assertBusy(() -> assertEquals(3, runCount.get()));
-        testRefreshListener.close();
+        testRefreshListener.drainRefreshes();
     }
 
     public void testExceptionDuringThreadPoolSchedule() throws Exception {
@@ -450,7 +450,7 @@ public class CloseableRetryableRefreshListenerTests extends OpenSearchTestCase {
         assertThrows(RuntimeException.class, () -> testRefreshListener.afterRefresh(true));
         assertBusy(() -> assertFalse(testRefreshListener.getRetryScheduledStatus()));
         assertEquals(1, runCount.get());
-        testRefreshListener.close();
+        testRefreshListener.drainRefreshes();
     }
 
     @After

--- a/server/src/test/java/org/opensearch/index/shard/ReleasableRetryableRefreshListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/ReleasableRetryableRefreshListenerTests.java
@@ -27,9 +27,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class CloseableRetryableRefreshListenerTests extends OpenSearchTestCase {
+public class ReleasableRetryableRefreshListenerTests extends OpenSearchTestCase {
 
-    private static final Logger logger = LogManager.getLogger(CloseableRetryableRefreshListenerTests.class);
+    private static final Logger logger = LogManager.getLogger(ReleasableRetryableRefreshListenerTests.class);
 
     private ThreadPool threadPool;
 
@@ -44,7 +44,7 @@ public class CloseableRetryableRefreshListenerTests extends OpenSearchTestCase {
     public void testPerformAfterRefresh() throws IOException {
 
         CountDownLatch countDownLatch = new CountDownLatch(2);
-        CloseableRetryableRefreshListener testRefreshListener = new CloseableRetryableRefreshListener(mock(ThreadPool.class)) {
+        ReleasableRetryableRefreshListener testRefreshListener = new ReleasableRetryableRefreshListener(mock(ThreadPool.class)) {
             @Override
             protected boolean performAfterRefreshWithPermit(boolean didRefresh) {
                 countDownLatch.countDown();
@@ -76,7 +76,7 @@ public class CloseableRetryableRefreshListenerTests extends OpenSearchTestCase {
     public void testCloseAfterRefresh() throws IOException {
         final int initialCount = randomIntBetween(10, 100);
         final CountDownLatch countDownLatch = new CountDownLatch(initialCount);
-        CloseableRetryableRefreshListener testRefreshListener = new CloseableRetryableRefreshListener(mock(ThreadPool.class)) {
+        ReleasableRetryableRefreshListener testRefreshListener = new ReleasableRetryableRefreshListener(mock(ThreadPool.class)) {
             @Override
             protected boolean performAfterRefreshWithPermit(boolean didRefresh) {
                 countDownLatch.countDown();
@@ -113,7 +113,7 @@ public class CloseableRetryableRefreshListenerTests extends OpenSearchTestCase {
     public void testNoRetry() throws IOException {
         int initialCount = randomIntBetween(10, 100);
         final CountDownLatch countDownLatch = new CountDownLatch(initialCount);
-        CloseableRetryableRefreshListener testRefreshListener = new CloseableRetryableRefreshListener(mock(ThreadPool.class)) {
+        ReleasableRetryableRefreshListener testRefreshListener = new ReleasableRetryableRefreshListener(mock(ThreadPool.class)) {
             @Override
             protected boolean performAfterRefreshWithPermit(boolean didRefresh) {
                 countDownLatch.countDown();
@@ -132,7 +132,7 @@ public class CloseableRetryableRefreshListenerTests extends OpenSearchTestCase {
         assertEquals(initialCount - 1, countDownLatch.getCount());
         testRefreshListener.drainRefreshes();
 
-        testRefreshListener = new CloseableRetryableRefreshListener(threadPool) {
+        testRefreshListener = new ReleasableRetryableRefreshListener(threadPool) {
             @Override
             protected boolean performAfterRefreshWithPermit(boolean didRefresh) {
                 countDownLatch.countDown();
@@ -151,7 +151,7 @@ public class CloseableRetryableRefreshListenerTests extends OpenSearchTestCase {
         assertEquals(initialCount - 2, countDownLatch.getCount());
         testRefreshListener.drainRefreshes();
 
-        testRefreshListener = new CloseableRetryableRefreshListener(threadPool) {
+        testRefreshListener = new ReleasableRetryableRefreshListener(threadPool) {
             @Override
             protected boolean performAfterRefreshWithPermit(boolean didRefresh) {
                 countDownLatch.countDown();
@@ -175,7 +175,7 @@ public class CloseableRetryableRefreshListenerTests extends OpenSearchTestCase {
         assertEquals(initialCount - 3, countDownLatch.getCount());
         testRefreshListener.drainRefreshes();
 
-        testRefreshListener = new CloseableRetryableRefreshListener(threadPool) {
+        testRefreshListener = new ReleasableRetryableRefreshListener(threadPool) {
             @Override
             protected boolean performAfterRefreshWithPermit(boolean didRefresh) {
                 countDownLatch.countDown();
@@ -206,7 +206,7 @@ public class CloseableRetryableRefreshListenerTests extends OpenSearchTestCase {
     public void testRetry() throws Exception {
         int initialCount = randomIntBetween(10, 20);
         final CountDownLatch countDownLatch = new CountDownLatch(initialCount);
-        CloseableRetryableRefreshListener testRefreshListener = new CloseableRetryableRefreshListener(threadPool) {
+        ReleasableRetryableRefreshListener testRefreshListener = new ReleasableRetryableRefreshListener(threadPool) {
             @Override
             protected boolean performAfterRefreshWithPermit(boolean didRefresh) {
                 countDownLatch.countDown();
@@ -247,7 +247,7 @@ public class CloseableRetryableRefreshListenerTests extends OpenSearchTestCase {
     public void testCloseWithRetryPending() throws IOException {
         int initialCount = randomIntBetween(10, 20);
         final CountDownLatch countDownLatch = new CountDownLatch(initialCount);
-        CloseableRetryableRefreshListener testRefreshListener = new CloseableRetryableRefreshListener(threadPool) {
+        ReleasableRetryableRefreshListener testRefreshListener = new ReleasableRetryableRefreshListener(threadPool) {
             @Override
             protected boolean performAfterRefreshWithPermit(boolean didRefresh) {
                 countDownLatch.countDown();
@@ -280,7 +280,7 @@ public class CloseableRetryableRefreshListenerTests extends OpenSearchTestCase {
 
     public void testCloseWaitsForAcquiringAllPermits() throws Exception {
         final CountDownLatch countDownLatch = new CountDownLatch(1);
-        CloseableRetryableRefreshListener testRefreshListener = new CloseableRetryableRefreshListener(threadPool) {
+        ReleasableRetryableRefreshListener testRefreshListener = new ReleasableRetryableRefreshListener(threadPool) {
             @Override
             protected boolean performAfterRefreshWithPermit(boolean didRefresh) {
                 try {
@@ -316,7 +316,7 @@ public class CloseableRetryableRefreshListenerTests extends OpenSearchTestCase {
     public void testScheduleRetryAfterClose() throws Exception {
         // This tests that once the listener has been closed, even the retries would not be scheduled.
         final AtomicLong runCount = new AtomicLong();
-        CloseableRetryableRefreshListener testRefreshListener = new CloseableRetryableRefreshListener(threadPool) {
+        ReleasableRetryableRefreshListener testRefreshListener = new ReleasableRetryableRefreshListener(threadPool) {
             @Override
             protected boolean performAfterRefreshWithPermit(boolean didRefresh) {
                 try {
@@ -378,7 +378,7 @@ public class CloseableRetryableRefreshListenerTests extends OpenSearchTestCase {
         // This tests that there can be only 1 retry that can be scheduled at a time.
         final AtomicLong runCount = new AtomicLong();
         final AtomicInteger retryCount = new AtomicInteger(0);
-        CloseableRetryableRefreshListener testRefreshListener = new CloseableRetryableRefreshListener(threadPool) {
+        ReleasableRetryableRefreshListener testRefreshListener = new ReleasableRetryableRefreshListener(threadPool) {
             @Override
             protected boolean performAfterRefreshWithPermit(boolean didRefresh) {
                 retryCount.incrementAndGet();
@@ -422,7 +422,7 @@ public class CloseableRetryableRefreshListenerTests extends OpenSearchTestCase {
         AtomicInteger runCount = new AtomicInteger();
         ThreadPool mockThreadPool = mock(ThreadPool.class);
         when(mockThreadPool.schedule(any(), any(), any())).thenThrow(new RuntimeException());
-        CloseableRetryableRefreshListener testRefreshListener = new CloseableRetryableRefreshListener(mockThreadPool) {
+        ReleasableRetryableRefreshListener testRefreshListener = new ReleasableRetryableRefreshListener(mockThreadPool) {
             @Override
             protected boolean performAfterRefreshWithPermit(boolean didRefresh) {
                 runCount.incrementAndGet();
@@ -461,7 +461,7 @@ public class CloseableRetryableRefreshListenerTests extends OpenSearchTestCase {
 
     public void testTimeoutDuringClose() throws Exception {
         // This test checks the expected behaviour when the drainRefreshes times out.
-        CloseableRetryableRefreshListener testRefreshListener = new CloseableRetryableRefreshListener(mock(ThreadPool.class)) {
+        ReleasableRetryableRefreshListener testRefreshListener = new ReleasableRetryableRefreshListener(mock(ThreadPool.class)) {
             @Override
             protected boolean performAfterRefreshWithPermit(boolean didRefresh) {
                 try {
@@ -481,7 +481,7 @@ public class CloseableRetryableRefreshListenerTests extends OpenSearchTestCase {
             }
 
             @Override
-            protected TimeValue getDrainTimeout() {
+            TimeValue getDrainTimeout() {
                 return TimeValue.timeValueSeconds(1);
             }
         };
@@ -502,7 +502,7 @@ public class CloseableRetryableRefreshListenerTests extends OpenSearchTestCase {
     public void testThreadInterruptDuringClose() throws Exception {
         // This test checks the expected behaviour when the thread performing the drainRefresh is interrupted.
         CountDownLatch latch = new CountDownLatch(2);
-        CloseableRetryableRefreshListener testRefreshListener = new CloseableRetryableRefreshListener(mock(ThreadPool.class)) {
+        ReleasableRetryableRefreshListener testRefreshListener = new ReleasableRetryableRefreshListener(mock(ThreadPool.class)) {
             @Override
             protected boolean performAfterRefreshWithPermit(boolean didRefresh) {
                 try {
@@ -522,7 +522,7 @@ public class CloseableRetryableRefreshListenerTests extends OpenSearchTestCase {
             }
 
             @Override
-            protected TimeValue getDrainTimeout() {
+            TimeValue getDrainTimeout() {
                 return TimeValue.timeValueSeconds(2);
             }
         };
@@ -551,7 +551,7 @@ public class CloseableRetryableRefreshListenerTests extends OpenSearchTestCase {
     public void testResumeRefreshesAfterDrainRefreshes() {
         // This test checks the expected behaviour when the refresh listener is drained, but then refreshes are resumed again
         // by closing the releasables acquired by calling the drainRefreshes method.
-        CloseableRetryableRefreshListener testRefreshListener = new CloseableRetryableRefreshListener(mock(ThreadPool.class)) {
+        ReleasableRetryableRefreshListener testRefreshListener = new ReleasableRetryableRefreshListener(mock(ThreadPool.class)) {
             @Override
             protected boolean performAfterRefreshWithPermit(boolean didRefresh) {
                 return true;
@@ -578,12 +578,12 @@ public class CloseableRetryableRefreshListenerTests extends OpenSearchTestCase {
         terminate(threadPool);
     }
 
-    private void assertRefreshListenerClosed(CloseableRetryableRefreshListener testRefreshListener) {
+    private void assertRefreshListenerClosed(ReleasableRetryableRefreshListener testRefreshListener) {
         assertTrue(testRefreshListener.isClosed());
         assertEquals(0, testRefreshListener.availablePermits());
     }
 
-    private void assertRefreshListenerOpen(CloseableRetryableRefreshListener testRefreshListener) {
+    private void assertRefreshListenerOpen(ReleasableRetryableRefreshListener testRefreshListener) {
         assertFalse(testRefreshListener.isClosed());
         assertEquals(1, testRefreshListener.availablePermits());
     }

--- a/server/src/test/java/org/opensearch/index/translog/RemoteFsTranslogTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/RemoteFsTranslogTests.java
@@ -879,21 +879,21 @@ public class RemoteFsTranslogTests extends OpenSearchTestCase {
             ops,
             new Translog.Index(String.valueOf(2), 2, primaryTerm.get(), new byte[] { 1 })
         );
-        assertEquals(2, translog.readers.size());
+        assertEquals(1, translog.readers.size());
         assertEquals(6, translog.allUploaded().size());
         assertEquals(mdFiles, blobStoreTransferService.listAll(getTranslogDirectory().add(METADATA_DIR)));
 
         // Refill the permits back
         Releasables.close(releasable);
         addToTranslogAndListAndUpload(translog, ops, new Translog.Index(String.valueOf(3), 3, primaryTerm.get(), new byte[] { 1 }));
-        assertEquals(3, translog.readers.size());
-        assertEquals(10, translog.allUploaded().size());
+        assertEquals(2, translog.readers.size());
+        assertEquals(8, translog.allUploaded().size());
         assertEquals(3, blobStoreTransferService.listAll(getTranslogDirectory().add(METADATA_DIR)).size());
 
         translog.setMinSeqNoToKeep(3);
         translog.trimUnreferencedReaders();
         assertEquals(1, translog.readers.size());
-        assertBusy(() -> assertEquals(6, translog.allUploaded().size()));
+        assertBusy(() -> assertEquals(4, translog.allUploaded().size()));
         assertBusy(() -> assertEquals(1, blobStoreTransferService.listAll(getTranslogDirectory().add(METADATA_DIR)).size()));
     }
 

--- a/server/src/test/java/org/opensearch/index/translog/TestTranslog.java
+++ b/server/src/test/java/org/opensearch/index/translog/TestTranslog.java
@@ -335,6 +335,18 @@ public class TestTranslog {
         }
     }
 
+    static class SlowDownWriteSwitch {
+        private volatile int sleepSeconds;
+
+        public void setSleepSeconds(int sleepSeconds) {
+            this.sleepSeconds = sleepSeconds;
+        }
+
+        public int getSleepSeconds() {
+            return sleepSeconds;
+        }
+    }
+
     static class SortedSnapshot implements Translog.Snapshot {
         private final Translog.Snapshot snapshot;
         private List<Translog.Operation> operations = null;


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR fixes an edge case during primary relocation that can lead to both existing primary and new primary uploading segments/translog metadata having same combination of primary term, segment info generation, translog generation under following scenarios.
### Situations - 
1. Internal flush triggered during shard inactivity or snapshot just before the primary mode of the existing primary is set to false. This is race condition where the new primary starts itself with generation n, but n+1 generation gets uploaded to remote store by existing primary. 
2. New primary does a syncTranslog in [here](https://github.com/opensearch-project/OpenSearch/blob/5bb6caec906f9e89d330332ebb74789571409eb1/server/src/main/java/org/opensearch/indices/recovery/RecoveryTarget.java#L256-L259) before actually becoming a primary from cluster manager’s perspective. It is possible that the old primary can continue to be primary due to relocation handoff failure.

This can lead to following impact: 
#### situation no. 1  -
1. Red or Yellow index if the primary or replica shard goes unassigned due to any reasons (like node leaving cluster).
2. Primary relocation failure if there is no indexing happening.

The above can be mitigated by flushing multiple times if the index is not red. This can still be fixed by deleting the metadata file uploaded by old primary.

#### situation no. 2  -
1. In cases where the translog gets uploaded from new primary, but metadata files fails. If a node drop happens, remote store restore will restore a translog that has been overwritten by new primary

The above issue can go away if the indexing continues for some more time.

### Related Issues
Resolves #11320, #11322, #11323
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [ ] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
