### PR TITLE
Fixes to prevent segment fault errors arising due to unexpected SDK b…

### DIFF
--- a/server/src/main/java/org/opensearch/common/StreamContext.java
+++ b/server/src/main/java/org/opensearch/common/StreamContext.java
@@ -57,6 +57,8 @@ public class StreamContext {
     /**
      * Vendor plugins can use this method to create new streams only when they are required for processing
      * New streams won't be created till this method is called with the specific <code>partNumber</code>
+     * It is the responsibility of caller to ensure that stream is properly closed after consumption
+     * otherwise it can leak resources.
      *
      * @param partNumber The index of the part
      * @return A stream reference to the part requested

--- a/server/src/main/java/org/opensearch/common/blobstore/transfer/stream/OffsetRangeIndexInputStream.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/transfer/stream/OffsetRangeIndexInputStream.java
@@ -8,10 +8,16 @@
 
 package org.opensearch.common.blobstore.transfer.stream;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.IndexInput;
+import org.opensearch.common.concurrent.RefCountedReleasable;
 import org.opensearch.common.lucene.store.InputStreamIndexInput;
+import org.opensearch.common.util.concurrent.RunOnce;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * OffsetRangeIndexInputStream extends InputStream to read from a specified offset using IndexInput
@@ -19,9 +25,12 @@ import java.io.IOException;
  * @opensearch.internal
  */
 public class OffsetRangeIndexInputStream extends OffsetRangeInputStream {
-
+    private static final Logger logger = LogManager.getLogger(OffsetRangeIndexInputStream.class);
     private final InputStreamIndexInput inputStreamIndexInput;
     private final IndexInput indexInput;
+    private AtomicBoolean closed;
+    private final OffsetRangeRefCount offsetRangeRefCount;
+    private final RunOnce closeOnce;
 
     /**
      * Construct a new OffsetRangeIndexInputStream object
@@ -35,16 +44,68 @@ public class OffsetRangeIndexInputStream extends OffsetRangeInputStream {
         indexInput.seek(position);
         this.indexInput = indexInput;
         this.inputStreamIndexInput = new InputStreamIndexInput(indexInput, size);
+        ClosingStreams closingStreams = new ClosingStreams(inputStreamIndexInput, indexInput);
+        offsetRangeRefCount = new OffsetRangeRefCount(closingStreams);
+        closeOnce = new RunOnce(offsetRangeRefCount::decRef);
+    }
+
+    @Override
+    public void setClose(AtomicBoolean close) {
+        this.closed = close;
     }
 
     @Override
     public int read(byte[] b, int off, int len) throws IOException {
-        return inputStreamIndexInput.read(b, off, len);
+        // There are two levels of check to ensure that we don't read an already closed stream and
+        // to not close the stream if it is already being read.
+        // 1. First check is a coarse-grained check outside reference check which allows us to fail fast if read
+        // was invoked after the stream was closed. We need a separate atomic boolean closed because we don't want a
+        // future read to succeed when #close has been invoked even if there are on-going reads. On-going reads would
+        // hold reference and since ref count will not be 0 even after close was invoked, future reads will go through
+        // without a check on closed. Also, we do need to set closed externally. It is shared across all streams of the
+        // file. Check on closed in this class makes sure that no other stream allows subsequent reads. closed is
+        // being set to true in RemoteTransferContainer#close which is invoked when we are done processing all
+        // parts/file. Processing completes when either all parts are completed successfully or if either of the parts
+        // failed. In successful case, subsequent read will anyway not go through since all streams would have been
+        // consumed fully but in case of failure, SDK can continue to invoke read and this would be a wasted compute
+        // and IO.
+        // 2. In second check, a tryIncRef is invoked which tries to increment reference under lock and fails if ref
+        // is already closed. If reference is successfully obtained by the stream then stream will not be closed.
+        // Ref counting ensures that stream isn't closed in between reads.
+        //
+        // All these protection mechanisms are required in order to prevent invalid access to streams happening
+        // from the new S3 async SDK.
+        ensureOpen();
+        try (OffsetRangeRefCount ignored = getStreamReference()) {
+            return inputStreamIndexInput.read(b, off, len);
+        }
+    }
+
+    private OffsetRangeRefCount getStreamReference() {
+        boolean successIncrement = offsetRangeRefCount.tryIncRef();
+        if (successIncrement == false) {
+            throw alreadyClosed("OffsetRangeIndexInputStream is already unreferenced.");
+        }
+        return offsetRangeRefCount;
+    }
+
+    private void ensureOpen() {
+        if (closed != null && closed.get() == true) {
+            logger.debug("Read on stream was attempted after during the close of overall file stream!");
+            throw alreadyClosed("Already closed: ");
+        }
+    }
+
+    AlreadyClosedException alreadyClosed(String msg) {
+        return new AlreadyClosedException(msg + this);
     }
 
     @Override
     public int read() throws IOException {
-        return inputStreamIndexInput.read();
+        ensureOpen();
+        try (OffsetRangeRefCount ignored = getStreamReference()) {
+            return inputStreamIndexInput.read();
+        }
     }
 
     @Override
@@ -68,8 +129,41 @@ public class OffsetRangeIndexInputStream extends OffsetRangeInputStream {
     }
 
     @Override
+    public String toString() {
+        return "OffsetRangeIndexInputStream{" + "indexInput=" + indexInput + ", closed=" + closed + '}';
+    }
+
+    private static class ClosingStreams {
+        private final InputStreamIndexInput inputStreamIndexInput;
+        private final IndexInput indexInput;
+
+        public ClosingStreams(InputStreamIndexInput inputStreamIndexInput, IndexInput indexInput) {
+            this.inputStreamIndexInput = inputStreamIndexInput;
+            this.indexInput = indexInput;
+        }
+    }
+
+    private static class OffsetRangeRefCount extends RefCountedReleasable<ClosingStreams> {
+        private static final Logger logger = LogManager.getLogger(OffsetRangeRefCount.class);
+
+        public OffsetRangeRefCount(ClosingStreams ref) {
+            super("OffsetRangeRefCount", ref, () -> {
+                try {
+                    ref.inputStreamIndexInput.close();
+                } catch (IOException ex) {
+                    logger.error("Failed to close indexStreamIndexInput", ex);
+                }
+                try {
+                    ref.indexInput.close();
+                } catch (IOException ex) {
+                    logger.error("Failed to close indexInput", ex);
+                }
+            });
+        }
+    }
+
+    @Override
     public void close() throws IOException {
-        inputStreamIndexInput.close();
-        indexInput.close();
+        closeOnce.run();
     }
 }

--- a/server/src/main/java/org/opensearch/common/blobstore/transfer/stream/OffsetRangeInputStream.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/transfer/stream/OffsetRangeInputStream.java
@@ -10,6 +10,7 @@ package org.opensearch.common.blobstore.transfer.stream;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * OffsetRangeInputStream is an abstract class that extends from {@link InputStream}
@@ -19,4 +20,8 @@ import java.io.InputStream;
  */
 public abstract class OffsetRangeInputStream extends InputStream {
     public abstract long getFilePointer() throws IOException;
+
+    public void setClose(AtomicBoolean close) {
+        // Nothing
+    }
 }

--- a/server/src/main/java/org/opensearch/common/blobstore/transfer/stream/OffsetRangeInputStream.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/transfer/stream/OffsetRangeInputStream.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public abstract class OffsetRangeInputStream extends InputStream {
     public abstract long getFilePointer() throws IOException;
 
-    public void setClose(AtomicBoolean close) {
+    public void setReadBlock(AtomicBoolean readBlock) {
         // Nothing
     }
 }

--- a/server/src/main/java/org/opensearch/common/blobstore/transfer/stream/RateLimitingOffsetRangeInputStream.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/transfer/stream/RateLimitingOffsetRangeInputStream.java
@@ -12,6 +12,7 @@ import org.apache.lucene.store.RateLimiter;
 import org.opensearch.common.StreamLimiter;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
 /**
@@ -38,6 +39,10 @@ public class RateLimitingOffsetRangeInputStream extends OffsetRangeInputStream {
     ) {
         this.streamLimiter = new StreamLimiter(rateLimiterSupplier, listener);
         this.delegate = delegate;
+    }
+
+    public void setClose(AtomicBoolean close) {
+        delegate.setClose(close);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/common/blobstore/transfer/stream/RateLimitingOffsetRangeInputStream.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/transfer/stream/RateLimitingOffsetRangeInputStream.java
@@ -41,8 +41,8 @@ public class RateLimitingOffsetRangeInputStream extends OffsetRangeInputStream {
         this.delegate = delegate;
     }
 
-    public void setClose(AtomicBoolean close) {
-        delegate.setClose(close);
+    public void setReadBlock(AtomicBoolean readBlock) {
+        delegate.setReadBlock(readBlock);
     }
 
     @Override

--- a/server/src/test/java/org/opensearch/common/blobstore/transfer/RemoteTransferContainerTests.java
+++ b/server/src/test/java/org/opensearch/common/blobstore/transfer/RemoteTransferContainerTests.java
@@ -8,21 +8,36 @@
 
 package org.opensearch.common.blobstore.transfer;
 
+import org.apache.lucene.store.AlreadyClosedException;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.RateLimiter;
 import org.opensearch.common.StreamContext;
 import org.opensearch.common.blobstore.stream.write.WriteContext;
 import org.opensearch.common.blobstore.stream.write.WritePriority;
 import org.opensearch.common.blobstore.transfer.stream.OffsetRangeFileInputStream;
+import org.opensearch.common.blobstore.transfer.stream.OffsetRangeIndexInputStream;
 import org.opensearch.common.blobstore.transfer.stream.OffsetRangeInputStream;
+import org.opensearch.common.blobstore.transfer.stream.RateLimitingOffsetRangeInputStream;
 import org.opensearch.common.blobstore.transfer.stream.ResettableCheckedInputStream;
 import org.opensearch.common.io.InputStreamContainer;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
 
 public class RemoteTransferContainerTests extends OpenSearchTestCase {
 
@@ -92,25 +107,37 @@ public class RemoteTransferContainerTests extends OpenSearchTestCase {
         int partCount = streamContext.getNumberOfParts();
         assertEquals(expectedPartCount, partCount);
         Thread[] threads = new Thread[partCount];
+        InputStream[] streams = new InputStream[partCount];
         long totalContentLength = remoteTransferContainer.getContentLength();
         assert partSize * (partCount - 1) + lastPartSize == totalContentLength
             : "part sizes and last part size don't add up to total content length";
         logger.info("partSize: {}, lastPartSize: {}, partCount: {}", partSize, lastPartSize, streamContext.getNumberOfParts());
-        for (int partIdx = 0; partIdx < partCount; partIdx++) {
-            int finalPartIdx = partIdx;
-            long expectedPartSize = (partIdx == partCount - 1) ? lastPartSize : partSize;
-            threads[partIdx] = new Thread(() -> {
+        try {
+            for (int partIdx = 0; partIdx < partCount; partIdx++) {
+                int finalPartIdx = partIdx;
+                long expectedPartSize = (partIdx == partCount - 1) ? lastPartSize : partSize;
+                threads[partIdx] = new Thread(() -> {
+                    try {
+                        InputStreamContainer inputStreamContainer = streamContext.provideStream(finalPartIdx);
+                        streams[finalPartIdx] = inputStreamContainer.getInputStream();
+                        assertEquals(expectedPartSize, inputStreamContainer.getContentLength());
+                    } catch (IOException e) {
+                        fail("IOException during stream creation");
+                    }
+                });
+                threads[partIdx].start();
+            }
+            for (int i = 0; i < partCount; i++) {
+                threads[i].join();
+            }
+        } finally {
+            Arrays.stream(streams).forEach(stream -> {
                 try {
-                    InputStreamContainer inputStreamContainer = streamContext.provideStream(finalPartIdx);
-                    assertEquals(expectedPartSize, inputStreamContainer.getContentLength());
+                    stream.close();
                 } catch (IOException e) {
-                    fail("IOException during stream creation");
+                    throw new RuntimeException(e);
                 }
             });
-            threads[partIdx].start();
-        }
-        for (int i = 0; i < partCount; i++) {
-            threads[i].join();
         }
     }
 
@@ -182,6 +209,7 @@ public class RemoteTransferContainerTests extends OpenSearchTestCase {
     }
 
     private void testTypeOfProvidedStreams(boolean isRemoteDataIntegritySupported) throws IOException {
+        InputStream inputStream = null;
         try (
             RemoteTransferContainer remoteTransferContainer = new RemoteTransferContainer(
                 testFile.getFileName().toString(),
@@ -201,12 +229,132 @@ public class RemoteTransferContainerTests extends OpenSearchTestCase {
         ) {
             StreamContext streamContext = remoteTransferContainer.supplyStreamContext(16);
             InputStreamContainer inputStreamContainer = streamContext.provideStream(0);
+            inputStream = inputStreamContainer.getInputStream();
             if (shouldOffsetInputStreamsBeChecked(isRemoteDataIntegritySupported)) {
                 assertTrue(inputStreamContainer.getInputStream() instanceof ResettableCheckedInputStream);
             } else {
                 assertTrue(inputStreamContainer.getInputStream() instanceof OffsetRangeInputStream);
             }
             assertThrows(RuntimeException.class, () -> remoteTransferContainer.supplyStreamContext(16));
+        } finally {
+            if (inputStream != null) {
+                inputStream.close();
+            }
+        }
+    }
+
+    public void testCloseDuringOngoingReadOnStream() throws IOException, InterruptedException {
+        Supplier<RateLimiter> rateLimiterSupplier = Mockito.mock(Supplier.class);
+        Mockito.when(rateLimiterSupplier.get()).thenReturn(null);
+        CountDownLatch readInvokedLatch = new CountDownLatch(1);
+        AtomicBoolean readAfterClose = new AtomicBoolean();
+        CountDownLatch streamClosed = new CountDownLatch(1);
+        AtomicBoolean indexInputClosed = new AtomicBoolean();
+        AtomicInteger closedCount = new AtomicInteger();
+        try (
+            RemoteTransferContainer remoteTransferContainer = new RemoteTransferContainer(
+                testFile.getFileName().toString(),
+                testFile.getFileName().toString(),
+                TEST_FILE_SIZE_BYTES,
+                true,
+                WritePriority.NORMAL,
+                new RemoteTransferContainer.OffsetRangeInputStreamSupplier() {
+                    @Override
+                    public OffsetRangeInputStream get(long size, long position) throws IOException {
+                        IndexInput indexInput = Mockito.mock(IndexInput.class);
+                        Mockito.doAnswer(invocation -> {
+                            indexInputClosed.set(true);
+                            closedCount.incrementAndGet();
+                            return null;
+                        }).when(indexInput).close();
+                        Mockito.when(indexInput.getFilePointer()).thenAnswer((Answer<Long>) invocation -> {
+                            if (readAfterClose.get() == false) {
+                                return 0L;
+                            }
+                            readInvokedLatch.countDown();
+                            boolean closedSuccess = streamClosed.await(30, TimeUnit.SECONDS);
+                            assertTrue(closedSuccess);
+                            assertFalse(indexInputClosed.get());
+                            return 0L;
+                        });
+
+                        OffsetRangeIndexInputStream offsetRangeIndexInputStream = new OffsetRangeIndexInputStream(
+                            indexInput,
+                            size,
+                            position
+                        );
+                        return new RateLimitingOffsetRangeInputStream(offsetRangeIndexInputStream, rateLimiterSupplier, null);
+                    }
+                },
+                0,
+                true
+            )
+        ) {
+            StreamContext streamContext = remoteTransferContainer.supplyStreamContext(16);
+            InputStreamContainer inputStreamContainer = streamContext.provideStream(0);
+            assertTrue(inputStreamContainer.getInputStream() instanceof RateLimitingOffsetRangeInputStream);
+            CountDownLatch latch = new CountDownLatch(1);
+            new Thread(() -> {
+                try {
+                    readAfterClose.set(true);
+                    inputStreamContainer.getInputStream().readAllBytes();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                } finally {
+                    latch.countDown();
+                }
+            }).start();
+            boolean successReadWait = readInvokedLatch.await(30, TimeUnit.SECONDS);
+            assertTrue(successReadWait);
+            // Closing stream here. Test Multiple invocations of close. Shouldn't throw any exception
+            inputStreamContainer.getInputStream().close();
+            inputStreamContainer.getInputStream().close();
+            inputStreamContainer.getInputStream().close();
+            streamClosed.countDown();
+            boolean processed = latch.await(30, TimeUnit.SECONDS);
+            assertTrue(processed);
+            assertTrue(readAfterClose.get());
+            assertTrue(indexInputClosed.get());
+
+            // Test Multiple invocations of close. Close count should always be 1.
+            inputStreamContainer.getInputStream().close();
+            inputStreamContainer.getInputStream().close();
+            inputStreamContainer.getInputStream().close();
+            assertEquals(1, closedCount.get());
+
+        }
+    }
+
+    public void testReadAccessWhenStreamClosed() throws IOException {
+        Supplier<RateLimiter> rateLimiterSupplier = Mockito.mock(Supplier.class);
+        Mockito.when(rateLimiterSupplier.get()).thenReturn(null);
+        try (
+            RemoteTransferContainer remoteTransferContainer = new RemoteTransferContainer(
+                testFile.getFileName().toString(),
+                testFile.getFileName().toString(),
+                TEST_FILE_SIZE_BYTES,
+                true,
+                WritePriority.NORMAL,
+                new RemoteTransferContainer.OffsetRangeInputStreamSupplier() {
+                    @Override
+                    public OffsetRangeInputStream get(long size, long position) throws IOException {
+                        IndexInput indexInput = Mockito.mock(IndexInput.class);
+                        OffsetRangeIndexInputStream offsetRangeIndexInputStream = new OffsetRangeIndexInputStream(
+                            indexInput,
+                            size,
+                            position
+                        );
+                        return new RateLimitingOffsetRangeInputStream(offsetRangeIndexInputStream, rateLimiterSupplier, null);
+                    }
+                },
+                0,
+                true
+            )
+        ) {
+            StreamContext streamContext = remoteTransferContainer.supplyStreamContext(16);
+            InputStreamContainer inputStreamContainer = streamContext.provideStream(0);
+            inputStreamContainer.getInputStream().close();
+            assertThrows(AlreadyClosedException.class, () -> inputStreamContainer.getInputStream().readAllBytes());
         }
     }
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR adds guards against unexpected S3 SDK errors. 
1. Guards against access to stream after callback from SDK. Cases were observed in which SDK was trying to access stream even after callback was invoked by it. This was leading to segment fault errors in segment upload path as MMap files were being removed from memory on close and attempts to read invalid references were happening by SDK. Also, JDK 17 is not handing these errors gracefully which was leading to JVM crash.
2. Multiple invocations to close was another cause of segment fault errors.

This is a forked PR from : https://github.com/opensearch-project/OpenSearch/pull/11327

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] ~~New functionality has been documented.~~
  - [ ] ~~New functionality has javadoc added~~
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [ ] ~~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~~
- [ ] ~~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
