### PR TITLE
[Remote Store] fail index template creation with refresh_interval less than cluster minimum

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/cluster/metadata/ClusterIndexRefreshIntervalIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/metadata/ClusterIndexRefreshIntervalIT.java
@@ -42,6 +42,7 @@ import org.opensearch.core.index.Index;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.indices.IndicesService;
+import org.opensearch.snapshots.AbstractSnapshotIntegTestCase;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.junit.Before;
 
@@ -54,7 +55,7 @@ import static org.opensearch.indices.IndicesService.CLUSTER_DEFAULT_INDEX_REFRES
 import static org.opensearch.indices.IndicesService.CLUSTER_MINIMUM_INDEX_REFRESH_INTERVAL_SETTING;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 2)
-public class ClusterIndexRefreshIntervalIT extends OpenSearchIntegTestCase {
+public class ClusterIndexRefreshIntervalIT extends AbstractSnapshotIntegTestCase {
 
     public static final String INDEX_NAME = "test-index";
 

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/metadata/ClusterIndexRefreshIntervalIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/metadata/ClusterIndexRefreshIntervalIT.java
@@ -86,7 +86,7 @@ public class ClusterIndexRefreshIntervalIT extends AbstractSnapshotIntegTestCase
         assertTrue(client().admin().indices().putTemplate(request).actionGet().isAcknowledged());
     }
 
-    public void testIndexTemplateCreationWithLessThanMinimumRefreshInterval() throws ExecutionException, InterruptedException {
+    public void testIndexTemplateCreationSucceedsWhenNoMinimumRefreshInterval() throws ExecutionException, InterruptedException {
         String clusterManagerName = internalCluster().getClusterManagerName();
         List<String> dataNodes = new ArrayList<>(internalCluster().getDataNodeNames());
         putIndexTemplate("2s");

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/metadata/ClusterIndexRefreshIntervalWithNodeSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/metadata/ClusterIndexRefreshIntervalWithNodeSettingsIT.java
@@ -8,12 +8,27 @@
 
 package org.opensearch.cluster.metadata;
 
+import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
+import org.opensearch.action.admin.indices.get.GetIndexRequest;
+import org.opensearch.action.admin.indices.get.GetIndexResponse;
+import org.opensearch.action.admin.indices.template.get.GetIndexTemplatesResponse;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.indices.IndicesService;
+import org.opensearch.snapshots.SnapshotInfo;
+import org.opensearch.snapshots.SnapshotState;
 
 import java.util.Locale;
 import java.util.concurrent.ExecutionException;
+
+import static org.opensearch.cluster.metadata.IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING;
+import static org.opensearch.index.IndexSettings.INDEX_REFRESH_INTERVAL_SETTING;
+import static org.opensearch.indices.IndicesService.CLUSTER_DEFAULT_INDEX_REFRESH_INTERVAL_SETTING;
+import static org.opensearch.indices.IndicesService.CLUSTER_MINIMUM_INDEX_REFRESH_INTERVAL_SETTING;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertIndexTemplateExists;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertIndexTemplateMissing;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 public class ClusterIndexRefreshIntervalWithNodeSettingsIT extends ClusterIndexRefreshIntervalIT {
 
@@ -41,6 +56,153 @@ public class ClusterIndexRefreshIntervalWithNodeSettingsIT extends ClusterIndexR
             )
         );
         super.testIndexTemplateCreationWithLessThanMinimumRefreshInterval();
+    }
+
+    public void testIndexTemplateSnapshotRestoreWithLessThanMinimumRefreshInterval() throws ExecutionException, InterruptedException {
+        putIndexTemplate("2s");
+        createRepository("test-repo", "fs");
+
+        final SnapshotInfo snapshotInfo = clusterAdmin().prepareCreateSnapshot("test-repo", "test-snap")
+            .setIndices()
+            .setWaitForCompletion(true)
+            .execute()
+            .get()
+            .getSnapshotInfo();
+        assertThat(snapshotInfo.state(), is(SnapshotState.SUCCESS));
+
+        assertThat(snapshotInfo.totalShards(), equalTo(0));
+        assertThat(snapshotInfo.successfulShards(), equalTo(0));
+
+        assertThat(client().admin().indices().prepareDeleteTemplate("my-template").get().isAcknowledged(), equalTo(true));
+
+        GetIndexTemplatesResponse getIndexTemplatesResponse = client().admin().indices().prepareGetTemplates().get();
+        assertIndexTemplateMissing(getIndexTemplatesResponse, "my-template");
+
+        String clusterManagerName = internalCluster().getClusterManagerName();
+        client(clusterManagerName).admin()
+            .cluster()
+            .prepareUpdateSettings()
+            .setTransientSettings(
+                Settings.builder()
+                    .put(CLUSTER_DEFAULT_INDEX_REFRESH_INTERVAL_SETTING.getKey(), "5s")
+                    .put(CLUSTER_MINIMUM_INDEX_REFRESH_INTERVAL_SETTING.getKey(), "4s")
+            )
+            .get();
+
+        logger.info("--> try restore cluster state -- should fail");
+        Throwable throwable = assertThrows(
+            IllegalArgumentException.class,
+            () -> clusterAdmin().prepareRestoreSnapshot("test-repo", "test-snap")
+                .setWaitForCompletion(true)
+                .setRestoreGlobalState(true)
+                .execute()
+                .actionGet()
+        );
+        assertEquals(
+            throwable.getMessage(),
+            "invalid index.refresh_interval [2s]: cannot be smaller than cluster.minimum.index.refresh_interval [4s]"
+        );
+
+        client(clusterManagerName).admin()
+            .cluster()
+            .prepareUpdateSettings()
+            .setTransientSettings(
+                Settings.builder()
+                    .put(CLUSTER_DEFAULT_INDEX_REFRESH_INTERVAL_SETTING.getKey(), "5s")
+                    .put(CLUSTER_MINIMUM_INDEX_REFRESH_INTERVAL_SETTING.getKey(), "1s")
+            )
+            .get();
+
+        logger.info("--> restore cluster state");
+        RestoreSnapshotResponse restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot("test-repo", "test-snap")
+            .setWaitForCompletion(true)
+            .setRestoreGlobalState(true)
+            .execute()
+            .actionGet();
+        assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), equalTo(0));
+
+        getIndexTemplatesResponse = client().admin().indices().prepareGetTemplates().get();
+        assertIndexTemplateExists(getIndexTemplatesResponse, "my-template");
+
+    }
+
+    public void testIndexSnapshotRestoreWithLessThanMinimumRefreshInterval() throws ExecutionException, InterruptedException {
+        createIndex(
+            "my-index",
+            Settings.builder()
+                .put(indexSettings())
+                .put(INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
+                .put(INDEX_REFRESH_INTERVAL_SETTING.getKey(), "2s")
+                .build()
+        );
+
+        createRepository("test-repo", "fs");
+
+        final SnapshotInfo snapshotInfo = clusterAdmin().prepareCreateSnapshot("test-repo", "test-snap")
+            .setIndices()
+            .setWaitForCompletion(true)
+            .execute()
+            .get()
+            .getSnapshotInfo();
+        assertThat(snapshotInfo.state(), is(SnapshotState.SUCCESS));
+
+        assertThat(snapshotInfo.totalShards(), equalTo(1));
+        assertThat(snapshotInfo.successfulShards(), equalTo(1));
+
+        GetIndexResponse getIndexResponse = client().admin().indices().getIndex(new GetIndexRequest().indices("my-index")).get();
+        assertEquals(1, getIndexResponse.indices().length);
+        assertEquals("2s", getIndexResponse.getSetting("my-index", INDEX_REFRESH_INTERVAL_SETTING.getKey()));
+
+        assertThat(client().admin().indices().prepareDelete("my-index").get().isAcknowledged(), equalTo(true));
+
+        getIndexResponse = client().admin().indices().getIndex(new GetIndexRequest()).get();
+        assertEquals(getIndexResponse.indices().length, 0);
+
+        String clusterManagerName = internalCluster().getClusterManagerName();
+        client(clusterManagerName).admin()
+            .cluster()
+            .prepareUpdateSettings()
+            .setTransientSettings(
+                Settings.builder()
+                    .put(CLUSTER_DEFAULT_INDEX_REFRESH_INTERVAL_SETTING.getKey(), "5s")
+                    .put(CLUSTER_MINIMUM_INDEX_REFRESH_INTERVAL_SETTING.getKey(), "4s")
+            )
+            .get();
+
+        logger.info("--> try restore cluster state -- should fail");
+        Throwable throwable = assertThrows(
+            IllegalArgumentException.class,
+            () -> clusterAdmin().prepareRestoreSnapshot("test-repo", "test-snap")
+                .setWaitForCompletion(true)
+                .setRestoreGlobalState(true)
+                .execute()
+                .actionGet()
+        );
+        assertEquals(
+            throwable.getMessage(),
+            "invalid index.refresh_interval [2s]: cannot be smaller than cluster.minimum.index.refresh_interval [4s]"
+        );
+
+        client(clusterManagerName).admin()
+            .cluster()
+            .prepareUpdateSettings()
+            .setTransientSettings(
+                Settings.builder()
+                    .put(CLUSTER_DEFAULT_INDEX_REFRESH_INTERVAL_SETTING.getKey(), "5s")
+                    .put(CLUSTER_MINIMUM_INDEX_REFRESH_INTERVAL_SETTING.getKey(), "1s")
+            )
+            .get();
+
+        logger.info("--> try restore cluster state -- should pass");
+        RestoreSnapshotResponse restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot("test-repo", "test-snap")
+            .setWaitForCompletion(true)
+            .setRestoreGlobalState(true)
+            .execute()
+            .actionGet();
+        assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), equalTo(1));
+
+        getIndexResponse = client().admin().indices().getIndex(new GetIndexRequest().indices("my-index")).get();
+        assertEquals(getIndexResponse.indices().length, 1);
     }
 
     @Override

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/metadata/ClusterIndexRefreshIntervalWithNodeSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/metadata/ClusterIndexRefreshIntervalWithNodeSettingsIT.java
@@ -55,7 +55,6 @@ public class ClusterIndexRefreshIntervalWithNodeSettingsIT extends ClusterIndexR
                 getMinRefreshIntervalForRefreshDisabled()
             )
         );
-        super.testIndexTemplateCreationWithLessThanMinimumRefreshInterval();
     }
 
     public void testIndexTemplateSnapshotRestoreWithLessThanMinimumRefreshInterval() throws ExecutionException, InterruptedException {

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/metadata/ClusterIndexRefreshIntervalWithNodeSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/metadata/ClusterIndexRefreshIntervalWithNodeSettingsIT.java
@@ -13,6 +13,7 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.indices.IndicesService;
 
 import java.util.Locale;
+import java.util.concurrent.ExecutionException;
 
 public class ClusterIndexRefreshIntervalWithNodeSettingsIT extends ClusterIndexRefreshIntervalIT {
 
@@ -28,7 +29,7 @@ public class ClusterIndexRefreshIntervalWithNodeSettingsIT extends ClusterIndexR
             .build();
     }
 
-    public void testIndexTemplateCreationFailsWithLessThanMinimumRefreshInterval() {
+    public void testIndexTemplateCreationFailsWithLessThanMinimumRefreshInterval() throws ExecutionException, InterruptedException {
         Throwable throwable = assertThrows(IllegalArgumentException.class, () -> putIndexTemplate("0s"));
         assertEquals(
             throwable.getMessage(),
@@ -39,6 +40,7 @@ public class ClusterIndexRefreshIntervalWithNodeSettingsIT extends ClusterIndexR
                 getMinRefreshIntervalForRefreshDisabled()
             )
         );
+        super.testIndexTemplateCreationWithLessThanMinimumRefreshInterval();
     }
 
     @Override

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/metadata/ClusterIndexRefreshIntervalWithNodeSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/metadata/ClusterIndexRefreshIntervalWithNodeSettingsIT.java
@@ -12,6 +12,8 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.indices.IndicesService;
 
+import java.util.Locale;
+
 public class ClusterIndexRefreshIntervalWithNodeSettingsIT extends ClusterIndexRefreshIntervalIT {
 
     @Override
@@ -24,6 +26,19 @@ public class ClusterIndexRefreshIntervalWithNodeSettingsIT extends ClusterIndexR
                 getMinRefreshIntervalForRefreshDisabled().toString()
             )
             .build();
+    }
+
+    public void testIndexTemplateCreationFailsWithLessThanMinimumRefreshInterval() {
+        Throwable throwable = assertThrows(IllegalArgumentException.class, () -> putIndexTemplate("0s"));
+        assertEquals(
+            throwable.getMessage(),
+            String.format(
+                Locale.ROOT,
+                "invalid index.refresh_interval [%s]: cannot be smaller than cluster.minimum.index.refresh_interval [%s]",
+                "0s",
+                getMinRefreshIntervalForRefreshDisabled()
+            )
+        );
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -1496,7 +1496,7 @@ public class MetadataCreateIndexService {
      * @param requestSettings settings passed in during index create/update request
      * @param clusterSettings cluster setting
      */
-    static void validateRefreshIntervalSettings(Settings requestSettings, ClusterSettings clusterSettings) {
+    public static void validateRefreshIntervalSettings(Settings requestSettings, ClusterSettings clusterSettings) {
         if (IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.exists(requestSettings) == false) {
             return;
         }

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -1497,25 +1497,11 @@ public class MetadataCreateIndexService {
      * @param clusterSettings cluster setting
      */
     public static void validateRefreshIntervalSettings(Settings requestSettings, ClusterSettings clusterSettings) {
-        validateRefreshIntervalSettings(requestSettings, clusterSettings, Settings.EMPTY);
-    }
-
-    /**
-     * Validates {@code index.refresh_interval} is equal or below the {@code cluster.minimum.index.refresh_interval}.
-     *
-     * @param requestSettings settings passed in during index create/update request
-     * @param clusterSettings cluster setting
-     * @param settings general settings to be checked for cluster minimum refresh interval. Useful while restoring ClusterState
-     */
-    public static void validateRefreshIntervalSettings(Settings requestSettings, ClusterSettings clusterSettings, Settings settings) {
         if (IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.exists(requestSettings) == false) {
             return;
         }
         TimeValue requestRefreshInterval = IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.get(requestSettings);
-        TimeValue clusterMinimumRefreshInterval = settings.getAsTime(
-            IndicesService.CLUSTER_MINIMUM_INDEX_REFRESH_INTERVAL_SETTING.getKey(),
-            clusterSettings.get(IndicesService.CLUSTER_MINIMUM_INDEX_REFRESH_INTERVAL_SETTING)
-        );
+        TimeValue clusterMinimumRefreshInterval = clusterSettings.get(IndicesService.CLUSTER_MINIMUM_INDEX_REFRESH_INTERVAL_SETTING);
         if (requestRefreshInterval.millis() < clusterMinimumRefreshInterval.millis()) {
             throw new IllegalArgumentException(
                 "invalid index.refresh_interval ["

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -1497,11 +1497,25 @@ public class MetadataCreateIndexService {
      * @param clusterSettings cluster setting
      */
     public static void validateRefreshIntervalSettings(Settings requestSettings, ClusterSettings clusterSettings) {
+        validateRefreshIntervalSettings(requestSettings, clusterSettings, Settings.EMPTY);
+    }
+
+    /**
+     * Validates {@code index.refresh_interval} is equal or below the {@code cluster.minimum.index.refresh_interval}.
+     *
+     * @param requestSettings settings passed in during index create/update request
+     * @param clusterSettings cluster setting
+     * @param settings general settings to be checked for cluster minimum refresh interval. Useful while restoring ClusterState
+     */
+    public static void validateRefreshIntervalSettings(Settings requestSettings, ClusterSettings clusterSettings, Settings settings) {
         if (IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.exists(requestSettings) == false) {
             return;
         }
         TimeValue requestRefreshInterval = IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.get(requestSettings);
-        TimeValue clusterMinimumRefreshInterval = clusterSettings.get(IndicesService.CLUSTER_MINIMUM_INDEX_REFRESH_INTERVAL_SETTING);
+        TimeValue clusterMinimumRefreshInterval = settings.getAsTime(
+            IndicesService.CLUSTER_MINIMUM_INDEX_REFRESH_INTERVAL_SETTING.getKey(),
+            clusterSettings.get(IndicesService.CLUSTER_MINIMUM_INDEX_REFRESH_INTERVAL_SETTING)
+        );
         if (requestRefreshInterval.millis() < clusterMinimumRefreshInterval.millis()) {
             throw new IllegalArgumentException(
                 "invalid index.refresh_interval ["

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -93,6 +93,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static org.opensearch.cluster.metadata.MetadataCreateDataStreamService.validateTimestampFieldMapping;
+import static org.opensearch.cluster.metadata.MetadataCreateIndexService.validateRefreshIntervalSettings;
 import static org.opensearch.indices.cluster.IndicesClusterStateService.AllocatedIndices.IndexRemovalReason.NO_LONGER_ASSIGNED;
 
 /**
@@ -1529,6 +1530,9 @@ public class MetadataIndexTemplateService {
                 Optional.empty()
             );
             validationErrors.addAll(indexSettingsValidation);
+
+            // validate index refresh interval settings
+            validateRefreshIntervalSettings(settings, clusterService.getClusterSettings());
         }
 
         if (indexPatterns.stream().anyMatch(Regex::isMatchAllPattern)) {

--- a/server/src/main/java/org/opensearch/index/recovery/RemoteStoreRestoreService.java
+++ b/server/src/main/java/org/opensearch/index/recovery/RemoteStoreRestoreService.java
@@ -266,11 +266,7 @@ public class RemoteStoreRestoreService {
         }
         if (remoteMetadata.templates() != null) {
             for (final IndexTemplateMetadata cursor : remoteMetadata.templates().values()) {
-                MetadataCreateIndexService.validateRefreshIntervalSettings(
-                    cursor.settings(),
-                    clusterService.getClusterSettings(),
-                    remoteMetadata.persistentSettings()
-                );
+                MetadataCreateIndexService.validateRefreshIntervalSettings(cursor.settings(), clusterService.getClusterSettings());
                 mdBuilder.put(cursor);
             }
         }

--- a/server/src/main/java/org/opensearch/index/recovery/RemoteStoreRestoreService.java
+++ b/server/src/main/java/org/opensearch/index/recovery/RemoteStoreRestoreService.java
@@ -266,6 +266,11 @@ public class RemoteStoreRestoreService {
         }
         if (remoteMetadata.templates() != null) {
             for (final IndexTemplateMetadata cursor : remoteMetadata.templates().values()) {
+                MetadataCreateIndexService.validateRefreshIntervalSettings(
+                    cursor.settings(),
+                    clusterService.getClusterSettings(),
+                    remoteMetadata.persistentSettings()
+                );
                 mdBuilder.put(cursor);
             }
         }

--- a/server/src/main/java/org/opensearch/index/recovery/RemoteStoreRestoreService.java
+++ b/server/src/main/java/org/opensearch/index/recovery/RemoteStoreRestoreService.java
@@ -266,7 +266,6 @@ public class RemoteStoreRestoreService {
         }
         if (remoteMetadata.templates() != null) {
             for (final IndexTemplateMetadata cursor : remoteMetadata.templates().values()) {
-                MetadataCreateIndexService.validateRefreshIntervalSettings(cursor.settings(), clusterService.getClusterSettings());
                 mdBuilder.put(cursor);
             }
         }

--- a/server/src/main/java/org/opensearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/opensearch/snapshots/RestoreService.java
@@ -429,6 +429,10 @@ public class RestoreService implements ClusterStateApplier {
                                     createIndexService.validateIndexName(renamedIndexName, currentState);
                                     createIndexService.validateDotIndex(renamedIndexName, isHidden);
                                     createIndexService.validateIndexSettings(renamedIndexName, snapshotIndexMetadata.getSettings(), false);
+                                    MetadataCreateIndexService.validateRefreshIntervalSettings(
+                                        snapshotIndexMetadata.getSettings(),
+                                        clusterSettings
+                                    );
                                     IndexMetadata.Builder indexMdBuilder = IndexMetadata.builder(snapshotIndexMetadata)
                                         .state(IndexMetadata.State.OPEN)
                                         .index(renamedIndexName);
@@ -578,6 +582,7 @@ public class RestoreService implements ClusterStateApplier {
                             if (metadata.templates() != null) {
                                 // TODO: Should all existing templates be deleted first?
                                 for (final IndexTemplateMetadata cursor : metadata.templates().values()) {
+                                    MetadataCreateIndexService.validateRefreshIntervalSettings(cursor.settings(), clusterSettings);
                                     mdBuilder.put(cursor);
                                 }
                             }

--- a/server/src/main/java/org/opensearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/opensearch/snapshots/RestoreService.java
@@ -582,7 +582,7 @@ public class RestoreService implements ClusterStateApplier {
                             if (metadata.templates() != null) {
                                 // TODO: Should all existing templates be deleted first?
                                 for (final IndexTemplateMetadata cursor : metadata.templates().values()) {
-                                    MetadataCreateIndexService.validateRefreshIntervalSettings(cursor.settings(), clusterSettings, metadata.persistentSettings());
+                                    MetadataCreateIndexService.validateRefreshIntervalSettings(cursor.settings(), clusterSettings);
                                     mdBuilder.put(cursor);
                                 }
                             }

--- a/server/src/main/java/org/opensearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/opensearch/snapshots/RestoreService.java
@@ -582,7 +582,7 @@ public class RestoreService implements ClusterStateApplier {
                             if (metadata.templates() != null) {
                                 // TODO: Should all existing templates be deleted first?
                                 for (final IndexTemplateMetadata cursor : metadata.templates().values()) {
-                                    MetadataCreateIndexService.validateRefreshIntervalSettings(cursor.settings(), clusterSettings);
+                                    MetadataCreateIndexService.validateRefreshIntervalSettings(cursor.settings(), clusterSettings, metadata.persistentSettings());
                                     mdBuilder.put(cursor);
                                 }
                             }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
We want to maintain following flows for index refresh interval for Remote Store Clusters. More details in https://github.com/opensearch-project/OpenSearch/issues/11348


### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/11348
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [ ] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
