### PR TITLE
Unmute nested sort related ITs

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/nested/SimpleNestedIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/nested/SimpleNestedIT.java
@@ -501,10 +501,6 @@ public class SimpleNestedIT extends ParameterizedOpenSearchIntegTestCase {
     }
 
     public void testSimpleNestedSorting() throws Exception {
-        assumeFalse(
-            "Concurrent search case muted pending fix: https://github.com/opensearch-project/OpenSearch/issues/11187",
-            internalCluster().clusterService().getClusterSettings().get(CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING)
-        );
         assertAcked(
             prepareCreate("test").setSettings(Settings.builder().put(indexSettings()).put("index.refresh_interval", -1))
                 .setMapping(
@@ -604,10 +600,6 @@ public class SimpleNestedIT extends ParameterizedOpenSearchIntegTestCase {
     }
 
     public void testSimpleNestedSortingWithNestedFilterMissing() throws Exception {
-        assumeFalse(
-            "Concurrent search case muted pending fix: https://github.com/opensearch-project/OpenSearch/issues/11187",
-            internalCluster().clusterService().getClusterSettings().get(CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING)
-        );
         assertAcked(
             prepareCreate("test").setSettings(Settings.builder().put(indexSettings()).put("index.refresh_interval", -1))
                 .setMapping(
@@ -740,10 +732,6 @@ public class SimpleNestedIT extends ParameterizedOpenSearchIntegTestCase {
     }
 
     public void testNestedSortWithMultiLevelFiltering() throws Exception {
-        assumeFalse(
-            "Concurrent search case muted pending fix: https://github.com/opensearch-project/OpenSearch/issues/11187",
-            internalCluster().clusterService().getClusterSettings().get(CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING)
-        );
         assertAcked(
             prepareCreate("test").setMapping(
                 "{\n"
@@ -986,10 +974,6 @@ public class SimpleNestedIT extends ParameterizedOpenSearchIntegTestCase {
 
     // https://github.com/elastic/elasticsearch/issues/31554
     public void testLeakingSortValues() throws Exception {
-        assumeFalse(
-            "Concurrent search case muted pending fix: https://github.com/opensearch-project/OpenSearch/issues/11187",
-            internalCluster().clusterService().getClusterSettings().get(CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING)
-        );
         assertAcked(
             prepareCreate("test").setSettings(Settings.builder().put("number_of_shards", 1))
                 .setMapping(
@@ -1079,10 +1063,6 @@ public class SimpleNestedIT extends ParameterizedOpenSearchIntegTestCase {
     }
 
     public void testSortNestedWithNestedFilter() throws Exception {
-        assumeFalse(
-            "Concurrent search case muted pending fix: https://github.com/opensearch-project/OpenSearch/issues/11187",
-            internalCluster().clusterService().getClusterSettings().get(CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING)
-        );
         assertAcked(
             prepareCreate("test").setMapping(
                 XContentFactory.jsonBuilder()
@@ -1481,10 +1461,6 @@ public class SimpleNestedIT extends ParameterizedOpenSearchIntegTestCase {
 
     // Issue #9305
     public void testNestedSortingWithNestedFilterAsFilter() throws Exception {
-        assumeFalse(
-            "Concurrent search case muted pending fix: https://github.com/opensearch-project/OpenSearch/issues/11187",
-            internalCluster().clusterService().getClusterSettings().get(CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING)
-        );
         assertAcked(
             prepareCreate("test").setMapping(
                 jsonBuilder().startObject()

--- a/server/src/internalClusterTest/java/org/opensearch/search/sort/FieldSortIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/sort/FieldSortIT.java
@@ -1863,10 +1863,6 @@ public class FieldSortIT extends ParameterizedOpenSearchIntegTestCase {
      * Test case for issue 6150: https://github.com/elastic/elasticsearch/issues/6150
      */
     public void testNestedSort() throws IOException, InterruptedException, ExecutionException {
-        assumeFalse(
-            "Concurrent search case muted pending fix: https://github.com/opensearch-project/OpenSearch/issues/11258",
-            internalCluster().clusterService().getClusterSettings().get(CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING)
-        );
         assertAcked(
             prepareCreate("test").setMapping(
                 XContentFactory.jsonBuilder()


### PR DESCRIPTION
### Description
Unmuting nested sort related tests for concurrent segment search. It's not super obvious why but both these tests and the underlying race condition itself was addressed by #11249.

The race condition comes from when `SortBuilder::buildSort` is called simultaneously by multiple threads which results in the `LinkedListed` in `NestedScope` being accessed concurrently leading to the stack traces found in #11187 & #11258.

In #11249 this was changed [here](https://github.com/opensearch-project/OpenSearch/pull/11249/files#diff-53095189f47932d79608f3c2fa2127fa0198a32b36c1d5b1b6a3f4e3bdc4c71eL627-L629) to instead pass in the same `SortAndFormats` from the search context instead of rebuilding it on each thread. This means that we won't run into this same race condition anymore for nested sorts and I also verified that `SortBuilder::buildSort` is not called in a multi-threaded fashion from anywhere else.

Thus since the underlying problem has been addressed, unmuting these tests.

### Related Issues
Resolves #11187
Resolves #11258

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
