### PR TITLE
Maintainer approval check

### DIFF
--- a/.github/workflows/maintainer-approval.yml
+++ b/.github/workflows/maintainer-approval.yml
@@ -29,8 +29,8 @@ jobs:
 
             return maintainersResponse.data.map(item => item.login).join(', ');
 
-      - uses: peternied/approved-by-maintainers@main
+      - uses: peternied/approved-by-maintainers@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           min-required: 1
-          maintainers: ${{ steps.find-maintainers.outputs.result }}
+          required-approvers-list: ${{ steps.find-maintainers.outputs.result }}

--- a/.github/workflows/maintainer-approval.yml
+++ b/.github/workflows/maintainer-approval.yml
@@ -29,7 +29,7 @@ jobs:
 
             return maintainersResponse.data.map(item => item.login).join(', ');
 
-      - uses: peternied/approved-by-maintainers@v1
+      - uses: peternied/required-approval@v1.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           min-required: 1

--- a/.github/workflows/maintainer-approval.yml
+++ b/.github/workflows/maintainer-approval.yml
@@ -4,9 +4,6 @@ on:
   pull_request_review:
     types: [submitted]
 
-  pull_request_target:
-    types: [opened, reopened]
-
 jobs:
   maintainer-approved-check:
     name: Minimum approval count

--- a/.github/workflows/maintainer-approved.yml
+++ b/.github/workflows/maintainer-approved.yml
@@ -1,0 +1,36 @@
+name: Maintainers approval
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+  pull_request_target:
+    types: [opened, reopened]
+
+jobs:
+  maintainer-approved-check:
+    name: Minimum approval count
+    runs-on: ubuntu-latest
+    steps:
+      - id: find-maintainers
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          result-encoding: string
+          script: |
+            // Get the collaborators - filtered to maintainer permissions
+            const maintainersResponse = await github.request('GET /repos/{owner}/{repo}/collaborators', {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                permission: 'maintain',
+                affiliation: 'all',
+                per_page: 100
+            });
+
+            return maintainersResponse.data.map(item => item.login).join(', ');
+
+      - uses: peternied/approved-by-maintainers@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-required: 1
+          maintainers: ${{ steps.find-maintainers.outputs.result }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add back half_float BKD based sort query optimization ([#11024](https://github.com/opensearch-project/OpenSearch/pull/11024))
 - Make number of segment metadata files in remote segment store configurable ([#11329](https://github.com/opensearch-project/OpenSearch/pull/11329))
 - [Admission Control] Integrate CPU AC with ResourceUsageCollector and add CPU AC stats to nodes/stats ([#10887](https://github.com/opensearch-project/OpenSearch/pull/10887))
+- Maintainer approval check ([#11378](https://github.com/opensearch-project/OpenSearch/pull/11378))
 
 ### Dependencies
 - Bump `log4j-core` from 2.18.0 to 2.19.0


### PR DESCRIPTION
### Description
_Implements proposal from https://github.com/opensearch-project/OpenSearch/issues/10613#issue-1942146755_
> Replace Codeowners to control accepting pull requests with a GitHub action check that reads from the list of maintainers any verifies they have approved the PR. Codeowners can still be used for mapping subject matter experts that want to be notified, but isn't a requirement for every maintainer to be listed on the top level.
>
> By modifying the branch protection rules 'maintainer has approved' check, could be required (only bypassable by an Admin), which would offer effectively the same security as Codeowners.

This is a new approval check that effectively doubles as the existing CODEOWNERS checks on this repository - which will allow that code owners check to be _removed_ in favor of this one.

This check pulls the list of maintainers from GitHub repository settings.  This also codifies the number of approvals needed in the repository in the event we increase or alter these requirements.

#### UX when PRs are blocked:
![image](https://github.com/opensearch-project/OpenSearch/assets/2754967/12a974dd-aed1-4bd7-870c-fc880f992588)

#### Example workflow:
https://github.com/peternied/OpenSearch-1/actions/runs/7026869463/job/19120342204?pr=138

#### Rollout plan:
After this PR has been merged, and been broadly accepted, a repository admin will change the required checks to include this workflow - this prevents changes from being merged even if this check isn't passing.  Then  the code owners file can be updated so maintainers can direct the kinds of changes they would like to be notified about.

### Related Issues
- Related https://github.com/opensearch-project/OpenSearch/issues/10613

### Check List
- [ ] ~New functionality includes testing.~
  - [ ] ~All tests pass~
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [X] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
