### PR TITLE
[Backport] [2.11] Fix Shadow JAR dependency publication (#11369)

### DIFF
--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -33,7 +33,6 @@ import com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin
 
 apply plugin: 'opensearch.validate-rest-spec'
 apply plugin: 'opensearch.yaml-rest-test'
-apply plugin: 'com.github.johnrengelman.shadow'
 
 opensearchplugin {
   description 'An easy, safe and fast scripting language for OpenSearch'
@@ -61,30 +60,6 @@ dependencies {
   api "org.ow2.asm:asm:${versions.asm}"
   api project('spi')
 }
-
-test {
-  doFirst {
-    test.classpath -= project.files(project.tasks.named('shadowJar'))
-    test.classpath -= project.configurations.getByName(ShadowBasePlugin.CONFIGURATION_NAME)
-    test.classpath += project.extensions.getByType(SourceSetContainer).getByName(SourceSet.MAIN_SOURCE_SET_NAME).runtimeClasspath
-  }
-}
-
-shadowJar {
-  archiveClassifier.set('')
-  relocate 'org.objectweb', 'org.opensearch.repackage.org.objectweb'
-  dependencies {
-    include(dependency("org.ow2.asm:asm:${versions.asm}"))
-    include(dependency("org.ow2.asm:asm-util:${versions.asm}"))
-    include(dependency("org.ow2.asm:asm-tree:${versions.asm}"))
-    include(dependency("org.ow2.asm:asm-commons:${versions.asm}"))
-    include(dependency("org.ow2.asm:asm-analysis:${versions.asm}"))
-  }
-}
-
-tasks.validateNebulaPom.dependsOn tasks.generatePomFileForShadowPublication
-tasks.validateShadowPom.dependsOn tasks.generatePomFileForNebulaPublication
-tasks.withType(AbstractPublishToMaven)*.dependsOn "generatePomFileForShadowPublication", "generatePomFileForNebulaPublication"
 
 tasks.named("dependencyLicenses").configure {
   mapping from: /asm-.*/, to: 'asm'

--- a/release-notes/opensearch.release-notes-2.11.1.md
+++ b/release-notes/opensearch.release-notes-2.11.1.md
@@ -8,3 +8,4 @@
 ### Fixed
 - [BUG] Disable sort optimization for HALF_FLOAT ([#10999](https://github.com/opensearch-project/OpenSearch/pull/10999))
 - Adding version condition while adding geoshape doc values to the index, to ensure backward compatibility.([#11095](https://github.com/opensearch-project/OpenSearch/pull/11095))
+- Remove shadowJar from `lang-painless` module publication ([#11369](https://github.com/opensearch-project/OpenSearch/issues/11369))


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/11369 to `2.11`