### PR TITLE
Add a failing test for "composite under filter aggregation" case.

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite.yml
@@ -510,6 +510,42 @@ setup:
   - match: { aggregations.1.2.buckets.1.doc_count:  1 }
 
 ---
+"Composite aggregation with filtered nested parent":
+  - do:
+        search:
+          rest_total_hits_as_int: true
+          index: test
+          body:
+            aggregations:
+              1:
+                nested:
+                  path: nested
+                aggs:
+                  2:
+                    filter:
+                      range:
+                        nested.nested_long:
+                          gt: 0
+                          lt: 100
+                    aggs:
+                      3:
+                        composite:
+                          sources: [
+                            "nested": {
+                              "terms": {
+                                "field": "nested.nested_long"
+                            }
+                          }
+                        ]
+
+  - match: {hits.total: 4}
+  - length: { aggregations.1.2.buckets: 2 }
+  - match: { aggregations.1.2.buckets.1.key.nested: 10 }
+  - match: { aggregations.1.2.buckets.1.doc_count:  2 }
+  - match: { aggregations.1.2.buckets.2.key.nested: 20 }
+  - match: { aggregations.1.2.buckets.2.doc_count:  2 }
+
+---
 "Composite aggregation with unmapped field":
   - skip:
       version: " - 7.1.99"


### PR DESCRIPTION
This failing test covers the issue discussed in #11131.

### Description

This adds a failing test case as requested in the discussion of #11131.

### Related Issues

Reproduces #11131.

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
