### PR TITLE
Support relocating shard between nodes in same host

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/SameShardAllocationDecider.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/SameShardAllocationDecider.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.cluster.routing.allocation.decider;
 
+import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.routing.RoutingNode;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.allocation.RoutingAllocation;
@@ -94,6 +95,8 @@ public class SameShardAllocationDecider extends AllocationDecider {
             return decision;
         }
         if (node.node() != null) {
+            DiscoveryNode sourceShardNode = allocation.nodes().get(shardRouting.currentNodeId());
+
             for (RoutingNode checkNode : allocation.routingNodes()) {
                 if (checkNode.node() == null) {
                     continue;
@@ -112,6 +115,9 @@ public class SameShardAllocationDecider extends AllocationDecider {
                 }
                 if (checkNodeOnSameHostAddress || checkNodeOnSameHostName) {
                     for (ShardRouting assignedShard : assignedShards) {
+                        if (sourceShardNode != null && sourceShardNode.equals(checkNode.node())) {
+                            continue;
+                        }
                         if (checkNode.nodeId().equals(assignedShard.currentNodeId())) {
                             String hostType = checkNodeOnSameHostAddress ? "address" : "name";
                             String host = checkNodeOnSameHostAddress ? node.node().getHostAddress() : node.node().getHostName();

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/SameShardRoutingTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/SameShardRoutingTests.java
@@ -50,6 +50,8 @@ import org.opensearch.cluster.routing.RoutingTable;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.ShardRoutingState;
 import org.opensearch.cluster.routing.TestShardRouting;
+import org.opensearch.cluster.routing.allocation.command.AllocationCommands;
+import org.opensearch.cluster.routing.allocation.command.MoveAllocationCommand;
 import org.opensearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.opensearch.cluster.routing.allocation.decider.Decision;
 import org.opensearch.cluster.routing.allocation.decider.SameShardAllocationDecider;
@@ -59,6 +61,8 @@ import org.opensearch.core.index.Index;
 import org.opensearch.snapshots.SnapshotShardSizeInfo;
 
 import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
 
 import static java.util.Collections.emptyMap;
 import static org.opensearch.cluster.routing.ShardRoutingState.INITIALIZING;
@@ -187,4 +191,51 @@ public class SameShardRoutingTests extends OpenSearchAllocationTestCase {
         decision = decider.canForceAllocatePrimary(newPrimary, unassignedNode, routingAllocation);
         assertEquals(Decision.Type.YES, decision.type());
     }
+
+    public void testRelocateBetweenNodesInSameHost() {
+        AllocationService strategy = createAllocationService(
+                Settings.builder().put(SameShardAllocationDecider.CLUSTER_ROUTING_ALLOCATION_SAME_HOST_SETTING.getKey(), true).build());
+
+        Metadata metaData = Metadata.builder()
+                .put(IndexMetadata.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(0))
+                .build();
+
+        RoutingTable routingTable = RoutingTable.builder()
+                .addAsNew(metaData.index("test"))
+                .build();
+        ClusterState clusterState = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY)).metadata(metaData)
+                .routingTable(routingTable).build();
+
+        logger.info("--> adding two nodes with the same host");
+        clusterState = ClusterState.builder(clusterState).nodes(
+                DiscoveryNodes.builder()
+                        .add(new DiscoveryNode("node1", "node1", "node1", "test1", "test1", buildNewFakeTransportAddress(), emptyMap(),
+                                CLUSTER_MANAGER_DATA_ROLES, Version.CURRENT))
+                        .add(new DiscoveryNode("node2", "node2", "node2", "test1", "test1", buildNewFakeTransportAddress(), emptyMap(),
+                                CLUSTER_MANAGER_DATA_ROLES, Version.CURRENT))).build();
+        clusterState = strategy.reroute(clusterState, "reroute");
+
+        assertThat(numberOfShardsOfType(clusterState.getRoutingNodes(), ShardRoutingState.INITIALIZING), equalTo(1));
+
+        logger.info("--> start all primary shards, no replica will be started since its on the same host");
+        clusterState = startInitializingShardsAndReroute(strategy, clusterState);
+
+        assertThat(numberOfShardsOfType(clusterState.getRoutingNodes(), ShardRoutingState.STARTED), equalTo(1));
+        assertThat(numberOfShardsOfType(clusterState.getRoutingNodes(), ShardRoutingState.INITIALIZING), equalTo(0));
+
+        List<ShardRouting> shardRoutings = clusterState.getRoutingNodes().shardsWithState(ShardRoutingState.STARTED);
+        String currentNodeId = shardRoutings.get(0).currentNodeId();
+
+        String targetNodeId = Objects.equals(currentNodeId, "node1") ? "node2" : "node1";
+
+        AllocationCommands commands = new AllocationCommands(new MoveAllocationCommand("test", 0, currentNodeId, targetNodeId));
+        AllocationService.CommandsResult reroute = strategy.reroute(clusterState, commands, true, false);
+        assertEquals(Decision.Type.YES, reroute.explanations().explanations().get(0).decisions().type());
+
+        clusterState = reroute.getClusterState();
+        assertThat(numberOfShardsOfType(clusterState.getRoutingNodes(), ShardRoutingState.INITIALIZING), equalTo(1));
+        List<ShardRouting> initializings = clusterState.getRoutingNodes().shardsWithState(INITIALIZING);
+        assertEquals(targetNodeId, initializings.get(0).currentNodeId());
+    }
+
 }


### PR DESCRIPTION


### Description
When `cluster.routing.allocation.same_shard.host` is set true, relocating shard between nodes in same host is not allowed. This PR allows this type of relocation.

### Related Issues

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
