### PR TITLE
Fix explanation message for TargetPoolAllocationDecider

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/TargetPoolAllocationDecider.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/TargetPoolAllocationDecider.java
@@ -44,7 +44,7 @@ public class TargetPoolAllocationDecider extends AllocationDecider {
             return allocation.decision(
                 Decision.NO,
                 NAME,
-                "Routing pools are incompatible. Shard pool: [%s], Node Pool: [%s]",
+                "Routing pools are incompatible. Shard pool: [%s], node pool: [%s]",
                 shardPool,
                 targetNodePool
             );
@@ -56,21 +56,21 @@ public class TargetPoolAllocationDecider extends AllocationDecider {
                     shardRouting,
                     shardPool,
                     node.node(),
-                    DiscoveryNodeRole.DATA_ROLE
+                    DiscoveryNodeRole.DATA_ROLE.roleName()
                 );
                 return allocation.decision(
                     Decision.NO,
                     NAME,
-                    "Routing pools are incompatible. Shard pool: [{}], Node Pool: [{}] without [{}] role",
+                    "Routing pools are incompatible. Shard pool: [%s], node pool: [%s] without [%s] role",
                     shardPool,
                     targetNodePool,
-                    DiscoveryNodeRole.DATA_ROLE
+                    DiscoveryNodeRole.DATA_ROLE.roleName()
                 );
             }
         return allocation.decision(
             Decision.YES,
             NAME,
-            "Routing pools are compatible. Shard pool: [%s], Node Pool: [%s]",
+            "Routing pools are compatible. Shard pool: [%s], node pool: [%s]",
             shardPool,
             targetNodePool
         );
@@ -106,7 +106,7 @@ public class TargetPoolAllocationDecider extends AllocationDecider {
             return allocation.decision(
                 Decision.NO,
                 NAME,
-                "Routing pools are incompatible. Index pool: [%s], Node Pool: [%s]",
+                "Routing pools are incompatible. Index pool: [%s], node pool: [%s]",
                 indexPool,
                 targetNodePool
             );
@@ -118,21 +118,21 @@ public class TargetPoolAllocationDecider extends AllocationDecider {
                     indexMetadata.getIndex().getName(),
                     indexPool,
                     node,
-                    DiscoveryNodeRole.DATA_ROLE
+                    DiscoveryNodeRole.DATA_ROLE.roleName()
                 );
                 return allocation.decision(
                     Decision.NO,
                     NAME,
-                    "Routing pools are incompatible. Index pool: [{}], Node Pool: [{}] without [{}] role",
+                    "Routing pools are incompatible. Index pool: [%s], node pool: [%s] without [%s] role",
                     indexPool,
                     targetNodePool,
-                    DiscoveryNodeRole.DATA_ROLE
+                    DiscoveryNodeRole.DATA_ROLE.roleName()
                 );
             }
         return allocation.decision(
             Decision.YES,
             NAME,
-            "Routing pools are compatible. Index pool: [%s], Node Pool: [%s]",
+            "Routing pools are compatible. Index pool: [%s], node pool: [%s]",
             indexPool,
             targetNodePool
         );

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/decider/TargetPoolAllocationDeciderTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/decider/TargetPoolAllocationDeciderTests.java
@@ -200,4 +200,88 @@ public class TargetPoolAllocationDeciderTests extends RemoteShardsBalancerBaseTe
         assertEquals(Decision.YES.type(), deciders.shouldAutoExpandToNode(localIdx, localOnlyNode.node(), globalAllocation).type());
         assertEquals(Decision.YES.type(), deciders.shouldAutoExpandToNode(remoteIdx, remoteCapableNode.node(), globalAllocation).type());
     }
+
+    public void testDebugMessage() {
+        ClusterState clusterState = createInitialCluster(3, 3, true, 2, 2);
+        AllocationService service = this.createRemoteCapableAllocationService();
+        clusterState = allocateShardsAndBalance(clusterState, service);
+
+        // Add an unassigned primary shard for force allocation checks
+        Metadata metadata = Metadata.builder(clusterState.metadata())
+            .put(IndexMetadata.builder("test_local_unassigned").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1))
+            .build();
+        RoutingTable routingTable = RoutingTable.builder(clusterState.routingTable())
+            .addAsNew(metadata.index("test_local_unassigned"))
+            .build();
+        clusterState = ClusterState.builder(clusterState).metadata(metadata).routingTable(routingTable).build();
+
+        // Add remote index unassigned primary
+        clusterState = createRemoteIndex(clusterState, "test_remote_unassigned");
+
+        RoutingNodes defaultRoutingNodes = clusterState.getRoutingNodes();
+        RoutingAllocation globalAllocation = getRoutingAllocation(clusterState, defaultRoutingNodes);
+        globalAllocation.setDebugMode(RoutingAllocation.DebugMode.ON);
+
+        ShardRouting localShard = clusterState.routingTable()
+            .allShards(getIndexName(0, false))
+            .stream()
+            .filter(ShardRouting::primary)
+            .collect(Collectors.toList())
+            .get(0);
+        ShardRouting remoteShard = clusterState.routingTable()
+            .allShards(getIndexName(0, true))
+            .stream()
+            .filter(ShardRouting::primary)
+            .collect(Collectors.toList())
+            .get(0);
+        ShardRouting unassignedLocalShard = clusterState.routingTable()
+            .allShards("test_local_unassigned")
+            .stream()
+            .filter(ShardRouting::primary)
+            .collect(Collectors.toList())
+            .get(0);
+        ShardRouting unassignedRemoteShard = clusterState.routingTable()
+            .allShards("test_remote_unassigned")
+            .stream()
+            .filter(ShardRouting::primary)
+            .collect(Collectors.toList())
+            .get(0);
+        IndexMetadata localIdx = globalAllocation.metadata().getIndexSafe(localShard.index());
+        IndexMetadata remoteIdx = globalAllocation.metadata().getIndexSafe(remoteShard.index());
+        String localNodeId = LOCAL_NODE_PREFIX;
+        for (RoutingNode routingNode : globalAllocation.routingNodes()) {
+            if (routingNode.nodeId().startsWith(LOCAL_NODE_PREFIX)) {
+                localNodeId = routingNode.nodeId();
+                break;
+            }
+        }
+        String remoteNodeId = remoteShard.currentNodeId();
+        RoutingNode localOnlyNode = defaultRoutingNodes.node(localNodeId);
+        RoutingNode remoteCapableNode = defaultRoutingNodes.node(remoteNodeId);
+
+        TargetPoolAllocationDecider targetPoolAllocationDecider = new TargetPoolAllocationDecider();
+        Decision decision = targetPoolAllocationDecider.canAllocate(localShard, remoteCapableNode, globalAllocation);
+        assertEquals(
+            "Routing pools are incompatible. Shard pool: [LOCAL_ONLY], node pool: [REMOTE_CAPABLE] without [data] role",
+            decision.getExplanation()
+        );
+
+        decision = targetPoolAllocationDecider.canAllocate(remoteShard, localOnlyNode, globalAllocation);
+        assertEquals("Routing pools are incompatible. Shard pool: [REMOTE_CAPABLE], node pool: [LOCAL_ONLY]", decision.getExplanation());
+
+        decision = targetPoolAllocationDecider.canAllocate(remoteShard, remoteCapableNode, globalAllocation);
+        assertEquals("Routing pools are compatible. Shard pool: [REMOTE_CAPABLE], node pool: [REMOTE_CAPABLE]", decision.getExplanation());
+
+        decision = targetPoolAllocationDecider.canAllocate(localIdx, remoteCapableNode, globalAllocation);
+        assertEquals(
+            "Routing pools are incompatible. Index pool: [LOCAL_ONLY], node pool: [REMOTE_CAPABLE] without [data] role",
+            decision.getExplanation()
+        );
+
+        decision = targetPoolAllocationDecider.canAllocate(remoteIdx, localOnlyNode, globalAllocation);
+        assertEquals("Routing pools are incompatible. Index pool: [REMOTE_CAPABLE], node pool: [LOCAL_ONLY]", decision.getExplanation());
+
+        decision = targetPoolAllocationDecider.canAllocate(remoteIdx, remoteCapableNode, globalAllocation);
+        assertEquals("Routing pools are compatible. Index pool: [REMOTE_CAPABLE], node pool: [REMOTE_CAPABLE]", decision.getExplanation());
+    }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]
TargetPoolAllocationDecider doesn't use correct format when return `Decision`, resulting in an explanation message that reads something like `Routing pools are incompatible. Shard pool: [{}], Node Pool: [{}] without [{}] role`.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
