### PR TITLE
Bump `org.apache.zookeeper:zookeper` from 3.8.0 to 3.8.3 (#11476)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump netty from 4.1.97.Final to 4.1.99.Final ([#10303](https://github.com/opensearch-project/OpenSearch/pull/10303))
 - Bump `netty` from 4.1.99.Final to 4.1.100.Final ([#10564](https://github.com/opensearch-project/OpenSearch/pull/10564))
 - Bump `netty` from 4.1.100.Final to 4.1.101.Final ([#11294](https://github.com/opensearch-project/OpenSearch/pull/11294))
+- Bump `org.apache.zookeeper:zookeper` from 3.8.0 to 3.8.3 ([#11476](https://github.com/opensearch-project/OpenSearch/pull/11476))
 
 ### Changed
 - Use iterative approach to evaluate Regex.simpleMatch ([#11060](https://github.com/opensearch-project/OpenSearch/pull/11060))

--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -55,7 +55,7 @@ dependencies {
   api "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
   api "com.fasterxml.woodstox:woodstox-core:${versions.woodstox}"
   api 'net.minidev:json-smart:2.4.10'
-  api 'org.apache.zookeeper:zookeeper:3.8.0'
+  api 'org.apache.zookeeper:zookeeper:3.8.3'
   api "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
   api "com.google.protobuf:protobuf-java:${versions.protobuf}"
   api "org.eclipse.jetty:jetty-server:${versions.jetty}"


### PR DESCRIPTION
Manual backport of https://github.com/opensearch-project/OpenSearch/pull/11476 to 1.3