### PR TITLE
Fix flaky test of IndexShardTests.testRestoreLocalHistoryFromTranslogOnPromotion

### DIFF
--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -1416,7 +1416,7 @@ public class IndexShardTests extends IndexShardTestCase {
             indexShard,
             indexShard.getPendingPrimaryTerm() + 1,
             globalCheckpoint,
-            randomLongBetween(SequenceNumbers.NO_OPS_PERFORMED, maxSeqNo),
+            randomLongBetween(SequenceNumbers.NO_OPS_PERFORMED, maxSeqNoOfUpdatesOrDeletesBeforeRollback),
             new ActionListener<Releasable>() {
                 @Override
                 public void onResponse(Releasable releasable) {


### PR DESCRIPTION
### Description
Fix flaky test of `IndexShardTests.testRestoreLocalHistoryFromTranslogOnPromotion`

Reason of flakyness: 
* We perform doc ingestion and update existing doc randomly. 
* After that we will generate random no between -1 to max_seqNo, and use it as `maxSeqNoOfUpdatesOrDelete` on replica operation. 
* Here random number should be generated between -1 to `maxSeqNoOfUpdatesOrDelete` as in first step docs are getting overridden randomly so max_seq no can be higher than `maxSeqNoOfUpdatesOrDelete`. If generated random number is generated higher than `maxSeqNoOfUpdatesOrDelete` then it will be updated during performing replica operation and fail the assertion.

Fix:
* Generate random number during replica operation between -1 to `maxSeqNoOfUpdatesOrDelete`. 

### Testing
* Test is passing with below seed for which it was failing. 
`./gradlew ':server:test' --tests "org.opensearch.index.shard.IndexShardTests.testRestoreLocalHistoryFromTranslogOnPromotion" -Dtests.seed=2A0B8EBB6B3C284B -Dtests.security.manager=true -Dtests.jvm.argline="-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m" -Dtests.locale=sq-AL -Dtests.timezone=Pacific/Apia`

### Related Issues
Resolves #6873 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
