### PR TITLE
Fix for flaky test SimpleBlocksIT.testAddBlockWhileDeletingIndices

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/blocks/SimpleBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/blocks/SimpleBlocksIT.java
@@ -47,6 +47,7 @@ import org.opensearch.cluster.block.ClusterBlockException;
 import org.opensearch.cluster.block.ClusterBlockLevel;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IndexMetadata.APIBlock;
+import org.opensearch.cluster.metadata.ProcessClusterEventTimeoutException;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.IndexNotFoundException;
@@ -491,10 +492,20 @@ public class SimpleBlocksIT extends OpenSearchIntegTestCase {
                     } catch (InterruptedException e) {
                         throw new AssertionError(e);
                     }
-                    try {
-                        assertAcked(client().admin().indices().prepareDelete(indexToDelete));
-                    } catch (final Exception e) {
-                        exceptionConsumer.accept(e);
+                    int pendingRetries = 3;
+                    boolean success = false;
+                    while (success == false && pendingRetries-- > 0) {
+                        try {
+                            assertAcked(client().admin().indices().prepareDelete(indexToDelete));
+                            success = true;
+                        } catch (final Exception e) {
+                            Throwable cause = ExceptionsHelper.unwrapCause(e);
+                            if (cause instanceof ProcessClusterEventTimeoutException && pendingRetries > 0) {
+                                // ignore error & retry
+                                continue;
+                            }
+                            exceptionConsumer.accept(e);
+                        }
                     }
                 }));
             }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fix for flaky test SimpleBlocksIT.testAddBlockWhileDeletingIndices

Adds a retry logic for delete index call incase the call fails due to `ProcessClusterEventTimeoutException `

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/2472

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
