### PR TITLE
Fix Flaky - testForceMergeWithSoftDeletesRetentionAndRecoverySource #5364

### DIFF
--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -1822,8 +1822,8 @@ public class InternalEngineTests extends EngineTestCase {
             )
         ) {
             int numDocs = scaledRandomIntBetween(10, 100);
+            boolean useRecoverySource = randomBoolean() || omitSourceAllTheTime;
             for (int i = 0; i < numDocs; i++) {
-                boolean useRecoverySource = randomBoolean() || omitSourceAllTheTime;
                 ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), B_1, null, useRecoverySource);
                 engine.index(indexForDoc(doc));
                 liveDocs.add(doc.id());
@@ -1832,14 +1832,14 @@ public class InternalEngineTests extends EngineTestCase {
                 }
             }
             for (int i = 0; i < numDocs; i++) {
-                boolean useRecoverySource = randomBoolean() || omitSourceAllTheTime;
                 ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), B_1, null, useRecoverySource);
-                if (randomBoolean()) {
+                boolean isDeleted = randomBoolean();
+                if (isDeleted) {
                     engine.delete(new Engine.Delete(doc.id(), newUid(doc.id()), primaryTerm.get()));
                     liveDocs.remove(doc.id());
                     liveDocsWithSource.remove(doc.id());
                 }
-                if (randomBoolean()) {
+                if (isDeleted) {
                     engine.index(indexForDoc(doc));
                     liveDocs.add(doc.id());
                     if (useRecoverySource == false) {
@@ -1896,7 +1896,6 @@ public class InternalEngineTests extends EngineTestCase {
                 numSegments = searcher.getDirectoryReader().leaves().size();
             }
             if (numSegments == 1) {
-                boolean useRecoverySource = randomBoolean() || omitSourceAllTheTime;
                 ParsedDocument doc = testParsedDocument("dummy", null, testDocument(), B_1, null, useRecoverySource);
                 engine.index(indexForDoc(doc));
                 if (useRecoverySource == false) {

--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -1848,9 +1848,8 @@ public class InternalEngineTests extends EngineTestCase {
                         liveDocsWithSource.remove(doc.id());
                     }
                 }
-                if (randomBoolean()) {
-                    engine.flush(randomBoolean(), true);
-                }
+                engine.flush(randomBoolean(), true);
+
             }
             engine.flush();
             globalCheckpoint.set(randomLongBetween(0, engine.getPersistedLocalCheckpoint()));


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The document that is deleted is the one that would be indexed again while we check for the ```useRecoverySource``` flag to populate the ```liveDocsWithSource``` set

The tests are also passing with the failed seeds

**C75D09DC5A0C3458**
<img width="1667" alt="Screenshot 2023-12-07 at 01 04 05" src="https://github.com/opensearch-project/OpenSearch/assets/25262500/5557ade7-3503-4e23-b39d-c3070b95de56">

**1766E6A3B733A7AA**
<img width="1680" alt="Screenshot 2023-12-07 at 01 04 13" src="https://github.com/opensearch-project/OpenSearch/assets/25262500/214df891-0ffc-4bcc-86c9-71912d9e78c5">

10K Iterations Passed
<img width="1103" alt="Screenshot 2023-12-07 at 01 46 51" src="https://github.com/opensearch-project/OpenSearch/assets/25262500/f79444e1-0a0d-4464-9190-b1aac7d3aefe">



### Related Issues
Resolves #5364 
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
