### PR TITLE
Fix invalid BulkRequest construction for indexRandom()

### DIFF
--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
@@ -71,6 +71,7 @@ import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.ClearScrollResponse;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.action.support.WriteRequest;
 import org.opensearch.client.AdminClient;
 import org.opensearch.client.Client;
 import org.opensearch.client.ClusterAdminClient;
@@ -1646,6 +1647,7 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
             for (List<IndexRequestBuilder> segmented : partition) {
                 BulkRequestBuilder bulkBuilder = client().prepareBulk();
                 for (IndexRequestBuilder indexRequestBuilder : segmented) {
+                    indexRequestBuilder.setRefreshPolicy(WriteRequest.RefreshPolicy.NONE);
                     bulkBuilder.add(indexRequestBuilder);
                 }
                 BulkResponse actionGet = bulkBuilder.execute().actionGet();


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fix invalid `BulkRequest` construction for indexRandom():

```
org.opensearch.action.ActionRequestValidationException: Validation Failed: 1: RefreshPolicy is not supported on an item request. Set it on the BulkRequest instead.;2: RefreshPolicy is not supported on an item request. Set it on the BulkRequest instead.;3: RefreshPolicy is not supported on an item request. Set it on the BulkRequest instead.;4: RefreshPolicy is not supported on an item request. Set it on the BulkRequest instead.;
	at __randomizedtesting.SeedInfo.seed([19EE5058CA5DFA10:CEAC4ADCAF30EA37]:0)
	at app//org.opensearch.action.ValidateActions.addValidationError(ValidateActions.java:44)
	at app//org.opensearch.action.bulk.BulkRequest.validate(BulkRequest.java:432)
	at app//org.opensearch.action.support.TransportAction.execute(TransportAction.java:177)
	at app//org.opensearch.action.support.TransportAction.execute(TransportAction.java:107)
	at app//org.opensearch.client.node.NodeClient.executeLocally(NodeClient.java:110)
	at app//org.opensearch.client.node.NodeClient.doExecute(NodeClient.java:97)
	at app//org.opensearch.client.support.AbstractClient.execute(AbstractClient.java:476)
	at app//org.opensearch.client.FilterClient.doExecute(FilterClient.java:83)
	at app//org.opensearch.client.support.AbstractClient.execute(AbstractClient.java:476)
	at app//org.opensearch.client.support.AbstractClient.execute(AbstractClient.java:463)
	at app//org.opensearch.action.ActionRequestBuilder.execute(ActionRequestBuilder.java:66)
	at app//org.opensearch.test.OpenSearchIntegTestCase.indexRandom(OpenSearchIntegTestCase.java:1651)
	at app//org.opensearch.test.OpenSearchIntegTestCase.indexRandom(OpenSearchIntegTestCase.java:1582)
	at app//org.opensearch.test.OpenSearchIntegTestCase.indexRandom(OpenSearchIntegTestCase.java:1566)
	at app//org.opensearch.search.suggest.CompletionSuggestSearchIT.testSkipDuplicates(CompletionSuggestSearchIT.java:1199)
```


### Related Issues

See please:
 - https://build.ci.opensearch.org/job/gradle-check/30587/testReport/junit/org.opensearch.search.suggest/CompletionSuggestSearchIT/testSkipDuplicates__p0___search_concurrent_segment_search_enabled___true___/

<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
