### PR TITLE
[Backport 1.3] Bump jetty from 9.4.51.v20230217 to 9.4.52.v20230823 (#11501)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump `org.apache.zookeeper:zookeper` from 3.8.0 to 3.8.3 ([#11476](https://github.com/opensearch-project/OpenSearch/pull/11476))
 - Bump `org.bouncycastle:bc-fips` from 1.0.2.3 to 1.0.2.4 ([#10297](https://github.com/opensearch-project/OpenSearch/pull/10297))
 - Bump `org.apache.avro:avro` from 1.10.2 to 1.11.3 ([#11502](https://github.com/opensearch-project/OpenSearch/pull/11502))
+- Bump `jetty` from 9.4.51.v20230217 to 9.4.52.v20230823 ([#11501](https://github.com/opensearch-project/OpenSearch/pull/11501))
 
 ### Changed
 - Use iterative approach to evaluate Regex.simpleMatch ([#11060](https://github.com/opensearch-project/OpenSearch/pull/11060))

--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -28,7 +28,7 @@ jna               = 5.5.0
 
 netty             = 4.1.101.Final
 joda              = 2.12.2
-jetty             = 9.4.51.v20230217
+jetty             = 9.4.52.v20230823
 
 # when updating this version, you need to ensure compatibility with:
 #  - plugins/ingest-attachment (transitive dependency, check the upstream POM)


### PR DESCRIPTION
Manual backport of https://github.com/opensearch-project/OpenSearch/pull/11501 to 1.3