### PR TITLE
[Backport 1.x] Bump jetty version in hdfs-fixture to 9.4.53.v20231009

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump `jetty` from 9.4.51.v20230217 to 9.4.52.v20230823 ([#11501](https://github.com/opensearch-project/OpenSearch/pull/11501))
 - Bump `io.projectreactor:reactor-core` from 3.4.23 to 3.4.34 and reactor-netty from 1.0.24 to 1.0.39 ([#11500](https://github.com/opensearch-project/OpenSearch/pull/11500))
 - Bump `logback-core` and `logback-classic` to 1.2.13 ([#11521](https://github.com/opensearch-project/OpenSearch/pull/11521))
+- Bumps `jetty` version from 9.4.52.v20230823 to 9.4.53.v20231009 ([#11539](https://github.com/opensearch-project/OpenSearch/pull/11539))
 
 ### Changed
 - Use iterative approach to evaluate Regex.simpleMatch ([#11060](https://github.com/opensearch-project/OpenSearch/pull/11060))

--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -28,7 +28,7 @@ netty             = 4.1.101.Final
 reactor_netty     = 1.0.39
 reactor           = 3.4.34
 joda              = 2.12.2
-jetty             = 9.4.52.v20230823
+jetty             = 9.4.53.v20231009
 
 # when updating this version, you need to ensure compatibility with:
 #  - plugins/ingest-attachment (transitive dependency, check the upstream POM)


### PR DESCRIPTION
Manual backport of https://github.com/opensearch-project/OpenSearch/pull/11539 to 1.x.