### PR TITLE
[Backport 1.3] Force version of logback-core and logback-classic to 1.2.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump `org.apache.avro:avro` from 1.10.2 to 1.11.3 ([#11502](https://github.com/opensearch-project/OpenSearch/pull/11502))
 - Bump `jetty` from 9.4.51.v20230217 to 9.4.52.v20230823 ([#11501](https://github.com/opensearch-project/OpenSearch/pull/11501))
 - Bump `io.projectreactor:reactor-core` from 3.4.23 to 3.4.34 and reactor-netty from 1.0.24 to 1.0.39 ([#11500](https://github.com/opensearch-project/OpenSearch/pull/11500))
+- Bump `logback-core` and `logback-classic` to 1.2.13 ([#11521](https://github.com/opensearch-project/OpenSearch/pull/11521))
 
 ### Changed
 - Use iterative approach to evaluate Regex.simpleMatch ([#11060](https://github.com/opensearch-project/OpenSearch/pull/11060))

--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -42,6 +42,8 @@ dependencies {
     exclude group: "com.squareup.okhttp3"
     exclude group: "org.xerial.snappy"
     exclude module: "json-io"
+    exclude module: "logback-core"
+    exclude module: "logback-classic"
   }
 
   api "org.codehaus.jettison:jettison:${versions.jettison}"
@@ -60,6 +62,8 @@ dependencies {
   api "com.google.protobuf:protobuf-java:${versions.protobuf}"
   api "org.eclipse.jetty:jetty-server:${versions.jetty}"
   api "org.eclipse.jetty.websocket:javax-websocket-server-impl:${versions.jetty}"
+  api "ch.qos.logback:logback-core:1.2.13"
+  api "ch.qos.logback:logback-classic:1.2.13"
   runtimeOnly "com.google.guava:guava:${versions.guava}"
   runtimeOnly("com.squareup.okhttp3:okhttp:4.11.0") {
     exclude group: "com.squareup.okio"


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/11536 to 1.3