### PR TITLE
[Backport 1.3] Bump com.github.tomakehurst:wiremock-jre8-standalone from 2.23.2 to 2.35.1 

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -141,7 +141,7 @@ dependencies {
   testFixturesApi "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${props.getProperty('randomizedrunner')}"
   testFixturesApi gradleApi()
   testFixturesApi gradleTestKit()
-  testImplementation 'com.github.tomakehurst:wiremock-jre8-standalone:2.23.2'
+  testImplementation 'com.github.tomakehurst:wiremock-jre8-standalone:2.35.1'
   testImplementation "org.mockito:mockito-core:${props.getProperty('mockito')}"
   integTestImplementation('org.spockframework:spock-core:2.3-groovy-2.5') {
     exclude module: "groovy"


### PR DESCRIPTION
backport https://github.com/opensearch-project/OpenSearch/commit/6d548cc0d2be2153484aac5ee5cd9b0448bdaafa to 1.3