### PR TITLE
Restore support for Java 8 for RestClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Improve boolean parsing performance ([#11308](https://github.com/opensearch-project/OpenSearch/pull/11308))
 - Interpret byte array as primitive using VarHandles ([#11362](https://github.com/opensearch-project/OpenSearch/pull/11362))
 - Change error message when per shard document limit is breached ([#11312](https://github.com/opensearch-project/OpenSearch/pull/11312))
+- Restore support for Java 8 for RestClient ([#11562](https://github.com/opensearch-project/OpenSearch/pull/11562))
 
 ### Deprecated
 

--- a/client/rest/build.gradle
+++ b/client/rest/build.gradle
@@ -34,8 +34,8 @@ apply plugin: 'opensearch.build'
 apply plugin: 'opensearch.publish'
 
 java {
-  targetCompatibility = JavaVersion.VERSION_11
-  sourceCompatibility = JavaVersion.VERSION_11
+  targetCompatibility = JavaVersion.VERSION_1_8
+  sourceCompatibility = JavaVersion.VERSION_1_8
 }
 
 base {
@@ -109,3 +109,10 @@ thirdPartyAudit.ignoreMissingClasses(
   'javax.servlet.ServletContextEvent',
   'javax.servlet.ServletContextListener'
 )
+
+tasks.withType(JavaCompile) {
+  // Suppressing '[options] target value 8 is obsolete and will be removed in a future release'
+  configure(options) {
+    options.compilerArgs << '-Xlint:-options'
+  }
+}

--- a/client/rest/src/main/java/org/opensearch/client/RestClient.java
+++ b/client/rest/src/main/java/org/opensearch/client/RestClient.java
@@ -1116,9 +1116,15 @@ public class RestClient implements Closeable {
                 if (chunkedEnabled.get()) {
                     return -1L;
                 } else {
-                    long size;
+                    long size = 0;
+                    final byte[] buf = new byte[8192];
+                    int nread = 0;
+
                     try (InputStream is = getContent()) {
-                        size = is.readAllBytes().length;
+                        // read to EOF which may read more or less than buffer size
+                        while ((nread = is.read(buf)) > 0) {
+                            size += nread;
+                        }
                     } catch (IOException ex) {
                         size = -1L;
                     }

--- a/client/rest/src/test/java/org/opensearch/client/nio/HeapBufferedAsyncEntityConsumerTests.java
+++ b/client/rest/src/test/java/org/opensearch/client/nio/HeapBufferedAsyncEntityConsumerTests.java
@@ -35,34 +35,34 @@ public class HeapBufferedAsyncEntityConsumerTests extends RestClientTestCase {
     }
 
     public void testConsumerAllocatesBufferLimit() throws IOException {
-        consumer.consume(randomByteBufferOfLength(1000).flip());
+        consumer.consume((ByteBuffer) randomByteBufferOfLength(1000).flip());
         assertThat(consumer.getBuffer().capacity(), equalTo(1000));
     }
 
     public void testConsumerAllocatesEmptyBuffer() throws IOException {
-        consumer.consume(ByteBuffer.allocate(0).flip());
+        consumer.consume((ByteBuffer) ByteBuffer.allocate(0).flip());
         assertThat(consumer.getBuffer().capacity(), equalTo(0));
     }
 
     public void testConsumerExpandsBufferLimits() throws IOException {
-        consumer.consume(randomByteBufferOfLength(1000).flip());
-        consumer.consume(randomByteBufferOfLength(2000).flip());
-        consumer.consume(randomByteBufferOfLength(3000).flip());
+        consumer.consume((ByteBuffer) randomByteBufferOfLength(1000).flip());
+        consumer.consume((ByteBuffer) randomByteBufferOfLength(2000).flip());
+        consumer.consume((ByteBuffer) randomByteBufferOfLength(3000).flip());
         assertThat(consumer.getBuffer().capacity(), equalTo(6000));
     }
 
     public void testConsumerAllocatesLimit() throws IOException {
-        consumer.consume(randomByteBufferOfLength(BUFFER_LIMIT).flip());
+        consumer.consume((ByteBuffer) randomByteBufferOfLength(BUFFER_LIMIT).flip());
         assertThat(consumer.getBuffer().capacity(), equalTo(BUFFER_LIMIT));
     }
 
     public void testConsumerFailsToAllocateOverLimit() throws IOException {
-        assertThrows(ContentTooLongException.class, () -> consumer.consume(randomByteBufferOfLength(BUFFER_LIMIT + 1).flip()));
+        assertThrows(ContentTooLongException.class, () -> consumer.consume((ByteBuffer) randomByteBufferOfLength(BUFFER_LIMIT + 1).flip()));
     }
 
     public void testConsumerFailsToExpandOverLimit() throws IOException {
-        consumer.consume(randomByteBufferOfLength(BUFFER_LIMIT).flip());
-        assertThrows(ContentTooLongException.class, () -> consumer.consume(randomByteBufferOfLength(1).flip()));
+        consumer.consume((ByteBuffer) randomByteBufferOfLength(BUFFER_LIMIT).flip());
+        assertThrows(ContentTooLongException.class, () -> consumer.consume((ByteBuffer) randomByteBufferOfLength(1).flip()));
     }
 
     private static ByteBuffer randomByteBufferOfLength(int length) {

--- a/client/test/build.gradle
+++ b/client/test/build.gradle
@@ -30,8 +30,8 @@
 apply plugin: 'opensearch.build'
 
 java {
-  targetCompatibility = JavaVersion.VERSION_11
-  sourceCompatibility = JavaVersion.VERSION_11
+  targetCompatibility = JavaVersion.VERSION_1_8
+  sourceCompatibility = JavaVersion.VERSION_1_8
 }
 
 base {
@@ -69,3 +69,10 @@ dependenciesInfo.enabled = false
 //we aren't releasing this jar
 thirdPartyAudit.enabled = false
 test.enabled = false
+
+tasks.withType(JavaCompile) {
+  // Suppressing '[options] target value 8 is obsolete and will be removed in a future release'
+  configure(options) {
+    options.compilerArgs << '-Xlint:-options'
+  }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Restore support for Java 8 for RestClient. There are still community asks for 2.x clients compatible with Java 8 baseline. The issue has worsen recently due to breaking changes in 2.x baseline (https://github.com/opensearch-project/OpenSearch/pull/5902, https://github.com/opensearch-project/OpenSearch/pull/9082), runtime replacement 1.x vs 2.x is not transparent anymore (causes compile time issues). 

### Related Issues
Part of https://github.com/opensearch-project/opensearch-java/issues/156
<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
