### PR TITLE
Fix fs info reporting negative available size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed rest-high-level client searchTemplate & mtermVectors endpoints to have a leading slash ([#14465](https://github.com/opensearch-project/OpenSearch/pull/14465))
 - Write shard level metadata blob when snapshotting searchable snapshot indexes ([#13190](https://github.com/opensearch-project/OpenSearch/pull/13190))
 - Fix aggs result of NestedAggregator with sub NestedAggregator ([#13324](https://github.com/opensearch-project/OpenSearch/pull/13324))
+- Fix fs info reporting negative available size ([#11573](https://github.com/opensearch-project/OpenSearch/pull/11573))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/monitor/fs/FsProbe.java
+++ b/server/src/main/java/org/opensearch/monitor/fs/FsProbe.java
@@ -82,6 +82,10 @@ public class FsProbe {
                 paths[i].fileCacheReserved = adjustForHugeFilesystems(dataLocations[i].fileCacheReservedSize.getBytes());
                 paths[i].fileCacheUtilized = adjustForHugeFilesystems(fileCache.usage().usage());
                 paths[i].available -= (paths[i].fileCacheReserved - paths[i].fileCacheUtilized);
+                // occurs if reserved file cache space is occupied by other files, like local indices
+                if (paths[i].available < 0) {
+                    paths[i].available = 0;
+                }
             }
         }
         FsInfo.IoStats ioStats = null;

--- a/server/src/test/java/org/opensearch/monitor/fs/FsProbeTests.java
+++ b/server/src/test/java/org/opensearch/monitor/fs/FsProbeTests.java
@@ -45,12 +45,9 @@ import org.opensearch.index.store.remote.filecache.FileCache;
 import org.opensearch.index.store.remote.filecache.FileCacheFactory;
 import org.opensearch.test.OpenSearchTestCase;
 
-import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.file.FileStore;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.attribute.FileStoreAttributeView;
 import java.util.Arrays;

--- a/server/src/test/java/org/opensearch/monitor/fs/FsProbeTests.java
+++ b/server/src/test/java/org/opensearch/monitor/fs/FsProbeTests.java
@@ -199,7 +199,6 @@ public class FsProbeTests extends OpenSearchTestCase {
             } else {
                 assertEquals(0L, total.available);
             }
-            assertTrue((total.free - total.available) < total.fileCacheReserved);
 
             for (FsInfo.Path path : stats) {
                 assertNotNull(path);
@@ -211,7 +210,6 @@ public class FsProbeTests extends OpenSearchTestCase {
 
                 if (path.fileCacheReserved > 0L) {
                     assertEquals(0L, path.available);
-                    assertTrue(path.free - path.available < path.fileCacheReserved);
                 } else {
                     assertTrue(path.available > 0L);
                 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Today, the fs info may report a negative available size, which happens when the following conditions are met:
1. A node has both `data` and `search` roles.
2. Some space is reserved for file cache.
3. The file cache space is being used by other files, primarily local indices files.

Related exception:
```
java.lang.IllegalArgumentException: Values less than -1 bytes are not supported: -1781760b
	at org.opensearch.core.common.unit.ByteSizeValue.<init>(ByteSizeValue.java:78) ~[classes/:?]
	at org.opensearch.core.common.unit.ByteSizeValue.<init>(ByteSizeValue.java:73) ~[classes/:?]
	at org.opensearch.monitor.fs.FsInfo$Path.getAvailable(FsInfo.java:141) ~[classes/:?]
	at org.opensearch.cluster.InternalClusterInfoService.fillDiskUsagePerNode(InternalClusterInfoService.java:452) ~[classes/:?]
	at org.opensearch.cluster.InternalClusterInfoService$1.onResponse(InternalClusterInfoService.java:265) ~[classes/:?]
	at org.opensearch.cluster.InternalClusterInfoService$1.onResponse(InternalClusterInfoService.java:260) [classes/:?]
	at org.opensearch.action.LatchedActionListener.onResponse(LatchedActionListener.java:58) [classes/:?]
	at org.opensearch.action.support.TransportAction$1.onResponse(TransportAction.java:113) ~[classes/:?]
	at org.opensearch.action.support.TransportAction$1.onResponse(TransportAction.java:107) [classes/:?]
	at org.opensearch.action.ActionRunnable.lambda$supply$0(ActionRunnable.java:74) [classes/:?]
	at org.opensearch.action.ActionRunnable$2.doRun(ActionRunnable.java:89) ~[classes/:?]
	at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) [classes/:?]
	at org.opensearch.common.util.concurrent.OpenSearchExecutors$DirectExecutorService.execute(OpenSearchExecutors.java:341) [classes/:?]
	at org.opensearch.action.support.nodes.TransportNodesAction$AsyncAction.finishHim(TransportNodesAction.java:315) [classes/:?]
```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
