### PR TITLE
[Backport] [2.x] Restore support for Java 8 for RestClient (#11562)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Change error message when per shard document limit is breached ([#11312](https://github.com/opensearch-project/OpenSearch/pull/11312))
 - Improve boolean parsing performance ([#11308](https://github.com/opensearch-project/OpenSearch/pull/11308))
 - Interpret byte array as primitive using VarHandles ([#11362](https://github.com/opensearch-project/OpenSearch/pull/11362))
+- Restore support for Java 8 for RestClient ([#11562](https://github.com/opensearch-project/OpenSearch/pull/11562))
 
 ### Deprecated
 

--- a/client/rest/build.gradle
+++ b/client/rest/build.gradle
@@ -34,8 +34,8 @@ apply plugin: 'opensearch.build'
 apply plugin: 'opensearch.publish'
 
 java {
-  targetCompatibility = JavaVersion.VERSION_11
-  sourceCompatibility = JavaVersion.VERSION_11
+  targetCompatibility = JavaVersion.VERSION_1_8
+  sourceCompatibility = JavaVersion.VERSION_1_8
 }
 
 base {
@@ -104,3 +104,10 @@ thirdPartyAudit.ignoreMissingClasses(
   'javax.servlet.ServletContextEvent',
   'javax.servlet.ServletContextListener'
 )
+
+tasks.withType(JavaCompile) {
+  // Suppressing '[options] target value 8 is obsolete and will be removed in a future release'
+  configure(options) {
+    options.compilerArgs << '-Xlint:-options'
+  }
+}

--- a/client/rest/src/main/java/org/opensearch/client/RestClient.java
+++ b/client/rest/src/main/java/org/opensearch/client/RestClient.java
@@ -1021,9 +1021,15 @@ public class RestClient implements Closeable {
                 if (chunkedEnabled.get()) {
                     return -1L;
                 } else {
-                    long size;
+                    long size = 0;
+                    final byte[] buf = new byte[8192];
+                    int nread = 0;
+
                     try (InputStream is = getContent()) {
-                        size = is.readAllBytes().length;
+                        // read to EOF which may read more or less than buffer size
+                        while ((nread = is.read(buf)) > 0) {
+                            size += nread;
+                        }
                     } catch (IOException ex) {
                         size = -1L;
                     }

--- a/client/test/build.gradle
+++ b/client/test/build.gradle
@@ -30,8 +30,8 @@
 apply plugin: 'opensearch.build'
 
 java {
-  targetCompatibility = JavaVersion.VERSION_11
-  sourceCompatibility = JavaVersion.VERSION_11
+  targetCompatibility = JavaVersion.VERSION_1_8
+  sourceCompatibility = JavaVersion.VERSION_1_8
 }
 
 base {
@@ -69,3 +69,10 @@ dependenciesInfo.enabled = false
 //we aren't releasing this jar
 thirdPartyAudit.enabled = false
 test.enabled = false
+
+tasks.withType(JavaCompile) {
+  // Suppressing '[options] target value 8 is obsolete and will be removed in a future release'
+  configure(options) {
+    options.compilerArgs << '-Xlint:-options'
+  }
+}


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/11562 to `2.x`