### PR TITLE
[Segment Replication] Introduce cluster level setting `cluster.index.restrict.replication.type` to prevent replication type setting override during index creations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [BWC and API enforcement] Introduce checks for enforcing the API restrictions ([#11175](https://github.com/opensearch-project/OpenSearch/pull/11175))
 - Create separate transport action for render search template action ([#11170](https://github.com/opensearch-project/OpenSearch/pull/11170))
 - Add additional handling in SearchTemplateRequest when simulate is set to true ([#11591](https://github.com/opensearch-project/OpenSearch/pull/11591))
+- Introduce cluster level setting `cluster.force.index.replication_type` that prevents new create index requests when replication type mis-matches with cluster level replication `cluster.indices.replication.strategy`([#11583](https://github.com/opensearch-project/OpenSearch/pull/11583))
 
 ### Dependencies
 - Bump Lucene from 9.7.0 to 9.8.0 ([10276](https://github.com/opensearch-project/OpenSearch/pull/10276))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,7 +122,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [BWC and API enforcement] Introduce checks for enforcing the API restrictions ([#11175](https://github.com/opensearch-project/OpenSearch/pull/11175))
 - Create separate transport action for render search template action ([#11170](https://github.com/opensearch-project/OpenSearch/pull/11170))
 - Add additional handling in SearchTemplateRequest when simulate is set to true ([#11591](https://github.com/opensearch-project/OpenSearch/pull/11591))
-- Introduce cluster level setting `cluster.force.index.replication_type` that prevents new create index requests when replication type mis-matches with cluster level replication `cluster.indices.replication.strategy`([#11583](https://github.com/opensearch-project/OpenSearch/pull/11583))
+- Introduce cluster level setting `cluster.force.index.replication.type` to prevent replication type setting override during index creations([#11583](https://github.com/opensearch-project/OpenSearch/pull/11583))
 
 ### Dependencies
 - Bump Lucene from 9.7.0 to 9.8.0 ([10276](https://github.com/opensearch-project/OpenSearch/pull/10276))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,7 +122,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [BWC and API enforcement] Introduce checks for enforcing the API restrictions ([#11175](https://github.com/opensearch-project/OpenSearch/pull/11175))
 - Create separate transport action for render search template action ([#11170](https://github.com/opensearch-project/OpenSearch/pull/11170))
 - Add additional handling in SearchTemplateRequest when simulate is set to true ([#11591](https://github.com/opensearch-project/OpenSearch/pull/11591))
-- Introduce cluster level setting `cluster.force.index.replication.type` to prevent replication type setting override during index creations([#11583](https://github.com/opensearch-project/OpenSearch/pull/11583))
+- Introduce cluster level setting `cluster.index.restrict.replication.type` to prevent replication type setting override during index creations([#11583](https://github.com/opensearch-project/OpenSearch/pull/11583))
 
 ### Dependencies
 - Bump Lucene from 9.7.0 to 9.8.0 ([10276](https://github.com/opensearch-project/OpenSearch/pull/10276))

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationClusterSettingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationClusterSettingIT.java
@@ -10,16 +10,31 @@ package org.opensearch.indices.replication;
 
 import org.opensearch.action.admin.indices.settings.get.GetSettingsRequest;
 import org.opensearch.action.admin.indices.settings.get.GetSettingsResponse;
+import org.opensearch.action.admin.indices.shrink.ResizeType;
+import org.opensearch.action.admin.indices.template.get.GetIndexTemplatesResponse;
 import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.index.Index;
 import org.opensearch.index.IndexModule;
+import org.opensearch.index.query.TermsQueryBuilder;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REPLICATION_TYPE;
+import static org.opensearch.indices.IndicesService.CLUSTER_RESTRICT_INDEX_REPLICATION_TYPE_SETTING;
 import static org.opensearch.indices.IndicesService.CLUSTER_SETTING_REPLICATION_TYPE;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
+import static org.hamcrest.Matchers.hasSize;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
 public class SegmentReplicationClusterSettingIT extends OpenSearchIntegTestCase {
@@ -28,6 +43,9 @@ public class SegmentReplicationClusterSettingIT extends OpenSearchIntegTestCase 
     private static final String SYSTEM_INDEX_NAME = ".test-system-index";
     protected static final int SHARD_COUNT = 1;
     protected static final int REPLICA_COUNT = 1;
+
+    protected static final String REPLICATION_MISMATCH_VALIDATION_ERROR =
+        "Validation Failed: 1: index setting [index.replication.type] is not allowed to be set as [cluster.force.index.replication_type=true];";
 
     @Override
     public Settings indexSettings() {
@@ -42,14 +60,6 @@ public class SegmentReplicationClusterSettingIT extends OpenSearchIntegTestCase 
     @Override
     protected boolean addMockInternalEngine() {
         return false;
-    }
-
-    @Override
-    protected Settings nodeSettings(int nodeOrdinal) {
-        return Settings.builder()
-            .put(super.nodeSettings(nodeOrdinal))
-            .put(CLUSTER_SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
-            .build();
     }
 
     public void testIndexReplicationSettingOverridesSegRepClusterSetting() throws Exception {
@@ -123,4 +133,262 @@ public class SegmentReplicationClusterSettingIT extends OpenSearchIntegTestCase 
         assertEquals(indicesService.indexService(anotherIndex).getIndexSettings().isSegRepEnabled(), false);
     }
 
+    public void testDifferentReplicationTypes_CreateIndex_StrictMode() throws Throwable {
+        final int documentCount = scaledRandomIntBetween(1, 10);
+        BiConsumer<List<ReplicationType>, List<String>> consumer = (replicationList, dataNodesList) -> {
+            Settings indexSettings = Settings.builder().put(indexSettings()).put(SETTING_REPLICATION_TYPE, replicationList.get(1)).build();
+            createIndex(INDEX_NAME, indexSettings);
+        };
+        executeTest(true, consumer, INDEX_NAME, documentCount);
+    }
+
+    public void testDifferentReplicationTypes_CreateIndex_NonStrictMode() throws Throwable {
+        final int documentCount = scaledRandomIntBetween(1, 10);
+        BiConsumer<List<ReplicationType>, List<String>> consumer = (replicationList, dataNodesList) -> {
+            Settings indexSettings = Settings.builder().put(indexSettings()).put(SETTING_REPLICATION_TYPE, replicationList.get(1)).build();
+            createIndex(INDEX_NAME, indexSettings);
+            for (int i = 0; i < documentCount; i++) {
+                client().prepareIndex(INDEX_NAME).setId(String.valueOf(i)).setSource("foo", "bar").get();
+            }
+        };
+        executeTest(false, consumer, INDEX_NAME, documentCount);
+    }
+
+    public void testDifferentReplicationTypes_IndexTemplates_StrictMode() throws Throwable {
+        final int documentCount = scaledRandomIntBetween(1, 10);
+
+        BiConsumer<List<ReplicationType>, List<String>> consumer = (replicationList, dataNodesList) -> {
+            client().admin()
+                .indices()
+                .preparePutTemplate("template_1")
+                .setPatterns(Collections.singletonList("test-idx*"))
+                .setSettings(Settings.builder().put(indexSettings()).put(SETTING_REPLICATION_TYPE, ReplicationType.DOCUMENT).build())
+                .setOrder(0)
+                .get();
+
+            GetIndexTemplatesResponse response = client().admin().indices().prepareGetTemplates().get();
+            assertThat(response.getIndexTemplates(), hasSize(1));
+
+            createIndex(INDEX_NAME);
+        };
+        executeTest(true, consumer, INDEX_NAME, documentCount);
+    }
+
+    public void testDifferentReplicationTypes_IndexTemplates_NonStrictMode() throws Throwable {
+        final int documentCount = scaledRandomIntBetween(1, 10);
+
+        // Create an index using current cluster level settings
+        BiConsumer<List<ReplicationType>, List<String>> consumer = (replicationList, dataNodesList) -> {
+            client().admin()
+                .indices()
+                .preparePutTemplate("template_1")
+                .setPatterns(Collections.singletonList("test-idx*"))
+                .setSettings(Settings.builder().put(indexSettings()).put(SETTING_REPLICATION_TYPE, replicationList.get(1)).build())
+                .setOrder(0)
+                .get();
+
+            GetIndexTemplatesResponse response = client().admin().indices().prepareGetTemplates().get();
+            assertThat(response.getIndexTemplates(), hasSize(1));
+
+            createIndex(INDEX_NAME);
+            for (int i = 0; i < documentCount; i++) {
+                client().prepareIndex(INDEX_NAME).setId(String.valueOf(i)).setSource("foo", "bar").get();
+            }
+        };
+        executeTest(false, consumer, INDEX_NAME, documentCount);
+    }
+
+    public void testMismatchingReplicationType_ResizeAction_StrictMode() throws Throwable {
+        // Define resize action and target shard count.
+        List<Tuple<ResizeType, Integer>> resizeActionsList = new ArrayList<>();
+        final int initialShardCount = 2;
+        resizeActionsList.add(new Tuple<>(ResizeType.SPLIT, 2 * initialShardCount));
+        resizeActionsList.add(new Tuple<>(ResizeType.SHRINK, SHARD_COUNT));
+        resizeActionsList.add(new Tuple<>(ResizeType.CLONE, initialShardCount));
+
+        Tuple<ResizeType, Integer> resizeActionTuple = resizeActionsList.get(random().nextInt(resizeActionsList.size()));
+        final String targetIndexName = resizeActionTuple.v1().name().toLowerCase(Locale.ROOT) + "-target";
+        final int documentCount = scaledRandomIntBetween(1, 10);
+
+        logger.info("--> Performing resize action {} with shard count {}", resizeActionTuple.v1(), resizeActionTuple.v2());
+
+        // Create an index using current cluster level settings
+        BiConsumer<List<ReplicationType>, List<String>> consumer = (replicationList, dataNodesList) -> {
+            Settings indexSettings = Settings.builder()
+                .put(indexSettings())
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, initialShardCount)
+                .put(SETTING_REPLICATION_TYPE, replicationList.get(0))
+                .build();
+            createIndex(INDEX_NAME, indexSettings);
+
+            for (int i = 0; i < documentCount; i++) {
+                client().prepareIndex(INDEX_NAME).setId(String.valueOf(i)).setSource("foo", "bar").get();
+            }
+
+            // Block writes
+            client().admin()
+                .indices()
+                .prepareUpdateSettings(INDEX_NAME)
+                .setSettings(Settings.builder().put("index.blocks.write", true))
+                .get();
+            ensureGreen();
+
+            try {
+                for (String node : dataNodesList) {
+                    assertBusy(() -> {
+                        assertHitCount(
+                            client(node).prepareSearch(INDEX_NAME).setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")).get(),
+                            documentCount
+                        );
+                    }, 30, TimeUnit.SECONDS);
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+
+            // Test create index fails
+            client().admin()
+                .indices()
+                .prepareResizeIndex(INDEX_NAME, targetIndexName)
+                .setResizeType(resizeActionTuple.v1())
+                .setSettings(
+                    Settings.builder()
+                        .put("index.number_of_replicas", 0)
+                        .put("index.number_of_shards", resizeActionTuple.v2())
+                        .putNull("index.blocks.write")
+                        .put(SETTING_REPLICATION_TYPE, replicationList.get(1))
+                        .build()
+                )
+                .get();
+        };
+        executeTest(true, consumer, targetIndexName, documentCount);
+    }
+
+    public void testMismatchingReplicationType_ResizeAction_NonStrictMode() throws Throwable {
+        final int initialShardCount = 2;
+        // Define resize action and target shard count.
+        List<Tuple<ResizeType, Integer>> resizeActionsList = new ArrayList<>();
+        resizeActionsList.add(new Tuple<>(ResizeType.SPLIT, 2 * initialShardCount));
+        resizeActionsList.add(new Tuple<>(ResizeType.SHRINK, SHARD_COUNT));
+        resizeActionsList.add(new Tuple<>(ResizeType.CLONE, initialShardCount));
+
+        Tuple<ResizeType, Integer> resizeActionTuple = resizeActionsList.get(random().nextInt(resizeActionsList.size()));
+        final String targetIndexName = resizeActionTuple.v1().name().toLowerCase(Locale.ROOT) + "-target";
+        final int documentCount = scaledRandomIntBetween(1, 10);
+
+        logger.info("--> Performing resize action {} with shard count {}", resizeActionTuple.v1(), resizeActionTuple.v2());
+
+        // Create an index using current cluster level settings
+        BiConsumer<List<ReplicationType>, List<String>> consumer = (replicationList, dataNodesList) -> {
+            Settings indexSettings = Settings.builder()
+                .put(indexSettings())
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, initialShardCount)
+                .put(SETTING_REPLICATION_TYPE, replicationList.get(0))
+                .build();
+
+            createIndex(INDEX_NAME, indexSettings);
+
+            for (int i = 0; i < documentCount; i++) {
+                client().prepareIndex(INDEX_NAME).setId(String.valueOf(i)).setSource("foo", "bar").get();
+            }
+
+            // Block writes
+            client().admin()
+                .indices()
+                .prepareUpdateSettings(INDEX_NAME)
+                .setSettings(Settings.builder().put("index.blocks.write", true))
+                .get();
+            ensureGreen();
+
+            try {
+                for (String node : dataNodesList) {
+                    assertBusy(() -> {
+                        assertHitCount(
+                            client(node).prepareSearch(INDEX_NAME).setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")).get(),
+                            documentCount
+                        );
+                    }, 30, TimeUnit.SECONDS);
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+
+            client().admin()
+                .indices()
+                .prepareResizeIndex(INDEX_NAME, targetIndexName)
+                .setResizeType(resizeActionTuple.v1())
+                .setSettings(
+                    Settings.builder()
+                        .put("index.number_of_replicas", 0)
+                        .put("index.number_of_shards", resizeActionTuple.v2())
+                        .putNull("index.blocks.write")
+                        .put(SETTING_REPLICATION_TYPE, replicationList.get(1))
+                        .build()
+                )
+                .get();
+        };
+        executeTest(false, consumer, targetIndexName, documentCount);
+    }
+
+    // Creates a cluster with mis-matching cluster level and index level replication strategies and validates that index
+    // creation fails when cluster level setting `cluster.force.index.replication_type` is set to true and creation goes
+    // through when it is false.
+    private void executeTest(
+        boolean restrictIndexLevelReplicationTypeSetting,
+        BiConsumer<List<ReplicationType>, List<String>> createIndexRunnable,
+        String targetIndexName,
+        int documentCount
+    ) throws Throwable {
+        // Generate mutually exclusive replication strategies at cluster and index level
+        List<ReplicationType> replicationStrategies = getRandomReplicationTypesAsList();
+        ReplicationType clusterLevelReplication = replicationStrategies.get(0);
+        ReplicationType indexLevelReplication = replicationStrategies.get(1);
+
+        Settings settings = Settings.builder()
+            .put(CLUSTER_SETTING_REPLICATION_TYPE, clusterLevelReplication)
+            .put(CLUSTER_RESTRICT_INDEX_REPLICATION_TYPE_SETTING.getKey(), restrictIndexLevelReplicationTypeSetting)
+            .build();
+        internalCluster().startClusterManagerOnlyNode(settings);
+        final String dataNodeOne = internalCluster().startDataOnlyNode(settings);
+        final String dataNodeTwo = internalCluster().startDataOnlyNode(settings);
+        List<String> dataNodes = Arrays.asList(dataNodeOne, dataNodeTwo);
+
+        logger.info(
+            "--> Create index with cluster level setting {} and index level replication setting {}",
+            clusterLevelReplication,
+            indexLevelReplication
+        );
+
+        if (restrictIndexLevelReplicationTypeSetting) {
+            try {
+                createIndexRunnable.accept(replicationStrategies, dataNodes);
+            } catch (IllegalArgumentException exception) {
+                assertEquals(REPLICATION_MISMATCH_VALIDATION_ERROR, exception.getMessage());
+            }
+        } else {
+            createIndexRunnable.accept(replicationStrategies, dataNodes);
+            ensureGreen(targetIndexName);
+            for (String node : dataNodes) {
+                assertBusy(() -> {
+                    assertHitCount(
+                        client(node).prepareSearch(targetIndexName).setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")).get(),
+                        documentCount
+                    );
+                });
+            }
+        }
+    }
+
+    /**
+     * Generate a list of ReplicationType with random ordering
+     *
+     * @return List of ReplicationType values
+     */
+    private List<ReplicationType> getRandomReplicationTypesAsList() {
+        List<ReplicationType> replicationStrategies = List.of(ReplicationType.SEGMENT, ReplicationType.DOCUMENT);
+        int randomReplicationIndex = random().nextInt(replicationStrategies.size());
+        ReplicationType clusterLevelReplication = replicationStrategies.get(randomReplicationIndex);
+        ReplicationType indexLevelReplication = replicationStrategies.get(1 - randomReplicationIndex);
+        return List.of(clusterLevelReplication, indexLevelReplication);
+    }
 }

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationClusterSettingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationClusterSettingIT.java
@@ -148,7 +148,7 @@ public class SegmentReplicationClusterSettingIT extends OpenSearchIntegTestCase 
         // Generate mutually exclusive replication strategies at cluster and index level
         List<ReplicationType> replicationStrategies = getRandomReplicationTypesAsList();
         ReplicationType clusterLevelReplication = replicationStrategies.get(0);
-        ReplicationType indexLevelReplication = replicationStrategies.get(1);
+        ReplicationType templateReplicationType = replicationStrategies.get(1);
         Settings nodeSettings = Settings.builder()
             .put(CLUSTER_SETTING_REPLICATION_TYPE, clusterLevelReplication)
             .put(CLUSTER_INDEX_RESTRICT_REPLICATION_TYPE_SETTING.getKey(), true)
@@ -157,8 +157,8 @@ public class SegmentReplicationClusterSettingIT extends OpenSearchIntegTestCase 
         internalCluster().startDataOnlyNode(nodeSettings);
         internalCluster().startDataOnlyNode(nodeSettings);
         logger.info(
-            "--> Create index with index level replication {} and cluster level replication {}",
-            indexLevelReplication,
+            "--> Create index with template replication {} and cluster level replication {}",
+            templateReplicationType,
             clusterLevelReplication
         );
         // Create index template
@@ -166,7 +166,7 @@ public class SegmentReplicationClusterSettingIT extends OpenSearchIntegTestCase 
             .indices()
             .preparePutTemplate("template_1")
             .setPatterns(Collections.singletonList("test-idx*"))
-            .setSettings(Settings.builder().put(indexSettings()).put(SETTING_REPLICATION_TYPE, ReplicationType.DOCUMENT).build())
+            .setSettings(Settings.builder().put(indexSettings()).put(SETTING_REPLICATION_TYPE, templateReplicationType).build())
             .setOrder(0)
             .get();
 

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationClusterSettingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationClusterSettingIT.java
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REPLICATION_TYPE;
-import static org.opensearch.indices.IndicesService.CLUSTER_RESTRICT_INDEX_REPLICATION_TYPE_SETTING;
+import static org.opensearch.indices.IndicesService.CLUSTER_FORCE_INDEX_REPLICATION_TYPE_SETTING;
 import static org.opensearch.indices.IndicesService.CLUSTER_SETTING_REPLICATION_TYPE;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.hasSize;
@@ -346,7 +346,7 @@ public class SegmentReplicationClusterSettingIT extends OpenSearchIntegTestCase 
 
         Settings settings = Settings.builder()
             .put(CLUSTER_SETTING_REPLICATION_TYPE, clusterLevelReplication)
-            .put(CLUSTER_RESTRICT_INDEX_REPLICATION_TYPE_SETTING.getKey(), restrictIndexLevelReplicationTypeSetting)
+            .put(CLUSTER_FORCE_INDEX_REPLICATION_TYPE_SETTING.getKey(), restrictIndexLevelReplicationTypeSetting)
             .build();
         internalCluster().startClusterManagerOnlyNode(settings);
         final String dataNodeOne = internalCluster().startDataOnlyNode(settings);

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/SegmentReplicationSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/SegmentReplicationSnapshotIT.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REPLICATION_TYPE;
+import static org.opensearch.indices.IndicesService.CLUSTER_RESTRICT_INDEX_REPLICATION_TYPE_SETTING;
 import static org.opensearch.indices.IndicesService.CLUSTER_SETTING_REPLICATION_TYPE;
 import static org.opensearch.indices.replication.SegmentReplicationBaseIT.waitForSearchableDocs;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
@@ -295,6 +296,73 @@ public class SegmentReplicationSnapshotIT extends AbstractSnapshotIntegTestCase 
         // Assertions
         assertEquals(restoreSnapshotResponse.status(), RestStatus.ACCEPTED);
         ensureGreen(RESTORED_INDEX_NAME);
+        GetSettingsResponse settingsResponse = client().admin()
+            .indices()
+            .getSettings(new GetSettingsRequest().indices(RESTORED_INDEX_NAME).includeDefaults(true))
+            .get();
+        assertEquals(settingsResponse.getSetting(RESTORED_INDEX_NAME, SETTING_REPLICATION_TYPE), ReplicationType.DOCUMENT.toString());
+
+        // Verify index setting isSegRepEnabled.
+        Index index = resolveIndex(RESTORED_INDEX_NAME);
+        IndicesService indicesService = internalCluster().getInstance(IndicesService.class);
+        assertEquals(indicesService.indexService(index).getIndexSettings().isSegRepEnabled(), false);
+    }
+
+    /**
+    * 1. Create index in DOCUMENT replication type
+    * 2. Snapshot index
+    * 3. Add new set of nodes with `cluster.indices.replication.strategy` set to SEGMENT and `cluster.force.index.replication_type`
+    *    set to true.
+    * 4. Perform restore on new set of nodes to validate restored index has `DOCUMENT` replication.
+    */
+    public void testSnapshotRestoreOnRestrictReplicationSetting() throws Exception {
+        final int documentCount = scaledRandomIntBetween(1, 10);
+        String originalClusterManagerNode = internalCluster().startClusterManagerOnlyNode();
+
+        // Starting two nodes with primary and replica shards respectively.
+        final String primaryNode = internalCluster().startDataOnlyNode();
+        prepareCreate(
+            INDEX_NAME,
+            Settings.builder()
+                // we want to override cluster replication setting by passing a index replication setting
+                .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.DOCUMENT)
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, REPLICA_COUNT)
+        ).get();
+        ensureYellowAndNoInitializingShards(INDEX_NAME);
+        final String replicaNode = internalCluster().startDataOnlyNode();
+        ensureGreen(INDEX_NAME);
+
+        for (int i = 0; i < documentCount; i++) {
+            client().prepareIndex(INDEX_NAME).setId(String.valueOf(i)).setSource("foo", "bar").get();
+        }
+
+        createSnapshot();
+
+        // Delete index
+        assertAcked(client().admin().indices().delete(new DeleteIndexRequest(INDEX_NAME)).get());
+        assertFalse("index [" + INDEX_NAME + "] should have been deleted", indexExists(INDEX_NAME));
+
+        // Start new set of nodes with cluster level replication type setting and restrict replication type setting.
+        Settings settings = Settings.builder()
+            .put(CLUSTER_SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+            .put(CLUSTER_RESTRICT_INDEX_REPLICATION_TYPE_SETTING.getKey(), true)
+            .build();
+        String newClusterManagerNode = internalCluster().startClusterManagerOnlyNode(settings);
+
+        // Remove older nodes
+        internalCluster().stopRandomNode(InternalTestCluster.nameFilter(originalClusterManagerNode));
+        internalCluster().stopRandomNode(InternalTestCluster.nameFilter(primaryNode));
+        internalCluster().stopRandomNode(InternalTestCluster.nameFilter(replicaNode));
+
+        String newPrimaryNode = internalCluster().startDataOnlyNode(settings);
+        String newReplicaNode = internalCluster().startDataOnlyNode(settings);
+
+        RestoreSnapshotResponse restoreSnapshotResponse = restoreSnapshotWithSettings(restoreIndexSegRepSettings());
+
+        // Assertions
+        assertEquals(restoreSnapshotResponse.status(), RestStatus.ACCEPTED);
+        ensureGreen(RESTORED_INDEX_NAME);
+        logger.info("--> ClusterState {}", client().admin().cluster().prepareState().execute().actionGet().getState());
         GetSettingsResponse settingsResponse = client().admin()
             .indices()
             .getSettings(new GetSettingsRequest().indices(RESTORED_INDEX_NAME).includeDefaults(true))

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/SegmentReplicationSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/SegmentReplicationSnapshotIT.java
@@ -49,7 +49,7 @@ public class SegmentReplicationSnapshotIT extends AbstractSnapshotIntegTestCase 
     private static final String SNAPSHOT_NAME = "test-segrep-snapshot";
 
     protected static final String REPLICATION_MISMATCH_VALIDATION_ERROR =
-        "Validation Failed: 1: index setting [index.replication.type] is not allowed to be set as [cluster.force.index.replication_type=true];";
+        "Validation Failed: 1: index setting [index.replication.type] is not allowed to be set as [cluster.force.index.replication.type=true];";
 
     public Settings segRepEnableIndexSettings() {
         return getShardSettings().put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT).build();
@@ -314,7 +314,7 @@ public class SegmentReplicationSnapshotIT extends AbstractSnapshotIntegTestCase 
     /**
     * 1. Create index in DOCUMENT replication type
     * 2. Snapshot index
-    * 3. Add new set of nodes with `cluster.indices.replication.strategy` set to SEGMENT and `cluster.force.index.replication_type`
+    * 3. Add new set of nodes with `cluster.indices.replication.strategy` set to SEGMENT and `cluster.force.index.replication.type`
     *    set to true.
     * 4. Perform restore on new set of nodes to validate restored index has `DOCUMENT` replication.
     */

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/SegmentReplicationSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/SegmentReplicationSnapshotIT.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REPLICATION_TYPE;
-import static org.opensearch.indices.IndicesService.CLUSTER_FORCE_INDEX_REPLICATION_TYPE_SETTING;
+import static org.opensearch.indices.IndicesService.CLUSTER_INDEX_RESTRICT_REPLICATION_TYPE_SETTING;
 import static org.opensearch.indices.IndicesService.CLUSTER_SETTING_REPLICATION_TYPE;
 import static org.opensearch.indices.replication.SegmentReplicationBaseIT.waitForSearchableDocs;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
@@ -49,7 +49,7 @@ public class SegmentReplicationSnapshotIT extends AbstractSnapshotIntegTestCase 
     private static final String SNAPSHOT_NAME = "test-segrep-snapshot";
 
     protected static final String REPLICATION_MISMATCH_VALIDATION_ERROR =
-        "Validation Failed: 1: index setting [index.replication.type] is not allowed to be set as [cluster.force.index.replication.type=true];";
+        "Validation Failed: 1: index setting [index.replication.type] is not allowed to be set as [cluster.index.restrict.replication.type=true];";
 
     public Settings segRepEnableIndexSettings() {
         return getShardSettings().put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT).build();
@@ -314,7 +314,7 @@ public class SegmentReplicationSnapshotIT extends AbstractSnapshotIntegTestCase 
     /**
     * 1. Create index in DOCUMENT replication type
     * 2. Snapshot index
-    * 3. Add new set of nodes with `cluster.indices.replication.strategy` set to SEGMENT and `cluster.force.index.replication.type`
+    * 3. Add new set of nodes with `cluster.indices.replication.strategy` set to SEGMENT and `cluster.index.restrict.replication.type`
     *    set to true.
     * 4. Perform restore on new set of nodes to validate restored index has `DOCUMENT` replication.
     */
@@ -349,7 +349,7 @@ public class SegmentReplicationSnapshotIT extends AbstractSnapshotIntegTestCase 
         // Start new set of nodes with cluster level replication type setting and restrict replication type setting.
         Settings settings = Settings.builder()
             .put(CLUSTER_SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
-            .put(CLUSTER_FORCE_INDEX_REPLICATION_TYPE_SETTING.getKey(), true)
+            .put(CLUSTER_INDEX_RESTRICT_REPLICATION_TYPE_SETTING.getKey(), true)
             .build();
 
         // Start new cluster manager node

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -1332,7 +1332,7 @@ public class MetadataCreateIndexService {
 
     /**
      * Validates {@code index.replication.type} is matches with cluster level setting {@code cluster.indices.replication.strategy}
-     * when {@code cluster.force.index.replication_type} is set to true.
+     * when {@code cluster.force.index.replication.type} is set to true.
      *
      * @param requestSettings settings passed in during index create request
      * @param clusterSettings cluster setting

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -1332,19 +1332,19 @@ public class MetadataCreateIndexService {
 
     /**
      * Validates {@code index.replication.type} is matches with cluster level setting {@code cluster.indices.replication.strategy}
-     * when {@code cluster.force.index.replication.type} is set to true.
+     * when {@code cluster.index.restrict.replication.type} is set to true.
      *
      * @param requestSettings settings passed in during index create request
      * @param clusterSettings cluster setting
      */
     private static Optional<String> validateIndexReplicationTypeSettings(Settings requestSettings, ClusterSettings clusterSettings) {
-        if (clusterSettings.get(IndicesService.CLUSTER_FORCE_INDEX_REPLICATION_TYPE_SETTING)
+        if (clusterSettings.get(IndicesService.CLUSTER_INDEX_RESTRICT_REPLICATION_TYPE_SETTING)
             && requestSettings.hasValue(SETTING_REPLICATION_TYPE)
             && requestSettings.get(INDEX_REPLICATION_TYPE_SETTING.getKey())
                 .equals(clusterSettings.get(CLUSTER_REPLICATION_TYPE_SETTING).name()) == false) {
             return Optional.of(
                 "index setting [index.replication.type] is not allowed to be set as ["
-                    + IndicesService.CLUSTER_FORCE_INDEX_REPLICATION_TYPE_SETTING.getKey()
+                    + IndicesService.CLUSTER_INDEX_RESTRICT_REPLICATION_TYPE_SETTING.getKey()
                     + "=true]"
             );
         }

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -702,7 +702,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 CpuBasedAdmissionControllerSettings.CPU_BASED_ADMISSION_CONTROLLER_TRANSPORT_LAYER_MODE,
                 CpuBasedAdmissionControllerSettings.INDEXING_CPU_USAGE_LIMIT,
                 CpuBasedAdmissionControllerSettings.SEARCH_CPU_USAGE_LIMIT,
-                IndicesService.CLUSTER_RESTRICT_INDEX_REPLICATION_TYPE_SETTING
+                IndicesService.CLUSTER_FORCE_INDEX_REPLICATION_TYPE_SETTING
             )
         )
     );

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -701,7 +701,8 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 AdmissionControlSettings.ADMISSION_CONTROL_TRANSPORT_LAYER_MODE,
                 CpuBasedAdmissionControllerSettings.CPU_BASED_ADMISSION_CONTROLLER_TRANSPORT_LAYER_MODE,
                 CpuBasedAdmissionControllerSettings.INDEXING_CPU_USAGE_LIMIT,
-                CpuBasedAdmissionControllerSettings.SEARCH_CPU_USAGE_LIMIT
+                CpuBasedAdmissionControllerSettings.SEARCH_CPU_USAGE_LIMIT,
+                IndicesService.CLUSTER_RESTRICT_INDEX_REPLICATION_TYPE_SETTING
             )
         )
     );

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -702,7 +702,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 CpuBasedAdmissionControllerSettings.CPU_BASED_ADMISSION_CONTROLLER_TRANSPORT_LAYER_MODE,
                 CpuBasedAdmissionControllerSettings.INDEXING_CPU_USAGE_LIMIT,
                 CpuBasedAdmissionControllerSettings.SEARCH_CPU_USAGE_LIMIT,
-                IndicesService.CLUSTER_FORCE_INDEX_REPLICATION_TYPE_SETTING
+                IndicesService.CLUSTER_INDEX_RESTRICT_REPLICATION_TYPE_SETTING
             )
         )
     );

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -307,8 +307,8 @@ public class IndicesService extends AbstractLifecycleComponent
      * does not match the cluster setting. If disabled, a user can choose a replication type on a per-index basis using
      * the index.replication.type setting.
      */
-    public static final Setting<Boolean> CLUSTER_FORCE_INDEX_REPLICATION_TYPE_SETTING = Setting.boolSetting(
-        "cluster.force.index.replication.type",
+    public static final Setting<Boolean> CLUSTER_INDEX_RESTRICT_REPLICATION_TYPE_SETTING = Setting.boolSetting(
+        "cluster.index.restrict.replication.type",
         false,
         Property.NodeScope,
         Property.Final

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -306,7 +306,7 @@ public class IndicesService extends AbstractLifecycleComponent
      * with the replication type index setting, set at cluster level i.e. 'cluster.indices.replication.strategy'.
      * If disabled, the replication type can be specified.
      */
-    public static final Setting<Boolean> CLUSTER_RESTRICT_INDEX_REPLICATION_TYPE_SETTING = Setting.boolSetting(
+    public static final Setting<Boolean> CLUSTER_FORCE_INDEX_REPLICATION_TYPE_SETTING = Setting.boolSetting(
         "cluster.force.index.replication_type",
         false,
         Property.NodeScope,

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -302,12 +302,13 @@ public class IndicesService extends AbstractLifecycleComponent
     );
 
     /**
-     * This setting is used to prevents creation of indices where the 'index.replication.type' setting does not match
-     * with the replication type index setting, set at cluster level i.e. 'cluster.indices.replication.strategy'.
-     * If disabled, the replication type can be specified.
+     * If enabled, this setting enforces that indexes will be created with a replication type matching the cluster setting
+     * defined in cluster.indices.replication.strategy by rejecting any request that specifies a replication type that
+     * does not match the cluster setting. If disabled, a user can choose a replication type on a per-index basis using
+     * the index.replication.type setting.
      */
     public static final Setting<Boolean> CLUSTER_FORCE_INDEX_REPLICATION_TYPE_SETTING = Setting.boolSetting(
-        "cluster.force.index.replication_type",
+        "cluster.force.index.replication.type",
         false,
         Property.NodeScope,
         Property.Final

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -302,6 +302,18 @@ public class IndicesService extends AbstractLifecycleComponent
     );
 
     /**
+     * This setting is used to prevents creation of indices where the 'index.replication.type' setting does not match
+     * with the replication type index setting, set at cluster level i.e. 'cluster.indices.replication.strategy'.
+     * If disabled, the replication type can be specified.
+     */
+    public static final Setting<Boolean> CLUSTER_RESTRICT_INDEX_REPLICATION_TYPE_SETTING = Setting.boolSetting(
+        "cluster.force.index.replication_type",
+        false,
+        Property.NodeScope,
+        Property.Final
+    );
+
+    /**
      * The node's settings.
      */
     private final Settings settings;

--- a/server/src/main/java/org/opensearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/opensearch/snapshots/RestoreService.java
@@ -428,7 +428,12 @@ public class RestoreService implements ClusterStateApplier {
                                     boolean isHidden = IndexMetadata.INDEX_HIDDEN_SETTING.get(snapshotIndexMetadata.getSettings());
                                     createIndexService.validateIndexName(renamedIndexName, currentState);
                                     createIndexService.validateDotIndex(renamedIndexName, isHidden);
-                                    createIndexService.validateIndexSettings(renamedIndexName, snapshotIndexMetadata.getSettings(), false);
+                                    createIndexService.validateIndexSettings(
+                                        renamedIndexName,
+                                        snapshotIndexMetadata.getSettings(),
+                                        false,
+                                        true
+                                    );
                                     MetadataCreateIndexService.validateRefreshIntervalSettings(
                                         snapshotIndexMetadata.getSettings(),
                                         clusterSettings

--- a/server/src/main/java/org/opensearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/opensearch/snapshots/RestoreService.java
@@ -428,12 +428,7 @@ public class RestoreService implements ClusterStateApplier {
                                     boolean isHidden = IndexMetadata.INDEX_HIDDEN_SETTING.get(snapshotIndexMetadata.getSettings());
                                     createIndexService.validateIndexName(renamedIndexName, currentState);
                                     createIndexService.validateDotIndex(renamedIndexName, isHidden);
-                                    createIndexService.validateIndexSettings(
-                                        renamedIndexName,
-                                        snapshotIndexMetadata.getSettings(),
-                                        false,
-                                        true
-                                    );
+                                    createIndexService.validateIndexSettings(renamedIndexName, snapshotIndexMetadata.getSettings(), false);
                                     MetadataCreateIndexService.validateRefreshIntervalSettings(
                                         snapshotIndexMetadata.getSettings(),
                                         clusterSettings

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -71,6 +71,7 @@ import org.opensearch.index.IndexSettings;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.translog.Translog;
+import org.opensearch.indices.IndexCreationException;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.InvalidAliasNameException;
 import org.opensearch.indices.InvalidIndexNameException;
@@ -137,6 +138,7 @@ import static org.opensearch.index.IndexSettings.INDEX_REMOTE_TRANSLOG_BUFFER_IN
 import static org.opensearch.index.IndexSettings.INDEX_SOFT_DELETES_SETTING;
 import static org.opensearch.index.IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING;
 import static org.opensearch.indices.IndicesService.CLUSTER_DEFAULT_INDEX_REFRESH_INTERVAL_SETTING;
+import static org.opensearch.indices.IndicesService.CLUSTER_FORCE_INDEX_REPLICATION_TYPE_SETTING;
 import static org.opensearch.indices.IndicesService.CLUSTER_MINIMUM_INDEX_REFRESH_INTERVAL_SETTING;
 import static org.opensearch.indices.IndicesService.CLUSTER_REMOTE_INDEX_RESTRICT_ASYNC_DURABILITY_SETTING;
 import static org.opensearch.indices.IndicesService.CLUSTER_REPLICATION_TYPE_SETTING;
@@ -165,6 +167,9 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
         + REMOTE_STORE_SEGMENT_REPOSITORY_NAME_ATTRIBUTE_KEY;
     private static final String translogRepositoryNameAttributeKey = NODE_ATTRIBUTES.getKey()
         + REMOTE_STORE_TRANSLOG_REPOSITORY_NAME_ATTRIBUTE_KEY;
+
+    final String REPLICATION_MISMATCH_VALIDATION_ERROR =
+        "Validation Failed: 1: index setting [index.replication.type] is not allowed to be set as [cluster.force.index.replication.type=true];";
 
     @Before
     public void setup() throws Exception {
@@ -1237,6 +1242,105 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
         );
         assertNotEquals(ReplicationType.SEGMENT, clusterSettings.get(CLUSTER_REPLICATION_TYPE_SETTING));
         assertEquals(ReplicationType.SEGMENT.toString(), indexSettings.get(INDEX_REPLICATION_TYPE_SETTING.getKey()));
+    }
+
+    public void testClusterForceReplicationTypeInAggregateSettings() {
+        Settings settings = Settings.builder()
+            .put(CLUSTER_REPLICATION_TYPE_SETTING.getKey(), ReplicationType.SEGMENT)
+            .put(CLUSTER_FORCE_INDEX_REPLICATION_TYPE_SETTING.getKey(), true)
+            .build();
+        ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        Settings matchingReplicationIndexSettings = Settings.builder()
+            .put(INDEX_REPLICATION_TYPE_SETTING.getKey(), ReplicationType.DOCUMENT)
+            .build();
+        request = new CreateIndexClusterStateUpdateRequest("create index", "test", "test");
+        request.settings(matchingReplicationIndexSettings);
+        IndexCreationException exception = expectThrows(
+            IndexCreationException.class,
+            () -> aggregateIndexSettings(
+                ClusterState.EMPTY_STATE,
+                request,
+                Settings.EMPTY,
+                null,
+                Settings.EMPTY,
+                IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
+                randomShardLimitService(),
+                Collections.emptySet(),
+                clusterSettings
+            )
+        );
+        assertEquals(REPLICATION_MISMATCH_VALIDATION_ERROR, exception.getCause().getMessage());
+
+        Settings nonMatchingReplicationIndexSettings = Settings.builder()
+            .put(INDEX_REPLICATION_TYPE_SETTING.getKey(), ReplicationType.SEGMENT)
+            .build();
+        request.settings(nonMatchingReplicationIndexSettings);
+        Settings aggregateIndexSettings = aggregateIndexSettings(
+            ClusterState.EMPTY_STATE,
+            request,
+            Settings.EMPTY,
+            null,
+            Settings.EMPTY,
+            IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
+            randomShardLimitService(),
+            Collections.emptySet(),
+            clusterSettings
+        );
+        assertEquals(ReplicationType.SEGMENT.toString(), aggregateIndexSettings.get(INDEX_REPLICATION_TYPE_SETTING.getKey()));
+    }
+
+    public void testClusterForceReplicationTypeInValidateIndexSettings() {
+        ClusterService clusterService = mock(ClusterService.class);
+        Metadata metadata = Metadata.builder()
+            .transientSettings(Settings.builder().put(Metadata.DEFAULT_REPLICA_COUNT_SETTING.getKey(), 1).build())
+            .build();
+        ClusterState clusterState = ClusterState.builder(org.opensearch.cluster.ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
+            .metadata(metadata)
+            .build();
+        ThreadPool threadPool = new TestThreadPool(getTestName());
+        // Enforce cluster level replication type setting
+        final Settings forceClusterSettingEnabled = Settings.builder()
+            .put(CLUSTER_REPLICATION_TYPE_SETTING.getKey(), ReplicationType.SEGMENT)
+            .put(CLUSTER_FORCE_INDEX_REPLICATION_TYPE_SETTING.getKey(), true)
+            .build();
+        ClusterSettings clusterSettings = new ClusterSettings(forceClusterSettingEnabled, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        when(clusterService.getSettings()).thenReturn(forceClusterSettingEnabled);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        when(clusterService.state()).thenReturn(clusterState);
+
+        final MetadataCreateIndexService checkerService = new MetadataCreateIndexService(
+            forceClusterSettingEnabled,
+            clusterService,
+            null,
+            null,
+            null,
+            createTestShardLimitService(randomIntBetween(1, 1000), false, clusterService),
+            new Environment(Settings.builder().put("path.home", "dummy").build(), null),
+            IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
+            threadPool,
+            null,
+            new SystemIndices(Collections.emptyMap()),
+            true,
+            new AwarenessReplicaBalance(forceClusterSettingEnabled, clusterService.getClusterSettings())
+        );
+        // Use DOCUMENT replication type setting for index creation
+        final Settings indexSettings = Settings.builder().put(INDEX_REPLICATION_TYPE_SETTING.getKey(), ReplicationType.DOCUMENT).build();
+
+        IndexCreationException exception = expectThrows(
+            IndexCreationException.class,
+            () -> checkerService.validateIndexSettings("test", indexSettings, false)
+        );
+        assertEquals(REPLICATION_MISMATCH_VALIDATION_ERROR, exception.getCause().getMessage());
+
+        // Cluster level replication type setting not enforced
+        final Settings forceClusterSettingDisabled = Settings.builder()
+            .put(CLUSTER_REPLICATION_TYPE_SETTING.getKey(), ReplicationType.SEGMENT)
+            .put(CLUSTER_FORCE_INDEX_REPLICATION_TYPE_SETTING.getKey(), false)
+            .build();
+        clusterSettings = new ClusterSettings(forceClusterSettingDisabled, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        checkerService.validateIndexSettings("test", indexSettings, false);
+        threadPool.shutdown();
     }
 
     public void testRemoteStoreNoUserOverrideExceptReplicationTypeSegmentIndexSettings() {

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -138,7 +138,7 @@ import static org.opensearch.index.IndexSettings.INDEX_REMOTE_TRANSLOG_BUFFER_IN
 import static org.opensearch.index.IndexSettings.INDEX_SOFT_DELETES_SETTING;
 import static org.opensearch.index.IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING;
 import static org.opensearch.indices.IndicesService.CLUSTER_DEFAULT_INDEX_REFRESH_INTERVAL_SETTING;
-import static org.opensearch.indices.IndicesService.CLUSTER_FORCE_INDEX_REPLICATION_TYPE_SETTING;
+import static org.opensearch.indices.IndicesService.CLUSTER_INDEX_RESTRICT_REPLICATION_TYPE_SETTING;
 import static org.opensearch.indices.IndicesService.CLUSTER_MINIMUM_INDEX_REFRESH_INTERVAL_SETTING;
 import static org.opensearch.indices.IndicesService.CLUSTER_REMOTE_INDEX_RESTRICT_ASYNC_DURABILITY_SETTING;
 import static org.opensearch.indices.IndicesService.CLUSTER_REPLICATION_TYPE_SETTING;
@@ -169,7 +169,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
         + REMOTE_STORE_TRANSLOG_REPOSITORY_NAME_ATTRIBUTE_KEY;
 
     final String REPLICATION_MISMATCH_VALIDATION_ERROR =
-        "Validation Failed: 1: index setting [index.replication.type] is not allowed to be set as [cluster.force.index.replication.type=true];";
+        "Validation Failed: 1: index setting [index.replication.type] is not allowed to be set as [cluster.index.restrict.replication.type=true];";
 
     @Before
     public void setup() throws Exception {
@@ -1247,7 +1247,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
     public void testClusterForceReplicationTypeInAggregateSettings() {
         Settings settings = Settings.builder()
             .put(CLUSTER_REPLICATION_TYPE_SETTING.getKey(), ReplicationType.SEGMENT)
-            .put(CLUSTER_FORCE_INDEX_REPLICATION_TYPE_SETTING.getKey(), true)
+            .put(CLUSTER_INDEX_RESTRICT_REPLICATION_TYPE_SETTING.getKey(), true)
             .build();
         ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         Settings matchingReplicationIndexSettings = Settings.builder()
@@ -1301,7 +1301,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
         // Enforce cluster level replication type setting
         final Settings forceClusterSettingEnabled = Settings.builder()
             .put(CLUSTER_REPLICATION_TYPE_SETTING.getKey(), ReplicationType.SEGMENT)
-            .put(CLUSTER_FORCE_INDEX_REPLICATION_TYPE_SETTING.getKey(), true)
+            .put(CLUSTER_INDEX_RESTRICT_REPLICATION_TYPE_SETTING.getKey(), true)
             .build();
         ClusterSettings clusterSettings = new ClusterSettings(forceClusterSettingEnabled, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         when(clusterService.getSettings()).thenReturn(forceClusterSettingEnabled);
@@ -1335,7 +1335,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
         // Cluster level replication type setting not enforced
         final Settings forceClusterSettingDisabled = Settings.builder()
             .put(CLUSTER_REPLICATION_TYPE_SETTING.getKey(), ReplicationType.SEGMENT)
-            .put(CLUSTER_FORCE_INDEX_REPLICATION_TYPE_SETTING.getKey(), false)
+            .put(CLUSTER_INDEX_RESTRICT_REPLICATION_TYPE_SETTING.getKey(), false)
             .build();
         clusterSettings = new ClusterSettings(forceClusterSettingDisabled, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -1250,11 +1250,11 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
             .put(CLUSTER_INDEX_RESTRICT_REPLICATION_TYPE_SETTING.getKey(), true)
             .build();
         ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        Settings matchingReplicationIndexSettings = Settings.builder()
+        Settings nonMatchingReplicationIndexSettings = Settings.builder()
             .put(INDEX_REPLICATION_TYPE_SETTING.getKey(), ReplicationType.DOCUMENT)
             .build();
         request = new CreateIndexClusterStateUpdateRequest("create index", "test", "test");
-        request.settings(matchingReplicationIndexSettings);
+        request.settings(nonMatchingReplicationIndexSettings);
         IndexCreationException exception = expectThrows(
             IndexCreationException.class,
             () -> aggregateIndexSettings(
@@ -1271,10 +1271,10 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
         );
         assertEquals(REPLICATION_MISMATCH_VALIDATION_ERROR, exception.getCause().getMessage());
 
-        Settings nonMatchingReplicationIndexSettings = Settings.builder()
+        Settings matchingReplicationIndexSettings = Settings.builder()
             .put(INDEX_REPLICATION_TYPE_SETTING.getKey(), ReplicationType.SEGMENT)
             .build();
-        request.settings(nonMatchingReplicationIndexSettings);
+        request.settings(matchingReplicationIndexSettings);
         Settings aggregateIndexSettings = aggregateIndexSettings(
             ClusterState.EMPTY_STATE,
             request,


### PR DESCRIPTION
### Description
Introduces node level cluster setting `cluster.index.restrict.replication.type` to restrict setting replication type setting at index level

### Related Issues
Resolves #https://github.com/opensearch-project/OpenSearch/issues/11457

### Documentation Issue
https://github.com/opensearch-project/documentation-website/issues/5806

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
