### PR TITLE
[Backport 2.x] Automatically add scheme to discovery.ec2.endpoint (#11512)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Change error message when per shard document limit is breached ([#11312](https://github.com/opensearch-project/OpenSearch/pull/11312))
 - Improve boolean parsing performance ([#11308](https://github.com/opensearch-project/OpenSearch/pull/11308))
 - Interpret byte array as primitive using VarHandles ([#11362](https://github.com/opensearch-project/OpenSearch/pull/11362))
+- Automatically add scheme to discovery.ec2.endpoint ([#11512](https://github.com/opensearch-project/OpenSearch/pull/11512))
 - Restore support for Java 8 for RestClient ([#11562](https://github.com/opensearch-project/OpenSearch/pull/11562))
 
 ### Deprecated

--- a/plugins/discovery-ec2/src/main/java/org/opensearch/discovery/ec2/AwsEc2ServiceImpl.java
+++ b/plugins/discovery-ec2/src/main/java/org/opensearch/discovery/ec2/AwsEc2ServiceImpl.java
@@ -99,7 +99,7 @@ class AwsEc2ServiceImpl implements AwsEc2Service {
 
         if (Strings.hasText(endpoint)) {
             logger.debug("using explicit ec2 endpoint [{}]", endpoint);
-            builder.endpointOverride(URI.create(endpoint));
+            builder.endpointOverride(URI.create(getFullEndpoint(endpoint)));
         }
 
         if (Strings.hasText(region)) {
@@ -108,6 +108,19 @@ class AwsEc2ServiceImpl implements AwsEc2Service {
         }
 
         return SocketAccess.doPrivileged(builder::build);
+    }
+
+    protected String getFullEndpoint(String endpoint) {
+        if (!Strings.hasText(endpoint)) {
+            return null;
+        }
+        if (endpoint.startsWith("http")) {
+            return endpoint;
+        }
+
+        // if no scheme is provided, default to https
+        logger.debug("no scheme found in endpoint [{}], defaulting to https", endpoint);
+        return "https://" + endpoint;
     }
 
     static ProxyConfiguration buildProxyConfiguration(Logger logger, Ec2ClientSettings clientSettings) {

--- a/plugins/discovery-ec2/src/test/java/org/opensearch/discovery/ec2/AwsEc2ServiceImplTests.java
+++ b/plugins/discovery-ec2/src/test/java/org/opensearch/discovery/ec2/AwsEc2ServiceImplTests.java
@@ -202,4 +202,26 @@ public class AwsEc2ServiceImplTests extends AbstractEc2DiscoveryTestCase {
         assertTrue(clientOverrideConfiguration.retryPolicy().isPresent());
         assertThat(clientOverrideConfiguration.retryPolicy().get().numRetries(), is(10));
     }
+
+    public void testGetFullEndpointWithScheme() {
+        final Settings settings = Settings.builder().put("discovery.ec2.endpoint", "http://ec2.us-west-2.amazonaws.com").build();
+        Ec2ClientSettings clientSettings = Ec2ClientSettings.getClientSettings(settings);
+
+        AwsEc2ServiceImpl awsEc2ServiceImpl = new AwsEc2ServiceImpl();
+
+        String endpoint = awsEc2ServiceImpl.getFullEndpoint(clientSettings.endpoint);
+        assertEquals("http://ec2.us-west-2.amazonaws.com", endpoint);
+    }
+
+    public void testGetFullEndpointWithoutScheme() {
+        final Settings settings = Settings.builder().put("discovery.ec2.endpoint", "ec2.us-west-2.amazonaws.com").build();
+        Ec2ClientSettings clientSettings = Ec2ClientSettings.getClientSettings(settings);
+
+        AwsEc2ServiceImpl awsEc2ServiceImpl = new AwsEc2ServiceImpl();
+
+        String endpoint = awsEc2ServiceImpl.getFullEndpoint(clientSettings.endpoint);
+        assertEquals("https://ec2.us-west-2.amazonaws.com", endpoint);
+
+        assertNull(awsEc2ServiceImpl.getFullEndpoint(""));
+    }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fix the problem that `discovery.ec2.endpoint` forgets to fill in the scheme
https://docs.aws.amazon.com/general/latest/gr/rande.html#ec2_region

Example
```
discovery.ec2.endpoint: ec2.us-east-1.amazonaws.com
```


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [ ] ~Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))~
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
 - [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
