### PR TITLE
[Backport 1.x] Maintainer approval check (#11378)

### DIFF
--- a/.github/workflows/maintainer-approval.yml
+++ b/.github/workflows/maintainer-approval.yml
@@ -1,0 +1,33 @@
+name: Maintainers approval
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  maintainer-approved-check:
+    name: Minimum approval count
+    runs-on: ubuntu-latest
+    steps:
+      - id: find-maintainers
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          result-encoding: string
+          script: |
+            // Get the collaborators - filtered to maintainer permissions
+            const maintainersResponse = await github.request('GET /repos/{owner}/{repo}/collaborators', {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                permission: 'maintain',
+                affiliation: 'all',
+                per_page: 100
+            });
+
+            return maintainersResponse.data.map(item => item.login).join(', ');
+
+      - uses: peternied/required-approval@v1.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-required: 1
+          required-approvers-list: ${{ steps.find-maintainers.outputs.result }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased 1.x]
 ### Added
+- Maintainer approval check ([#11378](https://github.com/opensearch-project/OpenSearch/pull/11378))
+
 ### Dependencies
 - Bump `netty` from 4.1.96.Final to 4.1.97.Final ([#9553](https://github.com/opensearch-project/OpenSearch/pull/9553))
 - Bump `netty` from 4.1.100.Final to 4.1.101.Final ([#11294](https://github.com/opensearch-project/OpenSearch/pull/11294))


### PR DESCRIPTION
### Description
Maintainer approval check (#11378)

Signed-off-by: Peter Nied <petern@amazon.com>
Signed-off-by: Peter Nied <peternied@hotmail.com>
(cherry picked from commit 87b30118673db54611078b3a8aaede20082ff59a)

### Related Issues
- Related https://github.com/opensearch-project/OpenSearch/pull/11598

### Check List
- [ ] ~New functionality includes testing.~
  - [ ] ~All tests pass~
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [X] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
