### PR TITLE
Fix flaky test RemoteIndexPrimaryRelocationIT

### DIFF
--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -3442,12 +3442,13 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                     + primaryContext
                     + "]";
         } else {
-            assert getLocalCheckpoint() == primaryContext.getCheckpointStates().get(routingEntry().allocationId().getId()).getLocalCheckpoint()
-                || indexSettings().getTranslogDurability() == Durability.ASYNC : "local checkpoint ["
-                + getLocalCheckpoint()
-                + "] does not match checkpoint from primary context ["
-                + primaryContext
-                + "]";
+            assert getLocalCheckpoint() == primaryContext.getCheckpointStates()
+                .get(routingEntry().allocationId().getId())
+                .getLocalCheckpoint() || indexSettings().getTranslogDurability() == Durability.ASYNC : "local checkpoint ["
+                    + getLocalCheckpoint()
+                    + "] does not match checkpoint from primary context ["
+                    + primaryContext
+                    + "]";
         }
         synchronized (mutex) {
             replicationTracker.activateWithPrimaryContext(primaryContext); // make changes to primaryMode flag only under mutex

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -3433,12 +3433,6 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             + "] does not contain relocation target ["
             + routingEntry()
             + "]";
-        assert getLocalCheckpoint() >= primaryContext.getCheckpointStates().get(routingEntry().allocationId().getId()).getLocalCheckpoint()
-            || indexSettings().getTranslogDurability() == Durability.ASYNC : "local checkpoint ["
-                + getLocalCheckpoint()
-                + "] does not match checkpoint from primary context ["
-                + primaryContext
-                + "]";
         if (isRemoteStoreEnabled()) {
             assert getLocalCheckpoint() == primaryContext.getCheckpointStates()
                 .get(primaryContext.getRoutingTable().primaryShard().allocationId().getId())
@@ -3447,6 +3441,13 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                     + "] does not match checkpoint from local checkpoint of old primary for remote store backed index ["
                     + primaryContext
                     + "]";
+        } else {
+            assert getLocalCheckpoint() == primaryContext.getCheckpointStates().get(routingEntry().allocationId().getId()).getLocalCheckpoint()
+                || indexSettings().getTranslogDurability() == Durability.ASYNC : "local checkpoint ["
+                + getLocalCheckpoint()
+                + "] does not match checkpoint from primary context ["
+                + primaryContext
+                + "]";
         }
         synchronized (mutex) {
             replicationTracker.activateWithPrimaryContext(primaryContext); // make changes to primaryMode flag only under mutex


### PR DESCRIPTION
### Description
- During primary relocation, once new primary is added to the replication group, if the old primary gets the indexing requests, these requests are also forwarded to the new primary.
- New primary, post processing these indexing requests, do not update the local checkpoint and sends the older local checkpoint in the replica response. 
- Code reference where RemoteFsTranslog does not update local checkpoint in ensureSynced: https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java#L259
- The primaryContext sent from old primary to new primary in the handoff process contains map of allocation ID to local checkpoint info. This map has older checkpoint for the new primary.
- Local checkpoint of the new primary is updated during [performSegRep](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/index/shard/IndexShard.java#L883C8-L883C8) step of the relocation.
- So, when the new primary receives the primaryContext, the local checkpoint in the context vs actual checkpoint differs, failing [this](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/index/shard/IndexShard.java#L3436) assertion.
- In this bugfix, we compare the local checkpoint of new primary with that of old primary for remote backed indexes.

### Related Issues
- https://github.com/opensearch-project/OpenSearch/issues/9191

### Check List
- [ ] ~New functionality includes testing.~
  - [ ] ~All tests pass~
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [ ] ~Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))~
- [x] Commits are signed per the DCO using --signoff
- [ ] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
