### PR TITLE
Add option to set user for test cluster to perform initial health checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [BWC and API enforcement] Introduce checks for enforcing the API restrictions ([#11175](https://github.com/opensearch-project/OpenSearch/pull/11175))
 - Create separate transport action for render search template action ([#11170](https://github.com/opensearch-project/OpenSearch/pull/11170))
 - Add additional handling in SearchTemplateRequest when simulate is set to true ([#11591](https://github.com/opensearch-project/OpenSearch/pull/11591))
+- Add option to set user for test cluster to perform health checks during run with security enabled ([#11641](https://github.com/opensearch-project/OpenSearch/pull/11641))
 
 ### Dependencies
 - Bump Lucene from 9.7.0 to 9.8.0 ([10276](https://github.com/opensearch-project/OpenSearch/pull/10276))

--- a/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchNode.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchNode.java
@@ -483,16 +483,16 @@ public class OpenSearchNode implements TestClusterConfiguration {
     @Override
     public synchronized void start() {
         LOGGER.info("Starting `{}`", this);
-        if (System.getProperty("tests.opensearch.secure") != null
-            && System.getProperty("tests.opensearch.secure").equalsIgnoreCase("true")) {
+        if (System.getProperty("tests.secure") != null
+            && System.getProperty("tests.secure").equalsIgnoreCase("true")) {
             secure = true;
         }
-        if (System.getProperty("tests.opensearch.username") != null) {
-            this.credentials.get(0).put("username", System.getProperty("tests.opensearch.username"));
+        if (System.getProperty("tests.username") != null) {
+            this.credentials.get(0).put("username", System.getProperty("tests.username"));
             LOGGER.info("Overwriting username to: " + this.getCredentials().get(0).get("username"));
         }
-        if (System.getProperty("tests.opensearch.password") != null) {
-            this.credentials.get(0).put("password", System.getProperty("tests.opensearch.password"));
+        if (System.getProperty("tests.password") != null) {
+            this.credentials.get(0).put("password", System.getProperty("tests.password"));
             LOGGER.info("Overwriting password to: " + this.getCredentials().get(0).get("password"));
         }
         if (Files.exists(getExtractedDistributionDir()) == false) {

--- a/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchNode.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchNode.java
@@ -483,16 +483,16 @@ public class OpenSearchNode implements TestClusterConfiguration {
     @Override
     public synchronized void start() {
         LOGGER.info("Starting `{}`", this);
-        if (System.getProperty("tests.secure") != null
-            && System.getProperty("tests.secure").equalsIgnoreCase("true")) {
+        if (System.getProperty("tests.opensearch.secure") != null
+            && System.getProperty("tests.opensearch.secure").equalsIgnoreCase("true")) {
             secure = true;
         }
-        if (System.getProperty("tests.username") != null) {
-            this.credentials.get(0).put("username", System.getProperty("tests.username"));
+        if (System.getProperty("tests.opensearch.username") != null) {
+            this.credentials.get(0).put("username", System.getProperty("tests.opensearch.username"));
             LOGGER.info("Overwriting username to: " + this.getCredentials().get(0).get("username"));
         }
-        if (System.getProperty("tests.password") != null) {
-            this.credentials.get(0).put("password", System.getProperty("tests.password"));
+        if (System.getProperty("tests.opensearch.password") != null) {
+            this.credentials.get(0).put("password", System.getProperty("tests.opensearch.password"));
             LOGGER.info("Overwriting password to: " + this.getCredentials().get(0).get("password"));
         }
         if (Files.exists(getExtractedDistributionDir()) == false) {

--- a/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchNode.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchNode.java
@@ -710,7 +710,7 @@ public class OpenSearchNode implements TestClusterConfiguration {
 
         if (userSpec.containsKey("username") && userSpec.containsKey("password")) {
             this.credentials.get(0).put("username", userSpec.get("username"));
-            this.credentials.get(0).put("password",  userSpec.get("password"));
+            this.credentials.get(0).put("password", userSpec.get("password"));
             return;
         }
 

--- a/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchNode.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchNode.java
@@ -703,7 +703,24 @@ public class OpenSearchNode implements TestClusterConfiguration {
     }
 
     @Override
-    public void user(Map<String, String> userSpec) {}
+    public void user(Map<String, String> userSpec) {
+        if (userSpec == null) {
+            return;
+        }
+
+        if (userSpec.containsKey("username") && userSpec.containsKey("password")) {
+            this.credentials.get(0).put("username", userSpec.get("username"));
+            this.credentials.get(0).put("password",  userSpec.get("password"));
+            return;
+        }
+
+        if (!userSpec.containsKey("username")) {
+            LOGGER.warn("Unable to set user. userSpec must contain username.");
+        }
+        if (!userSpec.containsKey("password")) {
+            LOGGER.warn("Unable to set user. userSpec must contain password.");
+        }
+    }
 
     private void runOpenSearchBinScriptWithInput(String input, String tool, CharSequence... args) {
         if (Files.exists(getDistroDir().resolve("bin").resolve(tool)) == false


### PR DESCRIPTION
### Description
I am working on adding gradle task for spinning up k-NN+security plugin for integration testing and debugging: https://github.com/opensearch-project/k-NN/pull/1307. Ive been able to get the cluster to come up and pass the health check for the `integTest` task, but for `run` had been failing for awhile with a 401 during the wait for yellow health check: https://github.com/opensearch-project/OpenSearch/blob/main/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchCluster.java#L559:
```
/gradlew run -Dsecurity.enabled=true --info
...
* Where:
Build file 'k-NN-1/build.gradle' line: 407

* What went wrong:
Execution failed for task ':run'.
> `cluster{::integTest}` failed to wait for cluster health yellow after 40 SECONDS
    IO error while waiting cluster
    401 Unauthorized

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

```

The problem is that it was unable to get the username and password from the credentials. These are set during Node start here: https://github.com/opensearch-project/OpenSearch/blob/main/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchNode.java#L485-L497. These need to be set via system properties and cannot be passed via cluster.systemProperty call. So, I modified my task to run:
```
task setCorrectSystemProperties {
    System.setProperty("tests.opensearch.secure", "true")
    System.setProperty("tests.opensearch.username", "admin")
    System.setProperty("tests.opensearch.password", "admin")
}

run {
    useCluster project.testClusters.integTest
    dependsOn buildJniLib, setCorrectSystemProperties

    doFirst {
        // There seems to be an issue when running multi node run or integ tasks with unicast_hosts
        // not being written, the waitForAllConditions ensures it's written
        getClusters().forEach { cluster ->
            cluster.waitForAllConditions()
        }
    }
}
```

However, I get the following error: 
```
=== Standard error of node `node{::integTest-0}` ===
»   ↓ last 40 non error or warning messages from k-NN-1/build/testclusters/integTest-0/logs/opensearch.stderr.log ↓
» uncaught exception in thread [main]
»  SettingsException[unknown setting [secure] please check that any required plugins are installed, or check the breaking changes documentation for removed settings]
»       at org.opensearch.common.settings.AbstractScopedSettings.validate(AbstractScopedSettings.java:606)
»       at org.opensearch.common.settings.AbstractScopedSettings.validate(AbstractScopedSettings.java:547)
»       at org.opensearch.common.settings.AbstractScopedSettings.validate(AbstractScopedSettings.java:517)
»       at org.opensearch.common.settings.AbstractScopedSettings.validate(AbstractScopedSettings.java:487)
»       at org.opensearch.common.settings.SettingsModule.<init>(SettingsModule.java:178)
»       at org.opensearch.node.Node.<init>(Node.java:580)
»       at org.opensearch.node.Node.<init>(Node.java:410)
»       at org.opensearch.bootstrap.Bootstrap$5.<init>(Bootstrap.java:242)
»       at org.opensearch.bootstrap.Bootstrap.setup(Bootstrap.java:242)
»       at org.opensearch.bootstrap.Bootstrap.init(Bootstrap.java:404)
»       at org.opensearch.bootstrap.OpenSearch.init(OpenSearch.java:180)
»       at org.opensearch.bootstrap.OpenSearch.execute(OpenSearch.java:171)
»       at org.opensearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:104)
»       at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
»       at org.opensearch.cli.Command.main(Command.java:101)
»       at org.opensearch.bootstrap.OpenSearch.main(OpenSearch.java:137)
»       at org.opensearch.bootstrap.OpenSearch.main(OpenSearch.java:103)
»  For complete error details, refer to the log at k-NN-1/build/testclusters/integTest-0/logs/integTest.log
```

This is because in the `RunTask`, it will pass any system properties with the prefix `tests.opensearch` as settings to the nodes: https://github.com/opensearch-project/OpenSearch/blob/main/buildSrc/src/main/java/org/opensearch/gradle/testclusters/RunTask.java#L143-L152. This is documented here: https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md#run-opensearch.

**EDIT**

I updated the PR to implement the `user` option in [OpenSearchNode](https://github.com/opensearch-project/OpenSearch/blob/main/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchNode.java#L706). When a user passes in a UserSpec map with "username" and "password" keys, they will be set for the initial credentials. I validated this works for `gradlew run` for my change in k-NN.

I am not sure if this is the correct solution or not and wanted to get feedback. A few alternatives I could think of:
1. Make these properties settable via cluster.systemProperty - not sure this information is required inside the node environment
2. Create setters on cluster to directly set credentials - seems cluster.setCredentials would be misleading. Maybe something like cluster.setCredentialsForHealthCheck, but this may be limiting.
3. Renaming system property to read the credentials from so they are not prefixed with "tests.opensearch"

@scrawfor99 @cwperks let me know if you have any thoughts.

### Related Issues
Resolves #11219
Related change: #8900 

### Check List
- [ ] ~New functionality includes testing.~
- [ ] ~All tests pass~
- [ ] ~New functionality has been documented.~
- [ ] ~New functionality has javadoc added~
- [X] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
