### PR TITLE
reproducer #11138 Date formatting bug on sorting missing dates

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/331_distributed_sort_basic_date_missing.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/331_distributed_sort_basic_date_missing.yml
@@ -1,0 +1,42 @@
+setup:
+  - do:
+      indices.create:
+          index: index_1
+          body:
+            settings:
+              number_of_shards: 1
+            mappings:
+              properties:
+                created_at:
+                   type: date
+                   #format: "strict_date" - passed ok
+                   format: "basic_date" ## failed with "java.time.DateTimeException: Field Year cannot be printed as the value -292275055 exceeds the maximum print width of 4"
+
+---
+"test sorting missing basic_* format":
+
+  - skip:
+      version:  " - 7.6.99" # TODO ????
+      reason:   "distributed sort optimization was added in 7.7.0"
+  - do:
+      index:
+        index: index_1
+        id: 1
+        body: { "created_at": "20160101"} #strict "2016-01-01"
+  - do:
+      index:
+        index: index_1
+        id: 2
+        body: { "name": "foo" }
+
+  - do:
+      indices.refresh: {}
+
+  # check that empty responses are correctly handled when rewriting to match_no_docs
+  - do:
+      search:
+        # ensure that one shard can return empty response
+        max_concurrent_shard_requests: 1
+        body: { "size" : 2, "sort": { "created_at": {"order":"desc"}} }
+
+  - match: { hits.total.value: 2 }

--- a/server/src/test/java/org/opensearch/common/time/DateFormattersTests.java
+++ b/server/src/test/java/org/opensearch/common/time/DateFormattersTests.java
@@ -683,4 +683,14 @@ public class DateFormattersTests extends OpenSearchTestCase {
             }
         }
     }
+
+    public void testMissingDateMaxValFormat() {
+        DateFormatter formatter = DateFormatters.forPattern("basic_date_time_no_millis");
+        formatter.formatMillis(Long.MAX_VALUE);
+    }
+
+    public void testMissingDateMinValFormat() {
+        DateFormatter formatter = DateFormatters.forPattern("basic_date_time_no_millis");
+        formatter.formatMillis(Long.MIN_VALUE);
+    }
 }


### PR DESCRIPTION
when sorting by date column, missing values transferred as Long.MIN/MAX_VAL see IndexFieldData.XFieldComparatorSource.missingObject() When this value formatted for merging in coordinator it hit the error.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Starting with reproducing Long.MIN_VAL formatting bug.

### Related Issues
Resolves #11138
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
