### PR TITLE
Change visibility of action constructor (public -> private)

### DIFF
--- a/server/src/main/java/org/opensearch/action/admin/cluster/remote/RemoteInfoAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/remote/RemoteInfoAction.java
@@ -44,7 +44,7 @@ public final class RemoteInfoAction extends ActionType<RemoteInfoResponse> {
     public static final String NAME = "cluster:monitor/remote/info";
     public static final RemoteInfoAction INSTANCE = new RemoteInfoAction();
 
-    public RemoteInfoAction() {
+    private RemoteInfoAction() {
         super(NAME, RemoteInfoResponse::new);
     }
 }

--- a/server/src/main/java/org/opensearch/action/main/MainAction.java
+++ b/server/src/main/java/org/opensearch/action/main/MainAction.java
@@ -44,7 +44,7 @@ public class MainAction extends ActionType<MainResponse> {
     public static final String NAME = "cluster:monitor/main";
     public static final MainAction INSTANCE = new MainAction();
 
-    public MainAction() {
+    private MainAction() {
         super(NAME, MainResponse::new);
     }
 }


### PR DESCRIPTION
### Description

Change access modifier of action constructors for consistency.

- MainAction
- RemoteInfoAction

### Related Issues

None

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
