### PR TITLE
Fix flaky testPostFilterDisablesCountOptimization with concurrent search enabled

### DIFF
--- a/server/src/test/java/org/opensearch/search/query/QueryProfilePhaseTests.java
+++ b/server/src/test/java/org/opensearch/search/query/QueryProfilePhaseTests.java
@@ -1401,12 +1401,22 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
             assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("score_count"), greaterThanOrEqualTo(6L));
             if (executor != null) {
-                assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
-                assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
-                assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
-                assertThat(query.getTimeBreakdown().get("max_score_count"), greaterThanOrEqualTo(6L));
-                assertThat(query.getTimeBreakdown().get("min_score_count"), greaterThanOrEqualTo(2L));
-                assertThat(query.getTimeBreakdown().get("avg_score_count"), greaterThanOrEqualTo(6L));
+                long maxScore = query.getTimeBreakdown().get("max_score");
+                long minScore = query.getTimeBreakdown().get("min_score");
+                long avgScore = query.getTimeBreakdown().get("avg_score");
+                long maxScoreCount = query.getTimeBreakdown().get("max_score_count");
+                long minScoreCount = query.getTimeBreakdown().get("min_score_count");
+                long avgScoreCount = query.getTimeBreakdown().get("avg_score_count");
+                assertThat(maxScore, greaterThan(0L));
+                assertThat(minScore, greaterThan(0L));
+                assertThat(avgScore, greaterThan(0L));
+                assertThat(maxScore, greaterThanOrEqualTo(avgScore));
+                assertThat(avgScore, greaterThanOrEqualTo(minScore));
+                assertThat(maxScoreCount, greaterThan(0L));
+                assertThat(minScoreCount, greaterThan(0L));
+                assertThat(avgScoreCount, greaterThan(0L));
+                assertThat(maxScoreCount, greaterThanOrEqualTo(avgScoreCount));
+                assertThat(avgScoreCount, greaterThanOrEqualTo(minScoreCount));
             }
             assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
@@ -1436,12 +1446,22 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
             assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("score_count"), greaterThanOrEqualTo(6L));
             if (executor != null) {
-                assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
-                assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
-                assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
-                assertThat(query.getTimeBreakdown().get("max_score_count"), greaterThanOrEqualTo(6L));
-                assertThat(query.getTimeBreakdown().get("min_score_count"), greaterThanOrEqualTo(2L));
-                assertThat(query.getTimeBreakdown().get("avg_score_count"), greaterThanOrEqualTo(6L));
+                long maxScore = query.getTimeBreakdown().get("max_score");
+                long minScore = query.getTimeBreakdown().get("min_score");
+                long avgScore = query.getTimeBreakdown().get("avg_score");
+                long maxScoreCount = query.getTimeBreakdown().get("max_score_count");
+                long minScoreCount = query.getTimeBreakdown().get("min_score_count");
+                long avgScoreCount = query.getTimeBreakdown().get("avg_score_count");
+                assertThat(maxScore, greaterThan(0L));
+                assertThat(minScore, greaterThan(0L));
+                assertThat(avgScore, greaterThan(0L));
+                assertThat(maxScore, greaterThanOrEqualTo(avgScore));
+                assertThat(avgScore, greaterThanOrEqualTo(minScore));
+                assertThat(maxScoreCount, greaterThan(0L));
+                assertThat(minScoreCount, greaterThan(0L));
+                assertThat(avgScoreCount, greaterThan(0L));
+                assertThat(maxScoreCount, greaterThanOrEqualTo(avgScoreCount));
+                assertThat(avgScoreCount, greaterThanOrEqualTo(minScoreCount));
             }
             assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
             assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This flaky test uses `RandomIndexWriter` to add random number of documents to the search index. As long as the score_count in the concurrent search case matches the non-concurrent search case, we can tune the expected value for min_score/min_score_count to make it less sensitive. I ran the new changes `1000+` times to make sure that they all passed.

### Related Issues
Resolves #10139
<!-- List any other related issues here -->

### Check List
- [ ] ~New functionality includes testing.~
  - [X] All tests pass
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [ ] ~Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))~
- [X] Commits are signed per the DCO using --signoff
- [ ] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
