### PR TITLE
Fix SimpleNestedIT.testExplain flaky test

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/nested/SimpleNestedExplainIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/nested/SimpleNestedExplainIT.java
@@ -1,0 +1,121 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.nested;
+
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.join.ScoreMode;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
+import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.opensearch.index.query.QueryBuilders.nestedQuery;
+import static org.opensearch.index.query.QueryBuilders.termQuery;
+import static org.opensearch.search.SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertNoFailures;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Creating a separate class with no parameterization to create and index documents in a single
+ * test run and compare search responses across concurrent and non-concurrent search. For more details,
+ * refer: https://github.com/opensearch-project/OpenSearch/issues/11413
+ */
+public class SimpleNestedExplainIT extends OpenSearchIntegTestCase {
+
+    @Override
+    protected Settings featureFlagSettings() {
+        return Settings.builder().put(super.featureFlagSettings()).put(FeatureFlags.CONCURRENT_SEGMENT_SEARCH, "true").build();
+    }
+
+    /*
+     * Tests the explain output for multiple docs. Concurrent search with multiple slices is tested
+     * here as call to indexRandomForMultipleSlices is made and compared with explain output for
+     * non-concurrent search use-case. Separate test class is created to test explain for 1 slice
+     * case in concurrent search, refer {@link SimpleExplainIT#testExplainWithSingleDoc}
+     * For more details, refer: https://github.com/opensearch-project/OpenSearch/issues/11413
+     * */
+    public void testExplainMultipleDocs() throws Exception {
+        assertAcked(
+            prepareCreate("test").setMapping(
+                jsonBuilder().startObject()
+                    .startObject("properties")
+                    .startObject("nested1")
+                    .field("type", "nested")
+                    .endObject()
+                    .endObject()
+                    .endObject()
+            )
+        );
+
+        ensureGreen();
+
+        client().prepareIndex("test")
+            .setId("1")
+            .setSource(
+                jsonBuilder().startObject()
+                    .field("field1", "value1")
+                    .startArray("nested1")
+                    .startObject()
+                    .field("n_field1", "n_value1")
+                    .endObject()
+                    .startObject()
+                    .field("n_field1", "n_value1")
+                    .endObject()
+                    .endArray()
+                    .endObject()
+            )
+            .setRefreshPolicy(IMMEDIATE)
+            .get();
+
+        indexRandomForMultipleSlices("test");
+
+        // Turn off the concurrent search setting to test search with non-concurrent search
+        client().admin()
+            .cluster()
+            .prepareUpdateSettings()
+            .setPersistentSettings(Settings.builder().put(CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING.getKey(), false).build())
+            .get();
+
+        SearchResponse nonConSearchResp = client().prepareSearch("test")
+            .setQuery(nestedQuery("nested1", termQuery("nested1.n_field1", "n_value1"), ScoreMode.Total))
+            .setExplain(true)
+            .get();
+        assertNoFailures(nonConSearchResp);
+        assertThat(nonConSearchResp.getHits().getTotalHits().value, equalTo(1L));
+        Explanation nonConSearchExplain = nonConSearchResp.getHits().getHits()[0].getExplanation();
+        assertThat(nonConSearchExplain.getValue(), equalTo(nonConSearchResp.getHits().getHits()[0].getScore()));
+
+        // Turn on the concurrent search setting to test search with concurrent search
+        client().admin()
+            .cluster()
+            .prepareUpdateSettings()
+            .setPersistentSettings(Settings.builder().put(CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING.getKey(), true).build())
+            .get();
+
+        SearchResponse conSearchResp = client().prepareSearch("test")
+            .setQuery(nestedQuery("nested1", termQuery("nested1.n_field1", "n_value1"), ScoreMode.Total))
+            .setExplain(true)
+            .get();
+        assertNoFailures(conSearchResp);
+        assertThat(conSearchResp.getHits().getTotalHits().value, equalTo(1L));
+        Explanation conSearchExplain = conSearchResp.getHits().getHits()[0].getExplanation();
+        assertThat(conSearchExplain.getValue(), equalTo(conSearchResp.getHits().getHits()[0].getScore()));
+
+        // assert that the explanation for concurrent search should be equal to the non-concurrent search's explanation
+        assertEquals(nonConSearchExplain, conSearchExplain);
+        client().admin()
+            .cluster()
+            .prepareUpdateSettings()
+            .setPersistentSettings(Settings.builder().putNull(CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING.getKey()).build())
+            .get();
+    }
+}

--- a/server/src/internalClusterTest/java/org/opensearch/search/nested/SimpleNestedIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/nested/SimpleNestedIT.java
@@ -455,7 +455,13 @@ public class SimpleNestedIT extends ParameterizedOpenSearchIntegTestCase {
         assertDocumentCount("test", 6);
     }
 
-    public void testExplain() throws Exception {
+    /*
+    * Tests the explain output for single doc. Concurrent search with only slice 1 is tested
+    * here as call to indexRandomForMultipleSlices has implications on the range of child docs
+    * in the explain output. Separate test class is created to test explain for multiple slices
+    * case in concurrent search, refer {@link SimpleNestedExplainIT}
+    * */
+    public void testExplainWithSingleDoc() throws Exception {
         assertAcked(
             prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
@@ -487,7 +493,6 @@ public class SimpleNestedIT extends ParameterizedOpenSearchIntegTestCase {
             )
             .setRefreshPolicy(IMMEDIATE)
             .get();
-        indexRandomForConcurrentSearch("test");
 
         SearchResponse searchResponse = client().prepareSearch("test")
             .setQuery(nestedQuery("nested1", termQuery("nested1.n_field1", "n_value1"), ScoreMode.Total))


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The explain itself is coming from Lucene: https://github.com/apache/lucene/blob/a6f70ad2bb0b682eb65feb522358ee6d16cad766/lucene/join/src/java/org/apache/lucene/search/join/ToParentBlockJoinQuery.java#L432-L440

Here's some info on the docIds in lucene:
- A DocId in lucene is not actually unique to the Index but is unique to a Segment. Lucene does this mainly to optimize writing and compression. Since it is only unique to a Segment, how can a Doc be uniquely identified at the Index level? The solution is simple. The segments are ordered. To take a simple example, an Index has two segments and each segment has 100 docs respectively. The DocId's in the Segment are 0-100 but when they are converted to the Index level, the range of the DocId's in the second Segment is converted to 100-200.

- DocId's are unique within a Segment, numbered progressively from zero. But this does not mean that the DocId's are continuous. When a Doc is deleted, there is a gap.

- The DocId corresponding to a document can change, usually when Segments are merged.

The test fails on the validation of range of the docIds in the assertion, the range changes as with indexRandomForConcurrentSearch function there are several bogus documents ingested and deleted which could trigger background merges and cause the range of the docIds matched with the search query to change.

One of the solutions is to call refresh after indexing the actual document which would create a new segment for the actual document and prevent it to be merged with the bogus documents, this is done as part of this PR.

### Related Issues
Resolves #11413


### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
