### PR TITLE
Fix flaky QueryProfilePhaseTests.testTerminateAfterEarlyTermination

### DIFF
--- a/server/src/test/java/org/opensearch/search/query/QueryProfilePhaseTests.java
+++ b/server/src/test/java/org/opensearch/search/query/QueryProfilePhaseTests.java
@@ -615,12 +615,22 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
                 assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("score_count"), greaterThan(0L));
                 if (executor != null) {
-                    assertThat(query.getTimeBreakdown().get("max_score"), greaterThan(0L));
-                    assertThat(query.getTimeBreakdown().get("min_score"), greaterThan(0L));
-                    assertThat(query.getTimeBreakdown().get("avg_score"), greaterThan(0L));
-                    assertThat(query.getTimeBreakdown().get("max_score_count"), greaterThan(0L));
-                    assertThat(query.getTimeBreakdown().get("min_score_count"), greaterThan(0L));
-                    assertThat(query.getTimeBreakdown().get("avg_score_count"), greaterThan(0L));
+                    long maxScore = query.getTimeBreakdown().get("max_score");
+                    long minScore = query.getTimeBreakdown().get("min_score");
+                    long avgScore = query.getTimeBreakdown().get("avg_score");
+                    long maxScoreCount = query.getTimeBreakdown().get("max_score_count");
+                    long minScoreCount = query.getTimeBreakdown().get("min_score_count");
+                    long avgScoreCount = query.getTimeBreakdown().get("avg_score_count");
+                    assertThat(maxScore, greaterThan(0L));
+                    assertThat(minScore, greaterThanOrEqualTo(0L));
+                    assertThat(avgScore, greaterThanOrEqualTo(0L));
+                    assertThat(maxScore, greaterThanOrEqualTo(avgScore));
+                    assertThat(avgScore, greaterThanOrEqualTo(minScore));
+                    assertThat(maxScoreCount, greaterThan(0L));
+                    assertThat(minScoreCount, greaterThanOrEqualTo(0L));
+                    assertThat(avgScoreCount, greaterThanOrEqualTo(0L));
+                    assertThat(maxScoreCount, greaterThanOrEqualTo(avgScoreCount));
+                    assertThat(avgScoreCount, greaterThanOrEqualTo(minScoreCount));
                 }
                 assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
                 assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
@@ -744,30 +754,50 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
                 assertThat(query.getProfiledChildren().get(0).getTime(), greaterThan(0L));
                 assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight"), greaterThan(0L));
                 assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
-                assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("score"), greaterThan(0L));
-                assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("score_count"), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("score"), greaterThanOrEqualTo(0L));
+                assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("score_count"), greaterThanOrEqualTo(0L));
                 if (executor != null) {
-                    assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("max_score"), greaterThan(0L));
-                    assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("min_score"), greaterThan(0L));
-                    assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("avg_score"), greaterThan(0L));
-                    assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("max_score_count"), greaterThan(0L));
-                    assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("min_score_count"), greaterThan(0L));
-                    assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("avg_score_count"), greaterThan(0L));
+                    long maxScore = query.getProfiledChildren().get(0).getTimeBreakdown().get("max_score");
+                    long minScore = query.getProfiledChildren().get(0).getTimeBreakdown().get("min_score");
+                    long avgScore = query.getProfiledChildren().get(0).getTimeBreakdown().get("avg_score");
+                    long maxScoreCount = query.getProfiledChildren().get(0).getTimeBreakdown().get("max_score_count");
+                    long minScoreCount = query.getProfiledChildren().get(0).getTimeBreakdown().get("min_score_count");
+                    long avgScoreCount = query.getProfiledChildren().get(0).getTimeBreakdown().get("avg_score_count");
+                    assertThat(maxScore, greaterThanOrEqualTo(0L));
+                    assertThat(minScore, greaterThanOrEqualTo(0L));
+                    assertThat(avgScore, greaterThanOrEqualTo(0L));
+                    assertThat(maxScore, greaterThanOrEqualTo(avgScore));
+                    assertThat(avgScore, greaterThanOrEqualTo(minScore));
+                    assertThat(maxScoreCount, greaterThanOrEqualTo(0L));
+                    assertThat(minScoreCount, greaterThanOrEqualTo(0L));
+                    assertThat(avgScoreCount, greaterThanOrEqualTo(0L));
+                    assertThat(maxScoreCount, greaterThanOrEqualTo(avgScoreCount));
+                    assertThat(avgScoreCount, greaterThanOrEqualTo(minScoreCount));
                 }
 
                 assertThat(query.getProfiledChildren().get(1).getQueryName(), equalTo("TermQuery"));
                 assertThat(query.getProfiledChildren().get(1).getTime(), greaterThan(0L));
                 assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("create_weight"), greaterThan(0L));
                 assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
-                assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("score"), greaterThan(0L));
-                assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("score_count"), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("score"), greaterThanOrEqualTo(0L));
+                assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("score_count"), greaterThanOrEqualTo(0L));
                 if (executor != null) {
-                    assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("max_score"), greaterThan(0L));
-                    assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("min_score"), greaterThan(0L));
-                    assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("avg_score"), greaterThan(0L));
-                    assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("max_score_count"), greaterThan(0L));
-                    assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("min_score_count"), greaterThan(0L));
-                    assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("avg_score_count"), greaterThan(0L));
+                    long maxScore = query.getProfiledChildren().get(1).getTimeBreakdown().get("max_score");
+                    long minScore = query.getProfiledChildren().get(1).getTimeBreakdown().get("min_score");
+                    long avgScore = query.getProfiledChildren().get(1).getTimeBreakdown().get("avg_score");
+                    long maxScoreCount = query.getProfiledChildren().get(1).getTimeBreakdown().get("max_score_count");
+                    long minScoreCount = query.getProfiledChildren().get(1).getTimeBreakdown().get("min_score_count");
+                    long avgScoreCount = query.getProfiledChildren().get(1).getTimeBreakdown().get("avg_score_count");
+                    assertThat(maxScore, greaterThanOrEqualTo(0L));
+                    assertThat(minScore, greaterThanOrEqualTo(0L));
+                    assertThat(avgScore, greaterThanOrEqualTo(0L));
+                    assertThat(maxScore, greaterThanOrEqualTo(avgScore));
+                    assertThat(avgScore, greaterThanOrEqualTo(minScore));
+                    assertThat(maxScoreCount, greaterThanOrEqualTo(0L));
+                    assertThat(minScoreCount, greaterThanOrEqualTo(0L));
+                    assertThat(avgScoreCount, greaterThanOrEqualTo(0L));
+                    assertThat(maxScoreCount, greaterThanOrEqualTo(avgScoreCount));
+                    assertThat(avgScoreCount, greaterThanOrEqualTo(minScoreCount));
                 }
             }, collector -> {
                 assertThat(collector.getReason(), equalTo("search_terminate_after_count"));


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
`QueryProfilePhaseTests.testTerminateAfterEarlyTermination` is flaky not only in the concurrent search case but also in the non-concurrent search case. In cases where the test query returns some total hits, it is possible that the `score` breakdown timing for certain rewritten or sub-queries is still zero. Consequently, we need to update the assertion check accordingly.
Additionally, in the concurrent search case, there is a particular scenario where some slices have zero `score` breakdown timing, while others have non-zero `score` breakdown timing. In this case, the `min_score` stat result will be expected zero. I ran the new changes `1000+` times to make sure that they all passed.

### Related Issues
Resolves #11611
<!-- List any other related issues here -->

### Check List
- [ ] ~New functionality includes testing.~
  - [X] All tests pass
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [ ] ~Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))~
- [X] Commits are signed per the DCO using --signoff
- [ ] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
