### PR TITLE
Fix issue when calling Delete PIT endpoint and no PITs exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix for stuck update action in a bulk with `retry_on_conflict` property ([#11152](https://github.com/opensearch-project/OpenSearch/issues/11152))
 - Fix template setting override for replication type ([#11417](https://github.com/opensearch-project/OpenSearch/pull/11417))
 - Fix Automatic addition of protocol broken in #11512 ([#11609](https://github.com/opensearch-project/OpenSearch/pull/11609))
+- Fix issue when calling Delete PIT endpoint and no PITs exist ([#11711](https://github.com/opensearch-project/OpenSearch/pull/11711))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/action/search/PitService.java
+++ b/server/src/main/java/org/opensearch/action/search/PitService.java
@@ -71,6 +71,7 @@ public class PitService {
     ) {
         if (nodeToContextsMap.size() == 0) {
             listener.onResponse(new DeletePitResponse(Collections.emptyList()));
+            return;
         }
         final Set<String> clusters = nodeToContextsMap.values()
             .stream()

--- a/server/src/test/java/org/opensearch/action/search/TransportDeletePitActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/TransportDeletePitActionTests.java
@@ -34,8 +34,8 @@ import org.opensearch.test.transport.MockTransportService;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.RemoteClusterConnectionTests;
 import org.opensearch.transport.Transport;
-import org.junit.Before;
 import org.opensearch.transport.TransportService;
+import org.junit.Before;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -268,19 +268,14 @@ public class TransportDeletePitActionTests extends OpenSearchTestCase {
         ActionFilters actionFilters = mock(ActionFilters.class);
         when(actionFilters.filters()).thenReturn(new ActionFilter[0]);
         List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
-        try (
-            MockTransportService cluster1Transport = startTransport("cluster_1_node", knownNodes, Version.CURRENT)
-        ) {
+        try (MockTransportService cluster1Transport = startTransport("cluster_1_node", knownNodes, Version.CURRENT)) {
             knownNodes.add(cluster1Transport.getLocalDiscoNode());
             TransportService mockTransportService = mock(TransportService.class);
             PitService pitService = new PitService(clusterServiceMock, mock(SearchTransportService.class), mockTransportService, client) {
                 @Override
                 public void getAllPits(ActionListener<GetAllPitNodesResponse> getAllPitsListener) {
                     List<ListPitInfo> list = new ArrayList<>();
-                    GetAllPitNodeResponse getAllPitNodeResponse = new GetAllPitNodeResponse(
-                        cluster1Transport.getLocalDiscoNode(),
-                        list
-                    );
+                    GetAllPitNodeResponse getAllPitNodeResponse = new GetAllPitNodeResponse(cluster1Transport.getLocalDiscoNode(), list);
                     List<GetAllPitNodeResponse> nodeList = new ArrayList();
                     nodeList.add(getAllPitNodeResponse);
                     getAllPitsListener.onResponse(new GetAllPitNodesResponse(new ClusterName("cn"), nodeList, new ArrayList()));

--- a/server/src/test/java/org/opensearch/action/search/TransportDeletePitActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/TransportDeletePitActionTests.java
@@ -21,6 +21,7 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.tasks.TaskId;
 import org.opensearch.index.query.IdsQueryBuilder;
 import org.opensearch.index.query.MatchAllQueryBuilder;
@@ -34,6 +35,7 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.RemoteClusterConnectionTests;
 import org.opensearch.transport.Transport;
 import org.junit.Before;
+import org.opensearch.transport.TransportService;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -259,6 +261,51 @@ public class TransportDeletePitActionTests extends OpenSearchTestCase {
                 assertEquals(3, deleteNodesInvoked.size());
 
             }
+        }
+    }
+
+    public void testDeleteAllPITSuccessWhenNoPITsExist() throws InterruptedException, ExecutionException {
+        ActionFilters actionFilters = mock(ActionFilters.class);
+        when(actionFilters.filters()).thenReturn(new ActionFilter[0]);
+        List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
+        try (
+            MockTransportService cluster1Transport = startTransport("cluster_1_node", knownNodes, Version.CURRENT)
+        ) {
+            knownNodes.add(cluster1Transport.getLocalDiscoNode());
+            TransportService mockTransportService = mock(TransportService.class);
+            PitService pitService = new PitService(clusterServiceMock, mock(SearchTransportService.class), mockTransportService, client) {
+                @Override
+                public void getAllPits(ActionListener<GetAllPitNodesResponse> getAllPitsListener) {
+                    List<ListPitInfo> list = new ArrayList<>();
+                    GetAllPitNodeResponse getAllPitNodeResponse = new GetAllPitNodeResponse(
+                        cluster1Transport.getLocalDiscoNode(),
+                        list
+                    );
+                    List<GetAllPitNodeResponse> nodeList = new ArrayList();
+                    nodeList.add(getAllPitNodeResponse);
+                    getAllPitsListener.onResponse(new GetAllPitNodesResponse(new ClusterName("cn"), nodeList, new ArrayList()));
+                }
+            };
+            TransportDeletePitAction action = new TransportDeletePitAction(
+                mockTransportService,
+                actionFilters,
+                namedWriteableRegistry,
+                pitService
+            );
+            DeletePitRequest deletePITRequest = new DeletePitRequest("_all");
+            ActionListener<DeletePitResponse> listener = new ActionListener<DeletePitResponse>() {
+                @Override
+                public void onResponse(DeletePitResponse deletePitResponse) {
+                    assertEquals(RestStatus.OK, deletePitResponse.status());
+                    assertEquals(0, deletePitResponse.getDeletePitResults().size());
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    fail("Should not receive Exception");
+                }
+            };
+            action.execute(task, deletePITRequest, listener);
         }
     }
 


### PR DESCRIPTION
### Description

When the DELETE PIT endpoint is called without any PITs in existence, its possible that an IllegalArgumentException (`IllegalArgumentException: groupSize must be greater than 0 but was 0`) is being swallowed and a malformed response (`{"error":{"`) can be returned. 

The opensearch logs contains the following error:

```
ERROR RestResponseListener:91 - failed to send failure response
java.lang.IllegalStateException: Channel is already closed
...
    Suppressed: java.lang.IllegalArgumentException: groupSize must be greater than 0 but was 0
```

When the DELETE PIT endpoint is called when no PITs exist, it tries to send multiple responses across the same REST channel. This PR fixes the behavior so that its no longer possible for `channel.sendResponse` to be called multiple times.

### Related Issues
- Related https://github.com/opensearch-project/security/issues/3424
- Related https://github.com/opensearch-project/security/pull/3871

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
