### PR TITLE
Fix testIndexDeletionDuringSnapshotCreationInQueue flaky test

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -1457,6 +1457,13 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
 
         clusterAdmin().prepareRestoreSnapshot("test-repo", "test-snap").get();
         ensureGreen("test-idx");
+
+        // Wait for snapshot process to complete before proceeding to prevent test failures on repository clean up
+        assertBusy(() -> {
+            SnapshotInfo snapshotInfo = getSnapshot("test-repo", "test-snap-2");
+            assertTrue(snapshotInfo.state().completed());
+            assertEquals(SnapshotState.PARTIAL, snapshotInfo.state());
+        }, 1, TimeUnit.MINUTES);
     }
 
     private long calculateTotalFilesSize(List<Path> files) {

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -1458,7 +1458,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         clusterAdmin().prepareRestoreSnapshot("test-repo", "test-snap").get();
         ensureGreen("test-idx");
 
-        // Wait for snapshot process to complete before proceeding to prevent test failures on repository clean up
+        // Wait for snapshot process to complete to prevent conflict with repository clean up
         assertBusy(() -> {
             SnapshotInfo snapshotInfo = getSnapshot("test-repo", "test-snap-2");
             assertTrue(snapshotInfo.state().completed());


### PR DESCRIPTION
### Description
Test `testIndexDeletionDuringSnapshotCreationInQueue` creates a async snapshot (`wait_for_completion=false`) which conflicts during test clean up where repository is deleted. The conflict happens due to in progress snapshot. The fix here is to wait for snapshot to be in `completed` state. 

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/5031

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [ ] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
