### PR TITLE
[Backport 2.x] Switch to more reliable OpenSearch Lucene snapshot loc…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Interpret byte array as primitive using VarHandles ([#11362](https://github.com/opensearch-project/OpenSearch/pull/11362))
 - Automatically add scheme to discovery.ec2.endpoint ([#11512](https://github.com/opensearch-project/OpenSearch/pull/11512))
 - Restore support for Java 8 for RestClient ([#11562](https://github.com/opensearch-project/OpenSearch/pull/11562))
+- Switched to more reliable OpenSearch Lucene snapshot location([#11728](https://github.com/opensearch-project/OpenSearch/pull/11728))
 
 ### Deprecated
 

--- a/buildSrc/src/main/java/org/opensearch/gradle/RepositoriesSetupPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/RepositoriesSetupPlugin.java
@@ -94,7 +94,7 @@ public class RepositoriesSetupPlugin implements Plugin<Project> {
             String revision = matcher.group(1);
             MavenArtifactRepository luceneRepo = repos.maven(repo -> {
                 repo.setName("lucene-snapshots");
-                repo.setUrl("https://d1nvenhzbhpy0q.cloudfront.net/snapshots/lucene/");
+                repo.setUrl("https://artifacts.opensearch.org/snapshots/lucene/");
             });
             repos.exclusiveContent(exclusiveRepo -> {
                 exclusiveRepo.filter(

--- a/gradle/code-coverage.gradle
+++ b/gradle/code-coverage.gradle
@@ -13,7 +13,7 @@ repositories {
   gradlePluginPortal()
   // TODO: Find the way to use the repositories from RepositoriesSetupPlugin
   maven {
-    url = "https://d1nvenhzbhpy0q.cloudfront.net/snapshots/lucene/"
+    url = "https://artifacts.opensearch.org/snapshots/lucene/"
   }
 }
 


### PR DESCRIPTION
### Description
Switched to more reliable OpenSearch Lucene snapshot location

### Related Issues
- Related Backport https://github.com/opensearch-project/OpenSearch/pull/11728

### Check List
- [ ] ~New functionality includes testing.~
  - [ ] ~All tests pass~
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [X] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
