### PR TITLE
Show only intersecting buckets to the Adjacency matrix aggregation

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/70_adjacency_matrix.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/70_adjacency_matrix.yml
@@ -125,3 +125,40 @@ setup:
 
   - match: { aggregations.conns.buckets.3.doc_count: 1 }
   - match: { aggregations.conns.buckets.3.key: "4" }
+
+
+---
+"Show only intersections":
+  - skip:
+      version: " - 2.99.99"
+      reason: "show_only_intersecting was added in 3.0.0"
+      features: node_selector
+  - do:
+      node_selector:
+        version: "3.0.0 - "
+      search:
+        index: test
+        rest_total_hits_as_int: true
+        body:
+          size: 0
+          aggs:
+            conns:
+              adjacency_matrix:
+                show_only_intersecting: true
+                filters:
+                  1:
+                    term:
+                      num: 1
+                  2:
+                    term:
+                      num: 2
+                  4:
+                    term:
+                      num: 4
+
+  - match: { hits.total: 3 }
+
+  - length: { aggregations.conns.buckets: 1 }
+
+  - match: { aggregations.conns.buckets.0.doc_count: 1 }
+  - match: { aggregations.conns.buckets.0.key: "1&2" }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregationBuilder.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.search.aggregations.bucket.adjacency;
 
+import org.opensearch.Version;
 import org.opensearch.core.ParseField;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -71,7 +72,10 @@ public class AdjacencyMatrixAggregationBuilder extends AbstractAggregationBuilde
 
     private static final ParseField SEPARATOR_FIELD = new ParseField("separator");
     private static final ParseField FILTERS_FIELD = new ParseField("filters");
+    private static final ParseField SHOW_ONLY_INTERSECTING = new ParseField("show_only_intersecting");
+
     private List<KeyedFilter> filters;
+    private boolean showOnlyIntersecting = false;
     private String separator = DEFAULT_SEPARATOR;
 
     private static final ObjectParser<AdjacencyMatrixAggregationBuilder, String> PARSER = ObjectParser.fromBuilder(
@@ -81,6 +85,10 @@ public class AdjacencyMatrixAggregationBuilder extends AbstractAggregationBuilde
     static {
         PARSER.declareString(AdjacencyMatrixAggregationBuilder::separator, SEPARATOR_FIELD);
         PARSER.declareNamedObjects(AdjacencyMatrixAggregationBuilder::setFiltersAsList, KeyedFilter.PARSER, FILTERS_FIELD);
+        PARSER.declareBoolean(
+            AdjacencyMatrixAggregationBuilder::setShowOnlyIntersecting,
+            AdjacencyMatrixAggregationBuilder.SHOW_ONLY_INTERSECTING
+        );
     }
 
     public static AggregationBuilder parse(XContentParser parser, String name) throws IOException {
@@ -115,6 +123,7 @@ public class AdjacencyMatrixAggregationBuilder extends AbstractAggregationBuilde
         super(clone, factoriesBuilder, metadata);
         this.filters = new ArrayList<>(clone.filters);
         this.separator = clone.separator;
+        this.showOnlyIntersecting = clone.showOnlyIntersecting;
     }
 
     @Override
@@ -139,12 +148,49 @@ public class AdjacencyMatrixAggregationBuilder extends AbstractAggregationBuilde
     }
 
     /**
+     * @param name
+     *            the name of this aggregation
+     * @param filters
+     *            the filters and their key to use with this aggregation.
+     * @param showOnlyIntersecting
+     *            show only the buckets that intersection multiple documents
+     */
+    public AdjacencyMatrixAggregationBuilder(String name, Map<String, QueryBuilder> filters, boolean showOnlyIntersecting) {
+        this(name, DEFAULT_SEPARATOR, filters, showOnlyIntersecting);
+    }
+
+    /**
+     * @param name
+     *            the name of this aggregation
+     * @param separator
+     *            the string used to separate keys in intersections buckets e.g.
+     *            &amp; character for keyed filters A and B would return an
+     *            intersection bucket named A&amp;B
+     * @param filters
+     *            the filters and their key to use with this aggregation.
+     * @param showOnlyIntersecting
+     *            show only the buckets that intersection multiple documents
+     */
+    public AdjacencyMatrixAggregationBuilder(
+        String name,
+        String separator,
+        Map<String, QueryBuilder> filters,
+        boolean showOnlyIntersecting
+    ) {
+        this(name, separator, filters);
+        this.showOnlyIntersecting = showOnlyIntersecting;
+    }
+
+    /**
      * Read from a stream.
      */
     public AdjacencyMatrixAggregationBuilder(StreamInput in) throws IOException {
         super(in);
         int filtersSize = in.readVInt();
         separator = in.readString();
+        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+            showOnlyIntersecting = in.readBoolean();
+        }
         filters = new ArrayList<>(filtersSize);
         for (int i = 0; i < filtersSize; i++) {
             filters.add(new KeyedFilter(in));
@@ -155,6 +201,9 @@ public class AdjacencyMatrixAggregationBuilder extends AbstractAggregationBuilde
     protected void doWriteTo(StreamOutput out) throws IOException {
         out.writeVInt(filters.size());
         out.writeString(separator);
+        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+            out.writeBoolean(showOnlyIntersecting);
+        }
         for (KeyedFilter keyedFilter : filters) {
             keyedFilter.writeTo(out);
         }
@@ -182,6 +231,11 @@ public class AdjacencyMatrixAggregationBuilder extends AbstractAggregationBuilde
         // internally we want to have a fixed order of filters, regardless of
         // the order of the filters in the request
         Collections.sort(this.filters, Comparator.comparing(KeyedFilter::key));
+        return this;
+    }
+
+    public AdjacencyMatrixAggregationBuilder setShowOnlyIntersecting(boolean showOnlyIntersecting) {
+        this.showOnlyIntersecting = showOnlyIntersecting;
         return this;
     }
 
@@ -214,6 +268,10 @@ public class AdjacencyMatrixAggregationBuilder extends AbstractAggregationBuilde
         return result;
     }
 
+    public boolean isShowOnlyIntersecting() {
+        return showOnlyIntersecting;
+    }
+
     @Override
     protected AdjacencyMatrixAggregationBuilder doRewrite(QueryRewriteContext queryShardContext) throws IOException {
         boolean modified = false;
@@ -224,7 +282,9 @@ public class AdjacencyMatrixAggregationBuilder extends AbstractAggregationBuilde
             rewrittenFilters.add(new KeyedFilter(kf.key(), rewritten));
         }
         if (modified) {
-            return new AdjacencyMatrixAggregationBuilder(name).separator(separator).setFiltersAsList(rewrittenFilters);
+            return new AdjacencyMatrixAggregationBuilder(name).separator(separator)
+                .setFiltersAsList(rewrittenFilters)
+                .setShowOnlyIntersecting(showOnlyIntersecting);
         }
         return this;
     }
@@ -245,7 +305,16 @@ public class AdjacencyMatrixAggregationBuilder extends AbstractAggregationBuilde
                     + "] index level setting."
             );
         }
-        return new AdjacencyMatrixAggregatorFactory(name, filters, separator, queryShardContext, parent, subFactoriesBuilder, metadata);
+        return new AdjacencyMatrixAggregatorFactory(
+            name,
+            filters,
+            showOnlyIntersecting,
+            separator,
+            queryShardContext,
+            parent,
+            subFactoriesBuilder,
+            metadata
+        );
     }
 
     @Override
@@ -257,7 +326,8 @@ public class AdjacencyMatrixAggregationBuilder extends AbstractAggregationBuilde
     protected XContentBuilder internalXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field(SEPARATOR_FIELD.getPreferredName(), separator);
-        builder.startObject(AdjacencyMatrixAggregator.FILTERS_FIELD.getPreferredName());
+        builder.field(SHOW_ONLY_INTERSECTING.getPreferredName(), showOnlyIntersecting);
+        builder.startObject(FILTERS_FIELD.getPreferredName());
         for (KeyedFilter keyedFilter : filters) {
             builder.field(keyedFilter.key(), keyedFilter.filter());
         }
@@ -268,7 +338,7 @@ public class AdjacencyMatrixAggregationBuilder extends AbstractAggregationBuilde
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), filters, separator);
+        return Objects.hash(super.hashCode(), filters, showOnlyIntersecting, separator);
     }
 
     @Override
@@ -277,7 +347,9 @@ public class AdjacencyMatrixAggregationBuilder extends AbstractAggregationBuilde
         if (obj == null || getClass() != obj.getClass()) return false;
         if (super.equals(obj) == false) return false;
         AdjacencyMatrixAggregationBuilder other = (AdjacencyMatrixAggregationBuilder) obj;
-        return Objects.equals(filters, other.filters) && Objects.equals(separator, other.separator);
+        return Objects.equals(filters, other.filters)
+            && Objects.equals(separator, other.separator)
+            && Objects.equals(showOnlyIntersecting, other.showOnlyIntersecting);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregator.java
@@ -36,7 +36,6 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.Bits;
 import org.opensearch.common.lucene.Lucene;
-import org.opensearch.core.ParseField;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
@@ -69,8 +68,6 @@ import static org.opensearch.index.query.AbstractQueryBuilder.parseInnerQueryBui
  * @opensearch.internal
  */
 public class AdjacencyMatrixAggregator extends BucketsAggregator {
-
-    public static final ParseField FILTERS_FIELD = new ParseField("filters");
 
     /**
      * A keyed filter
@@ -145,6 +142,8 @@ public class AdjacencyMatrixAggregator extends BucketsAggregator {
 
     private final String[] keys;
     private final Weight[] filters;
+
+    private final boolean showOnlyIntersecting;
     private final int totalNumKeys;
     private final int totalNumIntersections;
     private final String separator;
@@ -155,6 +154,7 @@ public class AdjacencyMatrixAggregator extends BucketsAggregator {
         String separator,
         String[] keys,
         Weight[] filters,
+        boolean showOnlyIntersecting,
         SearchContext context,
         Aggregator parent,
         Map<String, Object> metadata
@@ -163,6 +163,7 @@ public class AdjacencyMatrixAggregator extends BucketsAggregator {
         this.separator = separator;
         this.keys = keys;
         this.filters = filters;
+        this.showOnlyIntersecting = showOnlyIntersecting;
         this.totalNumIntersections = ((keys.length * keys.length) - keys.length) / 2;
         this.totalNumKeys = keys.length + totalNumIntersections;
     }
@@ -177,10 +178,12 @@ public class AdjacencyMatrixAggregator extends BucketsAggregator {
         return new LeafBucketCollectorBase(sub, null) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                // Check each of the provided filters
-                for (int i = 0; i < bits.length; i++) {
-                    if (bits[i].get(doc)) {
-                        collectBucket(sub, doc, bucketOrd(bucket, i));
+                if (!showOnlyIntersecting) {
+                    // Check each of the provided filters
+                    for (int i = 0; i < bits.length; i++) {
+                        if (bits[i].get(doc)) {
+                            collectBucket(sub, doc, bucketOrd(bucket, i));
+                        }
                     }
                 }
                 // Check all the possible intersections of the provided filters
@@ -229,7 +232,7 @@ public class AdjacencyMatrixAggregator extends BucketsAggregator {
             for (int i = 0; i < keys.length; i++) {
                 long bucketOrd = bucketOrd(owningBucketOrds[owningBucketOrdIdx], i);
                 long docCount = bucketDocCount(bucketOrd);
-                // Empty buckets are not returned because this aggregation will commonly be used under a
+                // Empty buckets are not returned because this aggregation will commonly be used under
                 // a date-histogram where we will look for transactions over time and can expect many
                 // empty buckets.
                 if (docCount > 0) {

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregatorFactory.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregatorFactory.java
@@ -57,11 +57,14 @@ public class AdjacencyMatrixAggregatorFactory extends AggregatorFactory {
 
     private final String[] keys;
     private final Weight[] weights;
+
+    private final boolean showOnlyIntersecting;
     private final String separator;
 
     public AdjacencyMatrixAggregatorFactory(
         String name,
         List<KeyedFilter> filters,
+        boolean showOnlyIntersecting,
         String separator,
         QueryShardContext queryShardContext,
         AggregatorFactory parent,
@@ -79,6 +82,7 @@ public class AdjacencyMatrixAggregatorFactory extends AggregatorFactory {
             Query filter = keyedFilter.filter().toQuery(queryShardContext);
             weights[i] = contextSearcher.createWeight(contextSearcher.rewrite(filter), ScoreMode.COMPLETE_NO_SCORES, 1f);
         }
+        this.showOnlyIntersecting = showOnlyIntersecting;
     }
 
     @Override
@@ -88,7 +92,17 @@ public class AdjacencyMatrixAggregatorFactory extends AggregatorFactory {
         CardinalityUpperBound cardinality,
         Map<String, Object> metadata
     ) throws IOException {
-        return new AdjacencyMatrixAggregator(name, factories, separator, keys, weights, searchContext, parent, metadata);
+        return new AdjacencyMatrixAggregator(
+            name,
+            factories,
+            separator,
+            keys,
+            weights,
+            showOnlyIntersecting,
+            searchContext,
+            parent,
+            metadata
+        );
     }
 
     @Override

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregationBuilderTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregationBuilderTests.java
@@ -109,17 +109,6 @@ public class AdjacencyMatrixAggregationBuilderTests extends OpenSearchTestCase {
 
     public void testShowOnlyIntersecting() throws Exception {
         QueryShardContext queryShardContext = mock(QueryShardContext.class);
-        IndexShard indexShard = mock(IndexShard.class);
-        Settings settings = Settings.builder()
-            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
-            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
-            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 2)
-            .build();
-        IndexMetadata indexMetadata = IndexMetadata.builder("index").settings(settings).build();
-        IndexSettings indexSettings = new IndexSettings(indexMetadata, Settings.EMPTY);
-        when(indexShard.indexSettings()).thenReturn(indexSettings);
-        when(queryShardContext.getIndexSettings()).thenReturn(indexSettings);
-        SearchContext context = new TestSearchContext(queryShardContext, indexShard);
 
         Map<String, QueryBuilder> filters = new HashMap<>(3);
         for (int i = 0; i < 2; i++) {

--- a/server/src/test/java/org/opensearch/search/aggregations/metrics/AdjacencyMatrixTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/metrics/AdjacencyMatrixTests.java
@@ -68,4 +68,22 @@ public class AdjacencyMatrixTests extends BaseAggregationTestCase<AdjacencyMatri
         assertEquals(original, builder.filters());
         assert original != builder.filters();
     }
+
+    public void testShowOnlyIntersecting() {
+        Map<String, QueryBuilder> original = new HashMap<>();
+        original.put("bbb", new MatchNoneQueryBuilder());
+        original.put("aaa", new MatchNoneQueryBuilder());
+        AdjacencyMatrixAggregationBuilder builder;
+        builder = new AdjacencyMatrixAggregationBuilder("my-agg", "&", original, true);
+        assertTrue(builder.isShowOnlyIntersecting());
+    }
+
+    public void testShowOnlyIntersectingAsFalse() {
+        Map<String, QueryBuilder> original = new HashMap<>();
+        original.put("bbb", new MatchNoneQueryBuilder());
+        original.put("aaa", new MatchNoneQueryBuilder());
+        AdjacencyMatrixAggregationBuilder builder;
+        builder = new AdjacencyMatrixAggregationBuilder("my-agg", original, false);
+        assertFalse(builder.isShowOnlyIntersecting());
+    }
 }


### PR DESCRIPTION
Re-release of a [previous PR](https://github.com/opensearch-project/OpenSearch/pull/10226) that did not correctly sign the commit

### Description

Show only intersecting buckets to the Adjacency matrix aggregation

The [Adjacency matrix aggregation](https://opensearch.org/docs/latest/query-dsl/aggregations/bucket/adjacency-matrix/) will compute and return all buckets related to any of the combinations of the filters specified, including hits on a single filter. However, sometimes a user would want to return only the buckets related to an intersection and not for a single filter. An optional show_only_intersecting parameter would stop buckets resulting from a single filter being hit to be created.

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/8832

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
