### PR TITLE
Add logging for tests in RemoteStoreStatsIT to catch assertion failure cause

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreStatsIT.java
@@ -277,6 +277,13 @@ public class RemoteStoreStatsIT extends RemoteStoreBaseIntegTestCase {
             .collect(Collectors.toList())
             .get(0)
             .getSegmentStats();
+        logger.info(
+            "Zero state primary stats: {}ms refresh time lag, {}b bytes lag, {}b upload bytes started and {}b upload bytes failed.",
+            zeroStatePrimaryStats.refreshTimeLagMs,
+            zeroStatePrimaryStats.bytesLag,
+            zeroStatePrimaryStats.uploadBytesStarted,
+            zeroStatePrimaryStats.uploadBytesFailed
+        );
         assertTrue(
             zeroStatePrimaryStats.totalUploadsStarted == zeroStatePrimaryStats.totalUploadsSucceeded
                 && zeroStatePrimaryStats.totalUploadsSucceeded == 1
@@ -371,6 +378,13 @@ public class RemoteStoreStatsIT extends RemoteStoreBaseIntegTestCase {
             .collect(Collectors.toList())
             .get(0)
             .getSegmentStats();
+        logger.info(
+            "Zero state primary stats: {}ms refresh time lag, {}b bytes lag, {}b upload bytes started and {}b upload bytes failed.",
+            zeroStatePrimaryStats.refreshTimeLagMs,
+            zeroStatePrimaryStats.bytesLag,
+            zeroStatePrimaryStats.uploadBytesStarted,
+            zeroStatePrimaryStats.uploadBytesFailed
+        );
         assertTrue(
             zeroStatePrimaryStats.totalUploadsStarted == zeroStatePrimaryStats.totalUploadsSucceeded
                 && zeroStatePrimaryStats.totalUploadsSucceeded == 1

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreStatsIT.java
@@ -29,6 +29,7 @@ import org.opensearch.plugins.Plugin;
 import org.opensearch.test.InternalTestCluster;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.disruption.NetworkDisruption;
+import org.opensearch.test.junit.annotations.TestLogging;
 import org.opensearch.test.transport.MockTransportService;
 
 import java.io.IOException;
@@ -249,6 +250,7 @@ public class RemoteStoreStatsIT extends RemoteStoreBaseIntegTestCase {
         }
     }
 
+    @TestLogging(reason = "Getting trace logs from remote store package", value = "org.opensearch.remotestore:TRACE")
     public void testDownloadStatsCorrectnessSinglePrimarySingleReplica() throws Exception {
         setup();
         // Scenario:
@@ -346,6 +348,7 @@ public class RemoteStoreStatsIT extends RemoteStoreBaseIntegTestCase {
         }
     }
 
+    @TestLogging(reason = "Getting trace logs from remote store package", value = "org.opensearch.remotestore:TRACE")
     public void testDownloadStatsCorrectnessSinglePrimaryMultipleReplicaShards() throws Exception {
         setup();
         // Scenario:


### PR DESCRIPTION

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
In RemoteStoreStatsIT, for tests (1) testDownloadStatsCorrectnessSinglePrimarySingleReplica and (2) testDownloadStatsCorrectnessSinglePrimaryMultipleReplicaShards, we see an assertion failure in a similar spot. 

The failing assertions check that a successful upload AND no failures took place for an index with remote store enabled. This is before any docs are indexed and after ensureGreen. 

Even after days of running this test, we weren't able to reproduce it. Judging by the point of assertion failure, the hypothesis is that we see this failure when the upload didn't take place in time after running refresh. To test this, we are adding in a lightweight log statement before these assertions so we can confirm this is the cause if it fails again. 

Previous build failures:

5 org.opensearch.remotestore.RemoteStoreStatsIT.testDownloadStatsCorrectnessSinglePrimarySingleReplica (30610,30654,31178,31469,31558)

5 org.opensearch.remotestore.RemoteStoreStatsIT.testDownloadStatsCorrectnessSinglePrimaryMultipleReplicaShards (31085,31091,31140,31369,31441) 

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/10152 
https://github.com/opensearch-project/OpenSearch/issues/10193 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
