### PR TITLE
Add the means to extract the contextual underlying channel from HttpChannel without excessive typecasting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,7 +162,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Mute the query profile IT with concurrent execution ([#9840](https://github.com/opensearch-project/OpenSearch/pull/9840))
 - Force merge with `only_expunge_deletes` honors max segment size ([#10036](https://github.com/opensearch-project/OpenSearch/pull/10036))
-- Add the means to extract the contextual properties from HttpChannel, TcpCChannel and TrasportChannel without excessive typecasting ([#10562](https://github.com/opensearch-project/OpenSearch/pull/10562))
+- Add the means to extract the contextual properties from HttpChannel, TcpCChannel and TrasportChannel without excessive typecasting ([#10562](https://github.com/opensearch-project/OpenSearch/pull/10562)), ([#11751](https://github.com/opensearch-project/OpenSearch/pull/11751))
 - Introduce new dynamic cluster setting to control slice computation for concurrent segment search ([#9107](https://github.com/opensearch-project/OpenSearch/pull/9107))
 - Search pipelines now support asynchronous request and response processors to avoid blocking on a transport thread ([#10598](https://github.com/opensearch-project/OpenSearch/pull/10598))
 - [Remote Store] Add Remote Store backpressure rejection stats to `_nodes/stats` ([#10524](https://github.com/opensearch-project/OpenSearch/pull/10524))

--- a/modules/transport-netty4/src/main/java/org/opensearch/http/netty4/Netty4HttpChannel.java
+++ b/modules/transport-netty4/src/main/java/org/opensearch/http/netty4/Netty4HttpChannel.java
@@ -46,6 +46,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelPipeline;
 
 public class Netty4HttpChannel implements HttpChannel {
+    private static final String CHANNEL_PROPERTY = "channel";
 
     private final Channel channel;
     private final CompletableContext<Void> closeContext = new CompletableContext<>();
@@ -102,6 +103,10 @@ public class Netty4HttpChannel implements HttpChannel {
     @SuppressWarnings("unchecked")
     @Override
     public <T> Optional<T> get(String name, Class<T> clazz) {
+        if (CHANNEL_PROPERTY.equalsIgnoreCase(name) && clazz.isAssignableFrom(Channel.class)) {
+            return (Optional<T>) Optional.of(getNettyChannel());
+        }
+
         Object handler = getNettyChannel().pipeline().get(name);
 
         if (handler == null && inboundPipeline() != null) {

--- a/modules/transport-netty4/src/test/java/org/opensearch/http/netty4/Netty4HttpChannelTests.java
+++ b/modules/transport-netty4/src/test/java/org/opensearch/http/netty4/Netty4HttpChannelTests.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.http.netty4;
+
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.Netty4NioSocketChannel;
+import org.junit.Before;
+
+import java.util.Optional;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelOutboundInvoker;
+import io.netty.channel.ServerChannel;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+
+public class Netty4HttpChannelTests extends OpenSearchTestCase {
+    private Netty4HttpChannel netty4HttpChannel;
+    private Channel channel;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        channel = new Netty4NioSocketChannel();
+        netty4HttpChannel = new Netty4HttpChannel(channel);
+    }
+
+    public void testChannelAttributeMatchesChannel() {
+        final Optional<Channel> channelOpt = netty4HttpChannel.get("channel", Channel.class);
+        assertThat(channelOpt.isPresent(), is(true));
+        assertThat(channelOpt.get(), sameInstance(channel));
+    }
+
+    public void testChannelAttributeMatchesChannelOutboundInvoker() {
+        final Optional<ChannelOutboundInvoker> channelOpt = netty4HttpChannel.get("channel", ChannelOutboundInvoker.class);
+        assertThat(channelOpt.isPresent(), is(true));
+        assertThat(channelOpt.get(), sameInstance(channel));
+    }
+
+    public void testChannelAttributeIsEmpty() {
+        final Optional<ServerChannel> channelOpt = netty4HttpChannel.get("channel", ServerChannel.class);
+        assertThat(channelOpt.isEmpty(), is(true));
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Follow up on  https://github.com/opensearch-project/OpenSearch/pull/10562 since more type casting code has been added into the `security` plugin.


### Related Issues
Relates to https://github.com/opensearch-project/security/issues/3911 
<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [X] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
