### PR TITLE
Update the skip version for match_only_text field Integ tests to 2.11.99

### DIFF
--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.query/11_match_field_match_only_text.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.query/11_match_field_match_only_text.yml
@@ -2,7 +2,7 @@
 
 "match query with stacked stems":
   - skip:
-      version: " - 2.99.99"
+      version: " - 2.11.99"
       reason: "match_only_text was added in 3.0"
   # Tests the match query stemmed tokens are "stacked" on top of the unstemmed
   # versions in the same position.

--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.query/11_match_field_match_only_text.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.query/11_match_field_match_only_text.yml
@@ -3,7 +3,7 @@
 "match query with stacked stems":
   - skip:
       version: " - 2.11.99"
-      reason: "match_only_text was added in 3.0"
+      reason: "match_only_text was added in 2.12"
   # Tests the match query stemmed tokens are "stacked" on top of the unstemmed
   # versions in the same position.
   - do:

--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.query/20_ngram_search_field_match_only_text.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.query/20_ngram_search_field_match_only_text.yml
@@ -1,6 +1,6 @@
 "ngram search":
   - skip:
-      version: " - 2.99.99"
+      version: " - 2.11.99"
       reason: "match_only_text was added in 3.0"
   - do:
       indices.create:
@@ -45,7 +45,7 @@
 ---
 "testNGramCopyField":
   - skip:
-      version: " - 2.99.99"
+      version: " - 2.11.99"
       reason: "match_only_text was added in 3.0"
   - do:
       indices.create:

--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.query/20_ngram_search_field_match_only_text.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.query/20_ngram_search_field_match_only_text.yml
@@ -1,7 +1,7 @@
 "ngram search":
   - skip:
       version: " - 2.11.99"
-      reason: "match_only_text was added in 3.0"
+      reason: "match_only_text was added in 2.12"
   - do:
       indices.create:
         index: test
@@ -46,7 +46,7 @@
 "testNGramCopyField":
   - skip:
       version: " - 2.11.99"
-      reason: "match_only_text was added in 3.0"
+      reason: "match_only_text was added in 2.12"
   - do:
       indices.create:
         index: test

--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.query/30_ngram_highligthing_field_match_only_text.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.query/30_ngram_highligthing_field_match_only_text.yml
@@ -1,7 +1,7 @@
 "ngram highlighting":
   - skip:
       version: " - 2.11.99"
-      reason: "match_only_text was added in 3.0"
+      reason: "match_only_text was added in 2.12"
   - do:
       indices.create:
         index: test

--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.query/30_ngram_highligthing_field_match_only_text.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.query/30_ngram_highligthing_field_match_only_text.yml
@@ -1,6 +1,6 @@
 "ngram highlighting":
   - skip:
-      version: " - 2.99.99"
+      version: " - 2.11.99"
       reason: "match_only_text was added in 3.0"
   - do:
       indices.create:

--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.query/40_query_string_field_match_only_text.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.query/40_query_string_field_match_only_text.yml
@@ -2,7 +2,7 @@
 "Test query string with snowball":
   - skip:
       version: " - 2.11.99"
-      reason: "match_only_text was added in 3.0"
+      reason: "match_only_text was added in 2.12"
   - do:
       indices.create:
           index:  test

--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.query/40_query_string_field_match_only_text.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.query/40_query_string_field_match_only_text.yml
@@ -1,7 +1,7 @@
 ---
 "Test query string with snowball":
   - skip:
-      version: " - 2.99.99"
+      version: " - 2.11.99"
       reason: "match_only_text was added in 3.0"
   - do:
       indices.create:

--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.query/41_query_string_with_default_analyzer_field_match_only_text.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.query/41_query_string_with_default_analyzer_field_match_only_text.yml
@@ -2,7 +2,7 @@
 "Test default search analyzer is applied":
   - skip:
       version: " - 2.11.99"
-      reason: "match_only_text was added in 3.0"
+      reason: "match_only_text was added in 2.12"
   - do:
       indices.create:
         index: test

--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.query/41_query_string_with_default_analyzer_field_match_only_text.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.query/41_query_string_with_default_analyzer_field_match_only_text.yml
@@ -1,7 +1,7 @@
 ---
 "Test default search analyzer is applied":
   - skip:
-      version: " - 2.99.99"
+      version: " - 2.11.99"
       reason: "match_only_text was added in 3.0"
   - do:
       indices.create:

--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.query/50_queries_with_synonyms_field_match_only_text.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.query/50_queries_with_synonyms_field_match_only_text.yml
@@ -1,7 +1,7 @@
 ---
 "Test common terms query with stacked tokens":
   - skip:
-      version: " - 2.99.99"
+      version: " - 2.11.99"
       reason: "match_only_text was added in 3.0"
       features: "allowed_warnings"
 
@@ -247,7 +247,7 @@
 ---
 "Test match query with synonyms - see #3881 for extensive description of the issue":
   - skip:
-      version: " - 2.99.99"
+      version: " - 2.11.99"
       reason: "match_only_text was added in 3.0"
   - do:
       indices.create:

--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.query/50_queries_with_synonyms_field_match_only_text.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.query/50_queries_with_synonyms_field_match_only_text.yml
@@ -2,7 +2,7 @@
 "Test common terms query with stacked tokens":
   - skip:
       version: " - 2.11.99"
-      reason: "match_only_text was added in 3.0"
+      reason: "match_only_text was added in 2.12"
       features: "allowed_warnings"
 
   - do:
@@ -248,7 +248,7 @@
 "Test match query with synonyms - see #3881 for extensive description of the issue":
   - skip:
       version: " - 2.11.99"
-      reason: "match_only_text was added in 3.0"
+      reason: "match_only_text was added in 2.12"
   - do:
       indices.create:
           index: test

--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.query/60_synonym_graph_field_match_only_text.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.query/60_synonym_graph_field_match_only_text.yml
@@ -1,6 +1,6 @@
 setup:
   - skip:
-      version: " - 2.99.99"
+      version: " - 2.11.99"
       reason: "match_only_text was added in 3.0"
   - do:
       indices.create:

--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.query/60_synonym_graph_field_match_only_text.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.query/60_synonym_graph_field_match_only_text.yml
@@ -1,7 +1,7 @@
 setup:
   - skip:
       version: " - 2.11.99"
-      reason: "match_only_text was added in 3.0"
+      reason: "match_only_text was added in 2.12"
   - do:
       indices.create:
         index: test

--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.query/70_intervals_field_match_only_text.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.query/70_intervals_field_match_only_text.yml
@@ -2,7 +2,7 @@
 setup:
   - skip:
       version: " - 2.11.99"
-      reason: "match_only_text was added in 3.0"
+      reason: "match_only_text was added in 2.12"
   - do:
       indices.create:
         index:  test
@@ -27,7 +27,7 @@ setup:
 "Test use_field":
   - skip:
       version: " - 2.11.99"
-      reason: "match_only_text was added in 3.0"
+      reason: "match_only_text was added in 2.12"
   - do:
       catch: bad_request
       search:

--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.query/70_intervals_field_match_only_text.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.query/70_intervals_field_match_only_text.yml
@@ -1,7 +1,7 @@
 # integration tests for intervals queries using analyzers
 setup:
   - skip:
-      version: " - 2.99.99"
+      version: " - 2.11.99"
       reason: "match_only_text was added in 3.0"
   - do:
       indices.create:
@@ -26,7 +26,7 @@ setup:
 ---
 "Test use_field":
   - skip:
-      version: " - 2.99.99"
+      version: " - 2.11.99"
       reason: "match_only_text was added in 3.0"
   - do:
       catch: bad_request

--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.suggest/20_phrase_field_match_only_text.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.suggest/20_phrase_field_match_only_text.yml
@@ -3,7 +3,7 @@
 setup:
   - skip:
       version: " - 2.11.99"
-      reason: "match_only_text was added in 3.0"
+      reason: "match_only_text was added in 2.12"
   - do:
       indices.create:
         index: test
@@ -123,7 +123,7 @@ setup:
 "breaks ties by sorting terms":
   - skip:
       version: " - 2.11.99"
-      reason: "match_only_text was added in 3.0"
+      reason: "match_only_text was added in 2.12"
   # This runs the suggester without bigrams so we can be sure of the sort order
   - do:
       search:
@@ -182,7 +182,7 @@ setup:
 "doesn't fail when asked to run on a field without unigrams when force_unigrams=false":
   - skip:
       version: " - 2.11.99"
-      reason: "match_only_text was added in 3.0"
+      reason: "match_only_text was added in 2.12"
   - do:
       search:
         rest_total_hits_as_int: true
@@ -214,7 +214,7 @@ setup:
 "reverse suggestions":
   - skip:
       version: " - 2.11.99"
-      reason: "match_only_text was added in 3.0"
+      reason: "match_only_text was added in 2.12"
   - do:
       search:
         rest_total_hits_as_int: true

--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.suggest/20_phrase_field_match_only_text.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/search.suggest/20_phrase_field_match_only_text.yml
@@ -2,7 +2,7 @@
 
 setup:
   - skip:
-      version: " - 2.99.99"
+      version: " - 2.11.99"
       reason: "match_only_text was added in 3.0"
   - do:
       indices.create:
@@ -122,7 +122,7 @@ setup:
 ---
 "breaks ties by sorting terms":
   - skip:
-      version: " - 2.99.99"
+      version: " - 2.11.99"
       reason: "match_only_text was added in 3.0"
   # This runs the suggester without bigrams so we can be sure of the sort order
   - do:
@@ -181,7 +181,7 @@ setup:
 ---
 "doesn't fail when asked to run on a field without unigrams when force_unigrams=false":
   - skip:
-      version: " - 2.99.99"
+      version: " - 2.11.99"
       reason: "match_only_text was added in 3.0"
   - do:
       search:
@@ -213,7 +213,7 @@ setup:
 ---
 "reverse suggestions":
   - skip:
-      version: " - 2.99.99"
+      version: " - 2.11.99"
       reason: "match_only_text was added in 3.0"
   - do:
       search:

--- a/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/search-as-you-type/20_highlighting_field_match_only_text.yml
+++ b/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/search-as-you-type/20_highlighting_field_match_only_text.yml
@@ -1,6 +1,6 @@
 setup:
   - skip:
-      version: " - 2.99.99"
+      version: " - 2.11.99"
       reason: "match_only_text was added in 3.0"
 
   - do:

--- a/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/search-as-you-type/20_highlighting_field_match_only_text.yml
+++ b/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/search-as-you-type/20_highlighting_field_match_only_text.yml
@@ -1,7 +1,7 @@
 setup:
   - skip:
       version: " - 2.11.99"
-      reason: "match_only_text was added in 3.0"
+      reason: "match_only_text was added in 2.12"
 
   - do:
       indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.validate_query/20_query_string_field_match_only_text.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.validate_query/20_query_string_field_match_only_text.yml
@@ -1,7 +1,7 @@
 ---
 "validate_query with query_string parameters":
   - skip:
-      version: " - 2.99.99"
+      version: " - 2.11.99"
       reason: "match_only_text was added in 3.0"
   - do:
       indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.validate_query/20_query_string_field_match_only_text.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.validate_query/20_query_string_field_match_only_text.yml
@@ -2,7 +2,7 @@
 "validate_query with query_string parameters":
   - skip:
       version: " - 2.11.99"
-      reason: "match_only_text was added in 3.0"
+      reason: "match_only_text was added in 2.12"
   - do:
       indices.create:
           index:  test

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/30_sig_terms_field_match_only_text.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/30_sig_terms_field_match_only_text.yml
@@ -1,7 +1,7 @@
 ---
 "Default index":
   - skip:
-      version: " - 2.99.99"
+      version: " - 2.11.99"
       reason: "match_only_text was added in 3.0"
   - do:
       indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/30_sig_terms_field_match_only_text.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/30_sig_terms_field_match_only_text.yml
@@ -2,7 +2,7 @@
 "Default index":
   - skip:
       version: " - 2.11.99"
-      reason: "match_only_text was added in 3.0"
+      reason: "match_only_text was added in 2.12"
   - do:
       indices.create:
           index:  goodbad

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/90_sig_text_field_match_only_text.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/90_sig_text_field_match_only_text.yml
@@ -1,7 +1,7 @@
 ---
 "Default index":
   - skip:
-      version: " - 2.99.99"
+      version: " - 2.11.99"
       reason: "match_only_text was added in 3.0"
   - do:
       indices.create:
@@ -78,7 +78,7 @@
 ---
 "Dedup noise":
   - skip:
-      version: " - 2.99.99"
+      version: " - 2.11.99"
       reason: "match_only_text was added in 3.0"
   - do:
       indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/90_sig_text_field_match_only_text.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/90_sig_text_field_match_only_text.yml
@@ -2,7 +2,7 @@
 "Default index":
   - skip:
       version: " - 2.11.99"
-      reason: "match_only_text was added in 3.0"
+      reason: "match_only_text was added in 2.12"
   - do:
       indices.create:
           index:  goodbad
@@ -79,7 +79,7 @@
 "Dedup noise":
   - skip:
       version: " - 2.11.99"
-      reason: "match_only_text was added in 3.0"
+      reason: "match_only_text was added in 2.12"
   - do:
       indices.create:
           index:  goodbad

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.inner_hits/20_highlighting_field_match_only_text.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.inner_hits/20_highlighting_field_match_only_text.yml
@@ -1,6 +1,6 @@
 setup:
   - skip:
-      version: " - 2.99.99"
+      version: " - 2.11.99"
       reason: "match_only_text was added in 3.0"
   - do:
       indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.inner_hits/20_highlighting_field_match_only_text.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.inner_hits/20_highlighting_field_match_only_text.yml
@@ -1,7 +1,7 @@
 setup:
   - skip:
       version: " - 2.11.99"
-      reason: "match_only_text was added in 3.0"
+      reason: "match_only_text was added in 2.12"
   - do:
       indices.create:
         index: test

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/160_exists_query_match_only_text.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/160_exists_query_match_only_text.yml
@@ -1,7 +1,7 @@
 setup:
   - skip:
       version: " - 2.11.99"
-      reason: "match_only_text was added in 3.0"
+      reason: "match_only_text was added in 2.12"
       features: ["headers"]
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/160_exists_query_match_only_text.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/160_exists_query_match_only_text.yml
@@ -1,6 +1,6 @@
 setup:
   - skip:
-      version: " - 2.99.99"
+      version: " - 2.11.99"
       reason: "match_only_text was added in 3.0"
       features: ["headers"]
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/200_phrase_search_field_match_only_text.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/200_phrase_search_field_match_only_text.yml
@@ -1,7 +1,7 @@
 ---
 "search with indexed phrases":
   - skip:
-      version: " - 2.99.99"
+      version: " - 2.11.99"
       reason: "match_only_text was added in 3.0"
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/200_phrase_search_field_match_only_text.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/200_phrase_search_field_match_only_text.yml
@@ -2,7 +2,7 @@
 "search with indexed phrases":
   - skip:
       version: " - 2.11.99"
-      reason: "match_only_text was added in 3.0"
+      reason: "match_only_text was added in 2.12"
 
   - do:
       indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/310_match_bool_prefix_field_match_only_text.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/310_match_bool_prefix_field_match_only_text.yml
@@ -1,6 +1,6 @@
 setup:
   - skip:
-      version: " - 2.99.99"
+      version: " - 2.11.99"
       reason: "match_only_text was added in 3.0"
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/310_match_bool_prefix_field_match_only_text.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/310_match_bool_prefix_field_match_only_text.yml
@@ -1,7 +1,7 @@
 setup:
   - skip:
       version: " - 2.11.99"
-      reason: "match_only_text was added in 3.0"
+      reason: "match_only_text was added in 2.12"
 
   - do:
       indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/320_disallow_queries_field_match_only_text.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/320_disallow_queries_field_match_only_text.yml
@@ -1,7 +1,7 @@
 ---
 setup:
   - skip:
-      version: " - 2.99.99"
+      version: " - 2.11.99"
       reason: "match_only_text was added in 3.0"
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/320_disallow_queries_field_match_only_text.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/320_disallow_queries_field_match_only_text.yml
@@ -2,7 +2,7 @@
 setup:
   - skip:
       version: " - 2.11.99"
-      reason: "match_only_text was added in 3.0"
+      reason: "match_only_text was added in 2.12"
 
   - do:
       indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search_shards/10_basic_field_match_only_field.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search_shards/10_basic_field_match_only_field.yml
@@ -2,7 +2,7 @@
 "Search shards aliases with and without filters":
   - skip:
       version: " - 2.11.99"
-      reason: "match_only_text was added in 3.0"
+      reason: "match_only_text was added in 2.12"
 
   - do:
       indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search_shards/10_basic_field_match_only_field.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search_shards/10_basic_field_match_only_field.yml
@@ -1,7 +1,7 @@
 ---
 "Search shards aliases with and without filters":
   - skip:
-      version: " - 2.99.99"
+      version: " - 2.11.99"
       reason: "match_only_text was added in 3.0"
 
   - do:


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Update the skip version for match_only_text field integ tests to 2.11.99 after the backport to 2.x -
More details - https://github.com/opensearch-project/OpenSearch/pull/11039#issuecomment-1823522002

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
