### PR TITLE
[Backport] [2.x] Add the means to extract the contextual underlying channel from HttpChannel without excessive typecasting (#11751)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - Force merge with `only_expunge_deletes` honors max segment size ([#10036](https://github.com/opensearch-project/OpenSearch/pull/10036))
-- Add the means to extract the contextual properties from HttpChannel, TcpCChannel and TrasportChannel without excessive typecasting ([#10562](https://github.com/opensearch-project/OpenSearch/pull/10562))
+- Add the means to extract the contextual properties from HttpChannel, TcpCChannel and TrasportChannel without excessive typecasting ([#10562](https://github.com/opensearch-project/OpenSearch/pull/10562)), ([#11751](https://github.com/opensearch-project/OpenSearch/pull/11751))
 - Backport the PR #9107 for updating CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_KEY setting to a dynamic setting ([#10606](https://github.com/opensearch-project/OpenSearch/pull/10606))
 - Search pipelines now support asynchronous request and response processors to avoid blocking on a transport thread ([#10598](https://github.com/opensearch-project/OpenSearch/pull/10598))
 - [Remote Store] Add Remote Store backpressure rejection stats to `_nodes/stats` ([#10524](https://github.com/opensearch-project/OpenSearch/pull/10524))

--- a/modules/transport-netty4/src/main/java/org/opensearch/http/netty4/Netty4HttpChannel.java
+++ b/modules/transport-netty4/src/main/java/org/opensearch/http/netty4/Netty4HttpChannel.java
@@ -44,6 +44,7 @@ import java.util.Optional;
 import io.netty.channel.Channel;
 
 public class Netty4HttpChannel implements HttpChannel {
+    private static final String CHANNEL_PROPERTY = "channel";
 
     private final Channel channel;
     private final CompletableContext<Void> closeContext = new CompletableContext<>();
@@ -90,6 +91,10 @@ public class Netty4HttpChannel implements HttpChannel {
     @SuppressWarnings("unchecked")
     @Override
     public <T> Optional<T> get(String name, Class<T> clazz) {
+        if (CHANNEL_PROPERTY.equalsIgnoreCase(name) && clazz.isAssignableFrom(Channel.class)) {
+            return (Optional<T>) Optional.of(getNettyChannel());
+        }
+
         Object handler = getNettyChannel().pipeline().get(name);
 
         if (handler != null && clazz.isInstance(handler) == true) {

--- a/modules/transport-netty4/src/test/java/org/opensearch/http/netty4/Netty4HttpChannelTests.java
+++ b/modules/transport-netty4/src/test/java/org/opensearch/http/netty4/Netty4HttpChannelTests.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.http.netty4;
+
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.Netty4NioSocketChannel;
+import org.junit.Before;
+
+import java.util.Optional;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelOutboundInvoker;
+import io.netty.channel.ServerChannel;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+
+public class Netty4HttpChannelTests extends OpenSearchTestCase {
+    private Netty4HttpChannel netty4HttpChannel;
+    private Channel channel;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        channel = new Netty4NioSocketChannel();
+        netty4HttpChannel = new Netty4HttpChannel(channel);
+    }
+
+    public void testChannelAttributeMatchesChannel() {
+        final Optional<Channel> channelOpt = netty4HttpChannel.get("channel", Channel.class);
+        assertThat(channelOpt.isPresent(), is(true));
+        assertThat(channelOpt.get(), sameInstance(channel));
+    }
+
+    public void testChannelAttributeMatchesChannelOutboundInvoker() {
+        final Optional<ChannelOutboundInvoker> channelOpt = netty4HttpChannel.get("channel", ChannelOutboundInvoker.class);
+        assertThat(channelOpt.isPresent(), is(true));
+        assertThat(channelOpt.get(), sameInstance(channel));
+    }
+
+    public void testChannelAttributeIsEmpty() {
+        final Optional<ServerChannel> channelOpt = netty4HttpChannel.get("channel", ServerChannel.class);
+        assertThat(channelOpt.isEmpty(), is(true));
+    }
+}


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/11751 to `2.x`