### PR TITLE
Fix flaky RemoteStoreRefreshListenerTests testTrackerData #11256

### DIFF
--- a/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
@@ -418,7 +418,7 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
         RemoteStoreRefreshListener listener = tuple.v1();
         RemoteStoreStatsTrackerFactory trackerFactory = tuple.v2();
         RemoteSegmentTransferTracker tracker = trackerFactory.getRemoteSegmentTransferTracker(indexShard.shardId());
-        assertNoLag(tracker);
+        assertBusy(() -> assertNoLag(tracker));
         indexDocs(100, randomIntBetween(100, 200));
         indexShard.refresh("test");
         listener.afterRefresh(true);
@@ -472,6 +472,14 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
                 .build(),
             new InternalEngineFactory()
         );
+
+        RemoteSegmentTransferTracker tracker = indexShard.getRemoteStoreStatsTrackerFactory()
+            .getRemoteSegmentTransferTracker(indexShard.shardId());
+        try {
+            assertBusy(() -> assertTrue(tracker.getTotalUploadsSucceeded() > 0));
+        } catch (Exception e) {
+            assert false;
+        }
 
         indexDocs(1, randomIntBetween(1, 100));
 
@@ -554,7 +562,6 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
         RecoverySettings recoverySettings = mock(RecoverySettings.class);
         when(recoverySettings.getMinRemoteSegmentMetadataFiles()).thenReturn(10);
         when(shard.getRecoverySettings()).thenReturn(recoverySettings);
-        RemoteSegmentTransferTracker tracker = remoteStoreStatsTrackerFactory.getRemoteSegmentTransferTracker(indexShard.shardId());
         RemoteStoreRefreshListener refreshListener = new RemoteStoreRefreshListener(shard, emptyCheckpointPublisher, tracker);
         refreshListener.afterRefresh(true);
         return Tuple.tuple(refreshListener, remoteStoreStatsTrackerFactory);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This closes #11256. The flakiness in the `RemoteStoreRefreshListenerTests.testTrackerData` test is happening due to `RemoteSegmentStoreDirectory.init()` method being called on account of simultaneous refreshes from test. In the test setup, we create a full fledged IndexShard and use it's remote store classes for mimicing/mocking certain test behaviours. Now, the refreshes of the underlying IndexShard and the manually invoked test's afterRefreshes were happening simultaneously causing the shared `RemoteSegmentStoreDirectory` object's `segmentsUploadedToRemoteStore` map to get cleared. The changes now ensures that the concurrency does not happen any more.

### Related Issues
Resolves #11256
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [ ] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
