### PR TITLE
Unmute testNoFailuresOnFileReads flaky test

### DIFF
--- a/server/src/test/java/org/opensearch/index/shard/RemoteIndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteIndexShardTests.java
@@ -465,7 +465,6 @@ public class RemoteIndexShardTests extends SegmentReplicationIndexShardTests {
      * blocking update of reader. Once this is done, it corrupts one segment file and ensure that file is deleted in next
      * round of segment replication by ensuring doc count.
      */
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/10885")
     public void testNoFailuresOnFileReads() throws Exception {
         try (ReplicationGroup shards = createGroup(1, getIndexSettings(), new NRTReplicationEngineFactory())) {
             shards.startAll();


### PR DESCRIPTION
### Description
The test fails while asserting non-emtpy set of corrupted files [here](https://github.com/opensearch-project/OpenSearch/blob/919aef6aa7a312d2477a1a8b7727c997aa37f603/server/src/test/java/org/opensearch/index/shard/RemoteIndexShardTests.java#L512C13-L512C49). I suspect the failure happens because first round of segment replication completes pre-maturely without actually copying any files, which breaks this assertion. This is possible as listener (for copying files) gets resolved immediately due to [exception](https://github.com/opensearch-project/OpenSearch/blob/ebda9639f4ca98a2181bdcb2c43f82224b1d2a34/server/src/test/java/org/opensearch/index/shard/RemoteIndexShardTests.java#L482) inside custom RemoteStoreReplicationSource. The actual file copy continues async BUT inside test we have already proceeded on validating assertions, which breaks. I recently [fixed](https://github.com/opensearch-project/OpenSearch/pull/11786) the logic to appropriately wait for files to copy over before performing any follow up action (corruption in this case). So as part of this change, we only need to unmute this test. 


### Error stack trace
```
java.lang.AssertionError
	at __randomizedtesting.SeedInfo.seed([A71542B40F44C18D:825D5DA2CC1735C3]:0)
	at org.junit.Assert.fail(Assert.java:87)
	at org.junit.Assert.assertTrue(Assert.java:42)
	at org.junit.Assert.assertNotNull(Assert.java:713)
	at org.junit.Assert.assertNotNull(Assert.java:723)
	at org.opensearch.index.shard.RemoteIndexShardTests.testNoFailuresOnFileReads(RemoteIndexShardTests.java:512)
...
```

### Issues
Resolves #10945 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
~- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
