### PR TITLE
[Backport 2.x] Fix parsing of flat object fields with dots in keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix the issue with DefaultSpanScope restoring wrong span in the TracerContextStorage upon detach ([#11316](https://github.com/opensearch-project/OpenSearch/issues/11316))
 - Remove shadowJar from `lang-painless` module publication ([#11369](https://github.com/opensearch-project/OpenSearch/issues/11369))
 - Fix remote shards balancer and remove unused variables ([#11167](https://github.com/opensearch-project/OpenSearch/pull/11167))
+- Fix parsing of flat object fields with dots in keys ([#11425](https://github.com/opensearch-project/OpenSearch/pull/11425))
 - Fix bug where replication lag grows post primary relocation ([#11238](https://github.com/opensearch-project/OpenSearch/pull/11238))
 - Fix for stuck update action in a bulk with `retry_on_conflict` property ([#11152](https://github.com/opensearch-project/OpenSearch/issues/11152))
 - Fix template setting override for replication type ([#11417](https://github.com/opensearch-project/OpenSearch/pull/11417))

--- a/server/src/main/java/org/opensearch/index/mapper/FlatObjectFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FlatObjectFieldMapper.java
@@ -572,7 +572,7 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
             JsonToStringXContentParser JsonToStringParser = new JsonToStringXContentParser(
                 NamedXContentRegistry.EMPTY,
                 DeprecationHandler.IGNORE_DEPRECATIONS,
-                context,
+                context.parser(),
                 fieldType().name()
             );
             /*

--- a/server/src/test/java/org/opensearch/common/xcontent/JsonToStringXContentParserTests.java
+++ b/server/src/test/java/org/opensearch/common/xcontent/JsonToStringXContentParserTests.java
@@ -1,0 +1,113 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.xcontent;
+
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.xcontent.DeprecationHandler;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+
+public class JsonToStringXContentParserTests extends OpenSearchTestCase {
+
+    private String flattenJsonString(String fieldName, String in) throws IOException {
+        String transformed;
+        try (
+            XContentParser parser = JsonXContent.jsonXContent.createParser(
+                xContentRegistry(),
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                in
+            )
+        ) {
+            JsonToStringXContentParser jsonToStringXContentParser = new JsonToStringXContentParser(
+                xContentRegistry(),
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                parser,
+                fieldName
+            );
+            // Skip the START_OBJECT token:
+            jsonToStringXContentParser.nextToken();
+
+            XContentParser transformedParser = jsonToStringXContentParser.parseObject();
+            try (XContentBuilder jsonBuilder = XContentFactory.jsonBuilder()) {
+                jsonBuilder.copyCurrentStructure(transformedParser);
+                return jsonBuilder.toString();
+            }
+        }
+    }
+
+    public void testNestedObjects() throws IOException {
+        String jsonExample = "{" + "\"first\" : \"1\"," + "\"second\" : {" + "  \"inner\":  \"2.0\"" + "}," + "\"third\": \"three\"" + "}";
+
+        assertEquals(
+            "{"
+                + "\"flat\":[\"first\",\"second\",\"inner\",\"third\"],"
+                + "\"flat._value\":[\"1\",\"2.0\",\"three\"],"
+                + "\"flat._valueAndPath\":[\"flat.first=1\",\"flat.second.inner=2.0\",\"flat.third=three\"]"
+                + "}",
+            flattenJsonString("flat", jsonExample)
+        );
+    }
+
+    public void testChildHasDots() throws IOException {
+        // This should be exactly the same as testNestedObjects. We're just using the "flat" notation for the inner
+        // object.
+        String jsonExample = "{" + "\"first\" : \"1\"," + "\"second.inner\" : \"2.0\"," + "\"third\": \"three\"" + "}";
+
+        assertEquals(
+            "{"
+                + "\"flat\":[\"first\",\"second\",\"inner\",\"third\"],"
+                + "\"flat._value\":[\"1\",\"2.0\",\"three\"],"
+                + "\"flat._valueAndPath\":[\"flat.first=1\",\"flat.second.inner=2.0\",\"flat.third=three\"]"
+                + "}",
+            flattenJsonString("flat", jsonExample)
+        );
+    }
+
+    public void testNestChildObjectWithDots() throws IOException {
+        String jsonExample = "{"
+            + "\"first\" : \"1\","
+            + "\"second.inner\" : {"
+            + "  \"really_inner\" : \"2.0\""
+            + "},"
+            + "\"third\": \"three\""
+            + "}";
+
+        assertEquals(
+            "{"
+                + "\"flat\":[\"first\",\"second\",\"inner\",\"really_inner\",\"third\"],"
+                + "\"flat._value\":[\"1\",\"2.0\",\"three\"],"
+                + "\"flat._valueAndPath\":[\"flat.first=1\",\"flat.second.inner.really_inner=2.0\",\"flat.third=three\"]"
+                + "}",
+            flattenJsonString("flat", jsonExample)
+        );
+    }
+
+    public void testNestChildObjectWithDotsAndFieldWithDots() throws IOException {
+        String jsonExample = "{"
+            + "\"first\" : \"1\","
+            + "\"second.inner\" : {"
+            + "  \"totally.absolutely.inner\" : \"2.0\""
+            + "},"
+            + "\"third\": \"three\""
+            + "}";
+
+        assertEquals(
+            "{"
+                + "\"flat\":[\"first\",\"second\",\"inner\",\"totally\",\"absolutely\",\"inner\",\"third\"],"
+                + "\"flat._value\":[\"1\",\"2.0\",\"three\"],"
+                + "\"flat._valueAndPath\":[\"flat.first=1\",\"flat.second.inner.totally.absolutely.inner=2.0\",\"flat.third=three\"]"
+                + "}",
+            flattenJsonString("flat", jsonExample)
+        );
+    }
+
+}


### PR DESCRIPTION
We have a bug where a flat object field with inner fields that contain dots will "push" the dotted name onto the dot-path from the root, but then would just "pop" off the last part of the dotted name.

This change adds more robust support for flat object keys and subkeys that contain dots (i.e. it pops off the entirety of the latest key, regardless of how many dots it contains).

Fixes https://github.com/opensearch-project/OpenSearch/issues/11402
Backport of https://github.com/opensearch-project/OpenSearch/pull/11425

Signed-off-by: Michael Froh <froh@amazon.com>
(cherry picked from commit 22b628bacaab56c145538898ca190ffce9778c6e)

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] ~~New functionality has been documented.~~
  - [ ] ~~New functionality has javadoc added~~
- [ ] ~~Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))~~
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] ~~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
