### PR TITLE
Remove unused segment replication feature flag

### DIFF
--- a/server/src/main/java/org/opensearch/common/settings/FeatureFlagSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/FeatureFlagSettings.java
@@ -11,9 +11,6 @@ package org.opensearch.common.settings;
 import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.common.util.FeatureFlags;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -32,17 +29,12 @@ public class FeatureFlagSettings extends AbstractScopedSettings {
         super(settings, settingsSet, settingUpgraders, scope);
     }
 
-    public static final Set<Setting<?>> BUILT_IN_FEATURE_FLAGS = Collections.unmodifiableSet(
-        new HashSet<>(
-            Arrays.asList(
-                FeatureFlags.SEGMENT_REPLICATION_EXPERIMENTAL_SETTING,
-                FeatureFlags.EXTENSIONS_SETTING,
-                FeatureFlags.IDENTITY_SETTING,
-                FeatureFlags.CONCURRENT_SEGMENT_SEARCH_SETTING,
-                FeatureFlags.TELEMETRY_SETTING,
-                FeatureFlags.DATETIME_FORMATTER_CACHING_SETTING,
-                FeatureFlags.WRITEABLE_REMOTE_INDEX_SETTING
-            )
-        )
+    public static final Set<Setting<?>> BUILT_IN_FEATURE_FLAGS = Set.of(
+        FeatureFlags.EXTENSIONS_SETTING,
+        FeatureFlags.IDENTITY_SETTING,
+        FeatureFlags.CONCURRENT_SEGMENT_SEARCH_SETTING,
+        FeatureFlags.TELEMETRY_SETTING,
+        FeatureFlags.DATETIME_FORMATTER_CACHING_SETTING,
+        FeatureFlags.WRITEABLE_REMOTE_INDEX_SETTING
     );
 }

--- a/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
+++ b/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
@@ -21,12 +21,6 @@ import org.opensearch.common.settings.Settings;
  */
 public class FeatureFlags {
     /**
-     * Gates the visibility of the segment replication experimental features that allows users to test unreleased beta features.
-     */
-    public static final String SEGMENT_REPLICATION_EXPERIMENTAL =
-        "opensearch.experimental.feature.segment_replication_experimental.enabled";
-
-    /**
      * Gates the ability for Searchable Snapshots to read snapshots that are older than the
      * guaranteed backward compatibility for OpenSearch (one prior major version) on a best effort basis.
      */
@@ -104,12 +98,6 @@ public class FeatureFlags {
             return featureFlag.getDefault(Settings.EMPTY);
         }
     }
-
-    public static final Setting<Boolean> SEGMENT_REPLICATION_EXPERIMENTAL_SETTING = Setting.boolSetting(
-        SEGMENT_REPLICATION_EXPERIMENTAL,
-        false,
-        Property.NodeScope
-    );
 
     public static final Setting<Boolean> EXTENSIONS_SETTING = Setting.boolSetting(EXTENSIONS, false, Property.NodeScope);
 


### PR DESCRIPTION
This feature has been released and the feature flag is no longer used.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
