### PR TITLE
[Backport] [2.x] Fix typo in API annotation check message (#11836)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix issue when calling Delete PIT endpoint and no PITs exist ([#11711](https://github.com/opensearch-project/OpenSearch/pull/11711))
 - Fix tracing context propagation for local transport instrumentation ([#11490](https://github.com/opensearch-project/OpenSearch/pull/11490))
 - Fix parsing of single line comments in `lang-painless` ([#11815](https://github.com/opensearch-project/OpenSearch/issues/11815))
+- Fix typo in API annotation check message ([11836](https://github.com/opensearch-project/OpenSearch/pull/11836))
 
 ### Security
 

--- a/libs/common/src/main/java/org/opensearch/common/annotation/processor/ApiAnnotationProcessor.java
+++ b/libs/common/src/main/java/org/opensearch/common/annotation/processor/ApiAnnotationProcessor.java
@@ -113,7 +113,7 @@ public class ApiAnnotationProcessor extends AbstractProcessor {
         // The executable element should not be internal (unless constructor for injectable core component)
         checkNotInternal(enclosing, executable);
 
-        // Check this elements annotations
+        // Check this element's annotations
         for (final AnnotationMirror annotation : executable.getAnnotationMirrors()) {
             final Element element = annotation.getAnnotationType().asElement();
             if (inspectable(element)) {
@@ -210,7 +210,7 @@ public class ApiAnnotationProcessor extends AbstractProcessor {
             }
         }
 
-        // Check this elements annotations
+        // Check this element's annotations
         for (final AnnotationMirror annotation : ref.getAnnotationMirrors()) {
             final Element element = annotation.getAnnotationType().asElement();
             if (inspectable(element)) {
@@ -316,7 +316,7 @@ public class ApiAnnotationProcessor extends AbstractProcessor {
                     reportFailureAs,
                     "The element "
                         + element
-                        + " is part of the public APIs but is not maked as @PublicApi, @ExperimentalApi or @DeprecatedApi"
+                        + " is part of the public APIs but is not marked as @PublicApi, @ExperimentalApi or @DeprecatedApi"
                         + ((referencedBy != null) ? " (referenced by " + referencedBy + ") " : "")
                 );
         }

--- a/libs/common/src/test/java/org/opensearch/common/annotation/processor/ApiAnnotationProcessorTests.java
+++ b/libs/common/src/test/java/org/opensearch/common/annotation/processor/ApiAnnotationProcessorTests.java
@@ -35,7 +35,7 @@ public class ApiAnnotationProcessorTests extends OpenSearchTestCase implements C
                 matching(
                     Diagnostic.Kind.ERROR,
                     containsString(
-                        "The element org.opensearch.common.annotation.processor.NotAnnotated is part of the public APIs but is not maked as @PublicApi, @ExperimentalApi or @DeprecatedApi "
+                        "The element org.opensearch.common.annotation.processor.NotAnnotated is part of the public APIs but is not marked as @PublicApi, @ExperimentalApi or @DeprecatedApi "
                             + "(referenced by org.opensearch.common.annotation.processor.PublicApiMethodArgumentNotAnnotated)"
                     )
                 )
@@ -56,7 +56,7 @@ public class ApiAnnotationProcessorTests extends OpenSearchTestCase implements C
                 matching(
                     Diagnostic.Kind.ERROR,
                     containsString(
-                        "The element org.opensearch.common.annotation.processor.NotAnnotated is part of the public APIs but is not maked as @PublicApi, @ExperimentalApi or @DeprecatedApi "
+                        "The element org.opensearch.common.annotation.processor.NotAnnotated is part of the public APIs but is not marked as @PublicApi, @ExperimentalApi or @DeprecatedApi "
                             + "(referenced by org.opensearch.common.annotation.processor.PublicApiMethodArgumentNotAnnotatedGenerics)"
                     )
                 )
@@ -77,7 +77,7 @@ public class ApiAnnotationProcessorTests extends OpenSearchTestCase implements C
                 matching(
                     Diagnostic.Kind.ERROR,
                     containsString(
-                        "The element org.opensearch.common.annotation.processor.NotAnnotatedException is part of the public APIs but is not maked as @PublicApi, @ExperimentalApi or @DeprecatedApi "
+                        "The element org.opensearch.common.annotation.processor.NotAnnotatedException is part of the public APIs but is not marked as @PublicApi, @ExperimentalApi or @DeprecatedApi "
                             + "(referenced by org.opensearch.common.annotation.processor.PublicApiMethodThrowsNotAnnotated)"
                     )
                 )
@@ -111,7 +111,7 @@ public class ApiAnnotationProcessorTests extends OpenSearchTestCase implements C
                 matching(
                     Diagnostic.Kind.ERROR,
                     containsString(
-                        "The element org.opensearch.common.annotation.processor.NotAnnotatedPackagePrivate is part of the public APIs but is not maked as @PublicApi, @ExperimentalApi or @DeprecatedApi "
+                        "The element org.opensearch.common.annotation.processor.NotAnnotatedPackagePrivate is part of the public APIs but is not marked as @PublicApi, @ExperimentalApi or @DeprecatedApi "
                             + "(referenced by org.opensearch.common.annotation.processor.PublicApiMethodArgumentNotAnnotatedPackagePrivate)"
                     )
                 )
@@ -209,7 +209,7 @@ public class ApiAnnotationProcessorTests extends OpenSearchTestCase implements C
                 matching(
                     Diagnostic.Kind.ERROR,
                     containsString(
-                        "The element org.opensearch.common.annotation.processor.NotAnnotated is part of the public APIs but is not maked as @PublicApi, @ExperimentalApi or @DeprecatedApi "
+                        "The element org.opensearch.common.annotation.processor.NotAnnotated is part of the public APIs but is not marked as @PublicApi, @ExperimentalApi or @DeprecatedApi "
                             + "(referenced by org.opensearch.common.annotation.processor.PublicApiMethodReturnNotAnnotated)"
                     )
                 )
@@ -230,7 +230,7 @@ public class ApiAnnotationProcessorTests extends OpenSearchTestCase implements C
                 matching(
                     Diagnostic.Kind.ERROR,
                     containsString(
-                        "The element org.opensearch.common.annotation.processor.NotAnnotated is part of the public APIs but is not maked as @PublicApi, @ExperimentalApi or @DeprecatedApi "
+                        "The element org.opensearch.common.annotation.processor.NotAnnotated is part of the public APIs but is not marked as @PublicApi, @ExperimentalApi or @DeprecatedApi "
                             + "(referenced by org.opensearch.common.annotation.processor.PublicApiMethodReturnNotAnnotatedGenerics)"
                     )
                 )
@@ -251,7 +251,7 @@ public class ApiAnnotationProcessorTests extends OpenSearchTestCase implements C
                 matching(
                     Diagnostic.Kind.ERROR,
                     containsString(
-                        "The element org.opensearch.common.annotation.processor.NotAnnotated is part of the public APIs but is not maked as @PublicApi, @ExperimentalApi or @DeprecatedApi "
+                        "The element org.opensearch.common.annotation.processor.NotAnnotated is part of the public APIs but is not marked as @PublicApi, @ExperimentalApi or @DeprecatedApi "
                             + "(referenced by org.opensearch.common.annotation.processor.PublicApiMethodReturnNotAnnotatedArray)"
                     )
                 )
@@ -272,7 +272,7 @@ public class ApiAnnotationProcessorTests extends OpenSearchTestCase implements C
                 matching(
                     Diagnostic.Kind.ERROR,
                     containsString(
-                        "The element org.opensearch.common.annotation.processor.NotAnnotated is part of the public APIs but is not maked as @PublicApi, @ExperimentalApi or @DeprecatedApi "
+                        "The element org.opensearch.common.annotation.processor.NotAnnotated is part of the public APIs but is not marked as @PublicApi, @ExperimentalApi or @DeprecatedApi "
                             + "(referenced by org.opensearch.common.annotation.processor.PublicApiMethodReturnNotAnnotatedBoundedGenerics)"
                     )
                 )
@@ -297,7 +297,7 @@ public class ApiAnnotationProcessorTests extends OpenSearchTestCase implements C
                 matching(
                     Diagnostic.Kind.ERROR,
                     containsString(
-                        "The element org.opensearch.common.annotation.processor.NotAnnotatedAnnotation is part of the public APIs but is not maked as @PublicApi, @ExperimentalApi or @DeprecatedApi "
+                        "The element org.opensearch.common.annotation.processor.NotAnnotatedAnnotation is part of the public APIs but is not marked as @PublicApi, @ExperimentalApi or @DeprecatedApi "
                             + "(referenced by org.opensearch.common.annotation.processor.PublicApiMethodReturnNotAnnotatedAnnotation)"
                     )
                 )
@@ -388,7 +388,7 @@ public class ApiAnnotationProcessorTests extends OpenSearchTestCase implements C
                 matching(
                     Diagnostic.Kind.ERROR,
                     containsString(
-                        "The element org.opensearch.common.annotation.processor.NotAnnotated is part of the public APIs but is not maked as @PublicApi, @ExperimentalApi or @DeprecatedApi "
+                        "The element org.opensearch.common.annotation.processor.NotAnnotated is part of the public APIs but is not marked as @PublicApi, @ExperimentalApi or @DeprecatedApi "
                             + "(referenced by org.opensearch.common.annotation.processor.PublicApiMethodGenericsArgumentNotAnnotated)"
                     )
                 )
@@ -453,7 +453,7 @@ public class ApiAnnotationProcessorTests extends OpenSearchTestCase implements C
                 matching(
                     Diagnostic.Kind.ERROR,
                     containsString(
-                        "The element org.opensearch.common.annotation.processor.NotAnnotatedAnnotation is part of the public APIs but is not maked as @PublicApi, @ExperimentalApi or @DeprecatedApi "
+                        "The element org.opensearch.common.annotation.processor.NotAnnotatedAnnotation is part of the public APIs but is not marked as @PublicApi, @ExperimentalApi or @DeprecatedApi "
                             + "(referenced by org.opensearch.common.annotation.processor.PublicApiMethodReturnAnnotatedGenerics)"
                     )
                 )


### PR DESCRIPTION
### Description
- Fixing some internal comments as well

Signed-off-by: Lukáš Vlček <lukas.vlcek@aiven.io>
(cherry picked from commit feeb595be5c998efca4d11d65ea6a3d00cea17dd)

### Related Issues
Resolves #11836 

### Check List
- [ ] ~New functionality includes testing.~
  - [x] All tests pass
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [ ] ~Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))~
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
