### PR TITLE
Fix log appender in InsecureSettingTests

### DIFF
--- a/server/src/test/java/org/opensearch/common/logging/LoggersTests.java
+++ b/server/src/test/java/org/opensearch/common/logging/LoggersTests.java
@@ -83,11 +83,11 @@ public class LoggersTests extends OpenSearchTestCase {
             assertThat(appender.lastParameterizedMessage().getParameters(), arrayContaining(Arrays.asList("yes", "no")));
 
             ex = randomException();
-            testLogger.trace(() -> new ParameterizedMessage("a trace message; element = [{}]", new Object[]{null}), ex);
+            testLogger.trace(() -> new ParameterizedMessage("a trace message; element = [{}]", new Object[] { null }), ex);
             assertThat(appender.lastEvent.getLevel(), equalTo(Level.TRACE));
             assertThat(appender.lastEvent.getThrown(), equalTo(ex));
             assertThat(appender.lastParameterizedMessage().getFormattedMessage(), equalTo("a trace message; element = [null]"));
-            assertThat(appender.lastParameterizedMessage().getParameters(), arrayContaining(new Object[]{null}));
+            assertThat(appender.lastParameterizedMessage().getParameters(), arrayContaining(new Object[] { null }));
         } finally {
             Loggers.removeAppender(testLogger, appender);
             appender.stop();

--- a/server/src/test/java/org/opensearch/common/logging/LoggersTests.java
+++ b/server/src/test/java/org/opensearch/common/logging/LoggersTests.java
@@ -53,40 +53,45 @@ public class LoggersTests extends OpenSearchTestCase {
         appender.start();
         final Logger testLogger = LogManager.getLogger(LoggersTests.class);
         Loggers.addAppender(testLogger, appender);
-        Loggers.setLevel(testLogger, Level.TRACE);
+        try {
+            Loggers.setLevel(testLogger, Level.TRACE);
 
-        Throwable ex = randomException();
-        testLogger.error(() -> new ParameterizedMessage("an error message"), ex);
-        assertThat(appender.lastEvent.getLevel(), equalTo(Level.ERROR));
-        assertThat(appender.lastEvent.getThrown(), equalTo(ex));
-        assertThat(appender.lastParameterizedMessage().getFormattedMessage(), equalTo("an error message"));
+            Throwable ex = randomException();
+            testLogger.error(() -> new ParameterizedMessage("an error message"), ex);
+            assertThat(appender.lastEvent.getLevel(), equalTo(Level.ERROR));
+            assertThat(appender.lastEvent.getThrown(), equalTo(ex));
+            assertThat(appender.lastParameterizedMessage().getFormattedMessage(), equalTo("an error message"));
 
-        ex = randomException();
-        testLogger.warn(() -> new ParameterizedMessage("a warn message: [{}]", "long gc"), ex);
-        assertThat(appender.lastEvent.getLevel(), equalTo(Level.WARN));
-        assertThat(appender.lastEvent.getThrown(), equalTo(ex));
-        assertThat(appender.lastParameterizedMessage().getFormattedMessage(), equalTo("a warn message: [long gc]"));
-        assertThat(appender.lastParameterizedMessage().getParameters(), arrayContaining("long gc"));
+            ex = randomException();
+            testLogger.warn(() -> new ParameterizedMessage("a warn message: [{}]", "long gc"), ex);
+            assertThat(appender.lastEvent.getLevel(), equalTo(Level.WARN));
+            assertThat(appender.lastEvent.getThrown(), equalTo(ex));
+            assertThat(appender.lastParameterizedMessage().getFormattedMessage(), equalTo("a warn message: [long gc]"));
+            assertThat(appender.lastParameterizedMessage().getParameters(), arrayContaining("long gc"));
 
-        testLogger.info(() -> new ParameterizedMessage("an info message a=[{}], b=[{}], c=[{}]", 1, 2, 3));
-        assertThat(appender.lastEvent.getLevel(), equalTo(Level.INFO));
-        assertThat(appender.lastEvent.getThrown(), nullValue());
-        assertThat(appender.lastParameterizedMessage().getFormattedMessage(), equalTo("an info message a=[1], b=[2], c=[3]"));
-        assertThat(appender.lastParameterizedMessage().getParameters(), arrayContaining(1, 2, 3));
+            testLogger.info(() -> new ParameterizedMessage("an info message a=[{}], b=[{}], c=[{}]", 1, 2, 3));
+            assertThat(appender.lastEvent.getLevel(), equalTo(Level.INFO));
+            assertThat(appender.lastEvent.getThrown(), nullValue());
+            assertThat(appender.lastParameterizedMessage().getFormattedMessage(), equalTo("an info message a=[1], b=[2], c=[3]"));
+            assertThat(appender.lastParameterizedMessage().getParameters(), arrayContaining(1, 2, 3));
 
-        ex = randomException();
-        testLogger.debug(() -> new ParameterizedMessage("a debug message options = {}", Arrays.asList("yes", "no")), ex);
-        assertThat(appender.lastEvent.getLevel(), equalTo(Level.DEBUG));
-        assertThat(appender.lastEvent.getThrown(), equalTo(ex));
-        assertThat(appender.lastParameterizedMessage().getFormattedMessage(), equalTo("a debug message options = [yes, no]"));
-        assertThat(appender.lastParameterizedMessage().getParameters(), arrayContaining(Arrays.asList("yes", "no")));
+            ex = randomException();
+            testLogger.debug(() -> new ParameterizedMessage("a debug message options = {}", Arrays.asList("yes", "no")), ex);
+            assertThat(appender.lastEvent.getLevel(), equalTo(Level.DEBUG));
+            assertThat(appender.lastEvent.getThrown(), equalTo(ex));
+            assertThat(appender.lastParameterizedMessage().getFormattedMessage(), equalTo("a debug message options = [yes, no]"));
+            assertThat(appender.lastParameterizedMessage().getParameters(), arrayContaining(Arrays.asList("yes", "no")));
 
-        ex = randomException();
-        testLogger.trace(() -> new ParameterizedMessage("a trace message; element = [{}]", new Object[] { null }), ex);
-        assertThat(appender.lastEvent.getLevel(), equalTo(Level.TRACE));
-        assertThat(appender.lastEvent.getThrown(), equalTo(ex));
-        assertThat(appender.lastParameterizedMessage().getFormattedMessage(), equalTo("a trace message; element = [null]"));
-        assertThat(appender.lastParameterizedMessage().getParameters(), arrayContaining(new Object[] { null }));
+            ex = randomException();
+            testLogger.trace(() -> new ParameterizedMessage("a trace message; element = [{}]", new Object[]{null}), ex);
+            assertThat(appender.lastEvent.getLevel(), equalTo(Level.TRACE));
+            assertThat(appender.lastEvent.getThrown(), equalTo(ex));
+            assertThat(appender.lastParameterizedMessage().getFormattedMessage(), equalTo("a trace message; element = [null]"));
+            assertThat(appender.lastParameterizedMessage().getParameters(), arrayContaining(new Object[]{null}));
+        } finally {
+            Loggers.removeAppender(testLogger, appender);
+            appender.stop();
+        }
     }
 
     private Throwable randomException() {

--- a/server/src/test/java/org/opensearch/common/settings/InsecureSettingTests.java
+++ b/server/src/test/java/org/opensearch/common/settings/InsecureSettingTests.java
@@ -51,12 +51,12 @@ public class InsecureSettingTests extends OpenSearchTestCase {
             }
         };
         rootAppender.start();
-        Loggers.addAppender(LogManager.getRootLogger(), rootAppender);
+        Loggers.addAppender(LogManager.getLogger(SecureSetting.class), rootAppender);
     }
 
     @After
     public void removeInsecureSettingsAppender() {
-        Loggers.removeAppender(LogManager.getRootLogger(), rootAppender);
+        Loggers.removeAppender(LogManager.getLogger(SecureSetting.class), rootAppender);
         rootAppender.stop();
     }
 

--- a/server/src/test/java/org/opensearch/common/settings/InsecureSettingTests.java
+++ b/server/src/test/java/org/opensearch/common/settings/InsecureSettingTests.java
@@ -25,7 +25,7 @@ public class InsecureSettingTests extends OpenSearchTestCase {
     private List<String> rootLogMsgs = new ArrayList<>();
     private AbstractAppender rootAppender;
 
-    protected void assertSettingWarning() {
+    private void assertSettingWarning() {
         assertWarnings(
             "[setting.name] setting was deprecated in OpenSearch and will be removed in a future release! See the breaking changes documentation for the next major version."
         );
@@ -50,13 +50,14 @@ public class InsecureSettingTests extends OpenSearchTestCase {
                 InsecureSettingTests.this.rootLogMsgs.add(message);
             }
         };
-        Loggers.addAppender(LogManager.getRootLogger(), rootAppender);
         rootAppender.start();
+        Loggers.addAppender(LogManager.getRootLogger(), rootAppender);
     }
 
     @After
     public void removeInsecureSettingsAppender() {
         Loggers.removeAppender(LogManager.getRootLogger(), rootAppender);
+        rootAppender.stop();
     }
 
     public void testShouldRaiseExceptionByDefault() {


### PR DESCRIPTION
The appender was being added to the logger before the appender was started. This can lead to logger errors with concurrently running tests because the logger is static state shared across the JVM. See #10799.

I've also added a removeAppender call that was missing from LoggersTests, but that is mostly hygiene and would not lead to failures.

Resolves #10799

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
