### PR TITLE
Add copy ingest processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,7 +124,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add additional handling in SearchTemplateRequest when simulate is set to true ([#11591](https://github.com/opensearch-project/OpenSearch/pull/11591))
 - Introduce cluster level setting `cluster.index.restrict.replication.type` to prevent replication type setting override during index creations([#11583](https://github.com/opensearch-project/OpenSearch/pull/11583))
 - Add match_only_text field that is optimized for storage by trading off positional queries performance ([#6836](https://github.com/opensearch-project/OpenSearch/pull/11039))
-- Add copy ingest processor
+- Add copy ingest processor ([#11870](https://github.com/opensearch-project/OpenSearch/pull/11870))
 - Introduce new feature flag "WRITEABLE_REMOTE_INDEX" to gate the writeable remote index functionality ([#11717](https://github.com/opensearch-project/OpenSearch/pull/11170))
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add additional handling in SearchTemplateRequest when simulate is set to true ([#11591](https://github.com/opensearch-project/OpenSearch/pull/11591))
 - Introduce cluster level setting `cluster.index.restrict.replication.type` to prevent replication type setting override during index creations([#11583](https://github.com/opensearch-project/OpenSearch/pull/11583))
 - Add match_only_text field that is optimized for storage by trading off positional queries performance ([#6836](https://github.com/opensearch-project/OpenSearch/pull/11039))
+- Add copy ingest processor
 - Introduce new feature flag "WRITEABLE_REMOTE_INDEX" to gate the writeable remote index functionality ([#11717](https://github.com/opensearch-project/OpenSearch/pull/11170))
 
 ### Dependencies

--- a/modules/ingest-common/src/main/java/org/opensearch/ingest/common/CopyProcessor.java
+++ b/modules/ingest-common/src/main/java/org/opensearch/ingest/common/CopyProcessor.java
@@ -1,0 +1,161 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.ingest.common;
+
+import org.opensearch.core.common.Strings;
+import org.opensearch.ingest.AbstractProcessor;
+import org.opensearch.ingest.ConfigurationUtils;
+import org.opensearch.ingest.IngestDocument;
+import org.opensearch.ingest.Processor;
+import org.opensearch.script.ScriptService;
+import org.opensearch.script.TemplateScript;
+
+import java.util.Map;
+
+public final class CopyProcessor extends AbstractProcessor {
+    public static final String TYPE = "copy";
+
+    private final TemplateScript.Factory sourceField;
+    private final TemplateScript.Factory targetField;
+
+    private final boolean ignoreMissing;
+
+    private final boolean removeSource;
+
+    private final boolean overrideTarget;
+
+    CopyProcessor(String tag, String description, TemplateScript.Factory sourceField, TemplateScript.Factory targetField) {
+        this(tag, description, sourceField, targetField, false, false, false);
+    }
+
+    CopyProcessor(
+        String tag,
+        String description,
+        TemplateScript.Factory sourceField,
+        TemplateScript.Factory targetField,
+        boolean ignoreMissing,
+        boolean removeSource,
+        boolean overrideTarget
+    ) {
+        super(tag, description);
+        this.sourceField = sourceField;
+        this.targetField = targetField;
+        this.ignoreMissing = ignoreMissing;
+        this.removeSource = removeSource;
+        this.overrideTarget = overrideTarget;
+    }
+
+    public TemplateScript.Factory getSourceField() {
+        return sourceField;
+    }
+
+    public TemplateScript.Factory getTargetField() {
+        return targetField;
+    }
+
+    public boolean isIgnoreMissing() {
+        return ignoreMissing;
+    }
+
+    public boolean isRemoveSource() {
+        return removeSource;
+    }
+
+    public boolean isOverrideTarget() {
+        return overrideTarget;
+    }
+
+    @Override
+    public IngestDocument execute(IngestDocument document) {
+        String source = document.renderTemplate(sourceField);
+        final boolean sourceFieldPathIsNullOrEmpty = Strings.isNullOrEmpty(source);
+        if (sourceFieldPathIsNullOrEmpty || document.hasField(source, true) == false) {
+            if (ignoreMissing) {
+                return document;
+            } else if (sourceFieldPathIsNullOrEmpty) {
+                throw new IllegalArgumentException("source field path cannot be null nor empty");
+            } else {
+                throw new IllegalArgumentException("source field [" + source + "] doesn't exist");
+            }
+        }
+
+        String target = document.renderTemplate(targetField);
+        if (Strings.isNullOrEmpty(target)) {
+            throw new IllegalArgumentException("target field path cannot be null nor empty");
+        }
+        if (source.equals(target)) {
+            throw new IllegalArgumentException("source field path and target field path cannot be same");
+        }
+
+        if (overrideTarget || document.hasField(target, true) == false || document.getFieldValue(target, Object.class) == null) {
+            Object sourceValue = document.getFieldValue(source, Object.class);
+            document.setFieldValue(target, IngestDocument.deepCopy(sourceValue));
+        } else {
+            throw new IllegalArgumentException("target field [" + target + "] already exists");
+        }
+
+        if (removeSource) {
+            document.removeField(source);
+        }
+
+        return document;
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    public static final class Factory implements Processor.Factory {
+
+        private final ScriptService scriptService;
+
+        public Factory(ScriptService scriptService) {
+            this.scriptService = scriptService;
+        }
+
+        @Override
+        public CopyProcessor create(
+            Map<String, Processor.Factory> registry,
+            String processorTag,
+            String description,
+            Map<String, Object> config
+        ) throws Exception {
+            String sourceField = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "source_field");
+            TemplateScript.Factory sourceFieldTemplate = ConfigurationUtils.compileTemplate(
+                TYPE,
+                processorTag,
+                "source_field",
+                sourceField,
+                scriptService
+            );
+            String targetField = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "target_field");
+            TemplateScript.Factory targetFieldTemplate = ConfigurationUtils.compileTemplate(
+                TYPE,
+                processorTag,
+                "target_field",
+                targetField,
+                scriptService
+            );
+            boolean ignoreMissing = ConfigurationUtils.readBooleanProperty(TYPE, processorTag, config, "ignore_missing", false);
+            boolean removeSource = ConfigurationUtils.readBooleanProperty(TYPE, processorTag, config, "remove_source", false);
+            boolean overrideTarget = ConfigurationUtils.readBooleanProperty(TYPE, processorTag, config, "override_target", false);
+
+            return new CopyProcessor(
+                processorTag,
+                description,
+                sourceFieldTemplate,
+                targetFieldTemplate,
+                ignoreMissing,
+                removeSource,
+                overrideTarget
+            );
+        }
+    }
+}

--- a/modules/ingest-common/src/main/java/org/opensearch/ingest/common/IngestCommonModulePlugin.java
+++ b/modules/ingest-common/src/main/java/org/opensearch/ingest/common/IngestCommonModulePlugin.java
@@ -106,6 +106,7 @@ public class IngestCommonModulePlugin extends Plugin implements ActionPlugin, In
         processors.put(DropProcessor.TYPE, new DropProcessor.Factory());
         processors.put(HtmlStripProcessor.TYPE, new HtmlStripProcessor.Factory());
         processors.put(CsvProcessor.TYPE, new CsvProcessor.Factory());
+        processors.put(CopyProcessor.TYPE, new CopyProcessor.Factory(parameters.scriptService));
         return Collections.unmodifiableMap(processors);
     }
 

--- a/modules/ingest-common/src/test/java/org/opensearch/ingest/common/CopyProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/opensearch/ingest/common/CopyProcessorFactoryTests.java
@@ -1,0 +1,101 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.ingest.common;
+
+import org.opensearch.OpenSearchException;
+import org.opensearch.OpenSearchParseException;
+import org.opensearch.ingest.TestTemplateService;
+import org.opensearch.test.OpenSearchTestCase;
+import org.junit.Before;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+
+public class CopyProcessorFactoryTests extends OpenSearchTestCase {
+
+    private CopyProcessor.Factory factory;
+
+    @Before
+    public void init() {
+        factory = new CopyProcessor.Factory(TestTemplateService.instance());
+    }
+
+    public void testCreate() throws Exception {
+        boolean ignoreMissing = randomBoolean();
+        boolean removeSource = randomBoolean();
+        boolean overrideTarget = randomBoolean();
+        Map<String, Object> config = new HashMap<>();
+        config.put("source_field", "source");
+        config.put("target_field", "target");
+        config.put("ignore_missing", ignoreMissing);
+        config.put("remove_source", removeSource);
+        config.put("override_target", overrideTarget);
+        String processorTag = randomAlphaOfLength(10);
+        CopyProcessor copyProcessor = factory.create(null, processorTag, null, config);
+        assertThat(copyProcessor.getTag(), equalTo(processorTag));
+        assertThat(copyProcessor.getSourceField().newInstance(Collections.emptyMap()).execute(), equalTo("source"));
+        assertThat(copyProcessor.getTargetField().newInstance(Collections.emptyMap()).execute(), equalTo("target"));
+        assertThat(copyProcessor.isIgnoreMissing(), equalTo(ignoreMissing));
+        assertThat(copyProcessor.isRemoveSource(), equalTo(removeSource));
+        assertThat(copyProcessor.isOverrideTarget(), equalTo(overrideTarget));
+    }
+
+    public void testCreateWithSourceField() throws Exception {
+        Map<String, Object> config = new HashMap<>();
+        try {
+            factory.create(null, null, null, config);
+            fail("factory create should have failed");
+        } catch (OpenSearchParseException e) {
+            assertThat(e.getMessage(), equalTo("[source_field] required property is missing"));
+        }
+
+        config.put("source_field", null);
+        try {
+            factory.create(null, null, null, config);
+            fail("factory create should have failed");
+        } catch (OpenSearchParseException e) {
+            assertThat(e.getMessage(), equalTo("[source_field] required property is missing"));
+        }
+    }
+
+    public void testCreateWithTargetField() throws Exception {
+        Map<String, Object> config = new HashMap<>();
+        config.put("source_field", "source");
+        try {
+            factory.create(null, null, null, config);
+            fail("factory create should have failed");
+        } catch (OpenSearchParseException e) {
+            assertThat(e.getMessage(), equalTo("[target_field] required property is missing"));
+        }
+
+        config.put("source_field", "source");
+        config.put("target_field", null);
+        try {
+            factory.create(null, null, null, config);
+            fail("factory create should have failed");
+        } catch (OpenSearchParseException e) {
+            assertThat(e.getMessage(), equalTo("[target_field] required property is missing"));
+        }
+    }
+
+    public void testInvalidMustacheTemplate() throws Exception {
+        CopyProcessor.Factory factory = new CopyProcessor.Factory(TestTemplateService.instance(true));
+        Map<String, Object> config = new HashMap<>();
+        config.put("source_field", "{{source}}");
+        config.put("target_field", "target");
+        String processorTag = randomAlphaOfLength(10);
+        OpenSearchException exception = expectThrows(OpenSearchException.class, () -> factory.create(null, processorTag, null, config));
+        assertThat(exception.getMessage(), equalTo("java.lang.RuntimeException: could not compile script"));
+        assertThat(exception.getMetadata("opensearch.processor_tag").get(0), equalTo(processorTag));
+    }
+
+}

--- a/modules/ingest-common/src/test/java/org/opensearch/ingest/common/CopyProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/opensearch/ingest/common/CopyProcessorTests.java
@@ -1,0 +1,125 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.ingest.common;
+
+import org.opensearch.ingest.IngestDocument;
+import org.opensearch.ingest.Processor;
+import org.opensearch.ingest.RandomDocumentPicks;
+import org.opensearch.ingest.TestTemplateService;
+import org.opensearch.test.OpenSearchTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class CopyProcessorTests extends OpenSearchTestCase {
+
+    public void testCopyExistingField() throws Exception {
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
+        String sourceFieldName = RandomDocumentPicks.randomExistingFieldName(random(), ingestDocument);
+        String targetFieldName = RandomDocumentPicks.randomFieldName(random());
+        Processor processor = createCopyProcessor(sourceFieldName, targetFieldName, false, false, false);
+        processor.execute(ingestDocument);
+        assertThat(ingestDocument.hasField(targetFieldName), equalTo(true));
+        Object sourceValue = ingestDocument.getFieldValue(sourceFieldName, Object.class);
+        assertThat(ingestDocument.getFieldValue(targetFieldName, Object.class), equalTo(sourceValue));
+        assertThat(ingestDocument.getFieldValue(sourceFieldName, Object.class), equalTo(sourceValue));
+
+        Processor processorWithEmptyTarget = createCopyProcessor(sourceFieldName, "", false, false, false);
+        assertThrows(
+            "target field path cannot be null nor empty",
+            IllegalArgumentException.class,
+            () -> processorWithEmptyTarget.execute(ingestDocument)
+        );
+
+        Processor processorWithSameSourceAndTarget = createCopyProcessor(sourceFieldName, sourceFieldName, false, false, false);
+        assertThrows(
+            "source field path and target field path cannot be same",
+            IllegalArgumentException.class,
+            () -> processorWithSameSourceAndTarget.execute(ingestDocument)
+        );
+    }
+
+    public void testCopyWithIgnoreMissing() throws Exception {
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
+        String targetFieldName = RandomDocumentPicks.randomFieldName(random());
+        Processor processor = createCopyProcessor("non-existing-field", targetFieldName, false, false, false);
+        assertThrows(
+            "source field [non-existing-field] doesn't exist",
+            IllegalArgumentException.class,
+            () -> processor.execute(ingestDocument)
+        );
+
+        Processor processorWithEmptyFieldName = createCopyProcessor("", targetFieldName, false, false, false);
+        assertThrows(
+            "source field path cannot be null nor empty",
+            IllegalArgumentException.class,
+            () -> processorWithEmptyFieldName.execute(ingestDocument)
+        );
+
+        Processor processorWithIgnoreMissing = createCopyProcessor("non-existing-field", targetFieldName, true, false, false);
+        processorWithIgnoreMissing.execute(ingestDocument);
+        assertThat(ingestDocument.hasField(targetFieldName), equalTo(false));
+    }
+
+    public void testCopyWithRemoveSource() throws Exception {
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
+        String sourceFieldName = RandomDocumentPicks.randomExistingFieldName(random(), ingestDocument);
+        String targetFieldName = RandomDocumentPicks.randomFieldName(random());
+        Object sourceValue = ingestDocument.getFieldValue(sourceFieldName, Object.class);
+
+        Processor processor = createCopyProcessor(sourceFieldName, targetFieldName, false, true, false);
+        processor.execute(ingestDocument);
+        assertThat(ingestDocument.hasField(targetFieldName), equalTo(true));
+        assertThat(ingestDocument.getFieldValue(targetFieldName, Object.class), equalTo(sourceValue));
+        assertThat(ingestDocument.hasField(sourceFieldName), equalTo(false));
+    }
+
+    public void testCopyToExistingField() throws Exception {
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
+        String targetFieldName = RandomDocumentPicks.randomExistingFieldName(random(), ingestDocument);
+        Object sourceValue = RandomDocumentPicks.randomFieldValue(random());
+        String sourceFieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, sourceValue);
+
+        Processor processor = createCopyProcessor(sourceFieldName, targetFieldName, false, false, false);
+        assertThrows(
+            "target field [" + targetFieldName + "] already exists",
+            IllegalArgumentException.class,
+            () -> processor.execute(ingestDocument)
+        );
+
+        // if override_target is false but target field's value is null, copy can execute successfully
+        String targetFieldWithNullValue = RandomDocumentPicks.addRandomField(random(), ingestDocument, null);
+        Processor processorWithTargetNullValue = createCopyProcessor(sourceFieldName, targetFieldWithNullValue, false, false, false);
+        processorWithTargetNullValue.execute(ingestDocument);
+        assertThat(ingestDocument.hasField(targetFieldWithNullValue), equalTo(true));
+        assertThat(ingestDocument.getFieldValue(targetFieldWithNullValue, Object.class), equalTo(sourceValue));
+
+        Processor processorWithOverrideTargetIsTrue = createCopyProcessor(sourceFieldName, targetFieldName, false, false, true);
+        processorWithOverrideTargetIsTrue.execute(ingestDocument);
+        assertThat(ingestDocument.hasField(targetFieldName), equalTo(true));
+        assertThat(ingestDocument.getFieldValue(targetFieldName, Object.class), equalTo(sourceValue));
+    }
+
+    private static Processor createCopyProcessor(
+        String sourceFieldName,
+        String targetFieldName,
+        boolean ignoreMissing,
+        boolean removeSource,
+        boolean overrideTarget
+    ) {
+        return new CopyProcessor(
+            randomAlphaOfLength(10),
+            null,
+            new TestTemplateService.MockTemplateScript.Factory(sourceFieldName),
+            new TestTemplateService.MockTemplateScript.Factory(targetFieldName),
+            ignoreMissing,
+            removeSource,
+            overrideTarget
+        );
+    }
+}

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/10_basic.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/10_basic.yml
@@ -36,3 +36,19 @@
     - contains:  { nodes.$cluster_manager.ingest.processors: { type: split } }
     - contains:  { nodes.$cluster_manager.ingest.processors: { type: trim } }
     - contains:  { nodes.$cluster_manager.ingest.processors: { type: uppercase } }
+
+"Copy processor exists":
+    - skip:
+          version: " - 2.11.99"
+          features: contains
+          reason: "copy processor was introduced in 2.12.0 and contains is a newly added assertion"
+    - do:
+          cluster.state: {}
+
+    # Get cluster-manager node id
+    - set: { cluster_manager_node: cluster_manager }
+
+    - do:
+          nodes.info: {}
+
+    - contains:  { nodes.$cluster_manager.ingest.processors: { type: copy } }

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/10_basic.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/10_basic.yml
@@ -37,6 +37,7 @@
     - contains:  { nodes.$cluster_manager.ingest.processors: { type: trim } }
     - contains:  { nodes.$cluster_manager.ingest.processors: { type: uppercase } }
 
+---
 "Copy processor exists":
     - skip:
           version: " - 2.11.99"

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/300_copy_processor.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/300_copy_processor.yml
@@ -1,0 +1,374 @@
+---
+teardown:
+  - do:
+      ingest.delete_pipeline:
+        id: "1"
+        ignore: 404
+
+---
+"Test creat copy processor":
+  - skip:
+      version: " - 2.11.99"
+      reason: "introduced in 2.12"
+  - do:
+      catch: /\[target\_field\] required property is missing/
+      ingest.put_pipeline:
+        id: "1"
+        body:  >
+          {
+            "processors": [
+              {
+                "copy" : {
+                  "source_field" : "source"
+                }
+              }
+            ]
+          }
+  - do:
+      catch: /\[source\_field\] required property is missing/
+      ingest.put_pipeline:
+        id: "1"
+        body:  >
+          {
+            "processors": [
+              {
+                "copy" : {
+                  "target_field" : "target"
+                }
+              }
+            ]
+          }
+  - do:
+      ingest.put_pipeline:
+        id: "1"
+        body:  >
+          {
+            "processors": [
+              {
+                "copy" : {
+                  "source_field" : "source",
+                  "target_field" : "target",
+                  "ignore_missing" : true,
+                  "remove_source" : true,
+                  "override_target" : true
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+---
+"Test copy processor with ignore_missing":
+  - skip:
+      version: " - 2.11.99"
+      reason: "introduced in 2.12"
+  - do:
+      ingest.put_pipeline:
+        id: "1"
+        body:  >
+          {
+            "processors": [
+              {
+                "copy" : {
+                  "source_field" : "unknown_field",
+                  "target_field" : "bar"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      catch: /source field \[unknown\_field\] doesn\'t exist/
+      index:
+        index: test
+        id: 1
+        pipeline: "1"
+        body: {
+          foo: "hello"
+        }
+
+  - do:
+      ingest.put_pipeline:
+        id: "1"
+        body:  >
+          {
+            "processors": [
+              {
+                "copy" : {
+                  "source_field" : "unknown_field",
+                  "target_field" : "bar",
+                  "ignore_missing" : true
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test
+        id: 1
+        pipeline: "1"
+        body: {
+          foo: "hello"
+        }
+  - do:
+      get:
+        index: test
+        id: 1
+  - match: { _source: { foo: "hello" } }
+
+---
+"Test copy processor with remove_source":
+  - skip:
+      version: " - 2.11.99"
+      reason: "introduced in 2.12"
+  - do:
+      ingest.put_pipeline:
+        id: "1"
+        body:  >
+          {
+            "processors": [
+              {
+                "copy" : {
+                  "source_field" : "foo",
+                  "target_field" : "bar"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test
+        id: 1
+        pipeline: "1"
+        body: {
+          foo: "hello"
+        }
+  - do:
+      get:
+        index: test
+        id: 1
+  - match: { _source: { foo: "hello", bar: "hello" } }
+
+  - do:
+      ingest.put_pipeline:
+        id: "1"
+        body:  >
+          {
+            "processors": [
+              {
+                "copy" : {
+                  "source_field" : "foo",
+                  "target_field" : "bar",
+                  "remove_source" : true
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test
+        id: 1
+        pipeline: "1"
+        body: {
+          foo: "hello"
+        }
+  - do:
+      get:
+        index: test
+        id: 1
+  - match: { _source: { bar: "hello" } }
+
+---
+"Test copy processor with override_target":
+  - skip:
+      version: " - 2.11.99"
+      reason: "introduced in 2.12"
+  - do:
+      ingest.put_pipeline:
+        id: "1"
+        body:  >
+          {
+            "processors": [
+              {
+                "copy" : {
+                  "source_field" : "foo",
+                  "target_field" : "bar"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      catch: /target field \[bar\] already exists/
+      index:
+        index: test
+        id: 1
+        pipeline: "1"
+        body: {
+          foo: "hello",
+          bar: "world"
+        }
+
+  - do:
+      ingest.put_pipeline:
+        id: "1"
+        body:  >
+          {
+            "processors": [
+              {
+                "copy" : {
+                  "source_field" : "foo",
+                  "target_field" : "bar",
+                  "override_target" : true
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test
+        id: 1
+        pipeline: "1"
+        body: {
+          foo: "hello",
+          bar: "world"
+        }
+  - do:
+      get:
+        index: test
+        id: 1
+  - match: { _source: { foo: "hello", bar: "hello" } }
+
+---
+"Test copy processor with template snippets":
+  - skip:
+      version: " - 2.11.99"
+      reason: "introduced in 2.12"
+  - do:
+      ingest.put_pipeline:
+        id: "1"
+        body:  >
+          {
+            "processors": [
+              {
+                "copy" : {
+                  "source_field" : "{{source}}",
+                  "target_field" : "{{target}}"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      catch: /source field path cannot be null nor empty/
+      index:
+        index: test
+        id: 1
+        pipeline: "1"
+        body: {
+          target: "bar",
+          foo: "hello",
+          bar: "world"
+        }
+
+  - do:
+      ingest.put_pipeline:
+        id: "1"
+        body:  >
+          {
+            "processors": [
+              {
+                "copy" : {
+                  "source_field" : "{{source}}",
+                  "target_field" : "{{target}}"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      catch: /target field path cannot be null nor empty/
+      index:
+        index: test
+        id: 1
+        pipeline: "1"
+        body: {
+          source: "foo",
+          foo: "hello",
+          bar: "world"
+        }
+
+  - do:
+      ingest.put_pipeline:
+        id: "1"
+        body:  >
+          {
+            "processors": [
+              {
+                "copy" : {
+                  "source_field" : "{{source}}",
+                  "target_field" : "{{target}}"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      catch: /source field path and target field path cannot be same/
+      index:
+        index: test
+        id: 1
+        pipeline: "1"
+        body: {
+          source: "foo",
+          target: "foo",
+          foo: "hello",
+          bar: "world"
+        }
+
+  - do:
+      ingest.put_pipeline:
+        id: "1"
+        body:  >
+          {
+            "processors": [
+              {
+                "copy" : {
+                  "source_field" : "{{source}}",
+                  "target_field" : "{{target}}",
+                  "override_target" : true
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test
+        id: 1
+        pipeline: "1"
+        body: {
+          source: "foo",
+          target: "bar",
+          foo: "hello",
+          bar: "world"
+        }
+  - do:
+      get:
+        index: test
+        id: 1
+  - match: { _source: { source: "foo", target: "bar", foo: "hello", bar: "hello" } }

--- a/server/src/main/java/org/opensearch/ingest/IngestDocument.java
+++ b/server/src/main/java/org/opensearch/ingest/IngestDocument.java
@@ -757,7 +757,7 @@ public final class IngestDocument {
         return (Map<K, V>) deepCopy(source);
     }
 
-    private static Object deepCopy(Object value) {
+    public static Object deepCopy(Object value) {
         if (value instanceof Map) {
             Map<?, ?> mapValue = (Map<?, ?>) value;
             Map<Object, Object> copy = new HashMap<>(mapValue.size());


### PR DESCRIPTION
### Description
This PR adds a new ingest processor called `copy` processor which can copy the whole object from one existing field to another field, this is useful when users want to copy a nested field to the root level and then delete the original field, this cannot be achieved by set processor because it doesn't support copying object, only basic data types are supported. In addition, even though script processor can be used to copy object, but writing painless script is not easy for users. The copy processor provides an easy way to copy object.

The usage of copy processor are as follows:
```
POST _ingest/pipeline/_simulate
{
  "pipeline": {
    "processors": [
      {
        "copy": {
          "source_field": "{{foo}}", 
          "target_field":"target",
          "ignore_missing":true,
          "override_target":true,
          "remove_source":true
        }
      }
    ]
  },
  "docs": [
    {
      "_version_type":"external_gte",
      "_version": 1,
      "_source": {
        "foo":"a", 
        "a": {
          "c":"1"
        },
        "target":1
      }
    }
  ]
}
```
, the result is:
```
{
  "docs": [
    {
      "doc": {
        "_index": "_index",
        "_id": "_id",
        "_version": "1",
        "_version_type": "external_gte",
        "_source": {
          "foo": "a",
          "target": {
            "c": "1"
          }
        },
        "_ingest": {
          "timestamp": "2024-01-12T13:44:27.287123Z"
        }
      }
    }
  ]
}
```
.
Both the `source_field` and `target_field` support template snippets, and there are three extra parameters:

- `ignore_missing`: if true, exit quietly when source_field doesn't exist or has a empty field path, defaults to false
- `override_target`: if true, override the value of target_field if it already exists, defaults to false
- `remove_source`: if true, remove the source_field after the copy operation, defaults to false


### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/10134

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
