### PR TITLE
Update supported version for must_exist parameter in update aliases API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Don't over-allocate in HeapBufferedAsyncEntityConsumer in order to consume the response ([#9993](https://github.com/opensearch-project/OpenSearch/pull/9993))
 - Update supported version for max_shard_size parameter in Shrink API ([#11439](https://github.com/opensearch-project/OpenSearch/pull/11439))
 - Fix typo in API annotation check message ([11836](https://github.com/opensearch-project/OpenSearch/pull/11836))
+- Update supported version for must_exist parameter in update aliases API
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Don't over-allocate in HeapBufferedAsyncEntityConsumer in order to consume the response ([#9993](https://github.com/opensearch-project/OpenSearch/pull/9993))
 - Update supported version for max_shard_size parameter in Shrink API ([#11439](https://github.com/opensearch-project/OpenSearch/pull/11439))
 - Fix typo in API annotation check message ([11836](https://github.com/opensearch-project/OpenSearch/pull/11836))
-- Update supported version for must_exist parameter in update aliases API
+- Update supported version for must_exist parameter in update aliases API ([#11872](https://github.com/opensearch-project/OpenSearch/pull/11872))
 
 ### Security
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.update_aliases/40_remove_with_must_exist.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.update_aliases/40_remove_with_must_exist.yml
@@ -1,8 +1,8 @@
 ---
 "Throw aliases missing exception when removing non-existing alias with setting must_exist to true":
   - skip:
-      version: " - 2.99.99"
-      reason: "introduced in 3.0"
+      version: " - 2.11.99"
+      reason: "introduced in 2.12.0"
 
   - do:
       indices.create:
@@ -47,8 +47,8 @@
 ---
 "Throw aliases missing exception when all of the specified aliases are non-existing":
   - skip:
-      version: " - 2.99.99"
-      reason: "introduced in 3.0"
+      version: " - 2.11.99"
+      reason: "introduced in 2.12.0"
 
   - do:
       indices.create:
@@ -81,8 +81,8 @@
 ---
 "Remove successfully when some specified aliases are non-existing":
   - skip:
-      version: " - 2.99.99"
-      reason: "introduced in 3.0"
+      version: " - 2.11.99"
+      reason: "introduced in 2.12.0"
 
   - do:
       indices.create:
@@ -116,8 +116,8 @@
 ---
 "Remove silently when all of the specified aliases are non-existing and must_exist is false":
   - skip:
-      version: " - 2.99.99"
-      reason: "introduced in 3.0"
+      version: " - 2.11.99"
+      reason: "introduced in 2.12.0"
 
   - do:
       indices.create:


### PR DESCRIPTION
### Description

This [PR](https://github.com/opensearch-project/OpenSearch/pull/11210) enables the parameter must_exist in update aliases API and will be release in 2.12.0, in order to ensure the backward compatibility checks pass, the supported version in yaml test file was set to 3.0.0 in that PR, after the PR was merged and backport to 2.x, we need to update the supported version to 2.12.0 in main branch so that the backward compatibility checks can cover the change.

Backport 2.x is not needed.

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/2949

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
