### PR TITLE
Expose RestController all handlers iterator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Introduce new feature flag "WRITEABLE_REMOTE_INDEX" to gate the writeable remote index functionality ([#11717](https://github.com/opensearch-project/OpenSearch/pull/11170))
 - Bump OpenTelemetry from 1.32.0 to 1.34.1 ([#11891](https://github.com/opensearch-project/OpenSearch/pull/11891))
 - Support index level allocation filtering for searchable snapshot index ([#11563](https://github.com/opensearch-project/OpenSearch/pull/11563))
+- Add `org.opensearch.rest.MethodHandlers` and `RestController#getAllHandlers` ([11876](https://github.com/opensearch-project/OpenSearch/pull/11876))
 
 ### Dependencies
 - Bumps jetty version to 9.4.52.v20230823 to fix GMS-2023-1857 ([#9822](https://github.com/opensearch-project/OpenSearch/pull/9822))

--- a/server/src/main/java/org/opensearch/common/path/PathTrie.java
+++ b/server/src/main/java/org/opensearch/common/path/PathTrie.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Stack;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
@@ -402,6 +403,47 @@ public class PathTrie<T> {
                     throw new NoSuchElementException("called next() without validating hasNext()! no more modes available");
                 }
                 return retrieve(path, paramSupplier.get(), TrieMatchingMode.values()[mode++]);
+            }
+        };
+    }
+
+    public Iterator<T> retrieveAll() {
+        Stack<TrieNode> stack = new Stack<>();
+        stack.add(root);
+
+        return new Iterator<T>() {
+            @Override
+            public boolean hasNext() {
+                while (!stack.empty()) {
+                    TrieNode node = stack.peek();
+
+                    if (node.value != null) {
+                        return true;
+                    }
+
+                    advance();
+                }
+
+                return false;
+            }
+
+            @Override
+            public T next() {
+                while (!stack.empty()) {
+                    TrieNode node = advance();
+
+                    if (node.value != null) {
+                        return node.value;
+                    }
+                }
+
+                throw new NoSuchElementException("called next() without validating hasNext()! no more nodes available");
+            }
+
+            private TrieNode advance() {
+                TrieNode node = stack.pop();
+                stack.addAll(node.children.values());
+                return node;
             }
         };
     }

--- a/server/src/main/java/org/opensearch/rest/MethodHandlers.java
+++ b/server/src/main/java/org/opensearch/rest/MethodHandlers.java
@@ -43,7 +43,7 @@ import java.util.Set;
  *
  * @opensearch.api
  */
-final class MethodHandlers {
+public final class MethodHandlers {
 
     private final String path;
     private final Map<RestRequest.Method, RestHandler> methodHandlers;
@@ -79,9 +79,16 @@ final class MethodHandlers {
     }
 
     /**
-     * Return a set of all valid HTTP methods for the particular path
+     * Return a set of all valid HTTP methods for the particular path.
      */
-    Set<RestRequest.Method> getValidMethods() {
+    public Set<RestRequest.Method> getValidMethods() {
         return methodHandlers.keySet();
+    }
+
+    /**
+     * Returns the relative HTTP path of the set of method handlers.
+     */
+    public String getPath() {
+        return path;
     }
 }

--- a/server/src/main/java/org/opensearch/rest/MethodHandlers.java
+++ b/server/src/main/java/org/opensearch/rest/MethodHandlers.java
@@ -6,89 +6,24 @@
  * compatible open source license.
  */
 
-/*
- * Licensed to Elasticsearch under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-/*
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
 package org.opensearch.rest;
 
-import org.opensearch.common.Nullable;
+import org.opensearch.common.annotation.PublicApi;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
 
 /**
- * Encapsulate multiple handlers for the same path, allowing different handlers for different HTTP verbs.
- *
- * @opensearch.api
+ * A collection of REST method handlers.
  */
-public final class MethodHandlers {
-
-    private final String path;
-    private final Map<RestRequest.Method, RestHandler> methodHandlers;
-
-    MethodHandlers(String path, RestHandler handler, RestRequest.Method... methods) {
-        this.path = path;
-        this.methodHandlers = new HashMap<>(methods.length);
-        for (RestRequest.Method method : methods) {
-            methodHandlers.put(method, handler);
-        }
-    }
-
-    /**
-     * Add a handler for an additional array of methods. Note that {@code MethodHandlers}
-     * does not allow replacing the handler for an already existing method.
-     */
-    MethodHandlers addMethods(RestHandler handler, RestRequest.Method... methods) {
-        for (RestRequest.Method method : methods) {
-            RestHandler existing = methodHandlers.putIfAbsent(method, handler);
-            if (existing != null) {
-                throw new IllegalArgumentException("Cannot replace existing handler for [" + path + "] for method: " + method);
-            }
-        }
-        return this;
-    }
-
-    /**
-     * Returns the handler for the given method or {@code null} if none exists.
-     */
-    @Nullable
-    RestHandler getHandler(RestRequest.Method method) {
-        return methodHandlers.get(method);
-    }
-
+@PublicApi(since = "2.12.0")
+public interface MethodHandlers {
     /**
      * Return a set of all valid HTTP methods for the particular path.
      */
-    public Set<RestRequest.Method> getValidMethods() {
-        return methodHandlers.keySet();
-    }
+    Set<RestRequest.Method> getValidMethods();
 
     /**
      * Returns the relative HTTP path of the set of method handlers.
      */
-    public String getPath() {
-        return path;
-    }
+    String getPath();
 }

--- a/server/src/main/java/org/opensearch/rest/RestController.java
+++ b/server/src/main/java/org/opensearch/rest/RestController.java
@@ -145,6 +145,14 @@ public class RestController implements HttpServerTransport.Dispatcher {
     }
 
     /**
+     * Returns an iterator over registered REST method handlers.
+     * @return {@link Iterator} of {@link MethodHandlers}
+     */
+    public Iterator<MethodHandlers> getAllHandlers() {
+        return handlers.retrieveAll();
+    }
+
+    /**
      * Registers a REST handler to be executed when the provided {@code method} and {@code path} match the request.
      *
      * @param method GET, POST, etc.

--- a/server/src/main/java/org/opensearch/rest/RestController.java
+++ b/server/src/main/java/org/opensearch/rest/RestController.java
@@ -65,6 +65,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -107,7 +108,7 @@ public class RestController implements HttpServerTransport.Dispatcher {
         }
     }
 
-    private final PathTrie<MethodHandlers> handlers = new PathTrie<>(RestUtils.REST_DECODER);
+    private final PathTrie<RestMethodHandlers> handlers = new PathTrie<>(RestUtils.REST_DECODER);
 
     private final UnaryOperator<RestHandler> handlerWrapper;
 
@@ -149,7 +150,9 @@ public class RestController implements HttpServerTransport.Dispatcher {
      * @return {@link Iterator} of {@link MethodHandlers}
      */
     public Iterator<MethodHandlers> getAllHandlers() {
-        return handlers.retrieveAll();
+        List<MethodHandlers> methodHandlers = new ArrayList<>();
+        handlers.retrieveAll().forEachRemaining(methodHandlers::add);
+        return methodHandlers.iterator();
     }
 
     /**
@@ -229,7 +232,7 @@ public class RestController implements HttpServerTransport.Dispatcher {
     private void registerHandlerNoWrap(RestRequest.Method method, String path, RestHandler maybeWrappedHandler) {
         handlers.insertOrUpdate(
             path,
-            new MethodHandlers(path, maybeWrappedHandler, method),
+            new RestMethodHandlers(path, maybeWrappedHandler, method),
             (mHandlers, newMHandler) -> mHandlers.addMethods(maybeWrappedHandler, method)
         );
     }
@@ -400,10 +403,10 @@ public class RestController implements HttpServerTransport.Dispatcher {
             // Resolves the HTTP method and fails if the method is invalid
             requestMethod = request.method();
             // Loop through all possible handlers, attempting to dispatch the request
-            Iterator<MethodHandlers> allHandlers = getAllHandlers(request.params(), rawPath);
+            Iterator<RestMethodHandlers> allHandlers = getAllRestMethodHandlers(request.params(), rawPath);
             while (allHandlers.hasNext()) {
                 final RestHandler handler;
-                final MethodHandlers handlers = allHandlers.next();
+                final RestMethodHandlers handlers = allHandlers.next();
                 if (handlers == null) {
                     handler = null;
                 } else {
@@ -431,7 +434,7 @@ public class RestController implements HttpServerTransport.Dispatcher {
         handleBadRequest(uri, requestMethod, channel);
     }
 
-    Iterator<MethodHandlers> getAllHandlers(@Nullable Map<String, String> requestParamsRef, String rawPath) {
+    Iterator<RestMethodHandlers> getAllRestMethodHandlers(@Nullable Map<String, String> requestParamsRef, String rawPath) {
         final Supplier<Map<String, String>> paramsSupplier;
         if (requestParamsRef == null) {
             paramsSupplier = () -> null;
@@ -569,7 +572,7 @@ public class RestController implements HttpServerTransport.Dispatcher {
      */
     private Set<RestRequest.Method> getValidHandlerMethodSet(String rawPath) {
         Set<RestRequest.Method> validMethods = new HashSet<>();
-        Iterator<MethodHandlers> allHandlers = getAllHandlers(null, rawPath);
+        Iterator<RestMethodHandlers> allHandlers = getAllRestMethodHandlers(null, rawPath);
         while (allHandlers.hasNext()) {
             final MethodHandlers methodHandlers = allHandlers.next();
             if (methodHandlers != null) {

--- a/server/src/main/java/org/opensearch/rest/RestMethodHandlers.java
+++ b/server/src/main/java/org/opensearch/rest/RestMethodHandlers.java
@@ -1,0 +1,92 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.rest;
+
+import org.opensearch.common.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Encapsulate multiple handlers for the same path, allowing different handlers for different HTTP verbs.
+ */
+final class RestMethodHandlers implements MethodHandlers {
+
+    private final String path;
+    private final Map<RestRequest.Method, RestHandler> methodHandlers;
+
+    RestMethodHandlers(String path, RestHandler handler, RestRequest.Method... methods) {
+        this.path = path;
+        this.methodHandlers = new HashMap<>(methods.length);
+        for (RestRequest.Method method : methods) {
+            methodHandlers.put(method, handler);
+        }
+    }
+
+    /**
+     * Add a handler for an additional array of methods. Note that {@code MethodHandlers}
+     * does not allow replacing the handler for an already existing method.
+     */
+    public RestMethodHandlers addMethods(RestHandler handler, RestRequest.Method... methods) {
+        for (RestRequest.Method method : methods) {
+            RestHandler existing = methodHandlers.putIfAbsent(method, handler);
+            if (existing != null) {
+                throw new IllegalArgumentException("Cannot replace existing handler for [" + path + "] for method: " + method);
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Returns the handler for the given method or {@code null} if none exists.
+     */
+    @Nullable
+    public RestHandler getHandler(RestRequest.Method method) {
+        return methodHandlers.get(method);
+    }
+
+    /**
+     * Return a set of all valid HTTP methods for the particular path.
+     */
+    public Set<RestRequest.Method> getValidMethods() {
+        return methodHandlers.keySet();
+    }
+
+    /**
+     * Returns the relative HTTP path of the set of method handlers.
+     */
+    public String getPath() {
+        return path;
+    }
+}

--- a/server/src/test/java/org/opensearch/common/path/PathTrieTests.java
+++ b/server/src/test/java/org/opensearch/common/path/PathTrieTests.java
@@ -36,8 +36,10 @@ import org.opensearch.common.path.PathTrie.TrieMatchingMode;
 import org.opensearch.rest.RestUtils;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -285,5 +287,34 @@ public class PathTrieTests extends OpenSearchTestCase {
         assertThat(params.get("index"), equalTo("<logstash-{now/d}>"));
         assertThat(params.get("type"), equalTo("type"));
         assertThat(params.get("id"), equalTo("id"));
+    }
+
+    public void testRetrieveAllEmpty() {
+        PathTrie<String> trie = new PathTrie<>(NO_DECODER);
+        Iterator<String> allPaths = trie.retrieveAll();
+        assertFalse(allPaths.hasNext());
+    }
+
+    public void testRetrieveAll() {
+        PathTrie<String> trie = new PathTrie<>(NO_DECODER);
+        trie.insert("{testA}", "test1");
+        trie.insert("{testA}/{testB}", "test2");
+        trie.insert("a/{testB}", "test3");
+        trie.insert("{testA}/b", "test4");
+        trie.insert("{testA}/b/c", "test5");
+
+        Iterator<String> iterator = trie.retrieveAll();
+        assertTrue(iterator.hasNext());
+        List<String> paths = new ArrayList<>();
+        iterator.forEachRemaining(paths::add);
+        assertEquals(paths, List.of("test1", "test4", "test5", "test2", "test3"));
+        assertFalse(iterator.hasNext());
+    }
+
+    public void testRetrieveAllWithNllValue() {
+        PathTrie<String> trie = new PathTrie<>(NO_DECODER);
+        trie.insert("{testA}", null);
+        Iterator<String> iterator = trie.retrieveAll();
+        assertFalse(iterator.hasNext());
     }
 }

--- a/server/src/test/java/org/opensearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/opensearch/rest/RestControllerTests.java
@@ -181,15 +181,15 @@ public class RestControllerTests extends OpenSearchTestCase {
         restHeaders.put("header.3", Collections.singletonList("false"));
         RestRequest fakeRequest = new FakeRestRequest.Builder(xContentRegistry()).withHeaders(restHeaders).build();
         final RestController spyRestController = spy(restController);
-        when(spyRestController.getAllHandlers(null, fakeRequest.rawPath())).thenReturn(new Iterator<MethodHandlers>() {
+        when(spyRestController.getAllRestMethodHandlers(null, fakeRequest.rawPath())).thenReturn(new Iterator<RestMethodHandlers>() {
             @Override
             public boolean hasNext() {
                 return false;
             }
 
             @Override
-            public MethodHandlers next() {
-                return new MethodHandlers("/", (RestRequest request, RestChannel channel, NodeClient client) -> {
+            public RestMethodHandlers next() {
+                return new RestMethodHandlers("/", (RestRequest request, RestChannel channel, NodeClient client) -> {
                     assertEquals("true", threadContext.getHeader("header.1"));
                     assertEquals("true", threadContext.getHeader("header.2"));
                     assertNull(threadContext.getHeader("header.3"));

--- a/server/src/test/java/org/opensearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/opensearch/rest/RestControllerTests.java
@@ -138,6 +138,37 @@ public class RestControllerTests extends OpenSearchTestCase {
         IOUtils.close(client);
     }
 
+    public void testDefaultRestControllerGetAllHandlersContainsFavicon() {
+        final RestController restController = new RestController(null, null, null, circuitBreakerService, usageService, identityService);
+        Iterator<MethodHandlers> handlers = restController.getAllHandlers();
+        assertTrue(handlers.hasNext());
+        MethodHandlers faviconHandler = handlers.next();
+        assertEquals(faviconHandler.getPath(), "/favicon.ico");
+        assertEquals(faviconHandler.getValidMethods(), Set.of(RestRequest.Method.GET));
+        assertFalse(handlers.hasNext());
+    }
+
+    public void testRestControllerGetAllHandlers() {
+        final RestController restController = new RestController(null, null, null, circuitBreakerService, usageService, identityService);
+
+        restController.registerHandler(RestRequest.Method.PATCH, "/foo", mock(RestHandler.class));
+        restController.registerHandler(RestRequest.Method.GET, "/foo", mock(RestHandler.class));
+
+        Iterator<MethodHandlers> handlers = restController.getAllHandlers();
+
+        assertTrue(handlers.hasNext());
+        MethodHandlers rootHandler = handlers.next();
+        assertEquals(rootHandler.getPath(), "/foo");
+        assertEquals(rootHandler.getValidMethods(), Set.of(RestRequest.Method.GET, RestRequest.Method.PATCH));
+
+        assertTrue(handlers.hasNext());
+        MethodHandlers faviconHandler = handlers.next();
+        assertEquals(faviconHandler.getPath(), "/favicon.ico");
+        assertEquals(faviconHandler.getValidMethods(), Set.of(RestRequest.Method.GET));
+
+        assertFalse(handlers.hasNext());
+    }
+
     public void testApplyRelevantHeaders() throws Exception {
         final ThreadContext threadContext = client.threadPool().getThreadContext();
         Set<RestHeaderDefinition> headers = new HashSet<>(


### PR DESCRIPTION
### Description

Coming from https://github.com/opensearch-project/OpenSearch/pull/11843, expose just enough methods to be able to move that plugin implementation out of OpenSearch core.

- Adds `PathTrie#retrieveAll`, an lazy-ish exhaustive iterator traversing the trie structure.
- Make public `MethodHandlers#getPath` and `getValidMethods`.
- Adds `RestController#getAllHandlers()` returning a method handlers iterator.

### Related Issues

- https://github.com/opensearch-project/OpenSearch/issues/3090
- https://github.com/opensearch-project/opensearch-api-specification/issues/168
- https://github.com/opensearch-project/opensearch-clients/issues/58

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
