### PR TITLE
Integrate IO Usage Tracker to the Resource Usage Collector Service and Emit IO Usage Stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add events correlation engine plugin ([#6854](https://github.com/opensearch-project/OpenSearch/issues/6854))
 - Implement on behalf of token passing for extensions ([#8679](https://github.com/opensearch-project/OpenSearch/pull/8679), [#10664](https://github.com/opensearch-project/OpenSearch/pull/10664))
 - Provide service accounts tokens to extensions ([#9618](https://github.com/opensearch-project/OpenSearch/pull/9618))
-- [AdmissionControl] Added changes for AdmissionControl Interceptor and AdmissionControlService for RateLimiting ([#9286](https://github.com/opensearch-project/OpenSearch/pull/9286))
 - GHA to verify checklist items completion in PR descriptions ([#10800](https://github.com/opensearch-project/OpenSearch/pull/10800))
 - Allow to pass the list settings through environment variables (like [], ["a", "b", "c"], ...) ([#10625](https://github.com/opensearch-project/OpenSearch/pull/10625))
-- [Admission Control] Integrate CPU AC with ResourceUsageCollector and add CPU AC stats to nodes/stats ([#10887](https://github.com/opensearch-project/OpenSearch/pull/10887))
 - [S3 Repository] Add setting to control connection count for sync client ([#12028](https://github.com/opensearch-project/OpenSearch/pull/12028))
 - Views, simplify data access and manipulation by providing a virtual layer over one or more indices ([#11957](https://github.com/opensearch-project/OpenSearch/pull/11957))
 - Add Remote Store Migration Experimental flag and allow mixed mode clusters under same ([#11986](https://github.com/opensearch-project/OpenSearch/pull/11986))
+- [Admission Control] Integrate IO Usage Tracker to the Resource Usage Collector Service and Emit IO Usage Stats ([#11880](https://github.com/opensearch-project/OpenSearch/pull/11880))
 
 ### Dependencies
 - Bump `log4j-core` from 2.18.0 to 2.19.0

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -667,6 +667,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 // Settings related to resource trackers
                 ResourceTrackerSettings.GLOBAL_CPU_USAGE_AC_WINDOW_DURATION_SETTING,
                 ResourceTrackerSettings.GLOBAL_JVM_USAGE_AC_WINDOW_DURATION_SETTING,
+                ResourceTrackerSettings.GLOBAL_IO_USAGE_AC_WINDOW_DURATION_SETTING,
 
                 // Settings related to Searchable Snapshots
                 Node.NODE_SEARCH_CACHE_SIZE_SETTING,

--- a/server/src/main/java/org/opensearch/monitor/fs/FsInfo.java
+++ b/server/src/main/java/org/opensearch/monitor/fs/FsInfo.java
@@ -448,9 +448,13 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContentFragm
             return (currentIOTime - previousIOTime);
         }
 
+        public String getDeviceName() {
+            return deviceName;
+        }
+
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            builder.field("device_name", deviceName);
+            builder.field("device_name", getDeviceName());
             builder.field(IoStats.OPERATIONS, operations());
             builder.field(IoStats.READ_OPERATIONS, readOperations());
             builder.field(IoStats.WRITE_OPERATIONS, writeOperations());

--- a/server/src/main/java/org/opensearch/node/IoUsageStats.java
+++ b/server/src/main/java/org/opensearch/node/IoUsageStats.java
@@ -58,7 +58,7 @@ public class IoUsageStats implements Writeable, ToXContentFragment {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field("io_utilization_percent", String.format(Locale.ROOT, "%.1f", this.ioUtilisationPercent));
+        builder.field("max_io_utilization_percent", String.format(Locale.ROOT, "%.1f", this.ioUtilisationPercent));
         return builder.endObject();
     }
 

--- a/server/src/main/java/org/opensearch/node/IoUsageStats.java
+++ b/server/src/main/java/org/opensearch/node/IoUsageStats.java
@@ -1,0 +1,69 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.node;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Locale;
+
+/**
+ * This class is to store tne IO Usage Stats and used to return in node stats API.
+ */
+public class IoUsageStats implements Writeable, ToXContentFragment {
+
+    private double ioUtilisationPercent;
+
+    public IoUsageStats(double ioUtilisationPercent) {
+        this.ioUtilisationPercent = ioUtilisationPercent;
+    }
+
+    /**
+     *
+     * @param in the stream to read from
+     * @throws IOException if an error occurs while reading from the StreamOutput
+     */
+    public IoUsageStats(StreamInput in) throws IOException {
+        this.ioUtilisationPercent = in.readDouble();
+    }
+
+    /**
+     * Write this into the {@linkplain StreamOutput}.
+     *
+     * @param out the output stream to write entity content to
+     */
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeDouble(this.ioUtilisationPercent);
+    }
+
+    public double getIoUtilisationPercent() {
+        return ioUtilisationPercent;
+    }
+
+    public void setIoUtilisationPercent(double ioUtilisationPercent) {
+        this.ioUtilisationPercent = ioUtilisationPercent;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("io_utilization_percent", String.format(Locale.ROOT, "%.1f", this.ioUtilisationPercent));
+        return builder.endObject();
+    }
+
+    @Override
+    public String toString() {
+        return "IO utilization percent: " + String.format(Locale.ROOT, "%.1f", this.ioUtilisationPercent);
+    }
+}

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -922,6 +922,7 @@ public class Node implements Closeable {
             final RestController restController = actionModule.getRestController();
 
             final NodeResourceUsageTracker nodeResourceUsageTracker = new NodeResourceUsageTracker(
+                monitorService.fsService(),
                 threadPool,
                 settings,
                 clusterService.getClusterSettings()

--- a/server/src/main/java/org/opensearch/node/NodeResourceUsageStats.java
+++ b/server/src/main/java/org/opensearch/node/NodeResourceUsageStats.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.node;
 
+import org.opensearch.Version;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
@@ -24,12 +25,20 @@ public class NodeResourceUsageStats implements Writeable {
     long timestamp;
     double cpuUtilizationPercent;
     double memoryUtilizationPercent;
+    private IoUsageStats ioUsageStats;
 
-    public NodeResourceUsageStats(String nodeId, long timestamp, double memoryUtilizationPercent, double cpuUtilizationPercent) {
+    public NodeResourceUsageStats(
+        String nodeId,
+        long timestamp,
+        double memoryUtilizationPercent,
+        double cpuUtilizationPercent,
+        IoUsageStats ioUsageStats
+    ) {
         this.nodeId = nodeId;
         this.timestamp = timestamp;
         this.cpuUtilizationPercent = cpuUtilizationPercent;
         this.memoryUtilizationPercent = memoryUtilizationPercent;
+        this.ioUsageStats = ioUsageStats;
     }
 
     public NodeResourceUsageStats(StreamInput in) throws IOException {
@@ -37,6 +46,11 @@ public class NodeResourceUsageStats implements Writeable {
         this.timestamp = in.readLong();
         this.cpuUtilizationPercent = in.readDouble();
         this.memoryUtilizationPercent = in.readDouble();
+        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+            this.ioUsageStats = in.readOptionalWriteable(IoUsageStats::new);
+        } else {
+            this.ioUsageStats = null;
+        }
     }
 
     @Override
@@ -45,6 +59,9 @@ public class NodeResourceUsageStats implements Writeable {
         out.writeLong(this.timestamp);
         out.writeDouble(this.cpuUtilizationPercent);
         out.writeDouble(this.memoryUtilizationPercent);
+        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+            out.writeOptionalWriteable(this.ioUsageStats);
+        }
     }
 
     @Override
@@ -52,8 +69,11 @@ public class NodeResourceUsageStats implements Writeable {
         StringBuilder sb = new StringBuilder("NodeResourceUsageStats[");
         sb.append(nodeId).append("](");
         sb.append("Timestamp: ").append(timestamp);
-        sb.append(", CPU utilization percent: ").append(String.format(Locale.ROOT, "%.1f", cpuUtilizationPercent));
-        sb.append(", Memory utilization percent: ").append(String.format(Locale.ROOT, "%.1f", memoryUtilizationPercent));
+        sb.append(", CPU utilization percent: ").append(String.format(Locale.ROOT, "%.1f", this.getCpuUtilizationPercent()));
+        sb.append(", Memory utilization percent: ").append(String.format(Locale.ROOT, "%.1f", this.getMemoryUtilizationPercent()));
+        if (this.ioUsageStats != null) {
+            sb.append(", ").append(this.getIoUsageStats());
+        }
         sb.append(")");
         return sb.toString();
     }
@@ -63,7 +83,8 @@ public class NodeResourceUsageStats implements Writeable {
             nodeResourceUsageStats.nodeId,
             nodeResourceUsageStats.timestamp,
             nodeResourceUsageStats.memoryUtilizationPercent,
-            nodeResourceUsageStats.cpuUtilizationPercent
+            nodeResourceUsageStats.cpuUtilizationPercent,
+            nodeResourceUsageStats.ioUsageStats
         );
     }
 
@@ -73,6 +94,14 @@ public class NodeResourceUsageStats implements Writeable {
 
     public double getCpuUtilizationPercent() {
         return cpuUtilizationPercent;
+    }
+
+    public IoUsageStats getIoUsageStats() {
+        return ioUsageStats;
+    }
+
+    public void setIoUsageStats(IoUsageStats ioUsageStats) {
+        this.ioUsageStats = ioUsageStats;
     }
 
     public long getTimestamp() {

--- a/server/src/main/java/org/opensearch/node/NodesResourceUsageStats.java
+++ b/server/src/main/java/org/opensearch/node/NodesResourceUsageStats.java
@@ -60,6 +60,9 @@ public class NodesResourceUsageStats implements Writeable, ToXContentFragment {
                     "memory_utilization_percent",
                     String.format(Locale.ROOT, "%.1f", resourceUsageStats.memoryUtilizationPercent)
                 );
+                if (resourceUsageStats.getIoUsageStats() != null) {
+                    builder.field("io_usage_stats", resourceUsageStats.getIoUsageStats());
+                }
             }
             builder.endObject();
         }

--- a/server/src/main/java/org/opensearch/node/ResourceUsageCollectorService.java
+++ b/server/src/main/java/org/opensearch/node/ResourceUsageCollectorService.java
@@ -78,14 +78,16 @@ public class ResourceUsageCollectorService extends AbstractLifecycleComponent im
         String nodeId,
         long timestamp,
         double memoryUtilizationPercent,
-        double cpuUtilizationPercent
+        double cpuUtilizationPercent,
+        IoUsageStats ioUsageStats
     ) {
         nodeIdToResourceUsageStats.compute(nodeId, (id, resourceUsageStats) -> {
             if (resourceUsageStats == null) {
-                return new NodeResourceUsageStats(nodeId, timestamp, memoryUtilizationPercent, cpuUtilizationPercent);
+                return new NodeResourceUsageStats(nodeId, timestamp, memoryUtilizationPercent, cpuUtilizationPercent, ioUsageStats);
             } else {
                 resourceUsageStats.cpuUtilizationPercent = cpuUtilizationPercent;
                 resourceUsageStats.memoryUtilizationPercent = memoryUtilizationPercent;
+                resourceUsageStats.setIoUsageStats(ioUsageStats);
                 resourceUsageStats.timestamp = timestamp;
                 return resourceUsageStats;
             }
@@ -129,7 +131,8 @@ public class ResourceUsageCollectorService extends AbstractLifecycleComponent im
                 clusterService.state().nodes().getLocalNodeId(),
                 System.currentTimeMillis(),
                 nodeResourceUsageTracker.getMemoryUtilizationPercent(),
-                nodeResourceUsageTracker.getCpuUtilizationPercent()
+                nodeResourceUsageTracker.getCpuUtilizationPercent(),
+                nodeResourceUsageTracker.getIoUsageStats()
             );
         }
     }

--- a/server/src/main/java/org/opensearch/node/resource/tracker/AbstractAverageUsageTracker.java
+++ b/server/src/main/java/org/opensearch/node/resource/tracker/AbstractAverageUsageTracker.java
@@ -24,12 +24,12 @@ import java.util.concurrent.atomic.AtomicReference;
 public abstract class AbstractAverageUsageTracker extends AbstractLifecycleComponent {
     private static final Logger LOGGER = LogManager.getLogger(AbstractAverageUsageTracker.class);
 
-    private final ThreadPool threadPool;
-    private final TimeValue pollingInterval;
+    protected final ThreadPool threadPool;
+    protected final TimeValue pollingInterval;
     private TimeValue windowDuration;
     private final AtomicReference<MovingAverage> observations = new AtomicReference<>();
 
-    private volatile Scheduler.Cancellable scheduledFuture;
+    protected volatile Scheduler.Cancellable scheduledFuture;
 
     public AbstractAverageUsageTracker(ThreadPool threadPool, TimeValue pollingInterval, TimeValue windowDuration) {
         this.threadPool = threadPool;

--- a/server/src/main/java/org/opensearch/node/resource/tracker/AverageIoUsageTracker.java
+++ b/server/src/main/java/org/opensearch/node/resource/tracker/AverageIoUsageTracker.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.node.resource.tracker;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.monitor.fs.FsInfo.DeviceStats;
+import org.opensearch.monitor.fs.FsService;
+import org.opensearch.node.IoUsageStats;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.util.HashMap;
+
+/**
+ * AverageIoUsageTracker tracks the IO usage by polling the FS Stats for IO metrics every (pollingInterval)
+ * and keeping track of the rolling average over a defined time window (windowDuration).
+ */
+public class AverageIoUsageTracker extends AbstractAverageUsageTracker {
+
+    private static final Logger LOGGER = LogManager.getLogger(AverageIoUsageTracker.class);
+    private final FsService fsService;
+    private final HashMap<String, Long> prevIoTimeDeviceMap;
+    private long prevTimeInMillis;
+    private final IoUsageStats ioUsageStats;
+
+    public AverageIoUsageTracker(FsService fsService, ThreadPool threadPool, TimeValue pollingInterval, TimeValue windowDuration) {
+        super(threadPool, pollingInterval, windowDuration);
+        this.fsService = fsService;
+        this.prevIoTimeDeviceMap = new HashMap<>();
+        this.prevTimeInMillis = -1;
+        this.ioUsageStats = new IoUsageStats(-1);
+    }
+
+    /**
+     * Get current IO usage percentage calculated using fs stats
+     */
+    @Override
+    public long getUsage() {
+        long usage = 0;
+        if (this.preValidateFsStats()) {
+            return usage;
+        }
+        // Currently even during the raid setup we have only one mount device and it is giving 0 io time from /proc/diskstats
+        DeviceStats[] devicesStats = fsService.stats().getIoStats().getDevicesStats();
+        long latestTimeInMillis = fsService.stats().getTimestamp();
+        for (DeviceStats devicesStat : devicesStats) {
+            long devicePreviousIoTime = prevIoTimeDeviceMap.getOrDefault(devicesStat.getDeviceName(), (long) -1);
+            long deviceCurrentIoTime = devicesStat.ioTimeInMillis();
+            if (prevTimeInMillis > 0 && (latestTimeInMillis - this.prevTimeInMillis > 0) && devicePreviousIoTime > 0) {
+                long absIoTime = (deviceCurrentIoTime - devicePreviousIoTime);
+                long deviceCurrentIoUsage = absIoTime * 100 / (latestTimeInMillis - this.prevTimeInMillis);
+                // We are returning the maximum IO Usage for all the attached devices
+                usage = Math.max(usage, deviceCurrentIoUsage);
+            }
+            prevIoTimeDeviceMap.put(devicesStat.getDeviceName(), devicesStat.ioTimeInMillis());
+        }
+        this.prevTimeInMillis = latestTimeInMillis;
+        return usage;
+    }
+
+    @Override
+    protected void doStart() {
+        scheduledFuture = threadPool.scheduleWithFixedDelay(() -> {
+            long usage = getUsage();
+            recordUsage(usage);
+            updateIoUsageStats();
+        }, pollingInterval, ThreadPool.Names.GENERIC);
+    }
+
+    private boolean preValidateFsStats() {
+        return fsService == null
+            || fsService.stats() == null
+            || fsService.stats().getIoStats() == null
+            || fsService.stats().getIoStats().getDevicesStats() == null;
+    }
+
+    private void updateIoUsageStats() {
+        this.ioUsageStats.setIoUtilisationPercent(this.isReady() ? this.getAverage() : -1);
+    }
+
+    public IoUsageStats getIoUsageStats() {
+        return this.ioUsageStats;
+    }
+}

--- a/server/src/main/java/org/opensearch/node/resource/tracker/ResourceTrackerSettings.java
+++ b/server/src/main/java/org/opensearch/node/resource/tracker/ResourceTrackerSettings.java
@@ -26,6 +26,14 @@ public class ResourceTrackerSettings {
          * This is the default window duration on which the average resource utilization values will be calculated
          */
         private static final long WINDOW_DURATION_IN_SECONDS = 30;
+        /**
+         * This is the default polling interval for IO usage tracker
+         */
+        private static final long IO_POLLING_INTERVAL_IN_MILLIS = 5000;
+        /**
+         * This is the default window duration for IO usage tracker on which the average resource utilization values will be calculated
+         */
+        private static final long IO_WINDOW_DURATION_IN_SECONDS = 120;
     }
 
     public static final Setting<TimeValue> GLOBAL_CPU_USAGE_AC_POLLING_INTERVAL_SETTING = Setting.positiveTimeSetting(
@@ -36,6 +44,18 @@ public class ResourceTrackerSettings {
     public static final Setting<TimeValue> GLOBAL_CPU_USAGE_AC_WINDOW_DURATION_SETTING = Setting.positiveTimeSetting(
         "node.resource.tracker.global_cpu_usage.window_duration",
         TimeValue.timeValueSeconds(Defaults.WINDOW_DURATION_IN_SECONDS),
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    public static final Setting<TimeValue> GLOBAL_IO_USAGE_AC_POLLING_INTERVAL_SETTING = Setting.positiveTimeSetting(
+        "node.resource.tracker.global_io_usage.polling_interval",
+        TimeValue.timeValueMillis(Defaults.IO_POLLING_INTERVAL_IN_MILLIS),
+        Setting.Property.NodeScope
+    );
+    public static final Setting<TimeValue> GLOBAL_IO_USAGE_AC_WINDOW_DURATION_SETTING = Setting.positiveTimeSetting(
+        "node.resource.tracker.global_io_usage.window_duration",
+        TimeValue.timeValueSeconds(Defaults.IO_WINDOW_DURATION_IN_SECONDS),
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
@@ -56,12 +76,16 @@ public class ResourceTrackerSettings {
     private volatile TimeValue cpuPollingInterval;
     private volatile TimeValue memoryWindowDuration;
     private volatile TimeValue memoryPollingInterval;
+    private volatile TimeValue ioWindowDuration;
+    private volatile TimeValue ioPollingInterval;
 
     public ResourceTrackerSettings(Settings settings) {
         this.cpuPollingInterval = GLOBAL_CPU_USAGE_AC_POLLING_INTERVAL_SETTING.get(settings);
         this.cpuWindowDuration = GLOBAL_CPU_USAGE_AC_WINDOW_DURATION_SETTING.get(settings);
         this.memoryPollingInterval = GLOBAL_JVM_USAGE_AC_POLLING_INTERVAL_SETTING.get(settings);
         this.memoryWindowDuration = GLOBAL_JVM_USAGE_AC_WINDOW_DURATION_SETTING.get(settings);
+        this.ioPollingInterval = GLOBAL_IO_USAGE_AC_POLLING_INTERVAL_SETTING.get(settings);
+        this.ioWindowDuration = GLOBAL_IO_USAGE_AC_WINDOW_DURATION_SETTING.get(settings);
     }
 
     public TimeValue getCpuWindowDuration() {
@@ -80,11 +104,23 @@ public class ResourceTrackerSettings {
         return memoryWindowDuration;
     }
 
+    public TimeValue getIoPollingInterval() {
+        return ioPollingInterval;
+    }
+
+    public TimeValue getIoWindowDuration() {
+        return ioWindowDuration;
+    }
+
     public void setCpuWindowDuration(TimeValue cpuWindowDuration) {
         this.cpuWindowDuration = cpuWindowDuration;
     }
 
     public void setMemoryWindowDuration(TimeValue memoryWindowDuration) {
         this.memoryWindowDuration = memoryWindowDuration;
+    }
+
+    public void setIoWindowDuration(TimeValue ioWindowDuration) {
+        this.ioWindowDuration = ioWindowDuration;
     }
 }

--- a/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -65,6 +65,7 @@ import org.opensearch.monitor.jvm.JvmStats;
 import org.opensearch.monitor.os.OsStats;
 import org.opensearch.monitor.process.ProcessStats;
 import org.opensearch.node.AdaptiveSelectionStats;
+import org.opensearch.node.IoUsageStats;
 import org.opensearch.node.NodeResourceUsageStats;
 import org.opensearch.node.NodesResourceUsageStats;
 import org.opensearch.node.ResponseCollectorService;
@@ -881,7 +882,8 @@ public class NodeStatsTests extends OpenSearchTestCase {
                         nodeId,
                         System.currentTimeMillis(),
                         randomDoubleBetween(1.0, 100.0, true),
-                        randomDoubleBetween(1.0, 100.0, true)
+                        randomDoubleBetween(1.0, 100.0, true),
+                        new IoUsageStats(100.0)
                     );
                     resourceUsageStatsMap.put(nodeId, stats);
                 }

--- a/server/src/test/java/org/opensearch/node/IoUsageStatsTests.java
+++ b/server/src/test/java/org/opensearch/node/IoUsageStatsTests.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.node;
+
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.Locale;
+
+public class IoUsageStatsTests extends OpenSearchTestCase {
+    IoUsageStats ioUsageStats;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        ioUsageStats = new IoUsageStats(10);
+    }
+
+    public void testDefaultsIoUsageStats() {
+        assertEquals(ioUsageStats.getIoUtilisationPercent(), 10.0, 0);
+    }
+
+    public void testUpdateIoUsageStats() {
+        assertEquals(ioUsageStats.getIoUtilisationPercent(), 10.0, 0);
+        ioUsageStats.setIoUtilisationPercent(20);
+        assertEquals(ioUsageStats.getIoUtilisationPercent(), 20.0, 0);
+    }
+
+    public void testIoUsageStats() throws IOException {
+        XContentBuilder builder = JsonXContent.contentBuilder();
+        builder = ioUsageStats.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String response = builder.toString();
+        assertEquals(response, "{\"io_utilization_percent\":\"10.0\"}");
+        ioUsageStats.setIoUtilisationPercent(20);
+        builder = JsonXContent.contentBuilder();
+        builder = ioUsageStats.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        response = builder.toString();
+        assertEquals(response, "{\"io_utilization_percent\":\"20.0\"}");
+    }
+
+    public void testIoUsageStatsToString() {
+        String expected = "IO utilization percent: " + String.format(Locale.ROOT, "%.1f", 10.0);
+        assertEquals(expected, ioUsageStats.toString());
+        ioUsageStats.setIoUtilisationPercent(20);
+        expected = "IO utilization percent: " + String.format(Locale.ROOT, "%.1f", 20.0);
+        assertEquals(expected, ioUsageStats.toString());
+    }
+}

--- a/server/src/test/java/org/opensearch/node/IoUsageStatsTests.java
+++ b/server/src/test/java/org/opensearch/node/IoUsageStatsTests.java
@@ -39,12 +39,12 @@ public class IoUsageStatsTests extends OpenSearchTestCase {
         XContentBuilder builder = JsonXContent.contentBuilder();
         builder = ioUsageStats.toXContent(builder, ToXContent.EMPTY_PARAMS);
         String response = builder.toString();
-        assertEquals(response, "{\"io_utilization_percent\":\"10.0\"}");
+        assertEquals(response, "{\"max_io_utilization_percent\":\"10.0\"}");
         ioUsageStats.setIoUtilisationPercent(20);
         builder = JsonXContent.contentBuilder();
         builder = ioUsageStats.toXContent(builder, ToXContent.EMPTY_PARAMS);
         response = builder.toString();
-        assertEquals(response, "{\"io_utilization_percent\":\"20.0\"}");
+        assertEquals(response, "{\"max_io_utilization_percent\":\"20.0\"}");
     }
 
     public void testIoUsageStatsToString() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

#### Integrate IO Based Usage Tracker and Stats for the Resource Usage Collector Service

- This change is to track IO Usage Stats and emit these stats as part of `resource_usage_stats`.
- Created AverageIoUsageTracker which uses IO stats from the fsService and evaluate the IO Usage Consumption. 
- Currently we are emitting only IO UsagePercent as part of io_usage_stats and eventually we will add more parameters. 

#### NodeStats Output on Linux
```
resource_usage_stats: {
    Edk086LhT_mu47MpzHgc4g: {
        timestamp: 1709545252312,
        cpu_utilization_percent: "0.0",
        memory_utilization_percent: "1.0",
        io_usage_stats: {
            max_io_utilization_percent: "99.6"
        }
    }
}
```

#### NodeStats Output on Mac
```
resource_usage_stats: {
    qi1V9avrSwC_OyRtA2khbA: {
        timestamp: 1709544705354,
        cpu_utilization_percent: "0.1",
        memory_utilization_percent: "35.5"
    }
}
```

### Related Issues

- Parent PR where we are exposing other resource_usage_stats - #9890
- #8910 
- #9504

<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
