### PR TITLE
Update supported version for fixing the bug of noop_update_total metric cannot be updated by bulk API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,14 +225,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix remote shards balancer and remove unused variables ([#11167](https://github.com/opensearch-project/OpenSearch/pull/11167))
 - Fix parsing of flat object fields with dots in keys ([#11425](https://github.com/opensearch-project/OpenSearch/pull/11425))
 - Fix bug where replication lag grows post primary relocation ([#11238](https://github.com/opensearch-project/OpenSearch/pull/11238))
-- Fix noop_update_total metric in indexing stats cannot be updated by bulk API ([#11485](https://github.com/opensearch-project/OpenSearch/pull/11485))
+- Fix noop_update_total metric in indexing stats cannot be updated by bulk API ([#11485](https://github.com/opensearch-project/OpenSearch/pull/11485),[#11917](https://github.com/opensearch-project/OpenSearch/pull/11917))
 - Fix for stuck update action in a bulk with `retry_on_conflict` property ([#11152](https://github.com/opensearch-project/OpenSearch/issues/11152))
 - Fix template setting override for replication type ([#11417](https://github.com/opensearch-project/OpenSearch/pull/11417))
 - Fix Automatic addition of protocol broken in #11512 ([#11609](https://github.com/opensearch-project/OpenSearch/pull/11609))
 - Fix issue when calling Delete PIT endpoint and no PITs exist ([#11711](https://github.com/opensearch-project/OpenSearch/pull/11711))
 - Fix tracing context propagation for local transport instrumentation ([#11490](https://github.com/opensearch-project/OpenSearch/pull/11490))
 - Fix parsing of single line comments in `lang-painless` ([#11815](https://github.com/opensearch-project/OpenSearch/issues/11815))
-- Update supported version for fixing the bug of noop_update_total metric cannot be updated by bulk API
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,6 +232,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix issue when calling Delete PIT endpoint and no PITs exist ([#11711](https://github.com/opensearch-project/OpenSearch/pull/11711))
 - Fix tracing context propagation for local transport instrumentation ([#11490](https://github.com/opensearch-project/OpenSearch/pull/11490))
 - Fix parsing of single line comments in `lang-painless` ([#11815](https://github.com/opensearch-project/OpenSearch/issues/11815))
+- Update supported version for fixing the bug of noop_update_total metric cannot be updated by bulk API
 
 ### Security
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/50_noop_update.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/50_noop_update.yml
@@ -23,8 +23,8 @@ setup:
 ---
 "Test noop_update_total metric can be updated by both update API and bulk API":
   - skip:
-      version: " - 2.99.99" #TODO: change to 2.11.99 after the PR is backported to 2.x branch
-      reason: "fixed in 3.0"
+      version: " - 2.11.99"
+      reason: "fixed in 2.12.0"
 
   - do:
       update:


### PR DESCRIPTION
### Description
Part of https://github.com/opensearch-project/OpenSearch/pull/11485, after the original PR has been backported to 2.x branch, we need to update the supported version to 2.12.0 so that the backward compatibility checks can cover the change.

This PR needs to backport to 2.x because the supported version in 2.x branch is also 3.0.0(it's done by the bot).

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/9857

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
