### PR TITLE
[Backport] [2.x] Extract cluster management for integration tests into JUnit test rule out of OpenSearchIntegTestCase (#11877)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Capture information for additional query types and aggregation types ([#11582](https://github.com/opensearch-project/OpenSearch/pull/11582))
 - Use slice_size == shard_size heuristic in terms aggs for concurrent segment search and properly calculate the doc_count_error ([#11732](https://github.com/opensearch-project/OpenSearch/pull/11732))
 - Ensure Jackson default maximums introduced in 2.16.0 do not conflict with OpenSearch settings ([#11890](https://github.com/opensearch-project/OpenSearch/pull/11890))
+- Extract cluster management for integration tests into JUnit test rule out of OpenSearchIntegTestCase ([#11877](https://github.com/opensearch-project/OpenSearch/pull/11877))
 
 ### Deprecated
 

--- a/modules/analysis-common/src/internalClusterTest/java/org/opensearch/analysis/common/QueryStringWithAnalyzersIT.java
+++ b/modules/analysis-common/src/internalClusterTest/java/org/opensearch/analysis/common/QueryStringWithAnalyzersIT.java
@@ -39,7 +39,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.index.query.Operator;
 import org.opensearch.plugins.Plugin;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -49,10 +49,10 @@ import static org.opensearch.search.SearchService.CLUSTER_CONCURRENT_SEGMENT_SEA
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
 
-public class QueryStringWithAnalyzersIT extends ParameterizedOpenSearchIntegTestCase {
+public class QueryStringWithAnalyzersIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public QueryStringWithAnalyzersIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public QueryStringWithAnalyzersIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/modules/analysis-common/src/test/java/org/opensearch/analysis/common/HighlighterWithAnalyzersTests.java
+++ b/modules/analysis-common/src/test/java/org/opensearch/analysis/common/HighlighterWithAnalyzersTests.java
@@ -44,7 +44,7 @@ import org.opensearch.index.query.Operator;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.fetch.subphase.highlight.HighlightBuilder;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -68,10 +68,10 @@ import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
 
-public class HighlighterWithAnalyzersTests extends ParameterizedOpenSearchIntegTestCase {
+public class HighlighterWithAnalyzersTests extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public HighlighterWithAnalyzersTests(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public HighlighterWithAnalyzersTests(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/modules/geo/src/internalClusterTest/java/org/opensearch/geo/GeoModulePluginIntegTestCase.java
+++ b/modules/geo/src/internalClusterTest/java/org/opensearch/geo/GeoModulePluginIntegTestCase.java
@@ -16,7 +16,7 @@ import org.opensearch.geometry.utils.StandardValidator;
 import org.opensearch.geometry.utils.WellKnownText;
 import org.opensearch.index.mapper.GeoShapeFieldMapper;
 import org.opensearch.plugins.Plugin;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.opensearch.test.TestGeoShapeFieldMapperPlugin;
 
 import java.util.Arrays;
@@ -29,14 +29,14 @@ import static org.opensearch.search.SearchService.CLUSTER_CONCURRENT_SEGMENT_SEA
  * This is the base class for all the Geo related integration tests. Use this class to add the features and settings
  * for the test cluster on which integration tests are running.
  */
-public abstract class GeoModulePluginIntegTestCase extends ParameterizedOpenSearchIntegTestCase {
+public abstract class GeoModulePluginIntegTestCase extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     protected static final double GEOHASH_TOLERANCE = 1E-5D;
 
     protected static final WellKnownText WKT = new WellKnownText(true, new StandardValidator(true));
 
-    public GeoModulePluginIntegTestCase(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public GeoModulePluginIntegTestCase(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/modules/geo/src/internalClusterTest/java/org/opensearch/geo/search/MissingValueIT.java
+++ b/modules/geo/src/internalClusterTest/java/org/opensearch/geo/search/MissingValueIT.java
@@ -44,8 +44,8 @@ public class MissingValueIT extends GeoModulePluginIntegTestCase {
     private GeoPoint bottomRight;
     private GeoPoint topLeft;
 
-    public MissingValueIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public MissingValueIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @Override

--- a/modules/lang-expression/src/internalClusterTest/java/org/opensearch/script/expression/MoreExpressionIT.java
+++ b/modules/lang-expression/src/internalClusterTest/java/org/opensearch/script/expression/MoreExpressionIT.java
@@ -57,7 +57,7 @@ import org.opensearch.search.aggregations.metrics.Stats;
 import org.opensearch.search.aggregations.pipeline.SimpleValue;
 import org.opensearch.search.sort.SortBuilders;
 import org.opensearch.search.sort.SortOrder;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.opensearch.test.hamcrest.OpenSearchAssertions;
 
 import java.util.Arrays;
@@ -80,10 +80,10 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.notNullValue;
 
 // TODO: please convert to unit tests!
-public class MoreExpressionIT extends ParameterizedOpenSearchIntegTestCase {
+public class MoreExpressionIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public MoreExpressionIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public MoreExpressionIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/modules/lang-expression/src/internalClusterTest/java/org/opensearch/script/expression/StoredExpressionIT.java
+++ b/modules/lang-expression/src/internalClusterTest/java/org/opensearch/script/expression/StoredExpressionIT.java
@@ -43,7 +43,7 @@ import org.opensearch.script.Script;
 import org.opensearch.script.ScriptType;
 import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.search.builder.SearchSourceBuilder;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -54,10 +54,10 @@ import static org.opensearch.search.SearchService.CLUSTER_CONCURRENT_SEGMENT_SEA
 import static org.hamcrest.Matchers.containsString;
 
 //TODO: please convert to unit tests!
-public class StoredExpressionIT extends ParameterizedOpenSearchIntegTestCase {
+public class StoredExpressionIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public StoredExpressionIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public StoredExpressionIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/modules/lang-mustache/src/internalClusterTest/java/org/opensearch/script/mustache/MultiSearchTemplateIT.java
+++ b/modules/lang-mustache/src/internalClusterTest/java/org/opensearch/script/mustache/MultiSearchTemplateIT.java
@@ -41,7 +41,7 @@ import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.script.ScriptType;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -58,10 +58,10 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
 
-public class MultiSearchTemplateIT extends ParameterizedOpenSearchIntegTestCase {
+public class MultiSearchTemplateIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public MultiSearchTemplateIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public MultiSearchTemplateIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/modules/parent-join/src/internalClusterTest/java/org/opensearch/join/query/ParentChildTestCase.java
+++ b/modules/parent-join/src/internalClusterTest/java/org/opensearch/join/query/ParentChildTestCase.java
@@ -41,7 +41,7 @@ import org.opensearch.join.ParentJoinPlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.test.InternalSettingsPlugin;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -51,10 +51,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE)
-public abstract class ParentChildTestCase extends ParameterizedOpenSearchIntegTestCase {
+public abstract class ParentChildTestCase extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public ParentChildTestCase(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public ParentChildTestCase(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @Override

--- a/modules/percolator/src/internalClusterTest/java/org/opensearch/percolator/PercolatorQuerySearchIT.java
+++ b/modules/percolator/src/internalClusterTest/java/org/opensearch/percolator/PercolatorQuerySearchIT.java
@@ -57,7 +57,7 @@ import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.search.fetch.subphase.highlight.HighlightBuilder;
 import org.opensearch.search.sort.SortOrder;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -90,10 +90,10 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.IsNull.notNullValue;
 
-public class PercolatorQuerySearchIT extends ParameterizedOpenSearchIntegTestCase {
+public class PercolatorQuerySearchIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public PercolatorQuerySearchIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public PercolatorQuerySearchIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/modules/rank-eval/src/internalClusterTest/java/org/opensearch/index/rankeval/RankEvalRequestIT.java
+++ b/modules/rank-eval/src/internalClusterTest/java/org/opensearch/index/rankeval/RankEvalRequestIT.java
@@ -47,7 +47,7 @@ import org.opensearch.index.rankeval.PrecisionAtK.Detail;
 import org.opensearch.indices.IndexClosedException;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.search.builder.SearchSourceBuilder;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.junit.Before;
 
 import java.util.ArrayList;
@@ -62,14 +62,14 @@ import static org.opensearch.search.SearchService.CLUSTER_CONCURRENT_SEGMENT_SEA
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.instanceOf;
 
-public class RankEvalRequestIT extends ParameterizedOpenSearchIntegTestCase {
+public class RankEvalRequestIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     private static final String TEST_INDEX = "test";
     private static final String INDEX_ALIAS = "alias0";
     private static final int RELEVANT_RATING_1 = 1;
 
-    public RankEvalRequestIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public RankEvalRequestIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/node/tasks/CancellableTasksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/node/tasks/CancellableTasksIT.java
@@ -69,7 +69,7 @@ import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskInfo;
 import org.opensearch.tasks.TaskManager;
 import org.opensearch.test.InternalTestCluster;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportException;
 import org.opensearch.transport.TransportResponseHandler;
@@ -99,7 +99,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 
-public class CancellableTasksIT extends ParameterizedOpenSearchIntegTestCase {
+public class CancellableTasksIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     static int idGenerator = 0;
     static final Map<TestRequest, CountDownLatch> beforeSendLatches = ConcurrentCollections.newConcurrentMap();
@@ -107,8 +107,8 @@ public class CancellableTasksIT extends ParameterizedOpenSearchIntegTestCase {
     static final Map<TestRequest, CountDownLatch> beforeExecuteLatches = ConcurrentCollections.newConcurrentMap();
     static final Map<TestRequest, CountDownLatch> completedLatches = ConcurrentCollections.newConcurrentMap();
 
-    public CancellableTasksIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public CancellableTasksIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/action/termvectors/GetTermVectorsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/termvectors/GetTermVectorsIT.java
@@ -74,8 +74,8 @@ import static org.hamcrest.Matchers.nullValue;
 
 public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
 
-    public GetTermVectorsIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public GetTermVectorsIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @Override

--- a/server/src/internalClusterTest/java/org/opensearch/action/termvectors/MultiTermVectorsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/termvectors/MultiTermVectorsIT.java
@@ -52,8 +52,8 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 public class MultiTermVectorsIT extends AbstractTermVectorsTestCase {
-    public MultiTermVectorsIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public MultiTermVectorsIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     public void testDuelESLucene() throws Exception {

--- a/server/src/internalClusterTest/java/org/opensearch/index/IndexSortIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/IndexSortIT.java
@@ -41,7 +41,7 @@ import org.apache.lucene.search.SortedSetSortField;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -51,11 +51,11 @@ import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.opensearch.search.SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING;
 import static org.hamcrest.Matchers.containsString;
 
-public class IndexSortIT extends ParameterizedOpenSearchIntegTestCase {
+public class IndexSortIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
     private static final XContentBuilder TEST_MAPPING = createTestMapping();
 
-    public IndexSortIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public IndexSortIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/index/search/MatchPhraseQueryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/search/MatchPhraseQueryIT.java
@@ -41,7 +41,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.index.query.MatchPhraseQueryBuilder;
 import org.opensearch.index.search.MatchQuery.ZeroTermsQuery;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.junit.Before;
 
 import java.util.ArrayList;
@@ -55,12 +55,12 @@ import static org.opensearch.search.SearchService.CLUSTER_CONCURRENT_SEGMENT_SEA
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
 
-public class MatchPhraseQueryIT extends ParameterizedOpenSearchIntegTestCase {
+public class MatchPhraseQueryIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     private static final String INDEX = "test";
 
-    public MatchPhraseQueryIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public MatchPhraseQueryIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/index/suggest/stats/SuggestStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/suggest/stats/SuggestStatsIT.java
@@ -50,7 +50,7 @@ import org.opensearch.search.suggest.SuggestBuilder;
 import org.opensearch.search.suggest.phrase.PhraseSuggestionBuilder;
 import org.opensearch.search.suggest.term.TermSuggestionBuilder;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -68,10 +68,10 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 @OpenSearchIntegTestCase.ClusterScope(minNumDataNodes = 2)
-public class SuggestStatsIT extends ParameterizedOpenSearchIntegTestCase {
+public class SuggestStatsIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public SuggestStatsIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public SuggestStatsIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/indices/IndicesRequestCacheIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/IndicesRequestCacheIT.java
@@ -49,7 +49,7 @@ import org.opensearch.search.aggregations.bucket.global.GlobalAggregationBuilder
 import org.opensearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.opensearch.search.aggregations.bucket.histogram.Histogram;
 import org.opensearch.search.aggregations.bucket.histogram.Histogram.Bucket;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.opensearch.test.hamcrest.OpenSearchAssertions;
 
 import java.time.ZoneId;
@@ -69,7 +69,7 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertSearchResp
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 
-public class IndicesRequestCacheIT extends ParameterizedOpenSearchIntegTestCase {
+public class IndicesRequestCacheIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
     public IndicesRequestCacheIT(Settings settings) {
         super(settings);
     }

--- a/server/src/internalClusterTest/java/org/opensearch/indices/memory/breaker/CircuitBreakerServiceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/memory/breaker/CircuitBreakerServiceIT.java
@@ -62,7 +62,7 @@ import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.opensearch.search.sort.SortOrder;
 import org.opensearch.test.OpenSearchIntegTestCase.ClusterScope;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.junit.After;
 import org.junit.Before;
 
@@ -94,9 +94,9 @@ import static org.hamcrest.Matchers.nullValue;
  * Integration tests for InternalCircuitBreakerService
  */
 @ClusterScope(scope = TEST, numClientNodes = 0, maxNumDataNodes = 1)
-public class CircuitBreakerServiceIT extends ParameterizedOpenSearchIntegTestCase {
-    public CircuitBreakerServiceIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+public class CircuitBreakerServiceIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
+    public CircuitBreakerServiceIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/indices/stats/IndexStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/stats/IndexStatsIT.java
@@ -85,7 +85,7 @@ import org.opensearch.search.sort.SortOrder;
 import org.opensearch.test.InternalSettingsPlugin;
 import org.opensearch.test.OpenSearchIntegTestCase.ClusterScope;
 import org.opensearch.test.OpenSearchIntegTestCase.Scope;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -122,7 +122,7 @@ import static org.hamcrest.Matchers.nullValue;
 
 @ClusterScope(scope = Scope.SUITE, numDataNodes = 2, numClientNodes = 0)
 @SuppressCodecs("*") // requires custom completion format
-public class IndexStatsIT extends ParameterizedOpenSearchIntegTestCase {
+public class IndexStatsIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
     public IndexStatsIT(Settings settings) {
         super(settings);
     }

--- a/server/src/internalClusterTest/java/org/opensearch/mget/SimpleMgetIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/mget/SimpleMgetIT.java
@@ -46,7 +46,7 @@ import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.search.fetch.subphase.FetchSourceContext;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -63,10 +63,10 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-public class SimpleMgetIT extends ParameterizedOpenSearchIntegTestCase {
+public class SimpleMgetIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public SimpleMgetIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public SimpleMgetIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/script/ScriptCacheIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/script/ScriptCacheIT.java
@@ -21,7 +21,7 @@ import org.opensearch.node.NodeMocksPlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.search.MockSearchService;
 import org.opensearch.test.MockHttpTransport;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.opensearch.test.TestGeoShapeFieldMapperPlugin;
 import org.opensearch.test.store.MockFSIndexStore;
 import org.opensearch.test.transport.MockTransportService;
@@ -38,7 +38,7 @@ import java.util.function.Function;
 import static org.opensearch.search.SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING;
 import static org.apache.logging.log4j.core.util.Throwables.getRootCause;
 
-public class ScriptCacheIT extends ParameterizedOpenSearchIntegTestCase {
+public class ScriptCacheIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
     public ScriptCacheIT(Settings settings) {
         super(settings);
     }

--- a/server/src/internalClusterTest/java/org/opensearch/search/SearchCancellationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/SearchCancellationIT.java
@@ -62,7 +62,7 @@ import org.opensearch.script.ScriptType;
 import org.opensearch.search.lookup.LeafFieldsLookup;
 import org.opensearch.tasks.TaskInfo;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.opensearch.transport.TransportException;
 import org.junit.After;
 
@@ -91,7 +91,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE)
-public class SearchCancellationIT extends ParameterizedOpenSearchIntegTestCase {
+public class SearchCancellationIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     private TimeValue requestCancellationTimeout = TimeValue.timeValueSeconds(1);
     private TimeValue clusterCancellationTimeout = TimeValue.timeValueMillis(1500);

--- a/server/src/internalClusterTest/java/org/opensearch/search/SearchTimeoutIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/SearchTimeoutIT.java
@@ -44,7 +44,7 @@ import org.opensearch.script.MockScriptPlugin;
 import org.opensearch.script.Script;
 import org.opensearch.script.ScriptType;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -59,7 +59,7 @@ import static org.opensearch.search.SearchService.CLUSTER_CONCURRENT_SEGMENT_SEA
 import static org.opensearch.search.SearchTimeoutIT.ScriptedTimeoutPlugin.SCRIPT_NAME;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE)
-public class SearchTimeoutIT extends ParameterizedOpenSearchIntegTestCase {
+public class SearchTimeoutIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
     public SearchTimeoutIT(Settings settings) {
         super(settings);
     }

--- a/server/src/internalClusterTest/java/org/opensearch/search/SearchWithRejectionsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/SearchWithRejectionsIT.java
@@ -40,7 +40,7 @@ import org.opensearch.action.search.SearchType;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -52,10 +52,10 @@ import static org.opensearch.search.SearchService.CLUSTER_CONCURRENT_SEGMENT_SEA
 import static org.hamcrest.Matchers.equalTo;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE)
-public class SearchWithRejectionsIT extends ParameterizedOpenSearchIntegTestCase {
+public class SearchWithRejectionsIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public SearchWithRejectionsIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public SearchWithRejectionsIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/StressSearchServiceReaperIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/StressSearchServiceReaperIT.java
@@ -40,7 +40,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.test.OpenSearchIntegTestCase.ClusterScope;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -53,7 +53,7 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertNoFailures;
 
 @ClusterScope(scope = SUITE)
-public class StressSearchServiceReaperIT extends ParameterizedOpenSearchIntegTestCase {
+public class StressSearchServiceReaperIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
     public StressSearchServiceReaperIT(Settings settings) {
         super(settings);
     }

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/AggregationsIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/AggregationsIntegrationIT.java
@@ -49,7 +49,7 @@ import org.opensearch.search.aggregations.bucket.terms.Terms;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregatorFactory;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -62,7 +62,7 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertSearchResponse;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class AggregationsIntegrationIT extends ParameterizedOpenSearchIntegTestCase {
+public class AggregationsIntegrationIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     static int numDocs;
 
@@ -71,8 +71,8 @@ public class AggregationsIntegrationIT extends ParameterizedOpenSearchIntegTestC
         + LARGE_STRING.length()
         + "] used in the request has exceeded the allowed maximum";
 
-    public AggregationsIntegrationIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public AggregationsIntegrationIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/CombiIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/CombiIT.java
@@ -42,7 +42,7 @@ import org.opensearch.search.aggregations.Aggregator.SubAggCollectionMode;
 import org.opensearch.search.aggregations.bucket.histogram.Histogram;
 import org.opensearch.search.aggregations.bucket.missing.Missing;
 import org.opensearch.search.aggregations.bucket.terms.Terms;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.hamcrest.Matchers;
 
 import java.util.Arrays;
@@ -61,10 +61,10 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 
-public class CombiIT extends ParameterizedOpenSearchIntegTestCase {
+public class CombiIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public CombiIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public CombiIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/EquivalenceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/EquivalenceIT.java
@@ -56,7 +56,7 @@ import org.opensearch.search.aggregations.bucket.range.RangeAggregationBuilder;
 import org.opensearch.search.aggregations.bucket.terms.Terms;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregatorFactory;
 import org.opensearch.search.aggregations.metrics.Sum;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.junit.After;
 import org.junit.Before;
 
@@ -94,10 +94,10 @@ import static org.hamcrest.core.IsNull.notNullValue;
  * Additional tests that aim at testing more complex aggregation trees on larger random datasets, so that things like
  * the growth of dynamic arrays is tested.
  */
-public class EquivalenceIT extends ParameterizedOpenSearchIntegTestCase {
+public class EquivalenceIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public EquivalenceIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public EquivalenceIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/MetadataIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/MetadataIT.java
@@ -41,7 +41,7 @@ import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.search.aggregations.bucket.terms.Terms;
 import org.opensearch.search.aggregations.metrics.Sum;
 import org.opensearch.search.aggregations.pipeline.InternalBucketMetricValue;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -57,10 +57,10 @@ import static org.opensearch.search.aggregations.PipelineAggregatorBuilders.maxB
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertSearchResponse;
 
-public class MetadataIT extends ParameterizedOpenSearchIntegTestCase {
+public class MetadataIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public MetadataIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public MetadataIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/MissingValueIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/MissingValueIT.java
@@ -47,7 +47,7 @@ import org.opensearch.search.aggregations.metrics.GeoCentroid;
 import org.opensearch.search.aggregations.metrics.Percentiles;
 import org.opensearch.search.aggregations.metrics.Stats;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -65,10 +65,10 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertSearchResp
 import static org.hamcrest.Matchers.closeTo;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class MissingValueIT extends ParameterizedOpenSearchIntegTestCase {
+public class MissingValueIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public MissingValueIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public MissingValueIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/AdjacencyMatrixIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/AdjacencyMatrixIT.java
@@ -50,7 +50,7 @@ import org.opensearch.search.aggregations.bucket.adjacency.AdjacencyMatrix.Bucke
 import org.opensearch.search.aggregations.bucket.histogram.Histogram;
 import org.opensearch.search.aggregations.metrics.Avg;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedDynamicSettingsOpenSearchIntegTestCase;
 import org.hamcrest.Matchers;
 
 import java.util.ArrayList;
@@ -75,7 +75,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class AdjacencyMatrixIT extends ParameterizedOpenSearchIntegTestCase {
+public class AdjacencyMatrixIT extends ParameterizedDynamicSettingsOpenSearchIntegTestCase {
 
     static int numDocs, numSingleTag1Docs, numSingleTag2Docs, numTag1Docs, numTag2Docs, numMultiTagDocs;
     static final int MAX_NUM_FILTERS = 3;

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/BooleanTermsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/BooleanTermsIT.java
@@ -40,7 +40,7 @@ import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.search.aggregations.Aggregator.SubAggCollectionMode;
 import org.opensearch.search.aggregations.bucket.terms.Terms;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedDynamicSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -53,7 +53,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsNull.notNullValue;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class BooleanTermsIT extends ParameterizedOpenSearchIntegTestCase {
+public class BooleanTermsIT extends ParameterizedDynamicSettingsOpenSearchIntegTestCase {
 
     private static final String SINGLE_VALUED_FIELD_NAME = "b_value";
     private static final String MULTI_VALUED_FIELD_NAME = "b_values";

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DateHistogramIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DateHistogramIT.java
@@ -59,7 +59,7 @@ import org.opensearch.search.aggregations.bucket.histogram.LongBounds;
 import org.opensearch.search.aggregations.metrics.Avg;
 import org.opensearch.search.aggregations.metrics.Sum;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.hamcrest.Matchers;
 import org.junit.After;
 
@@ -98,7 +98,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class DateHistogramIT extends ParameterizedOpenSearchIntegTestCase {
+public class DateHistogramIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     static Map<ZonedDateTime, Map<String, Object>> expectedMultiSortBuckets;
 
@@ -106,8 +106,8 @@ public class DateHistogramIT extends ParameterizedOpenSearchIntegTestCase {
         return ZonedDateTime.of(2012, month, day, 0, 0, 0, 0, ZoneOffset.UTC);
     }
 
-    public DateHistogramIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public DateHistogramIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DateHistogramOffsetIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DateHistogramOffsetIT.java
@@ -43,7 +43,7 @@ import org.opensearch.index.mapper.DateFieldMapper;
 import org.opensearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.opensearch.search.aggregations.bucket.histogram.Histogram;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.junit.After;
 import org.junit.Before;
 
@@ -69,13 +69,13 @@ import static org.hamcrest.core.IsNull.notNullValue;
  */
 @OpenSearchIntegTestCase.SuiteScopeTestCase
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE)
-public class DateHistogramOffsetIT extends ParameterizedOpenSearchIntegTestCase {
+public class DateHistogramOffsetIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     private static final String DATE_FORMAT = "yyyy-MM-dd:hh-mm-ss";
     private static final DateFormatter FORMATTER = DateFormatter.forPattern(DATE_FORMAT);
 
-    public DateHistogramOffsetIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public DateHistogramOffsetIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DateRangeIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DateRangeIT.java
@@ -49,7 +49,7 @@ import org.opensearch.search.aggregations.bucket.range.Range;
 import org.opensearch.search.aggregations.bucket.range.Range.Bucket;
 import org.opensearch.search.aggregations.metrics.Sum;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.hamcrest.Matchers;
 
 import java.time.ZoneId;
@@ -81,10 +81,10 @@ import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class DateRangeIT extends ParameterizedOpenSearchIntegTestCase {
+public class DateRangeIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public DateRangeIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public DateRangeIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DiversifiedSamplerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DiversifiedSamplerIT.java
@@ -48,7 +48,7 @@ import org.opensearch.search.aggregations.bucket.terms.Terms.Bucket;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.opensearch.search.aggregations.metrics.Max;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -71,12 +71,12 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
  * Tests the Sampler aggregation
  */
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class DiversifiedSamplerIT extends ParameterizedOpenSearchIntegTestCase {
+public class DiversifiedSamplerIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     public static final int NUM_SHARDS = 2;
 
-    public DiversifiedSamplerIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public DiversifiedSamplerIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DoubleTermsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DoubleTermsIT.java
@@ -88,8 +88,8 @@ import static org.hamcrest.core.IsNull.notNullValue;
 @OpenSearchIntegTestCase.SuiteScopeTestCase
 public class DoubleTermsIT extends AbstractTermsTestCase {
 
-    public DoubleTermsIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public DoubleTermsIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @Override

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/FilterIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/FilterIT.java
@@ -46,7 +46,7 @@ import org.opensearch.search.aggregations.bucket.filter.Filter;
 import org.opensearch.search.aggregations.bucket.histogram.Histogram;
 import org.opensearch.search.aggregations.metrics.Avg;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.hamcrest.Matchers;
 
 import java.util.ArrayList;
@@ -68,12 +68,12 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class FilterIT extends ParameterizedOpenSearchIntegTestCase {
+public class FilterIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     static int numDocs, numTag1Docs;
 
-    public FilterIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public FilterIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/FiltersIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/FiltersIT.java
@@ -48,7 +48,7 @@ import org.opensearch.search.aggregations.bucket.filter.FiltersAggregator.KeyedF
 import org.opensearch.search.aggregations.bucket.histogram.Histogram;
 import org.opensearch.search.aggregations.metrics.Avg;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedDynamicSettingsOpenSearchIntegTestCase;
 import org.hamcrest.Matchers;
 
 import java.util.ArrayList;
@@ -72,7 +72,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class FiltersIT extends ParameterizedOpenSearchIntegTestCase {
+public class FiltersIT extends ParameterizedDynamicSettingsOpenSearchIntegTestCase {
 
     static int numDocs, numTag1Docs, numTag2Docs, numOtherDocs;
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/GeoDistanceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/GeoDistanceIT.java
@@ -50,7 +50,7 @@ import org.opensearch.search.aggregations.bucket.range.Range;
 import org.opensearch.search.aggregations.bucket.range.Range.Bucket;
 import org.opensearch.search.aggregations.bucket.terms.Terms;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.opensearch.test.VersionUtils;
 import org.hamcrest.Matchers;
 
@@ -76,10 +76,10 @@ import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class GeoDistanceIT extends ParameterizedOpenSearchIntegTestCase {
+public class GeoDistanceIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public GeoDistanceIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public GeoDistanceIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @Override

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/GlobalIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/GlobalIT.java
@@ -43,7 +43,7 @@ import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.bucket.global.Global;
 import org.opensearch.search.aggregations.metrics.Stats;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -61,12 +61,12 @@ import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.core.IsNull.notNullValue;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class GlobalIT extends ParameterizedOpenSearchIntegTestCase {
+public class GlobalIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     static int numDocs;
 
-    public GlobalIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public GlobalIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/HistogramIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/HistogramIT.java
@@ -56,7 +56,7 @@ import org.opensearch.search.aggregations.metrics.Max;
 import org.opensearch.search.aggregations.metrics.Stats;
 import org.opensearch.search.aggregations.metrics.Sum;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.hamcrest.Matchers;
 
 import java.io.IOException;
@@ -91,7 +91,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.core.IsNull.notNullValue;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class HistogramIT extends ParameterizedOpenSearchIntegTestCase {
+public class HistogramIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     private static final String SINGLE_VALUED_FIELD_NAME = "l_value";
     private static final String MULTI_VALUED_FIELD_NAME = "l_values";
@@ -102,8 +102,8 @@ public class HistogramIT extends ParameterizedOpenSearchIntegTestCase {
     static long[] valueCounts, valuesCounts;
     static Map<Long, Map<String, Object>> expectedMultiSortBuckets;
 
-    public HistogramIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public HistogramIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/IpRangeIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/IpRangeIT.java
@@ -45,7 +45,7 @@ import org.opensearch.script.ScriptType;
 import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.search.aggregations.bucket.range.Range;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -60,10 +60,10 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class IpRangeIT extends ParameterizedOpenSearchIntegTestCase {
+public class IpRangeIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public IpRangeIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public IpRangeIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/IpTermsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/IpTermsIT.java
@@ -51,8 +51,8 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertSearchResp
 
 public class IpTermsIT extends AbstractTermsTestCase {
 
-    public IpTermsIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public IpTermsIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @Override

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/LongTermsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/LongTermsIT.java
@@ -86,8 +86,8 @@ import static org.hamcrest.core.IsNull.notNullValue;
 @OpenSearchIntegTestCase.SuiteScopeTestCase
 public class LongTermsIT extends AbstractTermsTestCase {
 
-    public LongTermsIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public LongTermsIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @Override

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/MinDocCountIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/MinDocCountIT.java
@@ -82,8 +82,8 @@ public class MinDocCountIT extends AbstractTermsTestCase {
     private static final QueryBuilder QUERY = QueryBuilders.termQuery("match", true);
     private static int cardinality;
 
-    public MinDocCountIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public MinDocCountIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @Override

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/MultiTermsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/MultiTermsIT.java
@@ -34,8 +34,8 @@ import static org.hamcrest.core.IsNull.notNullValue;
 @OpenSearchIntegTestCase.SuiteScopeTestCase
 public class MultiTermsIT extends BaseStringTermsTestCase {
 
-    public MultiTermsIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public MultiTermsIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     // the main purpose of this test is to make sure we're not allocating 2GB of memory per shard

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/NaNSortingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/NaNSortingIT.java
@@ -51,7 +51,7 @@ import org.opensearch.search.aggregations.metrics.ExtendedStatsAggregationBuilde
 import org.opensearch.search.aggregations.support.ValuesSource;
 import org.opensearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -67,7 +67,7 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertSearchResp
 import static org.hamcrest.core.IsNull.notNullValue;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class NaNSortingIT extends ParameterizedOpenSearchIntegTestCase {
+public class NaNSortingIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     private enum SubAggregation {
         AVG("avg") {
@@ -139,8 +139,8 @@ public class NaNSortingIT extends ParameterizedOpenSearchIntegTestCase {
         public abstract double getValue(Aggregation aggregation);
     }
 
-    public NaNSortingIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public NaNSortingIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/NestedIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/NestedIT.java
@@ -57,7 +57,7 @@ import org.opensearch.search.aggregations.metrics.Max;
 import org.opensearch.search.aggregations.metrics.Stats;
 import org.opensearch.search.aggregations.metrics.Sum;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.hamcrest.Matchers;
 
 import java.util.ArrayList;
@@ -92,14 +92,14 @@ import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.core.IsNull.notNullValue;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class NestedIT extends ParameterizedOpenSearchIntegTestCase {
+public class NestedIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     private static int numParents;
     private static int[] numChildren;
     private static SubAggCollectionMode aggCollectionMode;
 
-    public NestedIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public NestedIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/RangeIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/RangeIT.java
@@ -51,7 +51,7 @@ import org.opensearch.search.aggregations.bucket.range.Range.Bucket;
 import org.opensearch.search.aggregations.bucket.terms.Terms;
 import org.opensearch.search.aggregations.metrics.Sum;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.hamcrest.Matchers;
 
 import java.util.ArrayList;
@@ -79,15 +79,15 @@ import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class RangeIT extends ParameterizedOpenSearchIntegTestCase {
+public class RangeIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     private static final String SINGLE_VALUED_FIELD_NAME = "l_value";
     private static final String MULTI_VALUED_FIELD_NAME = "l_values";
 
     static int numDocs;
 
-    public RangeIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public RangeIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/ReverseNestedIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/ReverseNestedIT.java
@@ -47,7 +47,7 @@ import org.opensearch.search.aggregations.bucket.nested.ReverseNested;
 import org.opensearch.search.aggregations.bucket.terms.Terms;
 import org.opensearch.search.aggregations.metrics.ValueCount;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -76,10 +76,10 @@ import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.core.IsNull.notNullValue;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class ReverseNestedIT extends ParameterizedOpenSearchIntegTestCase {
+public class ReverseNestedIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public ReverseNestedIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public ReverseNestedIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/SamplerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/SamplerIT.java
@@ -48,7 +48,7 @@ import org.opensearch.search.aggregations.bucket.terms.Terms;
 import org.opensearch.search.aggregations.bucket.terms.Terms.Bucket;
 import org.opensearch.search.aggregations.metrics.Max;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -71,7 +71,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
  * Tests the Sampler aggregation
  */
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class SamplerIT extends ParameterizedOpenSearchIntegTestCase {
+public class SamplerIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     public static final int NUM_SHARDS = 2;
 
@@ -79,8 +79,8 @@ public class SamplerIT extends ParameterizedOpenSearchIntegTestCase {
         return randomBoolean() ? null : randomFrom(SamplerAggregator.ExecutionMode.values()).toString();
     }
 
-    public SamplerIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public SamplerIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/ShardReduceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/ShardReduceIT.java
@@ -49,7 +49,7 @@ import org.opensearch.search.aggregations.bucket.nested.Nested;
 import org.opensearch.search.aggregations.bucket.range.Range;
 import org.opensearch.search.aggregations.bucket.terms.Terms;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -77,10 +77,10 @@ import static org.hamcrest.Matchers.equalTo;
  * we can make sure that the reduce is properly propagated by checking that empty buckets were created.
  */
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class ShardReduceIT extends ParameterizedOpenSearchIntegTestCase {
+public class ShardReduceIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public ShardReduceIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public ShardReduceIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/ShardSizeTermsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/ShardSizeTermsIT.java
@@ -47,8 +47,8 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class ShardSizeTermsIT extends ShardSizeTestCase {
 
-    public ShardSizeTermsIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public ShardSizeTermsIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     public void testNoShardSizeString() throws Exception {

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/SignificantTermsSignificanceScoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/SignificantTermsSignificanceScoreIT.java
@@ -65,7 +65,7 @@ import org.opensearch.search.aggregations.bucket.terms.heuristic.MutualInformati
 import org.opensearch.search.aggregations.bucket.terms.heuristic.ScriptHeuristic;
 import org.opensearch.search.aggregations.bucket.terms.heuristic.SignificanceHeuristic;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.opensearch.test.search.aggregations.bucket.SharedSignificantTermsTestMethods;
 
 import java.io.IOException;
@@ -95,14 +95,14 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE)
-public class SignificantTermsSignificanceScoreIT extends ParameterizedOpenSearchIntegTestCase {
+public class SignificantTermsSignificanceScoreIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     static final String INDEX_NAME = "testidx";
     static final String TEXT_FIELD = "text";
     static final String CLASS_FIELD = "class";
 
-    public SignificantTermsSignificanceScoreIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public SignificantTermsSignificanceScoreIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/TermsDocCountErrorIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/TermsDocCountErrorIT.java
@@ -45,7 +45,7 @@ import org.opensearch.search.aggregations.bucket.terms.Terms;
 import org.opensearch.search.aggregations.bucket.terms.Terms.Bucket;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregatorFactory.ExecutionMode;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -67,7 +67,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.core.IsNull.notNullValue;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class TermsDocCountErrorIT extends ParameterizedOpenSearchIntegTestCase {
+public class TermsDocCountErrorIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     private static final String STRING_FIELD_NAME = "s_value";
     private static final String LONG_FIELD_NAME = "l_value";
@@ -79,8 +79,8 @@ public class TermsDocCountErrorIT extends ParameterizedOpenSearchIntegTestCase {
 
     private static int numRoutingValues;
 
-    public TermsDocCountErrorIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public TermsDocCountErrorIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/TermsFixedDocCountErrorIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/TermsFixedDocCountErrorIT.java
@@ -17,7 +17,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.search.aggregations.bucket.terms.Terms;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -29,12 +29,12 @@ import static org.opensearch.test.OpenSearchIntegTestCase.Scope.TEST;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = TEST, numClientNodes = 0, maxNumDataNodes = 1, supportsDedicatedMasters = false)
-public class TermsFixedDocCountErrorIT extends ParameterizedOpenSearchIntegTestCase {
+public class TermsFixedDocCountErrorIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     private static final String STRING_FIELD_NAME = "s_value";
 
-    public TermsFixedDocCountErrorIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public TermsFixedDocCountErrorIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/TermsShardMinDocCountIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/TermsShardMinDocCountIT.java
@@ -44,7 +44,7 @@ import org.opensearch.search.aggregations.bucket.filter.InternalFilter;
 import org.opensearch.search.aggregations.bucket.terms.SignificantTerms;
 import org.opensearch.search.aggregations.bucket.terms.SignificantTermsAggregatorFactory;
 import org.opensearch.search.aggregations.bucket.terms.Terms;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -61,12 +61,12 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 
-public class TermsShardMinDocCountIT extends ParameterizedOpenSearchIntegTestCase {
+public class TermsShardMinDocCountIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     private static final String index = "someindex";
 
-    public TermsShardMinDocCountIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public TermsShardMinDocCountIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/terms/BaseStringTermsTestCase.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/terms/BaseStringTermsTestCase.java
@@ -38,8 +38,8 @@ public class BaseStringTermsTestCase extends AbstractTermsTestCase {
     protected static final String MULTI_VALUED_FIELD_NAME = "s_values";
     protected static Map<String, Map<String, Object>> expectedMultiSortBuckets;
 
-    public BaseStringTermsTestCase(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public BaseStringTermsTestCase(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @Override

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/terms/StringTermsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/terms/StringTermsIT.java
@@ -79,8 +79,8 @@ import static org.hamcrest.core.IsNull.notNullValue;
 @OpenSearchIntegTestCase.SuiteScopeTestCase
 public class StringTermsIT extends BaseStringTermsTestCase {
 
-    public StringTermsIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public StringTermsIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     // the main purpose of this test is to make sure we're not allocating 2GB of memory per shard

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/CardinalityIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/CardinalityIT.java
@@ -48,7 +48,7 @@ import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.bucket.global.Global;
 import org.opensearch.search.aggregations.bucket.terms.Terms;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -71,10 +71,10 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.notNullValue;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class CardinalityIT extends ParameterizedOpenSearchIntegTestCase {
+public class CardinalityIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public CardinalityIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public CardinalityIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/CardinalityWithRequestBreakerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/CardinalityWithRequestBreakerIT.java
@@ -43,7 +43,7 @@ import org.opensearch.core.common.breaker.CircuitBreakingException;
 import org.opensearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.opensearch.search.aggregations.Aggregator;
 import org.opensearch.search.aggregations.BucketOrder;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -54,10 +54,10 @@ import static org.opensearch.search.SearchService.CLUSTER_CONCURRENT_SEGMENT_SEA
 import static org.opensearch.search.aggregations.AggregationBuilders.cardinality;
 import static org.opensearch.search.aggregations.AggregationBuilders.terms;
 
-public class CardinalityWithRequestBreakerIT extends ParameterizedOpenSearchIntegTestCase {
+public class CardinalityWithRequestBreakerIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public CardinalityWithRequestBreakerIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public CardinalityWithRequestBreakerIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/ExtendedStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/ExtendedStatsIT.java
@@ -70,8 +70,8 @@ import static org.hamcrest.Matchers.sameInstance;
 
 public class ExtendedStatsIT extends AbstractNumericTestCase {
 
-    public ExtendedStatsIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public ExtendedStatsIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @Override

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/GeoCentroidIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/GeoCentroidIT.java
@@ -55,8 +55,8 @@ import static org.hamcrest.Matchers.sameInstance;
 public class GeoCentroidIT extends AbstractGeoTestCase {
     private static final String aggName = "geoCentroid";
 
-    public GeoCentroidIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public GeoCentroidIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     public void testEmptyAggregation() throws Exception {

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/HDRPercentileRanksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/HDRPercentileRanksIT.java
@@ -72,8 +72,8 @@ import static org.hamcrest.Matchers.sameInstance;
 
 public class HDRPercentileRanksIT extends AbstractNumericTestCase {
 
-    public HDRPercentileRanksIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public HDRPercentileRanksIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @Override

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/HDRPercentilesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/HDRPercentilesIT.java
@@ -75,8 +75,8 @@ import static org.hamcrest.Matchers.sameInstance;
 
 public class HDRPercentilesIT extends AbstractNumericTestCase {
 
-    public HDRPercentilesIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public HDRPercentilesIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @Override

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/MedianAbsoluteDeviationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/MedianAbsoluteDeviationIT.java
@@ -91,8 +91,8 @@ public class MedianAbsoluteDeviationIT extends AbstractNumericTestCase {
     private static double singleValueExactMAD;
     private static double multiValueExactMAD;
 
-    public MedianAbsoluteDeviationIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public MedianAbsoluteDeviationIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @Override

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/ScriptedMetricIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/ScriptedMetricIT.java
@@ -56,7 +56,7 @@ import org.opensearch.search.aggregations.bucket.histogram.Histogram.Bucket;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.OpenSearchIntegTestCase.ClusterScope;
 import org.opensearch.test.OpenSearchIntegTestCase.Scope;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.junit.Before;
 
 import java.io.IOException;
@@ -93,12 +93,12 @@ import static org.hamcrest.Matchers.sameInstance;
 
 @ClusterScope(scope = Scope.SUITE)
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class ScriptedMetricIT extends ParameterizedOpenSearchIntegTestCase {
+public class ScriptedMetricIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     private static long numDocs;
 
-    public ScriptedMetricIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public ScriptedMetricIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/StatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/StatsIT.java
@@ -66,8 +66,8 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
 
 public class StatsIT extends AbstractNumericTestCase {
-    public StatsIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public StatsIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @Override

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/SumIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/SumIT.java
@@ -68,8 +68,8 @@ import static org.hamcrest.Matchers.notNullValue;
 
 public class SumIT extends AbstractNumericTestCase {
 
-    public SumIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public SumIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @Override

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/TDigestPercentileRanksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/TDigestPercentileRanksIT.java
@@ -72,8 +72,8 @@ import static org.hamcrest.Matchers.sameInstance;
 
 public class TDigestPercentileRanksIT extends AbstractNumericTestCase {
 
-    public TDigestPercentileRanksIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public TDigestPercentileRanksIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @Override

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/TDigestPercentilesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/TDigestPercentilesIT.java
@@ -74,8 +74,8 @@ import static org.hamcrest.Matchers.sameInstance;
 
 public class TDigestPercentilesIT extends AbstractNumericTestCase {
 
-    public TDigestPercentilesIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public TDigestPercentilesIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @Override

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/TopHitsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/TopHitsIT.java
@@ -70,7 +70,7 @@ import org.opensearch.search.sort.ScriptSortBuilder.ScriptSortType;
 import org.opensearch.search.sort.SortBuilders;
 import org.opensearch.search.sort.SortOrder;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -111,13 +111,13 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase()
-public class TopHitsIT extends ParameterizedOpenSearchIntegTestCase {
+public class TopHitsIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     private static final String TERMS_AGGS_FIELD = "terms";
     private static final String SORT_FIELD = "sort";
 
-    public TopHitsIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public TopHitsIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/ValueCountIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/ValueCountIT.java
@@ -45,7 +45,7 @@ import org.opensearch.search.aggregations.bucket.filter.Filter;
 import org.opensearch.search.aggregations.bucket.global.Global;
 import org.opensearch.search.aggregations.bucket.terms.Terms;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -73,10 +73,10 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class ValueCountIT extends ParameterizedOpenSearchIntegTestCase {
+public class ValueCountIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public ValueCountIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public ValueCountIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/AvgBucketIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/AvgBucketIT.java
@@ -46,7 +46,7 @@ import org.opensearch.search.aggregations.bucket.terms.Terms;
 import org.opensearch.search.aggregations.metrics.Sum;
 import org.opensearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -66,7 +66,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.core.IsNull.notNullValue;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class AvgBucketIT extends ParameterizedOpenSearchIntegTestCase {
+public class AvgBucketIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     private static final String SINGLE_VALUED_FIELD_NAME = "l_value";
 
@@ -77,8 +77,8 @@ public class AvgBucketIT extends ParameterizedOpenSearchIntegTestCase {
     static int numValueBuckets;
     static long[] valueCounts;
 
-    public AvgBucketIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public AvgBucketIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/BucketScriptIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/BucketScriptIT.java
@@ -51,7 +51,7 @@ import org.opensearch.search.aggregations.bucket.range.Range;
 import org.opensearch.search.aggregations.metrics.Sum;
 import org.opensearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -76,7 +76,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class BucketScriptIT extends ParameterizedOpenSearchIntegTestCase {
+public class BucketScriptIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     private static final String FIELD_1_NAME = "field1";
     private static final String FIELD_2_NAME = "field2";
@@ -90,8 +90,8 @@ public class BucketScriptIT extends ParameterizedOpenSearchIntegTestCase {
     private static int maxNumber;
     private static long date;
 
-    public BucketScriptIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public BucketScriptIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/BucketSelectorIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/BucketSelectorIT.java
@@ -50,7 +50,7 @@ import org.opensearch.search.aggregations.bucket.histogram.Histogram.Bucket;
 import org.opensearch.search.aggregations.metrics.Sum;
 import org.opensearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -77,7 +77,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class BucketSelectorIT extends ParameterizedOpenSearchIntegTestCase {
+public class BucketSelectorIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     private static final String FIELD_1_NAME = "field1";
     private static final String FIELD_2_NAME = "field2";
@@ -89,8 +89,8 @@ public class BucketSelectorIT extends ParameterizedOpenSearchIntegTestCase {
     private static int minNumber;
     private static int maxNumber;
 
-    public BucketSelectorIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public BucketSelectorIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/BucketSortIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/BucketSortIT.java
@@ -48,7 +48,7 @@ import org.opensearch.search.aggregations.metrics.Avg;
 import org.opensearch.search.sort.FieldSortBuilder;
 import org.opensearch.search.sort.SortOrder;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.io.IOException;
 import java.time.ZonedDateTime;
@@ -75,7 +75,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class BucketSortIT extends ParameterizedOpenSearchIntegTestCase {
+public class BucketSortIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     private static final String INDEX = "bucket-sort-it-data-index";
     private static final String INDEX_WITH_GAPS = "bucket-sort-it-data-index-with-gaps";
@@ -85,8 +85,8 @@ public class BucketSortIT extends ParameterizedOpenSearchIntegTestCase {
     private static final String VALUE_1_FIELD = "value_1";
     private static final String VALUE_2_FIELD = "value_2";
 
-    public BucketSortIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public BucketSortIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/DateDerivativeIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/DateDerivativeIT.java
@@ -48,7 +48,7 @@ import org.opensearch.search.aggregations.bucket.histogram.Histogram.Bucket;
 import org.opensearch.search.aggregations.metrics.Sum;
 import org.opensearch.search.aggregations.support.AggregationPath;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.hamcrest.Matcher;
 import org.junit.After;
 
@@ -76,15 +76,15 @@ import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class DateDerivativeIT extends ParameterizedOpenSearchIntegTestCase {
+public class DateDerivativeIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     // some index names used during these tests
     private static final String IDX_DST_START = "idx_dst_start";
     private static final String IDX_DST_END = "idx_dst_end";
     private static final String IDX_DST_KATHMANDU = "idx_dst_kathmandu";
 
-    public DateDerivativeIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public DateDerivativeIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/DerivativeIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/DerivativeIT.java
@@ -51,7 +51,7 @@ import org.opensearch.search.aggregations.metrics.Sum;
 import org.opensearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 import org.opensearch.search.aggregations.support.AggregationPath;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedDynamicSettingsOpenSearchIntegTestCase;
 import org.hamcrest.Matchers;
 
 import java.io.IOException;
@@ -78,7 +78,7 @@ import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class DerivativeIT extends ParameterizedOpenSearchIntegTestCase {
+public class DerivativeIT extends ParameterizedDynamicSettingsOpenSearchIntegTestCase {
 
     private static final String SINGLE_VALUED_FIELD_NAME = "l_value";
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/ExtendedStatsBucketIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/ExtendedStatsBucketIT.java
@@ -49,7 +49,7 @@ import org.opensearch.search.aggregations.metrics.ExtendedStats.Bounds;
 import org.opensearch.search.aggregations.metrics.Sum;
 import org.opensearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -69,7 +69,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.core.IsNull.notNullValue;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class ExtendedStatsBucketIT extends ParameterizedOpenSearchIntegTestCase {
+public class ExtendedStatsBucketIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     private static final String SINGLE_VALUED_FIELD_NAME = "l_value";
 
@@ -80,8 +80,8 @@ public class ExtendedStatsBucketIT extends ParameterizedOpenSearchIntegTestCase 
     static int numValueBuckets;
     static long[] valueCounts;
 
-    public ExtendedStatsBucketIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public ExtendedStatsBucketIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/MaxBucketIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/MaxBucketIT.java
@@ -58,7 +58,7 @@ import org.opensearch.search.aggregations.metrics.Sum;
 import org.opensearch.search.aggregations.metrics.SumAggregationBuilder;
 import org.opensearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -80,7 +80,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.core.IsNull.notNullValue;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class MaxBucketIT extends ParameterizedOpenSearchIntegTestCase {
+public class MaxBucketIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     private static final String SINGLE_VALUED_FIELD_NAME = "l_value";
 
@@ -91,8 +91,8 @@ public class MaxBucketIT extends ParameterizedOpenSearchIntegTestCase {
     static int numValueBuckets;
     static long[] valueCounts;
 
-    public MaxBucketIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public MaxBucketIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/MinBucketIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/MinBucketIT.java
@@ -46,7 +46,7 @@ import org.opensearch.search.aggregations.bucket.terms.Terms;
 import org.opensearch.search.aggregations.metrics.Sum;
 import org.opensearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -66,7 +66,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.core.IsNull.notNullValue;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class MinBucketIT extends ParameterizedOpenSearchIntegTestCase {
+public class MinBucketIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     private static final String SINGLE_VALUED_FIELD_NAME = "l_value";
 
@@ -77,8 +77,8 @@ public class MinBucketIT extends ParameterizedOpenSearchIntegTestCase {
     static int numValueBuckets;
     static long[] valueCounts;
 
-    public MinBucketIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public MinBucketIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/MovAvgIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/MovAvgIT.java
@@ -50,7 +50,7 @@ import org.opensearch.search.aggregations.bucket.histogram.Histogram.Bucket;
 import org.opensearch.search.aggregations.metrics.Avg;
 import org.opensearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.hamcrest.Matchers;
 
 import java.util.ArrayList;
@@ -77,7 +77,7 @@ import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class MovAvgIT extends ParameterizedOpenSearchIntegTestCase {
+public class MovAvgIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
     private static final String INTERVAL_FIELD = "l_value";
     private static final String VALUE_FIELD = "v_value";
     private static final String VALUE_FIELD2 = "v_value2";
@@ -133,8 +133,8 @@ public class MovAvgIT extends ParameterizedOpenSearchIntegTestCase {
         }
     }
 
-    public MovAvgIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public MovAvgIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/PercentilesBucketIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/PercentilesBucketIT.java
@@ -47,7 +47,7 @@ import org.opensearch.search.aggregations.bucket.terms.Terms;
 import org.opensearch.search.aggregations.metrics.Percentile;
 import org.opensearch.search.aggregations.metrics.Sum;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -69,7 +69,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.core.IsNull.notNullValue;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class PercentilesBucketIT extends ParameterizedOpenSearchIntegTestCase {
+public class PercentilesBucketIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     private static final String SINGLE_VALUED_FIELD_NAME = "l_value";
     private static final double[] PERCENTS = { 0.0, 1.0, 25.0, 50.0, 75.0, 99.0, 100.0 };
@@ -80,8 +80,8 @@ public class PercentilesBucketIT extends ParameterizedOpenSearchIntegTestCase {
     static int numValueBuckets;
     static long[] valueCounts;
 
-    public PercentilesBucketIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public PercentilesBucketIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/SerialDiffIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/SerialDiffIT.java
@@ -43,7 +43,7 @@ import org.opensearch.search.aggregations.bucket.histogram.Histogram;
 import org.opensearch.search.aggregations.bucket.histogram.Histogram.Bucket;
 import org.opensearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.hamcrest.Matchers;
 
 import java.util.ArrayList;
@@ -69,7 +69,7 @@ import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class SerialDiffIT extends ParameterizedOpenSearchIntegTestCase {
+public class SerialDiffIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
     private static final String INTERVAL_FIELD = "l_value";
     private static final String VALUE_FIELD = "v_value";
 
@@ -98,8 +98,8 @@ public class SerialDiffIT extends ParameterizedOpenSearchIntegTestCase {
         }
     }
 
-    public SerialDiffIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public SerialDiffIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/StatsBucketIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/StatsBucketIT.java
@@ -46,7 +46,7 @@ import org.opensearch.search.aggregations.bucket.terms.Terms;
 import org.opensearch.search.aggregations.metrics.Sum;
 import org.opensearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -66,7 +66,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.core.IsNull.notNullValue;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class StatsBucketIT extends ParameterizedOpenSearchIntegTestCase {
+public class StatsBucketIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     private static final String SINGLE_VALUED_FIELD_NAME = "l_value";
     static int numDocs;
@@ -76,8 +76,8 @@ public class StatsBucketIT extends ParameterizedOpenSearchIntegTestCase {
     static int numValueBuckets;
     static long[] valueCounts;
 
-    public StatsBucketIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public StatsBucketIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/SumBucketIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/SumBucketIT.java
@@ -46,7 +46,7 @@ import org.opensearch.search.aggregations.bucket.terms.Terms;
 import org.opensearch.search.aggregations.metrics.Sum;
 import org.opensearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -66,7 +66,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.core.IsNull.notNullValue;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class SumBucketIT extends ParameterizedOpenSearchIntegTestCase {
+public class SumBucketIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     private static final String SINGLE_VALUED_FIELD_NAME = "l_value";
 
@@ -77,8 +77,8 @@ public class SumBucketIT extends ParameterizedOpenSearchIntegTestCase {
     static int numValueBuckets;
     static long[] valueCounts;
 
-    public SumBucketIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public SumBucketIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/backpressure/SearchBackpressureIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/backpressure/SearchBackpressureIT.java
@@ -37,7 +37,7 @@ import org.opensearch.search.backpressure.settings.SearchTaskSettings;
 import org.opensearch.tasks.CancellableTask;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 import org.hamcrest.MatcherAssert;
@@ -61,13 +61,13 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE)
-public class SearchBackpressureIT extends ParameterizedOpenSearchIntegTestCase {
+public class SearchBackpressureIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     private static final TimeValue TIMEOUT = new TimeValue(10, TimeUnit.SECONDS);
     private static final int MOVING_AVERAGE_WINDOW_SIZE = 10;
 
-    public SearchBackpressureIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public SearchBackpressureIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/basic/SearchRedStateIndexIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/basic/SearchRedStateIndexIT.java
@@ -46,7 +46,7 @@ import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.search.SearchService;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.junit.After;
 
 import java.util.Arrays;
@@ -61,10 +61,10 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 
 @OpenSearchIntegTestCase.ClusterScope(minNumDataNodes = 2)
-public class SearchRedStateIndexIT extends ParameterizedOpenSearchIntegTestCase {
+public class SearchRedStateIndexIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public SearchRedStateIndexIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public SearchRedStateIndexIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/basic/SearchWhileCreatingIndexIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/basic/SearchWhileCreatingIndexIT.java
@@ -41,7 +41,7 @@ import org.opensearch.cluster.health.ClusterHealthStatus;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.index.query.QueryBuilders;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -54,10 +54,10 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
  * This test basically verifies that search with a single shard active (cause we indexed to it) and other
  * shards possibly not active at all (cause they haven't allocated) will still work.
  */
-public class SearchWhileCreatingIndexIT extends ParameterizedOpenSearchIntegTestCase {
+public class SearchWhileCreatingIndexIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public SearchWhileCreatingIndexIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public SearchWhileCreatingIndexIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/basic/SearchWhileRelocatingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/basic/SearchWhileRelocatingIT.java
@@ -43,7 +43,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.search.SearchHits;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -60,10 +60,10 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.formatShardStatu
 import static org.hamcrest.Matchers.equalTo;
 
 @OpenSearchIntegTestCase.ClusterScope(minNumDataNodes = 2)
-public class SearchWhileRelocatingIT extends ParameterizedOpenSearchIntegTestCase {
+public class SearchWhileRelocatingIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public SearchWhileRelocatingIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public SearchWhileRelocatingIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/basic/SearchWithRandomExceptionsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/basic/SearchWithRandomExceptionsIT.java
@@ -56,7 +56,7 @@ import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.search.sort.SortOrder;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.opensearch.test.engine.MockEngineSupport;
 import org.opensearch.test.engine.ThrowingLeafReaderWrapper;
 
@@ -71,10 +71,10 @@ import java.util.concurrent.ExecutionException;
 import static org.opensearch.search.SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 
-public class SearchWithRandomExceptionsIT extends ParameterizedOpenSearchIntegTestCase {
+public class SearchWithRandomExceptionsIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public SearchWithRandomExceptionsIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public SearchWithRandomExceptionsIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/basic/SearchWithRandomIOExceptionsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/basic/SearchWithRandomIOExceptionsIT.java
@@ -51,7 +51,7 @@ import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.search.sort.SortOrder;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.opensearch.test.store.MockFSDirectoryFactory;
 import org.opensearch.test.store.MockFSIndexStore;
 
@@ -64,10 +64,10 @@ import static org.opensearch.search.SearchService.CLUSTER_CONCURRENT_SEGMENT_SEA
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertNoFailures;
 
-public class SearchWithRandomIOExceptionsIT extends ParameterizedOpenSearchIntegTestCase {
+public class SearchWithRandomIOExceptionsIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public SearchWithRandomIOExceptionsIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public SearchWithRandomIOExceptionsIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/basic/TransportSearchFailuresIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/basic/TransportSearchFailuresIT.java
@@ -48,7 +48,7 @@ import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.query.MatchQueryBuilder;
 import org.opensearch.search.builder.SearchSourceBuilder;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -64,10 +64,10 @@ import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
-public class TransportSearchFailuresIT extends ParameterizedOpenSearchIntegTestCase {
+public class TransportSearchFailuresIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public TransportSearchFailuresIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public TransportSearchFailuresIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/basic/TransportTwoNodesSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/basic/TransportTwoNodesSearchIT.java
@@ -54,7 +54,7 @@ import org.opensearch.search.aggregations.bucket.filter.Filter;
 import org.opensearch.search.aggregations.bucket.global.Global;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.sort.SortOrder;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -80,10 +80,10 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 
-public class TransportTwoNodesSearchIT extends ParameterizedOpenSearchIntegTestCase {
+public class TransportTwoNodesSearchIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public TransportTwoNodesSearchIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public TransportTwoNodesSearchIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/fetch/FetchSubPhasePluginIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/fetch/FetchSubPhasePluginIT.java
@@ -54,7 +54,7 @@ import org.opensearch.search.SearchExtBuilder;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.test.OpenSearchIntegTestCase.ClusterScope;
 import org.opensearch.test.OpenSearchIntegTestCase.Scope;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -74,10 +74,10 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertSearchResp
 import static org.hamcrest.CoreMatchers.equalTo;
 
 @ClusterScope(scope = Scope.SUITE, supportsDedicatedMasters = false, numDataNodes = 2)
-public class FetchSubPhasePluginIT extends ParameterizedOpenSearchIntegTestCase {
+public class FetchSubPhasePluginIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public FetchSubPhasePluginIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public FetchSubPhasePluginIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/fetch/subphase/InnerHitsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/fetch/subphase/InnerHitsIT.java
@@ -58,7 +58,7 @@ import org.opensearch.search.fetch.subphase.highlight.HighlightBuilder;
 import org.opensearch.search.sort.FieldSortBuilder;
 import org.opensearch.search.sort.SortOrder;
 import org.opensearch.test.InternalSettingsPlugin;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -88,10 +88,10 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
-public class InnerHitsIT extends ParameterizedOpenSearchIntegTestCase {
+public class InnerHitsIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public InnerHitsIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public InnerHitsIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/fetch/subphase/MatchedQueriesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/fetch/subphase/MatchedQueriesIT.java
@@ -45,7 +45,7 @@ import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.search.SearchHit;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -64,10 +64,10 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItemInArray;
 
-public class MatchedQueriesIT extends ParameterizedOpenSearchIntegTestCase {
+public class MatchedQueriesIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public MatchedQueriesIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public MatchedQueriesIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/fetch/subphase/highlight/CustomHighlighterSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/fetch/subphase/highlight/CustomHighlighterSearchIT.java
@@ -40,7 +40,7 @@ import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.test.OpenSearchIntegTestCase.ClusterScope;
 import org.opensearch.test.OpenSearchIntegTestCase.Scope;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.junit.Before;
 
 import java.io.IOException;
@@ -57,10 +57,10 @@ import static org.hamcrest.Matchers.equalTo;
  * Integration test for highlighters registered by a plugin.
  */
 @ClusterScope(scope = Scope.SUITE, supportsDedicatedMasters = false, numDataNodes = 1)
-public class CustomHighlighterSearchIT extends ParameterizedOpenSearchIntegTestCase {
+public class CustomHighlighterSearchIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public CustomHighlighterSearchIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public CustomHighlighterSearchIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
@@ -75,7 +75,7 @@ import org.opensearch.search.sort.SortBuilders;
 import org.opensearch.search.sort.SortOrder;
 import org.opensearch.test.InternalSettingsPlugin;
 import org.opensearch.test.MockKeywordPlugin;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 
@@ -128,13 +128,13 @@ import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 
-public class HighlighterSearchIT extends ParameterizedOpenSearchIntegTestCase {
+public class HighlighterSearchIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     // TODO as we move analyzers out of the core we need to move some of these into HighlighterWithAnalyzersTests
     private static final String[] ALL_TYPES = new String[] { "plain", "fvh", "unified" };
 
-    public HighlighterSearchIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public HighlighterSearchIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/fieldcaps/FieldCapabilitiesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/fieldcaps/FieldCapabilitiesIT.java
@@ -44,7 +44,7 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.plugins.MapperPlugin;
 import org.opensearch.plugins.Plugin;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.junit.Before;
 
 import java.util.ArrayList;
@@ -59,10 +59,10 @@ import java.util.function.Predicate;
 import static org.opensearch.search.SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 
-public class FieldCapabilitiesIT extends ParameterizedOpenSearchIntegTestCase {
+public class FieldCapabilitiesIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public FieldCapabilitiesIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public FieldCapabilitiesIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/fields/SearchFieldsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/fields/SearchFieldsIT.java
@@ -63,7 +63,7 @@ import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.lookup.FieldLookup;
 import org.opensearch.search.sort.SortOrder;
 import org.opensearch.test.InternalSettingsPlugin;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
@@ -104,10 +104,10 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
-public class SearchFieldsIT extends ParameterizedOpenSearchIntegTestCase {
+public class SearchFieldsIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public SearchFieldsIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public SearchFieldsIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/functionscore/DecayFunctionScoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/functionscore/DecayFunctionScoreIT.java
@@ -56,7 +56,7 @@ import org.opensearch.index.query.functionscore.ScoreFunctionBuilders;
 import org.opensearch.search.MultiValueMode;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.opensearch.test.VersionUtils;
 
 import java.time.ZoneOffset;
@@ -91,10 +91,10 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 
-public class DecayFunctionScoreIT extends ParameterizedOpenSearchIntegTestCase {
+public class DecayFunctionScoreIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public DecayFunctionScoreIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public DecayFunctionScoreIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/functionscore/ExplainableScriptIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/functionscore/ExplainableScriptIT.java
@@ -58,7 +58,7 @@ import org.opensearch.search.SearchHits;
 import org.opensearch.search.lookup.SearchLookup;
 import org.opensearch.test.OpenSearchIntegTestCase.ClusterScope;
 import org.opensearch.test.OpenSearchIntegTestCase.Scope;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.opensearch.test.hamcrest.OpenSearchAssertions;
 
 import java.io.IOException;
@@ -83,10 +83,10 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 @ClusterScope(scope = Scope.SUITE, supportsDedicatedMasters = false, numDataNodes = 1)
-public class ExplainableScriptIT extends ParameterizedOpenSearchIntegTestCase {
+public class ExplainableScriptIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public ExplainableScriptIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public ExplainableScriptIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/functionscore/FunctionScoreFieldValueIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/functionscore/FunctionScoreFieldValueIT.java
@@ -40,7 +40,7 @@ import org.opensearch.common.lucene.search.function.FieldValueFactorFunction;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.search.SearchHit;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -61,10 +61,10 @@ import static org.hamcrest.Matchers.containsString;
 /**
  * Tests for the {@code field_value_factor} function in a function_score query.
  */
-public class FunctionScoreFieldValueIT extends ParameterizedOpenSearchIntegTestCase {
+public class FunctionScoreFieldValueIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public FunctionScoreFieldValueIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public FunctionScoreFieldValueIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/functionscore/FunctionScoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/functionscore/FunctionScoreIT.java
@@ -50,7 +50,7 @@ import org.opensearch.script.ScriptType;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.aggregations.bucket.terms.Terms;
 import org.opensearch.test.OpenSearchTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -78,13 +78,13 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
-public class FunctionScoreIT extends ParameterizedOpenSearchIntegTestCase {
+public class FunctionScoreIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     static final String TYPE = "type";
     static final String INDEX = "index";
 
-    public FunctionScoreIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public FunctionScoreIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/functionscore/FunctionScorePluginIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/functionscore/FunctionScorePluginIT.java
@@ -52,7 +52,7 @@ import org.opensearch.plugins.SearchPlugin;
 import org.opensearch.search.SearchHits;
 import org.opensearch.test.OpenSearchIntegTestCase.ClusterScope;
 import org.opensearch.test.OpenSearchIntegTestCase.Scope;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.opensearch.test.hamcrest.OpenSearchAssertions;
 
 import java.io.IOException;
@@ -71,10 +71,10 @@ import static org.opensearch.search.builder.SearchSourceBuilder.searchSource;
 import static org.hamcrest.Matchers.equalTo;
 
 @ClusterScope(scope = Scope.SUITE, supportsDedicatedMasters = false, numDataNodes = 1)
-public class FunctionScorePluginIT extends ParameterizedOpenSearchIntegTestCase {
+public class FunctionScorePluginIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public FunctionScorePluginIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public FunctionScorePluginIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/functionscore/QueryRescorerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/functionscore/QueryRescorerIT.java
@@ -55,7 +55,7 @@ import org.opensearch.search.SearchHits;
 import org.opensearch.search.rescore.QueryRescoreMode;
 import org.opensearch.search.rescore.QueryRescorerBuilder;
 import org.opensearch.search.sort.SortBuilders;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -91,10 +91,10 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
 
-public class QueryRescorerIT extends ParameterizedOpenSearchIntegTestCase {
+public class QueryRescorerIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public QueryRescorerIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public QueryRescorerIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/functionscore/RandomScoreFunctionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/functionscore/RandomScoreFunctionIT.java
@@ -47,7 +47,7 @@ import org.opensearch.script.ScoreAccessor;
 import org.opensearch.script.Script;
 import org.opensearch.script.ScriptType;
 import org.opensearch.search.SearchHit;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.hamcrest.CoreMatchers;
 
 import java.util.Arrays;
@@ -76,10 +76,10 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.nullValue;
 
-public class RandomScoreFunctionIT extends ParameterizedOpenSearchIntegTestCase {
+public class RandomScoreFunctionIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public RandomScoreFunctionIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public RandomScoreFunctionIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoFilterIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoFilterIT.java
@@ -64,7 +64,7 @@ import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.SearchHit;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.opensearch.test.VersionUtils;
 import org.junit.BeforeClass;
 
@@ -99,10 +99,10 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
-public class GeoFilterIT extends ParameterizedOpenSearchIntegTestCase {
+public class GeoFilterIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public GeoFilterIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public GeoFilterIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoPolygonIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoPolygonIT.java
@@ -42,7 +42,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.search.SearchHit;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.opensearch.test.VersionUtils;
 
 import java.util.ArrayList;
@@ -60,10 +60,10 @@ import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class GeoPolygonIT extends ParameterizedOpenSearchIntegTestCase {
+public class GeoPolygonIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public GeoPolygonIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public GeoPolygonIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoShapeIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoShapeIntegrationIT.java
@@ -48,7 +48,7 @@ import org.opensearch.index.IndexService;
 import org.opensearch.index.mapper.GeoShapeFieldMapper;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.indices.IndicesService;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -61,10 +61,10 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
-public class GeoShapeIntegrationIT extends ParameterizedOpenSearchIntegTestCase {
+public class GeoShapeIntegrationIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public GeoShapeIntegrationIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public GeoShapeIntegrationIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/geo/LegacyGeoShapeIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/geo/LegacyGeoShapeIntegrationIT.java
@@ -50,7 +50,7 @@ import org.opensearch.index.IndexService;
 import org.opensearch.index.mapper.LegacyGeoShapeFieldMapper;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.indices.IndicesService;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -63,10 +63,10 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
-public class LegacyGeoShapeIntegrationIT extends ParameterizedOpenSearchIntegTestCase {
+public class LegacyGeoShapeIntegrationIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public LegacyGeoShapeIntegrationIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public LegacyGeoShapeIntegrationIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/morelikethis/MoreLikeThisIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/morelikethis/MoreLikeThisIT.java
@@ -50,7 +50,7 @@ import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.test.InternalSettingsPlugin;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -79,10 +79,10 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 
-public class MoreLikeThisIT extends ParameterizedOpenSearchIntegTestCase {
+public class MoreLikeThisIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public MoreLikeThisIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public MoreLikeThisIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/msearch/MultiSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/msearch/MultiSearchIT.java
@@ -40,7 +40,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.index.query.QueryBuilders;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -52,10 +52,10 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertNoFailures
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.hasId;
 import static org.hamcrest.Matchers.equalTo;
 
-public class MultiSearchIT extends ParameterizedOpenSearchIntegTestCase {
+public class MultiSearchIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public MultiSearchIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public MultiSearchIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/nested/SimpleNestedIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/nested/SimpleNestedIT.java
@@ -56,7 +56,7 @@ import org.opensearch.search.sort.NestedSortBuilder;
 import org.opensearch.search.sort.SortBuilders;
 import org.opensearch.search.sort.SortMode;
 import org.opensearch.search.sort.SortOrder;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -77,10 +77,10 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
 
-public class SimpleNestedIT extends ParameterizedOpenSearchIntegTestCase {
+public class SimpleNestedIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public SimpleNestedIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public SimpleNestedIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/pit/PitMultiNodeIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/pit/PitMultiNodeIT.java
@@ -35,7 +35,7 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.search.builder.PointInTimeBuilder;
 import org.opensearch.test.InternalTestCluster;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 import org.junit.After;
@@ -65,7 +65,7 @@ import static org.hamcrest.Matchers.containsString;
  * Multi node integration tests for PIT creation and search operation with PIT ID.
  */
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, numDataNodes = 2)
-public class PitMultiNodeIT extends ParameterizedOpenSearchIntegTestCase {
+public class PitMultiNodeIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
     public PitMultiNodeIT(Settings settings) {
         super(settings);
     }

--- a/server/src/internalClusterTest/java/org/opensearch/search/preference/SearchPreferenceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/preference/SearchPreferenceIT.java
@@ -50,7 +50,7 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.node.Node;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -70,10 +70,10 @@ import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.not;
 
 @OpenSearchIntegTestCase.ClusterScope(minNumDataNodes = 2)
-public class SearchPreferenceIT extends ParameterizedOpenSearchIntegTestCase {
+public class SearchPreferenceIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public SearchPreferenceIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public SearchPreferenceIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/profile/aggregation/AggregationProfilerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/profile/aggregation/AggregationProfilerIT.java
@@ -50,7 +50,7 @@ import org.opensearch.search.profile.ProfileShardResult;
 import org.opensearch.search.profile.query.CollectorResult;
 import org.opensearch.search.profile.query.QueryProfileShardResult;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.hamcrest.core.IsNull;
 
 import java.util.ArrayList;
@@ -83,7 +83,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public class AggregationProfilerIT extends ParameterizedOpenSearchIntegTestCase {
+public class AggregationProfilerIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     private static final String BUILD_LEAF_COLLECTOR = AggregationTimingType.BUILD_LEAF_COLLECTOR.toString();
     private static final String COLLECT = AggregationTimingType.COLLECT.toString();
@@ -166,8 +166,8 @@ public class AggregationProfilerIT extends ParameterizedOpenSearchIntegTestCase 
     private static final String REASON_SEARCH_TOP_HITS = "search_top_hits";
     private static final String REASON_AGGREGATION = "aggregation";
 
-    public AggregationProfilerIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public AggregationProfilerIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/profile/query/QueryProfilerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/profile/query/QueryProfilerIT.java
@@ -49,7 +49,7 @@ import org.opensearch.search.SearchHit;
 import org.opensearch.search.profile.ProfileResult;
 import org.opensearch.search.profile.ProfileShardResult;
 import org.opensearch.search.sort.SortOrder;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedDynamicSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -68,7 +68,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
-public class QueryProfilerIT extends ParameterizedOpenSearchIntegTestCase {
+public class QueryProfilerIT extends ParameterizedDynamicSettingsOpenSearchIntegTestCase {
     private final boolean concurrentSearchEnabled;
     private static final String MAX_PREFIX = "max_";
     private static final String MIN_PREFIX = "min_";

--- a/server/src/internalClusterTest/java/org/opensearch/search/query/ExistsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/query/ExistsIT.java
@@ -44,7 +44,7 @@ import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.SearchHit;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -62,10 +62,10 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertSearchResponse;
 
-public class ExistsIT extends ParameterizedOpenSearchIntegTestCase {
+public class ExistsIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public ExistsIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public ExistsIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/query/MultiMatchQueryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/query/MultiMatchQueryIT.java
@@ -54,7 +54,7 @@ import org.opensearch.search.SearchHits;
 import org.opensearch.search.sort.SortBuilders;
 import org.opensearch.search.sort.SortOrder;
 import org.opensearch.test.MockKeywordPlugin;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.junit.Before;
 
 import java.io.IOException;
@@ -92,10 +92,10 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThan;
 
-public class MultiMatchQueryIT extends ParameterizedOpenSearchIntegTestCase {
+public class MultiMatchQueryIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public MultiMatchQueryIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public MultiMatchQueryIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/query/QueryStringIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/query/QueryStringIT.java
@@ -47,7 +47,7 @@ import org.opensearch.index.query.QueryStringQueryBuilder;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.SearchModule;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
@@ -70,12 +70,12 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
-public class QueryStringIT extends ParameterizedOpenSearchIntegTestCase {
+public class QueryStringIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     private static int CLUSTER_MAX_CLAUSE_COUNT;
 
-    public QueryStringIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public QueryStringIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/query/ScriptScoreQueryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/query/ScriptScoreQueryIT.java
@@ -46,7 +46,7 @@ import org.opensearch.plugins.Plugin;
 import org.opensearch.script.MockScriptPlugin;
 import org.opensearch.script.Script;
 import org.opensearch.script.ScriptType;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -67,10 +67,10 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertSecondHit;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertThirdHit;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.hasScore;
 
-public class ScriptScoreQueryIT extends ParameterizedOpenSearchIntegTestCase {
+public class ScriptScoreQueryIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public ScriptScoreQueryIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public ScriptScoreQueryIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/query/SearchQueryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/query/SearchQueryIT.java
@@ -80,7 +80,7 @@ import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.test.InternalSettingsPlugin;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.opensearch.test.junit.annotations.TestIssueLogging;
 
 import java.io.IOException;
@@ -147,10 +147,10 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
-public class SearchQueryIT extends ParameterizedOpenSearchIntegTestCase {
+public class SearchQueryIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public SearchQueryIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public SearchQueryIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/query/SimpleQueryStringIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/query/SimpleQueryStringIT.java
@@ -60,7 +60,7 @@ import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.SearchModule;
 import org.opensearch.search.builder.SearchSourceBuilder;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
@@ -95,12 +95,12 @@ import static org.hamcrest.Matchers.equalTo;
 /**
  * Tests for the {@code simple_query_string} query
  */
-public class SimpleQueryStringIT extends ParameterizedOpenSearchIntegTestCase {
+public class SimpleQueryStringIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     private static int CLUSTER_MAX_CLAUSE_COUNT;
 
-    public SimpleQueryStringIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public SimpleQueryStringIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/scriptfilter/ScriptQuerySearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/scriptfilter/ScriptQuerySearchIT.java
@@ -50,7 +50,7 @@ import org.opensearch.script.ScriptType;
 import org.opensearch.search.sort.SortOrder;
 import org.opensearch.test.InternalSettingsPlugin;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -71,7 +71,7 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertNoFailures
 import static org.hamcrest.Matchers.equalTo;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE)
-public class ScriptQuerySearchIT extends ParameterizedOpenSearchIntegTestCase {
+public class ScriptQuerySearchIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
     public ScriptQuerySearchIT(Settings settings) {
         super(settings);
     }

--- a/server/src/internalClusterTest/java/org/opensearch/search/scroll/DuelScrollIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/scroll/DuelScrollIT.java
@@ -47,7 +47,7 @@ import org.opensearch.search.SearchHits;
 import org.opensearch.search.sort.SortBuilder;
 import org.opensearch.search.sort.SortBuilders;
 import org.opensearch.search.sort.SortOrder;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -60,7 +60,7 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.equalTo;
 
-public class DuelScrollIT extends ParameterizedOpenSearchIntegTestCase {
+public class DuelScrollIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
     public DuelScrollIT(Settings settings) {
         super(settings);
     }

--- a/server/src/internalClusterTest/java/org/opensearch/search/scroll/SearchScrollIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/scroll/SearchScrollIT.java
@@ -60,7 +60,7 @@ import org.opensearch.search.SearchHit;
 import org.opensearch.search.sort.FieldSortBuilder;
 import org.opensearch.search.sort.SortOrder;
 import org.opensearch.test.InternalTestCluster;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.opensearch.test.hamcrest.OpenSearchAssertions;
 import org.junit.After;
 
@@ -92,7 +92,7 @@ import static org.hamcrest.Matchers.notNullValue;
 /**
  * Tests for scrolling.
  */
-public class SearchScrollIT extends ParameterizedOpenSearchIntegTestCase {
+public class SearchScrollIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
     public SearchScrollIT(Settings settings) {
         super(settings);
     }

--- a/server/src/internalClusterTest/java/org/opensearch/search/scroll/SearchScrollWithFailingNodesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/scroll/SearchScrollWithFailingNodesIT.java
@@ -41,7 +41,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -58,7 +58,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 2, numClientNodes = 0)
-public class SearchScrollWithFailingNodesIT extends ParameterizedOpenSearchIntegTestCase {
+public class SearchScrollWithFailingNodesIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
     public SearchScrollWithFailingNodesIT(Settings settings) {
         super(settings);
     }

--- a/server/src/internalClusterTest/java/org/opensearch/search/searchafter/SearchAfterIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/searchafter/SearchAfterIT.java
@@ -52,7 +52,7 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.builder.PointInTimeBuilder;
 import org.opensearch.search.sort.SortOrder;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.hamcrest.Matchers;
 
 import java.util.ArrayList;
@@ -69,7 +69,7 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
-public class SearchAfterIT extends ParameterizedOpenSearchIntegTestCase {
+public class SearchAfterIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
     private static final String INDEX_NAME = "test";
     private static final int NUM_DOCS = 100;
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/simple/SimpleSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/simple/SimpleSearchIT.java
@@ -52,7 +52,7 @@ import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.search.rescore.QueryRescorerBuilder;
 import org.opensearch.search.sort.SortOrder;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -77,7 +77,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.apache.lucene.search.TotalHits.Relation.EQUAL_TO;
 import static org.apache.lucene.search.TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO;
 
-public class SimpleSearchIT extends ParameterizedOpenSearchIntegTestCase {
+public class SimpleSearchIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     public SimpleSearchIT(Settings settings) {
         super(settings);

--- a/server/src/internalClusterTest/java/org/opensearch/search/slice/SearchSliceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/slice/SearchSliceIT.java
@@ -53,7 +53,7 @@ import org.opensearch.search.SearchException;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.builder.PointInTimeBuilder;
 import org.opensearch.search.sort.SortBuilders;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -70,9 +70,9 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
 
-public class SearchSliceIT extends ParameterizedOpenSearchIntegTestCase {
-    public SearchSliceIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+public class SearchSliceIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
+    public SearchSliceIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/sort/FieldSortIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/sort/FieldSortIT.java
@@ -63,7 +63,7 @@ import org.opensearch.script.ScriptType;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.test.InternalSettingsPlugin;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedDynamicSettingsOpenSearchIntegTestCase;
 import org.hamcrest.Matchers;
 
 import java.io.IOException;
@@ -109,7 +109,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.oneOf;
 
-public class FieldSortIT extends ParameterizedOpenSearchIntegTestCase {
+public class FieldSortIT extends ParameterizedDynamicSettingsOpenSearchIntegTestCase {
     public FieldSortIT(Settings dynamicSettings) {
         super(dynamicSettings);
     }

--- a/server/src/internalClusterTest/java/org/opensearch/search/sort/GeoDistanceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/sort/GeoDistanceIT.java
@@ -45,7 +45,7 @@ import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.geometry.utils.Geohash;
 import org.opensearch.index.query.QueryBuilders;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.opensearch.test.VersionUtils;
 
 import java.io.IOException;
@@ -66,10 +66,10 @@ import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 
-public class GeoDistanceIT extends ParameterizedOpenSearchIntegTestCase {
+public class GeoDistanceIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public GeoDistanceIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public GeoDistanceIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/sort/GeoDistanceSortBuilderIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/sort/GeoDistanceSortBuilderIT.java
@@ -45,7 +45,7 @@ import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.query.GeoValidationMethod;
 import org.opensearch.search.builder.SearchSourceBuilder;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.opensearch.test.VersionUtils;
 
 import java.io.IOException;
@@ -65,7 +65,7 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertOrderedSea
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertSortValues;
 import static org.hamcrest.Matchers.closeTo;
 
-public class GeoDistanceSortBuilderIT extends ParameterizedOpenSearchIntegTestCase {
+public class GeoDistanceSortBuilderIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
     public GeoDistanceSortBuilderIT(Settings settings) {
         super(settings);
     }

--- a/server/src/internalClusterTest/java/org/opensearch/search/sort/SimpleSortIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/sort/SimpleSortIT.java
@@ -49,7 +49,7 @@ import org.opensearch.script.ScriptType;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.sort.ScriptSortBuilder.ScriptSortType;
 import org.opensearch.test.InternalSettingsPlugin;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -75,12 +75,12 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
-public class SimpleSortIT extends ParameterizedOpenSearchIntegTestCase {
+public class SimpleSortIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     private static final String DOUBLE_APOSTROPHE = "\u0027\u0027";
 
-    public SimpleSortIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public SimpleSortIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/sort/SortFromPluginIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/sort/SortFromPluginIT.java
@@ -19,7 +19,7 @@ import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.sort.plugin.CustomSortBuilder;
 import org.opensearch.search.sort.plugin.CustomSortPlugin;
 import org.opensearch.test.InternalSettingsPlugin;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -27,7 +27,7 @@ import java.util.Collection;
 import static org.opensearch.search.SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING;
 import static org.hamcrest.Matchers.equalTo;
 
-public class SortFromPluginIT extends ParameterizedOpenSearchIntegTestCase {
+public class SortFromPluginIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
     public SortFromPluginIT(Settings settings) {
         super(settings);
     }

--- a/server/src/internalClusterTest/java/org/opensearch/search/source/MetadataFetchingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/source/MetadataFetchingIT.java
@@ -45,7 +45,7 @@ import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.search.SearchException;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.fetch.subphase.FetchSourceContext;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -57,10 +57,10 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
-public class MetadataFetchingIT extends ParameterizedOpenSearchIntegTestCase {
+public class MetadataFetchingIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public MetadataFetchingIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public MetadataFetchingIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/source/SourceFetchingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/source/SourceFetchingIT.java
@@ -37,7 +37,7 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -47,10 +47,10 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.IsEqual.equalTo;
 
-public class SourceFetchingIT extends ParameterizedOpenSearchIntegTestCase {
+public class SourceFetchingIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public SourceFetchingIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public SourceFetchingIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/stats/SearchStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/stats/SearchStatsIT.java
@@ -54,7 +54,7 @@ import org.opensearch.script.Script;
 import org.opensearch.script.ScriptType;
 import org.opensearch.search.fetch.subphase.highlight.HighlightBuilder;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -81,10 +81,10 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, minNumDataNodes = 2)
-public class SearchStatsIT extends ParameterizedOpenSearchIntegTestCase {
+public class SearchStatsIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public SearchStatsIT(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public SearchStatsIT(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/internalClusterTest/java/org/opensearch/search/suggest/CompletionSuggestSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/suggest/CompletionSuggestSearchIT.java
@@ -65,7 +65,7 @@ import org.opensearch.search.suggest.completion.context.CategoryContextMapping;
 import org.opensearch.search.suggest.completion.context.ContextMapping;
 import org.opensearch.search.suggest.completion.context.GeoContextMapping;
 import org.opensearch.test.InternalSettingsPlugin;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -100,7 +100,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 
 @SuppressCodecs("*") // requires custom completion format
-public class CompletionSuggestSearchIT extends ParameterizedOpenSearchIntegTestCase {
+public class CompletionSuggestSearchIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
     public CompletionSuggestSearchIT(Settings settings) {
         super(settings);
     }

--- a/server/src/internalClusterTest/java/org/opensearch/search/suggest/ContextCompletionSuggestSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/suggest/ContextCompletionSuggestSearchIT.java
@@ -53,7 +53,7 @@ import org.opensearch.search.suggest.completion.context.ContextBuilder;
 import org.opensearch.search.suggest.completion.context.ContextMapping;
 import org.opensearch.search.suggest.completion.context.GeoContextMapping;
 import org.opensearch.search.suggest.completion.context.GeoQueryContext;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -73,7 +73,7 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertNoFailures
 import static org.hamcrest.core.IsEqual.equalTo;
 
 @SuppressCodecs("*") // requires custom completion format
-public class ContextCompletionSuggestSearchIT extends ParameterizedOpenSearchIntegTestCase {
+public class ContextCompletionSuggestSearchIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
     public ContextCompletionSuggestSearchIT(Settings settings) {
         super(settings);
     }

--- a/server/src/internalClusterTest/java/org/opensearch/search/suggest/SuggestSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/suggest/SuggestSearchIT.java
@@ -57,7 +57,7 @@ import org.opensearch.search.suggest.phrase.PhraseSuggestionBuilder;
 import org.opensearch.search.suggest.phrase.StupidBackoff;
 import org.opensearch.search.suggest.term.TermSuggestionBuilder;
 import org.opensearch.search.suggest.term.TermSuggestionBuilder.SuggestMode;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.opensearch.test.hamcrest.OpenSearchAssertions;
 
 import java.io.IOException;
@@ -96,7 +96,7 @@ import static org.hamcrest.Matchers.nullValue;
  * possible these tests should declare for the first request, make the request, modify the configuration for the next request, make that
  * request, modify again, request again, etc.  This makes it very obvious what changes between requests.
  */
-public class SuggestSearchIT extends ParameterizedOpenSearchIntegTestCase {
+public class SuggestSearchIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
     public SuggestSearchIT(Settings settings) {
         super(settings);
     }

--- a/server/src/internalClusterTest/java/org/opensearch/similarity/SimilarityIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/similarity/SimilarityIT.java
@@ -37,7 +37,7 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -49,7 +49,7 @@ import static org.opensearch.search.SearchService.CLUSTER_CONCURRENT_SEGMENT_SEA
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
-public class SimilarityIT extends ParameterizedOpenSearchIntegTestCase {
+public class SimilarityIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
     public SimilarityIT(Settings settings) {
         super(settings);
     }

--- a/server/src/test/java/org/opensearch/action/termvectors/AbstractTermVectorsTestCase.java
+++ b/server/src/test/java/org/opensearch/action/termvectors/AbstractTermVectorsTestCase.java
@@ -66,7 +66,7 @@ import org.opensearch.action.admin.indices.alias.Alias;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -82,10 +82,10 @@ import static org.opensearch.search.SearchService.CLUSTER_CONCURRENT_SEGMENT_SEA
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 
-public abstract class AbstractTermVectorsTestCase extends ParameterizedOpenSearchIntegTestCase {
+public abstract class AbstractTermVectorsTestCase extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
-    public AbstractTermVectorsTestCase(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public AbstractTermVectorsTestCase(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/ShardSizeTestCase.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/ShardSizeTestCase.java
@@ -38,7 +38,7 @@ import org.opensearch.action.index.IndexRequestBuilder;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -52,7 +52,7 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.is;
 
-public abstract class ShardSizeTestCase extends ParameterizedOpenSearchIntegTestCase {
+public abstract class ShardSizeTestCase extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     public ShardSizeTestCase(Settings dynamicSettings) {
         super(dynamicSettings);

--- a/server/src/test/java/org/opensearch/search/aggregations/metrics/AbstractGeoTestCase.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/metrics/AbstractGeoTestCase.java
@@ -48,7 +48,7 @@ import org.opensearch.search.SearchHit;
 import org.opensearch.search.sort.SortBuilders;
 import org.opensearch.search.sort.SortOrder;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 import org.opensearch.test.geo.RandomGeoGenerator;
 
 import java.util.ArrayList;
@@ -65,7 +65,7 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertSearchResp
 import static org.hamcrest.Matchers.equalTo;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public abstract class AbstractGeoTestCase extends ParameterizedOpenSearchIntegTestCase {
+public abstract class AbstractGeoTestCase extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     protected static final String SINGLE_VALUED_FIELD_NAME = "geo_value";
     protected static final String MULTI_VALUED_FIELD_NAME = "geo_values";

--- a/test/framework/src/main/java/org/opensearch/search/aggregations/bucket/AbstractTermsTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/search/aggregations/bucket/AbstractTermsTestCase.java
@@ -40,7 +40,7 @@ import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.search.aggregations.Aggregator.SubAggCollectionMode;
 import org.opensearch.search.aggregations.bucket.terms.Terms;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregatorFactory.ExecutionMode;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -49,7 +49,7 @@ import static org.opensearch.search.SearchService.CLUSTER_CONCURRENT_SEGMENT_SEA
 import static org.opensearch.search.aggregations.AggregationBuilders.terms;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertSearchResponse;
 
-public abstract class AbstractTermsTestCase extends ParameterizedOpenSearchIntegTestCase {
+public abstract class AbstractTermsTestCase extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
     public AbstractTermsTestCase(Settings dynamicSettings) {
         super(dynamicSettings);

--- a/test/framework/src/main/java/org/opensearch/search/aggregations/metrics/AbstractNumericTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/search/aggregations/metrics/AbstractNumericTestCase.java
@@ -37,7 +37,7 @@ import org.opensearch.action.index.IndexRequestBuilder;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.ParameterizedOpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -48,11 +48,11 @@ import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.opensearch.search.SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING;
 
 @OpenSearchIntegTestCase.SuiteScopeTestCase
-public abstract class AbstractNumericTestCase extends ParameterizedOpenSearchIntegTestCase {
+public abstract class AbstractNumericTestCase extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
     protected static long minValue, maxValue, minValues, maxValues;
 
-    public AbstractNumericTestCase(Settings dynamicSettings) {
-        super(dynamicSettings);
+    public AbstractNumericTestCase(Settings staticSettings) {
+        super(staticSettings);
     }
 
     @ParametersFactory

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
@@ -32,12 +32,10 @@
 
 package org.opensearch.test;
 
-import com.carrotsearch.randomizedtesting.RandomizedContext;
 import com.carrotsearch.randomizedtesting.annotations.TestGroup;
 import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 
-import org.apache.http.HttpHost;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.TotalHits;
@@ -48,7 +46,6 @@ import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.opensearch.action.admin.cluster.node.hotthreads.NodeHotThreads;
-import org.opensearch.action.admin.cluster.node.info.NodeInfo;
 import org.opensearch.action.admin.cluster.node.info.NodesInfoResponse;
 import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.opensearch.action.admin.cluster.state.ClusterStateResponse;
@@ -77,7 +74,6 @@ import org.opensearch.client.Client;
 import org.opensearch.client.ClusterAdminClient;
 import org.opensearch.client.Requests;
 import org.opensearch.client.RestClient;
-import org.opensearch.client.RestClientBuilder;
 import org.opensearch.cluster.ClusterModule;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.RestoreInProgress;
@@ -101,7 +97,6 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.Priority;
 import org.opensearch.common.collect.Tuple;
-import org.opensearch.common.network.NetworkAddress;
 import org.opensearch.common.network.NetworkModule;
 import org.opensearch.common.regex.Regex;
 import org.opensearch.common.settings.FeatureFlagSettings;
@@ -111,7 +106,6 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.common.util.concurrent.ThreadContext;
-import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.common.xcontent.smile.SmileXContent;
@@ -133,7 +127,6 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.env.Environment;
 import org.opensearch.env.TestEnvironment;
-import org.opensearch.http.HttpInfo;
 import org.opensearch.index.IndexModule;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.MergeSchedulerConfig;
@@ -153,7 +146,6 @@ import org.opensearch.monitor.os.OsInfo;
 import org.opensearch.node.NodeMocksPlugin;
 import org.opensearch.plugins.NetworkPlugin;
 import org.opensearch.plugins.Plugin;
-import org.opensearch.rest.action.RestCancellableNodeClient;
 import org.opensearch.script.MockScriptService;
 import org.opensearch.script.ScriptMetadata;
 import org.opensearch.search.MockSearchService;
@@ -165,17 +157,15 @@ import org.opensearch.test.disruption.NetworkDisruption;
 import org.opensearch.test.disruption.ServiceDisruptionScheme;
 import org.opensearch.test.store.MockFSIndexStore;
 import org.opensearch.test.telemetry.MockTelemetryPlugin;
-import org.opensearch.test.telemetry.tracing.StrictCheckSpanProcessor;
 import org.opensearch.test.transport.MockTransportService;
 import org.opensearch.transport.TransportInterceptor;
 import org.opensearch.transport.TransportRequest;
 import org.opensearch.transport.TransportRequestHandler;
 import org.opensearch.transport.TransportService;
 import org.hamcrest.Matchers;
-import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 
 import java.io.IOException;
 import java.lang.Runtime.Version;
@@ -196,13 +186,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -223,7 +211,6 @@ import static org.opensearch.test.XContentTestUtils.differenceBetweenMapsIgnorin
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertNoFailures;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertNoTimeout;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -330,6 +317,10 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
     public static final String TESTS_ENABLE_MOCK_MODULES = "tests.enable_mock_modules";
 
     private static final boolean MOCK_MODULES_ENABLED = "true".equals(System.getProperty(TESTS_ENABLE_MOCK_MODULES, "true"));
+
+    @Rule
+    public static OpenSearchTestClusterRule testClusterRule = new OpenSearchTestClusterRule();
+
     /**
      * Threshold at which indexing switches from frequently async to frequently bulk.
      */
@@ -366,18 +357,6 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
     public static final String TESTS_CLUSTER_NAME = "tests.clustername";
 
     /**
-     * The current cluster depending on the configured {@link Scope}.
-     * By default if no {@link ClusterScope} is configured this will hold a reference to the suite cluster.
-     */
-    private static TestCluster currentCluster;
-    private static RestClient restClient = null;
-
-    private static final Map<Class<?>, TestCluster> clusters = new IdentityHashMap<>();
-
-    private static OpenSearchIntegTestCase INSTANCE = null; // see @SuiteScope
-    private static Long SUITE_SEED = null;
-
-    /**
      * The lucene_default {@link Codec} is not added to the list as it internally maps to Asserting {@link Codec}.
      * The override to fetch the {@link CompletionFieldMapper.CompletionFieldType} postings format is not available for this codec.
      */
@@ -390,8 +369,7 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
 
     @BeforeClass
     public static void beforeClass() throws Exception {
-        SUITE_SEED = randomLong();
-        initializeSuiteScope();
+        testClusterRule.beforeClass();
     }
 
     @Override
@@ -399,36 +377,6 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
         // In an integ test it doesn't make sense to keep track of warnings: if the cluster is external the warnings are in another jvm,
         // if the cluster is internal the deprecation logger is shared across all nodes
         return false;
-    }
-
-    protected final void beforeInternal() throws Exception {
-        final Scope currentClusterScope = getCurrentClusterScope();
-        Callable<Void> setup = () -> {
-            cluster().beforeTest(random());
-            cluster().wipe(excludeTemplates());
-            randomIndexTemplate();
-            return null;
-        };
-        switch (currentClusterScope) {
-            case SUITE:
-                assert SUITE_SEED != null : "Suite seed was not initialized";
-                currentCluster = buildAndPutCluster(currentClusterScope, SUITE_SEED);
-                RandomizedContext.current().runWithPrivateRandomness(SUITE_SEED, setup);
-                break;
-            case TEST:
-                currentCluster = buildAndPutCluster(currentClusterScope, randomLong());
-                setup.call();
-                break;
-        }
-
-    }
-
-    private void printTestMessage(String message) {
-        if (isSuiteScopedTest(getClass()) && (getTestName().equals("<unknown>"))) {
-            logger.info("[{}]: {} suite", getTestClass().getSimpleName(), message);
-        } else {
-            logger.info("[{}#{}]: {} test", getTestClass().getSimpleName(), getTestName(), message);
-        }
     }
 
     /**
@@ -554,85 +502,6 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
         return builder;
     }
 
-    private TestCluster buildWithPrivateContext(final Scope scope, final long seed) throws Exception {
-        return RandomizedContext.current().runWithPrivateRandomness(seed, () -> buildTestCluster(scope, seed));
-    }
-
-    private TestCluster buildAndPutCluster(Scope currentClusterScope, long seed) throws Exception {
-        final Class<?> clazz = this.getClass();
-        TestCluster testCluster = clusters.remove(clazz); // remove this cluster first
-        clearClusters(); // all leftovers are gone by now... this is really just a double safety if we miss something somewhere
-        switch (currentClusterScope) {
-            case SUITE:
-                if (testCluster == null) { // only build if it's not there yet
-                    testCluster = buildWithPrivateContext(currentClusterScope, seed);
-                }
-                break;
-            case TEST:
-                // close the previous one and create a new one
-                IOUtils.closeWhileHandlingException(testCluster);
-                testCluster = buildTestCluster(currentClusterScope, seed);
-                break;
-        }
-        clusters.put(clazz, testCluster);
-        return testCluster;
-    }
-
-    private static void clearClusters() throws Exception {
-        if (!clusters.isEmpty()) {
-            IOUtils.close(clusters.values());
-            clusters.clear();
-        }
-        if (restClient != null) {
-            restClient.close();
-            restClient = null;
-        }
-        assertBusy(() -> {
-            int numChannels = RestCancellableNodeClient.getNumChannels();
-            assertEquals(
-                numChannels
-                    + " channels still being tracked in "
-                    + RestCancellableNodeClient.class.getSimpleName()
-                    + " while there should be none",
-                0,
-                numChannels
-            );
-        });
-    }
-
-    private void afterInternal(boolean afterClass) throws Exception {
-        final Scope currentClusterScope = getCurrentClusterScope();
-        if (isInternalCluster()) {
-            internalCluster().clearDisruptionScheme();
-        }
-        try {
-            if (cluster() != null) {
-                if (currentClusterScope != Scope.TEST) {
-                    Metadata metadata = client().admin().cluster().prepareState().execute().actionGet().getState().getMetadata();
-
-                    final Set<String> persistentKeys = new HashSet<>(metadata.persistentSettings().keySet());
-                    assertThat("test leaves persistent cluster metadata behind", persistentKeys, empty());
-
-                    final Set<String> transientKeys = new HashSet<>(metadata.transientSettings().keySet());
-                    assertThat("test leaves transient cluster metadata behind", transientKeys, empty());
-                }
-                ensureClusterSizeConsistency();
-                ensureClusterStateConsistency();
-                ensureClusterStateCanBeReadByNodeTool();
-                beforeIndexDeletion();
-                cluster().wipe(excludeTemplates()); // wipe after to make sure we fail in the test that didn't ack the delete
-                if (afterClass || currentClusterScope == Scope.TEST) {
-                    cluster().close();
-                }
-                cluster().assertAfterTest();
-            }
-        } finally {
-            if (currentClusterScope == Scope.TEST) {
-                clearClusters(); // it is ok to leave persistent / transient cluster state behind if scope is TEST
-            }
-        }
-    }
-
     /**
      * @return An exclude set of index templates that will not be removed in between tests.
      */
@@ -645,18 +514,15 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
     }
 
     public static TestCluster cluster() {
-        return currentCluster;
+        return testClusterRule.cluster();
     }
 
     public static boolean isInternalCluster() {
-        return (currentCluster instanceof InternalTestCluster);
+        return testClusterRule.isInternalCluster();
     }
 
     public static InternalTestCluster internalCluster() {
-        if (!isInternalCluster()) {
-            throw new UnsupportedOperationException("current test cluster is immutable");
-        }
-        return (InternalTestCluster) currentCluster;
+        return testClusterRule.internalCluster().orElseThrow(() -> new UnsupportedOperationException("current test cluster is immutable"));
     }
 
     public ClusterService clusterService() {
@@ -668,14 +534,7 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
     }
 
     public static Client client(@Nullable String node) {
-        if (node != null) {
-            return internalCluster().client(node);
-        }
-        Client client = cluster().client();
-        if (frequently()) {
-            client = new RandomizingClient(client, random());
-        }
-        return client;
+        return testClusterRule.clientForNode(node);
     }
 
     public static Client dataNodeClient() {
@@ -1966,7 +1825,7 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
         assertThat(clearResponse.isSucceeded(), equalTo(true));
     }
 
-    private static <A extends Annotation> A getAnnotation(Class<?> clazz, Class<A> annotationClass) {
+    static <A extends Annotation> A getAnnotation(Class<?> clazz, Class<A> annotationClass) {
         if (clazz == Object.class || clazz == OpenSearchIntegTestCase.class) {
             return null;
         }
@@ -1975,16 +1834,6 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
             return annotation;
         }
         return getAnnotation(clazz.getSuperclass(), annotationClass);
-    }
-
-    private Scope getCurrentClusterScope() {
-        return getCurrentClusterScope(this.getClass());
-    }
-
-    private static Scope getCurrentClusterScope(Class<?> clazz) {
-        ClusterScope annotation = getAnnotation(clazz, ClusterScope.class);
-        // if we are not annotated assume suite!
-        return annotation == null ? Scope.SUITE : annotation.scope();
     }
 
     private boolean getSupportsDedicatedClusterManagers() {
@@ -2314,10 +2163,9 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
      * Returns path to a random directory that can be used to create a temporary file system repo
      */
     public Path randomRepoPath() {
-        if (currentCluster instanceof InternalTestCluster) {
-            return randomRepoPath(((InternalTestCluster) currentCluster).getDefaultSettings());
-        }
-        throw new UnsupportedOperationException("unsupported cluster type");
+        return testClusterRule.internalCluster()
+            .map(c -> randomRepoPath(c.getDefaultSettings()))
+            .orElseThrow(() -> new UnsupportedOperationException("unsupported cluster type"));
     }
 
     /**
@@ -2391,83 +2239,9 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
         }
     }
 
-    private static boolean runTestScopeLifecycle() {
-        return INSTANCE == null;
-    }
-
-    @Before
-    public final void setupTestCluster() throws Exception {
-        if (runTestScopeLifecycle()) {
-            printTestMessage("setting up");
-            beforeInternal();
-            printTestMessage("all set up");
-        }
-    }
-
-    @After
-    public final void cleanUpCluster() throws Exception {
-        // Deleting indices is going to clear search contexts implicitly so we
-        // need to check that there are no more in-flight search contexts before
-        // we remove indices
-        if (isInternalCluster()) {
-            internalCluster().setBootstrapClusterManagerNodeIndex(-1);
-        }
-        super.ensureAllSearchContextsReleased();
-        if (runTestScopeLifecycle()) {
-            printTestMessage("cleaning up after");
-            afterInternal(false);
-            printTestMessage("cleaned up after");
-        }
-    }
-
     @AfterClass
     public static void afterClass() throws Exception {
-        try {
-            if (runTestScopeLifecycle()) {
-                clearClusters();
-            } else {
-                INSTANCE.printTestMessage("cleaning up after");
-                INSTANCE.afterInternal(true);
-                checkStaticState(true);
-            }
-            StrictCheckSpanProcessor.validateTracingStateOnShutdown();
-        } finally {
-            SUITE_SEED = null;
-            currentCluster = null;
-            INSTANCE = null;
-        }
-    }
-
-    private static void initializeSuiteScope() throws Exception {
-        Class<?> targetClass = getTestClass();
-        /*
-          Note we create these test class instance via reflection
-          since JUnit creates a new instance per test and that is also
-          the reason why INSTANCE is static since this entire method
-          must be executed in a static context.
-         */
-        assert INSTANCE == null;
-        if (isSuiteScopedTest(targetClass)) {
-            // note we need to do this way to make sure this is reproducible
-            if (isSuiteScopedTestParameterized(targetClass)) {
-                INSTANCE = (OpenSearchIntegTestCase) targetClass.getConstructor(Settings.class).newInstance(Settings.EMPTY);
-            } else {
-                INSTANCE = (OpenSearchIntegTestCase) targetClass.getConstructor().newInstance();
-            }
-            boolean success = false;
-            try {
-                INSTANCE.printTestMessage("setup");
-                INSTANCE.beforeInternal();
-                INSTANCE.setupSuiteScopeCluster();
-                success = true;
-            } finally {
-                if (!success) {
-                    afterClass();
-                }
-            }
-        } else {
-            INSTANCE = null;
-        }
+        testClusterRule.afterClass();
     }
 
     /**
@@ -2499,41 +2273,9 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
      * The returned client gets automatically closed when needed, it shouldn't be closed as part of tests otherwise
      * it cannot be reused by other tests anymore.
      */
-    protected static synchronized RestClient getRestClient() {
-        if (restClient == null) {
-            restClient = createRestClient();
-        }
-        return restClient;
-    }
 
-    protected static RestClient createRestClient() {
-        return createRestClient(null, "http");
-    }
-
-    protected static RestClient createRestClient(RestClientBuilder.HttpClientConfigCallback httpClientConfigCallback, String protocol) {
-        NodesInfoResponse nodesInfoResponse = client().admin().cluster().prepareNodesInfo().get();
-        assertFalse(nodesInfoResponse.hasFailures());
-        return createRestClient(nodesInfoResponse.getNodes(), httpClientConfigCallback, protocol);
-    }
-
-    protected static RestClient createRestClient(
-        final List<NodeInfo> nodes,
-        RestClientBuilder.HttpClientConfigCallback httpClientConfigCallback,
-        String protocol
-    ) {
-        List<HttpHost> hosts = new ArrayList<>();
-        for (NodeInfo node : nodes) {
-            if (node.getInfo(HttpInfo.class) != null) {
-                TransportAddress publishAddress = node.getInfo(HttpInfo.class).address().publishAddress();
-                InetSocketAddress address = publishAddress.address();
-                hosts.add(new HttpHost(NetworkAddress.format(address.getAddress()), address.getPort(), protocol));
-            }
-        }
-        RestClientBuilder builder = RestClient.builder(hosts.toArray(new HttpHost[hosts.size()]));
-        if (httpClientConfigCallback != null) {
-            builder.setHttpClientConfigCallback(httpClientConfigCallback);
-        }
-        return builder.build();
+    protected static RestClient getRestClient() {
+        return testClusterRule.getRestClient();
     }
 
     /**
@@ -2543,20 +2285,6 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
      * @see SuiteScopeTestCase
      */
     protected void setupSuiteScopeCluster() throws Exception {}
-
-    private static boolean isSuiteScopedTest(Class<?> clazz) {
-        return clazz.getAnnotation(SuiteScopeTestCase.class) != null;
-    }
-
-    /*
-    * For tests defined with, SuiteScopeTestCase return true if the
-    * class has a constructor that takes a single Settings parameter
-    * */
-    private static boolean isSuiteScopedTestParameterized(Class<?> clazz) {
-        return Arrays.stream(clazz.getConstructors())
-            .filter(x -> x.getParameterTypes().length == 1)
-            .anyMatch(x -> x.getParameterTypes()[0].equals(Settings.class));
-    }
 
     /**
      * If a test is annotated with {@link SuiteScopeTestCase}

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchTestClusterRule.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchTestClusterRule.java
@@ -1,0 +1,397 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.test;
+
+import com.carrotsearch.randomizedtesting.RandomizedContext;
+
+import org.apache.http.HttpHost;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.admin.cluster.node.info.NodeInfo;
+import org.opensearch.action.admin.cluster.node.info.NodesInfoResponse;
+import org.opensearch.client.Client;
+import org.opensearch.client.RestClient;
+import org.opensearch.client.RestClientBuilder;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.common.Nullable;
+import org.opensearch.common.network.NetworkAddress;
+import org.opensearch.common.util.io.IOUtils;
+import org.opensearch.core.common.transport.TransportAddress;
+import org.opensearch.http.HttpInfo;
+import org.opensearch.rest.action.RestCancellableNodeClient;
+import org.opensearch.test.OpenSearchIntegTestCase.ClusterScope;
+import org.opensearch.test.OpenSearchIntegTestCase.Scope;
+import org.opensearch.test.OpenSearchIntegTestCase.SuiteScopeTestCase;
+import org.opensearch.test.client.RandomizingClient;
+import org.opensearch.test.telemetry.tracing.StrictCheckSpanProcessor;
+import org.junit.rules.MethodRule;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.MultipleFailureException;
+import org.junit.runners.model.Statement;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Callable;
+
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+
+/**
+ * The JUnit {@link MethodRule} that handles test method scoped and test suite scoped clusters for integration (internal cluster) tests. There rule is
+ * injected into {@link OpenSearchIntegTestCase} that every integration test suite should be subclassing. In case of the parameterized test suites,
+ * please subclass {@link ParameterizedStaticSettingsOpenSearchIntegTestCase} or {@link ParameterizedDynamicSettingsOpenSearchIntegTestCase}, depending
+ * on the way cluster settings are being managed.
+ */
+class OpenSearchTestClusterRule implements MethodRule {
+    private final Map<Class<?>, TestCluster> clusters = new IdentityHashMap<>();
+    private final Logger logger = LogManager.getLogger(getClass());
+
+    /**
+     * The current cluster depending on the configured {@link Scope}.
+     * By default if no {@link ClusterScope} is configured this will hold a reference to the suite cluster.
+     */
+    private TestCluster currentCluster = null;
+    private RestClient restClient = null;
+
+    private OpenSearchIntegTestCase suiteInstance = null; // see @SuiteScope
+    private Long suiteSeed = null;
+
+    @Override
+    public Statement apply(Statement base, FrameworkMethod method, Object target) {
+        return statement(base, method, target);
+    }
+
+    void beforeClass() throws Exception {
+        suiteSeed = OpenSearchTestCase.randomLong();
+    }
+
+    void afterClass() throws Exception {
+        try {
+            if (runTestScopeLifecycle()) {
+                clearClusters();
+            } else {
+                printTestMessage("cleaning up after");
+                afterInternal(true, null);
+                OpenSearchTestCase.checkStaticState(true);
+                clusters.remove(getTestClass());
+            }
+            StrictCheckSpanProcessor.validateTracingStateOnShutdown();
+        } finally {
+            suiteSeed = null;
+            currentCluster = null;
+            suiteInstance = null;
+        }
+    }
+
+    TestCluster cluster() {
+        return currentCluster;
+    }
+
+    boolean isInternalCluster() {
+        return (cluster() instanceof InternalTestCluster);
+    }
+
+    Optional<InternalTestCluster> internalCluster() {
+        if (!isInternalCluster()) {
+            return Optional.empty();
+        } else {
+            return Optional.of((InternalTestCluster) cluster());
+        }
+    }
+
+    Client clientForAnyNode() {
+        return clientForNode(null);
+    }
+
+    Client clientForNode(@Nullable String node) {
+        if (node != null) {
+            return internalCluster().orElseThrow(() -> new UnsupportedOperationException("current test cluster is immutable")).client(node);
+        }
+        Client client = cluster().client();
+        if (OpenSearchTestCase.frequently()) {
+            client = new RandomizingClient(client, OpenSearchTestCase.random());
+        }
+        return client;
+    }
+
+    synchronized RestClient getRestClient() {
+        if (restClient == null) {
+            restClient = createRestClient();
+        }
+        return restClient;
+    }
+
+    protected final void beforeInternal(OpenSearchIntegTestCase target) throws Exception {
+        final Scope currentClusterScope = getClusterScope(target.getClass());
+        Callable<Void> setup = () -> {
+            currentCluster.beforeTest(OpenSearchTestCase.random());
+            currentCluster.wipe(target.excludeTemplates());
+            target.randomIndexTemplate();
+            return null;
+        };
+        switch (currentClusterScope) {
+            case SUITE:
+                assert suiteSeed != null : "Suite seed was not initialized";
+                currentCluster = buildAndPutCluster(currentClusterScope, suiteSeed, target);
+                RandomizedContext.current().runWithPrivateRandomness(suiteSeed, setup);
+                break;
+            case TEST:
+                currentCluster = buildAndPutCluster(currentClusterScope, OpenSearchTestCase.randomLong(), target);
+                setup.call();
+                break;
+        }
+    }
+
+    protected void before(Object target, FrameworkMethod method) throws Throwable {
+        final OpenSearchIntegTestCase instance = (OpenSearchIntegTestCase) target;
+        initializeSuiteScope(instance, method);
+
+        if (runTestScopeLifecycle()) {
+            printTestMessage("setting up", method);
+            beforeInternal(instance);
+            printTestMessage("all set up", method);
+        }
+    }
+
+    protected void after(Object target, FrameworkMethod method) throws Exception {
+        final OpenSearchIntegTestCase instance = (OpenSearchIntegTestCase) target;
+
+        // Deleting indices is going to clear search contexts implicitly so we
+        // need to check that there are no more in-flight search contexts before
+        // we remove indices
+        internalCluster().ifPresent(c -> c.setBootstrapClusterManagerNodeIndex(-1));
+
+        instance.ensureAllSearchContextsReleased();
+        if (runTestScopeLifecycle()) {
+            printTestMessage("cleaning up after", method);
+            afterInternal(false, instance);
+            printTestMessage("cleaned up after", method);
+        }
+    }
+
+    protected RestClient createRestClient() {
+        return createRestClient(null, "http");
+    }
+
+    protected RestClient createRestClient(RestClientBuilder.HttpClientConfigCallback httpClientConfigCallback, String protocol) {
+        NodesInfoResponse nodesInfoResponse = clientForAnyNode().admin().cluster().prepareNodesInfo().get();
+        assertFalse(nodesInfoResponse.hasFailures());
+        return createRestClient(nodesInfoResponse.getNodes(), httpClientConfigCallback, protocol);
+    }
+
+    protected RestClient createRestClient(
+        final List<NodeInfo> nodes,
+        RestClientBuilder.HttpClientConfigCallback httpClientConfigCallback,
+        String protocol
+    ) {
+        List<HttpHost> hosts = new ArrayList<>();
+        for (NodeInfo node : nodes) {
+            if (node.getInfo(HttpInfo.class) != null) {
+                TransportAddress publishAddress = node.getInfo(HttpInfo.class).address().publishAddress();
+                InetSocketAddress address = publishAddress.address();
+                hosts.add(new HttpHost(NetworkAddress.format(address.getAddress()), address.getPort(), protocol));
+            }
+        }
+        RestClientBuilder builder = RestClient.builder(hosts.toArray(new HttpHost[0]));
+        if (httpClientConfigCallback != null) {
+            builder.setHttpClientConfigCallback(httpClientConfigCallback);
+        }
+        return builder.build();
+    }
+
+    private Scope getClusterScope(Class<?> clazz) {
+        ClusterScope annotation = OpenSearchIntegTestCase.getAnnotation(clazz, ClusterScope.class);
+        // if we are not annotated assume suite!
+        return annotation == null ? Scope.SUITE : annotation.scope();
+    }
+
+    private TestCluster buildWithPrivateContext(final Scope scope, final long seed, OpenSearchIntegTestCase target) throws Exception {
+        return RandomizedContext.current().runWithPrivateRandomness(seed, () -> target.buildTestCluster(scope, seed));
+    }
+
+    private static boolean isSuiteScopedTest(Class<?> clazz) {
+        return clazz.getAnnotation(SuiteScopeTestCase.class) != null;
+    }
+
+    private boolean hasParametersChanged(final ParameterizedOpenSearchIntegTestCase target) {
+        return !((ParameterizedOpenSearchIntegTestCase) suiteInstance).hasSameParametersAs(target);
+    }
+
+    private boolean runTestScopeLifecycle() {
+        return suiteInstance == null;
+    }
+
+    private TestCluster buildAndPutCluster(Scope currentClusterScope, long seed, OpenSearchIntegTestCase target) throws Exception {
+        final Class<?> clazz = target.getClass();
+
+        synchronized (clusters) {
+            TestCluster testCluster = clusters.remove(clazz); // remove this cluster first
+            clearClusters(); // all leftovers are gone by now... this is really just a double safety if we miss something somewhere
+            switch (currentClusterScope) {
+                case SUITE:
+                    if (testCluster == null) { // only build if it's not there yet
+                        testCluster = buildWithPrivateContext(currentClusterScope, seed, target);
+                    }
+                    break;
+                case TEST:
+                    // close the previous one and create a new one
+                    IOUtils.closeWhileHandlingException(testCluster);
+                    testCluster = target.buildTestCluster(currentClusterScope, seed);
+                    break;
+            }
+            clusters.put(clazz, testCluster);
+            return testCluster;
+        }
+    }
+
+    private void printTestMessage(String message) {
+        logger.info("[{}]: {} suite", getTestClass().getSimpleName(), message);
+    }
+
+    private static Class<?> getTestClass() {
+        return OpenSearchTestCase.getTestClass();
+    }
+
+    private void printTestMessage(String message, FrameworkMethod method) {
+        logger.info("[{}#{}]: {} test", getTestClass().getSimpleName(), method.getName(), message);
+    }
+
+    private void afterInternal(boolean afterClass, OpenSearchIntegTestCase target) throws Exception {
+        final Scope currentClusterScope = getClusterScope(getTestClass());
+        internalCluster().ifPresent(InternalTestCluster::clearDisruptionScheme);
+
+        OpenSearchIntegTestCase instance = suiteInstance;
+        if (instance == null) {
+            instance = target;
+        }
+
+        try {
+            if (cluster() != null) {
+                if (currentClusterScope != Scope.TEST) {
+                    Metadata metadata = clientForAnyNode().admin().cluster().prepareState().execute().actionGet().getState().getMetadata();
+
+                    final Set<String> persistentKeys = new HashSet<>(metadata.persistentSettings().keySet());
+                    assertThat("test leaves persistent cluster metadata behind", persistentKeys, empty());
+
+                    final Set<String> transientKeys = new HashSet<>(metadata.transientSettings().keySet());
+                    assertThat("test leaves transient cluster metadata behind", transientKeys, empty());
+                }
+                instance.ensureClusterSizeConsistency();
+                instance.ensureClusterStateConsistency();
+                instance.ensureClusterStateCanBeReadByNodeTool();
+                instance.beforeIndexDeletion();
+                cluster().wipe(instance.excludeTemplates()); // wipe after to make sure we fail in the test that didn't ack the delete
+                if (afterClass || currentClusterScope == Scope.TEST) {
+                    cluster().close();
+                }
+                cluster().assertAfterTest();
+            }
+        } finally {
+            if (currentClusterScope == Scope.TEST) {
+                clearClusters(); // it is ok to leave persistent / transient cluster state behind if scope is TEST
+            }
+        }
+    }
+
+    private void clearClusters() throws Exception {
+        synchronized (clusters) {
+            if (!clusters.isEmpty()) {
+                IOUtils.close(clusters.values());
+                clusters.clear();
+            }
+        }
+        if (restClient != null) {
+            restClient.close();
+            restClient = null;
+        }
+        OpenSearchTestCase.assertBusy(() -> {
+            int numChannels = RestCancellableNodeClient.getNumChannels();
+            OpenSearchTestCase.assertEquals(
+                numChannels
+                    + " channels still being tracked in "
+                    + RestCancellableNodeClient.class.getSimpleName()
+                    + " while there should be none",
+                0,
+                numChannels
+            );
+        });
+    }
+
+    private Statement statement(final Statement base, FrameworkMethod method, Object target) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                before(target, method);
+
+                List<Throwable> errors = new ArrayList<Throwable>();
+                try {
+                    base.evaluate();
+                } catch (Throwable t) {
+                    errors.add(t);
+                } finally {
+                    try {
+                        after(target, method);
+                    } catch (Throwable t) {
+                        errors.add(t);
+                    }
+                }
+                MultipleFailureException.assertEmpty(errors);
+            }
+        };
+    }
+
+    private void initializeSuiteScope(OpenSearchIntegTestCase target, FrameworkMethod method) throws Exception {
+        final Class<?> targetClass = getTestClass();
+        /*
+          Note we create these test class instance via reflection
+          since JUnit creates a new instance per test.
+         */
+        if (suiteInstance != null) {
+            // Catching the case when parameterized test cases are run: the test class stays the same but the test instances changes.
+            if (target instanceof ParameterizedOpenSearchIntegTestCase) {
+                assert suiteInstance instanceof ParameterizedOpenSearchIntegTestCase;
+                if (hasParametersChanged((ParameterizedOpenSearchIntegTestCase) target)) {
+                    printTestMessage("new instance of parameterized test class, recreating cluster scope", method);
+                    afterClass();
+                    beforeClass();
+                } else {
+                    return; /* same test class instance */
+                }
+            } else {
+                return; /* not a parameterized test */
+            }
+        }
+
+        assert suiteInstance == null;
+        if (isSuiteScopedTest(targetClass)) {
+            suiteInstance = target;
+
+            boolean success = false;
+            try {
+                printTestMessage("setup", method);
+                beforeInternal(target);
+                suiteInstance.setupSuiteScopeCluster();
+                success = true;
+            } finally {
+                if (!success) {
+                    afterClass();
+                }
+            }
+        } else {
+            suiteInstance = null;
+        }
+    }
+}

--- a/test/framework/src/main/java/org/opensearch/test/ParameterizedDynamicSettingsOpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/ParameterizedDynamicSettingsOpenSearchIntegTestCase.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.test;
+
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.settings.SettingsModule;
+import org.junit.After;
+import org.junit.Before;
+
+/**
+ * Base class for running the tests with parameterization using dynamic settings: the cluster will be created once before the test suite and the
+ * settings will be applied dynamically, please notice that not all settings could be changed dynamically (consider using {@link ParameterizedStaticSettingsOpenSearchIntegTestCase}
+ * instead).
+ * <p>
+ * Here is the simple illustration on of the execution flow per parameters combination:
+ * <ul>
+ *   <li><b>suite scope</b>: create cluster -&gt; for each test method { apply settings -&gt; run test method -&gt; unapply settings } -&gt; shutdown cluster</li>
+ *   <li><b>test scope</b>: for each test method { create cluster -&gt;  apply settings -&gt; run test method -&gt; unapply settings -&gt; shutdown cluster }</li>
+ * </ul>
+ */
+public abstract class ParameterizedDynamicSettingsOpenSearchIntegTestCase extends ParameterizedOpenSearchIntegTestCase {
+    public ParameterizedDynamicSettingsOpenSearchIntegTestCase(Settings dynamicSettings) {
+        super(dynamicSettings);
+    }
+
+    @Before
+    public void beforeTests() {
+        SettingsModule settingsModule = new SettingsModule(settings);
+        for (String key : settings.keySet()) {
+            assertTrue(
+                settingsModule.getClusterSettings().isDynamicSetting(key) || settingsModule.getIndexScopedSettings().isDynamicSetting(key)
+            );
+        }
+        client().admin().cluster().prepareUpdateSettings().setPersistentSettings(settings).get();
+    }
+
+    @After
+    public void afterTests() {
+        final Settings.Builder settingsToUnset = Settings.builder();
+        settings.keySet().forEach(settingsToUnset::putNull);
+        client().admin().cluster().prepareUpdateSettings().setPersistentSettings(settingsToUnset).get();
+    }
+
+    @Override
+    boolean hasSameParametersAs(ParameterizedOpenSearchIntegTestCase obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj == null) {
+            return false;
+        }
+
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/test/framework/src/main/java/org/opensearch/test/ParameterizedOpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/ParameterizedOpenSearchIntegTestCase.java
@@ -9,48 +9,43 @@
 package org.opensearch.test;
 
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.settings.SettingsModule;
-import org.junit.After;
-import org.junit.Before;
 
 import static org.opensearch.search.SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING;
 
 /**
- * Base class for running the tests with parameterization of the dynamic settings
- * For any class that wants to use parameterization, use @ParametersFactory to generate
- * different params only for dynamic settings. Refer SearchCancellationIT for an example.
- * Note: this doesn't work for the parameterization of feature flag/static settings.
+ * Base class for running the tests with parameterization of the settings.
+ * For any class that wants to use parameterization, use {@link com.carrotsearch.randomizedtesting.annotations.ParametersFactory} to generate
+ * different parameters.
+ *
+ * There are two flavors of applying the parameterized settings to the cluster on the suite level:
+ *  - static: the cluster will be pre-created with the settings at startup, please subclass {@link ParameterizedStaticSettingsOpenSearchIntegTestCase}, the method
+ *    {@link #hasSameParametersAs(ParameterizedOpenSearchIntegTestCase)} is being used by the test scaffolding to detect when the test suite is instantiated with
+ *    the new parameters and the test cluster has to be recreated
+ *  - dynamic: the cluster will be created once before the test suite and the settings will be applied dynamically , please subclass {@link ParameterizedDynamicSettingsOpenSearchIntegTestCase},
+ *    please notice that not all settings could be changed dynamically
+ *
+ * If the test suites use per-test level, the cluster will be recreated per each test method (applying static or dynamic settings).
  */
-public abstract class ParameterizedOpenSearchIntegTestCase extends OpenSearchIntegTestCase {
+abstract class ParameterizedOpenSearchIntegTestCase extends OpenSearchIntegTestCase {
+    protected final Settings settings;
 
-    private final Settings dynamicSettings;
-
-    public ParameterizedOpenSearchIntegTestCase(Settings dynamicSettings) {
-        this.dynamicSettings = dynamicSettings;
-    }
-
-    @Before
-    public void beforeTests() {
-        SettingsModule settingsModule = new SettingsModule(dynamicSettings);
-        for (String key : dynamicSettings.keySet()) {
-            assertTrue(
-                settingsModule.getClusterSettings().isDynamicSetting(key) || settingsModule.getIndexScopedSettings().isDynamicSetting(key)
-            );
-        }
-        client().admin().cluster().prepareUpdateSettings().setPersistentSettings(dynamicSettings).get();
-    }
-
-    @After
-    public void afterTests() {
-        final Settings.Builder settingsToUnset = Settings.builder();
-        dynamicSettings.keySet().forEach(settingsToUnset::putNull);
-        client().admin().cluster().prepareUpdateSettings().setPersistentSettings(settingsToUnset).get();
+    ParameterizedOpenSearchIntegTestCase(Settings settings) {
+        this.settings = settings;
     }
 
     // This method shouldn't be called in setupSuiteScopeCluster(). Only call this method inside single test.
     public void indexRandomForConcurrentSearch(String... indices) throws InterruptedException {
-        if (dynamicSettings.get(CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING.getKey()).equals("true")) {
+        if (settings.get(CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING.getKey()).equals("true")) {
             indexRandomForMultipleSlices(indices);
         }
     }
+
+    /**
+     * Compares the parameters of the two {@link ParameterizedOpenSearchIntegTestCase} test suite instances.
+     * This method is being use by {@link OpenSearchTestClusterRule} to determine when the parameterized test suite is instantiated with
+     * another set of parameters and the test cluster has to be recreated to reflect that.
+     * @param obj instance of the {@link ParameterizedOpenSearchIntegTestCase} to compare with
+     * @return {@code true} of the parameters of the test suites are the same, {@code false} otherwise
+     */
+    abstract boolean hasSameParametersAs(ParameterizedOpenSearchIntegTestCase obj);
 }

--- a/test/framework/src/main/java/org/opensearch/test/ParameterizedStaticSettingsOpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/ParameterizedStaticSettingsOpenSearchIntegTestCase.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.test;
+
+import org.opensearch.common.settings.Settings;
+
+import java.util.Objects;
+
+/**
+ * Base class for running the tests with parameterization with static settings: the cluster will be pre-created with the settings at startup, the method
+ * {@link #hasSameParametersAs(ParameterizedOpenSearchIntegTestCase)} is being used by the test scaffolding to detect when the test suite is instantiated with
+ * the new parameters and the test cluster has to be recreated.
+ * <p>
+ * Here is the simple illustration on of the execution flow per parameters combination:
+ * <ul>
+ *   <li><b>suite scope</b>: create cluster -&gt; for each test method { run test method } -&gt; shutdown cluster</li>
+ *   <li><b>test scope</b>: for each test method { create cluster -&gt; run test method -&gt; shutdown cluster }</li>
+ * </ul>
+ */
+public abstract class ParameterizedStaticSettingsOpenSearchIntegTestCase extends ParameterizedOpenSearchIntegTestCase {
+    public ParameterizedStaticSettingsOpenSearchIntegTestCase(Settings nodeSettings) {
+        super(nodeSettings);
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder().put(super.nodeSettings(nodeOrdinal)).put(settings).build();
+    }
+
+    @Override
+    boolean hasSameParametersAs(ParameterizedOpenSearchIntegTestCase obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj == null) {
+            return false;
+        }
+
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+
+        final ParameterizedStaticSettingsOpenSearchIntegTestCase other = (ParameterizedStaticSettingsOpenSearchIntegTestCase) obj;
+        return Objects.equals(settings, other.settings);
+    }
+}


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/11877 to `2.x`