### PR TITLE
Exposing a cache type setting and integrating it with IndicesRequestC…

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/IndicesRequestCacheIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/IndicesRequestCacheIT.java
@@ -40,6 +40,7 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchType;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.cache.CacheType;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.time.DateFormatter;
 import org.opensearch.common.util.FeatureFlags;
@@ -163,6 +164,8 @@ public class IndicesRequestCacheIT extends ParameterizedOpenSearchIntegTestCase 
                     Settings.builder()
                         .put(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true)
                         .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 5)
+                        .put(FeatureFlags.INDICES_REQUEST_CACHE_TYPE.getKey(), CacheType.ON_HEAP) // Set Cache type
+                        // to onHeap
                         .put("index.number_of_routing_shards", 5)
                         .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
                 )
@@ -446,6 +449,8 @@ public class IndicesRequestCacheIT extends ParameterizedOpenSearchIntegTestCase 
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 2)
             .put("index.number_of_routing_shards", 2)
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(FeatureFlags.INDICES_REQUEST_CACHE_TYPE.getKey(), "invalid") // Pass invalid cacheType. Should
+            // default to onHeap.
             .build();
         assertAcked(client.admin().indices().prepareCreate("index").setMapping("s", "type=date").setSettings(settings).get());
         indexRandom(

--- a/server/src/main/java/org/opensearch/common/cache/CacheBuilder.java
+++ b/server/src/main/java/org/opensearch/common/cache/CacheBuilder.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.common.cache;
 
+import org.opensearch.common.cache.cleaner.ICacheCleaner;
 import org.opensearch.common.unit.TimeValue;
 
 import java.util.Objects;
@@ -48,6 +49,8 @@ public class CacheBuilder<K, V> {
     private long expireAfterWriteNanos = -1;
     private ToLongBiFunction<K, V> weigher;
     private RemovalListener<K, V> removalListener;
+
+    private ICacheCleaner<K, V> cacheCleaner;
 
     public static <K, V> CacheBuilder<K, V> builder() {
         return new CacheBuilder<>();
@@ -93,6 +96,15 @@ public class CacheBuilder<K, V> {
         }
         this.expireAfterWriteNanos = expireAfterWriteNanos;
         return this;
+    }
+
+    public CacheBuilder<K, V> setCacheCleaner(ICacheCleaner<K, V> cacheCleaner) {
+        this.cacheCleaner = cacheCleaner;
+        return this;
+    }
+
+    public ICacheCleaner<K, V> getCacheCleaner(ICacheCleaner<K, V> cacheCleaner) {
+        return this.cacheCleaner;
     }
 
     public CacheBuilder<K, V> weigher(ToLongBiFunction<K, V> weigher) {

--- a/server/src/main/java/org/opensearch/common/cache/CacheType.java
+++ b/server/src/main/java/org/opensearch/common/cache/CacheType.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.cache;
+
+/**
+ * Cache types available to be integrated.
+ */
+public enum CacheType {
+
+    ON_HEAP("on_heap");
+    // TODO: Uncomment once Tiered caching is complete.
+    // TIERED("tiered");
+
+    private final String cacheType;
+
+    CacheType(String cacheType) {
+        this.cacheType = cacheType;
+    }
+
+    public String getCacheType() {
+        return cacheType;
+    }
+}

--- a/server/src/main/java/org/opensearch/common/cache/ICache.java
+++ b/server/src/main/java/org/opensearch/common/cache/ICache.java
@@ -8,6 +8,10 @@
 
 package org.opensearch.common.cache;
 
+import org.opensearch.common.cache.stats.CacheStats;
+
+import java.io.Closeable;
+
 /**
  * Represents a cache interface.
  * @param <K> Type of key.
@@ -15,7 +19,7 @@ package org.opensearch.common.cache;
  *
  * @opensearch.experimental
  */
-public interface ICache<K, V> {
+public interface ICache<K, V> extends Closeable {
     V get(K key);
 
     void put(K key, V value);
@@ -31,4 +35,6 @@ public interface ICache<K, V> {
     long count();
 
     void refresh();
+
+    CacheStats stats();
 }

--- a/server/src/main/java/org/opensearch/common/cache/cleaner/CacheCleaner.java
+++ b/server/src/main/java/org/opensearch/common/cache/cleaner/CacheCleaner.java
@@ -1,0 +1,103 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.cache.cleaner;
+
+import org.opensearch.common.cache.store.StoreAwareCache;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.util.Iterator;
+import java.util.function.Predicate;
+
+public class CacheCleaner<K, V> implements ICacheCleaner<K, V> {
+    ThreadPool threadPool;
+    TimeValue cleanInterval;
+    Predicate<K> keyCleanupCondition;
+    StoreAwareCache<K, V> cache;
+    Double threshold;
+    long staleCount; // TODO is this the right place ?
+
+    public CacheCleaner(
+        ThreadPool threadPool,
+        TimeValue cleanInterval,
+        Predicate<K> keyCleanupCondition,
+        StoreAwareCache<K, V> cache,
+        Double threshold
+    ) {
+        this.threadPool = threadPool;
+        this.cleanInterval = cleanInterval;
+        this.keyCleanupCondition = keyCleanupCondition;
+        this.cache = cache;
+        this.threshold = threshold; // TODO gather from settings and send it here
+        this.staleCount = 0;
+        threadPool.schedule(this::clean, this.cleanInterval, ThreadPool.Names.SAME);
+    }
+
+    @Override
+    public void clean() {
+        if(!crossesThreshold()) {
+            return;
+        }
+        for (Iterator<K> iterator = cache.keys().iterator(); iterator.hasNext(); ) {
+            K key = iterator.next();
+            if (keyCleanupCondition.test(key)) {
+                iterator.remove();
+            }
+        }
+    }
+
+    private boolean crossesThreshold() {
+        double staleThreshold = (double) staleCount / cache.stats().count();
+        return staleThreshold > this.threshold;
+    }
+
+    private void incrementStaleCount(long count) {
+        this.staleCount += count;
+    }
+
+    public static class Builder<K, V> {
+        private ThreadPool threadPool;
+        private TimeValue cleanInterval;
+        private Predicate<K> keyCleanupCondition;
+        private StoreAwareCache<K, V> cache;
+        private Double threshold;
+
+        public Builder<K, V> setThreadPool(ThreadPool threadPool) {
+            this.threadPool = threadPool;
+            return this;
+        }
+
+        public Builder<K, V> setCleanInterval(TimeValue cleanInterval) {
+            this.cleanInterval = cleanInterval;
+            return this;
+        }
+
+        public Builder<K, V> setKeyCleanupCondition(Predicate<K> keyCleanupCondition) {
+            this.keyCleanupCondition = keyCleanupCondition;
+            return this;
+        }
+
+        public Builder<K, V> setCache(StoreAwareCache<K, V> cache) {
+            this.cache = cache;
+            return this;
+        }
+
+        public Builder<K, V> setThreshold(Double threshold) {
+            this.threshold = threshold;
+            return this;
+        }
+
+        public CacheCleaner<K, V> build() {
+            if (threadPool == null || cleanInterval == null || keyCleanupCondition == null || cache == null || threshold == null) {
+                throw new IllegalStateException("All fields must be set");
+            }
+            return new CacheCleaner<>(threadPool, cleanInterval, keyCleanupCondition, cache, threshold);
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/common/cache/cleaner/ICacheCleaner.java
+++ b/server/src/main/java/org/opensearch/common/cache/cleaner/ICacheCleaner.java
@@ -1,0 +1,13 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.cache.cleaner;
+
+public interface ICacheCleaner<K, V> {
+    void clean();
+}

--- a/server/src/main/java/org/opensearch/common/cache/cleaner/package-info.java
+++ b/server/src/main/java/org/opensearch/common/cache/cleaner/package-info.java
@@ -1,0 +1,9 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.cache.cleaner;

--- a/server/src/main/java/org/opensearch/common/cache/stats/CacheStats.java
+++ b/server/src/main/java/org/opensearch/common/cache/stats/CacheStats.java
@@ -1,0 +1,18 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.cache.stats;
+
+/**
+ * Interface for any cache specific stats.
+ * TODO: Add rest of stats like hits/misses.
+ */
+public interface CacheStats {
+  // Provides the current number of entries in cache.
+  long count();
+}

--- a/server/src/main/java/org/opensearch/common/cache/stats/package-info.java
+++ b/server/src/main/java/org/opensearch/common/cache/stats/package-info.java
@@ -1,0 +1,9 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.cache.stats;

--- a/server/src/main/java/org/opensearch/common/cache/store/OpenSearchOnHeapCache.java
+++ b/server/src/main/java/org/opensearch/common/cache/store/OpenSearchOnHeapCache.java
@@ -13,6 +13,7 @@ import org.opensearch.common.cache.CacheBuilder;
 import org.opensearch.common.cache.LoadAwareCacheLoader;
 import org.opensearch.common.cache.RemovalListener;
 import org.opensearch.common.cache.RemovalNotification;
+import org.opensearch.common.cache.cleaner.ICacheCleaner;
 import org.opensearch.common.cache.store.builders.StoreAwareCacheBuilder;
 import org.opensearch.common.cache.store.enums.CacheStoreType;
 import org.opensearch.common.cache.store.listeners.StoreAwareCacheEventListener;
@@ -27,8 +28,9 @@ import org.opensearch.common.cache.store.listeners.StoreAwareCacheEventListener;
 public class OpenSearchOnHeapCache<K, V> implements StoreAwareCache<K, V>, RemovalListener<K, V> {
 
     private final Cache<K, V> cache;
-
     private final StoreAwareCacheEventListener<K, V> eventListener;
+
+    private ICacheCleaner<K, V> cacheCleaner;
 
     public OpenSearchOnHeapCache(Builder<K, V> builder) {
         CacheBuilder<K, V> cacheBuilder = CacheBuilder.<K, V>builder()
@@ -38,8 +40,23 @@ public class OpenSearchOnHeapCache<K, V> implements StoreAwareCache<K, V>, Remov
         if (builder.getExpireAfterAccess() != null) {
             cacheBuilder.setExpireAfterAccess(builder.getExpireAfterAccess());
         }
+
         cache = cacheBuilder.build();
+
+        if (builder.getCacheCleanerBuilder() != null) {
+            this.cacheCleaner = builder.getCacheCleanerBuilder()
+                .setCache(this)
+                .build();
+        }
+
         this.eventListener = builder.getEventListener();
+    }
+
+    // TODO - figure this out ^^ this does not look clean
+    public void clean() {
+        if (this.cacheCleaner != null) {
+            this.cacheCleaner.clean();
+        }
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/common/cache/store/OpenSearchOnHeapCache.java
+++ b/server/src/main/java/org/opensearch/common/cache/store/OpenSearchOnHeapCache.java
@@ -35,8 +35,8 @@ public class OpenSearchOnHeapCache<K, V> implements StoreAwareCache<K, V>, Remov
             .setMaximumWeight(builder.getMaxWeightInBytes())
             .weigher(builder.getWeigher())
             .removalListener(this);
-        if (builder.getExpireAfterAcess() != null) {
-            cacheBuilder.setExpireAfterAccess(builder.getExpireAfterAcess());
+        if (builder.getExpireAfterAccess() != null) {
+            cacheBuilder.setExpireAfterAccess(builder.getExpireAfterAccess());
         }
         cache = cacheBuilder.build();
         this.eventListener = builder.getEventListener();
@@ -115,6 +115,7 @@ public class OpenSearchOnHeapCache<K, V> implements StoreAwareCache<K, V>, Remov
 
     /**
      * Builder object
+     *
      * @param <K> Type of key
      * @param <V> Type of value
      */

--- a/server/src/main/java/org/opensearch/common/cache/store/OpenSearchOnHeapCache.java
+++ b/server/src/main/java/org/opensearch/common/cache/store/OpenSearchOnHeapCache.java
@@ -14,6 +14,7 @@ import org.opensearch.common.cache.LoadAwareCacheLoader;
 import org.opensearch.common.cache.RemovalListener;
 import org.opensearch.common.cache.RemovalNotification;
 import org.opensearch.common.cache.cleaner.ICacheCleaner;
+import org.opensearch.common.cache.stats.CacheStats;
 import org.opensearch.common.cache.store.builders.StoreAwareCacheBuilder;
 import org.opensearch.common.cache.store.enums.CacheStoreType;
 import org.opensearch.common.cache.store.listeners.StoreAwareCacheEventListener;
@@ -30,6 +31,7 @@ public class OpenSearchOnHeapCache<K, V> implements StoreAwareCache<K, V>, Remov
     private final Cache<K, V> cache;
     private final StoreAwareCacheEventListener<K, V> eventListener;
 
+    private final CacheStats stats = new OpenSearchOnHeapCacheStats();
     private ICacheCleaner<K, V> cacheCleaner;
 
     public OpenSearchOnHeapCache(Builder<K, V> builder) {
@@ -105,7 +107,15 @@ public class OpenSearchOnHeapCache<K, V> implements StoreAwareCache<K, V>, Remov
 
     @Override
     public long count() {
-        return cache.count();
+        return stats.count();
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public CacheStats stats() {
+        return stats;
     }
 
     @Override
@@ -128,6 +138,16 @@ public class OpenSearchOnHeapCache<K, V> implements StoreAwareCache<K, V>, Remov
                 CacheStoreType.ON_HEAP
             )
         );
+    }
+
+    /**
+     * Stats for Opensearch on heap cache.
+     */
+    class OpenSearchOnHeapCacheStats implements CacheStats {
+        @Override
+        public long count() {
+            return cache.count();
+        }
     }
 
     /**

--- a/server/src/main/java/org/opensearch/common/cache/store/builders/StoreAwareCacheBuilder.java
+++ b/server/src/main/java/org/opensearch/common/cache/store/builders/StoreAwareCacheBuilder.java
@@ -27,7 +27,7 @@ public abstract class StoreAwareCacheBuilder<K, V> {
 
     private ToLongBiFunction<K, V> weigher;
 
-    private TimeValue expireAfterAcess;
+    private TimeValue expireAfterAccess;
 
     private StoreAwareCacheEventListener<K, V> eventListener;
 
@@ -43,8 +43,8 @@ public abstract class StoreAwareCacheBuilder<K, V> {
         return this;
     }
 
-    public StoreAwareCacheBuilder<K, V> setExpireAfterAccess(TimeValue expireAfterAcess) {
-        this.expireAfterAcess = expireAfterAcess;
+    public StoreAwareCacheBuilder<K, V> setExpireAfterAccess(TimeValue expireAfterAccess) {
+        this.expireAfterAccess = expireAfterAccess;
         return this;
     }
 
@@ -57,8 +57,8 @@ public abstract class StoreAwareCacheBuilder<K, V> {
         return maxWeightInBytes;
     }
 
-    public TimeValue getExpireAfterAcess() {
-        return expireAfterAcess;
+    public TimeValue getExpireAfterAccess() {
+        return expireAfterAccess;
     }
 
     public ToLongBiFunction<K, V> getWeigher() {

--- a/server/src/main/java/org/opensearch/common/cache/store/builders/StoreAwareCacheBuilder.java
+++ b/server/src/main/java/org/opensearch/common/cache/store/builders/StoreAwareCacheBuilder.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.common.cache.store.builders;
 
+import org.opensearch.common.cache.cleaner.CacheCleaner;
 import org.opensearch.common.cache.store.StoreAwareCache;
 import org.opensearch.common.cache.store.listeners.StoreAwareCacheEventListener;
 import org.opensearch.common.unit.TimeValue;
@@ -30,6 +31,7 @@ public abstract class StoreAwareCacheBuilder<K, V> {
     private TimeValue expireAfterAccess;
 
     private StoreAwareCacheEventListener<K, V> eventListener;
+    private CacheCleaner.Builder<K, V> cacheCleanerBuilder;
 
     public StoreAwareCacheBuilder() {}
 
@@ -53,6 +55,11 @@ public abstract class StoreAwareCacheBuilder<K, V> {
         return this;
     }
 
+    public StoreAwareCacheBuilder<K, V> setCacheCleanerBuilder(CacheCleaner.Builder<K, V> cacheCleaner) {
+        this.cacheCleanerBuilder = cacheCleaner;
+        return this;
+    }
+
     public long getMaxWeightInBytes() {
         return maxWeightInBytes;
     }
@@ -67,6 +74,10 @@ public abstract class StoreAwareCacheBuilder<K, V> {
 
     public StoreAwareCacheEventListener<K, V> getEventListener() {
         return eventListener;
+    }
+
+    public CacheCleaner.Builder<K, V> getCacheCleanerBuilder() {
+        return cacheCleanerBuilder;
     }
 
     public abstract StoreAwareCache<K, V> build();

--- a/server/src/main/java/org/opensearch/common/cache/tier/TieredSpilloverCache.java
+++ b/server/src/main/java/org/opensearch/common/cache/tier/TieredSpilloverCache.java
@@ -11,6 +11,7 @@ package org.opensearch.common.cache.tier;
 import org.opensearch.common.cache.ICache;
 import org.opensearch.common.cache.LoadAwareCacheLoader;
 import org.opensearch.common.cache.RemovalReason;
+import org.opensearch.common.cache.stats.CacheStats;
 import org.opensearch.common.cache.store.StoreAwareCache;
 import org.opensearch.common.cache.store.StoreAwareCacheRemovalNotification;
 import org.opensearch.common.cache.store.StoreAwareCacheValue;
@@ -20,6 +21,7 @@ import org.opensearch.common.cache.store.listeners.StoreAwareCacheEventListener;
 import org.opensearch.common.util.concurrent.ReleasableLock;
 import org.opensearch.common.util.iterable.Iterables;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -179,6 +181,11 @@ public class TieredSpilloverCache<K, V> implements ICache<K, V>, StoreAwareCache
     }
 
     @Override
+    public CacheStats stats() {
+        return null;
+    }
+
+    @Override
     public void onMiss(K key, CacheStoreType cacheStoreType) {
         // Misses for tiered cache are tracked here itself.
     }
@@ -232,6 +239,11 @@ public class TieredSpilloverCache<K, V> implements ICache<K, V>, StoreAwareCache
             }
             return null;
         };
+    }
+
+    @Override
+    public void close() throws IOException {
+
     }
 
     /**

--- a/server/src/main/java/org/opensearch/common/cache/tier/TieredSpilloverCache.java
+++ b/server/src/main/java/org/opensearch/common/cache/tier/TieredSpilloverCache.java
@@ -97,7 +97,7 @@ public class TieredSpilloverCache<K, V> implements ICache<K, V>, StoreAwareCache
     public V computeIfAbsent(K key, LoadAwareCacheLoader<K, V> loader) throws Exception {
         // We are skipping calling event listeners at this step as we do another get inside below computeIfAbsent.
         // Where we might end up calling onMiss twice for a key not present in onHeap cache.
-        // Similary we might end up calling both onMiss and onHit for a key, in case we are receiving concurrent
+        // Similarly, we might end up calling both onMiss and onHit for a key, in case we are receiving concurrent
         // requests for the same key which requires loading only once.
         StoreAwareCacheValue<V> cacheValue = getValueFromTieredCache(false).apply(key);
         if (cacheValue == null) {

--- a/server/src/main/java/org/opensearch/common/settings/FeatureFlagSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/FeatureFlagSettings.java
@@ -35,6 +35,7 @@ public class FeatureFlagSettings extends AbstractScopedSettings {
         FeatureFlags.CONCURRENT_SEGMENT_SEARCH_SETTING,
         FeatureFlags.TELEMETRY_SETTING,
         FeatureFlags.DATETIME_FORMATTER_CACHING_SETTING,
-        FeatureFlags.WRITEABLE_REMOTE_INDEX_SETTING
+        FeatureFlags.WRITEABLE_REMOTE_INDEX_SETTING,
+        FeatureFlags.INDICES_REQUEST_CACHE_TYPE
     );
 }

--- a/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
+++ b/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.common.util;
 
+import org.opensearch.common.cache.CacheType;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.common.settings.Settings;
@@ -120,6 +121,12 @@ public class FeatureFlags {
     public static final Setting<Boolean> WRITEABLE_REMOTE_INDEX_SETTING = Setting.boolSetting(
         WRITEABLE_REMOTE_INDEX,
         false,
+        Property.NodeScope
+    );
+
+    public static final Setting<String> INDICES_REQUEST_CACHE_TYPE = Setting.simpleString(
+        "indices.requests.cache.type",
+        CacheType.ON_HEAP.getCacheType(),
         Property.NodeScope
     );
 }

--- a/server/src/main/java/org/opensearch/indices/AbstractIndexShardCacheEntity.java
+++ b/server/src/main/java/org/opensearch/indices/AbstractIndexShardCacheEntity.java
@@ -32,8 +32,9 @@
 
 package org.opensearch.indices;
 
-import org.opensearch.common.cache.RemovalNotification;
 import org.opensearch.common.cache.RemovalReason;
+import org.opensearch.common.cache.store.StoreAwareCacheRemovalNotification;
+import org.opensearch.common.cache.store.enums.CacheStoreType;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.index.cache.request.ShardRequestCache;
 import org.opensearch.index.shard.IndexShard;
@@ -51,22 +52,27 @@ abstract class AbstractIndexShardCacheEntity implements IndicesRequestCache.Cach
     protected abstract ShardRequestCache stats();
 
     @Override
-    public final void onCached(IndicesRequestCache.Key key, BytesReference value) {
+    public final void onCached(IndicesRequestCache.Key key, BytesReference value, CacheStoreType cacheStoreType) {
+        // TODO: Remove this once tiered cache is integrated. Same for below.
+        assert cacheStoreType.equals(CacheStoreType.ON_HEAP);
         stats().onCached(key, value);
     }
 
     @Override
-    public final void onHit() {
+    public final void onHit(CacheStoreType cacheStoreType) {
+        assert cacheStoreType.equals(CacheStoreType.ON_HEAP);
         stats().onHit();
     }
 
     @Override
-    public final void onMiss() {
+    public final void onMiss(CacheStoreType cacheStoreType) {
+        assert cacheStoreType.equals(CacheStoreType.ON_HEAP);
         stats().onMiss();
     }
 
     @Override
-    public final void onRemoval(RemovalNotification<IndicesRequestCache.Key, BytesReference> notification) {
+    public final void onRemoval(StoreAwareCacheRemovalNotification<IndicesRequestCache.Key, BytesReference> notification) {
+        assert notification.getCacheStoreType().equals(CacheStoreType.ON_HEAP);
         stats().onRemoval(notification.getKey(), notification.getValue(), notification.getRemovalReason() == RemovalReason.EVICTED);
     }
 }

--- a/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
@@ -42,6 +42,7 @@ import org.opensearch.common.CheckedSupplier;
 import org.opensearch.common.cache.CacheType;
 import org.opensearch.common.cache.ICache;
 import org.opensearch.common.cache.LoadAwareCacheLoader;
+import org.opensearch.common.cache.cleaner.CacheCleaner;
 import org.opensearch.common.cache.store.OpenSearchOnHeapCache;
 import org.opensearch.common.cache.store.StoreAwareCacheRemovalNotification;
 import org.opensearch.common.cache.store.builders.StoreAwareCacheBuilder;
@@ -61,6 +62,7 @@ import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.shard.IndexShard;
+import org.opensearch.threadpool.ThreadPool;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -73,6 +75,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * The indices request cache allows to cache a shard level request stage responses, helping with improving
@@ -123,7 +126,6 @@ public final class IndicesRequestCache implements StoreAwareCacheEventListener<I
     private final Function<ShardId, Optional<CacheEntity>> cacheEntityLookup;
     private final ICache<Key, BytesReference> cache;
 
-    IndicesRequestCache(Settings settings, Function<ShardId, Optional<CacheEntity>> cacheEntityFunction) {
     private final ThreadPool threadpool;
 
     IndicesRequestCache(

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -409,7 +409,10 @@ public class IndicesService extends AbstractLifecycleComponent
         this.shardsClosedTimeout = settings.getAsTime(INDICES_SHARDS_CLOSED_TIMEOUT, new TimeValue(1, TimeUnit.DAYS));
         this.analysisRegistry = analysisRegistry;
         this.indexNameExpressionResolver = indexNameExpressionResolver;
-        this.indicesRequestCache = new IndicesRequestCache(settings, (shardId -> {
+        this.indicesRequestCache = new IndicesRequestCache(
+            settings,
+            threadPool,
+            (shardId -> {
             IndexService indexService = this.indices.get(shardId.getIndex().getUUID());
             if (indexService == null) {
                 return Optional.empty();


### PR DESCRIPTION

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Exposes a cache type setting for IndicesRequestCache which can be set by user. For now, integrating only onHeap. When tiered cache are changes are done, it will added later.
This setting is being as added like a feature flag as it is meant to be experimental in initial phase.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/11947

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
