### PR TITLE
[Bugfix] Pass TwoPhaseIterator from subQueryScorer

### DIFF
--- a/server/src/main/java/org/opensearch/common/lucene/search/function/ScriptScoreQuery.java
+++ b/server/src/main/java/org/opensearch/common/lucene/search/function/ScriptScoreQuery.java
@@ -45,6 +45,7 @@ import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.Scorable;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.Bits;
 import org.opensearch.Version;
@@ -300,6 +301,11 @@ public class ScriptScoreQuery extends Query {
         @Override
         public DocIdSetIterator iterator() {
             return subQueryScorer.iterator();
+        }
+
+        @Override
+        public TwoPhaseIterator twoPhaseIterator() {
+            return subQueryScorer.twoPhaseIterator();
         }
 
         @Override

--- a/server/src/test/java/org/opensearch/search/query/ScriptScoreQueryTests.java
+++ b/server/src/test/java/org/opensearch/search/query/ScriptScoreQueryTests.java
@@ -39,9 +39,14 @@ import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.store.Directory;
 import org.opensearch.Version;
@@ -49,6 +54,7 @@ import org.opensearch.common.lucene.search.Queries;
 import org.opensearch.common.lucene.search.function.ScriptScoreQuery;
 import org.opensearch.script.ScoreScript;
 import org.opensearch.script.Script;
+import org.opensearch.script.ScriptType;
 import org.opensearch.search.lookup.LeafSearchLookup;
 import org.opensearch.search.lookup.SearchLookup;
 import org.opensearch.test.OpenSearchTestCase;
@@ -56,6 +62,8 @@ import org.junit.After;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Function;
 
 import static org.hamcrest.CoreMatchers.containsString;
@@ -177,6 +185,37 @@ public class ScriptScoreQueryTests extends OpenSearchTestCase {
         assertTrue(e.getMessage().contains("Must be a non-negative score!"));
     }
 
+    public void testTwoPhaseIteratorDelegation() throws IOException {
+        Map<String, Object> params = new HashMap<>();
+        String scriptSource = "doc['field'].value != null ? 2.0 : 0.0"; // Adjust based on actual field and logic
+        Script script = new Script(ScriptType.INLINE, "painless", scriptSource, params);
+        float minScore = 1.0f; // This should be below the score produced by the script for all docs
+        ScoreScript.LeafFactory factory = newFactory(script, false, explanation -> 2.0);
+
+        Query subQuery = new MatchAllDocsQuery();
+        ScriptScoreQuery scriptScoreQuery = new ScriptScoreQuery(subQuery, script, factory, minScore, "index", 0, Version.CURRENT);
+
+        Weight weight = searcher.createWeight(searcher.rewrite(scriptScoreQuery), ScoreMode.COMPLETE, 1f);
+
+        boolean foundMatchingDoc = false;
+        for (LeafReaderContext leafContext : searcher.getIndexReader().leaves()) {
+            Scorer scorer = weight.scorer(leafContext);
+            if (scorer != null) {
+                TwoPhaseIterator twoPhaseIterator = scorer.twoPhaseIterator();
+                assertNotNull("TwoPhaseIterator should not be null", twoPhaseIterator);
+                DocIdSetIterator docIdSetIterator = twoPhaseIterator.approximation();
+                int docId;
+                while ((docId = docIdSetIterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+                    if (twoPhaseIterator.matches()) {
+                        foundMatchingDoc = true;
+                        break;
+                    }
+                }
+            }
+        }
+        assertTrue("Expected to find at least one matching document", foundMatchingDoc);
+    }
+
     private ScoreScript.LeafFactory newFactory(
         Script script,
         boolean needsScore,
@@ -203,5 +242,4 @@ public class ScriptScoreQueryTests extends OpenSearchTestCase {
             }
         };
     }
-
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

This is a bug when `_score` is included in script, and the `TwoPhaseIterator` of a `MinScoreScorer` doesn't check the `ScriptScorer` for a `match` before asking it for a score for the current doc:
https://github.com/opensearch-project/OpenSearch/blob/a9ce180b57dc20408e5a36337dbdc85d6e1fd306/server/src/main/java/org/opensearch/common/lucene/search/function/MinScoreScorer.java#L98-L103

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

https://github.com/opensearch-project/OpenSearch/issues/8155

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [ ] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
