### PR TITLE
Fix memory leak issue in ReorganizingLongHash (#11953)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix tracing context propagation for local transport instrumentation ([#11490](https://github.com/opensearch-project/OpenSearch/pull/11490))
 - Fix parsing of single line comments in `lang-painless` ([#11815](https://github.com/opensearch-project/OpenSearch/issues/11815))
 - Fix typo in API annotation check message ([11836](https://github.com/opensearch-project/OpenSearch/pull/11836))
+- Fix memory leak issue in ReorganizingLongHash ([#11953](https://github.com/opensearch-project/OpenSearch/issues/11953))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/common/util/ReorganizingLongHash.java
+++ b/server/src/main/java/org/opensearch/common/util/ReorganizingLongHash.java
@@ -118,10 +118,17 @@ public class ReorganizingLongHash implements Releasable {
         mask = capacity - 1;
         grow = (long) (capacity * loadFactor);
         size = 0;
-
-        table = bigArrays.newLongArray(capacity, false);
-        table.fill(0, capacity, -1);  // -1 represents an empty slot
-        keys = bigArrays.newLongArray(initialCapacity, false);
+        try {
+            table = bigArrays.newLongArray(capacity, false);
+            table.fill(0, capacity, -1);  // -1 represents an empty slot
+            keys = bigArrays.newLongArray(initialCapacity, false);
+        } finally {
+            if (table == null || keys == null) {
+                // it's important to close the arrays initialized above to prevent memory leak
+                // refer: https://github.com/opensearch-project/OpenSearch/issues/10154
+                Releasables.closeWhileHandlingException(table, keys);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Neetika Singhal <neetiks@amazon.com>
(cherry picked from commit 84f303b6069893cf9350556a4c316153ba526901)

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Backports https://github.com/opensearch-project/OpenSearch/pull/11953


### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
