### PR TITLE
Abstracting Writeable to support multiple protocols

### DIFF
--- a/libs/core/src/main/java/org/opensearch/core/common/io/stream/BaseWriteable.java
+++ b/libs/core/src/main/java/org/opensearch/core/common/io/stream/BaseWriteable.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.core.common.io.stream;
+
+import org.opensearch.common.annotation.InternalApi;
+
+import java.io.IOException;
+
+/**
+ * Implementers can be written to a an output stream and read from an input stream. The type of input and output stream depends on the
+ * serialization/deserialization protocol.
+ *
+ * @opensearch.api
+ */
+public interface BaseWriteable<T, S> {
+
+    /**
+     * Write this into the specified output stream.
+     */
+    void writeTo(T out) throws IOException;
+
+    /**
+     * Reference to a method that can read some object from a specified input stream.
+     * @opensearch.api
+     */
+    @FunctionalInterface
+    @InternalApi
+    interface Reader<S, V> {
+
+        /**
+         * Read {@code V}-type value from a stream.
+         *
+         * @param in Input to read the value from
+         */
+        V read(final S in) throws IOException;
+    }
+}

--- a/libs/core/src/main/java/org/opensearch/core/common/io/stream/Writeable.java
+++ b/libs/core/src/main/java/org/opensearch/core/common/io/stream/Writeable.java
@@ -46,7 +46,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @opensearch.api
  */
 @PublicApi(since = "2.8.0")
-public interface Writeable {
+public interface Writeable extends BaseWriteable<StreamOutput, StreamInput> {
     /**
      * A WriteableRegistry registers {@link Writer} methods for writing data types over a
      * {@link StreamOutput} channel and {@link Reader} methods for reading data from a

--- a/server/src/main/java/org/opensearch/transport/OutboundMessage.java
+++ b/server/src/main/java/org/opensearch/transport/OutboundMessage.java
@@ -37,6 +37,7 @@ import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.common.bytes.CompositeBytesReference;
+import org.opensearch.core.common.io.stream.BaseWriteable;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
 
@@ -50,7 +51,7 @@ import java.util.Set;
  */
 abstract class OutboundMessage extends NetworkMessage {
 
-    private final Writeable message;
+    private final BaseWriteable message;
 
     OutboundMessage(ThreadContext threadContext, Version version, byte status, long requestId, Writeable message) {
         super(threadContext, version, status, requestId);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Coming from https://github.com/opensearch-project/OpenSearch/pull/11910#issuecomment-1899148313, abstracting out `Writeable` so that other serialization/deserialization protocols can be added extending `BaseWriteable`. 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
Part of #10684 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
