### PR TITLE
Disable index refresh for TermsFixedDocCountErrorIT

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/TermsFixedDocCountErrorIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/TermsFixedDocCountErrorIT.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.opensearch.index.IndexSettings.MINIMUM_REFRESH_INTERVAL;
 import static org.opensearch.search.SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING;
 import static org.opensearch.search.aggregations.AggregationBuilders.terms;
 import static org.opensearch.test.OpenSearchIntegTestCase.Scope.TEST;
@@ -71,7 +72,10 @@ public class TermsFixedDocCountErrorIT extends ParameterizedStaticSettingsOpenSe
         assertAcked(
             prepareCreate("idx_mshard_1").setMapping(STRING_FIELD_NAME, "type=keyword")
                 .setSettings(
-                    Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    Settings.builder()
+                        .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                        .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                        .put("index.refresh_interval", MINIMUM_REFRESH_INTERVAL)
                 )
         );
         client().prepareIndex("idx_mshard_1").setSource(jsonBuilder().startObject().field(STRING_FIELD_NAME, "A").endObject()).get();
@@ -89,7 +93,10 @@ public class TermsFixedDocCountErrorIT extends ParameterizedStaticSettingsOpenSe
         assertAcked(
             prepareCreate("idx_mshard_2").setMapping(STRING_FIELD_NAME, "type=keyword")
                 .setSettings(
-                    Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    Settings.builder()
+                        .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                        .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                        .put("index.refresh_interval", MINIMUM_REFRESH_INTERVAL)
                 )
         );
         client().prepareIndex("idx_mshard_2").setSource(jsonBuilder().startObject().field(STRING_FIELD_NAME, "A").endObject()).get();
@@ -127,7 +134,10 @@ public class TermsFixedDocCountErrorIT extends ParameterizedStaticSettingsOpenSe
         assertAcked(
             prepareCreate("idx_shard_error").setMapping(STRING_FIELD_NAME, "type=keyword")
                 .setSettings(
-                    Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    Settings.builder()
+                        .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                        .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                        .put("index.refresh_interval", MINIMUM_REFRESH_INTERVAL)
                 )
         );
         client().prepareIndex("idx_shard_error").setSource(jsonBuilder().startObject().field(STRING_FIELD_NAME, "A").endObject()).get();
@@ -170,7 +180,10 @@ public class TermsFixedDocCountErrorIT extends ParameterizedStaticSettingsOpenSe
         assertAcked(
             prepareCreate("idx_slice_error").setMapping(STRING_FIELD_NAME, "type=keyword")
                 .setSettings(
-                    Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    Settings.builder()
+                        .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                        .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                        .put("index.refresh_interval", MINIMUM_REFRESH_INTERVAL)
                 )
         );
         client().prepareIndex("idx_slice_error").setSource(jsonBuilder().startObject().field(STRING_FIELD_NAME, "A").endObject()).get();
@@ -248,7 +261,10 @@ public class TermsFixedDocCountErrorIT extends ParameterizedStaticSettingsOpenSe
         assertAcked(
             prepareCreate("idx_mshard_1").setMapping(STRING_FIELD_NAME, "type=keyword")
                 .setSettings(
-                    Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    Settings.builder()
+                        .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                        .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                        .put("index.refresh_interval", MINIMUM_REFRESH_INTERVAL)
                 )
         );
         client().prepareIndex("idx_mshard_1").setSource(jsonBuilder().startObject().field(STRING_FIELD_NAME, "A").endObject()).get();
@@ -288,7 +304,10 @@ public class TermsFixedDocCountErrorIT extends ParameterizedStaticSettingsOpenSe
         assertAcked(
             prepareCreate("idx_mshard_2").setMapping(STRING_FIELD_NAME, "type=keyword")
                 .setSettings(
-                    Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    Settings.builder()
+                        .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                        .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                        .put("index.refresh_interval", MINIMUM_REFRESH_INTERVAL)
                 )
         );
         client().prepareIndex("idx_mshard_2").setSource(jsonBuilder().startObject().field(STRING_FIELD_NAME, "A").endObject()).get();


### PR DESCRIPTION
### Description
Set index refresh interval to -1, should make segment count for these tests stable. Ran offline 10k times.

### Related Issues
Resolves #11950

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
