### PR TITLE
Fix typo in RemoveProcessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add search query categorizer ([#10255](https://github.com/opensearch-project/OpenSearch/pull/10255))
 - Per request phase latency ([#10351](https://github.com/opensearch-project/OpenSearch/issues/10351))
 - Add cluster state stats ([#10670](https://github.com/opensearch-project/OpenSearch/pull/10670))
-- Remove ingest processor supports excluding fields ([#10967](https://github.com/opensearch-project/OpenSearch/pull/10967))
+- Remove ingest processor supports excluding fields ([#10967](https://github.com/opensearch-project/OpenSearch/pull/10967), [#11983](https://github.com/opensearch-project/OpenSearch/pull/11983))
 - [Tiered caching] Enabling serialization for IndicesRequestCache key object ([#10275](https://github.com/opensearch-project/OpenSearch/pull/10275))
 - [Tiered caching] Defining interfaces, listeners and extending IndicesRequestCache with Tiered cache support ([#10753](https://github.com/opensearch-project/OpenSearch/pull/10753))
 - [Remote cluster state] Restore cluster state version during remote state auto restore ([#10853](https://github.com/opensearch-project/OpenSearch/pull/10853))
@@ -240,7 +240,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix tracing context propagation for local transport instrumentation ([#11490](https://github.com/opensearch-project/OpenSearch/pull/11490))
 - Fix parsing of single line comments in `lang-painless` ([#11815](https://github.com/opensearch-project/OpenSearch/issues/11815))
 - Fix memory leak issue in ReorganizingLongHash ([#11953](https://github.com/opensearch-project/OpenSearch/issues/11953))
-- Fix typo in RemoveProcessor
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,6 +240,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix tracing context propagation for local transport instrumentation ([#11490](https://github.com/opensearch-project/OpenSearch/pull/11490))
 - Fix parsing of single line comments in `lang-painless` ([#11815](https://github.com/opensearch-project/OpenSearch/issues/11815))
 - Fix memory leak issue in ReorganizingLongHash ([#11953](https://github.com/opensearch-project/OpenSearch/issues/11953))
+- Fix typo in RemoveProcessor
 
 ### Security
 

--- a/modules/ingest-common/src/main/java/org/opensearch/ingest/common/RemoveProcessor.java
+++ b/modules/ingest-common/src/main/java/org/opensearch/ingest/common/RemoveProcessor.java
@@ -72,7 +72,7 @@ public final class RemoveProcessor extends AbstractProcessor {
     ) {
         super(tag, description);
         if (fields == null && excludeFields == null || fields != null && excludeFields != null) {
-            throw new IllegalArgumentException("ether fields and excludeFields must be set");
+            throw new IllegalArgumentException("either fields or excludeFields must be set");
         }
         if (fields != null) {
             this.fields = new ArrayList<>(fields);
@@ -188,7 +188,7 @@ public final class RemoveProcessor extends AbstractProcessor {
             final Object excludeField = ConfigurationUtils.readOptionalObject(config, "exclude_field");
 
             if (field == null && excludeField == null || field != null && excludeField != null) {
-                throw newConfigurationException(TYPE, processorTag, "field", "ether field or exclude_field must be set");
+                throw newConfigurationException(TYPE, processorTag, "field", "either field or exclude_field must be set");
             }
 
             boolean ignoreMissing = ConfigurationUtils.readBooleanProperty(TYPE, processorTag, config, "ignore_missing", false);

--- a/modules/ingest-common/src/test/java/org/opensearch/ingest/common/RemoveProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/opensearch/ingest/common/RemoveProcessorFactoryTests.java
@@ -97,13 +97,13 @@ public class RemoveProcessorFactoryTests extends OpenSearchTestCase {
             OpenSearchParseException.class,
             () -> factory.create(null, processorTag, null, config)
         );
-        assertThat(exception.getMessage(), equalTo("[field] ether field or exclude_field must be set"));
+        assertThat(exception.getMessage(), equalTo("[field] either field or exclude_field must be set"));
 
         Map<String, Object> config2 = new HashMap<>();
         config2.put("field", "field1");
         config2.put("exclude_field", "field2");
         exception = expectThrows(OpenSearchParseException.class, () -> factory.create(null, processorTag, null, config2));
-        assertThat(exception.getMessage(), equalTo("[field] ether field or exclude_field must be set"));
+        assertThat(exception.getMessage(), equalTo("[field] either field or exclude_field must be set"));
 
         Map<String, Object> config6 = new HashMap<>();
         config6.put("exclude_field", "exclude_field");

--- a/modules/ingest-common/src/test/java/org/opensearch/ingest/common/RemoveProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/opensearch/ingest/common/RemoveProcessorTests.java
@@ -203,7 +203,7 @@ public class RemoveProcessorTests extends OpenSearchTestCase {
 
     public void testCreateRemoveProcessorWithBothFieldsAndExcludeFields() throws Exception {
         assertThrows(
-            "ether fields and excludeFields must be set",
+            "either fields or excludeFields must be set",
             IllegalArgumentException.class,
             () -> new RemoveProcessor(randomAlphaOfLength(10), null, null, null, false)
         );
@@ -223,7 +223,7 @@ public class RemoveProcessorTests extends OpenSearchTestCase {
         }
 
         assertThrows(
-            "ether fields and excludeFields must be set",
+            "either fields or excludeFields must be set",
             IllegalArgumentException.class,
             () -> new RemoveProcessor(randomAlphaOfLength(10), null, fields, excludeFields, false)
         );


### PR DESCRIPTION
### Description
Fix the typo in RemoveProcessor, ether should be `either`, and `either ... and` should be `either ... or`. 

### Related Issues

No issue, the typo was introduced by [this PR](https://github.com/opensearch-project/OpenSearch/pull/10967), when I wrote document for the functionality in that PR, I found this typo.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
