### PR TITLE
Fetch all the locks for a shard to avoid multiple remote store calls

### DIFF
--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -751,7 +751,9 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
         );
         Set<String> allLockFiles;
         try {
-            allLockFiles = new HashSet<>(((RemoteStoreMetadataLockManager) mdLockManager).fetchLocks(MetadataFilenameUtils.METADATA_PREFIX));
+            allLockFiles = new HashSet<>(
+                ((RemoteStoreMetadataLockManager) mdLockManager).fetchLocks(MetadataFilenameUtils.METADATA_PREFIX)
+            );
         } catch (Exception e) {
             logger.error("Exception while fetching segment metadata lock files, skipping deleteStaleSegments", e);
             return;

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -751,7 +751,7 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
         );
         Set<String> allLockFiles;
         try {
-            allLockFiles = new HashSet<>(mdLockManager.listAllLocks(MetadataFilenameUtils.METADATA_PREFIX));
+            allLockFiles = new HashSet<>(((RemoteStoreMetadataLockManager) mdLockManager).fetchLocks(MetadataFilenameUtils.METADATA_PREFIX));
         } catch (Exception e) {
             logger.error("Exception while fetching segment metadata lock files, skipping deleteStaleSegments", e);
             return;

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -751,9 +751,7 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
         );
         Set<String> allLockFiles;
         try {
-            allLockFiles = new HashSet<>(
-                ((RemoteStoreMetadataLockManager) mdLockManager).fetchLocks(MetadataFilenameUtils.METADATA_PREFIX)
-            );
+            allLockFiles = ((RemoteStoreMetadataLockManager) mdLockManager).fetchLocks(MetadataFilenameUtils.METADATA_PREFIX);
         } catch (Exception e) {
             logger.error("Exception while fetching segment metadata lock files, skipping deleteStaleSegments", e);
             return;

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -164,7 +164,7 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
      */
     public RemoteSegmentMetadata initializeToSpecificCommit(long primaryTerm, long commitGeneration, String acquirerId) throws IOException {
         String metadataFilePrefix = MetadataFilenameUtils.getMetadataFilePrefixForCommit(primaryTerm, commitGeneration);
-        String metadataFile = ((RemoteStoreMetadataLockManager) mdLockManager).fetchLock(metadataFilePrefix, acquirerId);
+        String metadataFile = ((RemoteStoreMetadataLockManager) mdLockManager).fetchLockedMetadataFile(metadataFilePrefix, acquirerId);
         RemoteSegmentMetadata remoteSegmentMetadata = readMetadataFile(metadataFile);
         if (remoteSegmentMetadata != null) {
             this.segmentsUploadedToRemoteStore = new ConcurrentHashMap<>(remoteSegmentMetadata.getMetadata());
@@ -751,7 +751,7 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
         );
         Set<String> allLockFiles;
         try {
-            allLockFiles = ((RemoteStoreMetadataLockManager) mdLockManager).fetchLocks(MetadataFilenameUtils.METADATA_PREFIX);
+            allLockFiles = ((RemoteStoreMetadataLockManager) mdLockManager).fetchLockedMetadataFiles(MetadataFilenameUtils.METADATA_PREFIX);
         } catch (Exception e) {
             logger.error("Exception while fetching segment metadata lock files, skipping deleteStaleSegments", e);
             return;

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -749,20 +749,16 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
             lastNMetadataFilesToKeep,
             sortedMetadataFileList.size()
         );
-        List<String> metadataFilesToBeDeleted = metadataFilesEligibleToDelete.stream().filter(metadataFile -> {
-            try {
-                return !isLockAcquired(metadataFile);
-            } catch (IOException e) {
-                logger.error(
-                    "skipping metadata file ("
-                        + metadataFile
-                        + ") deletion for this run,"
-                        + " as checking lock for metadata is failing with error: "
-                        + e
-                );
-                return false;
-            }
-        }).collect(Collectors.toList());
+        Set<String> allLockFiles;
+        try {
+            allLockFiles = new HashSet<>(mdLockManager.listAllLocks(MetadataFilenameUtils.METADATA_PREFIX));
+        } catch (Exception e) {
+            logger.error("Exception while fetching segment metadata lock files, skipping deleteStaleSegments", e);
+            return;
+        }
+        List<String> metadataFilesToBeDeleted = metadataFilesEligibleToDelete.stream()
+            .filter(metadataFile -> allLockFiles.contains(metadataFile) == false)
+            .collect(Collectors.toList());
 
         sortedMetadataFileList.removeAll(metadataFilesToBeDeleted);
         logger.debug(

--- a/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreLockManager.java
+++ b/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreLockManager.java
@@ -11,6 +11,7 @@ package org.opensearch.index.store.lockmanager;
 import org.opensearch.common.annotation.PublicApi;
 
 import java.io.IOException;
+import java.util.Collection;
 
 /**
  * An Interface that defines Remote Store Lock Manager.
@@ -42,6 +43,8 @@ public interface RemoteStoreLockManager {
      * @throws IOException throws exception in case there is a problem in checking if a given file is locked or not.
      */
     Boolean isAcquired(LockInfo lockInfo) throws IOException;
+
+    public Collection<String> listAllLocks(String prefix) throws IOException;
 
     /**
      * Acquires lock on the file mentioned in originalLockInfo for acquirer mentioned in clonedLockInfo.

--- a/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreLockManager.java
+++ b/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreLockManager.java
@@ -11,7 +11,6 @@ package org.opensearch.index.store.lockmanager;
 import org.opensearch.common.annotation.PublicApi;
 
 import java.io.IOException;
-import java.util.Collection;
 
 /**
  * An Interface that defines Remote Store Lock Manager.

--- a/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreLockManager.java
+++ b/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreLockManager.java
@@ -44,8 +44,6 @@ public interface RemoteStoreLockManager {
      */
     Boolean isAcquired(LockInfo lockInfo) throws IOException;
 
-    public Collection<String> listAllLocks(String prefix) throws IOException;
-
     /**
      * Acquires lock on the file mentioned in originalLockInfo for acquirer mentioned in clonedLockInfo.
      * There can occur a race condition where the original file is deleted before we can use it to acquire lock for the new acquirer. Until we have a

--- a/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreMetadataLockManager.java
+++ b/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreMetadataLockManager.java
@@ -90,9 +90,7 @@ public class RemoteStoreMetadataLockManager implements RemoteStoreLockManager {
 
     public Collection<String> fetchLocks(String filenamePrefix) throws IOException {
         Collection<String> lockFiles = lockDirectory.listFilesByPrefix(filenamePrefix);
-        return lockFiles.stream()
-            .map(FileLockInfo.LockFileUtils::getFileToLockNameFromLock)
-            .collect(Collectors.toList());
+        return lockFiles.stream().map(FileLockInfo.LockFileUtils::getFileToLockNameFromLock).collect(Collectors.toList());
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreMetadataLockManager.java
+++ b/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreMetadataLockManager.java
@@ -88,6 +88,13 @@ public class RemoteStoreMetadataLockManager implements RemoteStoreLockManager {
         return lockFilesForAcquirer.get(0);
     }
 
+    public Collection<String> fetchLocks(String filenamePrefix) throws IOException {
+        Collection<String> lockFiles = lockDirectory.listFilesByPrefix(filenamePrefix);
+        return lockFiles.stream()
+            .map(FileLockInfo.LockFileUtils::getFileToLockNameFromLock)
+            .collect(Collectors.toList());
+    }
+
     /**
      * Checks whether a given file have any lock on it or not.
      * @param lockInfo File Lock Info instance for which we need to check if lock is acquired.
@@ -99,10 +106,6 @@ public class RemoteStoreMetadataLockManager implements RemoteStoreLockManager {
         assert lockInfo instanceof FileLockInfo : "lockInfo should be instance of FileLockInfo";
         Collection<String> lockFiles = lockDirectory.listFilesByPrefix(((FileLockInfo) lockInfo).getLockPrefix());
         return !lockFiles.isEmpty();
-    }
-
-    public Collection<String> listAllLocks(String prefix) throws IOException {
-        return lockDirectory.listFilesByPrefix(prefix);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreMetadataLockManager.java
+++ b/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreMetadataLockManager.java
@@ -76,7 +76,7 @@ public class RemoteStoreMetadataLockManager implements RemoteStoreLockManager {
         }
     }
 
-    public String fetchLock(String filenamePrefix, String acquirerId) throws IOException {
+    public String fetchLockedMetadataFile(String filenamePrefix, String acquirerId) throws IOException {
         Collection<String> lockFiles = lockDirectory.listFilesByPrefix(filenamePrefix);
         List<String> lockFilesForAcquirer = lockFiles.stream()
             .filter(lockFile -> acquirerId.equals(FileLockInfo.LockFileUtils.getAcquirerIdFromLock(lockFile)))
@@ -89,7 +89,7 @@ public class RemoteStoreMetadataLockManager implements RemoteStoreLockManager {
         return lockFilesForAcquirer.get(0);
     }
 
-    public Set<String> fetchLocks(String filenamePrefix) throws IOException {
+    public Set<String> fetchLockedMetadataFiles(String filenamePrefix) throws IOException {
         Collection<String> lockFiles = lockDirectory.listFilesByPrefix(filenamePrefix);
         return lockFiles.stream().map(FileLockInfo.LockFileUtils::getFileToLockNameFromLock).collect(Collectors.toSet());
     }

--- a/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreMetadataLockManager.java
+++ b/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreMetadataLockManager.java
@@ -21,6 +21,7 @@ import java.nio.file.NoSuchFileException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -88,9 +89,9 @@ public class RemoteStoreMetadataLockManager implements RemoteStoreLockManager {
         return lockFilesForAcquirer.get(0);
     }
 
-    public Collection<String> fetchLocks(String filenamePrefix) throws IOException {
+    public Set<String> fetchLocks(String filenamePrefix) throws IOException {
         Collection<String> lockFiles = lockDirectory.listFilesByPrefix(filenamePrefix);
-        return lockFiles.stream().map(FileLockInfo.LockFileUtils::getFileToLockNameFromLock).collect(Collectors.toList());
+        return lockFiles.stream().map(FileLockInfo.LockFileUtils::getFileToLockNameFromLock).collect(Collectors.toSet());
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreMetadataLockManager.java
+++ b/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreMetadataLockManager.java
@@ -101,6 +101,10 @@ public class RemoteStoreMetadataLockManager implements RemoteStoreLockManager {
         return !lockFiles.isEmpty();
     }
 
+    public Collection<String> listAllLocks(String prefix) throws IOException {
+        return lockDirectory.listFilesByPrefix(prefix);
+    }
+
     /**
      * Acquires lock on the file mentioned in originalLockInfo for acquirer mentioned in clonedLockInfo.
      * Snapshot layer enforces thread safety by having checks in place to ensure that the source snapshot is not being deleted before proceeding

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -993,7 +993,7 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         remoteSegmentStoreDirectory.init();
 
         // Locking one of the metadata files to ensure that it is not getting deleted.
-        when(mdLockManager.fetchLocks(any())).thenReturn(List.of(metadataFilename2));
+        when(mdLockManager.fetchLocks(any())).thenReturn(Set.of(metadataFilename2));
 
         // popluateMetadata() adds stub to return 3 metadata files
         // We are passing lastNMetadataFilesToKeep=2 here so that oldest 1 metadata file will be deleted
@@ -1012,13 +1012,26 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         remoteSegmentStoreDirectory.init();
 
         // Locking all the old metadata files to ensure that none of the segment files are getting deleted.
-        when(mdLockManager.fetchLocks(any())).thenReturn(List.of(metadataFilename2, metadataFilename3));
+        when(mdLockManager.fetchLocks(any())).thenReturn(Set.of(metadataFilename2, metadataFilename3));
 
         // popluateMetadata() adds stub to return 3 metadata files
         // We are passing lastNMetadataFilesToKeep=2 here so that oldest 1 metadata file will be deleted
         remoteSegmentStoreDirectory.deleteStaleSegmentsAsync(1);
 
         assertBusy(() -> assertThat(remoteSegmentStoreDirectory.canDeleteStaleCommits.get(), is(true)));
+        verify(remoteMetadataDirectory, times(0)).deleteFile(any());
+    }
+
+    public void testDeleteStaleCommitsExceptionWhileFetchingLocks() throws Exception {
+        remoteSegmentStoreDirectory.init();
+
+        // Locking one of the metadata files to ensure that it is not getting deleted.
+        when(mdLockManager.fetchLocks(any())).thenThrow(new RuntimeException("Rate limit exceeded"));
+
+        // popluateMetadata() adds stub to return 3 metadata files
+        // We are passing lastNMetadataFilesToKeep=2 here so that oldest 1 metadata file will be deleted
+        remoteSegmentStoreDirectory.deleteStaleSegmentsAsync(1);
+
         verify(remoteMetadataDirectory, times(0)).deleteFile(any());
     }
 

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -993,7 +993,7 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         remoteSegmentStoreDirectory.init();
 
         // Locking one of the metadata files to ensure that it is not getting deleted.
-        when(mdLockManager.fetchLocks(any())).thenReturn(Set.of(metadataFilename2));
+        when(mdLockManager.fetchLockedMetadataFiles(any())).thenReturn(Set.of(metadataFilename2));
 
         // popluateMetadata() adds stub to return 3 metadata files
         // We are passing lastNMetadataFilesToKeep=2 here so that oldest 1 metadata file will be deleted
@@ -1012,7 +1012,7 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         remoteSegmentStoreDirectory.init();
 
         // Locking all the old metadata files to ensure that none of the segment files are getting deleted.
-        when(mdLockManager.fetchLocks(any())).thenReturn(Set.of(metadataFilename2, metadataFilename3));
+        when(mdLockManager.fetchLockedMetadataFiles(any())).thenReturn(Set.of(metadataFilename2, metadataFilename3));
 
         // popluateMetadata() adds stub to return 3 metadata files
         // We are passing lastNMetadataFilesToKeep=2 here so that oldest 1 metadata file will be deleted
@@ -1026,7 +1026,7 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         remoteSegmentStoreDirectory.init();
 
         // Locking one of the metadata files to ensure that it is not getting deleted.
-        when(mdLockManager.fetchLocks(any())).thenThrow(new RuntimeException("Rate limit exceeded"));
+        when(mdLockManager.fetchLockedMetadataFiles(any())).thenThrow(new RuntimeException("Rate limit exceeded"));
 
         // popluateMetadata() adds stub to return 3 metadata files
         // We are passing lastNMetadataFilesToKeep=2 here so that oldest 1 metadata file will be deleted

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -988,6 +988,40 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         verify(remoteMetadataDirectory).deleteFile(metadataFilename3);
     }
 
+    public void testDeleteStaleCommitsActualDeleteWithLocks() throws Exception {
+        Map<String, Map<String, String>> metadataFilenameContentMapping = populateMetadata();
+        remoteSegmentStoreDirectory.init();
+
+        // Locking one of the metadata files to ensure that it is not getting deleted.
+        when(mdLockManager.fetchLocks(any())).thenReturn(List.of(metadataFilename2));
+
+        // popluateMetadata() adds stub to return 3 metadata files
+        // We are passing lastNMetadataFilesToKeep=2 here so that oldest 1 metadata file will be deleted
+        remoteSegmentStoreDirectory.deleteStaleSegmentsAsync(1);
+
+        for (String metadata : metadataFilenameContentMapping.get(metadataFilename3).values()) {
+            String uploadedFilename = metadata.split(RemoteSegmentStoreDirectory.UploadedSegmentMetadata.SEPARATOR)[1];
+            verify(remoteDataDirectory).deleteFile(uploadedFilename);
+        }
+        assertBusy(() -> assertThat(remoteSegmentStoreDirectory.canDeleteStaleCommits.get(), is(true)));
+        verify(remoteMetadataDirectory).deleteFile(metadataFilename3);
+        verify(remoteMetadataDirectory, times(0)).deleteFile(metadataFilename2);
+    }
+
+    public void testDeleteStaleCommitsNoDeletesDueToLocks() throws Exception {
+        remoteSegmentStoreDirectory.init();
+
+        // Locking all the old metadata files to ensure that none of the segment files are getting deleted.
+        when(mdLockManager.fetchLocks(any())).thenReturn(List.of(metadataFilename2, metadataFilename3));
+
+        // popluateMetadata() adds stub to return 3 metadata files
+        // We are passing lastNMetadataFilesToKeep=2 here so that oldest 1 metadata file will be deleted
+        remoteSegmentStoreDirectory.deleteStaleSegmentsAsync(1);
+
+        assertBusy(() -> assertThat(remoteSegmentStoreDirectory.canDeleteStaleCommits.get(), is(true)));
+        verify(remoteMetadataDirectory, times(0)).deleteFile(any());
+    }
+
     public void testDeleteStaleCommitsDeleteDedup() throws Exception {
         Map<String, Map<String, String>> metadataFilenameContentMapping = new HashMap<>(populateMetadata());
         metadataFilenameContentMapping.put(metadataFilename4, metadataFilenameContentMapping.get(metadataFilename3));

--- a/server/src/test/java/org/opensearch/index/store/lockmanager/RemoteStoreMetadataLockManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/store/lockmanager/RemoteStoreMetadataLockManagerTests.java
@@ -17,6 +17,7 @@ import org.junit.Before;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Set;
 
 import junit.framework.TestCase;
 
@@ -95,5 +96,27 @@ public class RemoteStoreMetadataLockManagerTests extends OpenSearchTestCase {
     public void testIsAcquiredExceptionCase() { // metadata file is not passed during isAcquired call.
         FileLockInfo testLockInfo = FileLockInfo.getLockInfoBuilder().withAcquirerId(testAcquirerId).build();
         assertThrows(IllegalArgumentException.class, () -> remoteStoreMetadataLockManager.isAcquired(testLockInfo));
+    }
+
+    public void testFetchLocksEmpty() throws IOException {
+        when(lockDirectory.listFilesByPrefix("metadata")).thenReturn(Set.of());
+        assertEquals(0, remoteStoreMetadataLockManager.fetchLocks("metadata").size());
+    }
+
+    public void testFetchLocksNonEmpty() throws IOException {
+        String metadata1 = "metadata_1_2_3";
+        String metadata2 = "metadata_4_5_6";
+        when(lockDirectory.listFilesByPrefix("metadata")).thenReturn(
+            Set.of(
+                FileLockInfo.LockFileUtils.generateLockName(metadata1, "snapshot1"),
+                FileLockInfo.LockFileUtils.generateLockName(metadata2, "snapshot2")
+            )
+        );
+        assertEquals(Set.of(metadata1, metadata2), remoteStoreMetadataLockManager.fetchLocks("metadata"));
+    }
+
+    public void testFetchLocksException() throws IOException {
+        when(lockDirectory.listFilesByPrefix("metadata")).thenThrow(new IOException("Something went wrong"));
+        assertThrows(IOException.class, () -> remoteStoreMetadataLockManager.fetchLocks("metadata"));
     }
 }

--- a/server/src/test/java/org/opensearch/index/store/lockmanager/RemoteStoreMetadataLockManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/store/lockmanager/RemoteStoreMetadataLockManagerTests.java
@@ -100,7 +100,7 @@ public class RemoteStoreMetadataLockManagerTests extends OpenSearchTestCase {
 
     public void testFetchLocksEmpty() throws IOException {
         when(lockDirectory.listFilesByPrefix("metadata")).thenReturn(Set.of());
-        assertEquals(0, remoteStoreMetadataLockManager.fetchLocks("metadata").size());
+        assertEquals(0, remoteStoreMetadataLockManager.fetchLockedMetadataFiles("metadata").size());
     }
 
     public void testFetchLocksNonEmpty() throws IOException {
@@ -112,11 +112,11 @@ public class RemoteStoreMetadataLockManagerTests extends OpenSearchTestCase {
                 FileLockInfo.LockFileUtils.generateLockName(metadata2, "snapshot2")
             )
         );
-        assertEquals(Set.of(metadata1, metadata2), remoteStoreMetadataLockManager.fetchLocks("metadata"));
+        assertEquals(Set.of(metadata1, metadata2), remoteStoreMetadataLockManager.fetchLockedMetadataFiles("metadata"));
     }
 
     public void testFetchLocksException() throws IOException {
         when(lockDirectory.listFilesByPrefix("metadata")).thenThrow(new IOException("Something went wrong"));
-        assertThrows(IOException.class, () -> remoteStoreMetadataLockManager.fetchLocks("metadata"));
+        assertThrows(IOException.class, () -> remoteStoreMetadataLockManager.fetchLockedMetadataFiles("metadata"));
     }
 }


### PR DESCRIPTION
**<Pending Tests>**

### Description
- Currently, snapshot interop with remote store takes a lock on remote segment store metadata files.
- This lock ensures that the metadata file is not deleted as part of cleanup of stale files.
- Cleanup of stale metadata files happen at each flush and to check if the lock is acquired or not, a remote store call is made.
- This can result in too many remote store calls when there are too many snapshots present and frequent flushes.
- In this change, we list all the lock files to avoid multiple remote store calls.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/11409

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [ ] ~Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))~
- [x] Commits are signed per the DCO using --signoff
- [ ] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
