### PR TITLE
Ensure latest replication checkpoint post failover has correct operational primary term

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreRestoreIT.java
@@ -26,7 +26,6 @@ import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.repositories.Repository;
 import org.opensearch.test.InternalTestCluster;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.junit.annotations.TestIssueLogging;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -142,7 +141,6 @@ public class RemoteStoreRestoreIT extends BaseRemoteStoreRestoreIT {
         restoreAndVerify(shardCount, 0, indexStats);
     }
 
-    @TestIssueLogging(value = "org.opensearch:TRACE", issueUrl = "to get trace level logs for debug")
     public void testMultipleWriters() throws Exception {
         prepareCluster(1, 2, INDEX_NAME, 1, 1);
         Map<String, Long> indexStats = indexData(randomIntBetween(2, 5), true, true, INDEX_NAME);

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreRestoreIT.java
@@ -29,7 +29,6 @@ import org.opensearch.test.OpenSearchIntegTestCase;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -182,14 +181,11 @@ public class RemoteStoreRestoreIT extends BaseRemoteStoreRestoreIT {
         indexService = indicesService.indexService(indexObj);
         indexShard = indexService.getShard(0);
         IndexShard finalIndexShard = indexShard;
-        assertBusy(() -> assertTrue(finalIndexShard.isPrimaryMode()));
-        RemoteSegmentMetadata remoteSegmentMetadataAfterFailover = indexShard.getRemoteDirectory().readLatestMetadataFile();
-
-        assertNotEquals(
-            new ArrayList<>(remoteSegmentMetadataAfterFailover.toMapOfStrings().values()),
-            new ArrayList<>(remoteSegmentMetadataBeforeFailover.toMapOfStrings().values())
+        assertBusy(() -> assertTrue(finalIndexShard.isStartedPrimary() && finalIndexShard.isPrimaryMode()));
+        assertEquals(
+            finalIndexShard.getLatestSegmentInfosAndCheckpoint().v2().getPrimaryTerm(),
+            remoteSegmentMetadataBeforeFailover.getPrimaryTerm() + 1
         );
-        assertEquals(remoteSegmentMetadataAfterFailover.getPrimaryTerm(), remoteSegmentMetadataBeforeFailover.getPrimaryTerm() + 1);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1697,7 +1697,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         }
         final ReplicationCheckpoint latestReplicationCheckpoint = getLatestReplicationCheckpoint();
         if (latestReplicationCheckpoint.getSegmentInfosVersion() == segmentInfos.getVersion()
-            && latestReplicationCheckpoint.getSegmentsGen() == segmentInfos.getGeneration()) {
+            && latestReplicationCheckpoint.getSegmentsGen() == segmentInfos.getGeneration()
+            && latestReplicationCheckpoint.getPrimaryTerm() == getOperationPrimaryTerm()) {
             return latestReplicationCheckpoint;
         }
         final Map<String, StoreFileMetadata> metadataMap = store.getSegmentMetadataMap(segmentInfos);

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -2015,7 +2015,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     /*
     ToDo : Fix this https://github.com/opensearch-project/OpenSearch/issues/8003
      */
-    private RemoteSegmentStoreDirectory getRemoteDirectory() {
+    public RemoteSegmentStoreDirectory getRemoteDirectory() {
         assert indexSettings.isRemoteStoreEnabled();
         assert remoteStore.directory() instanceof FilterDirectory : "Store.directory is not an instance of FilterDirectory";
         FilterDirectory remoteStoreDirectory = (FilterDirectory) remoteStore.directory();

--- a/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
@@ -500,7 +500,7 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
         when(remoteStore.directory()).thenReturn(remoteStoreFilterDirectory);
 
         // Mock indexShard.getOperationPrimaryTerm()
-        when(shard.getOperationPrimaryTerm()).thenReturn(indexShard.getLatestReplicationCheckpoint().getPrimaryTerm());
+        when(shard.getOperationPrimaryTerm()).thenReturn(indexShard.getOperationPrimaryTerm());
         when(shard.getLatestReplicationCheckpoint()).thenReturn(indexShard.getLatestReplicationCheckpoint());
 
         // Mock indexShard.routingEntry().primary()

--- a/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
@@ -500,6 +500,7 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
         when(remoteStore.directory()).thenReturn(remoteStoreFilterDirectory);
 
         // Mock indexShard.getOperationPrimaryTerm()
+        when(shard.getOperationPrimaryTerm()).thenReturn(indexShard.getLatestReplicationCheckpoint().getPrimaryTerm());
         when(shard.getLatestReplicationCheckpoint()).thenReturn(indexShard.getLatestReplicationCheckpoint());
 
         // Mock indexShard.routingEntry().primary()

--- a/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
@@ -425,6 +425,33 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
         assertBusy(() -> assertNoLag(tracker));
     }
 
+    /**
+     * Tests segments upload fails with replication checkpoint and replication tracker primary term mismatch
+     */
+    public void testRefreshFailedDueToPrimaryTermMisMatch() throws Exception {
+        int totalAttempt = 1;
+        int checkpointPublishSucceedOnAttempt = 0;
+        // We spy on IndexShard.isPrimaryStarted() to validate that we have tried running remote time as per the expectation.
+        CountDownLatch refreshCountLatch = new CountDownLatch(totalAttempt);
+
+        // success latch should change as we would be failed primary term latest validation.
+        CountDownLatch successLatch = new CountDownLatch(1);
+        CountDownLatch reachedCheckpointPublishLatch = new CountDownLatch(0);
+        Tuple<RemoteStoreRefreshListener, RemoteStoreStatsTrackerFactory> tuple = mockIndexShardWithRetryAndScheduleRefresh(
+            totalAttempt,
+            refreshCountLatch,
+            successLatch,
+            checkpointPublishSucceedOnAttempt,
+            reachedCheckpointPublishLatch,
+            false
+        );
+
+        assertBusy(() -> assertEquals(1, tuple.v2().getRemoteSegmentTransferTracker(indexShard.shardId()).getTotalUploadsFailed()));
+        assertBusy(() -> assertEquals(0, refreshCountLatch.getCount()));
+        assertBusy(() -> assertEquals(1, successLatch.getCount()));
+        assertBusy(() -> assertEquals(0, reachedCheckpointPublishLatch.getCount()));
+    }
+
     private void assertNoLag(RemoteSegmentTransferTracker tracker) {
         assertEquals(0, tracker.getRefreshSeqNoLag());
         assertEquals(0, tracker.getBytesLag());
@@ -460,6 +487,24 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
         CountDownLatch successLatch,
         int succeedCheckpointPublishOnAttempt,
         CountDownLatch reachedCheckpointPublishLatch
+    ) throws IOException {
+        return mockIndexShardWithRetryAndScheduleRefresh(
+            succeedOnAttempt,
+            refreshCountLatch,
+            successLatch,
+            succeedCheckpointPublishOnAttempt,
+            reachedCheckpointPublishLatch,
+            true
+        );
+    }
+
+    private Tuple<RemoteStoreRefreshListener, RemoteStoreStatsTrackerFactory> mockIndexShardWithRetryAndScheduleRefresh(
+        int succeedOnAttempt,
+        CountDownLatch refreshCountLatch,
+        CountDownLatch successLatch,
+        int succeedCheckpointPublishOnAttempt,
+        CountDownLatch reachedCheckpointPublishLatch,
+        boolean mockPrimaryTerm
     ) throws IOException {
         // Create index shard that we will be using to mock different methods in IndexShard for the unit test
         indexShard = newStartedShard(
@@ -500,7 +545,9 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
         when(remoteStore.directory()).thenReturn(remoteStoreFilterDirectory);
 
         // Mock indexShard.getOperationPrimaryTerm()
-        when(shard.getOperationPrimaryTerm()).thenReturn(indexShard.getOperationPrimaryTerm());
+        if (mockPrimaryTerm) {
+            when(shard.getOperationPrimaryTerm()).thenReturn(indexShard.getOperationPrimaryTerm());
+        }
         when(shard.getLatestReplicationCheckpoint()).thenReturn(indexShard.getLatestReplicationCheckpoint());
 
         // Mock indexShard.routingEntry().primary()


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
- During primary failover, post primaryMode activate on the new primary, the new primary can still upload segment metadata with older primary term
- This is because the ReplicationCheckpoint used to get the primaryTerm during upload might itself have the older primaryTerm
- This is more prominent if indexing has stopped during failover(need to verify this)
- Currently it seems the replication checkpoint is only updated during recovery, failover, refresh, that too if the latest segmentInfos version and generation doesnt match with the current replication checkpoint.
- After failover we trigger refresh, which should update the replication checkpoint but since there is not new data, we use the cached replication checkpoint
- With this PR, we have added additional check on primaryTerm to make sure replication checkpoint is updated during failover as well with new primaryTerm

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [ ] ~Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))~
- [x] Commits are signed per the DCO using --signoff
- [ ] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
