### PR TITLE
Fixing Minio docker compose fixture

### DIFF
--- a/test/fixtures/minio-fixture/docker-compose.yml
+++ b/test/fixtures/minio-fixture/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.2'
 services:
   minio-fixture:
     build:


### PR DESCRIPTION
### Description
While I was trying to run the S3 `testRequestStats` tests,  Minio Fixture was seeing problems with docker-compose specifically with volumes having extended notation. 

```
> Task :test:fixtures:minio-fixture:composeBuild FAILED
The Compose file './docker-compose.yml' is invalid because:
services.minio-fixture.volumes contains an invalid type, it should be a string
services.minio-fixture-for-snapshot-tool.volumes contains an invalid type, it should be a string
services.minio-fixture-other.volumes contains an invalid type, it should be a string
``` 

From docker https://github.com/docker/compose/issues/4763, version 3.2 supports extended notations and it works!

Background: Was trying to fix https://github.com/opensearch-project/OpenSearch/issues/9859 and ended up on repository S3 test which was failing https://github.com/opensearch-project/OpenSearch/issues/10735 which has a test build dependency on minio-fixture (I do not know why though).

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
