### PR TITLE
Tuning Lucene Codec Block sizes to Optimize Performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Support index level allocation filtering for searchable snapshot index ([#11563](https://github.com/opensearch-project/OpenSearch/pull/11563))
 - Add `org.opensearch.rest.MethodHandlers` and `RestController#getAllHandlers` ([11876](https://github.com/opensearch-project/OpenSearch/pull/11876))
 - New DateTime format for RFC3339 compatible date fields ([#11465](https://github.com/opensearch-project/OpenSearch/pull/11465))
+- Tuning Lucene Codec Block sizes to optimize performance ([#12029](https://github.com/opensearch-project/OpenSearch/pull/12029))
 
 ### Dependencies
 - Bumps jetty version to 9.4.52.v20230823 to fix GMS-2023-1857 ([#9822](https://github.com/opensearch-project/OpenSearch/pull/9822))

--- a/server/src/main/java/org/opensearch/index/codec/CodecService.java
+++ b/server/src/main/java/org/opensearch/index/codec/CodecService.java
@@ -34,7 +34,6 @@ package org.opensearch.index.codec;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.codecs.Codec;
-import org.apache.lucene.codecs.lucene99.Lucene99Codec;
 import org.apache.lucene.codecs.lucene99.Lucene99Codec.Mode;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.collect.MapBuilder;
@@ -68,15 +67,15 @@ public class CodecService {
         final MapBuilder<String, Codec> codecs = MapBuilder.<String, Codec>newMapBuilder();
         assert null != indexSettings;
         if (mapperService == null) {
-            codecs.put(DEFAULT_CODEC, new Lucene99Codec());
-            codecs.put(LZ4, new Lucene99Codec());
-            codecs.put(BEST_COMPRESSION_CODEC, new Lucene99Codec(Mode.BEST_COMPRESSION));
-            codecs.put(ZLIB, new Lucene99Codec(Mode.BEST_COMPRESSION));
+            codecs.put(DEFAULT_CODEC, new Lucene99CoreCodec());
+            codecs.put(LZ4, new Lucene99CoreCodec());
+            codecs.put(BEST_COMPRESSION_CODEC, new Lucene99CoreCodec(Mode.BEST_COMPRESSION));
+            codecs.put(ZLIB, new Lucene99CoreCodec(Mode.BEST_COMPRESSION));
         } else {
-            codecs.put(DEFAULT_CODEC, new PerFieldMappingPostingFormatCodec(Mode.BEST_SPEED, mapperService, logger));
-            codecs.put(LZ4, new PerFieldMappingPostingFormatCodec(Mode.BEST_SPEED, mapperService, logger));
-            codecs.put(BEST_COMPRESSION_CODEC, new PerFieldMappingPostingFormatCodec(Mode.BEST_COMPRESSION, mapperService, logger));
-            codecs.put(ZLIB, new PerFieldMappingPostingFormatCodec(Mode.BEST_COMPRESSION, mapperService, logger));
+            codecs.put(DEFAULT_CODEC, new Lucene99CoreCodec(Mode.BEST_SPEED, mapperService, logger));
+            codecs.put(LZ4, new Lucene99CoreCodec(Mode.BEST_SPEED, mapperService, logger));
+            codecs.put(BEST_COMPRESSION_CODEC, new Lucene99CoreCodec(Mode.BEST_COMPRESSION, mapperService, logger));
+            codecs.put(ZLIB, new Lucene99CoreCodec(Mode.BEST_COMPRESSION, mapperService, logger));
         }
         codecs.put(LUCENE_DEFAULT_CODEC, Codec.getDefault());
         for (String codec : Codec.availableCodecs()) {

--- a/server/src/main/java/org/opensearch/index/codec/Lucene99CoreCodec.java
+++ b/server/src/main/java/org/opensearch/index/codec/Lucene99CoreCodec.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.codec;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.codecs.FilterCodec;
+import org.apache.lucene.codecs.StoredFieldsFormat;
+import org.apache.lucene.codecs.lucene99.Lucene99Codec;
+import org.opensearch.index.mapper.MapperService;
+
+/**
+ *
+ * Extends {@link FilterCodec} to reuse the functionality of Lucene Codec.
+ * Supports two lucene modes BEST_SPEED and BEST_COMPRESSION.
+ * Uses Lucene99 as the delegate codec
+ *
+ * @opensearch.internal
+ */
+public class Lucene99CoreCodec extends FilterCodec {
+
+    private final StoredFieldsFormat storedFieldsFormat;
+
+    public Lucene99CoreCodec() {
+        super("Lucene99Core", new Lucene99Codec());
+        storedFieldsFormat = new Lucene99CoreStoredFieldsFormat();
+    }
+
+    public Lucene99CoreCodec(Lucene99Codec.Mode mode) {
+        super("Lucene99Core", new Lucene99Codec(mode));
+        storedFieldsFormat = new Lucene99CoreStoredFieldsFormat(mode);
+    }
+
+    @Override
+    public StoredFieldsFormat storedFieldsFormat() {
+        return storedFieldsFormat;
+    }
+
+    public Lucene99CoreCodec(Lucene99Codec.Mode mode, MapperService mapperService, Logger logger) {
+        super("Lucene99Core", new PerFieldMappingPostingFormatCodec(mode, mapperService, logger));
+        this.storedFieldsFormat = new Lucene99CoreStoredFieldsFormat(mode);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
+}

--- a/server/src/main/java/org/opensearch/index/codec/Lucene99CoreStoredFieldsFormat.java
+++ b/server/src/main/java/org/opensearch/index/codec/Lucene99CoreStoredFieldsFormat.java
@@ -1,0 +1,163 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.codec;
+
+import org.apache.lucene.codecs.StoredFieldsFormat;
+import org.apache.lucene.codecs.StoredFieldsReader;
+import org.apache.lucene.codecs.StoredFieldsWriter;
+import org.apache.lucene.codecs.compressing.CompressionMode;
+import org.apache.lucene.codecs.lucene90.DeflateWithPresetDictCompressionMode;
+import org.apache.lucene.codecs.lucene90.LZ4WithPresetDictCompressionMode;
+import org.apache.lucene.codecs.lucene90.Lucene90StoredFieldsFormat;
+import org.apache.lucene.codecs.lucene90.compressing.Lucene90CompressingStoredFieldsFormat;
+import org.apache.lucene.codecs.lucene99.Lucene99Codec;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Stored field format used by pluggable codec
+ */
+public class Lucene99CoreStoredFieldsFormat extends StoredFieldsFormat {
+
+    /**
+     * A key that we use to map to a mode
+     */
+    public static final String MODE_KEY = Lucene99CoreStoredFieldsFormat.class.getSimpleName() + ".mode";
+
+    private final Lucene99Codec.Mode mode;
+
+    /**
+     * default constructor
+     */
+    public Lucene99CoreStoredFieldsFormat() {
+        this(Lucene99Codec.Mode.BEST_SPEED);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param mode The mode represents ZSTD or ZSTDNODICT
+     */
+
+    public Lucene99CoreStoredFieldsFormat(Lucene99Codec.Mode mode) {
+        this.mode = Objects.requireNonNull(mode);
+    }
+
+    /**
+     * Returns a {@link StoredFieldsReader} to load stored fields.
+     *
+     * @param directory The index directory.
+     * @param si        The SegmentInfo that stores segment information.
+     * @param fn        The fieldInfos.
+     * @param context   The IOContext that holds additional details on the merge/search context.
+     */
+    @Override
+    public StoredFieldsReader fieldsReader(Directory directory, SegmentInfo si, FieldInfos fn, IOContext context) throws IOException {
+
+        if (si.getAttribute(Lucene90StoredFieldsFormat.MODE_KEY) != null) {
+            String value = si.getAttribute(Lucene90StoredFieldsFormat.MODE_KEY);
+            Lucene90StoredFieldsFormat.Mode mode = Lucene90StoredFieldsFormat.Mode.valueOf(value);
+            return impl(mode).fieldsReader(directory, si, fn, context);
+        } else if (si.getAttribute(MODE_KEY) != null) {
+            String value = si.getAttribute(MODE_KEY);
+            Lucene99Codec.Mode mode = Lucene99Codec.Mode.valueOf(value);
+            return impl(mode).fieldsReader(directory, si, fn, context);
+        } else {
+            throw new IllegalStateException("missing value for " + MODE_KEY + " for segment: " + si.name);
+        }
+
+    }
+
+    private StoredFieldsFormat impl(Lucene90StoredFieldsFormat.Mode mode) {
+        switch (mode) {
+            case BEST_SPEED:
+                return getLZ4CompressingStoredFieldsFormat();
+            case BEST_COMPRESSION:
+                return getZlibCompressingStoredFieldsFormat();
+            default:
+                throw new AssertionError();
+        }
+    }
+
+    /**
+     * Returns a {@link StoredFieldsReader} to write stored fields.
+     *
+     * @param directory The index directory.
+     * @param si        The SegmentInfo that stores segment information.
+     * @param context   The IOContext that holds additional details on the merge/search context.
+     */
+
+    @Override
+    public StoredFieldsWriter fieldsWriter(Directory directory, SegmentInfo si, IOContext context) throws IOException {
+        String previous = si.putAttribute(MODE_KEY, mode.name());
+        if (previous != null && previous.equals(mode.name()) == false) {
+            throw new IllegalStateException(
+                "found existing value for " + MODE_KEY + " for segment: " + si.name + "old=" + previous + ", new=" + mode.name()
+            );
+        }
+        return impl(mode).fieldsWriter(directory, si, context);
+    }
+
+    StoredFieldsFormat impl(Lucene99Codec.Mode mode) {
+        switch (mode) {
+            case BEST_SPEED:
+                return getLZ4CompressingStoredFieldsFormat();
+            case BEST_COMPRESSION:
+                return getZlibCompressingStoredFieldsFormat();
+            default:
+                throw new AssertionError();
+        }
+    }
+
+    public Lucene99Codec.Mode getMode() {
+        return mode;
+    }
+
+    // Shoot for 10 sub blocks of 48kB each.
+    private static final int BEST_COMPRESSION_BLOCK_LENGTH = 10 * 48 * 1024;
+
+    /**
+     * Compression mode for {@link Lucene90StoredFieldsFormat.Mode#BEST_COMPRESSION}
+     */
+    public static final CompressionMode BEST_COMPRESSION_MODE = new DeflateWithPresetDictCompressionMode();
+
+    // Shoot for 10 sub blocks of 8kB each.
+    private static final int BEST_SPEED_BLOCK_LENGTH = 10 * 16 * 1024;
+
+    /**
+     * Compression mode for {@link Lucene90StoredFieldsFormat.Mode#BEST_SPEED}
+     */
+    public static final CompressionMode BEST_SPEED_MODE = new LZ4WithPresetDictCompressionMode();
+
+    private StoredFieldsFormat getLZ4CompressingStoredFieldsFormat() {
+        return new Lucene90CompressingStoredFieldsFormat(
+            "Lucene90StoredFieldsFastData",
+            BEST_SPEED_MODE,
+            BEST_SPEED_BLOCK_LENGTH,
+            1024,
+            10
+        );
+    }
+
+    private StoredFieldsFormat getZlibCompressingStoredFieldsFormat() {
+        return new Lucene90CompressingStoredFieldsFormat(
+            "Lucene90StoredFieldsHighData",
+            BEST_COMPRESSION_MODE,
+            BEST_COMPRESSION_BLOCK_LENGTH,
+            4096,
+            10
+        );
+    }
+
+}

--- a/server/src/main/java/org/opensearch/index/codec/Lucene99CoreStoredFieldsFormat.java
+++ b/server/src/main/java/org/opensearch/index/codec/Lucene99CoreStoredFieldsFormat.java
@@ -64,12 +64,7 @@ public class Lucene99CoreStoredFieldsFormat extends StoredFieldsFormat {
      */
     @Override
     public StoredFieldsReader fieldsReader(Directory directory, SegmentInfo si, FieldInfos fn, IOContext context) throws IOException {
-
-        if (si.getAttribute(Lucene90StoredFieldsFormat.MODE_KEY) != null) {
-            String value = si.getAttribute(Lucene90StoredFieldsFormat.MODE_KEY);
-            Lucene90StoredFieldsFormat.Mode mode = Lucene90StoredFieldsFormat.Mode.valueOf(value);
-            return impl(mode).fieldsReader(directory, si, fn, context);
-        } else if (si.getAttribute(MODE_KEY) != null) {
+        if (si.getAttribute(MODE_KEY) != null) {
             String value = si.getAttribute(MODE_KEY);
             Lucene99Codec.Mode mode = Lucene99Codec.Mode.valueOf(value);
             return impl(mode).fieldsReader(directory, si, fn, context);
@@ -77,17 +72,6 @@ public class Lucene99CoreStoredFieldsFormat extends StoredFieldsFormat {
             throw new IllegalStateException("missing value for " + MODE_KEY + " for segment: " + si.name);
         }
 
-    }
-
-    private StoredFieldsFormat impl(Lucene90StoredFieldsFormat.Mode mode) {
-        switch (mode) {
-            case BEST_SPEED:
-                return getLZ4CompressingStoredFieldsFormat();
-            case BEST_COMPRESSION:
-                return getZlibCompressingStoredFieldsFormat();
-            default:
-                throw new AssertionError();
-        }
     }
 
     /**

--- a/server/src/main/resources/META-INF/services/org.apache.lucene.codecs.Codec
+++ b/server/src/main/resources/META-INF/services/org.apache.lucene.codecs.Codec
@@ -1,0 +1,1 @@
+org.opensearch.index.codec.Lucene99CoreCodec

--- a/server/src/test/java/org/opensearch/index/codec/CodecTests.java
+++ b/server/src/test/java/org/opensearch/index/codec/CodecTests.java
@@ -67,8 +67,7 @@ public class CodecTests extends OpenSearchTestCase {
 
     public void testResolveDefaultCodecs() throws Exception {
         CodecService codecService = createCodecService(false);
-        assertThat(codecService.codec("default"), instanceOf(PerFieldMappingPostingFormatCodec.class));
-        assertThat(codecService.codec("default"), instanceOf(Lucene99Codec.class));
+        assertThat(codecService.codec("default"), instanceOf(Lucene99CoreCodec.class));
     }
 
     public void testDefault() throws Exception {
@@ -84,13 +83,13 @@ public class CodecTests extends OpenSearchTestCase {
     public void testLZ4() throws Exception {
         Codec codec = createCodecService(false).codec("lz4");
         assertStoredFieldsCompressionEquals(Lucene99Codec.Mode.BEST_SPEED, codec);
-        assert codec instanceof PerFieldMappingPostingFormatCodec;
+        assert codec instanceof Lucene99CoreCodec;
     }
 
     public void testZlib() throws Exception {
         Codec codec = createCodecService(false).codec("zlib");
         assertStoredFieldsCompressionEquals(Lucene99Codec.Mode.BEST_COMPRESSION, codec);
-        assert codec instanceof PerFieldMappingPostingFormatCodec;
+        assert codec instanceof Lucene99CoreCodec;
     }
 
     public void testBestCompressionWithCompressionLevel() {
@@ -144,7 +143,7 @@ public class CodecTests extends OpenSearchTestCase {
     // write some docs with it, inspect .si to see this was the used compression
     private void assertStoredFieldsCompressionEquals(Lucene99Codec.Mode expected, Codec actual) throws Exception {
         SegmentReader sr = getSegmentReader(actual);
-        String v = sr.getSegmentInfo().info.getAttribute(Lucene90StoredFieldsFormat.MODE_KEY);
+        String v = sr.getSegmentInfo().info.getAttribute(Lucene99CoreStoredFieldsFormat.MODE_KEY);
         assertNotNull(v);
         assertEquals(expected, Lucene99Codec.Mode.valueOf(v));
     }

--- a/server/src/test/java/org/opensearch/index/codec/CodecTests.java
+++ b/server/src/test/java/org/opensearch/index/codec/CodecTests.java
@@ -34,7 +34,6 @@ package org.opensearch.index.codec;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.codecs.Codec;
-import org.apache.lucene.codecs.lucene90.Lucene90StoredFieldsFormat;
 import org.apache.lucene.codecs.lucene99.Lucene99Codec;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Adds support to configure chunkSize aka Block Size for the ```default``` and ```best_compression``` codecs.

### Related Issues
Resolves #7475, #3769

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
