### PR TITLE
[Bug] Check phase name before SearchRequestOperationsListener onPhaseStart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Update supported version for max_shard_size parameter in Shrink API ([#11439](https://github.com/opensearch-project/OpenSearch/pull/11439))
 - Fix typo in API annotation check message ([11836](https://github.com/opensearch-project/OpenSearch/pull/11836))
 - Update supported version for must_exist parameter in update aliases API ([#11872](https://github.com/opensearch-project/OpenSearch/pull/11872))
+- [Bug] Check phase name before SearchRequestOperationsListener onPhaseStart ([#12035](https://github.com/opensearch-project/OpenSearch/pull/12035))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/opensearch/action/search/AbstractSearchAsyncAction.java
@@ -432,16 +432,18 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
     }
 
     private void onPhaseEnd(SearchRequestContext searchRequestContext) {
-        if (getCurrentPhase() != null) {
+        if (getCurrentPhase() != null && SearchPhaseName.isValidName(getName())) {
             long tookInNanos = System.nanoTime() - getCurrentPhase().getStartTimeInNanos();
             searchRequestContext.updatePhaseTookMap(getCurrentPhase().getName(), TimeUnit.NANOSECONDS.toMillis(tookInNanos));
+            this.searchRequestContext.getSearchRequestOperationsListener().onPhaseEnd(this, searchRequestContext);
         }
-        this.searchRequestContext.getSearchRequestOperationsListener().onPhaseEnd(this, searchRequestContext);
     }
 
-    private void onPhaseStart(SearchPhase phase) {
+    void onPhaseStart(SearchPhase phase) {
         setCurrentPhase(phase);
-        this.searchRequestContext.getSearchRequestOperationsListener().onPhaseStart(this);
+        if (SearchPhaseName.isValidName(phase.getName())) {
+            this.searchRequestContext.getSearchRequestOperationsListener().onPhaseStart(this);
+        }
     }
 
     private void onRequestEnd(SearchRequestContext searchRequestContext) {
@@ -714,7 +716,9 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
 
     @Override
     public final void onPhaseFailure(SearchPhase phase, String msg, Throwable cause) {
-        this.searchRequestContext.getSearchRequestOperationsListener().onPhaseFailure(this);
+        if (SearchPhaseName.isValidName(phase.getName())) {
+            this.searchRequestContext.getSearchRequestOperationsListener().onPhaseFailure(this);
+        }
         raisePhaseFailure(new SearchPhaseExecutionException(phase.getName(), msg, cause, buildShardFailures()));
     }
 

--- a/server/src/main/java/org/opensearch/action/search/SearchPhaseName.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchPhaseName.java
@@ -10,6 +10,9 @@ package org.opensearch.action.search;
 
 import org.opensearch.common.annotation.PublicApi;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * Enum for different Search Phases in OpenSearch
  *
@@ -25,6 +28,12 @@ public enum SearchPhaseName {
     CAN_MATCH("can_match");
 
     private final String name;
+    private static final Set<String> PHASE_NAMES = new HashSet<>();
+    static {
+        for (SearchPhaseName phaseName : SearchPhaseName.values()) {
+            PHASE_NAMES.add(phaseName.name);
+        }
+    }
 
     SearchPhaseName(final String name) {
         this.name = name;
@@ -32,5 +41,9 @@ public enum SearchPhaseName {
 
     public String getName() {
         return name;
+    }
+
+    public static boolean isValidName(String phaseName) {
+        return PHASE_NAMES.contains(phaseName);
     }
 }

--- a/server/src/main/java/org/opensearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/opensearch/action/search/TransportSearchAction.java
@@ -1238,7 +1238,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                         clusters,
                         searchRequestContext
                     );
-                    return new SearchPhase(action.getName()) {
+                    return new SearchPhase("none") {
                         @Override
                         public void run() {
                             action.start();


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The SearchRequestOperationsListener `onPhaseStart()` method is getting called TWICE consecutively during query phase in select cases. This occurs any time following can match phase. `onPhaseStart()` should only be called ONCE per search phase and must be paired with either `onPhaseEnd()` or `onPhaseFailure()`.

### Solution
1. Rename first instance of duplicate "query" phase to "none" phase as it is not yet reached `SearchQueryThenFetchAsyncAction`
2. Call onPhaseStart() only when current phase is one of 6 search phases we track
```
public enum SearchPhaseName {
    DFS_PRE_QUERY("dfs_pre_query"),
    QUERY("query"),
    FETCH("fetch"),
    DFS_QUERY("dfs_query"),
    EXPAND("expand"),
    CAN_MATCH("can_match");
}
```
### Testing
- existing UTs
- phase_took search
```
% curl -XGET 'localhost:9200/_search?pretty&phase_took' -H 'X-Opaque-Id: my-id' -H 'Content-Type: application/json' -d'{                               
 "query": { "match_all": {} }
}'

{
  "took" : 63,
  "phase_took" : {
    "dfs_pre_query" : 0,
    "query" : 32,
    "fetch" : 17,
    "dfs_query" : 0,
    "expand" : 0,
    "can_match" : 0
  },
  "timed_out" : false,
  "_shards" : {
    "total" : 10,
    "successful" : 10,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 2,
      "relation" : "eq"
    },
    "max_score" : 1.0,
    "hits" : [
      {
        "_index" : "test2",
        "_id" : "2",
        "_score" : 1.0,
        "_source" : {
          "field2" : "value2"
        }
      },
      {
        "_index" : "test2",
        "_id" : "1",
        "_score" : 1.0,
        "_source" : {
          "field1" : "value1"
        }
      }
    ]
  }
}
```
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
