### PR TITLE
Remove compounding retries within PrimaryShardReplicationSource

### DIFF
--- a/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/IndexingIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/IndexingIT.java
@@ -262,7 +262,6 @@ public class IndexingIT extends AbstractRollingTestCase {
      * @throws Exception if index creation fail
      * @throws UnsupportedOperationException if cluster type is unknown
      */
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/7679")
     public void testIndexingWithSegRep() throws Exception {
         if (UPGRADE_FROM_VERSION.before(Version.V_2_4_0)) {
             logger.info("--> Skip test for version {} where segment replication feature is not available", UPGRADE_FROM_VERSION);

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/SegmentReplicationUsingRemoteStoreDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/SegmentReplicationUsingRemoteStoreDisruptionIT.java
@@ -23,8 +23,6 @@ import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.replication.SegmentReplicationState;
 import org.opensearch.indices.replication.SegmentReplicationTarget;
 import org.opensearch.indices.replication.SegmentReplicationTargetService;
-import org.opensearch.indices.replication.common.ReplicationCollection;
-import org.opensearch.test.InternalTestCluster;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.disruption.SlowClusterStateProcessing;
 
@@ -32,6 +30,8 @@ import java.nio.file.Path;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 
 /**
  * This class runs tests with remote store + segRep while blocking file downloads
@@ -59,22 +59,18 @@ public class SegmentReplicationUsingRemoteStoreDisruptionIT extends AbstractRemo
         indexSingleDoc();
         refresh(INDEX_NAME);
         waitForBlock(replicaNode, REPOSITORY_NAME, TimeValue.timeValueSeconds(10));
-        final SegmentReplicationState state = targetService.getOngoingEventSegmentReplicationState(indexShard.shardId());
-        assertEquals(SegmentReplicationState.Stage.GET_FILES, state.getStage());
-        ReplicationCollection.ReplicationRef<SegmentReplicationTarget> segmentReplicationTargetReplicationRef = targetService.get(
-            state.getReplicationId()
-        );
-        final SegmentReplicationTarget segmentReplicationTarget = segmentReplicationTargetReplicationRef.get();
-        // close the target ref here otherwise it will hold a refcount
-        segmentReplicationTargetReplicationRef.close();
+        SegmentReplicationTarget segmentReplicationTarget = targetService.get(indexShard.shardId());
         assertNotNull(segmentReplicationTarget);
+        assertEquals(SegmentReplicationState.Stage.GET_FILES, segmentReplicationTarget.state().getStage());
         assertTrue(segmentReplicationTarget.refCount() > 0);
-        internalCluster().stopRandomNode(InternalTestCluster.nameFilter(primaryNode));
-        assertBusy(() -> {
-            assertTrue(indexShard.routingEntry().primary());
-            assertNull(targetService.getOngoingEventSegmentReplicationState(indexShard.shardId()));
-            assertEquals("Target should be closed", 0, segmentReplicationTarget.refCount());
-        });
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareUpdateSettings(INDEX_NAME)
+                .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0))
+        );
+        assertNull(targetService.getOngoingEventSegmentReplicationState(indexShard.shardId()));
+        assertEquals("Target should be closed", 0, segmentReplicationTarget.refCount());
         unblockNode(REPOSITORY_NAME, replicaNode);
         cleanupRepo();
     }
@@ -85,7 +81,6 @@ public class SegmentReplicationUsingRemoteStoreDisruptionIT extends AbstractRemo
 
         final Set<String> dataNodeNames = internalCluster().getDataNodeNames();
         final String replicaNode = getNode(dataNodeNames, false);
-        final String primaryNode = getNode(dataNodeNames, true);
 
         SegmentReplicationTargetService targetService = internalCluster().getInstance(SegmentReplicationTargetService.class, replicaNode);
         ensureGreen(INDEX_NAME);
@@ -94,22 +89,18 @@ public class SegmentReplicationUsingRemoteStoreDisruptionIT extends AbstractRemo
         indexSingleDoc();
         refresh(INDEX_NAME);
         waitForBlock(replicaNode, REPOSITORY_NAME, TimeValue.timeValueSeconds(10));
-        final SegmentReplicationState state = targetService.getOngoingEventSegmentReplicationState(indexShard.shardId());
-        assertEquals(SegmentReplicationState.Stage.GET_CHECKPOINT_INFO, state.getStage());
-        ReplicationCollection.ReplicationRef<SegmentReplicationTarget> segmentReplicationTargetReplicationRef = targetService.get(
-            state.getReplicationId()
-        );
-        final SegmentReplicationTarget segmentReplicationTarget = segmentReplicationTargetReplicationRef.get();
-        // close the target ref here otherwise it will hold a refcount
-        segmentReplicationTargetReplicationRef.close();
+        SegmentReplicationTarget segmentReplicationTarget = targetService.get(indexShard.shardId());
         assertNotNull(segmentReplicationTarget);
+        assertEquals(SegmentReplicationState.Stage.GET_CHECKPOINT_INFO, segmentReplicationTarget.state().getStage());
         assertTrue(segmentReplicationTarget.refCount() > 0);
-        internalCluster().stopRandomNode(InternalTestCluster.nameFilter(primaryNode));
-        assertBusy(() -> {
-            assertTrue(indexShard.routingEntry().primary());
-            assertNull(targetService.getOngoingEventSegmentReplicationState(indexShard.shardId()));
-            assertEquals("Target should be closed", 0, segmentReplicationTarget.refCount());
-        });
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareUpdateSettings(INDEX_NAME)
+                .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0))
+        );
+        assertNull(targetService.get(indexShard.shardId()));
+        assertEquals("Target should be closed", 0, segmentReplicationTarget.refCount());
         unblockNode(REPOSITORY_NAME, replicaNode);
         cleanupRepo();
     }

--- a/server/src/main/java/org/opensearch/indices/replication/PrimaryShardReplicationSource.java
+++ b/server/src/main/java/org/opensearch/indices/replication/PrimaryShardReplicationSource.java
@@ -8,16 +8,14 @@
 
 package org.opensearch.indices.replication;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.opensearch.action.ActionListenerResponseHandler;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.core.action.ActionListener;
-import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.store.StoreFileMetadata;
 import org.opensearch.indices.recovery.RecoverySettings;
-import org.opensearch.indices.recovery.RetryableTransportClient;
 import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
+import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportRequestOptions;
 import org.opensearch.transport.TransportService;
 
@@ -35,9 +33,7 @@ import static org.opensearch.indices.replication.SegmentReplicationSourceService
  */
 public class PrimaryShardReplicationSource implements SegmentReplicationSource {
 
-    private static final Logger logger = LogManager.getLogger(PrimaryShardReplicationSource.class);
-
-    private final RetryableTransportClient transportClient;
+    private final TransportService transportService;
 
     private final DiscoveryNode sourceNode;
     private final DiscoveryNode targetNode;
@@ -52,12 +48,7 @@ public class PrimaryShardReplicationSource implements SegmentReplicationSource {
         DiscoveryNode sourceNode
     ) {
         this.targetAllocationId = targetAllocationId;
-        this.transportClient = new RetryableTransportClient(
-            transportService,
-            sourceNode,
-            recoverySettings.internalActionRetryTimeout(),
-            logger
-        );
+        this.transportService = transportService;
         this.sourceNode = sourceNode;
         this.targetNode = targetNode;
         this.recoverySettings = recoverySettings;
@@ -69,10 +60,14 @@ public class PrimaryShardReplicationSource implements SegmentReplicationSource {
         ReplicationCheckpoint checkpoint,
         ActionListener<CheckpointInfoResponse> listener
     ) {
-        final Writeable.Reader<CheckpointInfoResponse> reader = CheckpointInfoResponse::new;
-        final ActionListener<CheckpointInfoResponse> responseListener = ActionListener.map(listener, r -> r);
         final CheckpointInfoRequest request = new CheckpointInfoRequest(replicationId, targetAllocationId, targetNode, checkpoint);
-        transportClient.executeRetryableAction(GET_CHECKPOINT_INFO, request, responseListener, reader);
+        transportService.sendRequest(
+            sourceNode,
+            GET_CHECKPOINT_INFO,
+            request,
+            TransportRequestOptions.builder().withTimeout(recoverySettings.internalActionRetryTimeout()).build(),
+            new ActionListenerResponseHandler<>(listener, CheckpointInfoResponse::new, ThreadPool.Names.GENERIC)
+        );
     }
 
     @Override
@@ -88,8 +83,6 @@ public class PrimaryShardReplicationSource implements SegmentReplicationSource {
         // MultiFileWriter takes care of progress tracking for downloads in this scenario
         // TODO: Move state management and tracking into replication methods and use chunking and data
         // copy mechanisms only from MultiFileWriter
-        final Writeable.Reader<GetSegmentFilesResponse> reader = GetSegmentFilesResponse::new;
-        final ActionListener<GetSegmentFilesResponse> responseListener = ActionListener.map(listener, r -> r);
         final GetSegmentFilesRequest request = new GetSegmentFilesRequest(
             replicationId,
             targetAllocationId,
@@ -97,20 +90,17 @@ public class PrimaryShardReplicationSource implements SegmentReplicationSource {
             filesToFetch,
             checkpoint
         );
-        final TransportRequestOptions options = TransportRequestOptions.builder()
-            .withTimeout(recoverySettings.internalActionLongTimeout())
-            .build();
-        transportClient.executeRetryableAction(GET_SEGMENT_FILES, request, options, responseListener, reader);
+        transportService.sendRequest(
+            sourceNode,
+            GET_SEGMENT_FILES,
+            request,
+            TransportRequestOptions.builder().withTimeout(recoverySettings.internalActionLongTimeout()).build(),
+            new ActionListenerResponseHandler<>(listener, GetSegmentFilesResponse::new, ThreadPool.Names.GENERIC)
+        );
     }
 
     @Override
     public String getDescription() {
         return sourceNode.getName();
     }
-
-    @Override
-    public void cancel() {
-        transportClient.cancel();
-    }
-
 }

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTarget.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTarget.java
@@ -84,6 +84,16 @@ public class SegmentReplicationTarget extends ReplicationTarget {
     }
 
     @Override
+    protected void onCancel(String reason) {
+        try {
+            notifyListener(new ReplicationFailedException(reason), false);
+        } finally {
+            source.cancel();
+            cancellableThreads.cancel(reason);
+        }
+    }
+
+    @Override
     protected String getPrefix() {
         return REPLICATION_PREFIX + UUIDs.randomBase64UUID() + ".";
     }
@@ -318,18 +328,6 @@ public class SegmentReplicationTarget extends ReplicationTarget {
             if (store != null) {
                 store.decRef();
             }
-        }
-    }
-
-    /**
-     * Trigger a cancellation, this method will not close the target a subsequent call to #fail is required from target service.
-     */
-    @Override
-    public void cancel(String reason) {
-        if (finished.get() == false) {
-            logger.trace(new ParameterizedMessage("Cancelling replication for target {}", description()));
-            cancellableThreads.cancel(reason);
-            source.cancel();
         }
     }
 }

--- a/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetServiceTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetServiceTests.java
@@ -620,6 +620,7 @@ public class SegmentReplicationTargetServiceTests extends IndexShardTestCase {
     }
 
     public void testTargetCancelledBeforeStartInvoked() {
+        final String cancelReason = "test";
         final SegmentReplicationTarget target = new SegmentReplicationTarget(
             replicaShard,
             primaryShard.getLatestReplicationCheckpoint(),
@@ -633,12 +634,12 @@ public class SegmentReplicationTargetServiceTests extends IndexShardTestCase {
                 @Override
                 public void onReplicationFailure(SegmentReplicationState state, ReplicationFailedException e, boolean sendShardFailure) {
                     // failures leave state object in last entered stage.
-                    assertEquals(SegmentReplicationState.Stage.GET_CHECKPOINT_INFO, state.getStage());
-                    assertTrue(e.getCause() instanceof CancellableThreads.ExecutionCancelledException);
+                    assertEquals(SegmentReplicationState.Stage.INIT, state.getStage());
+                    assertEquals(cancelReason, e.getMessage());
                 }
             }
         );
-        target.cancel("test");
+        target.cancel(cancelReason);
         sut.startReplication(target);
     }
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This change fixes and unmutes segrep bwc test testIndexingWithSegRep.

This change removes retries within PrimaryShardReplicationSource and relies on retries in one place at the start of replication. This is done within SegmentReplicationTargetService's processLatestReceivedCheckpoint after a failure/success occurs. The timeout on these retries is the cause of flaky failures from SegmentReplication's bwc test within IndexingIT, that can occur on node disconnect.  The retries will persist for over ~1m to the same primary node that has been relocated/shut down and cause the test to timeout.

This change also includes simplifications to the cancellation flow on the target service before the shard is closed. Previously we "request" a cancel that does not remove the target from the ongoing replications collection until a cancellation failure is thrown. The transport calls from PrimaryShardReplicationSource are no longer wrapped in CancellableThreads by the client so a call to "cancel" will not throw. Instead we now immediately remove the target and decref/close it.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/7679

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
