### PR TITLE
Fix Flaky CloseIndexIT.testCloseWhileDeletingIndices

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/state/CloseIndexIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/state/CloseIndexIT.java
@@ -287,7 +287,7 @@ public class CloseIndexIT extends OpenSearchIntegTestCase {
                     throw new AssertionError(e);
                 }
                 try {
-                    assertAcked(client().admin().indices().prepareDelete(indexToDelete));
+                    assertAcked(client().admin().indices().prepareDelete(indexToDelete).setTimeout("60s"));
                 } catch (final Exception e) {
                     assertException(e, indexToDelete);
                 }
@@ -301,7 +301,7 @@ public class CloseIndexIT extends OpenSearchIntegTestCase {
                     throw new AssertionError(e);
                 }
                 try {
-                    client().admin().indices().prepareClose(indexToClose).get();
+                    client().admin().indices().prepareClose(indexToClose).setTimeout("60s").get();
                 } catch (final Exception e) {
                     assertException(e, indexToClose);
                 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The test was errorring out due to timeout.

> java.lang.AssertionError: Unexpected exception: ProcessClusterEventTimeoutException[failed to process cluster event (add-block-index-to-close [[vquumsvuoq/KiZV1g8bRsWoscd3K-G7Tg]]) within 30s]

Increased the timeout to 60s. 5000 iterations passed locally.

Screenshot of 1000 iterations passing:
<img width="1692" alt="image" src="https://github.com/opensearch-project/OpenSearch/assets/25262500/d81ae8bf-bb45-453e-bc65-e0ff7adaa9ee">




### Related Issues
Resolves #11610

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
