### PR TITLE
Fix flaky SegRep test testScrollCreatedOnReplica

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -1079,8 +1079,16 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
         // there should be no active readers, snapshots, or on-disk commits containing the snapshotted files, check that they have been
         // deleted.
         Set<String> latestCommitSegments = new HashSet<>(replicaShard.store().readLastCommittedSegmentsInfo().files(false));
-        assertEquals("Snapshotted files are no longer part of the latest commit", Collections.emptySet(), Sets.intersection(latestCommitSegments, snapshottedSegments));
-        assertEquals("All snapshotted files should be deleted", Collections.emptySet(), Sets.intersection(filesAfterClearScroll, snapshottedSegments));
+        assertEquals(
+            "Snapshotted files are no longer part of the latest commit",
+            Collections.emptySet(),
+            Sets.intersection(latestCommitSegments, snapshottedSegments)
+        );
+        assertEquals(
+            "All snapshotted files should be deleted",
+            Collections.emptySet(),
+            Sets.intersection(filesAfterClearScroll, snapshottedSegments)
+        );
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/engine/ReplicaFileTracker.java
+++ b/server/src/main/java/org/opensearch/index/engine/ReplicaFileTracker.java
@@ -17,7 +17,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 /**
  * This class is heavily influenced by Lucene's ReplicaFileDeleter class used to keep track of
@@ -31,10 +31,10 @@ final class ReplicaFileTracker {
 
     public static final Logger logger = LogManager.getLogger(ReplicaFileTracker.class);
     private final Map<String, Integer> refCounts = new HashMap<>();
-    private final BiConsumer<String, String> fileDeleter;
+    private final Consumer<String> fileDeleter;
     private final Set<String> EXCLUDE_FILES = Set.of("write.lock");
 
-    public ReplicaFileTracker(BiConsumer<String, String> fileDeleter) {
+    public ReplicaFileTracker(Consumer<String> fileDeleter) {
         this.fileDeleter = fileDeleter;
     }
 
@@ -82,7 +82,7 @@ final class ReplicaFileTracker {
 
     private synchronized void delete(String fileName) {
         assert canDelete(fileName);
-        fileDeleter.accept("delete unreferenced", fileName);
+        fileDeleter.accept(fileName);
     }
 
     private synchronized boolean canDelete(String fileName) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This change fixes flakiness with segrep test for scroll requests.  The flakiness was with an assertion that all segments snapshotted by the scroll were deleted from disk after the scroll was cleared.  The failures were caused because the snapshotted segments were still referenced by the latest on-disk commit point that is always preserved.

The test was doing a lot of crazy random merges/deletes etc that made it difficult to follow why those files were sneaking in as part of the latest commit.
To make this easier to reason about I've simplified the test flow to:
1. Index 1 doc
2. Create the scroll
3. Index a few more docs
4. Refresh to create segments
5. Copy out segments
6. force merge to 1 segment
7. Copy out post force merge
8. Assert segments still exist on-disk
9. Clear scroll & assert segments are cleared

I've run this ~6k times without failure.

This PR also contains a bug fix to ReplicaFileDeleter to take a Consumer<String> instead of a BiConsumer<String, String>.  We use `Store::deleteQuiet` to purge files from disk which accepts a varargs of file names and does not have a reason parameter.  This ensures we aren't passing the literal "delete unreferenced" as a file to be deleted.  This would get passed to deleteQuiet and a NoSuchFileException would get swallowed.

### Related Issues
Resolves #10769

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
