### PR TITLE
Flaky testRelocateWhileContinuouslyIndexingAndWaitingForRefresh test: Enable trace logs on replication and recovery

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationRelocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationRelocationIT.java
@@ -219,6 +219,7 @@ public class SegmentReplicationRelocationIT extends SegmentReplicationBaseIT {
      * This test verifies primary recovery behavior with continuous ingestion
      *
      */
+    @TestLogging(reason = "Enable trace logs from replication and recovery package", value = "org.opensearch.indices.recovery:TRACE,org.opensearch.indices.replication:TRACE")
     public void testRelocateWhileContinuouslyIndexingAndWaitingForRefresh() throws Exception {
         final String primary = internalCluster().startNode();
         createIndex(1);


### PR DESCRIPTION
### Description
This changes enables trace logging on replication and recovery package for `testRelocateWhileContinuouslyIndexingAndWaitingForRefresh` test. This test currently fails due to documents not present on target primary shard post shard relocation. 

https://build.ci.opensearch.org/job/gradle-check/30438/testReport/org.opensearch.indices.replication/SegmentReplicationRelocationIT/testRelocateWhileContinuouslyIndexingAndWaitingForRefresh_2/
```
java.lang.AssertionError: Expected search hits on node: node_t2 to be at least 1000 but was: 873
```

### Related Issues
Related: #6778 

### Check List
- [ ] ~New functionality includes testing.~
  - [ ] ~All tests pass~
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [ ] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
