### PR TITLE
Add advance(int) for numeric values in order to allow point based optimization to kick in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -250,6 +250,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix memory leak issue in ReorganizingLongHash ([#11953](https://github.com/opensearch-project/OpenSearch/issues/11953))
 - Prevent setting remote_snapshot store type on index creation ([#11867](https://github.com/opensearch-project/OpenSearch/pull/11867))
 - [BUG] Fix remote shards balancer when filtering throttled nodes ([#11724](https://github.com/opensearch-project/OpenSearch/pull/11724))
+- Add advance(int) for numeric values in order to allow point based optimization to kick in ([#12089](https://github.com/opensearch-project/OpenSearch/pull/12089))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/index/fielddata/AbstractNumericDocValues.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/AbstractNumericDocValues.java
@@ -43,6 +43,9 @@ import java.io.IOException;
  * aggregations, which only use {@link #advanceExact(int)} and
  * {@link #longValue()}.
  *
+ * In case when optimizations based on point values are used, the {@link #advance(int)}
+ * and, optionally, {@link #cost()} have to be implemented as well.
+ *
  * @opensearch.internal
  */
 public abstract class AbstractNumericDocValues extends NumericDocValues {

--- a/server/src/main/java/org/opensearch/index/fielddata/FieldData.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/FieldData.java
@@ -37,6 +37,7 @@ import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.common.Numbers;
 import org.opensearch.common.geo.GeoPoint;
@@ -76,6 +77,10 @@ public enum FieldData {
                 throw new UnsupportedOperationException();
             }
 
+            @Override
+            public int advance(int target) throws IOException {
+                return DocIdSetIterator.NO_MORE_DOCS;
+            }
         };
     }
 
@@ -561,6 +566,10 @@ public enum FieldData {
             return values.advanceExact(doc);
         }
 
+        @Override
+        public int advance(int target) throws IOException {
+            return values.advance(target);
+        }
     }
 
     /**
@@ -591,6 +600,10 @@ public enum FieldData {
             return values.docValueCount();
         }
 
+        @Override
+        public int advance(int target) throws IOException {
+            return values.advance(target);
+        }
     }
 
     /**
@@ -620,6 +633,12 @@ public enum FieldData {
 
         @Override
         public int docID() {
+            return docID;
+        }
+
+        @Override
+        public int advance(int target) throws IOException {
+            docID = values.advance(target);
             return docID;
         }
     }
@@ -683,6 +702,11 @@ public enum FieldData {
             public long longValue() throws IOException {
                 return value;
             }
+
+            @Override
+            public int advance(int target) throws IOException {
+                return values.advance(target);
+            }
         };
     }
 
@@ -715,6 +739,11 @@ public enum FieldData {
             public long longValue() throws IOException {
                 return value.longValue();
             }
+
+            @Override
+            public int advance(int target) throws IOException {
+                return values.advance(target);
+            }
         };
     }
 
@@ -741,6 +770,11 @@ public enum FieldData {
             @Override
             public double doubleValue() throws IOException {
                 return value;
+            }
+
+            @Override
+            public int advance(int target) throws IOException {
+                return values.advance(target);
             }
         };
     }

--- a/server/src/main/java/org/opensearch/index/fielddata/NumericDoubleValues.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/NumericDoubleValues.java
@@ -71,6 +71,11 @@ public abstract class NumericDoubleValues extends DoubleValues {
             public int docID() {
                 return docID;
             }
+
+            @Override
+            public int advance(int target) throws IOException {
+                return NumericDoubleValues.this.advance(target);
+            }
         };
     }
 
@@ -95,6 +100,23 @@ public abstract class NumericDoubleValues extends DoubleValues {
             public int docID() {
                 return docID;
             }
+
+            @Override
+            public int advance(int target) throws IOException {
+                return NumericDoubleValues.this.advance(target);
+            }
         };
+    }
+
+    /**
+     * Advances to the first beyond the current whose document number is greater than or equal to
+     * <i>target</i>, and returns the document number itself. Exhausts the iterator and returns {@link
+     * org.apache.lucene.search.DocIdSetIterator#NO_MORE_DOCS} if <i>target</i> is greater than the highest document number in the set.
+     *
+     * This method is being used by {@link org.apache.lucene.search.comparators.NumericComparator.NumericLeafComparator} when point values optimization kicks
+     * in and is implemented by most numeric types.
+     */
+    public int advance(int target) throws IOException {
+        throw new UnsupportedOperationException();
     }
 }

--- a/server/src/main/java/org/opensearch/index/fielddata/SingletonSortedNumericDoubleValues.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/SingletonSortedNumericDoubleValues.java
@@ -69,4 +69,8 @@ final class SingletonSortedNumericDoubleValues extends SortedNumericDoubleValues
         return in.doubleValue();
     }
 
+    @Override
+    public int advance(int target) throws IOException {
+        return in.advance(target);
+    }
 }

--- a/server/src/main/java/org/opensearch/index/fielddata/SortableLongBitsNumericDocValues.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/SortableLongBitsNumericDocValues.java
@@ -74,4 +74,9 @@ final class SortableLongBitsNumericDocValues extends AbstractNumericDocValues {
         return values;
     }
 
+    @Override
+    public int advance(int target) throws IOException {
+        return values.advance(target);
+    }
+
 }

--- a/server/src/main/java/org/opensearch/index/fielddata/SortableLongBitsToNumericDoubleValues.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/SortableLongBitsToNumericDoubleValues.java
@@ -67,4 +67,8 @@ final class SortableLongBitsToNumericDoubleValues extends NumericDoubleValues {
         return values;
     }
 
+    @Override
+    public int advance(int target) throws IOException {
+        return values.advance(target);
+    }
 }

--- a/server/src/main/java/org/opensearch/index/fielddata/SortableLongBitsToSortedNumericDoubleValues.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/SortableLongBitsToSortedNumericDoubleValues.java
@@ -72,4 +72,8 @@ final class SortableLongBitsToSortedNumericDoubleValues extends SortedNumericDou
         return values;
     }
 
+    @Override
+    public int advance(int target) throws IOException {
+        return values.advance(target);
+    }
 }

--- a/server/src/main/java/org/opensearch/index/fielddata/SortedNumericDoubleValues.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/SortedNumericDoubleValues.java
@@ -70,4 +70,15 @@ public abstract class SortedNumericDoubleValues {
      */
     public abstract int docValueCount();
 
+    /**
+     * Advances to the first beyond the current whose document number is greater than or equal to
+     * <i>target</i>, and returns the document number itself. Exhausts the iterator and returns {@link
+     * org.apache.lucene.search.DocIdSetIterator#NO_MORE_DOCS} if <i>target</i> is greater than the highest document number in the set.
+     *
+     * This method is being used by {@link org.apache.lucene.search.comparators.NumericComparator.NumericLeafComparator} when point values optimization kicks
+     * in and is implemented by most numeric types.
+     */
+    public int advance(int target) throws IOException {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/server/src/main/java/org/opensearch/index/fielddata/UnsignedLongToNumericDoubleValues.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/UnsignedLongToNumericDoubleValues.java
@@ -42,4 +42,8 @@ final class UnsignedLongToNumericDoubleValues extends NumericDoubleValues {
         return values;
     }
 
+    @Override
+    public int advance(int target) throws IOException {
+        return values.advance(target);
+    }
 }

--- a/server/src/main/java/org/opensearch/index/fielddata/UnsignedLongToSortedNumericDoubleValues.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/UnsignedLongToSortedNumericDoubleValues.java
@@ -47,4 +47,8 @@ final class UnsignedLongToSortedNumericDoubleValues extends SortedNumericDoubleV
         return values;
     }
 
+    @Override
+    public int advance(int target) throws IOException {
+        return values.advance(target);
+    }
 }

--- a/server/src/main/java/org/opensearch/index/fielddata/plain/SortedNumericIndexFieldData.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/plain/SortedNumericIndexFieldData.java
@@ -336,6 +336,11 @@ public class SortedNumericIndexFieldData extends IndexNumericFieldData {
         public boolean advanceExact(int doc) throws IOException {
             return in.advanceExact(doc);
         }
+
+        @Override
+        public int advance(int target) throws IOException {
+            return in.advance(target);
+        }
     }
 
     /**
@@ -363,6 +368,11 @@ public class SortedNumericIndexFieldData extends IndexNumericFieldData {
         @Override
         public int docValueCount() {
             return in.docValueCount();
+        }
+
+        @Override
+        public int advance(int target) throws IOException {
+            return in.advance(target);
         }
     }
 
@@ -434,6 +444,11 @@ public class SortedNumericIndexFieldData extends IndexNumericFieldData {
         public boolean advanceExact(int doc) throws IOException {
             return in.advanceExact(doc);
         }
+
+        @Override
+        public int advance(int target) throws IOException {
+            return in.advance(target);
+        }
     }
 
     /**
@@ -461,6 +476,11 @@ public class SortedNumericIndexFieldData extends IndexNumericFieldData {
         @Override
         public int docValueCount() {
             return in.docValueCount();
+        }
+
+        @Override
+        public int advance(int target) throws IOException {
+            return in.advance(target);
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/query/functionscore/DecayFunctionBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/functionscore/DecayFunctionBuilder.java
@@ -561,6 +561,11 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
             final SortedNumericDoubleValues doubleValues = fieldData.load(context).getDoubleValues();
             return FieldData.replaceMissing(mode.select(new SortingNumericDoubleValues() {
                 @Override
+                public int advance(int target) throws IOException {
+                    return doubleValues.advance(target);
+                }
+
+                @Override
                 public boolean advanceExact(int docId) throws IOException {
                     if (doubleValues.advanceExact(docId)) {
                         int n = doubleValues.docValueCount();

--- a/server/src/main/java/org/opensearch/search/MultiValueMode.java
+++ b/server/src/main/java/org/opensearch/search/MultiValueMode.java
@@ -685,6 +685,11 @@ public enum MultiValueMode implements Writeable {
                 public double doubleValue() throws IOException {
                     return this.value;
                 }
+
+                @Override
+                public int advance(int target) throws IOException {
+                    return values.advance(target);
+                }
             };
         }
     }
@@ -744,6 +749,11 @@ public enum MultiValueMode implements Writeable {
             @Override
             public double doubleValue() throws IOException {
                 return lastEmittedValue;
+            }
+
+            @Override
+            public int advance(int target) throws IOException {
+                return values.advance(target);
             }
         };
     }

--- a/server/src/main/java/org/opensearch/search/aggregations/support/MissingValues.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/support/MissingValues.java
@@ -227,6 +227,10 @@ public enum MissingValues {
                 return "anon SortedNumericDoubleValues of [" + super.toString() + "]";
             }
 
+            @Override
+            public int advance(int target) throws IOException {
+                return values.advance(target);
+            }
         };
     }
 

--- a/server/src/main/java/org/opensearch/search/aggregations/support/ValuesSource.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/support/ValuesSource.java
@@ -576,6 +576,11 @@ public abstract class ValuesSource {
                     }
                     return false;
                 }
+
+                @Override
+                public int advance(int target) throws IOException {
+                    return doubleValues.advance(target);
+                }
             }
         }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Add advance(int) for numeric values in order to allow point based optimization to kick in, huge thanks to @jed326 for investigating the cause of the issue (quoting below):

It looks like we encounter the problem with sort for, double_value, and unsigned_long_value as well.

The problem seems to be related to this change: https://github.com/apache/lucene/pull/12405
Specifically: https://github.com/apache/lucene/commit/d9109907bcafd9e3ac6a23bff9e5b1b2605bb2f8#diff-79c6a57519ecd1ef504629e62e13d17859a4ffedc58f4602e583ce758a15adc8R291-R295

﻿﻿﻿﻿﻿﻿﻿As the comparator is getting set to NumericComparator::NumericLeafComparator. In the non-concurrent search case we don't go into the if statement so the competitiveIterator is not updated.

The if statement seems to be related to the number of documents on the segment though so it seems like we could still see this in the non-concurrent search case.

There are multiple ways to fix the issue:
 - disable optimization (not desirable)
 - add implementation of the `advance(int)` to `NumericDoubleValues` and `SortedNumericDoubleValues`, attempted in this pull request, since in most cases we delegate to `NumericDocValues`, the `advance(int)` is available in there 

### Related Issues
Closes https://github.com/opensearch-project/OpenSearch/issues/11875

<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
