### PR TITLE
Tracing for deep search path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Allow to pass the list settings through environment variables (like [], ["a", "b", "c"], ...) ([#10625](https://github.com/opensearch-project/OpenSearch/pull/10625))
 - [Admission Control] Integrate CPU AC with ResourceUsageCollector and add CPU AC stats to nodes/stats ([#10887](https://github.com/opensearch-project/OpenSearch/pull/10887))
 - [S3 Repository] Add setting to control connection count for sync client ([#12028](https://github.com/opensearch-project/OpenSearch/pull/12028))
+- Tracing for deep search path ([#12099](https://github.com/opensearch-project/OpenSearch/pull/12099))
 
 ### Dependencies
 - Bump `log4j-core` from 2.18.0 to 2.19.0

--- a/server/src/main/java/org/opensearch/action/search/SearchRequestCoordinatorTrace.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequestCoordinatorTrace.java
@@ -1,0 +1,71 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.search;
+
+import org.opensearch.telemetry.tracing.AttributeNames;
+import org.opensearch.telemetry.tracing.Span;
+import org.opensearch.telemetry.tracing.SpanBuilder;
+import org.opensearch.telemetry.tracing.SpanContext;
+import org.opensearch.telemetry.tracing.Tracer;
+
+import static org.opensearch.core.common.Strings.capitalize;
+
+/**
+ * Listener for search request tracing on the coordinator node
+ *
+ * @opensearch.internal
+ */
+public final class SearchRequestCoordinatorTrace extends SearchRequestOperationsListener {
+    private final Tracer tracer;
+
+    public SearchRequestCoordinatorTrace(Tracer tracer) {
+        this.tracer = tracer;
+    }
+
+    @Override
+    void onPhaseStart(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
+        searchRequestContext.setPhaseSpan(
+            tracer.startSpan(
+                SpanBuilder.from(
+                    "coord" + capitalize(context.getCurrentPhase().getName()),
+                    new SpanContext(searchRequestContext.getRequestSpan())
+                )
+            )
+        );
+    }
+
+    @Override
+    void onPhaseEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
+        searchRequestContext.getPhaseSpan().endSpan();
+    }
+
+    @Override
+    void onPhaseFailure(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
+        searchRequestContext.getPhaseSpan().endSpan();
+    }
+
+    @Override
+    void onRequestEnd(SearchRequestContext searchRequestContext) {
+        Span requestSpan = searchRequestContext.getRequestSpan();
+
+        // add response-related attributes on request end
+        requestSpan.addAttribute(
+            AttributeNames.TOTAL_HITS,
+            searchRequestContext.totalHits() == null ? "0" : searchRequestContext.totalHits().toString()
+        );
+        requestSpan.addAttribute(
+            AttributeNames.SHARDS,
+            searchRequestContext.formattedShardStats().isEmpty() ? "null" : searchRequestContext.formattedShardStats()
+        );
+        requestSpan.addAttribute(
+            AttributeNames.SOURCE,
+            searchRequestContext.getSearchRequest().source() == null ? "null" : searchRequestContext.getSearchRequest().source().toString()
+        );
+    }
+}

--- a/server/src/main/java/org/opensearch/action/search/SearchRequestOperationsListener.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequestOperationsListener.java
@@ -31,15 +31,15 @@ public abstract class SearchRequestOperationsListener {
         this.enabled = enabled;
     }
 
-    abstract void onPhaseStart(SearchPhaseContext context);
+    abstract void onPhaseStart(SearchPhaseContext context, SearchRequestContext searchRequestContext);
 
     abstract void onPhaseEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext);
 
-    abstract void onPhaseFailure(SearchPhaseContext context);
+    abstract void onPhaseFailure(SearchPhaseContext context, SearchRequestContext searchRequestContext);
 
     void onRequestStart(SearchRequestContext searchRequestContext) {}
 
-    void onRequestEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext) {}
+    void onRequestEnd(SearchRequestContext searchRequestContext) {}
 
     boolean isEnabled(SearchRequest searchRequest) {
         return isEnabled();
@@ -69,10 +69,10 @@ public abstract class SearchRequestOperationsListener {
         }
 
         @Override
-        void onPhaseStart(SearchPhaseContext context) {
+        void onPhaseStart(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
             for (SearchRequestOperationsListener listener : listeners) {
                 try {
-                    listener.onPhaseStart(context);
+                    listener.onPhaseStart(context, searchRequestContext);
                 } catch (Exception e) {
                     logger.warn(() -> new ParameterizedMessage("onPhaseStart listener [{}] failed", listener), e);
                 }
@@ -91,10 +91,10 @@ public abstract class SearchRequestOperationsListener {
         }
 
         @Override
-        void onPhaseFailure(SearchPhaseContext context) {
+        void onPhaseFailure(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
             for (SearchRequestOperationsListener listener : listeners) {
                 try {
-                    listener.onPhaseFailure(context);
+                    listener.onPhaseFailure(context, searchRequestContext);
                 } catch (Exception e) {
                     logger.warn(() -> new ParameterizedMessage("onPhaseFailure listener [{}] failed", listener), e);
                 }
@@ -113,10 +113,10 @@ public abstract class SearchRequestOperationsListener {
         }
 
         @Override
-        public void onRequestEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
+        public void onRequestEnd(SearchRequestContext searchRequestContext) {
             for (SearchRequestOperationsListener listener : listeners) {
                 try {
-                    listener.onRequestEnd(context, searchRequestContext);
+                    listener.onRequestEnd(searchRequestContext);
                 } catch (Exception e) {
                     logger.warn(() -> new ParameterizedMessage("onRequestEnd listener [{}] failed", listener), e);
                 }

--- a/server/src/main/java/org/opensearch/action/search/SearchRequestStats.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequestStats.java
@@ -58,7 +58,7 @@ public final class SearchRequestStats extends SearchRequestOperationsListener {
     }
 
     @Override
-    void onPhaseStart(SearchPhaseContext context) {
+    void onPhaseStart(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
         phaseStatsMap.get(context.getCurrentPhase().getSearchPhaseName()).current.inc();
     }
 
@@ -71,7 +71,7 @@ public final class SearchRequestStats extends SearchRequestOperationsListener {
     }
 
     @Override
-    void onPhaseFailure(SearchPhaseContext context) {
+    void onPhaseFailure(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
         phaseStatsMap.get(context.getCurrentPhase().getSearchPhaseName()).current.dec();
     }
 

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -46,6 +46,7 @@ import org.opensearch.action.ActionType;
 import org.opensearch.action.admin.cluster.snapshots.status.TransportNodesSnapshotsStatus;
 import org.opensearch.action.search.SearchExecutionStatsCollector;
 import org.opensearch.action.search.SearchPhaseController;
+import org.opensearch.action.search.SearchRequestCoordinatorTrace;
 import org.opensearch.action.search.SearchRequestOperationsCompositeListenerFactory;
 import org.opensearch.action.search.SearchRequestOperationsListener;
 import org.opensearch.action.search.SearchRequestSlowLog;
@@ -787,6 +788,7 @@ public class Node implements Closeable {
 
             final SearchRequestStats searchRequestStats = new SearchRequestStats(clusterService.getClusterSettings());
             final SearchRequestSlowLog searchRequestSlowLog = new SearchRequestSlowLog(clusterService);
+            final SearchRequestCoordinatorTrace searchRequestCoordinatorTrace = new SearchRequestCoordinatorTrace(tracer);
 
             remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(clusterService, settings);
             final IndicesService indicesService = new IndicesService(
@@ -885,7 +887,7 @@ public class Node implements Closeable {
             final SearchRequestOperationsCompositeListenerFactory searchRequestOperationsCompositeListenerFactory =
                 new SearchRequestOperationsCompositeListenerFactory(
                     Stream.concat(
-                        Stream.of(searchRequestStats, searchRequestSlowLog),
+                        Stream.of(searchRequestStats, searchRequestSlowLog, searchRequestCoordinatorTrace),
                         pluginComponents.stream()
                             .filter(p -> p instanceof SearchRequestOperationsListener)
                             .map(p -> (SearchRequestOperationsListener) p)
@@ -1284,6 +1286,7 @@ public class Node implements Closeable {
                 b.bind(Tracer.class).toInstance(tracer);
                 b.bind(SearchRequestStats.class).toInstance(searchRequestStats);
                 b.bind(SearchRequestSlowLog.class).toInstance(searchRequestSlowLog);
+                b.bind(SearchRequestCoordinatorTrace.class).toInstance(searchRequestCoordinatorTrace);
                 b.bind(MetricsRegistry.class).toInstance(metricsRegistry);
                 b.bind(RemoteClusterStateService.class).toProvider(() -> remoteClusterStateService);
                 b.bind(PersistedStateRegistry.class).toInstance(persistedStateRegistry);

--- a/server/src/main/java/org/opensearch/telemetry/tracing/AttributeNames.java
+++ b/server/src/main/java/org/opensearch/telemetry/tracing/AttributeNames.java
@@ -94,4 +94,19 @@ public final class AttributeNames {
      * Refresh Policy
      */
     public static final String REFRESH_POLICY = "refresh_policy";
+
+    /**
+     * Search Request Source
+     */
+    public static final String SOURCE = "source";
+
+    /**
+     * Search Response Shard Stats
+     */
+    public static final String SHARDS = "shards";
+
+    /**
+     * Search Response Total Hits
+     */
+    public static final String TOTAL_HITS = "total_hits";
 }

--- a/server/src/main/java/org/opensearch/telemetry/tracing/SpanBuilder.java
+++ b/server/src/main/java/org/opensearch/telemetry/tracing/SpanBuilder.java
@@ -43,6 +43,15 @@ public final class SpanBuilder {
     }
 
     /**
+     * Creates {@link SpanCreationContext} from String
+     * @param spanName String.
+     * @return context.
+     */
+    public static SpanCreationContext from(String spanName) {
+        return SpanCreationContext.server().name(spanName);
+    }
+
+    /**
      * Creates {@link SpanCreationContext} from the {@link HttpRequest}
      * @param request Http request.
      * @return context.
@@ -170,4 +179,13 @@ public final class SpanBuilder {
         return attributes;
     }
 
+    /**
+     * Creates {@link SpanCreationContext} with parent set to specified SpanContext.
+     * @param spanName name of span.
+     * @param parentSpan target parent span.
+     * @return context
+     */
+    public static SpanCreationContext from(String spanName, SpanContext parentSpan) {
+        return SpanCreationContext.server().name(spanName).parent(parentSpan);
+    }
 }

--- a/server/src/test/java/org/opensearch/action/search/AbstractSearchAsyncActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/AbstractSearchAsyncActionTests.java
@@ -420,17 +420,32 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
         action.onPhaseStart(new SearchPhase("test") {
             @Override
             public void run() {}
-        });
+        },
+            new SearchRequestContext(
+                new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
+                new SearchRequest()
+            )
+        );
         action.onPhaseStart(new SearchPhase("none") {
             @Override
             public void run() {}
-        });
+        },
+            new SearchRequestContext(
+                new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
+                new SearchRequest()
+            )
+        );
         assertEquals(0, testListener.getPhaseCurrent(action.getSearchPhaseName()));
 
         action.onPhaseStart(new SearchPhase(action.getName()) {
             @Override
             public void run() {}
-        });
+        },
+            new SearchRequestContext(
+                new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
+                new SearchRequest()
+            )
+        );
         assertEquals(1, testListener.getPhaseCurrent(action.getSearchPhaseName()));
     }
 

--- a/server/src/test/java/org/opensearch/action/search/SearchRequestOperationsCompositeListenerFactoryTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchRequestOperationsCompositeListenerFactoryTests.java
@@ -119,13 +119,13 @@ public class SearchRequestOperationsCompositeListenerFactoryTests extends OpenSe
     public SearchRequestOperationsListener createTestSearchRequestOperationsListener() {
         return new SearchRequestOperationsListener() {
             @Override
-            void onPhaseStart(SearchPhaseContext context) {}
+            void onPhaseStart(SearchPhaseContext context, SearchRequestContext searchRequestContext) {}
 
             @Override
             void onPhaseEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext) {}
 
             @Override
-            void onPhaseFailure(SearchPhaseContext context) {}
+            void onPhaseFailure(SearchPhaseContext context, SearchRequestContext searchRequestContext) {}
         };
     }
 }

--- a/server/src/test/java/org/opensearch/action/search/SearchRequestOperationsListenerSupport.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchRequestOperationsListenerSupport.java
@@ -17,7 +17,13 @@ import java.util.List;
  */
 public interface SearchRequestOperationsListenerSupport {
     default void onPhaseStart(SearchRequestOperationsListener listener, SearchPhaseContext context) {
-        listener.onPhaseStart(context);
+        listener.onPhaseStart(
+            context,
+            new SearchRequestContext(
+                new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
+                new SearchRequest()
+            )
+        );
     }
 
     default void onPhaseEnd(SearchRequestOperationsListener listener, SearchPhaseContext context) {

--- a/server/src/test/java/org/opensearch/action/search/SearchRequestStatsTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchRequestStatsTests.java
@@ -34,9 +34,21 @@ public class SearchRequestStatsTests extends OpenSearchTestCase {
 
         for (SearchPhaseName searchPhaseName : SearchPhaseName.values()) {
             when(mockSearchPhase.getSearchPhaseName()).thenReturn(searchPhaseName);
-            testRequestStats.onPhaseStart(ctx);
+            testRequestStats.onPhaseStart(
+                ctx,
+                new SearchRequestContext(
+                    new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
+                    new SearchRequest()
+                )
+            );
             assertEquals(1, testRequestStats.getPhaseCurrent(searchPhaseName));
-            testRequestStats.onPhaseFailure(ctx);
+            testRequestStats.onPhaseFailure(
+                ctx,
+                new SearchRequestContext(
+                    new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
+                    new SearchRequest()
+                )
+            );
             assertEquals(0, testRequestStats.getPhaseCurrent(searchPhaseName));
         }
     }
@@ -52,7 +64,13 @@ public class SearchRequestStatsTests extends OpenSearchTestCase {
         for (SearchPhaseName searchPhaseName : SearchPhaseName.values()) {
             when(mockSearchPhase.getSearchPhaseName()).thenReturn(searchPhaseName);
             long tookTimeInMillis = randomIntBetween(1, 10);
-            testRequestStats.onPhaseStart(ctx);
+            testRequestStats.onPhaseStart(
+                ctx,
+                new SearchRequestContext(
+                    new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
+                    new SearchRequest()
+                )
+            );
             long startTime = System.nanoTime() - TimeUnit.MILLISECONDS.toNanos(tookTimeInMillis);
             when(mockSearchPhase.getStartTimeInNanos()).thenReturn(startTime);
             assertEquals(1, testRequestStats.getPhaseCurrent(searchPhaseName));
@@ -84,7 +102,13 @@ public class SearchRequestStatsTests extends OpenSearchTestCase {
             for (int i = 0; i < numTasks; i++) {
                 threads[i] = new Thread(() -> {
                     phaser.arriveAndAwaitAdvance();
-                    testRequestStats.onPhaseStart(ctx);
+                    testRequestStats.onPhaseStart(
+                        ctx,
+                        new SearchRequestContext(
+                            new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
+                            new SearchRequest()
+                        )
+                    );
                     countDownLatch.countDown();
                 });
                 threads[i].start();
@@ -155,8 +179,20 @@ public class SearchRequestStatsTests extends OpenSearchTestCase {
             for (int i = 0; i < numTasks; i++) {
                 threads[i] = new Thread(() -> {
                     phaser.arriveAndAwaitAdvance();
-                    testRequestStats.onPhaseStart(ctx);
-                    testRequestStats.onPhaseFailure(ctx);
+                    testRequestStats.onPhaseStart(
+                        ctx,
+                        new SearchRequestContext(
+                            new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
+                            new SearchRequest()
+                        )
+                    );
+                    testRequestStats.onPhaseFailure(
+                        ctx,
+                        new SearchRequestContext(
+                            new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
+                            new SearchRequest()
+                        )
+                    );
                     countDownLatch.countDown();
                 });
                 threads[i].start();

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -2313,7 +2313,8 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                             client
                         ),
                         NoopMetricsRegistry.INSTANCE,
-                        searchRequestOperationsCompositeListenerFactory
+                        searchRequestOperationsCompositeListenerFactory,
+                        NoopTracer.INSTANCE
                     )
                 );
                 actions.put(


### PR DESCRIPTION
### Description
Tracing instrumentation at deep search path

Added spans at: 
1. Coordinator node request
2. Coordinator node search phases
### Testing
```
% curl -X PUT "localhost:9200/test2?pretty" -H 'Content-Type: application/json' -d'                                                                    
{                                                  
  "settings": {
    "number_of_shards": 10
  }
}'

% curl -X POST "localhost:9200/_bulk?pretty" -H 'Content-Type: application/json' -d'
{ "index" : { "_index" : "test2", "_id" : "1" } }
{ "field1" : "value1" }
{ "index" : { "_index" : "test2", "_id" : "2" } }
{ "field2" : "value2" }
'

% curl -XGET 'localhost:9200/_search?pretty&phase_took' -H 'X-Opaque-Id: my-id' -H 'Content-Type: application/json' -d'{
 "query": { "match_all": {} }
}'

```
![Screenshot 2024-01-30 at 3 38 16 PM](https://github.com/opensearch-project/OpenSearch/assets/38449481/ba714023-a1ff-47fe-85f2-4b5ffe0885c6)
![Screenshot 2024-01-30 at 3 38 27 PM](https://github.com/opensearch-project/OpenSearch/assets/38449481/7e825b40-c49e-4480-a355-12a6959fa331)

### Span Details
##### 1. Coordinator node request
![Screenshot 2023-12-13 at 2 10 42 PM](https://github.com/dzane17/OpenSearch/assets/38449481/949ccb76-0b51-4766-934c-eb268561a422)

```
{
   "traceId":"e522537a055adc6fc59667b58347942c",
   "spanId":"5b42e305497d91f8",
   "parentSpanId":"dab8a74cc0bb10c1",
   "name":"coordinatorRequest",
   "kind":2,
   "startTimeUnixNano":"1702333271222480100",
   "endTimeUnixNano":"1702333271229240384",
   "attributes":[
      {
         "key":"thread.name",
         "value":{
            "stringValue":"opensearch[88665a158598.ant.amazon.com][transport_worker][T#8]"
         }
      },
      {
         "key":"total_hits",
         "value":{
            "stringValue":"4 hits"
         }
      },
      {
         "key":"shards",
         "value":{
            "stringValue":"{total:2, successful:2, skipped:0, failed:0}"
         }
      }
   ],
   "status":{
      
   }
}
```

##### 2. Coordinator node phase
![Screenshot 2023-12-13 at 2 11 40 PM](https://github.com/dzane17/OpenSearch/assets/38449481/e6ff6ae2-945d-4fd7-8712-88032ebb97e7)

```
{
   "traceId":"e522537a055adc6fc59667b58347942c",
   "spanId":"c8ef2d7ad2584a6c",
   "parentSpanId":"5b42e305497d91f8",
   "name":"coordinatorQuery",
   "kind":2,
   "startTimeUnixNano":"1702333271223157629",
   "endTimeUnixNano":"1702333271225489595",
   "attributes":[
      {
         "key":"thread.name",
         "value":{
            "stringValue":"opensearch[88665a158598.ant.amazon.com][transport_worker][T#8]"
         }
      }
   ],
   "status":{
      
   }
}
```


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
