### PR TITLE
Tracing for deep search path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Views, simplify data access and manipulation by providing a virtual layer over one or more indices ([#11957](https://github.com/opensearch-project/OpenSearch/pull/11957))
 - Add Remote Store Migration Experimental flag and allow mixed mode clusters under same ([#11986](https://github.com/opensearch-project/OpenSearch/pull/11986))
 - [Admission Control] Integrate IO Usage Tracker to the Resource Usage Collector Service and Emit IO Usage Stats ([#11880](https://github.com/opensearch-project/OpenSearch/pull/11880))
+- Tracing for deep search path ([#12103](https://github.com/opensearch-project/OpenSearch/pull/12103))
 
 ### Dependencies
 - Bump `log4j-core` from 2.18.0 to 2.19.0

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/SpanContext.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/SpanContext.java
@@ -31,4 +31,19 @@ public final class SpanContext {
     Span getSpan() {
         return span;
     }
+
+    /**
+     * Sets the error for the current span behind this context
+     * @param cause error
+     */
+    public void setError(final Exception cause) {
+        span.setError(cause);
+    }
+
+    /**
+     * Ends current span
+     */
+    public void endSpan() {
+        span.endSpan();
+    }
 }

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/SpanCreationContext.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/tracing/SpanCreationContext.java
@@ -79,8 +79,8 @@ public final class SpanCreationContext {
     }
 
     /**
-     * Sets the parent for spann
-     * @param parent parent
+     * Sets the parent for span
+     * @param parent parent span context
      * @return spanCreationContext
      */
     public SpanCreationContext parent(SpanContext parent) {

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
@@ -116,7 +116,7 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
     public void onPhaseEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext) {}
 
     @Override
-    public void onPhaseFailure(SearchPhaseContext context) {}
+    public void onPhaseFailure(SearchPhaseContext context, Throwable cause) {}
 
     @Override
     public void onRequestStart(SearchRequestContext searchRequestContext) {}

--- a/server/src/main/java/org/opensearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/opensearch/action/search/AbstractSearchAsyncAction.java
@@ -221,6 +221,7 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
                     null
                 )
             );
+            onRequestEnd(searchRequestContext);
             return;
         }
         executePhase(this);
@@ -727,7 +728,7 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
     @Override
     public final void onPhaseFailure(SearchPhase phase, String msg, Throwable cause) {
         if (currentPhaseHasLifecycle) {
-            this.searchRequestContext.getSearchRequestOperationsListener().onPhaseFailure(this);
+            this.searchRequestContext.getSearchRequestOperationsListener().onPhaseFailure(this, cause);
         }
         raisePhaseFailure(new SearchPhaseExecutionException(phase.getName(), msg, cause, buildShardFailures()));
     }

--- a/server/src/main/java/org/opensearch/action/search/CanMatchPreFilterSearchPhase.java
+++ b/server/src/main/java/org/opensearch/action/search/CanMatchPreFilterSearchPhase.java
@@ -44,6 +44,7 @@ import org.opensearch.search.internal.AliasFilter;
 import org.opensearch.search.sort.FieldSortBuilder;
 import org.opensearch.search.sort.MinAndMax;
 import org.opensearch.search.sort.SortOrder;
+import org.opensearch.telemetry.tracing.Tracer;
 import org.opensearch.transport.Transport;
 
 import java.util.Comparator;
@@ -91,7 +92,8 @@ final class CanMatchPreFilterSearchPhase extends AbstractSearchAsyncAction<CanMa
         SearchTask task,
         Function<GroupShardsIterator<SearchShardIterator>, SearchPhase> phaseFactory,
         SearchResponse.Clusters clusters,
-        SearchRequestContext searchRequestContext
+        SearchRequestContext searchRequestContext,
+        Tracer tracer
     ) {
         // We set max concurrent shard requests to the number of shards so no throttling happens for can_match requests
         super(
@@ -112,7 +114,8 @@ final class CanMatchPreFilterSearchPhase extends AbstractSearchAsyncAction<CanMa
             new CanMatchSearchPhaseResults(shardsIts.size()),
             shardsIts.size(),
             clusters,
-            searchRequestContext
+            searchRequestContext,
+            tracer
         );
         this.phaseFactory = phaseFactory;
         this.shardsIts = shardsIts;

--- a/server/src/main/java/org/opensearch/action/search/SearchDfsQueryThenFetchAsyncAction.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchDfsQueryThenFetchAsyncAction.java
@@ -41,6 +41,7 @@ import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.dfs.AggregatedDfs;
 import org.opensearch.search.dfs.DfsSearchResult;
 import org.opensearch.search.internal.AliasFilter;
+import org.opensearch.telemetry.tracing.Tracer;
 import org.opensearch.transport.Transport;
 
 import java.util.List;
@@ -77,7 +78,8 @@ final class SearchDfsQueryThenFetchAsyncAction extends AbstractSearchAsyncAction
         final ClusterState clusterState,
         final SearchTask task,
         SearchResponse.Clusters clusters,
-        SearchRequestContext searchRequestContext
+        SearchRequestContext searchRequestContext,
+        final Tracer tracer
     ) {
         super(
             SearchPhaseName.DFS_PRE_QUERY.getName(),
@@ -97,7 +99,8 @@ final class SearchDfsQueryThenFetchAsyncAction extends AbstractSearchAsyncAction
             new ArraySearchPhaseResults<>(shardsIts.size()),
             request.getMaxConcurrentShardRequests(),
             clusters,
-            searchRequestContext
+            searchRequestContext,
+            tracer
         );
         this.queryPhaseResultConsumer = queryPhaseResultConsumer;
         this.searchPhaseController = searchPhaseController;

--- a/server/src/main/java/org/opensearch/action/search/SearchDfsQueryThenFetchAsyncAction.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchDfsQueryThenFetchAsyncAction.java
@@ -55,7 +55,7 @@ import java.util.function.BiFunction;
  *
  * @opensearch.internal
  */
-final class SearchDfsQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<DfsSearchResult> {
+class SearchDfsQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<DfsSearchResult> {
 
     private final SearchPhaseController searchPhaseController;
 

--- a/server/src/main/java/org/opensearch/action/search/SearchDfsQueryThenFetchAsyncAction.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchDfsQueryThenFetchAsyncAction.java
@@ -55,7 +55,7 @@ import java.util.function.BiFunction;
  *
  * @opensearch.internal
  */
-class SearchDfsQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<DfsSearchResult> {
+final class SearchDfsQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<DfsSearchResult> {
 
     private final SearchPhaseController searchPhaseController;
 

--- a/server/src/main/java/org/opensearch/action/search/SearchQueryThenFetchAsyncAction.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchQueryThenFetchAsyncAction.java
@@ -43,6 +43,7 @@ import org.opensearch.search.internal.AliasFilter;
 import org.opensearch.search.internal.SearchContext;
 import org.opensearch.search.internal.ShardSearchRequest;
 import org.opensearch.search.query.QuerySearchResult;
+import org.opensearch.telemetry.tracing.Tracer;
 import org.opensearch.transport.Transport;
 
 import java.util.Map;
@@ -82,7 +83,8 @@ class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<SearchPh
         ClusterState clusterState,
         SearchTask task,
         SearchResponse.Clusters clusters,
-        SearchRequestContext searchRequestContext
+        SearchRequestContext searchRequestContext,
+        final Tracer tracer
     ) {
         super(
             SearchPhaseName.QUERY.getName(),
@@ -102,7 +104,8 @@ class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<SearchPh
             resultConsumer,
             request.getMaxConcurrentShardRequests(),
             clusters,
-            searchRequestContext
+            searchRequestContext,
+            tracer
         );
         this.topDocsSize = SearchPhaseController.getTopDocsSize(request);
         this.trackTotalHitsUpTo = request.resolveTrackTotalHitsUpTo();

--- a/server/src/main/java/org/opensearch/action/search/SearchRequestContext.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequestContext.java
@@ -78,7 +78,7 @@ public class SearchRequestContext {
         this.totalHits = totalHits;
     }
 
-    TotalHits totalHits() {
+    public TotalHits totalHits() {
         return totalHits;
     }
 

--- a/server/src/main/java/org/opensearch/action/search/SearchRequestOperationsListener.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequestOperationsListener.java
@@ -22,6 +22,16 @@ import java.util.List;
 @InternalApi
 public abstract class SearchRequestOperationsListener {
     private volatile boolean enabled;
+    public static final SearchRequestOperationsListener NOOP = new SearchRequestOperationsListener(false) {
+        @Override
+        protected void onPhaseStart(SearchPhaseContext context) {}
+
+        @Override
+        protected void onPhaseEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext) {}
+
+        @Override
+        protected void onPhaseFailure(SearchPhaseContext context, Throwable cause) {}
+    };
 
     protected SearchRequestOperationsListener() {
         this.enabled = true;
@@ -35,7 +45,7 @@ public abstract class SearchRequestOperationsListener {
 
     protected abstract void onPhaseEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext);
 
-    protected abstract void onPhaseFailure(SearchPhaseContext context);
+    protected abstract void onPhaseFailure(SearchPhaseContext context, Throwable cause);
 
     protected void onRequestStart(SearchRequestContext searchRequestContext) {}
 
@@ -91,10 +101,10 @@ public abstract class SearchRequestOperationsListener {
         }
 
         @Override
-        protected void onPhaseFailure(SearchPhaseContext context) {
+        protected void onPhaseFailure(SearchPhaseContext context, Throwable cause) {
             for (SearchRequestOperationsListener listener : listeners) {
                 try {
-                    listener.onPhaseFailure(context);
+                    listener.onPhaseFailure(context, cause);
                 } catch (Exception e) {
                     logger.warn(() -> new ParameterizedMessage("onPhaseFailure listener [{}] failed", listener), e);
                 }

--- a/server/src/main/java/org/opensearch/action/search/SearchRequestSlowLog.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequestSlowLog.java
@@ -140,7 +140,7 @@ public final class SearchRequestSlowLog extends SearchRequestOperationsListener 
     protected void onPhaseEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext) {}
 
     @Override
-    protected void onPhaseFailure(SearchPhaseContext context) {}
+    protected void onPhaseFailure(SearchPhaseContext context, Throwable cause) {}
 
     @Override
     protected void onRequestStart(SearchRequestContext searchRequestContext) {}

--- a/server/src/main/java/org/opensearch/action/search/SearchRequestStats.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequestStats.java
@@ -71,7 +71,7 @@ public final class SearchRequestStats extends SearchRequestOperationsListener {
     }
 
     @Override
-    protected void onPhaseFailure(SearchPhaseContext context) {
+    protected void onPhaseFailure(SearchPhaseContext context, Throwable cause) {
         phaseStatsMap.get(context.getCurrentPhase().getSearchPhaseName()).current.dec();
     }
 

--- a/server/src/main/java/org/opensearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/opensearch/action/search/TransportSearchAction.java
@@ -393,7 +393,8 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                     new ArraySearchPhaseResults<>(shardsIts.size()),
                     searchRequest.getMaxConcurrentShardRequests(),
                     clusters,
-                    searchRequestContext
+                    searchRequestContext,
+                    tracer
                 ) {
                     @Override
                     protected void executePhaseOnShard(
@@ -1258,7 +1259,8 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                     )
                 ),
                 clusters,
-                searchRequestContext
+                searchRequestContext,
+                tracer
             );
         } else {
             final QueryPhaseResultConsumer queryResultConsumer = searchPhaseController.newSearchPhaseResults(
@@ -1289,7 +1291,8 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                         clusterState,
                         task,
                         clusters,
-                        searchRequestContext
+                        searchRequestContext,
+                        tracer
                     );
                     break;
                 case QUERY_THEN_FETCH:
@@ -1310,7 +1313,8 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                         clusterState,
                         task,
                         clusters,
-                        searchRequestContext
+                        searchRequestContext,
+                        tracer
                     );
                     break;
                 default:

--- a/server/src/main/java/org/opensearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/opensearch/action/search/TransportSearchAction.java
@@ -88,6 +88,12 @@ import org.opensearch.search.profile.SearchProfileShardResults;
 import org.opensearch.tasks.CancellableTask;
 import org.opensearch.tasks.Task;
 import org.opensearch.telemetry.metrics.MetricsRegistry;
+import org.opensearch.telemetry.tracing.Span;
+import org.opensearch.telemetry.tracing.SpanBuilder;
+import org.opensearch.telemetry.tracing.SpanScope;
+import org.opensearch.telemetry.tracing.Tracer;
+import org.opensearch.telemetry.tracing.listener.TraceableActionListener;
+import org.opensearch.telemetry.tracing.listener.TraceableSearchRequestOperationsListener;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.RemoteClusterAware;
 import org.opensearch.transport.RemoteClusterService;
@@ -173,6 +179,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
     private final CircuitBreaker circuitBreaker;
     private final SearchPipelineService searchPipelineService;
     private final SearchRequestOperationsCompositeListenerFactory searchRequestOperationsCompositeListenerFactory;
+    private final Tracer tracer;
 
     private volatile boolean searchQueryMetricsEnabled;
 
@@ -195,7 +202,8 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         NamedWriteableRegistry namedWriteableRegistry,
         SearchPipelineService searchPipelineService,
         MetricsRegistry metricsRegistry,
-        SearchRequestOperationsCompositeListenerFactory searchRequestOperationsCompositeListenerFactory
+        SearchRequestOperationsCompositeListenerFactory searchRequestOperationsCompositeListenerFactory,
+        Tracer tracer
     ) {
         super(SearchAction.NAME, transportService, actionFilters, (Writeable.Reader<SearchRequest>) SearchRequest::new);
         this.client = client;
@@ -215,6 +223,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         this.searchRequestOperationsCompositeListenerFactory = searchRequestOperationsCompositeListenerFactory;
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(SEARCH_QUERY_METRICS_ENABLED_SETTING, this::setSearchQueryMetricsEnabled);
+        this.tracer = tracer;
     }
 
     private void setSearchQueryMetricsEnabled(boolean searchQueryMetricsEnabled) {
@@ -431,49 +440,58 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         if (originalSearchRequest.isPhaseTook() == null) {
             originalSearchRequest.setPhaseTook(clusterService.getClusterSettings().get(SEARCH_PHASE_TOOK_ENABLED));
         }
-        SearchRequestOperationsListener.CompositeListener requestOperationsListeners = searchRequestOperationsCompositeListenerFactory
-            .buildCompositeListener(originalSearchRequest, logger);
-        SearchRequestContext searchRequestContext = new SearchRequestContext(requestOperationsListeners, originalSearchRequest);
-        searchRequestContext.getSearchRequestOperationsListener().onRequestStart(searchRequestContext);
 
-        PipelinedRequest searchRequest;
-        ActionListener<SearchResponse> listener;
-        try {
-            searchRequest = searchPipelineService.resolvePipeline(originalSearchRequest);
-            listener = searchRequest.transformResponseListener(originalListener);
-        } catch (Exception e) {
-            originalListener.onFailure(e);
-            return;
-        }
-
-        ActionListener<SearchRequest> requestTransformListener = ActionListener.wrap(sr -> {
-            if (searchQueryMetricsEnabled) {
-                try {
-                    searchQueryCategorizer.categorize(sr.source());
-                } catch (Exception e) {
-                    logger.error("Error while trying to categorize the query.", e);
-                }
-            }
-
-            ActionListener<SearchSourceBuilder> rewriteListener = buildRewriteListener(
-                sr,
-                task,
-                timeProvider,
-                searchAsyncActionProvider,
-                listener,
-                searchRequestContext
+        final Span requestSpan = tracer.startSpan(SpanBuilder.from(task, actionName));
+        try (final SpanScope spanScope = tracer.withSpanInScope(requestSpan)) {
+            SearchRequestOperationsListener.CompositeListener requestOperationsListeners;
+            final ActionListener<SearchResponse> updatedListener = TraceableActionListener.create(originalListener, requestSpan, tracer);
+            requestOperationsListeners = searchRequestOperationsCompositeListenerFactory.buildCompositeListener(
+                originalSearchRequest,
+                logger,
+                TraceableSearchRequestOperationsListener.create(tracer, requestSpan)
             );
-            if (sr.source() == null) {
-                rewriteListener.onResponse(sr.source());
-            } else {
-                Rewriteable.rewriteAndFetch(
-                    sr.source(),
-                    searchService.getRewriteContext(timeProvider::getAbsoluteStartMillis),
-                    rewriteListener
-                );
+            SearchRequestContext searchRequestContext = new SearchRequestContext(requestOperationsListeners, originalSearchRequest);
+            searchRequestContext.getSearchRequestOperationsListener().onRequestStart(searchRequestContext);
+
+            PipelinedRequest searchRequest;
+            ActionListener<SearchResponse> listener;
+            try {
+                searchRequest = searchPipelineService.resolvePipeline(originalSearchRequest);
+                listener = searchRequest.transformResponseListener(updatedListener);
+            } catch (Exception e) {
+                updatedListener.onFailure(e);
+                return;
             }
-        }, listener::onFailure);
-        searchRequest.transformRequest(requestTransformListener);
+
+            ActionListener<SearchRequest> requestTransformListener = ActionListener.wrap(sr -> {
+                if (searchQueryMetricsEnabled) {
+                    try {
+                        searchQueryCategorizer.categorize(sr.source());
+                    } catch (Exception e) {
+                        logger.error("Error while trying to categorize the query.", e);
+                    }
+                }
+
+                ActionListener<SearchSourceBuilder> rewriteListener = buildRewriteListener(
+                    sr,
+                    task,
+                    timeProvider,
+                    searchAsyncActionProvider,
+                    listener,
+                    searchRequestContext
+                );
+                if (sr.source() == null) {
+                    rewriteListener.onResponse(sr.source());
+                } else {
+                    Rewriteable.rewriteAndFetch(
+                        sr.source(),
+                        searchService.getRewriteContext(timeProvider::getAbsoluteStartMillis),
+                        rewriteListener
+                    );
+                }
+            }, listener::onFailure);
+            searchRequest.transformRequest(requestTransformListener);
+        }
     }
 
     private ActionListener<SearchSourceBuilder> buildRewriteListener(

--- a/server/src/main/java/org/opensearch/telemetry/tracing/AttributeNames.java
+++ b/server/src/main/java/org/opensearch/telemetry/tracing/AttributeNames.java
@@ -76,6 +76,16 @@ public final class AttributeNames {
     public static final String TRANSPORT_ACTION = "action";
 
     /**
+     * Task id
+     */
+    public static final String TASK_ID = "task_id";
+
+    /**
+     * Parent task id
+     */
+    public static final String PARENT_TASK_ID = "parent_task_id";
+
+    /**
      * Index Name
      */
     public static final String INDEX = "index";
@@ -99,4 +109,9 @@ public final class AttributeNames {
      * Refresh Policy
      */
     public static final String REFRESH_POLICY = "refresh_policy";
+
+    /**
+     * Search Response Total Hits
+     */
+    public static final String TOTAL_HITS = "total_hits";
 }

--- a/server/src/main/java/org/opensearch/telemetry/tracing/listener/TraceableSearchRequestOperationsListener.java
+++ b/server/src/main/java/org/opensearch/telemetry/tracing/listener/TraceableSearchRequestOperationsListener.java
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.telemetry.tracing.listener;
+
+import org.opensearch.action.search.SearchPhaseContext;
+import org.opensearch.action.search.SearchRequestContext;
+import org.opensearch.action.search.SearchRequestOperationsListener;
+import org.opensearch.telemetry.tracing.AttributeNames;
+import org.opensearch.telemetry.tracing.Span;
+import org.opensearch.telemetry.tracing.SpanBuilder;
+import org.opensearch.telemetry.tracing.SpanContext;
+import org.opensearch.telemetry.tracing.SpanScope;
+import org.opensearch.telemetry.tracing.Tracer;
+
+import static org.opensearch.core.common.Strings.capitalize;
+
+/**
+ * SearchRequestOperationsListener subscriber for search request tracing
+ *
+ * @opensearch.internal
+ */
+public final class TraceableSearchRequestOperationsListener extends SearchRequestOperationsListener {
+    private final Tracer tracer;
+    private final Span requestSpan;
+    private Span phaseSpan;
+    private SpanScope phaseSpanScope;
+
+    public TraceableSearchRequestOperationsListener(final Tracer tracer, final Span requestSpan) {
+        this.tracer = tracer;
+        this.requestSpan = requestSpan;
+        this.phaseSpan = null;
+        this.phaseSpanScope = null;
+    }
+
+    public static SearchRequestOperationsListener create(final Tracer tracer, final Span requestSpan) {
+        if (tracer.isRecording()) {
+            return new TraceableSearchRequestOperationsListener(tracer, requestSpan);
+        } else {
+            return SearchRequestOperationsListener.NOOP;
+        }
+    }
+
+    @Override
+    protected void onPhaseStart(SearchPhaseContext context) {
+        assert phaseSpan == null : "There should be only one search phase active at a time";
+        phaseSpan = tracer.startSpan(SpanBuilder.from(capitalize(context.getCurrentPhase().getName()), new SpanContext(requestSpan)));
+    }
+
+    @Override
+    protected void onPhaseEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
+        assert phaseSpan != null : "There should be a search phase active at that time";
+        phaseSpan.endSpan();
+        phaseSpan = null;
+    }
+
+    @Override
+    protected void onPhaseFailure(SearchPhaseContext context, Throwable cause) {
+        assert phaseSpan != null : "There should be a search phase active at that time";
+        phaseSpan.setError(new Exception(cause));
+        phaseSpan.endSpan();
+        phaseSpan = null;
+    }
+
+    @Override
+    public void onRequestStart(SearchRequestContext searchRequestContext) {}
+
+    @Override
+    public void onRequestEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
+        // add response-related attributes on request end
+        requestSpan.addAttribute(
+            AttributeNames.TOTAL_HITS,
+            searchRequestContext.totalHits() == null ? 0 : searchRequestContext.totalHits().value
+        );
+    }
+}

--- a/server/src/test/java/org/opensearch/action/search/AbstractSearchAsyncActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/AbstractSearchAsyncActionTests.java
@@ -58,6 +58,7 @@ import org.opensearch.search.internal.InternalSearchResponse;
 import org.opensearch.search.internal.ShardSearchContextId;
 import org.opensearch.search.internal.ShardSearchRequest;
 import org.opensearch.search.query.QuerySearchResult;
+import org.opensearch.telemetry.tracing.noop.NoopTracer;
 import org.opensearch.test.InternalAggregationTestCase;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
@@ -122,7 +123,7 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
             }
 
             @Override
-            protected void onPhaseFailure(SearchPhaseContext context) {
+            protected void onPhaseFailure(SearchPhaseContext context, Throwable cause) {
                 assertThat(phase, is(context.getCurrentPhase()));
                 phase = null;
             }
@@ -205,7 +206,8 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
             new SearchRequestContext(
                 new SearchRequestOperationsListener.CompositeListener(List.of(assertingListener), LogManager.getLogger()),
                 request
-            )
+            ),
+            NoopTracer.INSTANCE
         ) {
             @Override
             protected SearchPhase getNextPhase(final SearchPhaseResults<SearchPhaseResult> results, SearchPhaseContext context) {
@@ -746,7 +748,8 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
             new SearchRequestContext(
                 new SearchRequestOperationsListener.CompositeListener(searchRequestOperationsListeners, logger),
                 searchRequest
-            )
+            ),
+            NoopTracer.INSTANCE
         );
     }
 
@@ -799,7 +802,8 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
             new SearchRequestContext(
                 new SearchRequestOperationsListener.CompositeListener(searchRequestOperationsListeners, logger),
                 searchRequest
-            )
+            ),
+            NoopTracer.INSTANCE
         ) {
             @Override
             ShardSearchFailure[] buildShardFailures() {

--- a/server/src/test/java/org/opensearch/action/search/CanMatchPreFilterSearchPhaseTests.java
+++ b/server/src/test/java/org/opensearch/action/search/CanMatchPreFilterSearchPhaseTests.java
@@ -55,6 +55,7 @@ import org.opensearch.search.internal.ShardSearchRequest;
 import org.opensearch.search.sort.MinAndMax;
 import org.opensearch.search.sort.SortBuilders;
 import org.opensearch.search.sort.SortOrder;
+import org.opensearch.telemetry.tracing.noop.NoopTracer;
 import org.opensearch.test.InternalAggregationTestCase;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.Transport;
@@ -108,7 +109,7 @@ public class CanMatchPreFilterSearchPhaseTests extends OpenSearchTestCase {
             }
 
             @Override
-            protected void onPhaseFailure(SearchPhaseContext context) {
+            protected void onPhaseFailure(SearchPhaseContext context, Throwable cause) {
                 assertThat(phases.contains(context.getCurrentPhase()), is(true));
                 phases.remove(context.getCurrentPhase());
             }
@@ -190,7 +191,8 @@ public class CanMatchPreFilterSearchPhaseTests extends OpenSearchTestCase {
             new SearchRequestContext(
                 new SearchRequestOperationsListener.CompositeListener(List.of(assertingListener), LogManager.getLogger()),
                 searchRequest
-            )
+            ),
+            NoopTracer.INSTANCE
         );
 
         canMatchPhase.start();
@@ -286,7 +288,8 @@ public class CanMatchPreFilterSearchPhaseTests extends OpenSearchTestCase {
             new SearchRequestContext(
                 new SearchRequestOperationsListener.CompositeListener(List.of(assertingListener), LogManager.getLogger()),
                 searchRequest
-            )
+            ),
+            NoopTracer.INSTANCE
         );
 
         canMatchPhase.start();
@@ -380,7 +383,8 @@ public class CanMatchPreFilterSearchPhaseTests extends OpenSearchTestCase {
                 new SearchRequestContext(
                     new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
                     searchRequest
-                )
+                ),
+                NoopTracer.INSTANCE
             ) {
 
                 @Override
@@ -411,7 +415,8 @@ public class CanMatchPreFilterSearchPhaseTests extends OpenSearchTestCase {
             new SearchRequestContext(
                 new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
                 searchRequest
-            )
+            ),
+            NoopTracer.INSTANCE
         );
 
         canMatchPhase.start();
@@ -501,7 +506,8 @@ public class CanMatchPreFilterSearchPhaseTests extends OpenSearchTestCase {
                 new SearchRequestContext(
                     new SearchRequestOperationsListener.CompositeListener(List.of(assertingListener), LogManager.getLogger()),
                     searchRequest
-                )
+                ),
+                NoopTracer.INSTANCE
             );
 
             canMatchPhase.start();
@@ -606,7 +612,8 @@ public class CanMatchPreFilterSearchPhaseTests extends OpenSearchTestCase {
                 new SearchRequestContext(
                     new SearchRequestOperationsListener.CompositeListener(List.of(assertingListener), LogManager.getLogger()),
                     searchRequest
-                )
+                ),
+                NoopTracer.INSTANCE
             );
 
             canMatchPhase.start();
@@ -730,7 +737,8 @@ public class CanMatchPreFilterSearchPhaseTests extends OpenSearchTestCase {
                 };
             },
             SearchResponse.Clusters.EMPTY,
-            searchRequestContext
+            searchRequestContext,
+            NoopTracer.INSTANCE
         );
 
         canMatchPhase.start();
@@ -779,7 +787,8 @@ public class CanMatchPreFilterSearchPhaseTests extends OpenSearchTestCase {
                 new ArraySearchPhaseResults<>(shardsIts.size()),
                 request.getMaxConcurrentShardRequests(),
                 clusters,
-                searchRequestContext
+                searchRequestContext,
+                NoopTracer.INSTANCE
             );
             this.listener = searchRequestContext.getSearchRequestOperationsListener();
         }

--- a/server/src/test/java/org/opensearch/action/search/SearchAsyncActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchAsyncActionTests.java
@@ -137,6 +137,10 @@ public class SearchAsyncActionTests extends OpenSearchTestCase {
         lookup.put(replicaNode.getId(), new MockConnection(replicaNode));
         Map<String, AliasFilter> aliasFilters = Collections.singletonMap("_na_", new AliasFilter(null, Strings.EMPTY_ARRAY));
         AtomicInteger numRequests = new AtomicInteger(0);
+        final SearchRequestOperationsListener searchRequestOperationsListener = new SearchRequestOperationsListener.CompositeListener(
+            List.of(assertingListener),
+            LogManager.getLogger()
+        );
         AbstractSearchAsyncAction<TestSearchPhaseResult> asyncAction = new AbstractSearchAsyncAction<TestSearchPhaseResult>(
             "test",
             logger,
@@ -158,10 +162,7 @@ public class SearchAsyncActionTests extends OpenSearchTestCase {
             new ArraySearchPhaseResults<>(shardsIter.size()),
             request.getMaxConcurrentShardRequests(),
             SearchResponse.Clusters.EMPTY,
-            new SearchRequestContext(
-                new SearchRequestOperationsListener.CompositeListener(List.of(assertingListener), LogManager.getLogger()),
-                request
-            ),
+            new SearchRequestContext(searchRequestOperationsListener, request),
             NoopTracer.INSTANCE
         ) {
 
@@ -193,7 +194,7 @@ public class SearchAsyncActionTests extends OpenSearchTestCase {
                     @Override
                     public void run() {
                         assertTrue(searchPhaseDidRun.compareAndSet(false, true));
-                        assertingListener.onPhaseEnd(new MockSearchPhaseContext(1, request, this), null);
+                        searchRequestOperationsListener.onPhaseEnd(new MockSearchPhaseContext(1, request, this), null);
                     }
                 };
             }
@@ -261,6 +262,10 @@ public class SearchAsyncActionTests extends OpenSearchTestCase {
         Map<String, AliasFilter> aliasFilters = Collections.singletonMap("_na_", new AliasFilter(null, Strings.EMPTY_ARRAY));
         CountDownLatch awaitInitialRequests = new CountDownLatch(1);
         AtomicInteger numRequests = new AtomicInteger(0);
+        final SearchRequestOperationsListener searchRequestOperationsListener = new SearchRequestOperationsListener.CompositeListener(
+            List.of(assertingListener),
+            LogManager.getLogger()
+        );
         AbstractSearchAsyncAction<TestSearchPhaseResult> asyncAction = new AbstractSearchAsyncAction<TestSearchPhaseResult>(
             "test",
             logger,
@@ -282,10 +287,7 @@ public class SearchAsyncActionTests extends OpenSearchTestCase {
             new ArraySearchPhaseResults<>(shardsIter.size()),
             request.getMaxConcurrentShardRequests(),
             SearchResponse.Clusters.EMPTY,
-            new SearchRequestContext(
-                new SearchRequestOperationsListener.CompositeListener(List.of(assertingListener), LogManager.getLogger()),
-                request
-            ),
+            new SearchRequestContext(searchRequestOperationsListener, request),
             NoopTracer.INSTANCE
         ) {
 
@@ -324,7 +326,7 @@ public class SearchAsyncActionTests extends OpenSearchTestCase {
                 return new SearchPhase("test") {
                     @Override
                     public void run() {
-                        assertingListener.onPhaseEnd(new MockSearchPhaseContext(1, request, this), null);
+                        searchRequestOperationsListener.onPhaseEnd(new MockSearchPhaseContext(1, request, this), null);
                         assertTrue(searchPhaseDidRun.compareAndSet(false, true));
                     }
                 };
@@ -630,6 +632,10 @@ public class SearchAsyncActionTests extends OpenSearchTestCase {
         Map<String, AliasFilter> aliasFilters = Collections.singletonMap("_na_", new AliasFilter(null, Strings.EMPTY_ARRAY));
         AtomicInteger numRequests = new AtomicInteger(0);
         AtomicInteger numFailReplicas = new AtomicInteger(0);
+        final SearchRequestOperationsListener searchRequestOperationsListener = new SearchRequestOperationsListener.CompositeListener(
+            List.of(assertingListener),
+            LogManager.getLogger()
+        );
         AbstractSearchAsyncAction<TestSearchPhaseResult> asyncAction = new AbstractSearchAsyncAction<TestSearchPhaseResult>(
             "test",
             logger,
@@ -651,10 +657,7 @@ public class SearchAsyncActionTests extends OpenSearchTestCase {
             new ArraySearchPhaseResults<>(shardsIter.size()),
             request.getMaxConcurrentShardRequests(),
             SearchResponse.Clusters.EMPTY,
-            new SearchRequestContext(
-                new SearchRequestOperationsListener.CompositeListener(List.of(assertingListener), LogManager.getLogger()),
-                request
-            ),
+            new SearchRequestContext(searchRequestOperationsListener, request),
             NoopTracer.INSTANCE
         ) {
             @Override
@@ -688,7 +691,7 @@ public class SearchAsyncActionTests extends OpenSearchTestCase {
                     @Override
                     public void run() {
                         assertTrue(searchPhaseDidRun.compareAndSet(false, true));
-                        assertingListener.onPhaseEnd(new MockSearchPhaseContext(1, request, this), null);
+                        searchRequestOperationsListener.onPhaseEnd(new MockSearchPhaseContext(1, request, this), null);
                     }
                 };
             }

--- a/server/src/test/java/org/opensearch/action/search/SearchAsyncActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchAsyncActionTests.java
@@ -51,6 +51,7 @@ import org.opensearch.search.SearchShardTarget;
 import org.opensearch.search.internal.AliasFilter;
 import org.opensearch.search.internal.InternalSearchResponse;
 import org.opensearch.search.internal.ShardSearchContextId;
+import org.opensearch.telemetry.tracing.noop.NoopTracer;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.Transport;
 import org.opensearch.transport.TransportException;
@@ -138,7 +139,8 @@ public class SearchAsyncActionTests extends OpenSearchTestCase {
             new ArraySearchPhaseResults<>(shardsIter.size()),
             request.getMaxConcurrentShardRequests(),
             SearchResponse.Clusters.EMPTY,
-            new SearchRequestContext(new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()), request)
+            new SearchRequestContext(new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()), request),
+            NoopTracer.INSTANCE
         ) {
 
             @Override
@@ -257,7 +259,8 @@ public class SearchAsyncActionTests extends OpenSearchTestCase {
             new ArraySearchPhaseResults<>(shardsIter.size()),
             request.getMaxConcurrentShardRequests(),
             SearchResponse.Clusters.EMPTY,
-            new SearchRequestContext(new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()), request)
+            new SearchRequestContext(new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()), request),
+            NoopTracer.INSTANCE
         ) {
 
             @Override
@@ -375,7 +378,8 @@ public class SearchAsyncActionTests extends OpenSearchTestCase {
             new ArraySearchPhaseResults<>(shardsIter.size()),
             request.getMaxConcurrentShardRequests(),
             SearchResponse.Clusters.EMPTY,
-            new SearchRequestContext(new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()), request)
+            new SearchRequestContext(new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()), request),
+            NoopTracer.INSTANCE
         ) {
             TestSearchResponse response = new TestSearchResponse();
 
@@ -498,7 +502,8 @@ public class SearchAsyncActionTests extends OpenSearchTestCase {
             new ArraySearchPhaseResults<>(shardsIter.size()),
             request.getMaxConcurrentShardRequests(),
             SearchResponse.Clusters.EMPTY,
-            new SearchRequestContext(new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()), request)
+            new SearchRequestContext(new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()), request),
+            NoopTracer.INSTANCE
         ) {
             TestSearchResponse response = new TestSearchResponse();
 
@@ -612,7 +617,8 @@ public class SearchAsyncActionTests extends OpenSearchTestCase {
             new ArraySearchPhaseResults<>(shardsIter.size()),
             request.getMaxConcurrentShardRequests(),
             SearchResponse.Clusters.EMPTY,
-            new SearchRequestContext(new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()), request)
+            new SearchRequestContext(new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()), request),
+            NoopTracer.INSTANCE
         ) {
             @Override
             protected void executePhaseOnShard(

--- a/server/src/test/java/org/opensearch/action/search/SearchQueryThenFetchAsyncActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchQueryThenFetchAsyncActionTests.java
@@ -63,6 +63,8 @@ import org.opensearch.telemetry.tracing.noop.NoopTracer;
 import org.opensearch.test.InternalAggregationTestCase;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.Transport;
+import org.junit.After;
+import org.junit.Before;
 
 import java.util.Collections;
 import java.util.List;
@@ -78,6 +80,24 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
 
 public class SearchQueryThenFetchAsyncActionTests extends OpenSearchTestCase {
+    private SearchRequestOperationsListenerAssertingListener assertingListener;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        assertingListener = new SearchRequestOperationsListenerAssertingListener();
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+
+        assertingListener.assertFinished();
+    }
+
     public void testBottomFieldSort() throws Exception {
         testCase(false, false);
     }
@@ -219,7 +239,7 @@ public class SearchQueryThenFetchAsyncActionTests extends OpenSearchTestCase {
             task,
             SearchResponse.Clusters.EMPTY,
             new SearchRequestContext(
-                new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
+                new SearchRequestOperationsListener.CompositeListener(List.of(assertingListener), LogManager.getLogger()),
                 searchRequest
             ),
             NoopTracer.INSTANCE
@@ -229,6 +249,7 @@ public class SearchQueryThenFetchAsyncActionTests extends OpenSearchTestCase {
                 return new SearchPhase("test") {
                     @Override
                     public void run() {
+                        assertingListener.onPhaseEnd(new MockSearchPhaseContext(1, searchRequest, this), null);
                         latch.countDown();
                     }
                 };

--- a/server/src/test/java/org/opensearch/action/search/SearchQueryThenFetchAsyncActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchQueryThenFetchAsyncActionTests.java
@@ -59,6 +59,7 @@ import org.opensearch.search.internal.ShardSearchContextId;
 import org.opensearch.search.internal.ShardSearchRequest;
 import org.opensearch.search.query.QuerySearchResult;
 import org.opensearch.search.sort.SortBuilders;
+import org.opensearch.telemetry.tracing.noop.NoopTracer;
 import org.opensearch.test.InternalAggregationTestCase;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.Transport;
@@ -220,7 +221,8 @@ public class SearchQueryThenFetchAsyncActionTests extends OpenSearchTestCase {
             new SearchRequestContext(
                 new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
                 searchRequest
-            )
+            ),
+            NoopTracer.INSTANCE
         ) {
             @Override
             protected SearchPhase getNextPhase(SearchPhaseResults<SearchPhaseResult> results, SearchPhaseContext context) {

--- a/server/src/test/java/org/opensearch/action/search/SearchRequestOperationsCompositeListenerFactoryTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchRequestOperationsCompositeListenerFactoryTests.java
@@ -125,7 +125,7 @@ public class SearchRequestOperationsCompositeListenerFactoryTests extends OpenSe
             protected void onPhaseEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext) {}
 
             @Override
-            protected void onPhaseFailure(SearchPhaseContext context) {}
+            protected void onPhaseFailure(SearchPhaseContext context, Throwable cause) {}
         };
     }
 }

--- a/server/src/test/java/org/opensearch/action/search/SearchRequestOperationsListenerAssertingListener.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchRequestOperationsListenerAssertingListener.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.search;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class SearchRequestOperationsListenerAssertingListener extends SearchRequestOperationsListener {
+    private volatile SearchPhase phase;
+
+    @Override
+    protected void onPhaseStart(SearchPhaseContext context) {
+        assertThat(phase, is(nullValue()));
+        phase = context.getCurrentPhase();
+    }
+
+    @Override
+    protected void onPhaseEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
+        assertThat(phase, is(context.getCurrentPhase()));
+        phase = null;
+    }
+
+    @Override
+    protected void onPhaseFailure(SearchPhaseContext context, Throwable cause) {
+        assertThat(phase, is(context.getCurrentPhase()));
+        phase = null;
+    }
+
+    public void assertFinished() {
+        assertThat(phase, is(nullValue()));
+    }
+}

--- a/server/src/test/java/org/opensearch/action/search/SearchRequestOperationsListenerTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchRequestOperationsListenerTests.java
@@ -40,7 +40,7 @@ public class SearchRequestOperationsListenerTests extends OpenSearchTestCase {
             }
 
             @Override
-            public void onPhaseFailure(SearchPhaseContext context) {
+            public void onPhaseFailure(SearchPhaseContext context, Throwable cause) {
                 searchPhaseMap.get(context.getCurrentPhase().getSearchPhaseName()).current.dec();
             }
         };

--- a/server/src/test/java/org/opensearch/action/search/SearchRequestStatsTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchRequestStatsTests.java
@@ -36,7 +36,7 @@ public class SearchRequestStatsTests extends OpenSearchTestCase {
             when(mockSearchPhase.getSearchPhaseName()).thenReturn(searchPhaseName);
             testRequestStats.onPhaseStart(ctx);
             assertEquals(1, testRequestStats.getPhaseCurrent(searchPhaseName));
-            testRequestStats.onPhaseFailure(ctx);
+            testRequestStats.onPhaseFailure(ctx, new Throwable());
             assertEquals(0, testRequestStats.getPhaseCurrent(searchPhaseName));
         }
     }
@@ -156,7 +156,7 @@ public class SearchRequestStatsTests extends OpenSearchTestCase {
                 threads[i] = new Thread(() -> {
                     phaser.arriveAndAwaitAdvance();
                     testRequestStats.onPhaseStart(ctx);
-                    testRequestStats.onPhaseFailure(ctx);
+                    testRequestStats.onPhaseFailure(ctx, new Throwable());
                     countDownLatch.countDown();
                 });
                 threads[i].start();

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -2310,7 +2310,8 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                             client
                         ),
                         NoopMetricsRegistry.INSTANCE,
-                        searchRequestOperationsCompositeListenerFactory
+                        searchRequestOperationsCompositeListenerFactory,
+                        NoopTracer.INSTANCE
                     )
                 );
                 actions.put(

--- a/server/src/test/java/org/opensearch/telemetry/tracing/SpanBuilderTests.java
+++ b/server/src/test/java/org/opensearch/telemetry/tracing/SpanBuilderTests.java
@@ -21,6 +21,7 @@ import org.opensearch.http.HttpRequest;
 import org.opensearch.http.HttpResponse;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.telemetry.tracing.attributes.Attributes;
+import org.opensearch.telemetry.tracing.noop.NoopSpan;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.Transport;
 import org.opensearch.transport.TransportException;
@@ -102,6 +103,16 @@ public class SpanBuilderTests extends OpenSearchTestCase {
         Attributes attributes = context.getAttributes();
         assertEquals(action + " " + NetworkAddress.format(TransportAddress.META_ADDRESS), context.getSpanName());
         assertEquals(connection.getNode().getHostAddress(), attributes.getAttributesMap().get(AttributeNames.TRANSPORT_TARGET_HOST));
+    }
+
+    public void testParentSpan() {
+        String spanName = "test-name";
+        SpanContext parentSpanContext = new SpanContext(NoopSpan.INSTANCE);
+        SpanCreationContext context = SpanBuilder.from(spanName, parentSpanContext);
+        Attributes attributes = context.getAttributes();
+        assertNull(attributes);
+        assertEquals(spanName, context.getSpanName());
+        assertEquals(parentSpanContext, context.getParent());
     }
 
     private static Transport.Connection createTransportConnection() {


### PR DESCRIPTION
### Description
Tracing instrumentation at deep search path

Added spans at: 
1. Coordinator node request
2. Coordinator node search phases
### Testing
```
% curl -X PUT "localhost:9200/test2?pretty" -H 'Content-Type: application/json' -d'                                                                    
{                                                  
  "settings": {
    "number_of_shards": 10
  }
}'

% curl -X POST "localhost:9200/_bulk?pretty" -H 'Content-Type: application/json' -d'
{ "index" : { "_index" : "test2", "_id" : "1" } }
{ "field1" : "value1" }
{ "index" : { "_index" : "test2", "_id" : "2" } }
{ "field2" : "value2" }
'

% curl -XGET 'localhost:9200/_search?pretty&phase_took' -H 'X-Opaque-Id: my-id' -H 'Content-Type: application/json' -d'{
 "query": { "match_all": {} }
}'

% curl -XGET 'localhost:9200/_search?pretty&search_type=dfs_query_then_fetch&phase_took' -H 'X-Opaque-Id: my-id' -H 'Content-Type: application/json' -d'{
 "query": { "match_all": {} }
}'             
```

![Screenshot 2024-02-07 at 11 25 55 AM](https://github.com/opensearch-project/OpenSearch/assets/38449481/41823443-43d1-4ba9-b295-96af9afc8b3d)

#### search_type=dfs_query_then_fetch
![Screenshot 2024-02-07 at 11 26 35 AM](https://github.com/opensearch-project/OpenSearch/assets/38449481/3a50e2e6-7809-43ee-97b5-35a1606b1c2f)


### Span Details
##### 1. Coordinator node request
![Screenshot 2024-02-06 at 8 24 22 PM](https://github.com/opensearch-project/OpenSearch/assets/38449481/fc6de443-8b58-4a24-8dfc-6a4d6991e38d)

```
{
   "traceId":"c6a3a7a39cc2e81bdf964fd7d81dbe67",
   "spanId":"def6dc54cfe41cf7",
   "parentSpanId":"101e8811a19ff208",
   "name":"transport indices:data/read/search",
   "kind":1,
   "startTimeUnixNano":"1707279254012638047",
   "endTimeUnixNano":"1707279254017864739",
   "attributes":[
      {
         "key":"task_id",
         "value":{
            "intValue":"3360"
         }
      },
      {
         "key":"action",
         "value":{
            "stringValue":"indices:data/read/search"
         }
      },
      {
         "key":"thread.name",
         "value":{
            "stringValue":"opensearch[88665a158598.ant.amazon.com][transport_worker][T#9]"
         }
      },
      {
         "key":"total_hits",
         "value":{
            "intValue":"2"
         }
      }
   ],
   "status":{
      
   }
}
```

##### 2. Coordinator node phase
![Screenshot 2024-02-07 at 11 31 59 AM](https://github.com/opensearch-project/OpenSearch/assets/38449481/33c9ca85-6f6b-4901-93d6-21880959cf5f)
```
{
   "traceId":"e522537a055adc6fc59667b58347942c",
   "spanId":"c8ef2d7ad2584a6c",
   "parentSpanId":"5b42e305497d91f8",
   "name":"Query",
   "kind":2,
   "startTimeUnixNano":"1702333271223157629",
   "endTimeUnixNano":"1702333271225489595",
   "attributes":[
      {
         "key":"thread.name",
         "value":{
            "stringValue":"opensearch[88665a158598.ant.amazon.com][transport_worker][T#8]"
         }
      }
   ],
   "status":{
      
   }
}
```


### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/8554

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
