### PR TITLE
[Backport 2.x] Added New Fast DateTime parser implementation for RFC3339 Datetime format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Support index level allocation filtering for searchable snapshot index ([#11563](https://github.com/opensearch-project/OpenSearch/pull/11563))
 - [S3 Repository] Add setting to control connection count for sync client ([#12028](https://github.com/opensearch-project/OpenSearch/pull/12028))
 - Add support for Google Application Default Credentials in repository-gcs ([#8394](https://github.com/opensearch-project/OpenSearch/pull/8394))
+- New DateTime format for RFC3339 compatible date fields ([#11465](https://github.com/opensearch-project/OpenSearch/pull/11465))
 
 ### Dependencies
 - Bumps jetty version to 9.4.52.v20230823 to fix GMS-2023-1857 ([#9822](https://github.com/opensearch-project/OpenSearch/pull/9822))

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -10,3 +10,6 @@ Foundation (http://www.apache.org/).
 
 This product includes software developed by
 Joda.org (http://www.joda.org/).
+
+This product includes software developed by
+Morten Haraldsen (ethlo) (https://github.com/ethlo) under the Apache License, version 2.0.

--- a/server/src/main/java/org/opensearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/opensearch/common/time/DateFormatters.java
@@ -1299,6 +1299,41 @@ public class DateFormatters {
             .withResolverStyle(ResolverStyle.STRICT)
     );
 
+    /**
+     * Returns RFC 3339 a popular ISO 8601 profile compatible date time formatter and parser.
+     * This is not fully compatible to the existing spec, its more linient and closely follows w3c note on datetime
+     */
+
+    public static final DateFormatter RFC3339_LENIENT_DATE_FORMATTER = new JavaDateFormatter(
+        "rfc3339_lenient",
+        new OpenSearchDateTimeFormatter(STRICT_DATE_OPTIONAL_TIME_PRINTER),
+        new RFC3339CompatibleDateTimeFormatter(
+            new DateTimeFormatterBuilder().append(DATE_FORMATTER)
+                .optionalStart()
+                .appendLiteral('T')
+                .appendValue(HOUR_OF_DAY, 1, 2, SignStyle.NOT_NEGATIVE)
+                .appendLiteral(':')
+                .appendValue(MINUTE_OF_HOUR, 1, 2, SignStyle.NOT_NEGATIVE)
+                .optionalStart()
+                .appendLiteral(':')
+                .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NOT_NEGATIVE)
+                .optionalStart()
+                .appendFraction(NANO_OF_SECOND, 1, 9, true)
+                .optionalEnd()
+                .optionalStart()
+                .appendLiteral(',')
+                .appendFraction(NANO_OF_SECOND, 1, 9, false)
+                .optionalEnd()
+                .optionalStart()
+                .appendOffsetId()
+                .optionalEnd()
+                .optionalEnd()
+                .optionalEnd()
+                .toFormatter(Locale.ROOT)
+                .withResolverStyle(ResolverStyle.STRICT)
+        )
+    );
+
     private static final DateTimeFormatter HOUR_MINUTE_SECOND_FORMATTER = new DateTimeFormatterBuilder().append(HOUR_MINUTE_FORMATTER)
         .appendLiteral(":")
         .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NOT_NEGATIVE)
@@ -2152,6 +2187,8 @@ public class DateFormatters {
             return STRICT_YEAR_MONTH;
         } else if (FormatNames.STRICT_YEAR_MONTH_DAY.matches(input)) {
             return STRICT_YEAR_MONTH_DAY;
+        } else if (FormatNames.RFC3339_LENIENT.matches(input)) {
+            return RFC3339_LENIENT_DATE_FORMATTER;
         } else {
             try {
                 return new JavaDateFormatter(

--- a/server/src/main/java/org/opensearch/common/time/FormatNames.java
+++ b/server/src/main/java/org/opensearch/common/time/FormatNames.java
@@ -44,6 +44,7 @@ import java.util.stream.Stream;
  */
 public enum FormatNames {
     ISO8601(null, "iso8601"),
+    RFC3339_LENIENT(null, "rfc3339_lenient"),
     BASIC_DATE("basicDate", "basic_date"),
     BASIC_DATE_TIME("basicDateTime", "basic_date_time"),
     BASIC_DATE_TIME_NO_MILLIS("basicDateTimeNoMillis", "basic_date_time_no_millis"),

--- a/server/src/main/java/org/opensearch/common/time/OpenSearchDateTimeFormatter.java
+++ b/server/src/main/java/org/opensearch/common/time/OpenSearchDateTimeFormatter.java
@@ -1,0 +1,85 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.time;
+
+import java.text.Format;
+import java.text.ParsePosition;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalQuery;
+import java.util.Locale;
+
+/**
+* Wrapper class for DateTimeFormatter{@link java.time.format.DateTimeFormatter}
+* to allow for custom implementations for datetime parsing/formatting
+ */
+class OpenSearchDateTimeFormatter implements OpenSearchDateTimePrinter {
+    private final DateTimeFormatter formatter;
+
+    public OpenSearchDateTimeFormatter(String pattern) {
+        this.formatter = DateTimeFormatter.ofPattern(pattern, Locale.ROOT);
+    }
+
+    public OpenSearchDateTimeFormatter(String pattern, Locale locale) {
+        this.formatter = DateTimeFormatter.ofPattern(pattern, locale);
+    }
+
+    public OpenSearchDateTimeFormatter(DateTimeFormatter formatter) {
+        this.formatter = formatter;
+    }
+
+    public OpenSearchDateTimeFormatter withLocale(Locale locale) {
+        return new OpenSearchDateTimeFormatter(getFormatter().withLocale(locale));
+    }
+
+    public OpenSearchDateTimeFormatter withZone(ZoneId zoneId) {
+        return new OpenSearchDateTimeFormatter(getFormatter().withZone(zoneId));
+    }
+
+    public String format(TemporalAccessor temporal) {
+        return this.getFormatter().format(temporal);
+    }
+
+    public TemporalAccessor parse(CharSequence text, ParsePosition position) {
+        return this.getFormatter().parse(text, position);
+    }
+
+    public TemporalAccessor parse(CharSequence text) {
+        return this.getFormatter().parse(text);
+    }
+
+    public <T> T parse(CharSequence text, TemporalQuery<T> query) {
+        return this.getFormatter().parse(text, query);
+    }
+
+    public ZoneId getZone() {
+        return this.getFormatter().getZone();
+    }
+
+    public Locale getLocale() {
+        return this.getFormatter().getLocale();
+    }
+
+    public TemporalAccessor parse(String input) {
+        return formatter.parse(input);
+    }
+
+    public DateTimeFormatter getFormatter() {
+        return formatter;
+    }
+
+    public Format toFormat() {
+        return getFormatter().toFormat();
+    }
+
+    public Object parseObject(String text, ParsePosition pos) {
+        return getFormatter().toFormat().parseObject(text, pos);
+    }
+}

--- a/server/src/main/java/org/opensearch/common/time/OpenSearchDateTimePrinter.java
+++ b/server/src/main/java/org/opensearch/common/time/OpenSearchDateTimePrinter.java
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.time;
+
+import java.time.ZoneId;
+import java.time.temporal.TemporalAccessor;
+import java.util.Locale;
+
+/**
+ * Interface for DateTimeFormatter{@link java.time.format.DateTimeFormatter}
+ * to allow for custom implementations for datetime formatting
+ */
+interface OpenSearchDateTimePrinter {
+
+    public OpenSearchDateTimePrinter withLocale(Locale locale);
+
+    public OpenSearchDateTimePrinter withZone(ZoneId zoneId);
+
+    public String format(TemporalAccessor temporal);
+
+    public Locale getLocale();
+
+    public ZoneId getZone();
+}

--- a/server/src/main/java/org/opensearch/common/time/RFC3339CompatibleDateTimeFormatter.java
+++ b/server/src/main/java/org/opensearch/common/time/RFC3339CompatibleDateTimeFormatter.java
@@ -1,0 +1,428 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Based on code from the Internet Time Utility project (https://github.com/ethlo/itu) under the Apache License, version 2.0.
+ * Copyright (C) 2017 Morten Haraldsen (ethlo)
+ * Modifications (C) OpenSearch Contributors. All Rights Reserved.
+ */
+
+package org.opensearch.common.time;
+
+import java.text.ParsePosition;
+import java.time.DateTimeException;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.TemporalAccessor;
+import java.util.Arrays;
+import java.util.Locale;
+
+/**
+ * Defines a close profile of RFC3339 datetime format where the date is mandatory and the time is optional.
+ * <p>
+ * The returned formatter can only be used for parsing, printing is unsupported.
+ * <p>
+ * This parser can parse zoned datetimes.
+ * The parser is strict by default, thus time string {@code 24:00} cannot be parsed.
+ * <p>
+ * It accepts formats described by the following syntax:
+ * <pre>
+ * Year:
+ *       YYYY (eg 1997)
+ *    Year and month:
+ *       YYYY-MM (eg 1997-07)
+ *    Complete date:
+ *       YYYY-MM-DD (eg 1997-07-16)
+ *    Complete date plus hours and minutes:
+ *       YYYY-MM-DDThh:mmTZD (eg 1997-07-16T19:20+01:00)
+ *    Complete date plus hours, minutes and seconds:
+ *       YYYY-MM-DDThh:mm:ssTZD (eg 1997-07-16T19:20:30+01:00)
+ *    Complete date plus hours, minutes, seconds and a decimal fraction of a second
+ *       YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45+01:00)
+ *       YYYY-MM-DDThh:mm:ss,sTZD (eg 1997-07-16T19:20:30,45+01:00)
+ * where:
+ *
+ *      YYYY = four-digit year
+ *      MM   = two-digit month (01=January, etc.)
+ *      DD   = two-digit day of month (01 through 31)
+ *      hh   = two digits of hour (00 through 23) (am/pm NOT allowed)
+ *      mm   = two digits of minute (00 through 59)
+ *      ss   = two digits of second (00 through 59)
+ *      s    = one or more(max 9) digits representing a decimal fraction of a second
+ *      TZD  = time zone designator (Z or z or +hh:mm or -hh:mm)
+ * </pre>
+ */
+final class RFC3339CompatibleDateTimeFormatter extends OpenSearchDateTimeFormatter {
+    public static final char DATE_SEPARATOR = '-';
+    public static final char TIME_SEPARATOR = ':';
+    public static final char SEPARATOR_UPPER = 'T';
+    private static final char PLUS = '+';
+    private static final char MINUS = '-';
+    private static final char SEPARATOR_LOWER = 't';
+    private static final char SEPARATOR_SPACE = ' ';
+    private static final char FRACTION_SEPARATOR_1 = '.';
+    private static final char FRACTION_SEPARATOR_2 = ',';
+    private static final char ZULU_UPPER = 'Z';
+    private static final char ZULU_LOWER = 'z';
+
+    private ZoneId zone;
+
+    public RFC3339CompatibleDateTimeFormatter(String pattern) {
+        super(pattern);
+    }
+
+    public RFC3339CompatibleDateTimeFormatter(java.time.format.DateTimeFormatter formatter) {
+        super(formatter);
+    }
+
+    public RFC3339CompatibleDateTimeFormatter(java.time.format.DateTimeFormatter formatter, ZoneId zone) {
+        super(formatter);
+        this.zone = zone;
+    }
+
+    @Override
+    public OpenSearchDateTimeFormatter withZone(ZoneId zoneId) {
+        return new RFC3339CompatibleDateTimeFormatter(getFormatter().withZone(zoneId), zoneId);
+    }
+
+    @Override
+    public OpenSearchDateTimeFormatter withLocale(Locale locale) {
+        return new RFC3339CompatibleDateTimeFormatter(getFormatter().withLocale(locale));
+    }
+
+    @Override
+    public Object parseObject(String text, ParsePosition pos) {
+        try {
+            return parse(text);
+        } catch (DateTimeException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public TemporalAccessor parse(final String dateTime) {
+        OffsetDateTime parsedDatetime = parse(dateTime, new ParsePosition(0));
+        return zone == null ? parsedDatetime : parsedDatetime.atZoneSameInstant(zone);
+    }
+
+    public OffsetDateTime parse(String date, ParsePosition pos) {
+        if (date == null) {
+            throw new IllegalArgumentException("date cannot be null");
+        }
+
+        final int len = date.length() - pos.getIndex();
+        if (len <= 0) {
+            throw new DateTimeParseException("out of bound parse position", date, pos.getIndex());
+        }
+        final char[] chars = date.substring(pos.getIndex()).toCharArray();
+
+        // Date portion
+
+        // YEAR
+        final int years = getYear(chars, pos);
+        if (4 == len) {
+            return OffsetDateTime.of(years, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        }
+
+        // MONTH
+        consumeChar(chars, pos, DATE_SEPARATOR);
+        final int months = getMonth(chars, pos);
+        if (7 == len) {
+            return OffsetDateTime.of(years, months, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        }
+
+        // DAY
+        consumeChar(chars, pos, DATE_SEPARATOR);
+        final int days = getDay(chars, pos);
+        if (10 == len) {
+            return OffsetDateTime.of(years, months, days, 0, 0, 0, 0, ZoneOffset.UTC);
+        }
+
+        // HOURS
+        consumeChar(chars, pos, SEPARATOR_UPPER, SEPARATOR_LOWER, SEPARATOR_SPACE);
+        final int hours = getHour(chars, pos);
+
+        // MINUTES
+        consumeChar(chars, pos, TIME_SEPARATOR);
+        final int minutes = getMinute(chars, pos);
+        if (16 == len) {
+            throw new DateTimeParseException("No timezone offset information", new String(chars), pos.getIndex());
+        }
+
+        // SECONDS or TIMEZONE
+        return handleTime(chars, pos, years, months, days, hours, minutes);
+    }
+
+    private static boolean isDigit(char c) {
+        return (c >= '0' && c <= '9');
+    }
+
+    private static int digit(char c) {
+        return c - '0';
+    }
+
+    private static int readInt(final char[] strNum, ParsePosition pos, int n) {
+        int start = pos.getIndex(), end = start + n;
+        if (end > strNum.length) {
+            pos.setErrorIndex(end);
+            throw new DateTimeParseException("Unexpected end of expression at position " + strNum.length, new String(strNum), end);
+        }
+
+        int result = 0;
+        for (int i = start; i < end; i++) {
+            final char c = strNum[i];
+            if (isDigit(c) == false) {
+                pos.setErrorIndex(i);
+                throw new DateTimeParseException("Character " + c + " is not a digit", new String(strNum), i);
+            }
+            int digit = digit(c);
+            result = result * 10 + digit;
+        }
+        pos.setIndex(end);
+        return result;
+    }
+
+    private static int readIntUnchecked(final char[] strNum, ParsePosition pos, int n) {
+        int start = pos.getIndex(), end = start + n;
+        int result = 0;
+        for (int i = start; i < end; i++) {
+            final char c = strNum[i];
+            int digit = digit(c);
+            result = result * 10 + digit;
+        }
+        pos.setIndex(end);
+        return result;
+    }
+
+    private static int getHour(final char[] chars, ParsePosition pos) {
+        return readInt(chars, pos, 2);
+    }
+
+    private static int getMinute(final char[] chars, ParsePosition pos) {
+        return readInt(chars, pos, 2);
+    }
+
+    private static int getDay(final char[] chars, ParsePosition pos) {
+        return readInt(chars, pos, 2);
+    }
+
+    private static boolean isValidOffset(char[] chars, int offset) {
+        return offset < chars.length;
+    }
+
+    private static void consumeChar(char[] chars, ParsePosition pos, char expected) {
+        int offset = pos.getIndex();
+        if (isValidOffset(chars, offset) == false) {
+            throw new DateTimeParseException("Unexpected end of input", new String(chars), offset);
+        }
+
+        if (chars[offset] != expected) {
+            throw new DateTimeParseException("Expected character " + expected + " at position " + offset, new String(chars), offset);
+        }
+        pos.setIndex(offset + 1);
+    }
+
+    private static void consumeNextChar(char[] chars, ParsePosition pos) {
+        int offset = pos.getIndex();
+        if (isValidOffset(chars, offset) == false) {
+            throw new DateTimeParseException("Unexpected end of input", new String(chars), offset);
+        }
+        pos.setIndex(offset + 1);
+    }
+
+    private static boolean checkPositionContains(char[] chars, ParsePosition pos, char... expected) {
+        int offset = pos.getIndex();
+        if (offset >= chars.length) {
+            throw new DateTimeParseException("Unexpected end of input", new String(chars), offset);
+        }
+
+        boolean found = false;
+        for (char e : expected) {
+            if (chars[offset] == e) {
+                found = true;
+                break;
+            }
+        }
+        return found;
+    }
+
+    private static void consumeChar(char[] chars, ParsePosition pos, char... expected) {
+        int offset = pos.getIndex();
+        if (offset >= chars.length) {
+            throw new DateTimeParseException("Unexpected end of input", new String(chars), offset);
+        }
+
+        boolean found = false;
+        for (char e : expected) {
+            if (chars[offset] == e) {
+                found = true;
+                pos.setIndex(offset + 1);
+                break;
+            }
+        }
+        if (!found) {
+            throw new DateTimeParseException(
+                "Expected character " + Arrays.toString(expected) + " at position " + offset,
+                new String(chars),
+                offset
+            );
+        }
+    }
+
+    private static void assertNoMoreChars(char[] chars, ParsePosition pos) {
+        if (chars.length > pos.getIndex()) {
+            throw new DateTimeParseException("Trailing junk data after position " + pos.getIndex(), new String(chars), pos.getIndex());
+        }
+    }
+
+    private static ZoneOffset parseTimezone(char[] chars, ParsePosition pos) {
+        int offset = pos.getIndex();
+        final int left = chars.length - offset;
+        if (checkPositionContains(chars, pos, ZULU_LOWER, ZULU_UPPER)) {
+            consumeNextChar(chars, pos);
+            assertNoMoreChars(chars, pos);
+            return ZoneOffset.UTC;
+        }
+
+        if (left != 6) {
+            throw new DateTimeParseException("Invalid timezone offset", new String(chars, offset, left), offset);
+        }
+
+        final char sign = chars[offset];
+        consumeNextChar(chars, pos);
+        int hours = getHour(chars, pos);
+        consumeChar(chars, pos, TIME_SEPARATOR);
+        int minutes = getMinute(chars, pos);
+        if (sign == MINUS) {
+            if (hours == 0 && minutes == 0) {
+                throw new DateTimeParseException("Unknown 'Local Offset Convention' date-time not allowed", new String(chars), offset);
+            }
+            hours = -hours;
+            minutes = -minutes;
+        } else if (sign != PLUS) {
+            throw new DateTimeParseException("Invalid character starting at position " + offset, new String(chars), offset);
+        }
+
+        return ZoneOffset.ofHoursMinutes(hours, minutes);
+    }
+
+    private static OffsetDateTime handleTime(char[] chars, ParsePosition pos, int year, int month, int day, int hour, int minute) {
+        switch (chars[pos.getIndex()]) {
+            case TIME_SEPARATOR:
+                consumeChar(chars, pos, TIME_SEPARATOR);
+                return handleSeconds(year, month, day, hour, minute, chars, pos);
+
+            case PLUS:
+            case MINUS:
+            case ZULU_UPPER:
+            case ZULU_LOWER:
+                final ZoneOffset zoneOffset = parseTimezone(chars, pos);
+                return OffsetDateTime.of(year, month, day, hour, minute, 0, 0, zoneOffset);
+        }
+        throw new DateTimeParseException("Unexpected character " + " at position " + pos.getIndex(), new String(chars), pos.getIndex());
+    }
+
+    private static int getMonth(final char[] chars, ParsePosition pos) {
+        return readInt(chars, pos, 2);
+    }
+
+    private static int getYear(final char[] chars, ParsePosition pos) {
+        return readInt(chars, pos, 4);
+    }
+
+    private static int getSeconds(final char[] chars, ParsePosition pos) {
+        return readInt(chars, pos, 2);
+    }
+
+    private static int getFractions(final char[] chars, final ParsePosition pos, final int len) {
+        final int fractions;
+        fractions = readIntUnchecked(chars, pos, len);
+        switch (len) {
+            case 0:
+                throw new DateTimeParseException("Must have at least 1 fraction digit", new String(chars), pos.getIndex());
+            case 1:
+                return fractions * 100_000_000;
+            case 2:
+                return fractions * 10_000_000;
+            case 3:
+                return fractions * 1_000_000;
+            case 4:
+                return fractions * 100_000;
+            case 5:
+                return fractions * 10_000;
+            case 6:
+                return fractions * 1_000;
+            case 7:
+                return fractions * 100;
+            case 8:
+                return fractions * 10;
+            default:
+                return fractions;
+        }
+    }
+
+    public static int indexOfNonDigit(final char[] text, int offset) {
+        for (int i = offset; i < text.length; i++) {
+            if (isDigit(text[i]) == false) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    public static void consumeDigits(final char[] text, ParsePosition pos) {
+        final int idx = indexOfNonDigit(text, pos.getIndex());
+        if (idx == -1) {
+            pos.setErrorIndex(text.length);
+        } else {
+            pos.setIndex(idx);
+        }
+    }
+
+    private static OffsetDateTime handleSeconds(int year, int month, int day, int hour, int minute, char[] chars, ParsePosition pos) {
+        // From here the specification is more lenient
+        final int seconds = getSeconds(chars, pos);
+        int currPos = pos.getIndex();
+        final int remaining = chars.length - currPos;
+        if (remaining == 0) {
+            // No offset
+            throw new DateTimeParseException("No timezone offset information", new String(chars), pos.getIndex());
+        }
+
+        ZoneOffset offset = null;
+        int fractions = 0;
+        if (remaining == 1 && checkPositionContains(chars, pos, ZULU_LOWER, ZULU_UPPER)) {
+            consumeNextChar(chars, pos);
+            // Do nothing we are done
+            offset = ZoneOffset.UTC;
+            assertNoMoreChars(chars, pos);
+        } else if (remaining >= 1 && checkPositionContains(chars, pos, FRACTION_SEPARATOR_1, FRACTION_SEPARATOR_2)) {
+            // We have fractional seconds;
+            consumeNextChar(chars, pos);
+            ParsePosition initPosition = new ParsePosition(pos.getIndex());
+            consumeDigits(chars, pos);
+            if (pos.getErrorIndex() == -1) {
+                // We have an end of fractions
+                final int len = pos.getIndex() - initPosition.getIndex();
+                fractions = getFractions(chars, initPosition, len);
+                offset = parseTimezone(chars, pos);
+            } else {
+                throw new DateTimeParseException("No timezone offset information", new String(chars), pos.getIndex());
+            }
+        } else if (remaining >= 1 && checkPositionContains(chars, pos, PLUS, MINUS)) {
+            // No fractional sections
+            offset = parseTimezone(chars, pos);
+        } else {
+            throw new DateTimeParseException("Unexpected character at position " + (pos.getIndex()), new String(chars), pos.getIndex());
+        }
+
+        return OffsetDateTime.of(year, month, day, hour, minute, seconds, fractions, offset);
+    }
+}

--- a/server/src/test/java/org/opensearch/common/joda/JavaJodaTimeDuellingTests.java
+++ b/server/src/test/java/org/opensearch/common/joda/JavaJodaTimeDuellingTests.java
@@ -779,7 +779,9 @@ public class JavaJodaTimeDuellingTests extends OpenSearchTestCase {
         DateTime jodaDate = new DateTime(year, month, day, hour, minute, second, DateTimeZone.UTC);
 
         for (FormatNames format : FormatNames.values()) {
-            if (format == FormatNames.ISO8601 || format == FormatNames.STRICT_DATE_OPTIONAL_TIME_NANOS) {
+            if (format == FormatNames.ISO8601
+                || format == FormatNames.STRICT_DATE_OPTIONAL_TIME_NANOS
+                || format == FormatNames.RFC3339_LENIENT) {
                 // Nanos aren't supported by joda
                 continue;
             }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Backporting #11465

### Related Issues
Resolves #8361
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
