### PR TITLE
[Segment Replication] Modify shrink exception to be more informative

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationResizeRequestIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationResizeRequestIT.java
@@ -87,7 +87,8 @@ public class SegmentReplicationResizeRequestIT extends SegmentReplicationBaseIT 
                     .get()
             );
             assertEquals(
-                " For index [test] replica shards haven't caught up with primary, please retry after sometime.",
+                "Replication still in progress for index [test]. Please wait for replication to complete and retry. "
+                    + "Use the _cat/segment_replication/test api to check if the index is up to date (e.g. bytes_behind == 0).",
                 exception.getMessage()
             );
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/shrink/TransportResizeAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/shrink/TransportResizeAction.java
@@ -168,9 +168,11 @@ public class TransportResizeAction extends TransportClusterManagerNodeAction<Res
                                 .getSegments()
                                 .getReplicationStats().maxBytesBehind != 0) {
                                 throw new IllegalStateException(
-                                    " For index ["
+                                    "Replication still in progress for index ["
                                         + sourceIndex
-                                        + "] replica shards haven't caught up with primary, please retry after sometime."
+                                        + "]. Please wait for replication to complete and retry. Use the _cat/segment_replication/"
+                                        + sourceIndex
+                                        + " api to check if the index is up to date (e.g. bytes_behind == 0)."
                                 );
                             }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
For a call to shrink index in a segment replication enabled cluster, we perform a fast fail whenever the replica shards of the source index are not up to date with their primary shard. However, the exception we provide only asks customers/users to retry after sometime but does not specify how to check if their replicas are now up to date and ready for a retry of a shrink operation. Changed the exception to reflect this additional information. 

### Related Issues
Resolves #11352 partially.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
