### PR TITLE
[Backport] [2.x] Add advance(int) for numeric values in order to allow point based optimization to kick in (#12089)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Prevent setting remote_snapshot store type on index creation ([#11867](https://github.com/opensearch-project/OpenSearch/pull/11867))
 - [BUG] Fix remote shards balancer when filtering throttled nodes ([#11724](https://github.com/opensearch-project/OpenSearch/pull/11724))
 - [Bug] Check phase name before SearchRequestOperationsListener onPhaseStart ([#12094](https://github.com/opensearch-project/OpenSearch/pull/12094))
+- Add advance(int) for numeric values in order to allow point based optimization to kick in ([#12089](https://github.com/opensearch-project/OpenSearch/pull/12089))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/index/fielddata/AbstractNumericDocValues.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/AbstractNumericDocValues.java
@@ -43,6 +43,9 @@ import java.io.IOException;
  * aggregations, which only use {@link #advanceExact(int)} and
  * {@link #longValue()}.
  *
+ * In case when optimizations based on point values are used, the {@link #advance(int)}
+ * and, optionally, {@link #cost()} have to be implemented as well.
+ *
  * @opensearch.internal
  */
 public abstract class AbstractNumericDocValues extends NumericDocValues {

--- a/server/src/main/java/org/opensearch/index/fielddata/FieldData.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/FieldData.java
@@ -37,6 +37,7 @@ import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.common.Numbers;
 import org.opensearch.common.geo.GeoPoint;
@@ -76,6 +77,10 @@ public enum FieldData {
                 throw new UnsupportedOperationException();
             }
 
+            @Override
+            public int advance(int target) throws IOException {
+                return DocIdSetIterator.NO_MORE_DOCS;
+            }
         };
     }
 
@@ -561,6 +566,10 @@ public enum FieldData {
             return values.advanceExact(doc);
         }
 
+        @Override
+        public int advance(int target) throws IOException {
+            return values.advance(target);
+        }
     }
 
     /**
@@ -591,6 +600,10 @@ public enum FieldData {
             return values.docValueCount();
         }
 
+        @Override
+        public int advance(int target) throws IOException {
+            return values.advance(target);
+        }
     }
 
     /**
@@ -620,6 +633,12 @@ public enum FieldData {
 
         @Override
         public int docID() {
+            return docID;
+        }
+
+        @Override
+        public int advance(int target) throws IOException {
+            docID = values.advance(target);
             return docID;
         }
     }
@@ -683,6 +702,11 @@ public enum FieldData {
             public long longValue() throws IOException {
                 return value;
             }
+
+            @Override
+            public int advance(int target) throws IOException {
+                return values.advance(target);
+            }
         };
     }
 
@@ -715,6 +739,11 @@ public enum FieldData {
             public long longValue() throws IOException {
                 return value.longValue();
             }
+
+            @Override
+            public int advance(int target) throws IOException {
+                return values.advance(target);
+            }
         };
     }
 
@@ -741,6 +770,11 @@ public enum FieldData {
             @Override
             public double doubleValue() throws IOException {
                 return value;
+            }
+
+            @Override
+            public int advance(int target) throws IOException {
+                return values.advance(target);
             }
         };
     }

--- a/server/src/main/java/org/opensearch/index/fielddata/NumericDoubleValues.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/NumericDoubleValues.java
@@ -71,6 +71,11 @@ public abstract class NumericDoubleValues extends DoubleValues {
             public int docID() {
                 return docID;
             }
+
+            @Override
+            public int advance(int target) throws IOException {
+                return NumericDoubleValues.this.advance(target);
+            }
         };
     }
 
@@ -95,6 +100,23 @@ public abstract class NumericDoubleValues extends DoubleValues {
             public int docID() {
                 return docID;
             }
+
+            @Override
+            public int advance(int target) throws IOException {
+                return NumericDoubleValues.this.advance(target);
+            }
         };
+    }
+
+    /**
+     * Advances to the first beyond the current whose document number is greater than or equal to
+     * <i>target</i>, and returns the document number itself. Exhausts the iterator and returns {@link
+     * org.apache.lucene.search.DocIdSetIterator#NO_MORE_DOCS} if <i>target</i> is greater than the highest document number in the set.
+     *
+     * This method is being used by {@link org.apache.lucene.search.comparators.NumericComparator.NumericLeafComparator} when point values optimization kicks
+     * in and is implemented by most numeric types.
+     */
+    public int advance(int target) throws IOException {
+        throw new UnsupportedOperationException();
     }
 }

--- a/server/src/main/java/org/opensearch/index/fielddata/SingletonSortedNumericDoubleValues.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/SingletonSortedNumericDoubleValues.java
@@ -69,4 +69,8 @@ final class SingletonSortedNumericDoubleValues extends SortedNumericDoubleValues
         return in.doubleValue();
     }
 
+    @Override
+    public int advance(int target) throws IOException {
+        return in.advance(target);
+    }
 }

--- a/server/src/main/java/org/opensearch/index/fielddata/SortableLongBitsNumericDocValues.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/SortableLongBitsNumericDocValues.java
@@ -74,4 +74,9 @@ final class SortableLongBitsNumericDocValues extends AbstractNumericDocValues {
         return values;
     }
 
+    @Override
+    public int advance(int target) throws IOException {
+        return values.advance(target);
+    }
+
 }

--- a/server/src/main/java/org/opensearch/index/fielddata/SortableLongBitsToNumericDoubleValues.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/SortableLongBitsToNumericDoubleValues.java
@@ -67,4 +67,8 @@ final class SortableLongBitsToNumericDoubleValues extends NumericDoubleValues {
         return values;
     }
 
+    @Override
+    public int advance(int target) throws IOException {
+        return values.advance(target);
+    }
 }

--- a/server/src/main/java/org/opensearch/index/fielddata/SortableLongBitsToSortedNumericDoubleValues.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/SortableLongBitsToSortedNumericDoubleValues.java
@@ -72,4 +72,8 @@ final class SortableLongBitsToSortedNumericDoubleValues extends SortedNumericDou
         return values;
     }
 
+    @Override
+    public int advance(int target) throws IOException {
+        return values.advance(target);
+    }
 }

--- a/server/src/main/java/org/opensearch/index/fielddata/SortedNumericDoubleValues.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/SortedNumericDoubleValues.java
@@ -70,4 +70,15 @@ public abstract class SortedNumericDoubleValues {
      */
     public abstract int docValueCount();
 
+    /**
+     * Advances to the first beyond the current whose document number is greater than or equal to
+     * <i>target</i>, and returns the document number itself. Exhausts the iterator and returns {@link
+     * org.apache.lucene.search.DocIdSetIterator#NO_MORE_DOCS} if <i>target</i> is greater than the highest document number in the set.
+     *
+     * This method is being used by {@link org.apache.lucene.search.comparators.NumericComparator.NumericLeafComparator} when point values optimization kicks
+     * in and is implemented by most numeric types.
+     */
+    public int advance(int target) throws IOException {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/server/src/main/java/org/opensearch/index/fielddata/UnsignedLongToNumericDoubleValues.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/UnsignedLongToNumericDoubleValues.java
@@ -42,4 +42,8 @@ final class UnsignedLongToNumericDoubleValues extends NumericDoubleValues {
         return values;
     }
 
+    @Override
+    public int advance(int target) throws IOException {
+        return values.advance(target);
+    }
 }

--- a/server/src/main/java/org/opensearch/index/fielddata/UnsignedLongToSortedNumericDoubleValues.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/UnsignedLongToSortedNumericDoubleValues.java
@@ -47,4 +47,8 @@ final class UnsignedLongToSortedNumericDoubleValues extends SortedNumericDoubleV
         return values;
     }
 
+    @Override
+    public int advance(int target) throws IOException {
+        return values.advance(target);
+    }
 }

--- a/server/src/main/java/org/opensearch/index/fielddata/plain/SortedNumericIndexFieldData.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/plain/SortedNumericIndexFieldData.java
@@ -336,6 +336,11 @@ public class SortedNumericIndexFieldData extends IndexNumericFieldData {
         public boolean advanceExact(int doc) throws IOException {
             return in.advanceExact(doc);
         }
+
+        @Override
+        public int advance(int target) throws IOException {
+            return in.advance(target);
+        }
     }
 
     /**
@@ -363,6 +368,11 @@ public class SortedNumericIndexFieldData extends IndexNumericFieldData {
         @Override
         public int docValueCount() {
             return in.docValueCount();
+        }
+
+        @Override
+        public int advance(int target) throws IOException {
+            return in.advance(target);
         }
     }
 
@@ -434,6 +444,11 @@ public class SortedNumericIndexFieldData extends IndexNumericFieldData {
         public boolean advanceExact(int doc) throws IOException {
             return in.advanceExact(doc);
         }
+
+        @Override
+        public int advance(int target) throws IOException {
+            return in.advance(target);
+        }
     }
 
     /**
@@ -461,6 +476,11 @@ public class SortedNumericIndexFieldData extends IndexNumericFieldData {
         @Override
         public int docValueCount() {
             return in.docValueCount();
+        }
+
+        @Override
+        public int advance(int target) throws IOException {
+            return in.advance(target);
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/query/functionscore/DecayFunctionBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/functionscore/DecayFunctionBuilder.java
@@ -561,6 +561,11 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
             final SortedNumericDoubleValues doubleValues = fieldData.load(context).getDoubleValues();
             return FieldData.replaceMissing(mode.select(new SortingNumericDoubleValues() {
                 @Override
+                public int advance(int target) throws IOException {
+                    return doubleValues.advance(target);
+                }
+
+                @Override
                 public boolean advanceExact(int docId) throws IOException {
                     if (doubleValues.advanceExact(docId)) {
                         int n = doubleValues.docValueCount();

--- a/server/src/main/java/org/opensearch/search/MultiValueMode.java
+++ b/server/src/main/java/org/opensearch/search/MultiValueMode.java
@@ -685,6 +685,11 @@ public enum MultiValueMode implements Writeable {
                 public double doubleValue() throws IOException {
                     return this.value;
                 }
+
+                @Override
+                public int advance(int target) throws IOException {
+                    return values.advance(target);
+                }
             };
         }
     }
@@ -744,6 +749,11 @@ public enum MultiValueMode implements Writeable {
             @Override
             public double doubleValue() throws IOException {
                 return lastEmittedValue;
+            }
+
+            @Override
+            public int advance(int target) throws IOException {
+                return values.advance(target);
             }
         };
     }

--- a/server/src/main/java/org/opensearch/search/aggregations/support/MissingValues.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/support/MissingValues.java
@@ -227,6 +227,10 @@ public enum MissingValues {
                 return "anon SortedNumericDoubleValues of [" + super.toString() + "]";
             }
 
+            @Override
+            public int advance(int target) throws IOException {
+                return values.advance(target);
+            }
         };
     }
 

--- a/server/src/main/java/org/opensearch/search/aggregations/support/ValuesSource.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/support/ValuesSource.java
@@ -576,6 +576,11 @@ public abstract class ValuesSource {
                     }
                     return false;
                 }
+
+                @Override
+                public int advance(int target) throws IOException {
+                    return doubleValues.advance(target);
+                }
             }
         }
 


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/12089 to `2.x`