### PR TITLE
Refactor FilterPath parse function (#12067)

### DIFF
--- a/libs/core/src/main/java/org/opensearch/core/xcontent/filtering/FilterPath.java
+++ b/libs/core/src/main/java/org/opensearch/core/xcontent/filtering/FilterPath.java
@@ -99,32 +99,26 @@ public class FilterPath {
 
         List<FilterPath> paths = new ArrayList<>();
         for (String filter : filters) {
-            if (filter != null) {
+            if (filter != null && !filter.isEmpty()) {
                 filter = filter.trim();
                 if (filter.length() > 0) {
-                    paths.add(parse(filter, filter));
+                    paths.add(parse(filter));
                 }
             }
         }
         return paths.toArray(new FilterPath[0]);
     }
 
-    private static FilterPath parse(final String filter, final String segment) {
-        int end = segment.length();
+    private static FilterPath parse(final String filter) {
+        String[] segments = filter.split("(?<!\\\\)\\.");
+        FilterPath next = EMPTY;
 
-        for (int i = 0; i < end;) {
-            char c = segment.charAt(i);
-
-            if (c == '.') {
-                String current = segment.substring(0, i).replaceAll("\\\\.", ".");
-                return new FilterPath(filter, current, parse(filter, segment.substring(i + 1)));
-            }
-            ++i;
-            if ((c == '\\') && (i < end) && (segment.charAt(i) == '.')) {
-                ++i;
-            }
+        for (int i = segments.length - 1; i >= 0; i--) {
+            String segment = segments[i].replaceAll("\\\\.", ".");
+            next = new FilterPath(filter, segment, next);
         }
-        return new FilterPath(filter, segment.replaceAll("\\\\.", "."), EMPTY);
+
+        return next;
     }
 
     @Override

--- a/libs/core/src/main/java/org/opensearch/core/xcontent/filtering/FilterPath.java
+++ b/libs/core/src/main/java/org/opensearch/core/xcontent/filtering/FilterPath.java
@@ -32,6 +32,8 @@
 
 package org.opensearch.core.xcontent.filtering;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.common.Glob;
 
 import java.util.ArrayList;
@@ -46,7 +48,7 @@ import java.util.Set;
 public class FilterPath {
 
     static final FilterPath EMPTY = new FilterPath();
-
+    private static final Logger logger = LogManager.getLogger(FilterPath.class);
     private final String filter;
     private final String segment;
     private final FilterPath next;
@@ -103,6 +105,8 @@ public class FilterPath {
                 filter = filter.trim();
                 if (filter.length() > 0) {
                     paths.add(parse(filter));
+                } else {
+                    logger.warn("Filter is empty!");
                 }
             }
         }
@@ -110,10 +114,13 @@ public class FilterPath {
     }
 
     private static FilterPath parse(final String filter) {
+        // Split the filter into segments using a regex
+        // that avoids splitting escaped dots.
         String[] segments = filter.split("(?<!\\\\)\\.");
         FilterPath next = EMPTY;
 
         for (int i = segments.length - 1; i >= 0; i--) {
+            // Replace escaped dots with actual dots in the current segment.
             String segment = segments[i].replaceAll("\\\\.", ".");
             next = new FilterPath(filter, segment, next);
         }

--- a/libs/core/src/test/java/org/opensearch/core/xcontent/filtering/FilterPathTests.java
+++ b/libs/core/src/test/java/org/opensearch/core/xcontent/filtering/FilterPathTests.java
@@ -32,10 +32,10 @@
 
 package org.opensearch.core.xcontent.filtering;
 
-import java.util.HashSet;
 import org.opensearch.common.util.set.Sets;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import static java.util.Collections.singleton;

--- a/libs/core/src/test/java/org/opensearch/core/xcontent/filtering/FilterPathTests.java
+++ b/libs/core/src/test/java/org/opensearch/core/xcontent/filtering/FilterPathTests.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.core.xcontent.filtering;
 
+import java.util.HashSet;
 import org.opensearch.common.util.set.Sets;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -368,5 +369,21 @@ public class FilterPathTests extends OpenSearchTestCase {
         assertThat(filterPath.matches(), is(true));
         assertThat(filterPath.getSegment(), is(emptyString()));
         assertSame(filterPath, FilterPath.EMPTY);
+    }
+
+    public void testCompileWithEmptyString() {
+        Set<String> filters = new HashSet<>();
+        filters.add("");
+        FilterPath[] filterPaths = FilterPath.compile(filters);
+        assertNotNull(filterPaths);
+        assertEquals(0, filterPaths.length);
+    }
+
+    public void testCompileWithNull() {
+        Set<String> filters = new HashSet<>();
+        filters.add(null);
+        FilterPath[] filterPaths = FilterPath.compile(filters);
+        assertNotNull(filterPaths);
+        assertEquals(0, filterPaths.length);
     }
 }


### PR DESCRIPTION
Signed-off-by: Robin Friedmann <robinfriedmann.rf@gmail.com>

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Refactoring [FilterPath.parse](https://github.com/opensearch-project/OpenSearch/blob/main/libs/core/src/main/java/org/opensearch/core/xcontent/filtering/FilterPath.java#L112-L128) by using an iterative approach instead of recursion.

### Related Issues
Resolves #12067 
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
