### PR TITLE
Fix race condition in testTracerLog

### DIFF
--- a/test/framework/src/main/java/org/opensearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/transport/AbstractSimpleTransportTestCase.java
@@ -1283,9 +1283,17 @@ public abstract class AbstractSimpleTransportTestCase extends OpenSearchTestCase
                 Level.TRACE,
                 notSeenReceived
             );
+            final String notSeenResponseSent = ".*\\[internal:testNotSeen].*sent response.*";
+            final MockLogAppender.LoggingExpectation notSeenResponseSentExpectation = new MockLogAppender.PatternSeenEventExpectation(
+                "sent response",
+                "org.opensearch.transport.TransportService.tracer",
+                Level.TRACE,
+                notSeenResponseSent
+            );
 
             appender.addExpectation(notSeenSentExpectation);
             appender.addExpectation(notSeenReceivedExpectation);
+            appender.addExpectation(notSeenResponseSentExpectation);
 
             PlainTransportFuture<StringMessageResponse> future = new PlainTransportFuture<>(noopResponseHandler);
             serviceA.sendRequest(nodeB, "internal:testNotSeen", new StringMessageRequest(""), future);


### PR DESCRIPTION
The test currently blocks on receiving a response to the request for the "internal:testNotSeen" action. However, that response is sent from TransportService before the trace logger [writes its log message][1]. Since the test was not polling for this "sent response" log message to appear that meant it was possible for the test to remove/stop the mock log appender concurrently with the logging of that final message. The fix is to include this final log message as an expectation, so the test will poll until this message appears and the logger should be quiescent when the appender is removed and stopped.

[1]: https://github.com/opensearch-project/OpenSearch/blob/71f1fabe149fd0777edf44502ace4a8f0911feeb/server/src/main/java/org/opensearch/transport/TransportService.java#L1273

### Related Issues
Resolves #10799

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
