### PR TITLE
Fix a flaky test that relies on terminate_after for an exact count ma…

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/simple/SimpleSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/simple/SimpleSearchIT.java
@@ -341,9 +341,9 @@ public class SimpleSearchIT extends ParameterizedStaticSettingsOpenSearchIntegTe
      * If track_total_hits != true, but set to a value AND terminate_after is set:
      *   Again, due to the optimization, any count can be returned.
      *   Up to terminate_after, relation == EQUAL_TO.
-     *   But if track_total_hits_up_to >= terminate_after, relation can be EQ _or_ GTE.
+     *   But if track_total_hits_up_to &gte; terminate_after, relation can be EQ _or_ GTE.
      *   This ambiguity is due to the fact that totalHits == track_total_hits_up_to
-     *   or totalHits > track_total_hits_up_to and SearchPhaseController sets totalHits = track_total_hits_up_to when returning results
+     *   or totalHits &gt; track_total_hits_up_to and SearchPhaseController sets totalHits = track_total_hits_up_to when returning results
      *   in which case relation = GTE.
      *
      * @param size

--- a/server/src/internalClusterTest/java/org/opensearch/search/simple/SimpleSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/simple/SimpleSearchIT.java
@@ -341,7 +341,7 @@ public class SimpleSearchIT extends ParameterizedStaticSettingsOpenSearchIntegTe
      * If track_total_hits != true, but set to a value AND terminate_after is set:
      *   Again, due to the optimization, any count can be returned.
      *   Up to terminate_after, relation == EQUAL_TO.
-     *   But if track_total_hits_up_to &gte; terminate_after, relation can be EQ _or_ GTE.
+     *   But if track_total_hits_up_to &ge; terminate_after, relation can be EQ _or_ GTE.
      *   This ambiguity is due to the fact that totalHits == track_total_hits_up_to
      *   or totalHits &gt; track_total_hits_up_to and SearchPhaseController sets totalHits = track_total_hits_up_to when returning results
      *   in which case relation = GTE.

--- a/server/src/internalClusterTest/java/org/opensearch/search/simple/SimpleSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/simple/SimpleSearchIT.java
@@ -299,7 +299,15 @@ public class SimpleSearchIT extends ParameterizedStaticSettingsOpenSearchIntegTe
                 .setSize(size)
                 .setTrackTotalHits(true)
                 .get();
-            assertHitCount(searchResponse, i);
+
+            // Do not expect an exact match as an optimization introduced by https://issues.apache.org/jira/browse/LUCENE-10620
+            // can produce a total hit count > terminated_after, but this only kicks in
+            // when size = 0 which is when TotalHitCountCollector is used.
+            if (size == 0) {
+                assertHitCount(searchResponse, i, max);
+            } else {
+                assertHitCount(searchResponse, i);
+            }
             assertTrue(searchResponse.isTerminatedEarly());
             assertEquals(Math.min(i, size), searchResponse.getHits().getHits().length);
         }
@@ -313,7 +321,6 @@ public class SimpleSearchIT extends ParameterizedStaticSettingsOpenSearchIntegTe
         assertFalse(searchResponse.isTerminatedEarly());
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/10435")
     public void testSimpleTerminateAfterCountSize0() throws Exception {
         int max = randomIntBetween(3, 29);
         dotestSimpleTerminateAfterCountWithSize(0, max);
@@ -324,6 +331,24 @@ public class SimpleSearchIT extends ParameterizedStaticSettingsOpenSearchIntegTe
         dotestSimpleTerminateAfterCountWithSize(randomIntBetween(1, max), max);
     }
 
+    /**
+     * Special cases when size = 0:
+     *
+     * If track_total_hits = true:
+     *   Weight#count optimization can cause totalHits in the response to be up to the total doc count regardless of terminate_after.
+     *   So, we will have to do a range check, not an equality check.
+     *
+     * If track_total_hits != true, but set to a value AND terminate_after is set:
+     *   Again, due to the optimization, any count can be returned.
+     *   Up to terminate_after, relation == EQUAL_TO.
+     *   But if track_total_hits_up_to >= terminate_after, relation can be EQ _or_ GTE.
+     *   This ambiguity is due to the fact that totalHits == track_total_hits_up_to
+     *   or totalHits > track_total_hits_up_to and SearchPhaseController sets totalHits = track_total_hits_up_to when returning results
+     *   in which case relation = GTE.
+     *
+     * @param size
+     * @throws Exception
+     */
     public void doTestSimpleTerminateAfterTrackTotalHitsUpTo(int size) throws Exception {
         prepareCreate("test").setSettings(Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1).put(SETTING_NUMBER_OF_REPLICAS, 0)).get();
         ensureGreen();
@@ -340,6 +365,7 @@ public class SimpleSearchIT extends ParameterizedStaticSettingsOpenSearchIntegTe
         refresh();
 
         SearchResponse searchResponse;
+
         searchResponse = client().prepareSearch("test")
             .setQuery(QueryBuilders.rangeQuery("field").gte(1).lte(numDocs))
             .setTerminateAfter(10)
@@ -350,25 +376,28 @@ public class SimpleSearchIT extends ParameterizedStaticSettingsOpenSearchIntegTe
         assertEquals(5, searchResponse.getHits().getTotalHits().value);
         assertEquals(GREATER_THAN_OR_EQUAL_TO, searchResponse.getHits().getTotalHits().relation);
 
-        searchResponse = client().prepareSearch("test")
-            .setQuery(QueryBuilders.rangeQuery("field").gte(1).lte(numDocs))
-            .setTerminateAfter(5)
-            .setSize(size)
-            .setTrackTotalHitsUpTo(10)
-            .get();
-        assertTrue(searchResponse.isTerminatedEarly());
-        assertEquals(5, searchResponse.getHits().getTotalHits().value);
-        assertEquals(EQUAL_TO, searchResponse.getHits().getTotalHits().relation);
+        // For size = 0, the following queries terminate early, but hits and relation can vary.
+        if (size > 0) {
+            searchResponse = client().prepareSearch("test")
+                .setQuery(QueryBuilders.rangeQuery("field").gte(1).lte(numDocs))
+                .setTerminateAfter(5)
+                .setSize(size)
+                .setTrackTotalHitsUpTo(10)
+                .get();
+            assertTrue(searchResponse.isTerminatedEarly());
+            assertEquals(5, searchResponse.getHits().getTotalHits().value);
+            assertEquals(EQUAL_TO, searchResponse.getHits().getTotalHits().relation);
 
-        searchResponse = client().prepareSearch("test")
-            .setQuery(QueryBuilders.rangeQuery("field").gte(1).lte(numDocs))
-            .setTerminateAfter(5)
-            .setSize(size)
-            .setTrackTotalHitsUpTo(5)
-            .get();
-        assertTrue(searchResponse.isTerminatedEarly());
-        assertEquals(5, searchResponse.getHits().getTotalHits().value);
-        assertEquals(EQUAL_TO, searchResponse.getHits().getTotalHits().relation);
+            searchResponse = client().prepareSearch("test")
+                .setQuery(QueryBuilders.rangeQuery("field").gte(1).lte(numDocs))
+                .setTerminateAfter(5)
+                .setSize(size)
+                .setTrackTotalHitsUpTo(5)
+                .get();
+            assertTrue(searchResponse.isTerminatedEarly());
+            assertEquals(5, searchResponse.getHits().getTotalHits().value);
+            assertEquals(EQUAL_TO, searchResponse.getHits().getTotalHits().relation);
+        }
 
         searchResponse = client().prepareSearch("test")
             .setQuery(QueryBuilders.rangeQuery("field").gte(1).lte(numDocs))
@@ -377,7 +406,12 @@ public class SimpleSearchIT extends ParameterizedStaticSettingsOpenSearchIntegTe
             .setTrackTotalHits(true)
             .get();
         assertTrue(searchResponse.isTerminatedEarly());
-        assertEquals(5, searchResponse.getHits().getTotalHits().value);
+        if (size == 0) {
+            // Since terminate_after < track_total_hits, we need to do a range check.
+            assertHitCount(searchResponse, 5, numDocs);
+        } else {
+            assertEquals(5, searchResponse.getHits().getTotalHits().value);
+        }
         assertEquals(EQUAL_TO, searchResponse.getHits().getTotalHits().relation);
 
         searchResponse = client().prepareSearch("test")
@@ -399,12 +433,11 @@ public class SimpleSearchIT extends ParameterizedStaticSettingsOpenSearchIntegTe
         assertEquals(GREATER_THAN_OR_EQUAL_TO, searchResponse.getHits().getTotalHits().relation);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/10435")
-    public void testSimpleTerminateAfterTrackTotalHitsUpToRandomSize() throws Exception {
+    public void testSimpleTerminateAfterTrackTotalHitsUpToRandomSize0() throws Exception {
         doTestSimpleTerminateAfterTrackTotalHitsUpTo(0);
     }
 
-    public void testSimpleTerminateAfterTrackTotalHitsUpToSize0() throws Exception {
+    public void testSimpleTerminateAfterTrackTotalHitsUpToSize() throws Exception {
         doTestSimpleTerminateAfterTrackTotalHitsUpTo(randomIntBetween(1, 29));
     }
 

--- a/test/framework/src/main/java/org/opensearch/test/hamcrest/OpenSearchAssertions.java
+++ b/test/framework/src/main/java/org/opensearch/test/hamcrest/OpenSearchAssertions.java
@@ -304,6 +304,22 @@ public class OpenSearchAssertions {
         }
     }
 
+    public static void assertHitCount(SearchResponse countResponse, long minHitCount, long maxHitCount) {
+        final TotalHits totalHits = countResponse.getHits().getTotalHits();
+        if (!(totalHits.relation == TotalHits.Relation.EQUAL_TO && totalHits.value >= minHitCount && totalHits.value <= maxHitCount)) {
+            fail(
+                "Count is "
+                    + totalHits
+                    + " not between "
+                    + minHitCount
+                    + " and "
+                    + maxHitCount
+                    + " inclusive. "
+                    + formatShardStatus(countResponse)
+            );
+        }
+    }
+
     public static void assertExists(GetResponse response) {
         String message = String.format(Locale.ROOT, "Expected %s/%s to exist, but does not", response.getIndex(), response.getId());
         assertThat(message, response.isExists(), is(true));


### PR DESCRIPTION
…tch.  (Issue # 10435)

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #10435 
<!-- List any other related issues here -->

### Check List
- [ ] ~~New functionality includes testing.~~
  - [ ] ~~All tests pass~~
- [ ] ~~New functionality has been documented.~~
  - [ ] ~~New functionality has javadoc added~~
- [ ] ~~Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))~~
- [x] Commits are signed per the DCO using --signoff
- [ ] ~~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~~
- [ ] ~~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
