### PR TITLE
Resolve listener passed to WriteActionReplicasProxy#failShardIfNeeded when replica not failed

### DIFF
--- a/server/src/main/java/org/opensearch/action/support/replication/TransportWriteAction.java
+++ b/server/src/main/java/org/opensearch/action/support/replication/TransportWriteAction.java
@@ -586,6 +586,8 @@ public abstract class TransportWriteAction<
                     exception,
                     listener
                 );
+            } else {
+                listener.onResponse(null);
             }
         }
 

--- a/server/src/test/java/org/opensearch/action/support/replication/TransportWriteActionTests.java
+++ b/server/src/test/java/org/opensearch/action/support/replication/TransportWriteActionTests.java
@@ -440,8 +440,10 @@ public class TransportWriteActionTests extends OpenSearchTestCase {
                 new PrimaryShardClosedException(shardId),
                 ActionListener.wrap(callbackCount::incrementAndGet)
             );
+        // emptyArray ensures no failure call is invoked
         MatcherAssert.assertThat(transport.getCapturedRequestsAndClear(), emptyArray());
-        MatcherAssert.assertThat(callbackCount.get(), equalTo(0));
+        // listener should get invoked
+        MatcherAssert.assertThat(callbackCount.get(), equalTo(1));
     }
 
     private class TestAction extends TransportWriteAction<TestRequest, TestRequest, TestResponse> {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
On write operations we do not fail the replicas if the primary has been closed.  However in this case we are never resolving the listener passed to ReplicasProxy.  This can leave write requests open as `pendingActions` is never decref'd to 0 inside ReplicaOperation.

I found this while debugging https://github.com/opensearch-project/OpenSearch/issues/12114.  The requests that are left open are start_recovery and retention_lease_sync.  retention_lease_sync is a write operation that occurs as a step in recovery.  The recovery is cancelled and primary shut down while there is an ongoing sync.  The sync will hit this condition where the primary is shut down before the req is ack'd and closed on the node, leaving both the sync and original recovery req open.

leaving as draft for now will try and write a more thorough integ test of this case.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/12114

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
