### PR TITLE
[Backport 2.x] [Snapshot Interop] Fix Flakiness in Snapshot Interop C…

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteRestoreSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteRestoreSnapshotIT.java
@@ -10,7 +10,6 @@ package org.opensearch.remotestore;
 
 import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.admin.cluster.remotestore.restore.RestoreRemoteStoreRequest;
-import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
 import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.opensearch.action.admin.indices.get.GetIndexRequest;
@@ -140,32 +139,21 @@ public class RemoteRestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
 
         internalCluster().startDataOnlyNode();
         logger.info("--> snapshot");
-        CreateSnapshotResponse createSnapshotResponse = client.admin()
-            .cluster()
-            .prepareCreateSnapshot(snapshotRepoName, snapshotName1)
-            .setWaitForCompletion(true)
-            .setIndices(indexName1, indexName2)
-            .get();
-        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
-        assertThat(
-            createSnapshotResponse.getSnapshotInfo().successfulShards(),
-            equalTo(createSnapshotResponse.getSnapshotInfo().totalShards())
-        );
-        assertThat(createSnapshotResponse.getSnapshotInfo().state(), equalTo(SnapshotState.SUCCESS));
+
+        SnapshotInfo snapshotInfo = createSnapshot(snapshotRepoName, snapshotName1, new ArrayList<>(Arrays.asList(indexName1, indexName2)));
+        assertThat(snapshotInfo.state(), equalTo(SnapshotState.SUCCESS));
+        assertThat(snapshotInfo.successfulShards(), greaterThan(0));
+        assertThat(snapshotInfo.successfulShards(), equalTo(snapshotInfo.totalShards()));
 
         updateRepository(snapshotRepoName, "fs", getRepositorySettings(absolutePath1, false));
-        CreateSnapshotResponse createSnapshotResponse2 = client.admin()
-            .cluster()
-            .prepareCreateSnapshot(snapshotRepoName, snapshotName2)
-            .setWaitForCompletion(true)
-            .setIndices(indexName1, indexName2)
-            .get();
-        assertThat(createSnapshotResponse2.getSnapshotInfo().successfulShards(), greaterThan(0));
-        assertThat(
-            createSnapshotResponse2.getSnapshotInfo().successfulShards(),
-            equalTo(createSnapshotResponse2.getSnapshotInfo().totalShards())
+        SnapshotInfo snapshotInfo2 = createSnapshot(
+            snapshotRepoName,
+            snapshotName2,
+            new ArrayList<>(Arrays.asList(indexName1, indexName2))
         );
-        assertThat(createSnapshotResponse2.getSnapshotInfo().state(), equalTo(SnapshotState.SUCCESS));
+        assertThat(snapshotInfo2.state(), equalTo(SnapshotState.SUCCESS));
+        assertThat(snapshotInfo2.successfulShards(), greaterThan(0));
+        assertThat(snapshotInfo2.successfulShards(), equalTo(snapshotInfo2.totalShards()));
 
         DeleteResponse deleteResponse = client().prepareDelete(indexName1, "0").execute().actionGet();
         assertEquals(deleteResponse.getResult(), DocWriteResponse.Result.DELETED);
@@ -269,7 +257,6 @@ public class RemoteRestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         assertDocsPresentInIndex(client, restoredIndexName1Doc, numDocsInIndex1 + 2);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/9326")
     public void testRestoreInSameRemoteStoreEnabledIndex() throws IOException {
         String clusterManagerNode = internalCluster().startClusterManagerOnlyNode();
         String primary = internalCluster().startDataOnlyNode();
@@ -300,32 +287,24 @@ public class RemoteRestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
 
         internalCluster().startDataOnlyNode();
         logger.info("--> snapshot");
-        CreateSnapshotResponse createSnapshotResponse = client.admin()
-            .cluster()
-            .prepareCreateSnapshot(snapshotRepoName, snapshotName1)
-            .setWaitForCompletion(true)
-            .setIndices(indexName1, indexName2)
-            .get();
-        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
-        assertThat(
-            createSnapshotResponse.getSnapshotInfo().successfulShards(),
-            equalTo(createSnapshotResponse.getSnapshotInfo().totalShards())
+        SnapshotInfo snapshotInfo1 = createSnapshot(
+            snapshotRepoName,
+            snapshotName1,
+            new ArrayList<>(Arrays.asList(indexName1, indexName2))
         );
-        assertThat(createSnapshotResponse.getSnapshotInfo().state(), equalTo(SnapshotState.SUCCESS));
+        assertThat(snapshotInfo1.successfulShards(), greaterThan(0));
+        assertThat(snapshotInfo1.successfulShards(), equalTo(snapshotInfo1.totalShards()));
+        assertThat(snapshotInfo1.state(), equalTo(SnapshotState.SUCCESS));
 
         updateRepository(snapshotRepoName, "fs", getRepositorySettings(absolutePath1, false));
-        CreateSnapshotResponse createSnapshotResponse2 = client.admin()
-            .cluster()
-            .prepareCreateSnapshot(snapshotRepoName, snapshotName2)
-            .setWaitForCompletion(true)
-            .setIndices(indexName1, indexName2)
-            .get();
-        assertThat(createSnapshotResponse2.getSnapshotInfo().successfulShards(), greaterThan(0));
-        assertThat(
-            createSnapshotResponse2.getSnapshotInfo().successfulShards(),
-            equalTo(createSnapshotResponse2.getSnapshotInfo().totalShards())
+        SnapshotInfo snapshotInfo2 = createSnapshot(
+            snapshotRepoName,
+            snapshotName2,
+            new ArrayList<>(Arrays.asList(indexName1, indexName2))
         );
-        assertThat(createSnapshotResponse2.getSnapshotInfo().state(), equalTo(SnapshotState.SUCCESS));
+        assertThat(snapshotInfo2.successfulShards(), greaterThan(0));
+        assertThat(snapshotInfo2.successfulShards(), equalTo(snapshotInfo2.totalShards()));
+        assertThat(snapshotInfo2.state(), equalTo(SnapshotState.SUCCESS));
 
         DeleteResponse deleteResponse = client().prepareDelete(indexName1, "0").execute().actionGet();
         assertEquals(deleteResponse.getResult(), DocWriteResponse.Result.DELETED);
@@ -355,6 +334,10 @@ public class RemoteRestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         assertRemoteSegmentsAndTranslogUploaded(restoredIndexName2);
         assertDocsPresentInIndex(client, indexName1, numDocsInIndex1);
         assertDocsPresentInIndex(client, restoredIndexName2, numDocsInIndex2);
+        // indexing some new docs and validating
+        indexDocuments(client, indexName1, numDocsInIndex1, numDocsInIndex1 + 2);
+        ensureGreen(indexName1);
+        assertDocsPresentInIndex(client, indexName1, numDocsInIndex1 + 2);
 
         // deleting data for restoredIndexName1 and restoring from remote store.
         internalCluster().stopRandomNode(InternalTestCluster.nameFilter(primary));
@@ -369,9 +352,9 @@ public class RemoteRestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         ensureGreen(indexName1);
         assertDocsPresentInIndex(client(), indexName1, numDocsInIndex1);
         // indexing some new docs and validating
-        indexDocuments(client, indexName1, numDocsInIndex1, numDocsInIndex1 + 2);
+        indexDocuments(client, indexName1, numDocsInIndex1 + 2, numDocsInIndex1 + 4);
         ensureGreen(indexName1);
-        assertDocsPresentInIndex(client, indexName1, numDocsInIndex1 + 2);
+        assertDocsPresentInIndex(client, indexName1, numDocsInIndex1 + 4);
     }
 
     void assertRemoteSegmentsAndTranslogUploaded(String idx) throws IOException {
@@ -496,18 +479,14 @@ public class RemoteRestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         internalCluster().startDataOnlyNode();
 
         logger.info("--> snapshot");
-        CreateSnapshotResponse createSnapshotResponse = client.admin()
-            .cluster()
-            .prepareCreateSnapshot(snapshotRepoName, snapshotName1)
-            .setWaitForCompletion(true)
-            .setIndices(indexName1, indexName2)
-            .get();
-        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
-        assertThat(
-            createSnapshotResponse.getSnapshotInfo().successfulShards(),
-            equalTo(createSnapshotResponse.getSnapshotInfo().totalShards())
+        SnapshotInfo snapshotInfo1 = createSnapshot(
+            snapshotRepoName,
+            snapshotName1,
+            new ArrayList<>(Arrays.asList(indexName1, indexName2))
         );
-        assertThat(createSnapshotResponse.getSnapshotInfo().state(), equalTo(SnapshotState.SUCCESS));
+        assertThat(snapshotInfo1.successfulShards(), greaterThan(0));
+        assertThat(snapshotInfo1.successfulShards(), equalTo(snapshotInfo1.totalShards()));
+        assertThat(snapshotInfo1.state(), equalTo(SnapshotState.SUCCESS));
 
         Settings remoteStoreIndexSettings = Settings.builder()
             .put(IndexMetadata.SETTING_REMOTE_SEGMENT_STORE_REPOSITORY, remoteStoreRepo2Name)
@@ -583,18 +562,10 @@ public class RemoteRestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         ensureGreen(indexName1);
 
         logger.info("--> snapshot");
-        CreateSnapshotResponse createSnapshotResponse = client.admin()
-            .cluster()
-            .prepareCreateSnapshot(snapshotRepoName, snapshotName1)
-            .setWaitForCompletion(true)
-            .setIndices(indexName1)
-            .get();
-        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
-        assertThat(
-            createSnapshotResponse.getSnapshotInfo().successfulShards(),
-            equalTo(createSnapshotResponse.getSnapshotInfo().totalShards())
-        );
-        assertThat(createSnapshotResponse.getSnapshotInfo().state(), equalTo(SnapshotState.SUCCESS));
+        SnapshotInfo snapshotInfo1 = createSnapshot(snapshotRepoName, snapshotName1, new ArrayList<>(List.of(indexName1)));
+        assertThat(snapshotInfo1.successfulShards(), greaterThan(0));
+        assertThat(snapshotInfo1.successfulShards(), equalTo(snapshotInfo1.totalShards()));
+        assertThat(snapshotInfo1.state(), equalTo(SnapshotState.SUCCESS));
 
         client().admin().indices().close(Requests.closeIndexRequest(indexName1)).get();
         createRepository(remoteStoreRepoNameUpdated, "fs", remoteRepoPath);

--- a/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryHelperTests.java
+++ b/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryHelperTests.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.repositories.blobstore;
 
+import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
 import org.opensearch.action.support.master.AcknowledgedResponse;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.metadata.IndexMetadata;
@@ -15,6 +16,7 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.blobstore.BlobContainer;
 import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.core.common.Strings;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.env.Environment;
 import org.opensearch.index.IndexModule;
@@ -29,6 +31,8 @@ import org.opensearch.plugins.RepositoryPlugin;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.repositories.Repository;
 import org.opensearch.repositories.fs.FsRepository;
+import org.opensearch.snapshots.SnapshotInfo;
+import org.opensearch.snapshots.SnapshotState;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
 
@@ -36,9 +40,12 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
 
 public class BlobStoreRepositoryHelperTests extends OpenSearchSingleNodeTestCase {
 
@@ -124,13 +131,28 @@ public class BlobStoreRepositoryHelperTests extends OpenSearchSingleNodeTestCase
             .build();
     }
 
+    protected SnapshotInfo createSnapshot(String repositoryName, String snapshot, List<String> indices) {
+        logger.info("--> creating snapshot [{}] of {} in [{}]", snapshot, indices, repositoryName);
+
+        final CreateSnapshotResponse response = client().admin()
+            .cluster()
+            .prepareCreateSnapshot(repositoryName, snapshot)
+            .setIndices(indices.toArray(Strings.EMPTY_ARRAY))
+            .setWaitForCompletion(true)
+            .get();
+        SnapshotInfo snapshotInfo = response.getSnapshotInfo();
+        assertThat(snapshotInfo.state(), is(SnapshotState.SUCCESS));
+        assertThat(snapshotInfo.successfulShards(), greaterThan(0));
+        assertThat(snapshotInfo.failedShards(), equalTo(0));
+        return snapshotInfo;
+    }
+
     protected void indexDocuments(Client client, String indexName) {
         int numDocs = randomIntBetween(10, 20);
         for (int i = 0; i < numDocs; i++) {
             String id = Integer.toString(i);
             client.prepareIndex(indexName).setId(id).setSource("text", "sometext").get();
         }
-        client.admin().indices().prepareFlush(indexName).get();
     }
 
     protected IndexSettings getIndexSettings(String indexName) {

--- a/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryRemoteIndexTests.java
+++ b/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryRemoteIndexTests.java
@@ -33,7 +33,6 @@
 package org.opensearch.repositories.blobstore;
 
 import org.opensearch.action.admin.cluster.repositories.get.GetRepositoriesResponse;
-import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.metadata.RepositoryMetadata;
 import org.opensearch.common.settings.Settings;
@@ -48,10 +47,12 @@ import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.repositories.RepositoryData;
 import org.opensearch.repositories.fs.FsRepository;
 import org.opensearch.snapshots.SnapshotId;
+import org.opensearch.snapshots.SnapshotInfo;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -135,13 +136,12 @@ public class BlobStoreRepositoryRemoteIndexTests extends BlobStoreRepositoryHelp
         indexDocuments(client, remoteStoreIndexName);
 
         logger.info("--> create first snapshot");
-        CreateSnapshotResponse createSnapshotResponse = client.admin()
-            .cluster()
-            .prepareCreateSnapshot(snapshotRepositoryName, "test-snap-1")
-            .setWaitForCompletion(true)
-            .setIndices(indexName, remoteStoreIndexName)
-            .get();
-        final SnapshotId snapshotId1 = createSnapshotResponse.getSnapshotInfo().snapshotId();
+        SnapshotInfo snapshotInfo = createSnapshot(
+            snapshotRepositoryName,
+            "test-snap-1",
+            new ArrayList<>(Arrays.asList(indexName, remoteStoreIndexName))
+        );
+        final SnapshotId snapshotId1 = snapshotInfo.snapshotId();
 
         String[] lockFiles = getLockFilesInRemoteStore(remoteStoreIndexName, remoteStoreRepositoryName);
         assertEquals("there should be no lock files present in directory, but found " + Arrays.toString(lockFiles), 0, lockFiles.length);
@@ -152,13 +152,12 @@ public class BlobStoreRepositoryRemoteIndexTests extends BlobStoreRepositoryHelp
             .build();
         updateRepository(client, snapshotRepositoryName, snapshotRepoSettingsForShallowCopy);
 
-        createSnapshotResponse = client.admin()
-            .cluster()
-            .prepareCreateSnapshot(snapshotRepositoryName, "test-snap-2")
-            .setWaitForCompletion(true)
-            .setIndices(indexName, remoteStoreIndexName)
-            .get();
-        final SnapshotId snapshotId2 = createSnapshotResponse.getSnapshotInfo().snapshotId();
+        snapshotInfo = createSnapshot(
+            snapshotRepositoryName,
+            "test-snap-2",
+            new ArrayList<>(Arrays.asList(indexName, remoteStoreIndexName))
+        );
+        final SnapshotId snapshotId2 = snapshotInfo.snapshotId();
 
         lockFiles = getLockFilesInRemoteStore(remoteStoreIndexName, remoteStoreRepositoryName);
         assertEquals("there should be only one lock file, but found " + Arrays.toString(lockFiles), 1, lockFiles.length);
@@ -166,13 +165,12 @@ public class BlobStoreRepositoryRemoteIndexTests extends BlobStoreRepositoryHelp
 
         logger.info("--> create another normal snapshot");
         updateRepository(client, snapshotRepositoryName, snapshotRepoSettings);
-        createSnapshotResponse = client.admin()
-            .cluster()
-            .prepareCreateSnapshot(snapshotRepositoryName, "test-snap-3")
-            .setWaitForCompletion(true)
-            .setIndices(indexName, remoteStoreIndexName)
-            .get();
-        final SnapshotId snapshotId3 = createSnapshotResponse.getSnapshotInfo().snapshotId();
+        snapshotInfo = createSnapshot(
+            snapshotRepositoryName,
+            "test-snap-3",
+            new ArrayList<>(Arrays.asList(indexName, remoteStoreIndexName))
+        );
+        final SnapshotId snapshotId3 = snapshotInfo.snapshotId();
 
         lockFiles = getLockFilesInRemoteStore(remoteStoreIndexName, remoteStoreRepositoryName);
         assertEquals("there should be only one lock file, but found " + Arrays.toString(lockFiles), 1, lockFiles.length);
@@ -227,13 +225,8 @@ public class BlobStoreRepositoryRemoteIndexTests extends BlobStoreRepositoryHelp
             .build();
         updateRepository(client, snapshotRepositoryName, snapshotRepoSettingsForShallowCopy);
 
-        CreateSnapshotResponse createSnapshotResponse = client.admin()
-            .cluster()
-            .prepareCreateSnapshot(snapshotRepositoryName, "test-snap-2")
-            .setWaitForCompletion(true)
-            .setIndices(remoteStoreIndexName)
-            .get();
-        final SnapshotId snapshotId = createSnapshotResponse.getSnapshotInfo().snapshotId();
+        SnapshotInfo snapshotInfo = createSnapshot(snapshotRepositoryName, "test-snap-2", new ArrayList<>(List.of(remoteStoreIndexName)));
+        final SnapshotId snapshotId = snapshotInfo.snapshotId();
 
         String[] lockFiles = getLockFilesInRemoteStore(remoteStoreIndexName, remoteStoreRepositoryName);
         assertEquals("there should be only one lock file, but found " + Arrays.toString(lockFiles), 1, lockFiles.length);
@@ -303,26 +296,24 @@ public class BlobStoreRepositoryRemoteIndexTests extends BlobStoreRepositoryHelp
 
         assertTrue(updatedRepositoryMetadata.settings().getAsBoolean(BlobStoreRepository.REMOTE_STORE_INDEX_SHALLOW_COPY.getKey(), false));
 
-        CreateSnapshotResponse createSnapshotResponse = client.admin()
-            .cluster()
-            .prepareCreateSnapshot(snapshotRepositoryName, "test-snap-1")
-            .setWaitForCompletion(true)
-            .setIndices(indexName, remoteStoreIndexName)
-            .get();
-        final SnapshotId snapshotId1 = createSnapshotResponse.getSnapshotInfo().snapshotId();
+        SnapshotInfo snapshotInfo = createSnapshot(
+            snapshotRepositoryName,
+            "test-snap-1",
+            new ArrayList<>(Arrays.asList(indexName, remoteStoreIndexName))
+        );
+        final SnapshotId snapshotId1 = snapshotInfo.snapshotId();
 
         String[] lockFiles = getLockFilesInRemoteStore(remoteStoreIndexName, remoteStoreRepositoryName);
         assertEquals("lock files are " + Arrays.toString(lockFiles), 1, lockFiles.length);
         assertTrue(lockFiles[0].endsWith(snapshotId1.getUUID() + ".v2_lock"));
 
         logger.info("--> create second remote index shallow snapshot");
-        createSnapshotResponse = client.admin()
-            .cluster()
-            .prepareCreateSnapshot(snapshotRepositoryName, "test-snap-2")
-            .setWaitForCompletion(true)
-            .setIndices(indexName, remoteStoreIndexName)
-            .get();
-        final SnapshotId snapshotId2 = createSnapshotResponse.getSnapshotInfo().snapshotId();
+        snapshotInfo = createSnapshot(
+            snapshotRepositoryName,
+            "test-snap-2",
+            new ArrayList<>(Arrays.asList(indexName, remoteStoreIndexName))
+        );
+        final SnapshotId snapshotId2 = snapshotInfo.snapshotId();
 
         lockFiles = getLockFilesInRemoteStore(remoteStoreIndexName, remoteStoreRepositoryName);
         assertEquals("lock files are " + Arrays.toString(lockFiles), 2, lockFiles.length);
@@ -331,13 +322,12 @@ public class BlobStoreRepositoryRemoteIndexTests extends BlobStoreRepositoryHelp
             assertTrue(lockFiles[0].contains(snapshotId.getUUID()) || lockFiles[1].contains(snapshotId.getUUID()));
         }
         logger.info("--> create third remote index shallow snapshot");
-        createSnapshotResponse = client.admin()
-            .cluster()
-            .prepareCreateSnapshot(snapshotRepositoryName, "test-snap-3")
-            .setWaitForCompletion(true)
-            .setIndices(indexName, remoteStoreIndexName)
-            .get();
-        final SnapshotId snapshotId3 = createSnapshotResponse.getSnapshotInfo().snapshotId();
+        snapshotInfo = createSnapshot(
+            snapshotRepositoryName,
+            "test-snap-3",
+            new ArrayList<>(Arrays.asList(indexName, remoteStoreIndexName))
+        );
+        final SnapshotId snapshotId3 = snapshotInfo.snapshotId();
 
         lockFiles = getLockFilesInRemoteStore(remoteStoreIndexName, remoteStoreRepositoryName);
         assertEquals(3, lockFiles.length);
@@ -351,13 +341,12 @@ public class BlobStoreRepositoryRemoteIndexTests extends BlobStoreRepositoryHelp
         }
         logger.info("--> create normal snapshot");
         createRepository(client, snapshotRepositoryName, snapshotRepoSettings);
-        createSnapshotResponse = client.admin()
-            .cluster()
-            .prepareCreateSnapshot(snapshotRepositoryName, "test-snap-4")
-            .setWaitForCompletion(true)
-            .setIndices(indexName, remoteStoreIndexName)
-            .get();
-        final SnapshotId snapshotId4 = createSnapshotResponse.getSnapshotInfo().snapshotId();
+        snapshotInfo = createSnapshot(
+            snapshotRepositoryName,
+            "test-snap-4",
+            new ArrayList<>(Arrays.asList(indexName, remoteStoreIndexName))
+        );
+        final SnapshotId snapshotId4 = snapshotInfo.snapshotId();
 
         lockFiles = getLockFilesInRemoteStore(remoteStoreIndexName, remoteStoreRepositoryName);
         assertEquals("lock files are " + Arrays.toString(lockFiles), 3, lockFiles.length);

--- a/test/framework/src/main/java/org/opensearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -487,11 +487,12 @@ public abstract class AbstractSnapshotIntegTestCase extends OpenSearchIntegTestC
 
     protected SnapshotInfo createFullSnapshot(String repoName, String snapshotName) {
         logger.info("--> creating full snapshot [{}] in [{}]", snapshotName, repoName);
-        CreateSnapshotResponse createSnapshotResponse = clusterAdmin().prepareCreateSnapshot(repoName, snapshotName)
-            .setIncludeGlobalState(true)
+        final CreateSnapshotResponse response = client().admin()
+            .cluster()
+            .prepareCreateSnapshot(repoName, snapshotName)
             .setWaitForCompletion(true)
             .get();
-        final SnapshotInfo snapshotInfo = createSnapshotResponse.getSnapshotInfo();
+        final SnapshotInfo snapshotInfo = response.getSnapshotInfo();
         assertThat(snapshotInfo.successfulShards(), is(snapshotInfo.totalShards()));
         assertThat(snapshotInfo.state(), is(SnapshotState.SUCCESS));
         return snapshotInfo;
@@ -505,8 +506,8 @@ public abstract class AbstractSnapshotIntegTestCase extends OpenSearchIntegTestC
             .setIndices(indices.toArray(Strings.EMPTY_ARRAY))
             .setWaitForCompletion(true)
             .get();
+        SnapshotInfo snapshotInfo = response.getSnapshotInfo();
 
-        final SnapshotInfo snapshotInfo = response.getSnapshotInfo();
         assertThat(snapshotInfo.state(), is(SnapshotState.SUCCESS));
         assertThat(snapshotInfo.successfulShards(), greaterThan(0));
         assertThat(snapshotInfo.failedShards(), equalTo(0));


### PR DESCRIPTION
…ode (#9795)



<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Backporting https://github.com/opensearch-project/OpenSearch/commit/951f051580a9feef37affd409d5892f50e9585a4 to 2.x which failed as part of https://github.com/opensearch-project/OpenSearch/pull/9867

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
