### PR TITLE
Increase index_searcher thread count to 2x processor

### DIFF
--- a/server/src/main/java/org/opensearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/opensearch/threadpool/ThreadPool.java
@@ -281,7 +281,13 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         );
         builders.put(
             Names.INDEX_SEARCHER,
-            new ResizableExecutorBuilder(settings, Names.INDEX_SEARCHER, allocatedProcessors, 1000, runnableTaskListener)
+            new ResizableExecutorBuilder(
+                settings,
+                Names.INDEX_SEARCHER,
+                twiceAllocatedProcessors(allocatedProcessors),
+                1000,
+                runnableTaskListener
+            )
         );
 
         for (final ExecutorBuilder<?> builder : customBuilders) {


### PR DESCRIPTION
### Description
With the Lucene 9.9 changes the `search` threadpool will now offload *all* the tasks to the `index_searcher` threadpool. Since the number of threads for the `index_searcher` threadpool today is `allocatedProcessors`, this will significantly reduce the throughput of concurrent segment search.

Previously, there are 1.5x processors for the search threadpool and 1x processors for the index_searcher threadpool, giving 2.5x processor threads available for search. With the Lucene 9.9 change there will only be 1x processors available for the `index_searcher` threadpool to use. Even for the single slice case this is a significant throughput decrease as previously the single slice case would be executed on the `search` threadpool which has 1.5x processor threads.

This PR bumps the `index_searcher` thread count to 2x to move the search throughput back towards the original level.

### Related Issues

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
