### PR TITLE
[Backport 2.12] Increase index_searcher thread count to 2x processor (#12196)

### DIFF
--- a/server/src/main/java/org/opensearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/opensearch/threadpool/ThreadPool.java
@@ -295,7 +295,7 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
             new AutoQueueAdjustingExecutorBuilder(
                 settings,
                 Names.INDEX_SEARCHER,
-                allocatedProcessors,
+                twiceAllocatedProcessors(allocatedProcessors),
                 1000,
                 1000,
                 1000,


### PR DESCRIPTION
### Description
Backport #12196 to 2.12

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
