### PR TITLE
Light weight Transport action to verify local term before fetching cluster-state from remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Admission Control] Integrated IO Based AdmissionController to AdmissionControl Framework ([#12583](https://github.com/opensearch-project/OpenSearch/pull/12583))
 - Introduce a new setting `index.check_pending_flush.enabled` to expose the ability to disable the check for pending flushes by write threads ([#12710](https://github.com/opensearch-project/OpenSearch/pull/12710))
 - Built-in secure transports support ([#12435](https://github.com/opensearch-project/OpenSearch/pull/12435))
+- Lightweight Transport action to verify local term before fetching cluster-state from remote ([#12252](https://github.com/opensearch-project/OpenSearch/pull/12252/))
 
 ### Dependencies
 - Bump `peter-evans/find-comment` from 2 to 3 ([#12288](https://github.com/opensearch-project/OpenSearch/pull/12288))

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/state/FetchByTermVersionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/state/FetchByTermVersionIT.java
@@ -1,0 +1,161 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.state;
+
+import org.opensearch.action.admin.cluster.state.ClusterStateRequest;
+import org.opensearch.action.admin.cluster.state.ClusterStateResponse;
+import org.opensearch.action.admin.cluster.state.term.GetTermVersionAction;
+import org.opensearch.action.admin.cluster.state.term.GetTermVersionResponse;
+import org.opensearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.coordination.ClusterStateTermVersion;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.test.transport.MockTransportService;
+import org.opensearch.transport.TransportService;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.Matchers.is;
+
+@SuppressWarnings("unchecked")
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class FetchByTermVersionIT extends OpenSearchIntegTestCase {
+
+    AtomicBoolean isTermVersionCheckEnabled = new AtomicBoolean();
+
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(MockTransportService.TestPlugin.class);
+    }
+
+    AtomicBoolean forceFetchFromCM = new AtomicBoolean();
+
+    public void testClusterStateResponseFromDataNode() throws Exception {
+        String cm = internalCluster().startClusterManagerOnlyNode();
+        List<String> dns = internalCluster().startDataOnlyNodes(5);
+        int numberOfShards = dns.size();
+        stubClusterTermResponse(cm);
+
+        ensureClusterSizeConsistency();
+        ensureGreen();
+
+        List<String> indices = new ArrayList<>();
+
+        // Create a large sized cluster-state by creating field mappings
+        IntStream.range(0, 20).forEachOrdered(n -> {
+            String index = "index_" + n;
+            createIndex(
+                index,
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numberOfShards)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put(MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING.getKey(), Long.MAX_VALUE)
+                    .build()
+            );
+            indices.add(index);
+        });
+        IntStream.range(0, 5).forEachOrdered(n -> {
+            List<String> mappings = new ArrayList<>();
+            for (int i = 0; i < 2000; i++) {
+                mappings.add("t-123456789-123456789-" + n + "-" + i);
+                mappings.add("type=keyword");
+            }
+            PutMappingRequest request = new PutMappingRequest().source(mappings.toArray(new String[0]))
+                .indices(indices.toArray(new String[0]));
+            internalCluster().dataNodeClient().admin().indices().putMapping(request).actionGet();
+        });
+        ensureGreen();
+
+        ClusterStateResponse stateResponseM = internalCluster().clusterManagerClient()
+            .admin()
+            .cluster()
+            .state(new ClusterStateRequest())
+            .actionGet();
+
+        waitUntil(() -> {
+            ClusterStateResponse stateResponseD = internalCluster().dataNodeClient()
+                .admin()
+                .cluster()
+                .state(new ClusterStateRequest())
+                .actionGet();
+            return stateResponseD.getState().stateUUID().equals(stateResponseM.getState().stateUUID());
+        });
+        // cluster state response time with term check enabled on datanode
+        isTermVersionCheckEnabled.set(true);
+        {
+            List<Long> latencies = new ArrayList<>();
+            IntStream.range(0, 50).forEachOrdered(n1 -> {
+                ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
+                long start = System.currentTimeMillis();
+                ClusterStateResponse stateResponse = dataNodeClient().admin().cluster().state(clusterStateRequest).actionGet();
+                latencies.add(System.currentTimeMillis() - start);
+                assertThat(stateResponse.getClusterName().value(), is(internalCluster().getClusterName()));
+                assertThat(stateResponse.getState().nodes().getSize(), is(internalCluster().getNodeNames().length));
+                assertThat(stateResponse.getState().metadata().indices().size(), is(indices.size()));
+                Map<String, Object> fieldMappings = (Map<String, Object>) stateResponse.getState()
+                    .metadata()
+                    .index(indices.get(0))
+                    .mapping()
+                    .sourceAsMap()
+                    .get("properties");
+
+                assertThat(fieldMappings.size(), is(10000));
+            });
+            Collections.sort(latencies);
+
+            logger.info("cluster().state() fetch with Term Version enabled took {} milliseconds", (latencies.get(latencies.size() / 2)));
+        }
+        // cluster state response time with term check disabled on datanode
+        isTermVersionCheckEnabled.set(false);
+        {
+            List<Long> latencies = new ArrayList<>();
+            IntStream.range(0, 50).forEachOrdered(n1 -> {
+                ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
+                long start = System.currentTimeMillis();
+                ClusterStateResponse stateResponse = dataNodeClient().admin().cluster().state(clusterStateRequest).actionGet();
+                latencies.add(System.currentTimeMillis() - start);
+                assertThat(stateResponse.getClusterName().value(), is(internalCluster().getClusterName()));
+                assertThat(stateResponse.getState().nodes().getSize(), is(internalCluster().getNodeNames().length));
+                assertThat(stateResponse.getState().metadata().indices().size(), is(indices.size()));
+                Map<String, Object> typeProperties = (Map<String, Object>) stateResponse.getState()
+                    .metadata()
+                    .index(indices.get(0))
+                    .mapping()
+                    .sourceAsMap()
+                    .get("properties");
+                assertThat(typeProperties.size(), is(10000));
+
+            });
+            Collections.sort(latencies);
+            logger.info("cluster().state() fetch with Term Version disabled took {} milliseconds", (latencies.get(latencies.size() / 2)));
+        }
+
+    }
+
+    private void stubClusterTermResponse(String master) {
+        MockTransportService primaryService = (MockTransportService) internalCluster().getInstance(TransportService.class, master);
+        primaryService.addRequestHandlingBehavior(GetTermVersionAction.NAME, (handler, request, channel, task) -> {
+            if (isTermVersionCheckEnabled.get()) {
+                handler.messageReceived(request, channel, task);
+            } else {
+                // always return response that does not match
+                channel.sendResponse(new GetTermVersionResponse(new ClusterStateTermVersion(new ClusterName("test"), "1", -1, -1)));
+            }
+        });
+    }
+}

--- a/server/src/main/java/org/opensearch/action/ActionModule.java
+++ b/server/src/main/java/org/opensearch/action/ActionModule.java
@@ -107,6 +107,8 @@ import org.opensearch.action.admin.cluster.snapshots.status.SnapshotsStatusActio
 import org.opensearch.action.admin.cluster.snapshots.status.TransportSnapshotsStatusAction;
 import org.opensearch.action.admin.cluster.state.ClusterStateAction;
 import org.opensearch.action.admin.cluster.state.TransportClusterStateAction;
+import org.opensearch.action.admin.cluster.state.term.GetTermVersionAction;
+import org.opensearch.action.admin.cluster.state.term.TransportGetTermVersionAction;
 import org.opensearch.action.admin.cluster.stats.ClusterStatsAction;
 import org.opensearch.action.admin.cluster.stats.TransportClusterStatsAction;
 import org.opensearch.action.admin.cluster.storedscripts.DeleteStoredScriptAction;
@@ -614,6 +616,7 @@ public class ActionModule extends AbstractModule {
         actions.register(ClusterAllocationExplainAction.INSTANCE, TransportClusterAllocationExplainAction.class);
         actions.register(ClusterStatsAction.INSTANCE, TransportClusterStatsAction.class);
         actions.register(ClusterStateAction.INSTANCE, TransportClusterStateAction.class);
+        actions.register(GetTermVersionAction.INSTANCE, TransportGetTermVersionAction.class);
         actions.register(ClusterHealthAction.INSTANCE, TransportClusterHealthAction.class);
         actions.register(ClusterUpdateSettingsAction.INSTANCE, TransportClusterUpdateSettingsAction.class);
         actions.register(ClusterRerouteAction.INSTANCE, TransportClusterRerouteAction.class);

--- a/server/src/main/java/org/opensearch/action/admin/cluster/state/TransportClusterStateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/state/TransportClusterStateAction.java
@@ -231,4 +231,8 @@ public class TransportClusterStateAction extends TransportClusterManagerNodeRead
         return new ClusterStateResponse(currentState.getClusterName(), builder.build(), false);
     }
 
+    @Override
+    protected boolean checkTermVersion() {
+        return true;
+    }
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/state/TransportClusterStateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/state/TransportClusterStateAction.java
@@ -235,7 +235,7 @@ public class TransportClusterStateAction extends TransportClusterManagerNodeRead
     }
 
     @Override
-    protected boolean canUseLocalNodeClusterState() {
+    protected boolean localExecuteSupportedByAction() {
         return true;
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/state/TransportClusterStateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/state/TransportClusterStateAction.java
@@ -125,9 +125,12 @@ public class TransportClusterStateAction extends TransportClusterManagerNodeRead
             ? clusterState -> true
             : clusterState -> clusterState.metadata().version() >= request.waitForMetadataVersion();
 
+        // action will be executed on local node, if either the request is local only (or) the local node has the same cluster-state as
+        // ClusterManager
         final Predicate<ClusterState> acceptableClusterStateOrNotMasterPredicate = request.local()
-            ? acceptableClusterStatePredicate
-            : acceptableClusterStatePredicate.or(clusterState -> clusterState.nodes().isLocalNodeElectedClusterManager() == false);
+            || !state.nodes().isLocalNodeElectedClusterManager()
+                ? acceptableClusterStatePredicate
+                : acceptableClusterStatePredicate.or(clusterState -> clusterState.nodes().isLocalNodeElectedClusterManager() == false);
 
         if (acceptableClusterStatePredicate.test(state)) {
             ActionListener.completeWith(listener, () -> buildResponse(request, state));

--- a/server/src/main/java/org/opensearch/action/admin/cluster/state/TransportClusterStateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/state/TransportClusterStateAction.java
@@ -232,7 +232,7 @@ public class TransportClusterStateAction extends TransportClusterManagerNodeRead
     }
 
     @Override
-    protected boolean checkTermVersion() {
+    protected boolean canUseLocalNodeClusterState() {
         return true;
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/state/term/GetTermVersionAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/state/term/GetTermVersionAction.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.state.term;
+
+import org.opensearch.action.ActionType;
+
+/**
+ * Transport action for fetching cluster term and version
+ *
+ * @opensearch.internal
+ */
+public class GetTermVersionAction extends ActionType<GetTermVersionResponse> {
+
+    public static final GetTermVersionAction INSTANCE = new GetTermVersionAction();
+    public static final String NAME = "cluster:monitor/term";
+
+    private GetTermVersionAction() {
+        super(NAME, GetTermVersionResponse::new);
+    }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/state/term/GetTermVersionRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/state/term/GetTermVersionRequest.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.state.term;
+
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.support.clustermanager.ClusterManagerNodeReadRequest;
+import org.opensearch.core.common.io.stream.StreamInput;
+
+import java.io.IOException;
+
+/**
+ * Request object to get cluster term
+ *
+ * @opensearch.internal
+ */
+public class GetTermVersionRequest extends ClusterManagerNodeReadRequest<GetTermVersionRequest> {
+
+    public GetTermVersionRequest() {}
+
+    public GetTermVersionRequest(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/state/term/GetTermVersionRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/state/term/GetTermVersionRequest.java
@@ -15,7 +15,7 @@ import org.opensearch.core.common.io.stream.StreamInput;
 import java.io.IOException;
 
 /**
- * Request object to get cluster term
+ * Request object to get cluster term and version
  *
  * @opensearch.internal
  */

--- a/server/src/main/java/org/opensearch/action/admin/cluster/state/term/GetTermVersionResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/state/term/GetTermVersionResponse.java
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.state.term;
+
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+/**
+ * Response object of cluster term
+ *
+ * @opensearch.internal
+ */
+public class GetTermVersionResponse extends ActionResponse {
+
+    private final ClusterName clusterName;
+    private final String stateUUID;
+    private final long term;
+    private final long version;
+
+    public GetTermVersionResponse(ClusterName clusterName, String stateUUID, long term, long version) {
+        this.clusterName = clusterName;
+        this.stateUUID = stateUUID;
+        this.term = term;
+        this.version = version;
+    }
+
+    public GetTermVersionResponse(StreamInput in) throws IOException {
+        super(in);
+        this.clusterName = new ClusterName(in);
+        this.stateUUID = in.readString();
+        this.term = in.readLong();
+        this.version = in.readLong();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        clusterName.writeTo(out);
+        out.writeString(stateUUID);
+        out.writeLong(term);
+        out.writeLong(version);
+    }
+
+    public long getTerm() {
+        return term;
+    }
+
+    public long getVersion() {
+        return version;
+    }
+
+    public ClusterName getClusterName() {
+        return clusterName;
+    }
+
+    public String getStateUUID() {
+        return stateUUID;
+    }
+
+    public boolean matches(ClusterState clusterState) {
+        return clusterName.equals(clusterState.getClusterName())
+            && stateUUID.equals(clusterState.stateUUID())
+            && term == clusterState.term()
+            && version == clusterState.version();
+    }
+
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/state/term/GetTermVersionResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/state/term/GetTermVersionResponse.java
@@ -8,8 +8,8 @@
 
 package org.opensearch.action.admin.cluster.state.term;
 
-import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.coordination.ClusterStateTermVersion;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -23,55 +23,32 @@ import java.io.IOException;
  */
 public class GetTermVersionResponse extends ActionResponse {
 
-    private final ClusterName clusterName;
-    private final String clusterUUID;
-    private final long term;
-    private final long version;
+    private final ClusterStateTermVersion clusterStateTermVersion;
 
-    public GetTermVersionResponse(ClusterName clusterName, String clusterUUID, long term, long version) {
-        this.clusterName = clusterName;
-        this.clusterUUID = clusterUUID;
-        this.term = term;
-        this.version = version;
+    public GetTermVersionResponse(ClusterStateTermVersion clusterStateTermVersion) {
+        this.clusterStateTermVersion = clusterStateTermVersion;
     }
 
     public GetTermVersionResponse(StreamInput in) throws IOException {
         super(in);
-        this.clusterName = new ClusterName(in);
-        this.clusterUUID = in.readString();
-        this.term = in.readLong();
-        this.version = in.readLong();
+        this.clusterStateTermVersion = new ClusterStateTermVersion(in);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        clusterName.writeTo(out);
-        out.writeString(clusterUUID);
-        out.writeLong(term);
-        out.writeLong(version);
+        clusterStateTermVersion.writeTo(out);
     }
 
-    public long getTerm() {
-        return term;
-    }
-
-    public long getVersion() {
-        return version;
-    }
-
-    public ClusterName getClusterName() {
-        return clusterName;
-    }
-
-    public String getClusterUUID() {
-        return clusterUUID;
+    public ClusterStateTermVersion getClusterStateTermVersion() {
+        return clusterStateTermVersion;
     }
 
     public boolean matches(ClusterState clusterState) {
-        return clusterName.equals(clusterState.getClusterName())
-            && clusterUUID.equals(clusterState.metadata().clusterUUID())
-            && term == clusterState.term()
-            && version == clusterState.version();
+        return clusterStateTermVersion != null
+            && clusterStateTermVersion.getClusterName().equals(clusterState.getClusterName())
+            && clusterStateTermVersion.getClusterUUID().equals(clusterState.metadata().clusterUUID())
+            && clusterStateTermVersion.getTerm() == clusterState.term()
+            && clusterStateTermVersion.getVersion() == clusterState.version();
     }
 
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/state/term/GetTermVersionResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/state/term/GetTermVersionResponse.java
@@ -24,13 +24,13 @@ import java.io.IOException;
 public class GetTermVersionResponse extends ActionResponse {
 
     private final ClusterName clusterName;
-    private final String stateUUID;
+    private final String clusterUUID;
     private final long term;
     private final long version;
 
-    public GetTermVersionResponse(ClusterName clusterName, String stateUUID, long term, long version) {
+    public GetTermVersionResponse(ClusterName clusterName, String clusterUUID, long term, long version) {
         this.clusterName = clusterName;
-        this.stateUUID = stateUUID;
+        this.clusterUUID = clusterUUID;
         this.term = term;
         this.version = version;
     }
@@ -38,7 +38,7 @@ public class GetTermVersionResponse extends ActionResponse {
     public GetTermVersionResponse(StreamInput in) throws IOException {
         super(in);
         this.clusterName = new ClusterName(in);
-        this.stateUUID = in.readString();
+        this.clusterUUID = in.readString();
         this.term = in.readLong();
         this.version = in.readLong();
     }
@@ -46,7 +46,7 @@ public class GetTermVersionResponse extends ActionResponse {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         clusterName.writeTo(out);
-        out.writeString(stateUUID);
+        out.writeString(clusterUUID);
         out.writeLong(term);
         out.writeLong(version);
     }
@@ -63,13 +63,13 @@ public class GetTermVersionResponse extends ActionResponse {
         return clusterName;
     }
 
-    public String getStateUUID() {
-        return stateUUID;
+    public String getClusterUUID() {
+        return clusterUUID;
     }
 
     public boolean matches(ClusterState clusterState) {
         return clusterName.equals(clusterState.getClusterName())
-            && stateUUID.equals(clusterState.stateUUID())
+            && clusterUUID.equals(clusterState.metadata().clusterUUID())
             && term == clusterState.term()
             && version == clusterState.version();
     }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/state/term/GetTermVersionResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/state/term/GetTermVersionResponse.java
@@ -44,11 +44,7 @@ public class GetTermVersionResponse extends ActionResponse {
     }
 
     public boolean matches(ClusterState clusterState) {
-        return clusterStateTermVersion != null
-            && clusterStateTermVersion.getClusterName().equals(clusterState.getClusterName())
-            && clusterStateTermVersion.getClusterUUID().equals(clusterState.metadata().clusterUUID())
-            && clusterStateTermVersion.getTerm() == clusterState.term()
-            && clusterStateTermVersion.getVersion() == clusterState.version();
+        return clusterStateTermVersion != null && clusterStateTermVersion.equals(new ClusterStateTermVersion(clusterState));
     }
 
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/state/term/TransportGetTermVersionAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/state/term/TransportGetTermVersionAction.java
@@ -80,8 +80,6 @@ public class TransportGetTermVersionAction extends TransportClusterManagerNodeRe
     }
 
     private GetTermVersionResponse buildResponse(GetTermVersionRequest request, ClusterState state) {
-        return new GetTermVersionResponse(
-            new ClusterStateTermVersion(state.getClusterName(), state.metadata().clusterUUID(), state.term(), state.getVersion())
-        );
+        return new GetTermVersionResponse(new ClusterStateTermVersion(state));
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/state/term/TransportGetTermVersionAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/state/term/TransportGetTermVersionAction.java
@@ -14,6 +14,7 @@ import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeReadAction;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.block.ClusterBlockException;
+import org.opensearch.cluster.coordination.ClusterStateTermVersion;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
@@ -79,6 +80,8 @@ public class TransportGetTermVersionAction extends TransportClusterManagerNodeRe
     }
 
     private GetTermVersionResponse buildResponse(GetTermVersionRequest request, ClusterState state) {
-        return new GetTermVersionResponse(state.getClusterName(), state.metadata().clusterUUID(), state.term(), state.getVersion());
+        return new GetTermVersionResponse(
+            new ClusterStateTermVersion(state.getClusterName(), state.metadata().clusterUUID(), state.term(), state.getVersion())
+        );
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/state/term/TransportGetTermVersionAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/state/term/TransportGetTermVersionAction.java
@@ -79,7 +79,6 @@ public class TransportGetTermVersionAction extends TransportClusterManagerNodeRe
     }
 
     private GetTermVersionResponse buildResponse(GetTermVersionRequest request, ClusterState state) {
-        logger.trace("Serving cluster term version request using term {} and version {}", state.term(), state.version());
-        return new GetTermVersionResponse(state.getClusterName(), state.stateUUID(), state.term(), state.getVersion());
+        return new GetTermVersionResponse(state.getClusterName(), state.metadata().clusterUUID(), state.term(), state.getVersion());
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/state/term/TransportGetTermVersionAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/state/term/TransportGetTermVersionAction.java
@@ -1,0 +1,85 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.state.term;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeReadAction;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.block.ClusterBlockException;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+import java.io.IOException;
+
+/**
+ * Transport action for obtaining cluster term and version from cluster-manager
+ *
+ * @opensearch.internal
+ */
+public class TransportGetTermVersionAction extends TransportClusterManagerNodeReadAction<GetTermVersionRequest, GetTermVersionResponse> {
+
+    private final Logger logger = LogManager.getLogger(getClass());
+
+    @Inject
+    public TransportGetTermVersionAction(
+        TransportService transportService,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        ActionFilters actionFilters,
+        IndexNameExpressionResolver indexNameExpressionResolver
+    ) {
+        super(
+            GetTermVersionAction.NAME,
+            false,
+            transportService,
+            clusterService,
+            threadPool,
+            actionFilters,
+            GetTermVersionRequest::new,
+            indexNameExpressionResolver
+        );
+    }
+
+    @Override
+    protected String executor() {
+        return ThreadPool.Names.SAME;
+    }
+
+    @Override
+    public GetTermVersionResponse read(StreamInput in) throws IOException {
+        return new GetTermVersionResponse(in);
+    }
+
+    @Override
+    protected ClusterBlockException checkBlock(GetTermVersionRequest request, ClusterState state) {
+        // cluster state term and version needs to be retrieved even on a fully blocked cluster
+        return null;
+    }
+
+    @Override
+    protected void clusterManagerOperation(
+        GetTermVersionRequest request,
+        ClusterState state,
+        ActionListener<GetTermVersionResponse> listener
+    ) throws Exception {
+        ActionListener.completeWith(listener, () -> buildResponse(request, state));
+    }
+
+    private GetTermVersionResponse buildResponse(GetTermVersionRequest request, ClusterState state) {
+        logger.trace("Serving cluster term version request using term {} and version {}", state.term(), state.version());
+        return new GetTermVersionResponse(state.getClusterName(), state.stateUUID(), state.term(), state.getVersion());
+    }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/state/term/package-info.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/state/term/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/** Cluster Term transport handler. */
+package org.opensearch.action.admin.cluster.state.term;

--- a/server/src/main/java/org/opensearch/action/support/clustermanager/TransportClusterManagerNodeAction.java
+++ b/server/src/main/java/org/opensearch/action/support/clustermanager/TransportClusterManagerNodeAction.java
@@ -366,9 +366,8 @@ public abstract class TransportClusterManagerNodeAction<Request extends ClusterM
                         public void handleResponse(GetTermVersionResponse response) {
                             boolean isLatestClusterStatePresentOnLocalNode = response.matches(clusterState);
                             logger.trace(
-                                "Received GetTermVersionResponse response : term {}, version {}, latest-on-local {}",
-                                response.getTerm(),
-                                response.getVersion(),
+                                "Received GetTermVersionResponse response : ClusterStateTermVersion {}, latest-on-local {}",
+                                response.getClusterStateTermVersion(),
                                 isLatestClusterStatePresentOnLocalNode
                             );
                             if (isLatestClusterStatePresentOnLocalNode) {

--- a/server/src/main/java/org/opensearch/cluster/coordination/ClusterStateTermVersion.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/ClusterStateTermVersion.java
@@ -1,0 +1,99 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.coordination;
+
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+
+import java.io.IOException;
+
+public class ClusterStateTermVersion implements Writeable {
+
+    private final ClusterName clusterName;
+    private final String clusterUUID;
+    private final long term;
+    private final long version;
+
+    public ClusterStateTermVersion(ClusterName clusterName, String clusterUUID, long term, long version) {
+        this.clusterName = clusterName;
+        this.clusterUUID = clusterUUID;
+        this.term = term;
+        this.version = version;
+    }
+
+    public ClusterStateTermVersion(StreamInput in) throws IOException {
+        this.clusterName = new ClusterName(in);
+        this.clusterUUID = in.readString();
+        this.term = in.readLong();
+        this.version = in.readLong();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        clusterName.writeTo(out);
+        out.writeString(clusterUUID);
+        out.writeLong(term);
+        out.writeLong(version);
+    }
+
+    public ClusterName getClusterName() {
+        return clusterName;
+    }
+
+    public String getClusterUUID() {
+        return clusterUUID;
+    }
+
+    public long getTerm() {
+        return term;
+    }
+
+    public long getVersion() {
+        return version;
+    }
+
+    @Override
+    public String toString() {
+        return "ClusterStateTermVersion{"
+            + "clusterName="
+            + clusterName
+            + ", clusterUUID='"
+            + clusterUUID
+            + '\''
+            + ", term="
+            + term
+            + ", version="
+            + version
+            + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ClusterStateTermVersion that = (ClusterStateTermVersion) o;
+
+        if (term != that.term) return false;
+        if (version != that.version) return false;
+        if (!clusterName.equals(that.clusterName)) return false;
+        return clusterUUID.equals(that.clusterUUID);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = clusterName.hashCode();
+        result = 31 * result + clusterUUID.hashCode();
+        result = 31 * result + (int) (term ^ (term >>> 32));
+        result = 31 * result + (int) (version ^ (version >>> 32));
+        return result;
+    }
+}

--- a/server/src/main/java/org/opensearch/cluster/coordination/ClusterStateTermVersion.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/ClusterStateTermVersion.java
@@ -9,6 +9,7 @@
 package org.opensearch.cluster.coordination;
 
 import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.ClusterState;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
@@ -37,6 +38,13 @@ public class ClusterStateTermVersion implements Writeable {
         this.clusterUUID = in.readString();
         this.term = in.readLong();
         this.version = in.readLong();
+    }
+
+    public ClusterStateTermVersion(ClusterState state) {
+        this.clusterName = state.getClusterName();
+        this.clusterUUID = state.metadata().clusterUUID();
+        this.term = state.term();
+        this.version = state.version();
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/cluster/coordination/ClusterStateTermVersion.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/ClusterStateTermVersion.java
@@ -15,6 +15,9 @@ import org.opensearch.core.common.io.stream.Writeable;
 
 import java.io.IOException;
 
+/**
+ * Identifies a specific version of ClusterState at a node.
+ */
 public class ClusterStateTermVersion implements Writeable {
 
     private final ClusterName clusterName;

--- a/server/src/test/java/org/opensearch/action/admin/cluster/state/term/ClusterTermVersionIT.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/state/term/ClusterTermVersionIT.java
@@ -1,0 +1,120 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.state.term;
+
+import org.opensearch.action.admin.cluster.state.ClusterStateAction;
+import org.opensearch.action.admin.cluster.state.ClusterStateRequest;
+import org.opensearch.action.admin.cluster.state.ClusterStateResponse;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.test.transport.MockTransportService;
+import org.opensearch.transport.TransportService;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.Matchers.is;
+
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class ClusterTermVersionIT extends OpenSearchIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(MockTransportService.TestPlugin.class);
+    }
+
+    public void testClusterStateResponseFromDataNode() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNode();
+
+        ensureClusterSizeConsistency();
+        ensureGreen();
+
+        ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
+        clusterStateRequest.waitForTimeout(TimeValue.timeValueHours(1));
+        ClusterStateResponse stateResponse = dataNodeClient().admin().cluster().state(clusterStateRequest).get();
+        assertThat(stateResponse.getClusterName().value(), is(internalCluster().getClusterName()));
+        assertThat(stateResponse.getState().nodes().getSize(), is(internalCluster().getNodeNames().length));
+        assertThat(stateResponse.isWaitForTimedOut(), is(false));
+
+    }
+
+    public void testClusterStateResponseFromClusterManagerNode() throws Exception {
+        String master = internalCluster().startClusterManagerOnlyNode();
+        String data = internalCluster().startDataOnlyNode();
+        ensureClusterSizeConsistency();
+        ensureGreen();
+        Map<String, AtomicInteger> callCounters = Map.ofEntries(
+            Map.entry(ClusterStateAction.NAME, new AtomicInteger()),
+            Map.entry(GetTermVersionAction.NAME, new AtomicInteger())
+        );
+
+        addCallCountInterceptor(master, callCounters);
+
+        ClusterStateResponse stateResponse = dataNodeClient().admin().cluster().state(new ClusterStateRequest()).get();
+
+        AtomicInteger clusterStateCallsOnMaster = callCounters.get(ClusterStateAction.NAME);
+        AtomicInteger termCallsOnMaster = callCounters.get(GetTermVersionAction.NAME);
+
+        assertThat(clusterStateCallsOnMaster.get(), is(0));
+        assertThat(termCallsOnMaster.get(), is(1));
+
+        assertThat(stateResponse.getClusterName().value(), is(internalCluster().getClusterName()));
+        assertThat(stateResponse.getState().nodes().getSize(), is(internalCluster().getNodeNames().length));
+
+    }
+
+    public void testDatanodeOutOfSync() throws Exception {
+        String master = internalCluster().startClusterManagerOnlyNode();
+        String data = internalCluster().startDataOnlyNode();
+        ensureClusterSizeConsistency();
+        ensureGreen();
+        Map<String, AtomicInteger> callCounters = Map.ofEntries(
+            Map.entry(ClusterStateAction.NAME, new AtomicInteger()),
+            Map.entry(GetTermVersionAction.NAME, new AtomicInteger())
+        );
+
+        stubClusterTermResponse(master);
+        addCallCountInterceptor(master, callCounters);
+
+        ClusterStateResponse stateResponse = dataNodeClient().admin().cluster().state(new ClusterStateRequest()).get();
+
+        AtomicInteger clusterStateCallsOnMaster = callCounters.get(ClusterStateAction.NAME);
+        AtomicInteger termCallsOnMaster = callCounters.get(GetTermVersionAction.NAME);
+
+        assertThat(clusterStateCallsOnMaster.get(), is(1));
+        assertThat(termCallsOnMaster.get(), is(1));
+
+        assertThat(stateResponse.getClusterName().value(), is(internalCluster().getClusterName()));
+        assertThat(stateResponse.getState().nodes().getSize(), is(internalCluster().getNodeNames().length));
+    }
+
+    private void addCallCountInterceptor(String nodeName, Map<String, AtomicInteger> callCounters) {
+        MockTransportService primaryService = (MockTransportService) internalCluster().getInstance(TransportService.class, nodeName);
+        for (var ctrEnty : callCounters.entrySet()) {
+            primaryService.addRequestHandlingBehavior(ctrEnty.getKey(), (handler, request, channel, task) -> {
+                ctrEnty.getValue().incrementAndGet();
+                logger.info("-->  {} response redirect", ClusterStateAction.NAME);
+                handler.messageReceived(request, channel, task);
+            });
+        }
+    }
+
+    private void stubClusterTermResponse(String master) {
+        MockTransportService primaryService = (MockTransportService) internalCluster().getInstance(TransportService.class, master);
+        primaryService.addRequestHandlingBehavior(GetTermVersionAction.NAME, (handler, request, channel, task) -> {
+            channel.sendResponse(new GetTermVersionResponse(new ClusterName("test"), "1", -1, -1));
+        });
+    }
+
+}

--- a/server/src/test/java/org/opensearch/action/admin/cluster/state/term/ClusterTermVersionIT.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/state/term/ClusterTermVersionIT.java
@@ -12,6 +12,7 @@ import org.opensearch.action.admin.cluster.state.ClusterStateAction;
 import org.opensearch.action.admin.cluster.state.ClusterStateRequest;
 import org.opensearch.action.admin.cluster.state.ClusterStateResponse;
 import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.coordination.ClusterStateTermVersion;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.test.OpenSearchIntegTestCase;
@@ -113,7 +114,7 @@ public class ClusterTermVersionIT extends OpenSearchIntegTestCase {
     private void stubClusterTermResponse(String master) {
         MockTransportService primaryService = (MockTransportService) internalCluster().getInstance(TransportService.class, master);
         primaryService.addRequestHandlingBehavior(GetTermVersionAction.NAME, (handler, request, channel, task) -> {
-            channel.sendResponse(new GetTermVersionResponse(new ClusterName("test"), "1", -1, -1));
+            channel.sendResponse(new GetTermVersionResponse(new ClusterStateTermVersion(new ClusterName("test"), "1", -1, -1)));
         });
     }
 

--- a/server/src/test/java/org/opensearch/action/admin/cluster/state/term/ClusterTermVersionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/state/term/ClusterTermVersionTests.java
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.state.term;
+
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.test.OpenSearchSingleNodeTestCase;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.hamcrest.Matchers.is;
+
+public class ClusterTermVersionTests extends OpenSearchSingleNodeTestCase {
+
+    public void testTransportTermResponse() throws ExecutionException, InterruptedException {
+        GetTermVersionRequest request = new GetTermVersionRequest();
+        GetTermVersionResponse resp = client().execute(GetTermVersionAction.INSTANCE, request).get();
+
+        final ClusterService clusterService = getInstanceFromNode(ClusterService.class);
+        final ClusterState clusterState = clusterService.state();
+
+        assertThat(resp.getTerm(), is(clusterState.term()));
+        assertThat(resp.getVersion(), is(clusterState.version()));
+        assertThat(resp.getStateUUID(), is(clusterState.stateUUID()));
+        assertThat(resp.getClusterName().value().startsWith("single-node-cluster"), is(true));
+    }
+}

--- a/server/src/test/java/org/opensearch/action/admin/cluster/state/term/ClusterTermVersionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/state/term/ClusterTermVersionTests.java
@@ -8,13 +8,10 @@
 
 package org.opensearch.action.admin.cluster.state.term;
 
-import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
 
 import java.util.concurrent.ExecutionException;
-
-import static org.hamcrest.Matchers.is;
 
 public class ClusterTermVersionTests extends OpenSearchSingleNodeTestCase {
 
@@ -23,11 +20,7 @@ public class ClusterTermVersionTests extends OpenSearchSingleNodeTestCase {
         GetTermVersionResponse resp = client().execute(GetTermVersionAction.INSTANCE, request).get();
 
         final ClusterService clusterService = getInstanceFromNode(ClusterService.class);
-        final ClusterState clusterState = clusterService.state();
 
-        assertThat(resp.getTerm(), is(clusterState.term()));
-        assertThat(resp.getVersion(), is(clusterState.version()));
-        assertThat(resp.getClusterUUID(), is(clusterState.metadata().clusterUUID()));
-        assertThat(resp.getClusterName().value().startsWith("single-node-cluster"), is(true));
+        assertTrue(resp.matches(clusterService.state()));
     }
 }

--- a/server/src/test/java/org/opensearch/action/admin/cluster/state/term/ClusterTermVersionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/state/term/ClusterTermVersionTests.java
@@ -27,7 +27,7 @@ public class ClusterTermVersionTests extends OpenSearchSingleNodeTestCase {
 
         assertThat(resp.getTerm(), is(clusterState.term()));
         assertThat(resp.getVersion(), is(clusterState.version()));
-        assertThat(resp.getStateUUID(), is(clusterState.stateUUID()));
+        assertThat(resp.getClusterUUID(), is(clusterState.metadata().clusterUUID()));
         assertThat(resp.getClusterName().value().startsWith("single-node-cluster"), is(true));
     }
 }

--- a/server/src/test/java/org/opensearch/action/support/clustermanager/TransportClusterManagerNodeActionTests.java
+++ b/server/src/test/java/org/opensearch/action/support/clustermanager/TransportClusterManagerNodeActionTests.java
@@ -7,24 +7,6 @@
  */
 
 /*
- * Licensed to Elasticsearch under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-/*
  * Modifications Copyright OpenSearch Contributors. See
  * GitHub history for details.
  */

--- a/server/src/test/java/org/opensearch/action/support/clustermanager/TransportClusterManagerTermCheckTests.java
+++ b/server/src/test/java/org/opensearch/action/support/clustermanager/TransportClusterManagerTermCheckTests.java
@@ -190,7 +190,7 @@ public class TransportClusterManagerTermCheckTests extends OpenSearchTestCase {
         }
 
         @Override
-        protected boolean canUseLocalNodeClusterState() {
+        protected boolean localExecuteSupportedByAction() {
             return true;
         }
 
@@ -276,7 +276,7 @@ public class TransportClusterManagerTermCheckTests extends OpenSearchTestCase {
 
     public void testTermCheckOnOldVersionClusterManager() throws ExecutionException, InterruptedException {
 
-        setUpCluster(Version.V_2_13_0);
+        setUpCluster(Version.V_2_12_0);
         TransportClusterManagerTermCheckTests.Request request = new TransportClusterManagerTermCheckTests.Request();
 
         PlainActionFuture<TransportClusterManagerTermCheckTests.Response> listener = new PlainActionFuture<>();

--- a/server/src/test/java/org/opensearch/action/support/clustermanager/TransportClusterManagerTermCheckTests.java
+++ b/server/src/test/java/org/opensearch/action/support/clustermanager/TransportClusterManagerTermCheckTests.java
@@ -250,15 +250,15 @@ public class TransportClusterManagerTermCheckTests extends OpenSearchTestCase {
         CapturingTransport.CapturedRequest termCheckRequest = transport.capturedRequests()[0];
         assertTrue(termCheckRequest.node.isClusterManagerNode());
         assertThat(termCheckRequest.action, equalTo("cluster:monitor/term"));
-        GetTermVersionResponse termVersionResponse = new GetTermVersionResponse(
+        GetTermVersionResponse noMatchResponse = new GetTermVersionResponse(
             new ClusterStateTermVersion(
                 clusterService.state().getClusterName(),
-                clusterService.state().stateUUID(),
+                clusterService.state().metadata().clusterUUID(),
                 clusterService.state().term(),
                 clusterService.state().version() - 1
             )
         );
-        transport.handleResponse(termCheckRequest.requestId, termVersionResponse);
+        transport.handleResponse(termCheckRequest.requestId, noMatchResponse);
         assertFalse(listener.isDone());
 
         assertThat(transport.capturedRequests().length, equalTo(2));

--- a/server/src/test/java/org/opensearch/action/support/clustermanager/TransportClusterManagerTermCheckTests.java
+++ b/server/src/test/java/org/opensearch/action/support/clustermanager/TransportClusterManagerTermCheckTests.java
@@ -189,7 +189,7 @@ public class TransportClusterManagerTermCheckTests extends OpenSearchTestCase {
         }
 
         @Override
-        protected boolean checkTermVersion() {
+        protected boolean canUseLocalNodeClusterState() {
             return true;
         }
 
@@ -225,7 +225,7 @@ public class TransportClusterManagerTermCheckTests extends OpenSearchTestCase {
         assertThat(capturedRequest.action, equalTo("cluster:monitor/term"));
         GetTermVersionResponse response = new GetTermVersionResponse(
             clusterService.state().getClusterName(),
-            clusterService.state().stateUUID(),
+            clusterService.state().metadata().clusterUUID(),
             clusterService.state().term(),
             clusterService.state().version()
         );

--- a/server/src/test/java/org/opensearch/action/support/clustermanager/TransportClusterManagerTermCheckTests.java
+++ b/server/src/test/java/org/opensearch/action/support/clustermanager/TransportClusterManagerTermCheckTests.java
@@ -1,0 +1,315 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.action.support.clustermanager;
+
+import org.opensearch.Version;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.admin.cluster.state.term.GetTermVersionResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.action.support.ThreadedActionListener;
+import org.opensearch.action.support.replication.ClusterStateCreationUtils;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.block.ClusterBlockException;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.node.DiscoveryNodeRole;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.tasks.Task;
+import org.opensearch.telemetry.tracing.noop.NoopTracer;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.transport.CapturingTransport;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.opensearch.test.ClusterServiceUtils.createClusterService;
+import static org.opensearch.test.ClusterServiceUtils.setState;
+import static org.hamcrest.Matchers.equalTo;
+
+public class TransportClusterManagerTermCheckTests extends OpenSearchTestCase {
+    private static ThreadPool threadPool;
+
+    private ClusterService clusterService;
+    private TransportService transportService;
+    private CapturingTransport transport;
+    private DiscoveryNode localNode;
+    private DiscoveryNode remoteNode;
+    private DiscoveryNode[] allNodes;
+
+    @BeforeClass
+    public static void beforeClass() {
+        threadPool = new TestThreadPool("TransportMasterNodeActionTests");
+    }
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        transport = new CapturingTransport();
+        clusterService = createClusterService(threadPool);
+        transportService = transport.createTransportService(
+            clusterService.getSettings(),
+            threadPool,
+            TransportService.NOOP_TRANSPORT_INTERCEPTOR,
+            x -> clusterService.localNode(),
+            null,
+            Collections.emptySet(),
+            NoopTracer.INSTANCE
+        );
+        transportService.start();
+        transportService.acceptIncomingRequests();
+
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+        clusterService.close();
+        transportService.close();
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS);
+        threadPool = null;
+    }
+
+    public static class Request extends ClusterManagerNodeRequest<Request> {
+        Request() {}
+
+        Request(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            return null;
+        }
+    }
+
+    class Response extends ActionResponse {
+        private long identity = randomLong();
+
+        Response() {}
+
+        Response(StreamInput in) throws IOException {
+            super(in);
+            identity = in.readLong();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Response response = (Response) o;
+            return identity == response.identity;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(identity);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeLong(identity);
+        }
+    }
+
+    class Action extends TransportClusterManagerNodeAction<Request, Response> {
+        Action(String actionName, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {
+            super(
+                actionName,
+                transportService,
+                clusterService,
+                threadPool,
+                new ActionFilters(new HashSet<>()),
+                Request::new,
+                new IndexNameExpressionResolver(new ThreadContext(Settings.EMPTY))
+            );
+        }
+
+        @Override
+        protected void doExecute(Task task, final Request request, ActionListener<Response> listener) {
+            // remove unneeded threading by wrapping listener with SAME to prevent super.doExecute from wrapping it with LISTENER
+            super.doExecute(task, request, new ThreadedActionListener<>(logger, threadPool, ThreadPool.Names.SAME, listener, false));
+        }
+
+        @Override
+        protected String executor() {
+            // very lightweight operation in memory, no need to fork to a thread
+            return ThreadPool.Names.SAME;
+        }
+
+        @Override
+        protected boolean checkTermVersion() {
+            return true;
+        }
+
+        @Override
+        protected Response read(StreamInput in) throws IOException {
+            return new Response(in);
+        }
+
+        @Override
+        protected void clusterManagerOperation(Request request, ClusterState state, ActionListener<Response> listener) throws Exception {
+            listener.onResponse(new Response()); // default implementation, overridden in specific tests
+        }
+
+        @Override
+        protected ClusterBlockException checkBlock(Request request, ClusterState state) {
+            return null; // default implementation, overridden in specific tests
+        }
+    }
+
+    public void testTermCheckMatchWithClusterManager() throws ExecutionException, InterruptedException {
+        setUpCluster(Version.CURRENT);
+
+        TransportClusterManagerTermCheckTests.Request request = new TransportClusterManagerTermCheckTests.Request();
+        PlainActionFuture<TransportClusterManagerTermCheckTests.Response> listener = new PlainActionFuture<>();
+        new TransportClusterManagerTermCheckTests.Action("internal:testAction", transportService, clusterService, threadPool).execute(
+            request,
+            listener
+        );
+
+        assertThat(transport.capturedRequests().length, equalTo(1));
+        CapturingTransport.CapturedRequest capturedRequest = transport.capturedRequests()[0];
+        assertTrue(capturedRequest.node.isClusterManagerNode());
+        assertThat(capturedRequest.action, equalTo("cluster:monitor/term"));
+        GetTermVersionResponse response = new GetTermVersionResponse(
+            clusterService.state().getClusterName(),
+            clusterService.state().stateUUID(),
+            clusterService.state().term(),
+            clusterService.state().version()
+        );
+        transport.handleResponse(capturedRequest.requestId, response);
+        assertTrue(listener.isDone());
+    }
+
+    public void testTermCheckNoMatchWithClusterManager() throws ExecutionException, InterruptedException {
+        setUpCluster(Version.CURRENT);
+        TransportClusterManagerTermCheckTests.Request request = new TransportClusterManagerTermCheckTests.Request();
+
+        PlainActionFuture<TransportClusterManagerTermCheckTests.Response> listener = new PlainActionFuture<>();
+        new TransportClusterManagerTermCheckTests.Action("internal:testAction", transportService, clusterService, threadPool).execute(
+            request,
+            listener
+        );
+
+        assertThat(transport.capturedRequests().length, equalTo(1));
+        CapturingTransport.CapturedRequest termCheckRequest = transport.capturedRequests()[0];
+        assertTrue(termCheckRequest.node.isClusterManagerNode());
+        assertThat(termCheckRequest.action, equalTo("cluster:monitor/term"));
+        GetTermVersionResponse termVersionResponse = new GetTermVersionResponse(
+            clusterService.state().getClusterName(),
+            clusterService.state().stateUUID(),
+            clusterService.state().term(),
+            clusterService.state().version() - 1
+        );
+        transport.handleResponse(termCheckRequest.requestId, termVersionResponse);
+        assertFalse(listener.isDone());
+
+        assertThat(transport.capturedRequests().length, equalTo(2));
+        CapturingTransport.CapturedRequest capturedRequest = transport.capturedRequests()[1];
+        assertTrue(capturedRequest.node.isClusterManagerNode());
+        assertThat(capturedRequest.request, equalTo(request));
+        assertThat(capturedRequest.action, equalTo("internal:testAction"));
+
+        TransportClusterManagerTermCheckTests.Response response = new TransportClusterManagerTermCheckTests.Response();
+        transport.handleResponse(capturedRequest.requestId, response);
+        assertTrue(listener.isDone());
+        assertThat(listener.get(), equalTo(response));
+
+    }
+
+    public void testTermCheckOnOldVersionClusterManager() throws ExecutionException, InterruptedException {
+
+        setUpCluster(Version.V_2_13_0);
+        TransportClusterManagerTermCheckTests.Request request = new TransportClusterManagerTermCheckTests.Request();
+
+        PlainActionFuture<TransportClusterManagerTermCheckTests.Response> listener = new PlainActionFuture<>();
+        new TransportClusterManagerTermCheckTests.Action("internal:testAction", transportService, clusterService, threadPool).execute(
+            request,
+            listener
+        );
+
+        assertThat(transport.capturedRequests().length, equalTo(1));
+        CapturingTransport.CapturedRequest capturedRequest = transport.capturedRequests()[0];
+        assertTrue(capturedRequest.node.isClusterManagerNode());
+        assertThat(capturedRequest.request, equalTo(request));
+        assertThat(capturedRequest.action, equalTo("internal:testAction"));
+
+        TransportClusterManagerTermCheckTests.Response response = new TransportClusterManagerTermCheckTests.Response();
+        transport.handleResponse(capturedRequest.requestId, response);
+        assertTrue(listener.isDone());
+        assertThat(listener.get(), equalTo(response));
+
+    }
+
+    private void setUpCluster(Version clusterManagerVersion) {
+        localNode = new DiscoveryNode(
+            "local_node",
+            buildNewFakeTransportAddress(),
+            Collections.emptyMap(),
+            Collections.singleton(DiscoveryNodeRole.DATA_ROLE),
+            Version.CURRENT
+        );
+        remoteNode = new DiscoveryNode(
+            "remote_node",
+            buildNewFakeTransportAddress(),
+            Collections.emptyMap(),
+            Collections.singleton(DiscoveryNodeRole.CLUSTER_MANAGER_ROLE),
+            clusterManagerVersion
+        );
+        allNodes = new DiscoveryNode[] { localNode, remoteNode };
+        setState(clusterService, ClusterStateCreationUtils.state(localNode, remoteNode, allNodes));
+
+    }
+}

--- a/server/src/test/java/org/opensearch/action/support/clustermanager/TransportClusterManagerTermCheckTests.java
+++ b/server/src/test/java/org/opensearch/action/support/clustermanager/TransportClusterManagerTermCheckTests.java
@@ -40,6 +40,7 @@ import org.opensearch.action.support.ThreadedActionListener;
 import org.opensearch.action.support.replication.ClusterStateCreationUtils;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.block.ClusterBlockException;
+import org.opensearch.cluster.coordination.ClusterStateTermVersion;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodeRole;
@@ -224,10 +225,12 @@ public class TransportClusterManagerTermCheckTests extends OpenSearchTestCase {
         assertTrue(capturedRequest.node.isClusterManagerNode());
         assertThat(capturedRequest.action, equalTo("cluster:monitor/term"));
         GetTermVersionResponse response = new GetTermVersionResponse(
-            clusterService.state().getClusterName(),
-            clusterService.state().metadata().clusterUUID(),
-            clusterService.state().term(),
-            clusterService.state().version()
+            new ClusterStateTermVersion(
+                clusterService.state().getClusterName(),
+                clusterService.state().metadata().clusterUUID(),
+                clusterService.state().term(),
+                clusterService.state().version()
+            )
         );
         transport.handleResponse(capturedRequest.requestId, response);
         assertTrue(listener.isDone());
@@ -248,10 +251,12 @@ public class TransportClusterManagerTermCheckTests extends OpenSearchTestCase {
         assertTrue(termCheckRequest.node.isClusterManagerNode());
         assertThat(termCheckRequest.action, equalTo("cluster:monitor/term"));
         GetTermVersionResponse termVersionResponse = new GetTermVersionResponse(
-            clusterService.state().getClusterName(),
-            clusterService.state().stateUUID(),
-            clusterService.state().term(),
-            clusterService.state().version() - 1
+            new ClusterStateTermVersion(
+                clusterService.state().getClusterName(),
+                clusterService.state().stateUUID(),
+                clusterService.state().term(),
+                clusterService.state().version() - 1
+            )
         );
         transport.handleResponse(termCheckRequest.requestId, termVersionResponse);
         assertFalse(listener.isDone());

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -66,6 +66,8 @@ import org.opensearch.action.admin.cluster.state.ClusterStateAction;
 import org.opensearch.action.admin.cluster.state.ClusterStateRequest;
 import org.opensearch.action.admin.cluster.state.ClusterStateResponse;
 import org.opensearch.action.admin.cluster.state.TransportClusterStateAction;
+import org.opensearch.action.admin.cluster.state.term.GetTermVersionAction;
+import org.opensearch.action.admin.cluster.state.term.TransportGetTermVersionAction;
 import org.opensearch.action.admin.indices.create.CreateIndexAction;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.admin.indices.create.CreateIndexResponse;
@@ -2437,6 +2439,18 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                         indexNameExpressionResolver
                     )
                 );
+
+                actions.put(
+                    GetTermVersionAction.INSTANCE,
+                    new TransportGetTermVersionAction(
+                        transportService,
+                        clusterService,
+                        threadPool,
+                        actionFilters,
+                        indexNameExpressionResolver
+                    )
+                );
+
                 DynamicActionRegistry dynamicActionRegistry = new DynamicActionRegistry();
                 dynamicActionRegistry.registerUnmodifiableActionMap(actions);
                 client.initialize(


### PR DESCRIPTION
Cluster State TermVersion Fetch
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
If the local node has up-to-date cluster-state it can serve Read requests. This issue introduces a transport action to get the term and version of cluster-state from cluster-manager. If the retrieved data matches with local term and version, the subsequent call to retrieve cluster-state is avoided and the local cluster-state is used. This offloads the responsibility of serving read requests of cluster-data to local node there-by reducing the load on cluster-manager.

### Related Issues
Resolves #12272
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
