### PR TITLE
Fix flaky test FieldSortIT.testIssue6614

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/sort/FieldSortIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/sort/FieldSortIT.java
@@ -197,7 +197,8 @@ public class FieldSortIT extends ParameterizedDynamicSettingsOpenSearchIntegTest
     public void testIssue6614() throws ExecutionException, InterruptedException {
         List<IndexRequestBuilder> builders = new ArrayList<>();
         boolean strictTimeBasedIndices = randomBoolean();
-        final int numIndices = randomIntBetween(2, 25); // at most 25 days in the month
+        // consider only 15 days of the month to avoid hitting open file limit
+        final int numIndices = randomIntBetween(2, 15);
         int docs = 0;
         for (int i = 0; i < numIndices; i++) {
             final String indexId = strictTimeBasedIndices ? "idx_" + i : "idx";


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
testIssue6614 was a flaky test failing intermittently due to FileSystemException "Too many open files". This was caused due to the high number of shards created by the test (~750 shards). 

Reducing the range of possible number of indices created solved this issue with minimal change required to underlying OpenSearchIntegTestCase and the rest of the randomized parameters for the test (shards, replicas, data nodes, etc). It also doesn't affect the logic of the test. 

More details in linked issue. 

### Related Issues
Resolves #11347 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
