### PR TITLE
Fix: reset the filter built at segment level for date histogram optimization

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/FilterRewriteIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/FilterRewriteIT.java
@@ -8,5 +8,115 @@
 
 package org.opensearch.search.aggregations.bucket;
 
-public class FilterRewriteIT {
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+import org.opensearch.action.index.IndexRequestBuilder;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.time.DateFormatter;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.search.aggregations.bucket.histogram.DateHistogramInterval;
+import org.opensearch.search.aggregations.bucket.histogram.Histogram;
+import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedDynamicSettingsOpenSearchIntegTestCase;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.opensearch.search.SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING;
+import static org.opensearch.search.aggregations.AggregationBuilders.dateHistogram;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+
+@OpenSearchIntegTestCase.SuiteScopeTestCase
+public class FilterRewriteIT extends ParameterizedDynamicSettingsOpenSearchIntegTestCase {
+
+    // simulate segment level match all
+    private static final QueryBuilder QUERY = QueryBuilders.termQuery("match", true);
+    private static final Map<String, Long> expected = new HashMap<>();
+
+    public FilterRewriteIT(Settings dynamicSettings) {
+        super(dynamicSettings);
+    }
+
+    @ParametersFactory
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(
+            new Object[] { Settings.builder().put(CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING.getKey(), false).build() },
+            new Object[] { Settings.builder().put(CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING.getKey(), true).build() }
+        );
+    }
+
+    @Override
+    protected void setupSuiteScopeCluster() throws Exception {
+        assertAcked(client().admin().indices().prepareCreate("idx").get());
+
+        // one segment has some docs
+        // the other segment has some other docs
+        // check the results are correct
+        final int segmentCount = randomIntBetween(2, 10);
+        final Set<Long> longTerms = new HashSet();
+
+        final Map<String, Integer> dateTerms = new HashMap<>();
+        for (int i = 0; i < segmentCount; i++) {
+            final List<IndexRequestBuilder> indexRequests = new ArrayList<>();
+
+
+            long longTerm;
+            do {
+                longTerm = randomInt(segmentCount * 2);
+            } while (!longTerms.add(longTerm));
+            ZonedDateTime time = ZonedDateTime.of(2024, 1, ((int) longTerm % 20) + 1, 0, 0, 0, 0, ZoneOffset.UTC);
+            String dateTerm = DateFormatter.forPattern("yyyy-MM-dd").format(time);
+
+            final int frequency = randomBoolean() ? 1 : randomIntBetween(2, 20);
+            for (int j = 0; j < frequency; j++) {
+                indexRequests.add(
+                    client().prepareIndex("idx")
+                        .setSource(
+                            jsonBuilder().startObject()
+                                .field("date", dateTerm)
+                                .field("match", true)
+                                .endObject()
+                        )
+                );
+            }
+            expected.put(dateTerm+"T00:00:00.000Z", (long) frequency);
+
+            indexRandom(true, false, indexRequests);
+        }
+
+        logger.info("expected results dateTerms={}", dateTerms);
+
+        ensureSearchable();
+    }
+
+    public void testMinDocCountOnDateHistogram() throws Exception {
+        final SearchResponse allResponse = client().prepareSearch("idx")
+            .setSize(0)
+            .setQuery(QUERY)
+            .addAggregation(
+                dateHistogram("histo").field("date").dateHistogramInterval(DateHistogramInterval.DAY).minDocCount(0)
+            )
+            .get();
+
+        final Histogram allHisto = allResponse.getAggregations().get("histo");
+        logger.info("allHisto={}", allHisto);
+        Map<String, Long> results = new HashMap<>();
+        allHisto.getBuckets().forEach(bucket ->
+            results.put(bucket.getKeyAsString(), bucket.getDocCount())
+        );
+
+        for (Map.Entry<String, Long> entry : expected.entrySet()) {
+            assertEquals(entry.getValue(), results.get(entry.getKey()));
+        }
+    }
 }

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/FilterRewriteIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/FilterRewriteIT.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.aggregations.bucket;
+
+public class FilterRewriteIT {
+}

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/MinDocCountIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/MinDocCountIT.java
@@ -34,11 +34,19 @@ package org.opensearch.search.aggregations.bucket;
 
 import com.carrotsearch.randomizedtesting.generators.RandomStrings;
 
+import org.opensearch.action.admin.indices.segments.IndexShardSegments;
+import org.opensearch.action.admin.indices.segments.IndicesSegmentResponse;
+import org.opensearch.action.admin.indices.segments.IndicesSegmentsRequest;
+import org.opensearch.action.admin.indices.segments.ShardSegments;
 import org.opensearch.action.index.IndexRequestBuilder;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.time.DateFormatter;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.engine.Segment;
 import org.opensearch.index.fielddata.ScriptDocValues;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
@@ -433,6 +441,14 @@ public class MinDocCountIT extends AbstractTermsTestCase {
     }
 
     private void testMinDocCountOnDateHistogram(BucketOrder order) throws Exception {
+
+        IndicesSegmentsRequest segmentReq = new IndicesSegmentsRequest("idx");
+        IndicesSegmentResponse segmentRes = client().admin().indices().segments(segmentReq).get();
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        segmentRes.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String jsonString = builder.toString();
+        logger.info("segmentRes={}", jsonString);
+
         final SearchResponse allResponse = client().prepareSearch("idx")
             .setSize(0)
             .setQuery(QUERY)

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/MinDocCountIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/MinDocCountIT.java
@@ -34,19 +34,11 @@ package org.opensearch.search.aggregations.bucket;
 
 import com.carrotsearch.randomizedtesting.generators.RandomStrings;
 
-import org.opensearch.action.admin.indices.segments.IndexShardSegments;
-import org.opensearch.action.admin.indices.segments.IndicesSegmentResponse;
-import org.opensearch.action.admin.indices.segments.IndicesSegmentsRequest;
-import org.opensearch.action.admin.indices.segments.ShardSegments;
 import org.opensearch.action.index.IndexRequestBuilder;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.time.DateFormatter;
-import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.core.xcontent.ToXContent;
-import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.index.engine.Segment;
 import org.opensearch.index.fielddata.ScriptDocValues;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
@@ -135,7 +127,6 @@ public class MinDocCountIT extends AbstractTermsTestCase {
         final List<IndexRequestBuilder> indexRequests = new ArrayList<>();
         final Set<String> stringTerms = new HashSet<>();
         final Set<Long> longTerms = new HashSet();
-        final HashMap<String, Integer> dateTerms = new HashMap<>();
         for (int i = 0; i < cardinality; ++i) {
             String stringTerm;
             do {
@@ -151,7 +142,6 @@ public class MinDocCountIT extends AbstractTermsTestCase {
             String dateTerm = DateFormatter.forPattern("yyyy-MM-dd").format(time);
             final int frequency = randomBoolean() ? 1 : randomIntBetween(2, 20);
             for (int j = 0; j < frequency; ++j) {
-                final boolean match = randomBoolean();
                 indexRequests.add(
                     client().prepareIndex("idx")
                         .setSource(
@@ -160,18 +150,14 @@ public class MinDocCountIT extends AbstractTermsTestCase {
                                 .field("l", longTerm)
                                 .field("d", doubleTerm)
                                 .field("date", dateTerm)
-                                .field("match", match)
+                                .field("match", randomBoolean())
                                 .endObject()
                         )
                 );
-                if (match) {
-                    dateTerms.put(dateTerm, dateTerms.getOrDefault(dateTerm, 0) + 1);
-                }
             }
         }
         cardinality = stringTerms.size();
 
-        logger.info("date terms {}", dateTerms);
         indexRandom(true, indexRequests);
         ensureSearchable();
     }
@@ -441,14 +427,6 @@ public class MinDocCountIT extends AbstractTermsTestCase {
     }
 
     private void testMinDocCountOnDateHistogram(BucketOrder order) throws Exception {
-
-        IndicesSegmentsRequest segmentReq = new IndicesSegmentsRequest("idx");
-        IndicesSegmentResponse segmentRes = client().admin().indices().segments(segmentReq).get();
-        XContentBuilder builder = XContentFactory.jsonBuilder();
-        segmentRes.toXContent(builder, ToXContent.EMPTY_PARAMS);
-        String jsonString = builder.toString();
-        logger.info("segmentRes={}", jsonString);
-
         final SearchResponse allResponse = client().prepareSearch("idx")
             .setSize(0)
             .setQuery(QUERY)
@@ -458,7 +436,6 @@ public class MinDocCountIT extends AbstractTermsTestCase {
             .get();
 
         final Histogram allHisto = allResponse.getAggregations().get("histo");
-        logger.info("allHisto={}", allHisto);
 
         for (long minDocCount = 0; minDocCount < 50; ++minDocCount) {
             final SearchResponse response = client().prepareSearch("idx")
@@ -471,8 +448,6 @@ public class MinDocCountIT extends AbstractTermsTestCase {
                         .minDocCount(minDocCount)
                 )
                 .get();
-            final Histogram minDocHisto = response.getAggregations().get("histo");
-            logger.info("minDocCount={},minDocHisto={}", minDocCount, minDocHisto);
             assertSubset(allHisto, response.getAggregations().get("histo"), minDocCount);
         }
     }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/FastFilterRewriteHelper.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/FastFilterRewriteHelper.java
@@ -340,7 +340,6 @@ public final class FastFilterRewriteHelper {
 
         private Weight[] buildFastFilter(SearchContext context, long[] bounds) throws IOException {
             bounds = processHardBounds(bounds);
-            logger.debug("Bounds are {} for shard {} with hard bound", bounds, context.indexShard().shardId());
             if (bounds == null) {
                 return null;
             }
@@ -424,11 +423,6 @@ public final class FastFilterRewriteHelper {
         if (!fastFilterContext.rewriteable) {
             return false;
         }
-        logger.debug(
-            "try fast filter on Shard {} segment {}",
-            fastFilterContext.context.indexShard().shardId(),
-            ctx.ord
-        );
 
         NumericDocValues docCountValues = DocValues.getNumeric(ctx.reader(), DocCountFieldMapper.NAME);
         if (docCountValues.nextDoc() != NO_MORE_DOCS) {
@@ -447,11 +441,6 @@ public final class FastFilterRewriteHelper {
         }
         Weight[] filters = fastFilterContext.filters;
         boolean filtersBuiltAtSegmentLevel = false;
-        logger.debug(
-            "Shard {} segment {} functionally match all documents",
-            fastFilterContext.context.indexShard().shardId(),
-            ctx.ord
-        );
         if (filters == null) {
             logger.debug(
                 "Shard {} segment {} functionally match all documents. Build the fast filter",
@@ -498,7 +487,7 @@ public final class FastFilterRewriteHelper {
             }
         }
 
-        // each segment computes its own filters, so reset
+        // each segment computes its own filters, so reset the filters built at segment level
         if (filtersBuiltAtSegmentLevel) {
             fastFilterContext.filters = null;
         }
@@ -509,12 +498,6 @@ public final class FastFilterRewriteHelper {
 
     private static boolean segmentMatchAll(SearchContext ctx, LeafReaderContext leafCtx) throws IOException {
         Weight weight = ctx.searcher().createWeight(ctx.query(), ScoreMode.COMPLETE_NO_SCORES, 1f);
-        if (weight == null) {
-            return false;
-        }
-        int count = weight.count(leafCtx);
-        int numDocs = leafCtx.reader().numDocs();
-        logger.debug("Shard {} segment {} has {} count and {} num docs", ctx.indexShard().shardId(), leafCtx.ord, count, numDocs);
         return weight != null && weight.count(leafCtx) == leafCtx.reader().numDocs();
     }
 }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/FastFilterRewriteHelper.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/FastFilterRewriteHelper.java
@@ -424,6 +424,11 @@ public final class FastFilterRewriteHelper {
         if (!fastFilterContext.rewriteable) {
             return false;
         }
+        logger.debug(
+            "try fast filter on Shard {} segment {}",
+            fastFilterContext.context.indexShard().shardId(),
+            ctx.ord
+        );
 
         NumericDocValues docCountValues = DocValues.getNumeric(ctx.reader(), DocCountFieldMapper.NAME);
         if (docCountValues.nextDoc() != NO_MORE_DOCS) {
@@ -442,6 +447,11 @@ public final class FastFilterRewriteHelper {
         }
         Weight[] filters = fastFilterContext.filters;
         boolean filtersBuiltAtSegmentLevel = false;
+        logger.debug(
+            "Shard {} segment {} functionally match all documents",
+            fastFilterContext.context.indexShard().shardId(),
+            ctx.ord
+        );
         if (filters == null) {
             logger.debug(
                 "Shard {} segment {} functionally match all documents. Build the fast filter",
@@ -499,6 +509,12 @@ public final class FastFilterRewriteHelper {
 
     private static boolean segmentMatchAll(SearchContext ctx, LeafReaderContext leafCtx) throws IOException {
         Weight weight = ctx.searcher().createWeight(ctx.query(), ScoreMode.COMPLETE_NO_SCORES, 1f);
+        if (weight == null) {
+            return false;
+        }
+        int count = weight.count(leafCtx);
+        int numDocs = leafCtx.reader().numDocs();
+        logger.debug("Shard {} segment {} has {} count and {} num docs", ctx.indexShard().shardId(), leafCtx.ord, count, numDocs);
         return weight != null && weight.count(leafCtx) == leafCtx.reader().numDocs();
     }
 }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/FastFilterRewriteHelper.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/FastFilterRewriteHelper.java
@@ -477,6 +477,8 @@ public final class FastFilterRewriteHelper {
                         NumericUtils.sortableBytesToLong(((PointRangeQuery) filters[i].getQuery()).getLowerPoint(), 0)
                     );
                 }
+                // TODO remove
+                logger.info("Shard {} segment {} increase bucket key {} by count {}", fastFilterContext.context.indexShard().shardId(), ctx.ord, bucketKey, counts[i]);
                 incrementDocCount.accept(bucketKey, counts[i]);
                 s++;
                 if (s > size) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
#12073 handle the segment level match all scenario and build fast filters at segment level. However the built filter from a segment is saved in the FastFilterContext lived through the shard search and stop the subsequent segments from computing their filters. This change reset the filters built at segment level and add integration tests to cover that.

The reason previous flaky test catches this is pretty interesting. It's flaky because it happens at this scenario:
first search hit one shard (s1_1), second search hit another shard (s1_2)
The segments on these 2 shards are different, and the indexRandom method from test framework introduces random dummy document deletions which will stop the fast filter optimization we added in. So imagine s1_1 has multiple segments without deletion and gets the optimization kicks in while the segment level filters never change. s1_2 segments have deletion and optimization never kicks in and fall back to old code path. In the end, the results from these 2 searchs become different.

### Related Issues
Resolves #12268 
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [ ] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
