### PR TITLE
[Backport 2.x] Add support for dependencies in plugin descriptor properties with semver range #11441

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Metrics Framework] Adds support for Histogram metric ([#12062](https://github.com/opensearch-project/OpenSearch/pull/12062))
 - [AdmissionControl] Added changes for AdmissionControl Interceptor and AdmissionControlService for RateLimiting ([#9286](https://github.com/opensearch-project/OpenSearch/pull/9286))
 - [Admission Control] Integrate CPU AC with ResourceUsageCollector and add CPU AC stats to nodes/stats ([#10887](https://github.com/opensearch-project/OpenSearch/pull/10887))
+- Add support for dependencies in plugin descriptor properties with semver range ([#11441](https://github.com/opensearch-project/OpenSearch/pull/11441))
 
 ### Dependencies
 - Bumps jetty version to 9.4.52.v20230823 to fix GMS-2023-1857 ([#9822](https://github.com/opensearch-project/OpenSearch/pull/9822))

--- a/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/ListPluginsCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/ListPluginsCommand.java
@@ -78,15 +78,14 @@ class ListPluginsCommand extends EnvironmentAwareCommand {
         PluginInfo info = PluginInfo.readFromProperties(env.pluginsFile().resolve(plugin));
         terminal.println(Terminal.Verbosity.SILENT, prefix + info.getName());
         terminal.println(Terminal.Verbosity.VERBOSE, info.toString(prefix));
-        if (info.getOpenSearchVersion().equals(Version.CURRENT) == false) {
+        if (!PluginsService.isPluginVersionCompatible(info, Version.CURRENT)) {
             terminal.errorPrintln(
                 "WARNING: plugin ["
                     + info.getName()
                     + "] was built for OpenSearch version "
-                    + info.getVersion()
-                    + " but version "
+                    + info.getOpenSearchVersionRangesString()
+                    + " and is not compatible with "
                     + Version.CURRENT
-                    + " is required"
             );
         }
     }

--- a/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/ListPluginsCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/ListPluginsCommandTests.java
@@ -278,12 +278,49 @@ public class ListPluginsCommandTests extends OpenSearchTestCase {
         buildFakePlugin(env, "fake desc 2", "fake_plugin2", "org.fake2");
 
         MockTerminal terminal = listPlugins(home);
-        String message = "plugin [fake_plugin1] was built for OpenSearch version 1.0 but version " + Version.CURRENT + " is required";
+        String message = "plugin [fake_plugin1] was built for OpenSearch version 5.0.0 and is not compatible with " + Version.CURRENT;
         assertEquals("fake_plugin1\nfake_plugin2\n", terminal.getOutput());
         assertEquals("WARNING: " + message + "\n", terminal.getErrorOutput());
 
         String[] params = { "-s" };
         terminal = listPlugins(home, params);
         assertEquals("fake_plugin1\nfake_plugin2\n", terminal.getOutput());
+    }
+
+    public void testPluginWithDependencies() throws Exception {
+        PluginTestUtil.writePluginProperties(
+            env.pluginsFile().resolve("fake_plugin1"),
+            "description",
+            "fake desc 1",
+            "name",
+            "fake_plugin1",
+            "version",
+            "1.0",
+            "dependencies",
+            "{opensearch:\"" + Version.CURRENT + "\"}",
+            "java.version",
+            System.getProperty("java.specification.version"),
+            "classname",
+            "org.fake1"
+        );
+        String[] params = { "-v" };
+        MockTerminal terminal = listPlugins(home, params);
+        assertEquals(
+            buildMultiline(
+                "Plugins directory: " + env.pluginsFile(),
+                "fake_plugin1",
+                "- Plugin information:",
+                "Name: fake_plugin1",
+                "Description: fake desc 1",
+                "Version: 1.0",
+                "OpenSearch Version: " + Version.CURRENT.toString(),
+                "Java Version: " + System.getProperty("java.specification.version"),
+                "Native Controller: false",
+                "Extended Plugins: []",
+                " * Classname: org.fake1",
+                "Folder name: null"
+            ),
+            terminal.getOutput()
+        );
     }
 }

--- a/libs/core/src/main/java/org/opensearch/core/common/io/stream/StreamInput.java
+++ b/libs/core/src/main/java/org/opensearch/core/common/io/stream/StreamInput.java
@@ -56,6 +56,7 @@ import org.opensearch.core.common.text.Text;
 import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException;
 import org.opensearch.core.xcontent.MediaType;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.semver.SemverRange;
 
 import java.io.ByteArrayInputStream;
 import java.io.EOFException;
@@ -748,6 +749,8 @@ public abstract class StreamInput extends InputStream {
                 return readCollection(StreamInput::readGenericValue, HashSet::new, Collections.emptySet());
             case 26:
                 return readBigInteger();
+            case 27:
+                return readSemverRange();
             default:
                 throw new IOException("Can't read unknown type [" + type + "]");
         }
@@ -1086,6 +1089,10 @@ public abstract class StreamInput extends InputStream {
     /** Reads the OpenSearch Version from the input stream */
     public Version readVersion() throws IOException {
         return Version.fromId(readVInt());
+    }
+
+    public SemverRange readSemverRange() throws IOException {
+        return SemverRange.fromString(readString());
     }
 
     /** Reads the {@link Version} from the input stream */

--- a/libs/core/src/main/java/org/opensearch/core/common/io/stream/StreamOutput.java
+++ b/libs/core/src/main/java/org/opensearch/core/common/io/stream/StreamOutput.java
@@ -54,6 +54,7 @@ import org.opensearch.core.common.io.stream.Writeable.Writer;
 import org.opensearch.core.common.settings.SecureString;
 import org.opensearch.core.common.text.Text;
 import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException;
+import org.opensearch.semver.SemverRange;
 
 import java.io.EOFException;
 import java.io.FileNotFoundException;
@@ -784,6 +785,10 @@ public abstract class StreamOutput extends OutputStream {
             o.writeByte((byte) 26);
             o.writeString(v.toString());
         });
+        writers.put(SemverRange.class, (o, v) -> {
+            o.writeByte((byte) 27);
+            o.writeSemverRange((SemverRange) v);
+        });
         WRITERS = Collections.unmodifiableMap(writers);
     }
 
@@ -1099,6 +1104,10 @@ public abstract class StreamOutput extends OutputStream {
     /** Writes the OpenSearch {@link Version} to the output stream */
     public void writeVersion(final Version version) throws IOException {
         writeVInt(version.id);
+    }
+
+    public void writeSemverRange(final SemverRange range) throws IOException {
+        writeString(range.toString());
     }
 
     /** Writes the OpenSearch {@link Build} informn to the output stream */

--- a/libs/core/src/main/java/org/opensearch/semver/SemverRange.java
+++ b/libs/core/src/main/java/org/opensearch/semver/SemverRange.java
@@ -1,0 +1,170 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.semver;
+
+import org.opensearch.Version;
+import org.opensearch.common.Nullable;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.semver.expr.Caret;
+import org.opensearch.semver.expr.Equal;
+import org.opensearch.semver.expr.Expression;
+import org.opensearch.semver.expr.Tilde;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Arrays.stream;
+
+/**
+ * Represents a single semver range that allows for specifying which {@code org.opensearch.Version}s satisfy the range.
+ * It is composed of a range version and a range operator. Following are the supported operators:
+ * <ul>
+ *     <li>'=' Requires exact match with the range version. For example, =1.2.3 range would match only 1.2.3</li>
+ *     <li>'~' Allows for patch version variability starting from the range version. For example, ~1.2.3 range would match versions greater than or equal to 1.2.3 but less than 1.3.0</li>
+ *     <li>'^' Allows for patch and minor version variability starting from the range version. For example, ^1.2.3 range would match versions greater than or equal to 1.2.3 but less than 2.0.0</li>
+ * </ul>
+ */
+public class SemverRange implements ToXContentFragment {
+
+    private final Version rangeVersion;
+    private final RangeOperator rangeOperator;
+
+    public SemverRange(final Version rangeVersion, final RangeOperator rangeOperator) {
+        this.rangeVersion = rangeVersion;
+        this.rangeOperator = rangeOperator;
+    }
+
+    /**
+     * Constructs a {@code SemverRange} from its string representation.
+     * @param range given range
+     * @return a {@code SemverRange}
+     */
+    public static SemverRange fromString(final String range) {
+        RangeOperator rangeOperator = RangeOperator.fromRange(range);
+        String version = range.replaceFirst(rangeOperator.asEscapedString(), "");
+        if (!Version.stringHasLength(version)) {
+            throw new IllegalArgumentException("Version cannot be empty");
+        }
+        return new SemverRange(Version.fromString(version), rangeOperator);
+    }
+
+    /**
+     * Return the range operator for this range.
+     * @return range operator
+     */
+    public RangeOperator getRangeOperator() {
+        return rangeOperator;
+    }
+
+    /**
+     * Return the version for this range.
+     * @return the range version
+     */
+    public Version getRangeVersion() {
+        return rangeVersion;
+    }
+
+    /**
+     * Check if range is satisfied by given version string.
+     *
+     * @param versionToEvaluate version to check
+     * @return {@code true} if range is satisfied by version, {@code false} otherwise
+     */
+    public boolean isSatisfiedBy(final String versionToEvaluate) {
+        return isSatisfiedBy(Version.fromString(versionToEvaluate));
+    }
+
+    /**
+     * Check if range is satisfied by given version.
+     *
+     * @param versionToEvaluate version to check
+     * @return {@code true} if range is satisfied by version, {@code false} otherwise
+     * @see #isSatisfiedBy(String)
+     */
+    public boolean isSatisfiedBy(final Version versionToEvaluate) {
+        return this.rangeOperator.expression.evaluate(this.rangeVersion, versionToEvaluate);
+    }
+
+    @Override
+    public boolean equals(@Nullable final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SemverRange range = (SemverRange) o;
+        return Objects.equals(rangeVersion, range.rangeVersion) && rangeOperator == range.rangeOperator;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(rangeVersion, rangeOperator);
+    }
+
+    @Override
+    public String toString() {
+        return rangeOperator.asString() + rangeVersion;
+    }
+
+    @Override
+    public XContentBuilder toXContent(final XContentBuilder builder, final Params params) throws IOException {
+        return builder.value(toString());
+    }
+
+    /**
+     * A range operator.
+     */
+    public enum RangeOperator {
+
+        EQ("=", new Equal()),
+        TILDE("~", new Tilde()),
+        CARET("^", new Caret()),
+        DEFAULT("", new Equal());
+
+        private final String operator;
+        private final Expression expression;
+
+        RangeOperator(final String operator, final Expression expression) {
+            this.operator = operator;
+            this.expression = expression;
+        }
+
+        /**
+         * String representation of the range operator.
+         *
+         * @return range operator as string
+         */
+        public String asString() {
+            return operator;
+        }
+
+        /**
+         * Escaped string representation of the range operator,
+         * if operator is a regex character.
+         *
+         * @return range operator as escaped string, if operator is a regex character
+         */
+        public String asEscapedString() {
+            if (Objects.equals(operator, "^")) {
+                return "\\^";
+            }
+            return operator;
+        }
+
+        public static RangeOperator fromRange(final String range) {
+            Optional<RangeOperator> rangeOperator = stream(values()).filter(
+                operator -> operator != DEFAULT && range.startsWith(operator.asString())
+            ).findFirst();
+            return rangeOperator.orElse(DEFAULT);
+        }
+    }
+}

--- a/libs/core/src/main/java/org/opensearch/semver/expr/Caret.java
+++ b/libs/core/src/main/java/org/opensearch/semver/expr/Caret.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.semver.expr;
+
+import org.opensearch.Version;
+
+/**
+ * Expression to evaluate version compatibility allowing for minor and patch version variability.
+ */
+public class Caret implements Expression {
+
+    /**
+     * Checks if the given version is compatible with the range version allowing for minor and
+     * patch version variability.
+     * Allows all versions starting from the rangeVersion upto next major version (exclusive).
+     * @param rangeVersion the version specified in range
+     * @param versionToEvaluate the version to evaluate
+     * @return {@code true} if the versions are compatible {@code false} otherwise
+     */
+    @Override
+    public boolean evaluate(final Version rangeVersion, final Version versionToEvaluate) {
+        Version lower = rangeVersion;
+        Version upper = Version.fromString((rangeVersion.major + 1) + ".0.0");
+        return versionToEvaluate.onOrAfter(lower) && versionToEvaluate.before(upper);
+    }
+}

--- a/libs/core/src/main/java/org/opensearch/semver/expr/Equal.java
+++ b/libs/core/src/main/java/org/opensearch/semver/expr/Equal.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.semver.expr;
+
+import org.opensearch.Version;
+
+/**
+ * Expression to evaluate equality of versions.
+ */
+public class Equal implements Expression {
+
+    /**
+     * Checks if a given version matches a certain range version.
+     *
+     * @param rangeVersion the version specified in range
+     * @param versionToEvaluate the version to evaluate
+     * @return {@code true} if the versions are equal {@code false} otherwise
+     */
+    @Override
+    public boolean evaluate(final Version rangeVersion, final Version versionToEvaluate) {
+        return versionToEvaluate.equals(rangeVersion);
+    }
+}

--- a/libs/core/src/main/java/org/opensearch/semver/expr/Expression.java
+++ b/libs/core/src/main/java/org/opensearch/semver/expr/Expression.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.semver.expr;
+
+import org.opensearch.Version;
+
+/**
+ * An evaluation expression.
+ */
+public interface Expression {
+
+    /**
+     * Evaluates an expression.
+     *
+     * @param rangeVersion the version specified in range
+     * @param versionToEvaluate the version to evaluate
+     * @return the result of the expression evaluation
+     */
+    boolean evaluate(final Version rangeVersion, final Version versionToEvaluate);
+}

--- a/libs/core/src/main/java/org/opensearch/semver/expr/Tilde.java
+++ b/libs/core/src/main/java/org/opensearch/semver/expr/Tilde.java
@@ -1,0 +1,31 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.semver.expr;
+
+import org.opensearch.Version;
+
+/**
+ * Expression to evaluate version compatibility allowing patch version variability.
+ */
+public class Tilde implements Expression {
+
+    /**
+     * Checks if the given version is compatible with a range version allowing for patch version variability.
+     * Allows all versions starting from the rangeVersion upto next minor version (exclusive).
+     * @param rangeVersion the version specified in range
+     * @param versionToEvaluate the version to evaluate
+     * @return {@code true} if the versions are compatible {@code false} otherwise
+     */
+    @Override
+    public boolean evaluate(final Version rangeVersion, final Version versionToEvaluate) {
+        Version lower = rangeVersion;
+        Version upper = Version.fromString(rangeVersion.major + "." + (rangeVersion.minor + 1) + "." + 0);
+        return versionToEvaluate.onOrAfter(lower) && versionToEvaluate.before(upper);
+    }
+}

--- a/libs/core/src/main/java/org/opensearch/semver/expr/package-info.java
+++ b/libs/core/src/main/java/org/opensearch/semver/expr/package-info.java
@@ -1,0 +1,9 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+/** Expressions library module */
+package org.opensearch.semver.expr;

--- a/libs/core/src/main/java/org/opensearch/semver/package-info.java
+++ b/libs/core/src/main/java/org/opensearch/semver/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/** Semver library module */
+package org.opensearch.semver;

--- a/libs/core/src/test/java/org/opensearch/semver/SemverRangeTests.java
+++ b/libs/core/src/test/java/org/opensearch/semver/SemverRangeTests.java
@@ -1,0 +1,105 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.semver;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+public class SemverRangeTests extends OpenSearchTestCase {
+
+    public void testRangeWithEqualsOperator() {
+        SemverRange range = SemverRange.fromString("=1.2.3");
+        assertEquals(range.getRangeOperator(), SemverRange.RangeOperator.EQ);
+        assertTrue(range.isSatisfiedBy("1.2.3"));
+        assertFalse(range.isSatisfiedBy("1.2.4"));
+        assertFalse(range.isSatisfiedBy("1.3.3"));
+        assertFalse(range.isSatisfiedBy("2.2.3"));
+    }
+
+    public void testRangeWithDefaultOperator() {
+        SemverRange range = SemverRange.fromString("1.2.3");
+        assertEquals(range.getRangeOperator(), SemverRange.RangeOperator.DEFAULT);
+        assertTrue(range.isSatisfiedBy("1.2.3"));
+        assertFalse(range.isSatisfiedBy("1.2.4"));
+        assertFalse(range.isSatisfiedBy("1.3.3"));
+        assertFalse(range.isSatisfiedBy("2.2.3"));
+    }
+
+    public void testRangeWithTildeOperator() {
+        SemverRange range = SemverRange.fromString("~2.3.4");
+        assertEquals(range.getRangeOperator(), SemverRange.RangeOperator.TILDE);
+        assertTrue(range.isSatisfiedBy("2.3.4"));
+        assertTrue(range.isSatisfiedBy("2.3.5"));
+        assertTrue(range.isSatisfiedBy("2.3.12"));
+
+        assertFalse(range.isSatisfiedBy("2.3.0"));
+        assertFalse(range.isSatisfiedBy("2.3.3"));
+        assertFalse(range.isSatisfiedBy("2.4.0"));
+        assertFalse(range.isSatisfiedBy("3.0.0"));
+    }
+
+    public void testRangeWithCaretOperator() {
+        SemverRange range = SemverRange.fromString("^2.3.4");
+        assertEquals(range.getRangeOperator(), SemverRange.RangeOperator.CARET);
+        assertTrue(range.isSatisfiedBy("2.3.4"));
+        assertTrue(range.isSatisfiedBy("2.3.5"));
+        assertTrue(range.isSatisfiedBy("2.4.12"));
+
+        assertFalse(range.isSatisfiedBy("2.3.3"));
+        assertFalse(range.isSatisfiedBy("3.0.0"));
+    }
+
+    public void testInvalidRanges() {
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> SemverRange.fromString(""));
+        assertEquals("Version cannot be empty", ex.getMessage());
+
+        ex = expectThrows(IllegalArgumentException.class, () -> SemverRange.fromString("1"));
+        assertTrue(ex.getMessage().contains("the version needs to contain major, minor, and revision, and optionally the build"));
+
+        ex = expectThrows(IllegalArgumentException.class, () -> SemverRange.fromString("1.2"));
+        assertTrue(ex.getMessage().contains("the version needs to contain major, minor, and revision, and optionally the build"));
+
+        ex = expectThrows(IllegalArgumentException.class, () -> SemverRange.fromString("="));
+        assertEquals("Version cannot be empty", ex.getMessage());
+
+        ex = expectThrows(IllegalArgumentException.class, () -> SemverRange.fromString("=1"));
+        assertTrue(ex.getMessage().contains("the version needs to contain major, minor, and revision, and optionally the build"));
+
+        ex = expectThrows(IllegalArgumentException.class, () -> SemverRange.fromString("=1.2"));
+        assertTrue(ex.getMessage().contains("the version needs to contain major, minor, and revision, and optionally the build"));
+
+        ex = expectThrows(IllegalArgumentException.class, () -> SemverRange.fromString("~"));
+        assertEquals("Version cannot be empty", ex.getMessage());
+
+        ex = expectThrows(IllegalArgumentException.class, () -> SemverRange.fromString("~1"));
+        assertTrue(ex.getMessage().contains("the version needs to contain major, minor, and revision, and optionally the build"));
+
+        ex = expectThrows(IllegalArgumentException.class, () -> SemverRange.fromString("~1.2"));
+        assertTrue(ex.getMessage().contains("the version needs to contain major, minor, and revision, and optionally the build"));
+
+        ex = expectThrows(IllegalArgumentException.class, () -> SemverRange.fromString("^"));
+        assertEquals("Version cannot be empty", ex.getMessage());
+
+        ex = expectThrows(IllegalArgumentException.class, () -> SemverRange.fromString("^1"));
+        assertTrue(ex.getMessage().contains("the version needs to contain major, minor, and revision, and optionally the build"));
+
+        ex = expectThrows(IllegalArgumentException.class, () -> SemverRange.fromString("^1.2"));
+        assertTrue(ex.getMessage().contains("the version needs to contain major, minor, and revision, and optionally the build"));
+
+        ex = expectThrows(IllegalArgumentException.class, () -> SemverRange.fromString("$"));
+        assertTrue(ex.getMessage().contains("the version needs to contain major, minor, and revision, and optionally the build"));
+
+        ex = expectThrows(IllegalArgumentException.class, () -> SemverRange.fromString("$1"));
+        assertTrue(ex.getMessage().contains("the version needs to contain major, minor, and revision, and optionally the build"));
+
+        ex = expectThrows(IllegalArgumentException.class, () -> SemverRange.fromString("$1.2"));
+        assertTrue(ex.getMessage().contains("the version needs to contain major, minor, and revision, and optionally the build"));
+
+        expectThrows(NumberFormatException.class, () -> SemverRange.fromString("$1.2.3"));
+    }
+}

--- a/libs/core/src/test/java/org/opensearch/semver/expr/CaretTests.java
+++ b/libs/core/src/test/java/org/opensearch/semver/expr/CaretTests.java
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.semver.expr;
+
+import org.opensearch.Version;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class CaretTests extends OpenSearchTestCase {
+
+    public void testMinorAndPatchVersionVariability() {
+        Caret caretExpr = new Caret();
+        Version rangeVersion = Version.fromString("1.2.3");
+
+        // Compatible versions
+        assertTrue(caretExpr.evaluate(rangeVersion, Version.fromString("1.2.3")));
+        assertTrue(caretExpr.evaluate(rangeVersion, Version.fromString("1.2.4")));
+        assertTrue(caretExpr.evaluate(rangeVersion, Version.fromString("1.3.3")));
+        assertTrue(caretExpr.evaluate(rangeVersion, Version.fromString("1.9.9")));
+
+        // Incompatible versions
+        assertFalse(caretExpr.evaluate(rangeVersion, Version.fromString("1.2.2")));
+        assertFalse(caretExpr.evaluate(rangeVersion, Version.fromString("2.0.0")));
+    }
+}

--- a/libs/core/src/test/java/org/opensearch/semver/expr/EqualTests.java
+++ b/libs/core/src/test/java/org/opensearch/semver/expr/EqualTests.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.semver.expr;
+
+import org.opensearch.Version;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class EqualTests extends OpenSearchTestCase {
+
+    public void testEquality() {
+        Equal equalExpr = new Equal();
+        Version rangeVersion = Version.fromString("1.2.3");
+        assertTrue(equalExpr.evaluate(rangeVersion, Version.fromString("1.2.3")));
+        assertFalse(equalExpr.evaluate(rangeVersion, Version.fromString("1.2.4")));
+    }
+}

--- a/libs/core/src/test/java/org/opensearch/semver/expr/TildeTests.java
+++ b/libs/core/src/test/java/org/opensearch/semver/expr/TildeTests.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.semver.expr;
+
+import org.opensearch.Version;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class TildeTests extends OpenSearchTestCase {
+
+    public void testPatchVersionVariability() {
+        Tilde tildeExpr = new Tilde();
+        Version rangeVersion = Version.fromString("1.2.3");
+
+        assertTrue(tildeExpr.evaluate(rangeVersion, Version.fromString("1.2.3")));
+        assertTrue(tildeExpr.evaluate(rangeVersion, Version.fromString("1.2.4")));
+        assertTrue(tildeExpr.evaluate(rangeVersion, Version.fromString("1.2.9")));
+
+        assertFalse(tildeExpr.evaluate(rangeVersion, Version.fromString("1.2.0")));
+        assertFalse(tildeExpr.evaluate(rangeVersion, Version.fromString("1.2.2")));
+        assertFalse(tildeExpr.evaluate(rangeVersion, Version.fromString("1.3.0")));
+        assertFalse(tildeExpr.evaluate(rangeVersion, Version.fromString("2.0.0")));
+    }
+}

--- a/qa/full-cluster-restart/src/test/java/org/opensearch/upgrades/PluginInfoIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/opensearch/upgrades/PluginInfoIT.java
@@ -1,0 +1,27 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.upgrades;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.test.rest.yaml.ObjectPath;
+
+import java.util.Map;
+
+public class PluginInfoIT extends AbstractFullClusterRestartTestCase {
+    public void testPluginInfoSerialization() throws Exception {
+        // Ensure all nodes are able to come up, validate with GET _nodes.
+        Response response = client().performRequest(new Request("GET", "_nodes"));
+        ObjectPath objectPath = ObjectPath.createFromResponse(response);
+        final Map<String, Object> nodeMap = objectPath.evaluate("nodes");
+        // Any issue in PluginInfo serialization logic will result into connection failures
+        // and hence reduced number of nodes.
+        assertEquals(2, nodeMap.keySet().size());
+    }
+}

--- a/qa/mixed-cluster/src/test/java/org/opensearch/backwards/PluginInfoIT.java
+++ b/qa/mixed-cluster/src/test/java/org/opensearch/backwards/PluginInfoIT.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.backwards;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.test.rest.OpenSearchRestTestCase;
+import org.opensearch.test.rest.yaml.ObjectPath;
+
+import java.util.Map;
+
+public class PluginInfoIT extends OpenSearchRestTestCase {
+    public void testPluginInfoSerialization() throws Exception {
+        // Ensure all nodes are able to come up, validate with GET _nodes.
+        Response response = client().performRequest(new Request("GET", "_nodes"));
+        ObjectPath objectPath = ObjectPath.createFromResponse(response);
+        final Map<String, Object> nodeMap = objectPath.evaluate("nodes");
+        assertEquals(4, nodeMap.keySet().size());
+    }
+}

--- a/server/src/internalClusterTest/java/org/opensearch/plugins/PluginsServiceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/plugins/PluginsServiceIT.java
@@ -1,0 +1,115 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugins;
+
+import org.opensearch.Version;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.env.Environment;
+import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.test.VersionUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.hamcrest.Matchers.containsString;
+
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class PluginsServiceIT extends OpenSearchIntegTestCase {
+
+    public void testNodeBootstrapWithCompatiblePlugin() throws IOException {
+        // Prepare the plugins directory and then start a node
+        Path baseDir = createTempDir();
+        Path pluginDir = baseDir.resolve("plugins/dummy-plugin");
+        PluginTestUtil.writePluginProperties(
+            pluginDir,
+            "description",
+            "dummy desc",
+            "name",
+            "dummyPlugin",
+            "version",
+            "1.0",
+            "opensearch.version",
+            Version.CURRENT.toString(),
+            "java.version",
+            System.getProperty("java.specification.version"),
+            "classname",
+            "test.DummyPlugin"
+        );
+        try (InputStream jar = PluginsServiceTests.class.getResourceAsStream("dummy-plugin.jar")) {
+            Files.copy(jar, pluginDir.resolve("dummy-plugin.jar"));
+        }
+        internalCluster().startNode(Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), baseDir));
+        for (PluginsService pluginsService : internalCluster().getDataNodeInstances(PluginsService.class)) {
+            // Ensure plugins service was able to load the plugin
+            assertEquals(1, pluginsService.info().getPluginInfos().stream().filter(info -> info.getName().equals("dummyPlugin")).count());
+        }
+    }
+
+    public void testNodeBootstrapWithRangeCompatiblePlugin() throws IOException {
+        // Prepare the plugins directory and then start a node
+        Path baseDir = createTempDir();
+        Path pluginDir = baseDir.resolve("plugins/dummy-plugin");
+        PluginTestUtil.writePluginProperties(
+            pluginDir,
+            "description",
+            "dummy desc",
+            "name",
+            "dummyPlugin",
+            "version",
+            "1.0",
+            "dependencies",
+            "{opensearch:\"~" + Version.CURRENT + "\"}",
+            "java.version",
+            System.getProperty("java.specification.version"),
+            "classname",
+            "test.DummyPlugin"
+        );
+        try (InputStream jar = PluginsServiceTests.class.getResourceAsStream("dummy-plugin.jar")) {
+            Files.copy(jar, pluginDir.resolve("dummy-plugin.jar"));
+        }
+        internalCluster().startNode(Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), baseDir));
+        for (PluginsService pluginsService : internalCluster().getDataNodeInstances(PluginsService.class)) {
+            // Ensure plugins service was able to load the plugin
+            assertEquals(1, pluginsService.info().getPluginInfos().stream().filter(info -> info.getName().equals("dummyPlugin")).count());
+        }
+    }
+
+    public void testNodeBootstrapWithInCompatiblePlugin() throws IOException {
+        // Prepare the plugins directory with an incompatible plugin and attempt to start a node
+        Path baseDir = createTempDir();
+        Path pluginDir = baseDir.resolve("plugins/dummy-plugin");
+        String incompatibleRange = "~"
+            + VersionUtils.getVersion(Version.CURRENT.major, Version.CURRENT.minor, (byte) (Version.CURRENT.revision + 1));
+        PluginTestUtil.writePluginProperties(
+            pluginDir,
+            "description",
+            "dummy desc",
+            "name",
+            "dummyPlugin",
+            "version",
+            "1.0",
+            "dependencies",
+            "{opensearch:\"" + incompatibleRange + "\"}",
+            "java.version",
+            System.getProperty("java.specification.version"),
+            "classname",
+            "test.DummyPlugin"
+        );
+        try (InputStream jar = PluginsServiceTests.class.getResourceAsStream("dummy-plugin.jar")) {
+            Files.copy(jar, pluginDir.resolve("dummy-plugin.jar"));
+        }
+        IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> internalCluster().startNode(Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), baseDir))
+        );
+        assertThat(e.getMessage(), containsString("Plugin [dummyPlugin] was built for OpenSearch version "));
+    }
+}

--- a/server/src/main/java/org/opensearch/plugins/PluginInfo.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginInfo.java
@@ -32,20 +32,28 @@
 
 package org.opensearch.plugins;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
+
 import org.opensearch.Version;
 import org.opensearch.bootstrap.JarHell;
 import org.opensearch.common.annotation.PublicApi;
+import org.opensearch.common.xcontent.json.JsonXContentParser;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.DeprecationHandler;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.semver.SemverRange;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -65,11 +73,15 @@ public class PluginInfo implements Writeable, ToXContentObject {
 
     public static final String OPENSEARCH_PLUGIN_PROPERTIES = "plugin-descriptor.properties";
     public static final String OPENSEARCH_PLUGIN_POLICY = "plugin-security.policy";
+    private static final JsonFactory jsonFactory = new JsonFactory().configure(
+        JsonReadFeature.ALLOW_UNQUOTED_FIELD_NAMES.mappedFeature(),
+        true
+    );
 
     private final String name;
     private final String description;
     private final String version;
-    private final Version opensearchVersion;
+    private final List<SemverRange> opensearchVersionRanges;
     private final String javaVersion;
     private final String classname;
     private final String customFolderName;
@@ -100,10 +112,40 @@ public class PluginInfo implements Writeable, ToXContentObject {
         List<String> extendedPlugins,
         boolean hasNativeController
     ) {
+        this(
+            name,
+            description,
+            version,
+            List.of(SemverRange.fromString(opensearchVersion.toString())),
+            javaVersion,
+            classname,
+            customFolderName,
+            extendedPlugins,
+            hasNativeController
+        );
+    }
+
+    public PluginInfo(
+        String name,
+        String description,
+        String version,
+        List<SemverRange> opensearchVersionRanges,
+        String javaVersion,
+        String classname,
+        String customFolderName,
+        List<String> extendedPlugins,
+        boolean hasNativeController
+    ) {
         this.name = name;
         this.description = description;
         this.version = version;
-        this.opensearchVersion = opensearchVersion;
+        // Ensure only one range is specified (for now)
+        if (opensearchVersionRanges.size() != 1) {
+            throw new IllegalArgumentException(
+                "Exactly one range is allowed to be specified in dependencies for the plugin [" + name + "]"
+            );
+        }
+        this.opensearchVersionRanges = opensearchVersionRanges;
         this.javaVersion = javaVersion;
         this.classname = classname;
         this.customFolderName = customFolderName;
@@ -152,11 +194,16 @@ public class PluginInfo implements Writeable, ToXContentObject {
      * @param in the stream
      * @throws IOException if an I/O exception occurred reading the plugin info from the stream
      */
+    @SuppressWarnings("unchecked")
     public PluginInfo(final StreamInput in) throws IOException {
         this.name = in.readString();
         this.description = in.readString();
         this.version = in.readString();
-        this.opensearchVersion = in.readVersion();
+        if (in.getVersion().onOrAfter(Version.V_2_13_0)) {
+            this.opensearchVersionRanges = (List<SemverRange>) in.readGenericValue();
+        } else {
+            this.opensearchVersionRanges = List.of(new SemverRange(in.readVersion(), SemverRange.RangeOperator.DEFAULT));
+        }
         this.javaVersion = in.readString();
         this.classname = in.readString();
         if (in.getVersion().onOrAfter(Version.V_1_1_0)) {
@@ -173,7 +220,15 @@ public class PluginInfo implements Writeable, ToXContentObject {
         out.writeString(name);
         out.writeString(description);
         out.writeString(version);
-        out.writeVersion(opensearchVersion);
+        if (out.getVersion().onOrAfter(Version.V_2_13_0)) {
+            out.writeGenericValue(opensearchVersionRanges);
+        } else {
+            /*
+            This works for currently supported range notations (=,~)
+            As more notations get added, then a suitable version must be picked.
+             */
+            out.writeVersion(opensearchVersionRanges.get(0).getRangeVersion());
+        }
         out.writeString(javaVersion);
         out.writeString(classname);
         if (out.getVersion().onOrAfter(Version.V_1_1_0)) {
@@ -220,10 +275,49 @@ public class PluginInfo implements Writeable, ToXContentObject {
         }
 
         final String opensearchVersionString = propsMap.remove("opensearch.version");
-        if (opensearchVersionString == null) {
-            throw new IllegalArgumentException("property [opensearch.version] is missing for plugin [" + name + "]");
+        final String dependenciesValue = propsMap.remove("dependencies");
+        if (opensearchVersionString == null && dependenciesValue == null) {
+            throw new IllegalArgumentException(
+                "Either [opensearch.version] or [dependencies] property must be specified for the plugin [" + name + "]"
+            );
         }
-        final Version opensearchVersion = Version.fromString(opensearchVersionString);
+        if (opensearchVersionString != null && dependenciesValue != null) {
+            throw new IllegalArgumentException(
+                "Only one of [opensearch.version] or [dependencies] property can be specified for the plugin [" + name + "]"
+            );
+        }
+
+        final List<SemverRange> opensearchVersionRanges = new ArrayList<>();
+        if (opensearchVersionString != null) {
+            opensearchVersionRanges.add(SemverRange.fromString(opensearchVersionString));
+        } else {
+            Map<String, String> dependenciesMap;
+            try (
+                final JsonXContentParser parser = new JsonXContentParser(
+                    NamedXContentRegistry.EMPTY,
+                    DeprecationHandler.IGNORE_DEPRECATIONS,
+                    jsonFactory.createParser(dependenciesValue)
+                )
+            ) {
+                dependenciesMap = parser.mapStrings();
+            }
+            if (dependenciesMap.size() != 1) {
+                throw new IllegalArgumentException(
+                    "Exactly one dependency is allowed to be specified in plugin descriptor properties: " + dependenciesMap
+                );
+            }
+            if (dependenciesMap.keySet().stream().noneMatch(s -> s.equals("opensearch"))) {
+                throw new IllegalArgumentException("Only opensearch is allowed to be specified as a plugin dependency: " + dependenciesMap);
+            }
+            String[] ranges = dependenciesMap.get("opensearch").split(",");
+            if (ranges.length != 1) {
+                throw new IllegalArgumentException(
+                    "Exactly one range is allowed to be specified in dependencies for the plugin [\" + name + \"]"
+                );
+            }
+            opensearchVersionRanges.add(SemverRange.fromString(ranges[0].trim()));
+        }
+
         final String javaVersionString = propsMap.remove("java.version");
         if (javaVersionString == null) {
             throw new IllegalArgumentException("property [java.version] is missing for plugin [" + name + "]");
@@ -235,12 +329,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
         }
 
         final String customFolderNameValue = propsMap.remove("custom.foldername");
-        final String customFolderName;
-        if (opensearchVersion.onOrAfter(Version.V_1_1_0)) {
-            customFolderName = customFolderNameValue;
-        } else {
-            customFolderName = name;
-        }
+        final String customFolderName = customFolderNameValue;
 
         final String extendedString = propsMap.remove("extended.plugins");
         final List<String> extendedPlugins;
@@ -283,7 +372,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
             name,
             description,
             version,
-            opensearchVersion,
+            opensearchVersionRanges,
             javaVersionString,
             classname,
             customFolderName,
@@ -347,12 +436,26 @@ public class PluginInfo implements Writeable, ToXContentObject {
     }
 
     /**
-     * The version of OpenSearch the plugin was built for.
+     * The list of OpenSearch version ranges the plugin is compatible with.
      *
-     * @return an OpenSearch version
+     * @return a list of OpenSearch version ranges
      */
-    public Version getOpenSearchVersion() {
-        return opensearchVersion;
+    public List<SemverRange> getOpenSearchVersionRanges() {
+        return opensearchVersionRanges;
+    }
+
+    /**
+     * Pretty print the semver ranges and return the string.
+     * @return semver ranges string
+     */
+    public String getOpenSearchVersionRangesString() {
+        if (opensearchVersionRanges == null || opensearchVersionRanges.isEmpty()) {
+            return "";
+        }
+        if (opensearchVersionRanges.size() == 1) {
+            return opensearchVersionRanges.get(0).toString();
+        }
+        return opensearchVersionRanges.stream().map(Object::toString).collect(Collectors.joining(",", "[", "]"));
     }
 
     /**
@@ -388,7 +491,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
         {
             builder.field("name", name);
             builder.field("version", version);
-            builder.field("opensearch_version", opensearchVersion);
+            builder.field("opensearch_version", opensearchVersionRanges);
             builder.field("java_version", javaVersion);
             builder.field("description", description);
             builder.field("classname", classname);
@@ -442,7 +545,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
             .append("\n")
             .append(prefix)
             .append("OpenSearch Version: ")
-            .append(opensearchVersion)
+            .append(getOpenSearchVersionRangesString())
             .append("\n")
             .append(prefix)
             .append("Java Version: ")

--- a/server/src/main/java/org/opensearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginsService.java
@@ -52,6 +52,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.service.ReportingService;
 import org.opensearch.index.IndexModule;
+import org.opensearch.semver.SemverRange;
 import org.opensearch.threadpool.ExecutorBuilder;
 import org.opensearch.transport.TransportSettings;
 
@@ -387,18 +388,28 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
      * Verify the given plugin is compatible with the current OpenSearch installation.
      */
     static void verifyCompatibility(PluginInfo info) {
-        if (info.getOpenSearchVersion().equals(Version.CURRENT) == false) {
+        if (!isPluginVersionCompatible(info, Version.CURRENT)) {
             throw new IllegalArgumentException(
                 "Plugin ["
                     + info.getName()
                     + "] was built for OpenSearch version "
-                    + info.getOpenSearchVersion()
+                    + info.getOpenSearchVersionRangesString()
                     + " but version "
                     + Version.CURRENT
                     + " is running"
             );
         }
         JarHell.checkJavaVersion(info.getName(), info.getJavaVersion());
+    }
+
+    public static boolean isPluginVersionCompatible(final PluginInfo pluginInfo, final Version coreVersion) {
+        // Core version must satisfy the semver range in plugin info
+        for (SemverRange range : pluginInfo.getOpenSearchVersionRanges()) {
+            if (!range.isSatisfiedBy(coreVersion)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     static void checkForFailedPluginRemovals(final Path pluginsDirectory) throws IOException {

--- a/server/src/test/java/org/opensearch/plugins/PluginInfoTests.java
+++ b/server/src/test/java/org/opensearch/plugins/PluginInfoTests.java
@@ -32,10 +32,13 @@
 
 package org.opensearch.plugins;
 
+import com.fasterxml.jackson.core.JsonParseException;
+
 import org.opensearch.Version;
 import org.opensearch.action.admin.cluster.node.info.PluginsAndModules;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.ByteBufferStreamInput;
+import org.opensearch.semver.SemverRange;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.nio.ByteBuffer;
@@ -74,10 +77,11 @@ public class PluginInfoTests extends OpenSearchTestCase {
         assertEquals("fake desc", info.getDescription());
         assertEquals("1.0", info.getVersion());
         assertEquals("FakePlugin", info.getClassname());
+        assertEquals(Version.CURRENT.toString(), info.getOpenSearchVersionRanges().get(0).toString());
         assertThat(info.getExtendedPlugins(), empty());
     }
 
-    public void testReadFromPropertiesWithFolderNameAndVersionBefore() throws Exception {
+    public void testReadFromPropertiesWithSingleOpenSearchRange() throws Exception {
         Path pluginDir = createTempDir().resolve("fake-plugin");
         PluginTestUtil.writePluginProperties(
             pluginDir,
@@ -87,21 +91,19 @@ public class PluginInfoTests extends OpenSearchTestCase {
             "my_plugin",
             "version",
             "1.0",
-            "opensearch.version",
-            Version.V_1_0_0.toString(),
+            "dependencies",
+            "{opensearch:\"~" + Version.CURRENT.toString() + "\"}",
             "java.version",
             System.getProperty("java.specification.version"),
             "classname",
-            "FakePlugin",
-            "custom.foldername",
-            "custom-folder"
+            "FakePlugin"
         );
         PluginInfo info = PluginInfo.readFromProperties(pluginDir);
         assertEquals("my_plugin", info.getName());
         assertEquals("fake desc", info.getDescription());
         assertEquals("1.0", info.getVersion());
         assertEquals("FakePlugin", info.getClassname());
-        assertEquals("my_plugin", info.getTargetFolderName());
+        assertEquals("~" + Version.CURRENT.toString(), info.getOpenSearchVersionRanges().get(0).toString());
         assertThat(info.getExtendedPlugins(), empty());
     }
 
@@ -130,6 +132,7 @@ public class PluginInfoTests extends OpenSearchTestCase {
         assertEquals("1.0", info.getVersion());
         assertEquals("FakePlugin", info.getClassname());
         assertEquals("custom-folder", info.getTargetFolderName());
+        assertEquals(Version.CURRENT.toString(), info.getOpenSearchVersionRanges().get(0).toString());
         assertThat(info.getExtendedPlugins(), empty());
     }
 
@@ -158,11 +161,40 @@ public class PluginInfoTests extends OpenSearchTestCase {
         assertThat(e.getMessage(), containsString("[version] is missing"));
     }
 
-    public void testReadFromPropertiesOpenSearchVersionMissing() throws Exception {
+    public void testReadFromPropertiesOpenSearchVersionAndDependenciesMissing() throws Exception {
         Path pluginDir = createTempDir().resolve("fake-plugin");
         PluginTestUtil.writePluginProperties(pluginDir, "description", "fake desc", "name", "my_plugin", "version", "1.0");
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
-        assertThat(e.getMessage(), containsString("[opensearch.version] is missing"));
+        assertThat(
+            e.getMessage(),
+            containsString("Either [opensearch.version] or [dependencies] property must be specified for the plugin ")
+        );
+    }
+
+    public void testReadFromPropertiesWithDependenciesAndOpenSearchVersion() throws Exception {
+        Path pluginDir = createTempDir().resolve("fake-plugin");
+        PluginTestUtil.writePluginProperties(
+            pluginDir,
+            "description",
+            "fake desc",
+            "name",
+            "my_plugin",
+            "version",
+            "1.0",
+            "opensearch.version",
+            Version.CURRENT.toString(),
+            "dependencies",
+            "{opensearch:" + Version.CURRENT.toString() + "}",
+            "java.version",
+            System.getProperty("java.specification.version"),
+            "classname",
+            "FakePlugin"
+        );
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        assertThat(
+            e.getMessage(),
+            containsString("Only one of [opensearch.version] or [dependencies] property can be specified for the plugin")
+        );
     }
 
     public void testReadFromPropertiesJavaVersionMissing() throws Exception {
@@ -333,7 +365,6 @@ public class PluginInfoTests extends OpenSearchTestCase {
         ByteBufferStreamInput input = new ByteBufferStreamInput(buffer);
         PluginInfo info2 = new PluginInfo(input);
         assertThat(info2.toString(), equalTo(info.toString()));
-
     }
 
     public void testPluginListSorted() {
@@ -375,4 +406,193 @@ public class PluginInfoTests extends OpenSearchTestCase {
         assertThat(e.getMessage(), containsString("Unknown properties in plugin descriptor"));
     }
 
+    public void testMultipleDependencies() throws Exception {
+        Path pluginDir = createTempDir().resolve("fake-plugin");
+        PluginTestUtil.writePluginProperties(
+            pluginDir,
+            "description",
+            "fake desc",
+            "name",
+            "my_plugin",
+            "version",
+            "1.0",
+            "dependencies",
+            "{opensearch:\"~" + Version.CURRENT.toString() + "\", dependency2:\"1.0.0\"}",
+            "java.version",
+            System.getProperty("java.specification.version"),
+            "classname",
+            "FakePlugin"
+        );
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        assertThat(e.getMessage(), containsString("Exactly one dependency is allowed to be specified in plugin descriptor properties"));
+    }
+
+    public void testNonOpenSearchDependency() throws Exception {
+        Path pluginDir = createTempDir().resolve("fake-plugin");
+        PluginTestUtil.writePluginProperties(
+            pluginDir,
+            "description",
+            "fake desc",
+            "name",
+            "my_plugin",
+            "version",
+            "1.0",
+            "dependencies",
+            "{some_dependency:\"~" + Version.CURRENT.toString() + "\"}",
+            "java.version",
+            System.getProperty("java.specification.version"),
+            "classname",
+            "FakePlugin"
+        );
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        assertThat(e.getMessage(), containsString("Only opensearch is allowed to be specified as a plugin dependency"));
+    }
+
+    public void testEmptyDependenciesProperty() throws Exception {
+        Path pluginDir = createTempDir().resolve("fake-plugin");
+        PluginTestUtil.writePluginProperties(
+            pluginDir,
+            "description",
+            "fake desc",
+            "name",
+            "my_plugin",
+            "version",
+            "1.0",
+            "dependencies",
+            "{}",
+            "java.version",
+            System.getProperty("java.specification.version"),
+            "classname",
+            "FakePlugin"
+        );
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        assertThat(e.getMessage(), containsString("Exactly one dependency is allowed to be specified in plugin descriptor properties"));
+    }
+
+    public void testInvalidDependenciesProperty() throws Exception {
+        Path pluginDir = createTempDir().resolve("fake-plugin");
+        PluginTestUtil.writePluginProperties(
+            pluginDir,
+            "description",
+            "fake desc",
+            "name",
+            "my_plugin",
+            "version",
+            "1.0",
+            "dependencies",
+            "{invalid}",
+            "java.version",
+            System.getProperty("java.specification.version"),
+            "classname",
+            "FakePlugin"
+        );
+        expectThrows(JsonParseException.class, () -> PluginInfo.readFromProperties(pluginDir));
+    }
+
+    public void testEmptyOpenSearchVersionInDependencies() throws Exception {
+        Path pluginDir = createTempDir().resolve("fake-plugin");
+        PluginTestUtil.writePluginProperties(
+            pluginDir,
+            "description",
+            "fake desc",
+            "name",
+            "my_plugin",
+            "version",
+            "1.0",
+            "dependencies",
+            "{opensearch:\"\"}",
+            "java.version",
+            System.getProperty("java.specification.version"),
+            "classname",
+            "FakePlugin"
+        );
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        assertThat(e.getMessage(), containsString("Version cannot be empty"));
+    }
+
+    public void testInvalidOpenSearchVersionInDependencies() throws Exception {
+        Path pluginDir = createTempDir().resolve("fake-plugin");
+        PluginTestUtil.writePluginProperties(
+            pluginDir,
+            "description",
+            "fake desc",
+            "name",
+            "my_plugin",
+            "version",
+            "1.0",
+            "dependencies",
+            "{opensearch:\"1.2\"}",
+            "java.version",
+            System.getProperty("java.specification.version"),
+            "classname",
+            "FakePlugin"
+        );
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        assertThat(
+            e.getMessage(),
+            containsString("the version needs to contain major, minor, and revision, and optionally the build: 1.2")
+        );
+    }
+
+    public void testInvalidRangeInDependencies() throws Exception {
+        Path pluginDir = createTempDir().resolve("fake-plugin");
+        PluginTestUtil.writePluginProperties(
+            pluginDir,
+            "description",
+            "fake desc",
+            "name",
+            "my_plugin",
+            "version",
+            "1.0",
+            "dependencies",
+            "{opensearch:\"<2.2.0\"}",
+            "java.version",
+            System.getProperty("java.specification.version"),
+            "classname",
+            "FakePlugin"
+        );
+        expectThrows(NumberFormatException.class, () -> PluginInfo.readFromProperties(pluginDir));
+    }
+
+    public void testhMultipleOpenSearchRangesInDependencies() throws Exception {
+        Path pluginDir = createTempDir().resolve("fake-plugin");
+        PluginTestUtil.writePluginProperties(
+            pluginDir,
+            "description",
+            "fake desc",
+            "name",
+            "my_plugin",
+            "version",
+            "1.0",
+            "dependencies",
+            "{opensearch:\"~1.2.3, =1.2.3\"}",
+            "java.version",
+            System.getProperty("java.specification.version"),
+            "classname",
+            "FakePlugin"
+        );
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        assertThat(e.getMessage(), containsString("Exactly one range is allowed to be specified in dependencies for the plugin"));
+    }
+
+    public void testhMultipleOpenSearchRangesInConstructor() throws Exception {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> new PluginInfo(
+                "plugin_name",
+                "foo",
+                "dummy",
+                List.of(
+                    new SemverRange(Version.CURRENT, SemverRange.RangeOperator.EQ),
+                    new SemverRange(Version.CURRENT, SemverRange.RangeOperator.DEFAULT)
+                ),
+                "1.8",
+                "dummyclass",
+                null,
+                Collections.emptyList(),
+                randomBoolean()
+            )
+        );
+        assertThat(e.getMessage(), containsString("Exactly one range is allowed to be specified in dependencies for the plugin"));
+    }
 }

--- a/test/framework/src/main/java/org/opensearch/test/VersionUtils.java
+++ b/test/framework/src/main/java/org/opensearch/test/VersionUtils.java
@@ -354,4 +354,14 @@ public class VersionUtils {
         // but 7.2.0 for minimum compat
         return randomVersionBetween(random, version.minimumIndexCompatibilityVersion(), getPreviousVersion(version));
     }
+
+    /**
+     * Returns a {@link Version} with a given major, minor and revision version.
+     * Build version is skipped for the sake of simplicity.
+     */
+    public static Version getVersion(byte major, byte minor, byte revision) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(major).append('.').append(minor).append('.').append(revision);
+        return Version.fromString(sb.toString());
+    }
 }


### PR DESCRIPTION
### Description
Backport https://github.com/opensearch-project/OpenSearch/pull/11441 to 2.x.
Following are the additional changes: 
1. Updated PluginInfo version check for serialization of semver range list to use V_2_13_0.
2. Updated PluginInfo version check of Version.V_1_1_0 for custom folder name and related test. 
3. Resolved minor conflicts in ListPluginsCommandTests.java

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/1707


### Check List
- [X] New functionality includes testing.
  - [ ] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
