### PR TITLE
[Backport] [2.x] Add a system property to configure YamlParser codepoint limits (#12301)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 ### Fixed
+- Add a system property to configure YamlParser codepoint limits ([#12298](https://github.com/opensearch-project/OpenSearch/pull/12298))
 
 ### Security
 

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentContraints.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentContraints.java
@@ -19,6 +19,7 @@ import org.opensearch.common.annotation.InternalApi;
  */
 @InternalApi
 public interface XContentContraints {
+    final String DEFAULT_CODEPOINT_LIMIT_PROPERTY = "opensearch.xcontent.codepoint.max";
     final String DEFAULT_MAX_STRING_LEN_PROPERTY = "opensearch.xcontent.string.length.max";
     final String DEFAULT_MAX_NAME_LEN_PROPERTY = "opensearch.xcontent.name.length.max";
     final String DEFAULT_MAX_DEPTH_PROPERTY = "opensearch.xcontent.depth.max";
@@ -34,4 +35,6 @@ public interface XContentContraints {
     final int DEFAULT_MAX_DEPTH = Integer.parseInt(
         System.getProperty(DEFAULT_MAX_DEPTH_PROPERTY, Integer.toString(Integer.MAX_VALUE) /* no limit */ )
     );
+
+    final int DEFAULT_CODEPOINT_LIMIT = Integer.parseInt(System.getProperty(DEFAULT_CODEPOINT_LIMIT_PROPERTY, "52428800" /* ~50 Mb */));
 }

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/yaml/YamlXContent.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/yaml/YamlXContent.java
@@ -39,6 +39,7 @@ import com.fasterxml.jackson.core.StreamReadFeature;
 import com.fasterxml.jackson.core.StreamWriteConstraints;
 import com.fasterxml.jackson.core.StreamWriteFeature;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactoryBuilder;
 
 import org.opensearch.common.xcontent.XContentContraints;
 import org.opensearch.common.xcontent.XContentType;
@@ -56,6 +57,8 @@ import java.io.OutputStream;
 import java.io.Reader;
 import java.util.Set;
 
+import org.yaml.snakeyaml.LoaderOptions;
+
 /**
  * A YAML based content implementation using Jackson.
  */
@@ -70,7 +73,9 @@ public class YamlXContent implements XContent, XContentContraints {
     public static final YamlXContent yamlXContent;
 
     static {
-        yamlFactory = new YAMLFactory();
+        final LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setCodePointLimit(DEFAULT_CODEPOINT_LIMIT);
+        yamlFactory = new YAMLFactoryBuilder(new YAMLFactory()).loaderOptions(loaderOptions).build();
         yamlFactory.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true);
         yamlFactory.setStreamWriteConstraints(StreamWriteConstraints.builder().maxNestingDepth(DEFAULT_MAX_DEPTH).build());
         yamlFactory.setStreamReadConstraints(

--- a/libs/x-content/src/test/java/org/opensearch/common/xcontent/XContentParserTests.java
+++ b/libs/x-content/src/test/java/org/opensearch/common/xcontent/XContentParserTests.java
@@ -79,7 +79,7 @@ public class XContentParserTests extends OpenSearchTestCase {
         () -> randomAlphaOfLengthBetween(1, SmileXContent.DEFAULT_MAX_STRING_LEN / 10), /* limit to ~200Mb */
         /* YAML parser limitation */
         XContentType.YAML,
-        () -> randomAlphaOfLengthBetween(1, 3140000)
+        () -> randomRealisticUnicodeOfCodepointLengthBetween(1, YamlXContent.DEFAULT_CODEPOINT_LIMIT)
     );
 
     private static final Map<XContentType, Supplier<String>> FIELD_NAME_GENERATORS = Map.of(
@@ -106,7 +106,7 @@ public class XContentParserTests extends OpenSearchTestCase {
 
     public void testStringOffLimit() throws IOException {
         final String field = randomAlphaOfLengthBetween(1, 5);
-        final String value = randomRealisticUnicodeOfCodepointLength(3145730);
+        final String value = randomRealisticUnicodeOfCodepointLength(YamlXContent.DEFAULT_CODEPOINT_LIMIT + 1);
 
         try (XContentBuilder builder = XContentBuilder.builder(XContentType.YAML.xContent())) {
             builder.startObject();


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/12301 to `2.x`