### PR TITLE
Add toString() to MultiSearchRequest, MultiGetRequest and CreateIndex…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add support for dependencies in plugin descriptor properties with semver range ([#11441](https://github.com/opensearch-project/OpenSearch/pull/11441))
 - Add community_id ingest processor ([#12121](https://github.com/opensearch-project/OpenSearch/pull/12121))
 - Introduce query level setting `index.query.max_nested_depth` limiting nested queries ([#3268](https://github.com/opensearch-project/OpenSearch/issues/3268)
+- Add toString methods to MultiSearchRequest, MultiGetRequest and CreateIndexRequest ([#12163](https://github.com/opensearch-project/OpenSearch/pull/12163))
 
 ### Dependencies
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/create/CreateIndexRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/create/CreateIndexRequest.java
@@ -601,4 +601,25 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
         }
         waitForActiveShards.writeTo(out);
     }
+
+    @Override
+    public String toString() {
+        return "CreateIndexRequest{"
+            + "cause='"
+            + cause
+            + '\''
+            + ", index='"
+            + index
+            + '\''
+            + ", settings="
+            + settings
+            + ", mappings='"
+            + mappings
+            + '\''
+            + ", aliases="
+            + aliases
+            + ", waitForActiveShards="
+            + waitForActiveShards
+            + '}';
+    }
 }

--- a/server/src/main/java/org/opensearch/action/get/MultiGetRequest.java
+++ b/server/src/main/java/org/opensearch/action/get/MultiGetRequest.java
@@ -590,4 +590,19 @@ public class MultiGetRequest extends ActionRequest
         return builder;
     }
 
+    @Override
+    public String toString() {
+        return "MultiGetRequest{"
+            + "preference='"
+            + preference
+            + '\''
+            + ", realtime="
+            + realtime
+            + ", refresh="
+            + refresh
+            + ", items="
+            + items
+            + '}';
+    }
+
 }

--- a/server/src/main/java/org/opensearch/action/search/MultiSearchRequest.java
+++ b/server/src/main/java/org/opensearch/action/search/MultiSearchRequest.java
@@ -398,4 +398,16 @@ public class MultiSearchRequest extends ActionRequest implements CompositeIndice
             }
         };
     }
+
+    @Override
+    public String toString() {
+        return "MultiSearchRequest{"
+            + "maxConcurrentSearchRequests="
+            + maxConcurrentSearchRequests
+            + ", requests="
+            + requests
+            + ", indicesOptions="
+            + indicesOptions
+            + '}';
+    }
 }

--- a/server/src/test/java/org/opensearch/action/admin/indices/create/CreateIndexRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/create/CreateIndexRequestTests.java
@@ -50,6 +50,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 
 public class CreateIndexRequestTests extends OpenSearchTestCase {
@@ -148,6 +149,20 @@ public class CreateIndexRequestTests extends OpenSearchTestCase {
         CreateIndexRequest parsedCreateIndexRequest = new CreateIndexRequest();
         OpenSearchParseException e = expectThrows(OpenSearchParseException.class, () -> parsedCreateIndexRequest.source(builder));
         assertThat(e.getMessage(), equalTo("key [settings] must be an object"));
+    }
+
+    public void testToString() throws IOException {
+        CreateIndexRequest request = new CreateIndexRequest("foo");
+        String mapping = JsonXContent.contentBuilder()
+            .startObject()
+            .startObject(MapperService.SINGLE_MAPPING_NAME)
+            .endObject()
+            .endObject()
+            .toString();
+        request.mapping(mapping);
+
+        assertThat(request.toString(), containsString("index='foo'"));
+        assertThat(request.toString(), containsString("mappings='{\"_doc\":{}}'"));
     }
 
     public static void assertMappingsEqual(Map<String, String> expected, Map<String, String> actual) throws IOException {

--- a/server/src/test/java/org/opensearch/action/get/MultiGetRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/get/MultiGetRequestTests.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.action.get;
 
+import org.opensearch.action.get.MultiGetRequest.Item;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.common.ParsingException;
@@ -138,6 +139,13 @@ public class MultiGetRequestTests extends OpenSearchTestCase {
                     assertThat(actualItem, equalTo(expectedItem));
                 }
             }
+        }
+    }
+
+    public void testToString() {
+        MultiGetRequest req = createTestInstance();
+        for (Item items : req.getItems()) {
+            assertThat(req.toString(), containsString(items.toString()));
         }
     }
 

--- a/server/src/test/java/org/opensearch/action/search/MultiSearchRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/search/MultiSearchRequestTests.java
@@ -73,6 +73,7 @@ import java.util.concurrent.TimeUnit;
 import static java.util.Collections.singletonList;
 import static org.opensearch.search.RandomSearchRequestGenerator.randomSearchRequest;
 import static org.opensearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashCode;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -563,6 +564,13 @@ public class MultiSearchRequestTests extends OpenSearchTestCase {
 
     public void testEqualsAndHashcode() {
         checkEqualsAndHashCode(createMultiSearchRequest(), MultiSearchRequestTests::copyRequest, MultiSearchRequestTests::mutate);
+    }
+
+    public void testToString() {
+        MultiSearchRequest req = createMultiSearchRequest();
+        for (SearchRequest subReq : req.requests()) {
+            assertThat(req.toString(), containsString(subReq.toString()));
+        }
     }
 
     private static MultiSearchRequest mutate(MultiSearchRequest searchRequest) throws IOException {


### PR DESCRIPTION
fix #12144

### Description
Make debugging easier with toString() method in MultiSearchRequest class.

backport of https://github.com/opensearch-project/OpenSearch/pull/12163

### Related Issues
Resolves #12144

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
