### PR TITLE
[Backport] [2.x] Bump com.squareup.okio:okio from 3.7.0 to 3.8.0 in /test/fixtures/hdfs-fixture (#12290)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Introduce query level setting `index.query.max_nested_depth` limiting nested queries ([#3268](https://github.com/opensearch-project/OpenSearch/issues/3268)
 
 ### Dependencies
+- Bump `com.squareup.okio:okio` from 3.7.0 to 3.8.0 ([#12290](https://github.com/opensearch-project/OpenSearch/pull/12290))
 
 ### Changed
 

--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -77,6 +77,6 @@ dependencies {
   runtimeOnly("com.squareup.okhttp3:okhttp:4.12.0") {
     exclude group: "com.squareup.okio"
   }
-  runtimeOnly "com.squareup.okio:okio:3.7.0"
+  runtimeOnly "com.squareup.okio:okio:3.8.0"
   runtimeOnly "org.xerial.snappy:snappy-java:1.1.10.5"
 }


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/12290 to `2.x`