### PR TITLE
Fix flaky test cases

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
@@ -245,8 +245,10 @@ public class DiskThresholdDeciderIT extends OpenSearchIntegTestCase {
             (discoveryNode, fsInfoPath) -> setDiskUsage(fsInfoPath, TOTAL_SPACE_BYTES, TOTAL_SPACE_BYTES)
         );
 
-        // Validate if index create block is removed on the cluster
+        // Validate if index create block is removed on the cluster. Need to refresh this periodically as well to remove
+        // the node from high watermark breached list.
         assertBusy(() -> {
+            clusterInfoService.refresh();
             ClusterState state1 = client().admin().cluster().prepareState().setLocal(true).get().getState();
             assertFalse(state1.blocks().hasGlobalBlockWithId(Metadata.CLUSTER_CREATE_INDEX_BLOCK.id()));
         }, 30L, TimeUnit.SECONDS);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fixing following test cases:
1. InternalEngineTests.testUnreferencedFileCleanUpOnSegmentMergeFailureWithCleanUpEnabled: Right now [merge policy created](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java#L1393) for IndexWriter can create an Alcoholic Merge policy as well. This does not sometimes trigger segment merges. Also using ForceMerge policy to avoid regular merge (triggered due to) closing shard before force merge kicks in.
2. org.opensearch.index.engine.InternalEngineTests.testUnreferencedFileCleanUpOnSegmentMergeFailureWithCleanUpDisabled
3. InternalEngineTests.testUnreferencedFileCleanUpFailsOnSegmentMergeFailureWhenDirectoryClosed:  Right now [merge policy created](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java#L1393) for IndexWriter can create an Alcoholic Merge policy as well. This does not sometimes trigger segment merges.
4. DiskThresholdDeciderIT.testIndexCreateBlockIsRemovedWhenAnyNodesNotExceedHighWatermarkWithAutoReleaseEnabled: Need to refresh DiskThresholdMonitor periodically as well to remove the node from high watermark breached list once available space is above high watermark on all nodes.
5. ClusterShardLimitIT.testCreateIndexWithMaxClusterShardSetting: Ensure Max shard per cluster is always greater than max shard per node.

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/10903
https://github.com/opensearch-project/OpenSearch/issues/10739
https://github.com/opensearch-project/OpenSearch/issues/9891
https://github.com/opensearch-project/OpenSearch/issues/6445
https://github.com/opensearch-project/OpenSearch/issues/6287

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
