### PR TITLE
[DRAFT] Cardinality aggregation dynamic pruning changes (to be used only for prototype and reference purpose, not intended to merge to main)

### DIFF
--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/DisjunctionWithDynamicPruningScorer.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/DisjunctionWithDynamicPruningScorer.java
@@ -1,0 +1,264 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.aggregations.metrics;
+
+import org.apache.lucene.search.DisiPriorityQueue;
+import org.apache.lucene.search.DisiWrapper;
+import org.apache.lucene.search.DisjunctionDISIApproximation;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.TwoPhaseIterator;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.PriorityQueue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+
+/**
+ * Clone of {@link org.apache.lucene.search} {@code DisjunctionScorer.java} in lucene with following modifications -
+ * 1. {@link #removeAllDISIsOnCurrentDoc()} - it removes all the DISIs for subscorer pointing to current doc. This is
+ * helpful in dynamic pruning for Cardinality aggregation, where once a term is found, it becomes irrelevant for
+ * rest of the search space, so this term's subscorer DISI can be safely removed from list of subscorer to process.
+ * <p>
+ * 2. {@link #removeAllDISIsOnCurrentDoc()} breaks the invariant of Conjuction DISI i.e. the docIDs of all sub-scorers should be
+ * less than or equal to current docID iterator is pointing to. When we remove elements from priority, it results in heapify action, which modifies
+ * the top of the priority queye, which represents the current docID for subscorers here. To address this, we are wrapping the
+ * iterator with {@link SlowDocIdPropagatorDISI} which keeps the iterator pointing to last docID before {@link #removeAllDISIsOnCurrentDoc()}
+ * is called and updates this docID only when next() or advance() is called.
+ */
+public class DisjunctionWithDynamicPruningScorer extends Scorer {
+
+    private final boolean needsScores;
+    private final DisiPriorityQueue subScorers;
+    private final DocIdSetIterator approximation;
+    private final TwoPhase twoPhase;
+
+    private Integer docID;
+
+    public DisjunctionWithDynamicPruningScorer(Weight weight, List<Scorer> subScorers)
+        throws IOException {
+        super(weight);
+        if (subScorers.size() <= 1) {
+            throw new IllegalArgumentException("There must be at least 2 subScorers");
+        }
+        this.subScorers = new DisiPriorityQueue(subScorers.size());
+        for (Scorer scorer : subScorers) {
+            final DisiWrapper w = new DisiWrapper(scorer);
+            this.subScorers.add(w);
+        }
+        this.needsScores = false;
+        this.approximation = new DisjunctionDISIApproximation(this.subScorers);
+
+        boolean hasApproximation = false;
+        float sumMatchCost = 0;
+        long sumApproxCost = 0;
+        // Compute matchCost as the average over the matchCost of the subScorers.
+        // This is weighted by the cost, which is an expected number of matching documents.
+        for (DisiWrapper w : this.subScorers) {
+            long costWeight = (w.cost <= 1) ? 1 : w.cost;
+            sumApproxCost += costWeight;
+            if (w.twoPhaseView != null) {
+                hasApproximation = true;
+                sumMatchCost += w.matchCost * costWeight;
+            }
+        }
+
+        if (hasApproximation == false) { // no sub scorer supports approximations
+            twoPhase = null;
+        } else {
+            final float matchCost = sumMatchCost / sumApproxCost;
+            twoPhase = new TwoPhase(approximation, matchCost);
+        }
+    }
+
+    public void removeAllDISIsOnCurrentDoc() {
+        docID = this.docID();
+        while (subScorers.size() > 0 && subScorers.top().doc == docID) {
+            subScorers.pop();
+        }
+    }
+
+    @Override
+    public DocIdSetIterator iterator() {
+       DocIdSetIterator disi = getIterator();
+       docID = disi.docID();
+       return new SlowDocIdPropagatorDISI(getIterator(), docID);
+    }
+
+    private static class SlowDocIdPropagatorDISI extends DocIdSetIterator {
+        DocIdSetIterator disi;
+
+        Integer curDocId;
+
+        SlowDocIdPropagatorDISI(DocIdSetIterator disi, Integer curDocId) {
+            this.disi = disi;
+            this.curDocId = curDocId;
+        }
+
+        @Override
+        public int docID() {
+            assert curDocId <= disi.docID();
+            return curDocId;
+        }
+
+        @Override
+        public int nextDoc() throws IOException {
+            return advance(curDocId + 1);
+        }
+
+        @Override
+        public int advance(int i) throws IOException {
+            if (i <= disi.docID()) {
+                // since we are slow propagating docIDs, it may happen the disi is already advanced to a higher docID than i
+                // in such scenarios we can simply return the docID where disi is pointing to and update the curDocId
+                curDocId = disi.docID();
+                return disi.docID();
+            }
+            curDocId = disi.advance(i);
+            return curDocId;
+        }
+
+        @Override
+        public long cost() {
+            return disi.cost();
+        }
+    }
+
+    private DocIdSetIterator getIterator() {
+        if (twoPhase != null) {
+            return TwoPhaseIterator.asDocIdSetIterator(twoPhase);
+        } else {
+            return approximation;
+        }
+    }
+
+    @Override
+    public TwoPhaseIterator twoPhaseIterator() {
+        return twoPhase;
+    }
+
+    @Override
+    public float getMaxScore(int i) throws IOException {
+        return 0;
+    }
+
+    private class TwoPhase extends TwoPhaseIterator {
+
+        private final float matchCost;
+        // list of verified matches on the current doc
+        DisiWrapper verifiedMatches;
+        // priority queue of approximations on the current doc that have not been verified yet
+        final PriorityQueue<DisiWrapper> unverifiedMatches;
+
+        private TwoPhase(DocIdSetIterator approximation, float matchCost) {
+            super(approximation);
+            this.matchCost = matchCost;
+            unverifiedMatches =
+                new PriorityQueue<DisiWrapper>(DisjunctionWithDynamicPruningScorer.this.subScorers.size()) {
+                    @Override
+                    protected boolean lessThan(DisiWrapper a, DisiWrapper b) {
+                        return a.matchCost < b.matchCost;
+                    }
+                };
+        }
+
+        DisiWrapper getSubMatches() throws IOException {
+            // iteration order does not matter
+            for (DisiWrapper w : unverifiedMatches) {
+                if (w.twoPhaseView.matches()) {
+                    w.next = verifiedMatches;
+                    verifiedMatches = w;
+                }
+            }
+            unverifiedMatches.clear();
+            return verifiedMatches;
+        }
+
+        @Override
+        public boolean matches() throws IOException {
+            verifiedMatches = null;
+            unverifiedMatches.clear();
+
+            for (DisiWrapper w = subScorers.topList(); w != null; ) {
+                DisiWrapper next = w.next;
+
+                if (w.twoPhaseView == null) {
+                    // implicitly verified, move it to verifiedMatches
+                    w.next = verifiedMatches;
+                    verifiedMatches = w;
+
+                    if (needsScores == false) {
+                        // we can stop here
+                        return true;
+                    }
+                } else {
+                    unverifiedMatches.add(w);
+                }
+                w = next;
+            }
+
+            if (verifiedMatches != null) {
+                return true;
+            }
+
+            // verify subs that have an two-phase iterator
+            // least-costly ones first
+            while (unverifiedMatches.size() > 0) {
+                DisiWrapper w = unverifiedMatches.pop();
+                if (w.twoPhaseView.matches()) {
+                    w.next = null;
+                    verifiedMatches = w;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        @Override
+        public float matchCost() {
+            return matchCost;
+        }
+    }
+
+
+    @Override
+    public final int docID() {
+        return subScorers.top().doc;
+    }
+
+    DisiWrapper getSubMatches() throws IOException {
+        if (twoPhase == null) {
+            return subScorers.topList();
+        } else {
+            return twoPhase.getSubMatches();
+        }
+    }
+
+    @Override
+    public final float score() throws IOException {
+        return score(getSubMatches());
+    }
+
+    protected float score(DisiWrapper topList) throws IOException {
+        return 1f;
+    }
+
+    @Override
+    public final Collection<ChildScorable> getChildren() throws IOException {
+        ArrayList<ChildScorable> children = new ArrayList<>();
+        for (DisiWrapper scorer = getSubMatches(); scorer != null; scorer = scorer.next) {
+            children.add(new ChildScorable(scorer.scorer, "SHOULD"));
+        }
+        return children;
+    }
+}

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/DynamicPruningCollectorWrapper.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/DynamicPruningCollectorWrapper.java
@@ -1,0 +1,106 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.aggregations.metrics;
+
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.search.CollectionTerminatedException;
+import org.apache.lucene.search.ConjunctionUtils;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.Bits;
+import org.opensearch.search.aggregations.support.FieldContext;
+import org.opensearch.search.aggregations.support.ValuesSource;
+import org.opensearch.search.internal.SearchContext;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class DynamicPruningCollectorWrapper extends CardinalityAggregator.Collector {
+
+    private final LeafReaderContext ctx;
+    private final DisjunctionWithDynamicPruningScorer disjunctionScorer;
+    private final DocIdSetIterator disi;
+    private final CardinalityAggregator.Collector delegateCollector;
+
+    DynamicPruningCollectorWrapper(CardinalityAggregator.Collector delegateCollector,
+                                   SearchContext context, LeafReaderContext ctx, FieldContext fieldContext,
+                                   ValuesSource.Bytes.WithOrdinals source) throws IOException {
+        this.ctx = ctx;
+        this.delegateCollector = delegateCollector;
+        final SortedSetDocValues ordinalValues = source.ordinalsValues(ctx);
+        boolean isCardinalityLow = ordinalValues.getValueCount() < 10;
+        boolean isCardinalityAggregationOnlyAggregation = true;
+        boolean isFieldSupportedForDynamicPruning = true;
+        if (isCardinalityLow && isCardinalityAggregationOnlyAggregation && isFieldSupportedForDynamicPruning) {
+            // create disjunctions from terms
+            // this logic should be pluggable depending on the type of leaf bucket collector by CardinalityAggregator
+            TermsEnum terms = ordinalValues.termsEnum();
+            Weight weight = context.searcher().createWeight(context.searcher().rewrite(context.query()), ScoreMode.COMPLETE_NO_SCORES, 1f);
+            Map<Long, Boolean> found = new HashMap<>();
+            List<Scorer> subScorers = new ArrayList<>();
+            while (terms.next() != null && !found.containsKey(terms.ord())) {
+                // TODO can we get rid of terms previously encountered in other segments?
+                TermQuery termQuery = new TermQuery(new Term(fieldContext.field(), terms.term()));
+                Weight subWeight = context.searcher().createWeight(termQuery, ScoreMode.COMPLETE_NO_SCORES, 1f);
+                Scorer scorer = subWeight.scorer(ctx);
+                if (scorer != null) {
+                    subScorers.add(scorer);
+                }
+                found.put(terms.ord(), true);
+            }
+            disjunctionScorer = new DisjunctionWithDynamicPruningScorer(weight, subScorers);
+            disi = ConjunctionUtils.intersectScorers(List.of(disjunctionScorer, weight.scorer(ctx)));
+        } else {
+            disjunctionScorer = null;
+            disi = null;
+        }
+    }
+
+    @Override
+    public void collect(int doc, long bucketOrd) throws IOException {
+        if (disi == null || disjunctionScorer == null) {
+            delegateCollector.collect(doc, bucketOrd);
+        } else {
+            // perform the full iteration using dynamic pruning of DISIs and return right away
+            disi.advance(doc);
+            int currDoc = disi.docID();
+            assert currDoc == doc;
+            final Bits liveDocs = ctx.reader().getLiveDocs();
+            assert liveDocs == null || liveDocs.get(currDoc);
+            do {
+                if (liveDocs == null || liveDocs.get(currDoc)) {
+                    delegateCollector.collect(currDoc, bucketOrd);
+                    disjunctionScorer.removeAllDISIsOnCurrentDoc();
+                }
+                currDoc = disi.nextDoc();
+            } while (currDoc != DocIdSetIterator.NO_MORE_DOCS);
+            throw new CollectionTerminatedException();
+        }
+    }
+
+    @Override
+    public void close() {
+        delegateCollector.close();
+    }
+
+    @Override
+    public void postCollect() throws IOException {
+        delegateCollector.postCollect();
+    }
+}


### PR DESCRIPTION
Changes to experiment with Dynamic pruning for cardinality aggregation described in #11959. 

Here is the breakdown of algorithm - 


1. Check for all preconditions on when this optimization can be enabled - 
 - 1. Only enabled when Cardinality Aggregation is the only aggregation. 
 - 2. The field is a low cardinality field. 
 - 3. Field type is one of Keyword, Numeric? 
 - 4. Other?

2. Once preconditions are met, while collectors are created and picked for a given segment, create a `DynamicPruningCollectorWrapper` to wrap the collector with optimization. 

3. `DynamicPruningCollectorWrapper` will enumerate all the terms for the given field and creates a `DisjunctionWithDynamicPruningScorer` similar to `DisjunctionScorer` in lucene in conjunction with the parent query. `DisjunctionWithDynamicPruningScorer` scorer should have following capabilities in addition to what `DisjunctionScorer` have - 
-  1. `#removeAllDISIsOnCurrentDoc()` - it removes all the DISIs for subscorer pointing to current doc. This is helpful in dynamic pruning for Cardinality aggregation, where once a term is found, it becomes irrelevant for rest of the search space, so this term's subscorer DISI can be safely removed from list of subscorer to process.

-  2. `#removeAllDISIsOnCurrentDoc()` breaks the invariant of Conjuction DISI i.e. the docIDs of all sub-scorers should be ess than or equal to current docID iterator is pointing to. When we remove elements from priority, it results in heapify action, which modifies the top of the priority queye, which represents the current docID for subscorers here. To address this, we are wrapping the iterator with `SlowDocIdPropagatorDISI` which keeps the iterator pointing to last docID before `#removeAllDISIsOnCurrentDoc()` is called and updates this docID only when next() or advance() is called.

4. When collection of document will start and `DynamicPruningCollectorWrapper` is used, it will collect all the documents at once by iterating over all the document from the query created in step 3.

5. Dynamic pruning step when collecting a document - when a match is found, all the terms for a given document will be enumerated and collected for cardinality computation. Once done, the subscorer DISI corresponding to each of these terms collector can be safely removed from the `DisjunctionWithDynamicPruningScorer` by calling `removeAllDISIsOnCurrentDoc()`. Once all docs are collector, we can straightaway throw `CollectionTerminatedException` for early termination of query. 

**Note:  to be used only for prototype and reference purpose, not intended to merge to main. It may contain a lot of bugs and definitely doesn't cover all preconditions.** 

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
7. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
8. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #11959
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
