### PR TITLE
test: fix flaky for testMinDocCountOnDateHistogram

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/FilterRewriteIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/FilterRewriteIT.java
@@ -59,19 +59,19 @@ public class FilterRewriteIT extends ParameterizedDynamicSettingsOpenSearchInteg
     @Override
     protected void setupSuiteScopeCluster() throws Exception {
         assertAcked(client().admin().indices().prepareCreate("idx").get());
+        expected.clear();
 
-        final int segmentCount = randomIntBetween(2, 10);
-        final Set<Long> longTerms = new HashSet();
+        final int repeat = randomIntBetween(2, 10);
+        final Set<Long> longTerms = new HashSet<>();
 
-        final Map<String, Integer> dateTerms = new HashMap<>();
-        for (int i = 0; i < segmentCount; i++) {
+        for (int i = 0; i < repeat; i++) {
             final List<IndexRequestBuilder> indexRequests = new ArrayList<>();
 
             long longTerm;
             do {
-                longTerm = randomInt(segmentCount * 2);
+                longTerm = randomInt(repeat * 2);
             } while (!longTerms.add(longTerm));
-            ZonedDateTime time = ZonedDateTime.of(2024, 1, ((int) longTerm % 20) + 1, 0, 0, 0, 0, ZoneOffset.UTC);
+            ZonedDateTime time = ZonedDateTime.of(2024, 1, ((int) longTerm) + 1, 0, 0, 0, 0, ZoneOffset.UTC);
             String dateTerm = DateFormatter.forPattern("yyyy-MM-dd").format(time);
 
             final int frequency = randomBoolean() ? 1 : randomIntBetween(2, 20);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The test is flaky because `time` or `dateTerm` can be same after mod operation `%20` because `longTerm` can be 0 or 20. So line 84, expected is wrong when the value is overriden by the same key.
Only the test has problem, not the date histogram.

### Related Issues
Resolves #12303 

### Check List
- [ ] ~New functionality includes testing.~
  - [x] All tests pass
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [ ] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
