### PR TITLE
Allow security manager in IntelliJ unit tests

### DIFF
--- a/gradle/ide.gradle
+++ b/gradle/ide.gradle
@@ -82,6 +82,9 @@ if (System.getProperty('idea.active') == 'true') {
         runConfigurations {
           defaults(JUnit) {
             vmParameters = '-ea -Djava.locale.providers=SPI,COMPAT'
+            if (BuildParams.runtimeJavaVersion > JavaVersion.VERSION_17) {
+              vmParameters += ' -Djava.security.manager=allow'
+            }
           }
         }
         copyright {


### PR DESCRIPTION
If you configure IntelliJ to use JDK 21 then all unit tests will fail to run in the IDE when attempting to set the security manager in the test bootstrap code. This change configures all tests to include the required VM argument to enable the security manager.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
