### PR TITLE
Avoid string out of bounds error in snapshot delete

### DIFF
--- a/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
@@ -1592,8 +1592,11 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                                 Map<String, BlobMetadata> shardLevelBlobs = shardBlob.getValue().listBlobs();
                                 for (Map.Entry<String, BlobMetadata> shardLevelBlob : shardLevelBlobs.entrySet()) {
                                     String blob = shardLevelBlob.getKey();
-                                    String snapshotUUID = blob.substring(SHALLOW_SNAPSHOT_PREFIX.length(), blob.length() - ".dat".length());
                                     if (blob.startsWith(SHALLOW_SNAPSHOT_PREFIX) && blob.endsWith(".dat")) {
+                                        String snapshotUUID = blob.substring(
+                                            SHALLOW_SNAPSHOT_PREFIX.length(),
+                                            blob.length() - ".dat".length()
+                                        );
                                         RemoteStoreShardShallowCopySnapshot remoteStoreShardShallowCopySnapshot =
                                             REMOTE_STORE_SHARD_SHALLOW_COPY_SNAPSHOT_FORMAT.read(
                                                 shardBlob.getValue(),

--- a/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
@@ -1116,10 +1116,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                                 String indexId = fileToDeletePath[1];
                                 String shardId = fileToDeletePath[2];
                                 String shallowSnapBlob = fileToDeletePath[3];
-                                String snapshotUUID = shallowSnapBlob.substring(
-                                    SHALLOW_SNAPSHOT_PREFIX.length(),
-                                    shallowSnapBlob.length() - ".dat".length()
-                                );
+                                String snapshotUUID = extractShallowSnapshotUUID(shallowSnapBlob).orElseThrow();
                                 BlobContainer shardContainer = blobStore().blobContainer(indicesPath().add(indexId).add(shardId));
                                 RemoteStoreShardShallowCopySnapshot remoteStoreShardShallowCopySnapshot =
                                     REMOTE_STORE_SHARD_SHALLOW_COPY_SNAPSHOT_FORMAT.read(
@@ -1586,47 +1583,43 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 try {
                     logger.debug("[{}] Found stale index [{}]. Cleaning it up", metadata.name(), indexSnId);
                     if (remoteStoreLockManagerFactory != null) {
-                        Map<String, BlobContainer> shardBlobs = indexEntry.getValue().children();
-                        if (!shardBlobs.isEmpty()) {
-                            for (Map.Entry<String, BlobContainer> shardBlob : shardBlobs.entrySet()) {
-                                Map<String, BlobMetadata> shardLevelBlobs = shardBlob.getValue().listBlobs();
-                                for (Map.Entry<String, BlobMetadata> shardLevelBlob : shardLevelBlobs.entrySet()) {
-                                    String blob = shardLevelBlob.getKey();
-                                    if (blob.startsWith(SHALLOW_SNAPSHOT_PREFIX) && blob.endsWith(".dat")) {
-                                        String snapshotUUID = blob.substring(
-                                            SHALLOW_SNAPSHOT_PREFIX.length(),
-                                            blob.length() - ".dat".length()
+                        final Map<String, BlobContainer> shardBlobs = indexEntry.getValue().children();
+                        for (Map.Entry<String, BlobContainer> shardBlob : shardBlobs.entrySet()) {
+                            for (String blob : shardBlob.getValue().listBlobs().keySet()) {
+                                final Optional<String> snapshotUUID = extractShallowSnapshotUUID(blob);
+                                if (snapshotUUID.isPresent()) {
+                                    RemoteStoreShardShallowCopySnapshot remoteStoreShardShallowCopySnapshot =
+                                        REMOTE_STORE_SHARD_SHALLOW_COPY_SNAPSHOT_FORMAT.read(
+                                            shardBlob.getValue(),
+                                            snapshotUUID.get(),
+                                            namedXContentRegistry
                                         );
-                                        RemoteStoreShardShallowCopySnapshot remoteStoreShardShallowCopySnapshot =
-                                            REMOTE_STORE_SHARD_SHALLOW_COPY_SNAPSHOT_FORMAT.read(
-                                                shardBlob.getValue(),
-                                                snapshotUUID,
-                                                namedXContentRegistry
-                                            );
-                                        String indexUUID = remoteStoreShardShallowCopySnapshot.getIndexUUID();
-                                        String remoteStoreRepoForIndex = remoteStoreShardShallowCopySnapshot.getRemoteStoreRepository();
-                                        // Releasing lock files before deleting the shallow-snap-UUID file because in case of any failure
-                                        // while releasing the lock file, we would still have the corresponding shallow-snap-UUID file
-                                        // and that would be used during next delete operation for releasing this stale lock file
-                                        RemoteStoreLockManager remoteStoreMetadataLockManager = remoteStoreLockManagerFactory
-                                            .newLockManager(remoteStoreRepoForIndex, indexUUID, shardBlob.getKey());
-                                        remoteStoreMetadataLockManager.release(
-                                            FileLockInfo.getLockInfoBuilder().withAcquirerId(snapshotUUID).build()
-                                        );
-                                        if (!isIndexPresent(clusterService, indexUUID)) {
-                                            // this is a temporary solution where snapshot deletion triggers remote store side
-                                            // cleanup if index is already deleted. We will add a poller in future to take
-                                            // care of remote store side cleanup.
-                                            // see https://github.com/opensearch-project/OpenSearch/issues/8469
-                                            new RemoteSegmentStoreDirectoryFactory(
-                                                remoteStoreLockManagerFactory.getRepositoriesService(),
-                                                threadPool
-                                            ).newDirectory(
-                                                remoteStoreRepoForIndex,
-                                                indexUUID,
-                                                new ShardId(Index.UNKNOWN_INDEX_NAME, indexUUID, Integer.valueOf(shardBlob.getKey()))
-                                            ).close();
-                                        }
+                                    String indexUUID = remoteStoreShardShallowCopySnapshot.getIndexUUID();
+                                    String remoteStoreRepoForIndex = remoteStoreShardShallowCopySnapshot.getRemoteStoreRepository();
+                                    // Releasing lock files before deleting the shallow-snap-UUID file because in case of any failure
+                                    // while releasing the lock file, we would still have the corresponding shallow-snap-UUID file
+                                    // and that would be used during next delete operation for releasing this stale lock file
+                                    RemoteStoreLockManager remoteStoreMetadataLockManager = remoteStoreLockManagerFactory.newLockManager(
+                                        remoteStoreRepoForIndex,
+                                        indexUUID,
+                                        shardBlob.getKey()
+                                    );
+                                    remoteStoreMetadataLockManager.release(
+                                        FileLockInfo.getLockInfoBuilder().withAcquirerId(snapshotUUID.get()).build()
+                                    );
+                                    if (!isIndexPresent(clusterService, indexUUID)) {
+                                        // this is a temporary solution where snapshot deletion triggers remote store side
+                                        // cleanup if index is already deleted. We will add a poller in future to take
+                                        // care of remote store side cleanup.
+                                        // see https://github.com/opensearch-project/OpenSearch/issues/8469
+                                        new RemoteSegmentStoreDirectoryFactory(
+                                            remoteStoreLockManagerFactory.getRepositoriesService(),
+                                            threadPool
+                                        ).newDirectory(
+                                            remoteStoreRepoForIndex,
+                                            indexUUID,
+                                            new ShardId(Index.UNKNOWN_INDEX_NAME, indexUUID, Integer.parseInt(shardBlob.getKey()))
+                                        ).close();
                                     }
                                 }
                             }
@@ -3365,12 +3358,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                             blob.substring(SNAPSHOT_PREFIX.length(), blob.length() - ".dat".length())
                         ) == false)
                     || (remoteStoreLockManagerFactory != null
-                        ? (blob.startsWith(SHALLOW_SNAPSHOT_PREFIX)
-                            && blob.endsWith(".dat")
-                            && survivingSnapshotUUIDs.contains(
-                                blob.substring(SHALLOW_SNAPSHOT_PREFIX.length(), blob.length() - ".dat".length())
-                            ) == false)
-                        : false)
+                        && extractShallowSnapshotUUID(blob).map(survivingSnapshotUUIDs::contains).orElse(false))
                     || (blob.startsWith(UPLOADED_DATA_BLOB_PREFIX) && updatedSnapshots.findNameFile(canonicalName(blob)) == null)
                     || FsBlobContainer.isTempBlobName(blob)
             )
@@ -3510,6 +3498,13 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 logger.warn("store cannot be marked as corrupted", inner);
             }
         }
+    }
+
+    private static Optional<String> extractShallowSnapshotUUID(String blobName) {
+        if (blobName.startsWith(SHALLOW_SNAPSHOT_PREFIX)) {
+            return Optional.of(blobName.substring(SHALLOW_SNAPSHOT_PREFIX.length(), blobName.length() - ".dat".length()));
+        }
+        return Optional.empty();
     }
 
     /**


### PR DESCRIPTION
Test failure #8771 shows cases where certain random seeds trigger this case. The bug is clear: the substring() call should happen after the startsWith() check in case the blob name is shorter than the prefix length being used as the start index of the substring call. I don't yet know if/how this manifests in real deployments.

This bug is deterministically reproducible with the following seed, which also verifies the fix:

```
./gradlew ':server:test' --tests "org.opensearch.snapshots.SnapshotResiliencyTests.testConcurrentSnapshotDeleteAndDeleteIndex" -Dtests.seed=E816C7242330BF50
```

### Related Issues
Resolves #8771

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
