### PR TITLE
Add a new write_only_allow_delete indexing block

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/tasks/PendingTasksBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/tasks/PendingTasksBlocksIT.java
@@ -44,6 +44,7 @@ import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_READ;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_WRITE;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_WRITE_ONLY_ALLOW_DELETE;
 
 public class PendingTasksBlocksIT extends OpenSearchIntegTestCase {
 
@@ -57,7 +58,8 @@ public class PendingTasksBlocksIT extends OpenSearchIntegTestCase {
             SETTING_BLOCKS_WRITE,
             SETTING_READ_ONLY,
             SETTING_BLOCKS_METADATA,
-            SETTING_READ_ONLY_ALLOW_DELETE
+            SETTING_READ_ONLY_ALLOW_DELETE,
+            SETTING_WRITE_ONLY_ALLOW_DELETE
         )) {
             try {
                 enableIndexBlock("test", blockSetting);

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/cache/clear/ClearIndicesCacheBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/cache/clear/ClearIndicesCacheBlocksIT.java
@@ -43,6 +43,7 @@ import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_READ;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_WRITE;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_WRITE_ONLY_ALLOW_DELETE;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertBlocked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.equalTo;
@@ -60,7 +61,8 @@ public class ClearIndicesCacheBlocksIT extends OpenSearchIntegTestCase {
             SETTING_BLOCKS_READ,
             SETTING_BLOCKS_WRITE,
             SETTING_READ_ONLY,
-            SETTING_READ_ONLY_ALLOW_DELETE
+            SETTING_READ_ONLY_ALLOW_DELETE,
+            SETTING_WRITE_ONLY_ALLOW_DELETE
         )) {
             try {
                 enableIndexBlock("test", blockSetting);
@@ -102,7 +104,8 @@ public class ClearIndicesCacheBlocksIT extends OpenSearchIntegTestCase {
             SETTING_BLOCKS_READ,
             SETTING_BLOCKS_WRITE,
             SETTING_READ_ONLY,
-            SETTING_READ_ONLY_ALLOW_DELETE
+            SETTING_READ_ONLY_ALLOW_DELETE,
+            SETTING_WRITE_ONLY_ALLOW_DELETE
         )) {
             try {
                 enableIndexBlock("test", blockSetting);

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/delete/DeleteIndexBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/delete/DeleteIndexBlocksIT.java
@@ -57,7 +57,10 @@ public class DeleteIndexBlocksIT extends OpenSearchIntegTestCase {
     }
 
     public void testDeleteIndexOnIndexReadOnlyAllowDeleteSetting() {
-        assertDeleteIndexOnAllowDeleteSetting(IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE, IndexMetadata.INDEX_READ_ONLY_ALLOW_DELETE_BLOCK);
+        assertDeleteIndexOnAllowDeleteSetting(
+            IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE,
+            IndexMetadata.INDEX_READ_ONLY_ALLOW_DELETE_BLOCK
+        );
     }
 
     public void testClusterBlockMessageHasIndexName() {
@@ -112,10 +115,13 @@ public class DeleteIndexBlocksIT extends OpenSearchIntegTestCase {
     }
 
     public void testDeleteIndexOnIndexWriteOnlyAllowDeleteSetting() {
-        assertDeleteIndexOnAllowDeleteSetting(IndexMetadata.SETTING_WRITE_ONLY_ALLOW_DELETE, IndexMetadata.INDEX_WRITE_ONLY_ALLOW_DELETE_BLOCK);
+        assertDeleteIndexOnAllowDeleteSetting(
+            IndexMetadata.SETTING_WRITE_ONLY_ALLOW_DELETE,
+            IndexMetadata.INDEX_WRITE_ONLY_ALLOW_DELETE_BLOCK
+        );
     }
 
-    private void  assertDeleteIndexOnAllowDeleteSetting(String settingName, ClusterBlock blockToAssert){
+    private void assertDeleteIndexOnAllowDeleteSetting(String settingName, ClusterBlock blockToAssert) {
         createIndex("test");
         ensureGreen("test");
         client().prepareIndex().setIndex("test").setId("1").setSource("foo", "bar").get();
@@ -124,10 +130,7 @@ public class DeleteIndexBlocksIT extends OpenSearchIntegTestCase {
             Settings settings = Settings.builder().put(settingName, true).build();
             assertAcked(client().admin().indices().prepareUpdateSettings("test").setSettings(settings).get());
             assertSearchHits(client().prepareSearch().get(), "1");
-            assertBlocked(
-                client().prepareIndex().setIndex("test").setId("2").setSource("foo", "bar"),
-                blockToAssert
-            );
+            assertBlocked(client().prepareIndex().setIndex("test").setId("2").setSource("foo", "bar"), blockToAssert);
             assertBlocked(
                 client().admin().indices().prepareUpdateSettings("test").setSettings(Settings.builder().put("index.number_of_replicas", 2)),
                 blockToAssert

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/delete/DeleteIndexBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/delete/DeleteIndexBlocksIT.java
@@ -33,6 +33,7 @@
 package org.opensearch.action.admin.indices.delete;
 
 import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.cluster.block.ClusterBlock;
 import org.opensearch.cluster.block.ClusterBlockException;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.Metadata;
@@ -56,35 +57,7 @@ public class DeleteIndexBlocksIT extends OpenSearchIntegTestCase {
     }
 
     public void testDeleteIndexOnIndexReadOnlyAllowDeleteSetting() {
-        createIndex("test");
-        ensureGreen("test");
-        client().prepareIndex().setIndex("test").setId("1").setSource("foo", "bar").get();
-        refresh();
-        try {
-            Settings settings = Settings.builder().put(IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE, true).build();
-            assertAcked(client().admin().indices().prepareUpdateSettings("test").setSettings(settings).get());
-            assertSearchHits(client().prepareSearch().get(), "1");
-            assertBlocked(
-                client().prepareIndex().setIndex("test").setId("2").setSource("foo", "bar"),
-                IndexMetadata.INDEX_READ_ONLY_ALLOW_DELETE_BLOCK
-            );
-            assertBlocked(
-                client().admin().indices().prepareUpdateSettings("test").setSettings(Settings.builder().put("index.number_of_replicas", 2)),
-                IndexMetadata.INDEX_READ_ONLY_ALLOW_DELETE_BLOCK
-            );
-            assertSearchHits(client().prepareSearch().get(), "1");
-            assertAcked(client().admin().indices().prepareDelete("test"));
-        } finally {
-            Settings settings = Settings.builder().putNull(IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE).build();
-            assertAcked(
-                client().admin()
-                    .indices()
-                    .prepareUpdateSettings("test")
-                    .setIndicesOptions(IndicesOptions.lenientExpandOpen())
-                    .setSettings(settings)
-                    .get()
-            );
-        }
+        assertDeleteIndexOnAllowDeleteSetting(IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE, IndexMetadata.INDEX_READ_ONLY_ALLOW_DELETE_BLOCK);
     }
 
     public void testClusterBlockMessageHasIndexName() {
@@ -135,6 +108,42 @@ public class DeleteIndexBlocksIT extends OpenSearchIntegTestCase {
         } finally {
             Settings settings = Settings.builder().putNull(Metadata.SETTING_READ_ONLY_ALLOW_DELETE_SETTING.getKey()).build();
             assertAcked(client().admin().cluster().prepareUpdateSettings().setTransientSettings(settings).get());
+        }
+    }
+
+    public void testDeleteIndexOnIndexWriteOnlyAllowDeleteSetting() {
+        assertDeleteIndexOnAllowDeleteSetting(IndexMetadata.SETTING_WRITE_ONLY_ALLOW_DELETE, IndexMetadata.INDEX_WRITE_ONLY_ALLOW_DELETE_BLOCK);
+    }
+
+    private void  assertDeleteIndexOnAllowDeleteSetting(String settingName, ClusterBlock blockToAssert){
+        createIndex("test");
+        ensureGreen("test");
+        client().prepareIndex().setIndex("test").setId("1").setSource("foo", "bar").get();
+        refresh();
+        try {
+            Settings settings = Settings.builder().put(settingName, true).build();
+            assertAcked(client().admin().indices().prepareUpdateSettings("test").setSettings(settings).get());
+            assertSearchHits(client().prepareSearch().get(), "1");
+            assertBlocked(
+                client().prepareIndex().setIndex("test").setId("2").setSource("foo", "bar"),
+                blockToAssert
+            );
+            assertBlocked(
+                client().admin().indices().prepareUpdateSettings("test").setSettings(Settings.builder().put("index.number_of_replicas", 2)),
+                blockToAssert
+            );
+            assertSearchHits(client().prepareSearch().get(), "1");
+            assertAcked(client().admin().indices().prepareDelete("test"));
+        } finally {
+            Settings settings = Settings.builder().putNull(settingName).build();
+            assertAcked(
+                client().admin()
+                    .indices()
+                    .prepareUpdateSettings("test")
+                    .setIndicesOptions(IndicesOptions.lenientExpandOpen())
+                    .setSettings(settings)
+                    .get()
+            );
         }
     }
 }

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/flush/FlushBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/flush/FlushBlocksIT.java
@@ -42,6 +42,7 @@ import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_READ;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_WRITE;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_WRITE_ONLY_ALLOW_DELETE;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -64,7 +65,8 @@ public class FlushBlocksIT extends OpenSearchIntegTestCase {
             SETTING_BLOCKS_WRITE,
             SETTING_READ_ONLY,
             SETTING_BLOCKS_METADATA,
-            SETTING_READ_ONLY_ALLOW_DELETE
+            SETTING_READ_ONLY_ALLOW_DELETE,
+            SETTING_WRITE_ONLY_ALLOW_DELETE
         )) {
             try {
                 enableIndexBlock("test", blockSetting);

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/forcemerge/ForceMergeBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/forcemerge/ForceMergeBlocksIT.java
@@ -42,6 +42,7 @@ import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_READ;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_WRITE;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_WRITE_ONLY_ALLOW_DELETE;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertBlocked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.equalTo;
@@ -73,7 +74,7 @@ public class ForceMergeBlocksIT extends OpenSearchIntegTestCase {
         }
 
         // Request is blocked
-        for (String blockSetting : Arrays.asList(SETTING_READ_ONLY, SETTING_BLOCKS_METADATA, SETTING_READ_ONLY_ALLOW_DELETE)) {
+        for (String blockSetting : Arrays.asList(SETTING_READ_ONLY, SETTING_BLOCKS_METADATA, SETTING_READ_ONLY_ALLOW_DELETE, SETTING_WRITE_ONLY_ALLOW_DELETE)) {
             try {
                 enableIndexBlock("test", blockSetting);
                 assertBlocked(client().admin().indices().prepareForceMerge("test"));

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/forcemerge/ForceMergeBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/forcemerge/ForceMergeBlocksIT.java
@@ -74,7 +74,12 @@ public class ForceMergeBlocksIT extends OpenSearchIntegTestCase {
         }
 
         // Request is blocked
-        for (String blockSetting : Arrays.asList(SETTING_READ_ONLY, SETTING_BLOCKS_METADATA, SETTING_READ_ONLY_ALLOW_DELETE, SETTING_WRITE_ONLY_ALLOW_DELETE)) {
+        for (String blockSetting : Arrays.asList(
+            SETTING_READ_ONLY,
+            SETTING_BLOCKS_METADATA,
+            SETTING_READ_ONLY_ALLOW_DELETE,
+            SETTING_WRITE_ONLY_ALLOW_DELETE
+        )) {
             try {
                 enableIndexBlock("test", blockSetting);
                 assertBlocked(client().admin().indices().prepareForceMerge("test"));

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/get/GetIndexIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/get/GetIndexIT.java
@@ -214,7 +214,13 @@ public class GetIndexIT extends OpenSearchIntegTestCase {
     }
 
     public void testGetIndexWithBlocks() {
-        for (String block : Arrays.asList(SETTING_BLOCKS_READ, SETTING_BLOCKS_WRITE, SETTING_READ_ONLY, SETTING_READ_ONLY_ALLOW_DELETE, SETTING_WRITE_ONLY_ALLOW_DELETE)) {
+        for (String block : Arrays.asList(
+            SETTING_BLOCKS_READ,
+            SETTING_BLOCKS_WRITE,
+            SETTING_READ_ONLY,
+            SETTING_READ_ONLY_ALLOW_DELETE,
+            SETTING_WRITE_ONLY_ALLOW_DELETE
+        )) {
             try {
                 enableIndexBlock("idx", block);
                 GetIndexResponse response = client().admin()

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/get/GetIndexIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/get/GetIndexIT.java
@@ -52,6 +52,7 @@ import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_READ;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_WRITE;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_WRITE_ONLY_ALLOW_DELETE;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertBlocked;
 import static org.hamcrest.Matchers.equalTo;
@@ -213,7 +214,7 @@ public class GetIndexIT extends OpenSearchIntegTestCase {
     }
 
     public void testGetIndexWithBlocks() {
-        for (String block : Arrays.asList(SETTING_BLOCKS_READ, SETTING_BLOCKS_WRITE, SETTING_READ_ONLY, SETTING_READ_ONLY_ALLOW_DELETE)) {
+        for (String block : Arrays.asList(SETTING_BLOCKS_READ, SETTING_BLOCKS_WRITE, SETTING_READ_ONLY, SETTING_READ_ONLY_ALLOW_DELETE, SETTING_WRITE_ONLY_ALLOW_DELETE)) {
             try {
                 enableIndexBlock("idx", block);
                 GetIndexResponse response = client().admin()

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/refresh/RefreshBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/refresh/RefreshBlocksIT.java
@@ -42,6 +42,7 @@ import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_READ;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_WRITE;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_WRITE_ONLY_ALLOW_DELETE;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -59,7 +60,8 @@ public class RefreshBlocksIT extends OpenSearchIntegTestCase {
             SETTING_BLOCKS_WRITE,
             SETTING_READ_ONLY,
             SETTING_BLOCKS_METADATA,
-            SETTING_READ_ONLY_ALLOW_DELETE
+            SETTING_READ_ONLY_ALLOW_DELETE,
+            SETTING_WRITE_ONLY_ALLOW_DELETE
         )) {
             try {
                 enableIndexBlock("test", blockSetting);

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/segments/IndicesSegmentsBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/segments/IndicesSegmentsBlocksIT.java
@@ -42,6 +42,7 @@ import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_READ;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_WRITE;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_WRITE_ONLY_ALLOW_DELETE;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertBlocked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertNoFailures;
 
@@ -62,7 +63,8 @@ public class IndicesSegmentsBlocksIT extends OpenSearchIntegTestCase {
             SETTING_BLOCKS_READ,
             SETTING_BLOCKS_WRITE,
             SETTING_READ_ONLY,
-            SETTING_READ_ONLY_ALLOW_DELETE
+            SETTING_READ_ONLY_ALLOW_DELETE,
+            SETTING_WRITE_ONLY_ALLOW_DELETE
         )) {
             try {
                 enableIndexBlock("test-blocks", blockSetting);

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/stats/IndicesStatsBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/stats/IndicesStatsBlocksIT.java
@@ -43,6 +43,7 @@ import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_READ;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_WRITE;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_WRITE_ONLY_ALLOW_DELETE;
 
 @ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST)
 public class IndicesStatsBlocksIT extends OpenSearchIntegTestCase {
@@ -56,7 +57,8 @@ public class IndicesStatsBlocksIT extends OpenSearchIntegTestCase {
             SETTING_BLOCKS_READ,
             SETTING_BLOCKS_WRITE,
             SETTING_READ_ONLY,
-            SETTING_READ_ONLY_ALLOW_DELETE
+            SETTING_READ_ONLY_ALLOW_DELETE,
+            SETTING_WRITE_ONLY_ALLOW_DELETE
         )) {
             try {
                 enableIndexBlock("ro", blockSetting);

--- a/server/src/internalClusterTest/java/org/opensearch/blocks/SimpleBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/blocks/SimpleBlocksIT.java
@@ -68,6 +68,7 @@ import static java.util.stream.Collectors.toList;
 import static org.opensearch.action.support.IndicesOptions.lenientExpandOpen;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_WRITE;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_WRITE_ONLY_ALLOW_DELETE;
 import static org.opensearch.search.internal.SearchContext.TRACK_TOTAL_HITS_ACCURATE;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertBlocked;
@@ -201,6 +202,16 @@ public class SimpleBlocksIT extends OpenSearchIntegTestCase {
         assertThat(settingsResponse, notNullValue());
     }
 
+    private void setIndexWriteOnlyDeleteAllow(String index, Object value) {
+        HashMap<String, Object> newSettings = new HashMap<>();
+        newSettings.put(SETTING_WRITE_ONLY_ALLOW_DELETE, value);
+
+        UpdateSettingsRequestBuilder settingsRequest = client().admin().indices().prepareUpdateSettings(index);
+        settingsRequest.setSettings(newSettings);
+        AcknowledgedResponse settingsResponse = settingsRequest.execute().actionGet();
+        assertThat(settingsResponse, notNullValue());
+    }
+
     public void testAddBlocksWhileExistingBlocks() {
         createIndex("test");
         ensureGreen("test");
@@ -223,7 +234,7 @@ public class SimpleBlocksIT extends OpenSearchIntegTestCase {
                 }
             }
 
-            for (APIBlock block : Arrays.asList(APIBlock.READ_ONLY, APIBlock.METADATA, APIBlock.READ_ONLY_ALLOW_DELETE)) {
+            for (APIBlock block : Arrays.asList(APIBlock.READ_ONLY, APIBlock.METADATA, APIBlock.READ_ONLY_ALLOW_DELETE, APIBlock.WRITE_ONLY_ALLOW_DELETE)) {
                 boolean success = false;
                 try {
                     enableIndexBlock("test", block.settingName());
@@ -540,6 +551,33 @@ public class SimpleBlocksIT extends OpenSearchIntegTestCase {
                 }
             }
         }
+    }
+
+    public void testVerifyIndexWriteOnlyAllowDelete() {
+        // newly created an index has no plocks
+        canCreateIndex("test1");
+        canIndexDocument("test1");
+        canIndexExists("test1");
+
+        // adds index write-only-allow-delete block
+        setIndexWriteOnlyDeleteAllow("test1", "true");
+        assertIndexHasBlock(APIBlock.WRITE_ONLY_ALLOW_DELETE, "test1");
+        canNotIndexDocument("test1");
+        canIndexExists("test1");
+
+        // other indices not blocked
+        canCreateIndex("test2");
+        canIndexDocument("test2");
+        canIndexExists("test2");
+
+        // assert index can be deleted
+        assertAcked(client().admin().indices().prepareDelete("test1"));
+
+        // assert block can be removed
+        setIndexWriteOnlyDeleteAllow("test2", "true");
+        assertIndexHasBlock(APIBlock.WRITE_ONLY_ALLOW_DELETE, "test2");
+        setIndexWriteOnlyDeleteAllow("test2", "false");
+        canIndexDocument("test2");
     }
 
     static void assertIndexHasBlock(APIBlock block, final String... indices) {

--- a/server/src/internalClusterTest/java/org/opensearch/blocks/SimpleBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/blocks/SimpleBlocksIT.java
@@ -234,7 +234,12 @@ public class SimpleBlocksIT extends OpenSearchIntegTestCase {
                 }
             }
 
-            for (APIBlock block : Arrays.asList(APIBlock.READ_ONLY, APIBlock.METADATA, APIBlock.READ_ONLY_ALLOW_DELETE, APIBlock.WRITE_ONLY_ALLOW_DELETE)) {
+            for (APIBlock block : Arrays.asList(
+                APIBlock.READ_ONLY,
+                APIBlock.METADATA,
+                APIBlock.READ_ONLY_ALLOW_DELETE,
+                APIBlock.WRITE_ONLY_ALLOW_DELETE
+            )) {
                 boolean success = false;
                 try {
                     enableIndexBlock("test", block.settingName());

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/allocation/ClusterRerouteIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/allocation/ClusterRerouteIT.java
@@ -80,6 +80,7 @@ import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_READ;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_WRITE;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_WRITE_ONLY_ALLOW_DELETE;
 import static org.opensearch.cluster.routing.allocation.decider.EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE_SETTING;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertBlocked;
@@ -557,7 +558,8 @@ public class ClusterRerouteIT extends OpenSearchIntegTestCase {
             SETTING_BLOCKS_WRITE,
             SETTING_READ_ONLY,
             SETTING_BLOCKS_METADATA,
-            SETTING_READ_ONLY_ALLOW_DELETE
+            SETTING_READ_ONLY_ALLOW_DELETE,
+            SETTING_WRITE_ONLY_ALLOW_DELETE
         )) {
             try {
                 enableIndexBlock("test-blocks", blockSetting);

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/shards/ClusterSearchShardsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/shards/ClusterSearchShardsIT.java
@@ -47,6 +47,7 @@ import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_READ;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_WRITE;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_WRITE_ONLY_ALLOW_DELETE;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertBlocked;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -182,7 +183,8 @@ public class ClusterSearchShardsIT extends OpenSearchIntegTestCase {
             SETTING_BLOCKS_READ,
             SETTING_BLOCKS_WRITE,
             SETTING_READ_ONLY,
-            SETTING_READ_ONLY_ALLOW_DELETE
+            SETTING_READ_ONLY_ALLOW_DELETE,
+            SETTING_WRITE_ONLY_ALLOW_DELETE
         )) {
             try {
                 enableIndexBlock("test-blocks", blockSetting);

--- a/server/src/internalClusterTest/java/org/opensearch/indices/exists/indices/IndicesExistsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/exists/indices/IndicesExistsIT.java
@@ -44,6 +44,7 @@ import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_READ;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_WRITE;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_WRITE_ONLY_ALLOW_DELETE;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -88,7 +89,8 @@ public class IndicesExistsIT extends OpenSearchIntegTestCase {
             SETTING_BLOCKS_READ,
             SETTING_BLOCKS_WRITE,
             SETTING_READ_ONLY,
-            SETTING_READ_ONLY_ALLOW_DELETE
+            SETTING_READ_ONLY_ALLOW_DELETE,
+            SETTING_WRITE_ONLY_ALLOW_DELETE
         )) {
             try {
                 enableIndexBlock("ro", blockSetting);

--- a/server/src/internalClusterTest/java/org/opensearch/indices/settings/GetSettingsBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/settings/GetSettingsBlocksIT.java
@@ -44,6 +44,7 @@ import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_READ;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_WRITE;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_WRITE_ONLY_ALLOW_DELETE;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertBlocked;
 import static org.hamcrest.Matchers.equalTo;
@@ -60,7 +61,7 @@ public class GetSettingsBlocksIT extends OpenSearchIntegTestCase {
             )
         );
 
-        for (String block : Arrays.asList(SETTING_BLOCKS_READ, SETTING_BLOCKS_WRITE, SETTING_READ_ONLY, SETTING_READ_ONLY_ALLOW_DELETE)) {
+        for (String block : Arrays.asList(SETTING_BLOCKS_READ, SETTING_BLOCKS_WRITE, SETTING_READ_ONLY, SETTING_READ_ONLY_ALLOW_DELETE, SETTING_WRITE_ONLY_ALLOW_DELETE)) {
             try {
                 enableIndexBlock("test", block);
                 GetSettingsResponse response = client().admin().indices().prepareGetSettings("test").get();

--- a/server/src/internalClusterTest/java/org/opensearch/indices/settings/GetSettingsBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/settings/GetSettingsBlocksIT.java
@@ -61,7 +61,13 @@ public class GetSettingsBlocksIT extends OpenSearchIntegTestCase {
             )
         );
 
-        for (String block : Arrays.asList(SETTING_BLOCKS_READ, SETTING_BLOCKS_WRITE, SETTING_READ_ONLY, SETTING_READ_ONLY_ALLOW_DELETE, SETTING_WRITE_ONLY_ALLOW_DELETE)) {
+        for (String block : Arrays.asList(
+            SETTING_BLOCKS_READ,
+            SETTING_BLOCKS_WRITE,
+            SETTING_READ_ONLY,
+            SETTING_READ_ONLY_ALLOW_DELETE,
+            SETTING_WRITE_ONLY_ALLOW_DELETE
+        )) {
             try {
                 enableIndexBlock("test", block);
                 GetSettingsResponse response = client().admin().indices().prepareGetSettings("test").get();

--- a/server/src/internalClusterTest/java/org/opensearch/indices/state/OpenCloseIndexIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/state/OpenCloseIndexIT.java
@@ -376,7 +376,12 @@ public class OpenCloseIndexIT extends OpenSearchIntegTestCase {
         assertIndexIsClosed("test");
 
         // Opening an index is blocked
-        for (String blockSetting : Arrays.asList(SETTING_READ_ONLY, SETTING_READ_ONLY_ALLOW_DELETE, SETTING_BLOCKS_METADATA, SETTING_WRITE_ONLY_ALLOW_DELETE)) {
+        for (String blockSetting : Arrays.asList(
+            SETTING_READ_ONLY,
+            SETTING_READ_ONLY_ALLOW_DELETE,
+            SETTING_BLOCKS_METADATA,
+            SETTING_WRITE_ONLY_ALLOW_DELETE
+        )) {
             try {
                 enableIndexBlock("test", blockSetting);
                 assertBlocked(client().admin().indices().prepareOpen("test"));

--- a/server/src/internalClusterTest/java/org/opensearch/indices/state/OpenCloseIndexIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/state/OpenCloseIndexIT.java
@@ -60,6 +60,7 @@ import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_READ;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_WRITE;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_WRITE_ONLY_ALLOW_DELETE;
 import static org.opensearch.indices.state.CloseIndexIT.assertIndexIsClosed;
 import static org.opensearch.indices.state.CloseIndexIT.assertIndexIsOpened;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
@@ -375,7 +376,7 @@ public class OpenCloseIndexIT extends OpenSearchIntegTestCase {
         assertIndexIsClosed("test");
 
         // Opening an index is blocked
-        for (String blockSetting : Arrays.asList(SETTING_READ_ONLY, SETTING_READ_ONLY_ALLOW_DELETE, SETTING_BLOCKS_METADATA)) {
+        for (String blockSetting : Arrays.asList(SETTING_READ_ONLY, SETTING_READ_ONLY_ALLOW_DELETE, SETTING_BLOCKS_METADATA, SETTING_WRITE_ONLY_ALLOW_DELETE)) {
             try {
                 enableIndexBlock("test", blockSetting);
                 assertBlocked(client().admin().indices().prepareOpen("test"));

--- a/server/src/main/java/org/opensearch/action/admin/indices/settings/put/TransportUpdateSettingsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/settings/put/TransportUpdateSettingsAction.java
@@ -123,7 +123,8 @@ public class TransportUpdateSettingsAction extends TransportClusterManagerNodeAc
         if (request.settings().size() == 1 &&  // we have to allow resetting these settings otherwise users can't unblock an index
             IndexMetadata.INDEX_BLOCKS_METADATA_SETTING.exists(request.settings())
             || IndexMetadata.INDEX_READ_ONLY_SETTING.exists(request.settings())
-            || IndexMetadata.INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING.exists(request.settings())) {
+            || IndexMetadata.INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING.exists(request.settings())
+            || IndexMetadata.INDEX_BLOCKS_WRITE_ONLY_ALLOW_DELETE_SETTING.exists(request.settings())) {
             return null;
         }
 

--- a/server/src/main/java/org/opensearch/cluster/block/ClusterBlocks.java
+++ b/server/src/main/java/org/opensearch/cluster/block/ClusterBlocks.java
@@ -402,6 +402,9 @@ public class ClusterBlocks extends AbstractDiffable<ClusterBlocks> {
             if (IndexModule.Type.REMOTE_SNAPSHOT.match(indexMetadata.getSettings().get(IndexModule.INDEX_STORE_TYPE_SETTING.getKey()))) {
                 addIndexBlock(indexName, IndexMetadata.REMOTE_READ_ONLY_ALLOW_DELETE);
             }
+            if(IndexMetadata.INDEX_BLOCKS_WRITE_ONLY_ALLOW_DELETE_SETTING.get(indexMetadata.getSettings())) {
+                addIndexBlock(indexName, IndexMetadata.INDEX_WRITE_ONLY_ALLOW_DELETE_BLOCK);
+            }
             return this;
         }
 

--- a/server/src/main/java/org/opensearch/cluster/block/ClusterBlocks.java
+++ b/server/src/main/java/org/opensearch/cluster/block/ClusterBlocks.java
@@ -402,7 +402,7 @@ public class ClusterBlocks extends AbstractDiffable<ClusterBlocks> {
             if (IndexModule.Type.REMOTE_SNAPSHOT.match(indexMetadata.getSettings().get(IndexModule.INDEX_STORE_TYPE_SETTING.getKey()))) {
                 addIndexBlock(indexName, IndexMetadata.REMOTE_READ_ONLY_ALLOW_DELETE);
             }
-            if(IndexMetadata.INDEX_BLOCKS_WRITE_ONLY_ALLOW_DELETE_SETTING.get(indexMetadata.getSettings())) {
+            if (IndexMetadata.INDEX_BLOCKS_WRITE_ONLY_ALLOW_DELETE_SETTING.get(indexMetadata.getSettings())) {
                 addIndexBlock(indexName, IndexMetadata.INDEX_WRITE_ONLY_ALLOW_DELETE_BLOCK);
             }
             return this;

--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
@@ -541,6 +541,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
     public static final String SETTING_READ_ONLY_ALLOW_DELETE = APIBlock.READ_ONLY_ALLOW_DELETE.settingName();
     public static final Setting<Boolean> INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING = APIBlock.READ_ONLY_ALLOW_DELETE.setting();
     public static final Setting<Boolean> INDEX_BLOCKS_WRITE_ONLY_ALLOW_DELETE_SETTING = APIBlock.WRITE_ONLY_ALLOW_DELETE.setting();
+    public static final String SETTING_WRITE_ONLY_ALLOW_DELETE = APIBlock.WRITE_ONLY_ALLOW_DELETE.settingName();
 
     public static final String SETTING_VERSION_CREATED = "index.version.created";
 

--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
@@ -158,6 +158,16 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         EnumSet.of(ClusterBlockLevel.METADATA_WRITE, ClusterBlockLevel.WRITE)
     );
 
+    public static final ClusterBlock INDEX_WRITE_ONLY_ALLOW_DELETE_BLOCK = new ClusterBlock(
+        14,
+        "Index cannot be written. Only reads and deletes allowed",
+        false,
+        false,
+        true,
+        RestStatus.FORBIDDEN,
+        EnumSet.of(ClusterBlockLevel.METADATA_WRITE, ClusterBlockLevel.WRITE)
+    );
+
     /**
      * The state of the index.
      *
@@ -461,7 +471,8 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         READ("read", INDEX_READ_BLOCK),
         WRITE("write", INDEX_WRITE_BLOCK),
         METADATA("metadata", INDEX_METADATA_BLOCK),
-        READ_ONLY_ALLOW_DELETE("read_only_allow_delete", INDEX_READ_ONLY_ALLOW_DELETE_BLOCK);
+        READ_ONLY_ALLOW_DELETE("read_only_allow_delete", INDEX_READ_ONLY_ALLOW_DELETE_BLOCK),
+        WRITE_ONLY_ALLOW_DELETE("write_only_allow_delete", INDEX_WRITE_ONLY_ALLOW_DELETE_BLOCK);
 
         final String name;
         final String settingName;
@@ -529,6 +540,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
 
     public static final String SETTING_READ_ONLY_ALLOW_DELETE = APIBlock.READ_ONLY_ALLOW_DELETE.settingName();
     public static final Setting<Boolean> INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING = APIBlock.READ_ONLY_ALLOW_DELETE.setting();
+    public static final Setting<Boolean> INDEX_BLOCKS_WRITE_ONLY_ALLOW_DELETE_SETTING = APIBlock.WRITE_ONLY_ALLOW_DELETE.setting();
 
     public static final String SETTING_VERSION_CREATED = "index.version.created";
 

--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -102,6 +102,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 IndexMetadata.INDEX_BLOCKS_WRITE_SETTING,
                 IndexMetadata.INDEX_BLOCKS_METADATA_SETTING,
                 IndexMetadata.INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING,
+                IndexMetadata.INDEX_BLOCKS_WRITE_ONLY_ALLOW_DELETE_SETTING,
                 IndexMetadata.INDEX_PRIORITY_SETTING,
                 IndexMetadata.INDEX_DATA_PATH_SETTING,
                 IndexMetadata.INDEX_FORMAT_SETTING,


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Added a new `write_only_allow_delete` block for indices. 
This was proposed here: https://github.com/opensearch-project/OpenSearch/issues/12362

[Describe what this change achieves]
This will allow user to manually add block that has similar permissions as `read_only_allow_delete` block, since `read_only_allow_delete` is used only for internal purposes

```
 curl -X PUT "localhost:9200/test-2/_block/read_only_allow_delete?pretty"

{
  "error" : {
    "root_cause" : [
      {
        "type" : "action_request_validation_exception",
        "reason" : "Validation Failed: 1: read_only_allow_delete block is for internal use only;"
      }
    ],
    "type" : "action_request_validation_exception",
    "reason" : "Validation Failed: 1: read_only_allow_delete block is for internal use only;"
  },
  "status" : 400
}
```

### Related Issues
Resolves :  https://github.com/opensearch-project/OpenSearch/issues/12362
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
