### PR TITLE
Mute RemoteIndexPrimaryRelocationIT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -516,7 +516,6 @@ subprojects {
         includeClasses.add("org.opensearch.remotestore.CreateRemoteIndexClusterDefaultDocRep")
         includeClasses.add("org.opensearch.remotestore.CreateRemoteIndexIT")
         includeClasses.add("org.opensearch.remotestore.CreateRemoteIndexTranslogDisabledIT")
-        includeClasses.add("org.opensearch.remotestore.RemoteIndexPrimaryRelocationIT")
         includeClasses.add("org.opensearch.remotestore.RemoteStoreBackpressureIT")
         includeClasses.add("org.opensearch.remotestore.RemoteStoreIT")
         includeClasses.add("org.opensearch.remotestore.RemoteStoreRefreshListenerIT")

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteIndexPrimaryRelocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteIndexPrimaryRelocationIT.java
@@ -44,6 +44,7 @@ public class RemoteIndexPrimaryRelocationIT extends IndexPrimaryRelocationIT {
             .build();
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/9191")
     public void testPrimaryRelocationWhileIndexing() throws Exception {
         internalCluster().startClusterManagerOnlyNode();
         super.testPrimaryRelocationWhileIndexing();


### PR DESCRIPTION
When this test fails, it takes [15 minutes to timeout][1]. There are many examples like this. While it generally succeeds after a retry or two, I think it is better to mute this test rather than observe regular failures that extend build times.

[1]: https://build.ci.opensearch.org/job/gradle-check/33937/testReport/

### Related Issues
Relates #9191

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
