### PR TITLE
[Backport 2.x] Add support for scored named queries (#11626)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Introduce query level setting `index.query.max_nested_depth` limiting nested queries ([#3268](https://github.com/opensearch-project/OpenSearch/issues/3268)
 - Add toString methods to MultiSearchRequest, MultiGetRequest and CreateIndexRequest ([#12163](https://github.com/opensearch-project/OpenSearch/pull/12163))
 - Fix error in RemoteSegmentStoreDirectory when debug logging is enabled ([#12328](https://github.com/opensearch-project/OpenSearch/pull/12328))
+- Support for returning scores in matched queries ([#11626](https://github.com/opensearch-project/OpenSearch/pull/11626))
 
 ### Dependencies
 - Bump `com.squareup.okio:okio` from 3.7.0 to 3.8.0 ([#12290](https://github.com/opensearch-project/OpenSearch/pull/12290))

--- a/release-notes/opensearch.release-notes-2.12.0.md
+++ b/release-notes/opensearch.release-notes-2.12.0.md
@@ -52,7 +52,6 @@
 - Remove concurrent segment search feature flag for GA launch ([#12074](https://github.com/opensearch-project/OpenSearch/pull/12074))
 - Enable Fuzzy codec for doc id fields using a bloom filter ([#11022](https://github.com/opensearch-project/OpenSearch/pull/11022))
 - [Metrics Framework] Adds support for Histogram metric ([#12062](https://github.com/opensearch-project/OpenSearch/pull/12062))
-- Support for returning scores in matched queries ([#11626](https://github.com/opensearch-project/OpenSearch/pull/11626))
 
 ### Dependencies
 - Bumps jetty version to 9.4.52.v20230823 to fix GMS-2023-1857 ([#9822](https://github.com/opensearch-project/OpenSearch/pull/9822))

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
@@ -229,6 +229,11 @@
       "search_pipeline": {
         "type": "string",
         "description": "The search pipeline to use to execute this request"
+      },
+      "include_named_queries_score":{
+        "type": "boolean",
+        "description":"Indicates whether hit.matched_queries should be rendered as a map that includes the name of the matched query associated with its score (true) or as an array containing the name of the matched queries (false)",
+        "default":false
       }
     },
     "body":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/350_matched_queries.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/350_matched_queries.yml
@@ -1,7 +1,7 @@
 setup:
   - skip:
-      version: " - 2.12.0"
-      reason: "implemented for versions post 2.12.0"
+      version: " - 2.12.99"
+      reason: "implemented for versions post 2.12.99"
 
 ---
 "matched queries":

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/350_matched_queries.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/350_matched_queries.yml
@@ -1,0 +1,103 @@
+setup:
+  - skip:
+      version: " - 2.12.0"
+      reason: "implemented for versions post 2.12.0"
+
+---
+"matched queries":
+  - do:
+      indices.create:
+        index: test
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{ "index" : { "_index" : "test_1", "_id" : "1" } }'
+          - '{"field" : 1 }'
+          - '{ "index" : { "_index" : "test_1", "_id" : "2" } }'
+          - '{"field" : [1, 2] }'
+
+  - do:
+      search:
+        index: test_1
+        body:
+          query:
+            bool: {
+              should: [
+                {
+                  match: {
+                    field: {
+                      query: 1,
+                      _name: match_field_1
+                    }
+                  }
+                },
+                {
+                  match: {
+                    field: {
+                      query: 2,
+                      _name: match_field_2,
+                      boost: 10
+                    }
+                  }
+                }
+              ]
+            }
+
+  - match: {hits.total.value: 2}
+  - length: {hits.hits.0.matched_queries: 2}
+  - match: {hits.hits.0.matched_queries: [ "match_field_1", "match_field_2" ]}
+  - length: {hits.hits.1.matched_queries: 1}
+  - match: {hits.hits.1.matched_queries: [ "match_field_1" ]}
+
+---
+
+"matched queries with scores":
+  - do:
+      indices.create:
+        index: test
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{ "index" : { "_index" : "test_1", "_id" : "1" } }'
+          - '{"field" : 1 }'
+          - '{ "index" : { "_index" : "test_1", "_id" : "2" } }'
+          - '{"field" : [1, 2] }'
+
+  - do:
+      search:
+        include_named_queries_score: true
+        index: test_1
+        body:
+          query:
+            bool: {
+              should: [
+                {
+                  match: {
+                    field: {
+                      query: 1,
+                      _name: match_field_1
+                    }
+                  }
+                },
+                {
+                  match: {
+                    field: {
+                      query: 2,
+                      _name: match_field_2,
+                      boost: 10
+                    }
+                  }
+                }
+              ]
+            }
+
+  - match: { hits.total.value: 2 }
+  - length: { hits.hits.0.matched_queries: 2 }
+  - match: { hits.hits.0.matched_queries.match_field_1: 1 }
+  - match: { hits.hits.0.matched_queries.match_field_2: 10 }
+  - length: { hits.hits.1.matched_queries: 1 }
+  - match: { hits.hits.1.matched_queries.match_field_1: 1 }

--- a/server/src/internalClusterTest/java/org/opensearch/search/fetch/subphase/MatchedQueriesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/fetch/subphase/MatchedQueriesIT.java
@@ -61,7 +61,9 @@ import static org.opensearch.index.query.QueryBuilders.wrapperQuery;
 import static org.opensearch.search.SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItemInArray;
+import static org.hamcrest.Matchers.hasKey;
 
 public class MatchedQueriesIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
 
@@ -95,15 +97,18 @@ public class MatchedQueriesIT extends ParameterizedStaticSettingsOpenSearchInteg
                             .should(rangeQuery("number").gte(2).queryName("test2"))
                     )
             )
+            .setIncludeNamedQueriesScore(true)
             .get();
         assertHitCount(searchResponse, 3L);
         for (SearchHit hit : searchResponse.getHits()) {
             if (hit.getId().equals("3") || hit.getId().equals("2")) {
-                assertThat(hit.getMatchedQueries().length, equalTo(1));
-                assertThat(hit.getMatchedQueries(), hasItemInArray("test2"));
+                assertThat(hit.getMatchedQueriesAndScores().size(), equalTo(1));
+                assertThat(hit.getMatchedQueriesAndScores(), hasKey("test2"));
+                assertThat(hit.getMatchedQueryScore("test2"), equalTo(1f));
             } else if (hit.getId().equals("1")) {
-                assertThat(hit.getMatchedQueries().length, equalTo(1));
-                assertThat(hit.getMatchedQueries(), hasItemInArray("test1"));
+                assertThat(hit.getMatchedQueriesAndScores().size(), equalTo(1));
+                assertThat(hit.getMatchedQueriesAndScores(), hasKey("test1"));
+                assertThat(hit.getMatchedQueryScore("test1"), equalTo(1f));
             } else {
                 fail("Unexpected document returned with id " + hit.getId());
             }
@@ -113,15 +118,18 @@ public class MatchedQueriesIT extends ParameterizedStaticSettingsOpenSearchInteg
             .setQuery(
                 boolQuery().should(rangeQuery("number").lte(2).queryName("test1")).should(rangeQuery("number").gt(2).queryName("test2"))
             )
+            .setIncludeNamedQueriesScore(true)
             .get();
         assertHitCount(searchResponse, 3L);
         for (SearchHit hit : searchResponse.getHits()) {
             if (hit.getId().equals("1") || hit.getId().equals("2")) {
-                assertThat(hit.getMatchedQueries().length, equalTo(1));
-                assertThat(hit.getMatchedQueries(), hasItemInArray("test1"));
+                assertThat(hit.getMatchedQueriesAndScores().size(), equalTo(1));
+                assertThat(hit.getMatchedQueriesAndScores(), hasKey("test1"));
+                assertThat(hit.getMatchedQueryScore("test1"), equalTo(1f));
             } else if (hit.getId().equals("3")) {
-                assertThat(hit.getMatchedQueries().length, equalTo(1));
-                assertThat(hit.getMatchedQueries(), hasItemInArray("test2"));
+                assertThat(hit.getMatchedQueriesAndScores().size(), equalTo(1));
+                assertThat(hit.getMatchedQueriesAndScores(), hasKey("test2"));
+                assertThat(hit.getMatchedQueryScore("test2"), equalTo(1f));
             } else {
                 fail("Unexpected document returned with id " + hit.getId());
             }
@@ -147,12 +155,15 @@ public class MatchedQueriesIT extends ParameterizedStaticSettingsOpenSearchInteg
         assertHitCount(searchResponse, 3L);
         for (SearchHit hit : searchResponse.getHits()) {
             if (hit.getId().equals("1")) {
-                assertThat(hit.getMatchedQueries().length, equalTo(2));
-                assertThat(hit.getMatchedQueries(), hasItemInArray("name"));
-                assertThat(hit.getMatchedQueries(), hasItemInArray("title"));
+                assertThat(hit.getMatchedQueriesAndScores().size(), equalTo(2));
+                assertThat(hit.getMatchedQueriesAndScores(), hasKey("name"));
+                assertThat(hit.getMatchedQueryScore("name"), greaterThan(0f));
+                assertThat(hit.getMatchedQueriesAndScores(), hasKey("title"));
+                assertThat(hit.getMatchedQueryScore("title"), greaterThan(0f));
             } else if (hit.getId().equals("2") || hit.getId().equals("3")) {
-                assertThat(hit.getMatchedQueries().length, equalTo(1));
-                assertThat(hit.getMatchedQueries(), hasItemInArray("name"));
+                assertThat(hit.getMatchedQueriesAndScores().size(), equalTo(1));
+                assertThat(hit.getMatchedQueriesAndScores(), hasKey("name"));
+                assertThat(hit.getMatchedQueryScore("name"), greaterThan(0f));
             } else {
                 fail("Unexpected document returned with id " + hit.getId());
             }
@@ -168,12 +179,15 @@ public class MatchedQueriesIT extends ParameterizedStaticSettingsOpenSearchInteg
         assertHitCount(searchResponse, 3L);
         for (SearchHit hit : searchResponse.getHits()) {
             if (hit.getId().equals("1")) {
-                assertThat(hit.getMatchedQueries().length, equalTo(2));
-                assertThat(hit.getMatchedQueries(), hasItemInArray("name"));
-                assertThat(hit.getMatchedQueries(), hasItemInArray("title"));
+                assertThat(hit.getMatchedQueriesAndScores().size(), equalTo(2));
+                assertThat(hit.getMatchedQueriesAndScores(), hasKey("name"));
+                assertThat(hit.getMatchedQueryScore("name"), greaterThan(0f));
+                assertThat(hit.getMatchedQueriesAndScores(), hasKey("title"));
+                assertThat(hit.getMatchedQueryScore("title"), greaterThan(0f));
             } else if (hit.getId().equals("2") || hit.getId().equals("3")) {
-                assertThat(hit.getMatchedQueries().length, equalTo(1));
-                assertThat(hit.getMatchedQueries(), hasItemInArray("name"));
+                assertThat(hit.getMatchedQueriesAndScores().size(), equalTo(1));
+                assertThat(hit.getMatchedQueriesAndScores(), hasKey("name"));
+                assertThat(hit.getMatchedQueryScore("name"), greaterThan(0f));
             } else {
                 fail("Unexpected document returned with id " + hit.getId());
             }
@@ -197,9 +211,11 @@ public class MatchedQueriesIT extends ParameterizedStaticSettingsOpenSearchInteg
         assertHitCount(searchResponse, 3L);
         for (SearchHit hit : searchResponse.getHits()) {
             if (hit.getId().equals("1") || hit.getId().equals("2") || hit.getId().equals("3")) {
-                assertThat(hit.getMatchedQueries().length, equalTo(2));
-                assertThat(hit.getMatchedQueries(), hasItemInArray("name"));
-                assertThat(hit.getMatchedQueries(), hasItemInArray("title"));
+                assertThat(hit.getMatchedQueriesAndScores().size(), equalTo(2));
+                assertThat(hit.getMatchedQueriesAndScores(), hasKey("name"));
+                assertThat(hit.getMatchedQueryScore("name"), greaterThan(0f));
+                assertThat(hit.getMatchedQueriesAndScores(), hasKey("title"));
+                assertThat(hit.getMatchedQueryScore("title"), greaterThan(0f));
             } else {
                 fail("Unexpected document returned with id " + hit.getId());
             }
@@ -231,13 +247,15 @@ public class MatchedQueriesIT extends ParameterizedStaticSettingsOpenSearchInteg
 
         SearchResponse searchResponse = client().prepareSearch()
             .setQuery(QueryBuilders.regexpQuery("title", "title1").queryName("regex"))
+            .setIncludeNamedQueriesScore(true)
             .get();
         assertHitCount(searchResponse, 1L);
 
         for (SearchHit hit : searchResponse.getHits()) {
             if (hit.getId().equals("1")) {
-                assertThat(hit.getMatchedQueries().length, equalTo(1));
-                assertThat(hit.getMatchedQueries(), hasItemInArray("regex"));
+                assertThat(hit.getMatchedQueriesAndScores().size(), equalTo(1));
+                assertThat(hit.getMatchedQueriesAndScores(), hasKey("regex"));
+                assertThat(hit.getMatchedQueryScore("regex"), equalTo(1f));
             } else {
                 fail("Unexpected document returned with id " + hit.getId());
             }
@@ -252,15 +270,17 @@ public class MatchedQueriesIT extends ParameterizedStaticSettingsOpenSearchInteg
         refresh();
         indexRandomForConcurrentSearch("test1");
 
-        SearchResponse searchResponse = client().prepareSearch()
+        var query = client().prepareSearch()
             .setQuery(QueryBuilders.prefixQuery("title", "title").queryName("prefix"))
-            .get();
+            .setIncludeNamedQueriesScore(true);
+        var searchResponse = query.get();
         assertHitCount(searchResponse, 1L);
 
         for (SearchHit hit : searchResponse.getHits()) {
             if (hit.getId().equals("1")) {
-                assertThat(hit.getMatchedQueries().length, equalTo(1));
-                assertThat(hit.getMatchedQueries(), hasItemInArray("prefix"));
+                assertThat(hit.getMatchedQueriesAndScores().size(), equalTo(1));
+                assertThat(hit.getMatchedQueriesAndScores(), hasKey("prefix"));
+                assertThat(hit.getMatchedQueryScore("prefix"), equalTo(1f));
             } else {
                 fail("Unexpected document returned with id " + hit.getId());
             }
@@ -282,8 +302,9 @@ public class MatchedQueriesIT extends ParameterizedStaticSettingsOpenSearchInteg
 
         for (SearchHit hit : searchResponse.getHits()) {
             if (hit.getId().equals("1")) {
-                assertThat(hit.getMatchedQueries().length, equalTo(1));
-                assertThat(hit.getMatchedQueries(), hasItemInArray("fuzzy"));
+                assertThat(hit.getMatchedQueriesAndScores().size(), equalTo(1));
+                assertThat(hit.getMatchedQueriesAndScores(), hasKey("fuzzy"));
+                assertThat(hit.getMatchedQueryScore("fuzzy"), greaterThan(0f));
             } else {
                 fail("Unexpected document returned with id " + hit.getId());
             }
@@ -300,13 +321,15 @@ public class MatchedQueriesIT extends ParameterizedStaticSettingsOpenSearchInteg
 
         SearchResponse searchResponse = client().prepareSearch()
             .setQuery(QueryBuilders.wildcardQuery("title", "titl*").queryName("wildcard"))
+            .setIncludeNamedQueriesScore(true)
             .get();
         assertHitCount(searchResponse, 1L);
 
         for (SearchHit hit : searchResponse.getHits()) {
             if (hit.getId().equals("1")) {
-                assertThat(hit.getMatchedQueries().length, equalTo(1));
-                assertThat(hit.getMatchedQueries(), hasItemInArray("wildcard"));
+                assertThat(hit.getMatchedQueriesAndScores().size(), equalTo(1));
+                assertThat(hit.getMatchedQueriesAndScores(), hasKey("wildcard"));
+                assertThat(hit.getMatchedQueryScore("wildcard"), equalTo(1f));
             } else {
                 fail("Unexpected document returned with id " + hit.getId());
             }
@@ -328,8 +351,9 @@ public class MatchedQueriesIT extends ParameterizedStaticSettingsOpenSearchInteg
 
         for (SearchHit hit : searchResponse.getHits()) {
             if (hit.getId().equals("1")) {
-                assertThat(hit.getMatchedQueries().length, equalTo(1));
-                assertThat(hit.getMatchedQueries(), hasItemInArray("span"));
+                assertThat(hit.getMatchedQueriesAndScores().size(), equalTo(1));
+                assertThat(hit.getMatchedQueriesAndScores(), hasKey("span"));
+                assertThat(hit.getMatchedQueryScore("span"), greaterThan(0f));
             } else {
                 fail("Unexpected document returned with id " + hit.getId());
             }
@@ -363,11 +387,13 @@ public class MatchedQueriesIT extends ParameterizedStaticSettingsOpenSearchInteg
             assertHitCount(searchResponse, 2L);
             for (SearchHit hit : searchResponse.getHits()) {
                 if (hit.getId().equals("1")) {
-                    assertThat(hit.getMatchedQueries().length, equalTo(1));
-                    assertThat(hit.getMatchedQueries(), hasItemInArray("dolor"));
+                    assertThat(hit.getMatchedQueriesAndScores().size(), equalTo(1));
+                    assertThat(hit.getMatchedQueriesAndScores(), hasKey("dolor"));
+                    assertThat(hit.getMatchedQueryScore("dolor"), greaterThan(0f));
                 } else if (hit.getId().equals("2")) {
-                    assertThat(hit.getMatchedQueries().length, equalTo(1));
-                    assertThat(hit.getMatchedQueries(), hasItemInArray("elit"));
+                    assertThat(hit.getMatchedQueriesAndScores().size(), equalTo(1));
+                    assertThat(hit.getMatchedQueriesAndScores(), hasKey("elit"));
+                    assertThat(hit.getMatchedQueryScore("elit"), greaterThan(0f));
                 } else {
                     fail("Unexpected document returned with id " + hit.getId());
                 }
@@ -391,7 +417,10 @@ public class MatchedQueriesIT extends ParameterizedStaticSettingsOpenSearchInteg
         for (QueryBuilder query : queries) {
             SearchResponse searchResponse = client().prepareSearch().setQuery(query).get();
             assertHitCount(searchResponse, 1L);
-            assertThat(searchResponse.getHits().getAt(0).getMatchedQueries()[0], equalTo("abc"));
+            SearchHit hit = searchResponse.getHits().getAt(0);
+            assertThat(hit.getMatchedQueriesAndScores().size(), equalTo(1));
+            assertThat(hit.getMatchedQueriesAndScores(), hasKey("abc"));
+            assertThat(hit.getMatchedQueryScore("abc"), greaterThan(0f));
         }
     }
 }

--- a/server/src/internalClusterTest/java/org/opensearch/search/functionscore/QueryRescorerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/functionscore/QueryRescorerIT.java
@@ -83,6 +83,7 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertSearchResp
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertSecondHit;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertThirdHit;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.hasId;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.hasMatchedQueries;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.hasScore;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -594,7 +595,7 @@ public class QueryRescorerIT extends ParameterizedStaticSettingsOpenSearchIntegT
 
             SearchResponse searchResponse = client().prepareSearch()
                 .setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
-                .setQuery(QueryBuilders.matchQuery("field1", "the quick brown").operator(Operator.OR))
+                .setQuery(QueryBuilders.matchQuery("field1", "the quick brown").operator(Operator.OR).queryName("hello-world"))
                 .setRescorer(innerRescoreQuery, 5)
                 .setExplain(true)
                 .get();
@@ -602,7 +603,10 @@ public class QueryRescorerIT extends ParameterizedStaticSettingsOpenSearchIntegT
             assertFirstHit(searchResponse, hasId("1"));
             assertSecondHit(searchResponse, hasId("2"));
             assertThirdHit(searchResponse, hasId("3"));
-
+            final String[] matchedQueries = { "hello-world" };
+            assertFirstHit(searchResponse, hasMatchedQueries(matchedQueries));
+            assertSecondHit(searchResponse, hasMatchedQueries(matchedQueries));
+            assertThirdHit(searchResponse, hasMatchedQueries(matchedQueries));
             for (int j = 0; j < 3; j++) {
                 assertThat(searchResponse.getHits().getAt(j).getExplanation().getDescription(), equalTo(descriptionModes[innerMode]));
             }

--- a/server/src/main/java/org/opensearch/action/search/SearchRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequestBuilder.java
@@ -407,6 +407,15 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
     }
 
     /**
+     * Applies when fetching scores with named queries, and controls if scores will be tracked as well.
+     * Defaults to {@code false}.
+     */
+    public SearchRequestBuilder setIncludeNamedQueriesScore(boolean includeNamedQueriesScore) {
+        sourceBuilder().includeNamedQueriesScores(includeNamedQueriesScore);
+        return this;
+    }
+
+    /**
      * Indicates if the total hit count for the query should be tracked. Requests will count total hit count accurately
      * up to 10,000 by default, see {@link #setTrackTotalHitsUpTo(int)} to change this value or set to true/false to always/never
      * count accurately.

--- a/server/src/main/java/org/opensearch/rest/action/search/RestSearchAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/search/RestSearchAction.java
@@ -86,10 +86,13 @@ public class RestSearchAction extends BaseRestHandler {
      */
     public static final String TOTAL_HITS_AS_INT_PARAM = "rest_total_hits_as_int";
     public static final String TYPED_KEYS_PARAM = "typed_keys";
+    public static final String INCLUDE_NAMED_QUERIES_SCORE_PARAM = "include_named_queries_score";
     private static final Set<String> RESPONSE_PARAMS;
 
     static {
-        final Set<String> responseParams = new HashSet<>(Arrays.asList(TYPED_KEYS_PARAM, TOTAL_HITS_AS_INT_PARAM));
+        final Set<String> responseParams = new HashSet<>(
+            Arrays.asList(TYPED_KEYS_PARAM, TOTAL_HITS_AS_INT_PARAM, INCLUDE_NAMED_QUERIES_SCORE_PARAM)
+        );
         RESPONSE_PARAMS = Collections.unmodifiableSet(responseParams);
     }
 
@@ -209,6 +212,7 @@ public class RestSearchAction extends BaseRestHandler {
         searchRequest.pipeline(request.param("search_pipeline"));
 
         checkRestTotalHits(request, searchRequest);
+        request.paramAsBoolean(INCLUDE_NAMED_QUERIES_SCORE_PARAM, false);
 
         if (searchRequest.pointInTimeBuilder() != null) {
             preparePointInTime(searchRequest, request, namedWriteableRegistry);
@@ -284,6 +288,10 @@ public class RestSearchAction extends BaseRestHandler {
 
         if (request.hasParam("track_scores")) {
             searchSourceBuilder.trackScores(request.paramAsBoolean("track_scores", false));
+        }
+
+        if (request.hasParam("include_named_queries_score")) {
+            searchSourceBuilder.includeNamedQueriesScores(request.paramAsBoolean("include_named_queries_score", false));
         }
 
         if (request.hasParam("track_total_hits")) {

--- a/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
@@ -148,6 +148,8 @@ final class DefaultSearchContext extends SearchContext {
     private SortAndFormats sort;
     private Float minimumScore;
     private boolean trackScores = false; // when sorting, track scores as well...
+
+    private boolean includeNamedQueriesScore = false;
     private int trackTotalHitsUpTo = SearchContext.DEFAULT_TRACK_TOTAL_HITS_UP_TO;
     private FieldDoc searchAfter;
     private CollapseContext collapse;
@@ -633,6 +635,17 @@ final class DefaultSearchContext extends SearchContext {
     @Override
     public boolean trackScores() {
         return this.trackScores;
+    }
+
+    @Override
+    public SearchContext includeNamedQueriesScore(boolean includeNamedQueriesScore) {
+        this.includeNamedQueriesScore = includeNamedQueriesScore;
+        return this;
+    }
+
+    @Override
+    public boolean includeNamedQueriesScore() {
+        return includeNamedQueriesScore;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/SearchHit.java
+++ b/server/src/main/java/org/opensearch/search/SearchHit.java
@@ -65,19 +65,21 @@ import org.opensearch.index.mapper.IgnoredFieldMapper;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.SourceFieldMapper;
 import org.opensearch.index.seqno.SequenceNumbers;
+import org.opensearch.rest.action.search.RestSearchAction;
 import org.opensearch.search.fetch.subphase.highlight.HighlightField;
 import org.opensearch.search.lookup.SourceLookup;
 import org.opensearch.transport.RemoteClusterAware;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
@@ -121,7 +123,7 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
 
     private SearchSortValues sortValues = SearchSortValues.EMPTY;
 
-    private String[] matchedQueries = Strings.EMPTY_ARRAY;
+    private Map<String, Float> matchedQueries = new HashMap<>();
 
     private Explanation explanation;
 
@@ -216,10 +218,20 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
         sortValues = new SearchSortValues(in);
 
         size = in.readVInt();
-        if (size > 0) {
-            matchedQueries = new String[size];
+        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+            if (size > 0) {
+                Map<String, Float> tempMap = in.readMap(StreamInput::readString, StreamInput::readFloat);
+                matchedQueries = tempMap.entrySet()
+                    .stream()
+                    .sorted(Map.Entry.comparingByKey())
+                    .collect(
+                        Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (oldValue, newValue) -> oldValue, LinkedHashMap::new)
+                    );
+            }
+        } else {
+            matchedQueries = new LinkedHashMap<>(size);
             for (int i = 0; i < size; i++) {
-                matchedQueries[i] = in.readString();
+                matchedQueries.put(in.readString(), Float.NaN);
             }
         }
         // we call the setter here because that also sets the local index parameter
@@ -234,36 +246,6 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
             }
         } else {
             innerHits = null;
-        }
-    }
-
-    private Map<String, DocumentField> readFields(StreamInput in) throws IOException {
-        Map<String, DocumentField> fields;
-        int size = in.readVInt();
-        if (size == 0) {
-            fields = emptyMap();
-        } else if (size == 1) {
-            DocumentField hitField = new DocumentField(in);
-            fields = singletonMap(hitField.getName(), hitField);
-        } else {
-            fields = new HashMap<>(size);
-            for (int i = 0; i < size; i++) {
-                DocumentField field = new DocumentField(in);
-                fields.put(field.getName(), field);
-            }
-            fields = unmodifiableMap(fields);
-        }
-        return fields;
-    }
-
-    private void writeFields(StreamOutput out, Map<String, DocumentField> fields) throws IOException {
-        if (fields == null) {
-            out.writeVInt(0);
-        } else {
-            out.writeVInt(fields.size());
-            for (DocumentField field : fields.values()) {
-                field.writeTo(out);
-            }
         }
     }
 
@@ -303,11 +285,13 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
         }
         sortValues.writeTo(out);
 
-        if (matchedQueries.length == 0) {
-            out.writeVInt(0);
+        out.writeVInt(matchedQueries.size());
+        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+            if (!matchedQueries.isEmpty()) {
+                out.writeMap(matchedQueries, StreamOutput::writeString, StreamOutput::writeFloat);
+            }
         } else {
-            out.writeVInt(matchedQueries.length);
-            for (String matchedFilter : matchedQueries) {
+            for (String matchedFilter : matchedQueries.keySet()) {
                 out.writeString(matchedFilter);
             }
         }
@@ -475,11 +459,11 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
     }
 
     /*
-    * Adds a new DocumentField to the map in case both parameters are not null.
-    * */
+     * Adds a new DocumentField to the map in case both parameters are not null.
+     * */
     public void setDocumentField(String fieldName, DocumentField field) {
         if (fieldName == null || field == null) return;
-        if (documentFields.size() == 0) this.documentFields = new HashMap<>();
+        if (documentFields.isEmpty()) this.documentFields = new HashMap<>();
         this.documentFields.put(fieldName, field);
     }
 
@@ -492,7 +476,7 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
      * were required to be loaded.
      */
     public Map<String, DocumentField> getFields() {
-        if (metaFields.size() > 0 || documentFields.size() > 0) {
+        if (!metaFields.isEmpty() || !documentFields.isEmpty()) {
             final Map<String, DocumentField> fields = new HashMap<>();
             fields.putAll(metaFields);
             fields.putAll(documentFields);
@@ -577,14 +561,45 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
     }
 
     public void matchedQueries(String[] matchedQueries) {
-        this.matchedQueries = matchedQueries;
+        if (matchedQueries != null) {
+            for (String query : matchedQueries) {
+                this.matchedQueries.put(query, Float.NaN);
+            }
+        }
+    }
+
+    public void matchedQueriesWithScores(Map<String, Float> matchedQueries) {
+        if (matchedQueries != null) {
+            this.matchedQueries = matchedQueries;
+        }
     }
 
     /**
      * The set of query and filter names the query matched with. Mainly makes sense for compound filters and queries.
      */
     public String[] getMatchedQueries() {
-        return this.matchedQueries;
+        return matchedQueries == null ? new String[0] : matchedQueries.keySet().toArray(new String[0]);
+    }
+
+    /**
+     * Returns the score of the provided named query if it matches.
+     * <p>
+     * If the 'include_named_queries_score' is not set, this method will return {@link Float#NaN}
+     * for each named query instead of a numerical score.
+     * </p>
+     *
+     * @param name The name of the query to retrieve the score for.
+     * @return The score of the named query, or {@link Float#NaN} if 'include_named_queries_score' is not set.
+     */
+    public Float getMatchedQueryScore(String name) {
+        return getMatchedQueriesAndScores().get(name);
+    }
+
+    /**
+     * @return The map of the named queries that matched and their associated score.
+     */
+    public Map<String, Float> getMatchedQueriesAndScores() {
+        return matchedQueries == null ? Collections.emptyMap() : matchedQueries;
     }
 
     /**
@@ -671,7 +686,7 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
 
         for (DocumentField field : metaFields.values()) {
             // ignore empty metadata fields
-            if (field.getValues().size() == 0) {
+            if (field.getValues().isEmpty()) {
                 continue;
             }
             // _ignored is the only multi-valued meta field
@@ -687,10 +702,10 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
         }
         if (documentFields.isEmpty() == false &&
         // ignore fields all together if they are all empty
-            documentFields.values().stream().anyMatch(df -> df.getValues().size() > 0)) {
+            documentFields.values().stream().anyMatch(df -> !df.getValues().isEmpty())) {
             builder.startObject(Fields.FIELDS);
             for (DocumentField field : documentFields.values()) {
-                if (field.getValues().size() > 0) {
+                if (!field.getValues().isEmpty()) {
                     field.toXContent(builder, params);
                 }
             }
@@ -704,12 +719,21 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
             builder.endObject();
         }
         sortValues.toXContent(builder, params);
-        if (matchedQueries.length > 0) {
-            builder.startArray(Fields.MATCHED_QUERIES);
-            for (String matchedFilter : matchedQueries) {
-                builder.value(matchedFilter);
+        if (!matchedQueries.isEmpty()) {
+            boolean includeMatchedQueriesScore = params.paramAsBoolean(RestSearchAction.INCLUDE_NAMED_QUERIES_SCORE_PARAM, false);
+            if (includeMatchedQueriesScore) {
+                builder.startObject(Fields.MATCHED_QUERIES);
+                for (Map.Entry<String, Float> entry : matchedQueries.entrySet()) {
+                    builder.field(entry.getKey(), entry.getValue());
+                }
+                builder.endObject();
+            } else {
+                builder.startArray(Fields.MATCHED_QUERIES);
+                for (String matchedFilter : matchedQueries.keySet()) {
+                    builder.value(matchedFilter);
+                }
+                builder.endArray();
             }
-            builder.endArray();
         }
         if (getExplanation() != null) {
             builder.field(Fields._EXPLANATION);
@@ -814,7 +838,27 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
             (p, c) -> parseInnerHits(p),
             new ParseField(Fields.INNER_HITS)
         );
-        parser.declareStringArray((map, list) -> map.put(Fields.MATCHED_QUERIES, list), new ParseField(Fields.MATCHED_QUERIES));
+        parser.declareField((p, map, context) -> {
+            XContentParser.Token token = p.currentToken();
+            Map<String, Float> matchedQueries = new LinkedHashMap<>();
+            if (token == XContentParser.Token.START_OBJECT) {
+                String fieldName = null;
+                while ((token = p.nextToken()) != XContentParser.Token.END_OBJECT) {
+                    if (token == XContentParser.Token.FIELD_NAME) {
+                        fieldName = p.currentName();
+                    } else if (token.isValue()) {
+                        matchedQueries.put(fieldName, p.floatValue());
+                    }
+                }
+            } else if (token == XContentParser.Token.START_ARRAY) {
+                while (p.nextToken() != XContentParser.Token.END_ARRAY) {
+                    matchedQueries.put(p.text(), Float.NaN);
+                }
+            } else {
+                throw new IllegalStateException("expected object or array but got [" + token + "]");
+            }
+            map.put(Fields.MATCHED_QUERIES, matchedQueries);
+        }, new ParseField(Fields.MATCHED_QUERIES), ObjectParser.ValueType.OBJECT_ARRAY);
         parser.declareField(
             (map, list) -> map.put(Fields.SORT, list),
             SearchSortValues::fromXContent,
@@ -845,7 +889,7 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
             assert shardId.getIndexName().equals(index);
             searchHit.shard(new SearchShardTarget(nodeId, shardId, clusterAlias, OriginalIndices.NONE));
         } else {
-            // these fields get set anyways when setting the shard target,
+            // these fields get set anyway when setting the shard target,
             // but we set them explicitly when we don't have enough info to rebuild the shard target
             searchHit.index = index;
             searchHit.clusterAlias = clusterAlias;
@@ -859,10 +903,7 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
         searchHit.sourceRef(get(SourceFieldMapper.NAME, values, null));
         searchHit.explanation(get(Fields._EXPLANATION, values, null));
         searchHit.setInnerHits(get(Fields.INNER_HITS, values, null));
-        List<String> matchedQueries = get(Fields.MATCHED_QUERIES, values, null);
-        if (matchedQueries != null) {
-            searchHit.matchedQueries(matchedQueries.toArray(new String[0]));
-        }
+        searchHit.matchedQueriesWithScores(get(Fields.MATCHED_QUERIES, values, null));
         return searchHit;
     }
 
@@ -982,7 +1023,7 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
             && Objects.equals(documentFields, other.documentFields)
             && Objects.equals(metaFields, other.metaFields)
             && Objects.equals(getHighlightFields(), other.getHighlightFields())
-            && Arrays.equals(matchedQueries, other.matchedQueries)
+            && Objects.equals(getMatchedQueriesAndScores(), other.getMatchedQueriesAndScores())
             && Objects.equals(explanation, other.explanation)
             && Objects.equals(shard, other.shard)
             && Objects.equals(innerHits, other.innerHits)
@@ -1002,7 +1043,7 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
             documentFields,
             metaFields,
             getHighlightFields(),
-            Arrays.hashCode(matchedQueries),
+            getMatchedQueriesAndScores(),
             explanation,
             shard,
             innerHits,

--- a/server/src/main/java/org/opensearch/search/SearchService.java
+++ b/server/src/main/java/org/opensearch/search/SearchService.java
@@ -1275,6 +1275,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             }
         }
         context.trackScores(source.trackScores());
+        context.includeNamedQueriesScore(source.includeNamedQueriesScore());
         if (source.trackTotalHitsUpTo() != null
             && source.trackTotalHitsUpTo() != SearchContext.TRACK_TOTAL_HITS_ACCURATE
             && context.scrollContext() != null) {

--- a/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
@@ -118,6 +118,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
     public static final ParseField IGNORE_FAILURE_FIELD = new ParseField("ignore_failure");
     public static final ParseField SORT_FIELD = new ParseField("sort");
     public static final ParseField TRACK_SCORES_FIELD = new ParseField("track_scores");
+    public static final ParseField INCLUDE_NAMED_QUERIES_SCORE = new ParseField("include_named_queries_score");
     public static final ParseField TRACK_TOTAL_HITS_FIELD = new ParseField("track_total_hits");
     public static final ParseField INDICES_BOOST_FIELD = new ParseField("indices_boost");
     public static final ParseField AGGREGATIONS_FIELD = new ParseField("aggregations");
@@ -175,6 +176,8 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
     private List<SortBuilder<?>> sorts;
 
     private boolean trackScores = false;
+
+    private Boolean includeNamedQueriesScore;
 
     private Integer trackTotalHitsUpTo;
 
@@ -285,6 +288,9 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
                 searchPipelineSource = in.readMap();
             }
         }
+        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+            includeNamedQueriesScore = in.readOptionalBoolean();
+        }
     }
 
     @Override
@@ -357,6 +363,9 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
             if (searchPipelineSource != null) {
                 out.writeMap(searchPipelineSource);
             }
+        }
+        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+            out.writeOptionalBoolean(includeNamedQueriesScore);
         }
     }
 
@@ -583,6 +592,22 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
     public SearchSourceBuilder trackScores(boolean trackScores) {
         this.trackScores = trackScores;
         return this;
+    }
+
+    /**
+     * Applies when there are named queries, to return the scores along as well
+     * Defaults to {@code false}.
+     */
+    public SearchSourceBuilder includeNamedQueriesScores(boolean includeNamedQueriesScore) {
+        this.includeNamedQueriesScore = includeNamedQueriesScore;
+        return this;
+    }
+
+    /**
+     * Indicates whether scores will be returned as part of every search matched query.s
+     */
+    public boolean includeNamedQueriesScore() {
+        return includeNamedQueriesScore != null && includeNamedQueriesScore;
     }
 
     /**
@@ -1120,6 +1145,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         rewrittenBuilder.terminateAfter = terminateAfter;
         rewrittenBuilder.timeout = timeout;
         rewrittenBuilder.trackScores = trackScores;
+        rewrittenBuilder.includeNamedQueriesScore = includeNamedQueriesScore;
         rewrittenBuilder.trackTotalHitsUpTo = trackTotalHitsUpTo;
         rewrittenBuilder.version = version;
         rewrittenBuilder.seqNoAndPrimaryTerm = seqNoAndPrimaryTerm;
@@ -1172,6 +1198,8 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
                     explain = parser.booleanValue();
                 } else if (TRACK_SCORES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     trackScores = parser.booleanValue();
+                } else if (INCLUDE_NAMED_QUERIES_SCORE.match(currentFieldName, parser.getDeprecationHandler())) {
+                    includeNamedQueriesScore = parser.booleanValue();
                 } else if (TRACK_TOTAL_HITS_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     if (token == XContentParser.Token.VALUE_BOOLEAN
                         || (token == XContentParser.Token.VALUE_STRING && Booleans.isBoolean(parser.text()))) {
@@ -1433,6 +1461,10 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
 
         if (trackScores) {
             builder.field(TRACK_SCORES_FIELD.getPreferredName(), true);
+        }
+
+        if (includeNamedQueriesScore != null) {
+            builder.field(INCLUDE_NAMED_QUERIES_SCORE.getPreferredName(), includeNamedQueriesScore);
         }
 
         if (trackTotalHitsUpTo != null) {
@@ -1766,6 +1798,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
             terminateAfter,
             timeout,
             trackScores,
+            includeNamedQueriesScore,
             version,
             seqNoAndPrimaryTerm,
             profile,
@@ -1808,6 +1841,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
             && Objects.equals(terminateAfter, other.terminateAfter)
             && Objects.equals(timeout, other.timeout)
             && Objects.equals(trackScores, other.trackScores)
+            && Objects.equals(includeNamedQueriesScore, other.includeNamedQueriesScore)
             && Objects.equals(version, other.version)
             && Objects.equals(seqNoAndPrimaryTerm, other.seqNoAndPrimaryTerm)
             && Objects.equals(profile, other.profile)

--- a/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
@@ -288,7 +288,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
                 searchPipelineSource = in.readMap();
             }
         }
-        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_2_13_0)) {
             includeNamedQueriesScore = in.readOptionalBoolean();
         }
     }
@@ -364,7 +364,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
                 out.writeMap(searchPipelineSource);
             }
         }
-        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_2_13_0)) {
             out.writeOptionalBoolean(includeNamedQueriesScore);
         }
     }

--- a/server/src/main/java/org/opensearch/search/fetch/FetchContext.java
+++ b/server/src/main/java/org/opensearch/search/fetch/FetchContext.java
@@ -188,6 +188,10 @@ public class FetchContext {
         return searchContext.sort() != null && searchContext.trackScores();
     }
 
+    public boolean includeNamedQueriesScore() {
+        return searchContext.includeNamedQueriesScore();
+    }
+
     /**
      * Configuration for returning inner hits
      */

--- a/server/src/main/java/org/opensearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/opensearch/search/fetch/FetchPhase.java
@@ -91,7 +91,7 @@ import static java.util.Collections.emptyMap;
 
 /**
  * Fetch phase of a search request, used to fetch the actual top matching documents to be returned to the client, identified
- * after reducing all of the matches returned by the query phase
+ * after reducing all the matches returned by the query phase
  *
  * @opensearch.api
  */

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/MatchedQueriesPhase.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/MatchedQueriesPhase.java
@@ -28,12 +28,12 @@
  * Modifications Copyright OpenSearch Contributors. See
  * GitHub history for details.
  */
-
 package org.opensearch.search.fetch.subphase;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.Bits;
@@ -45,6 +45,7 @@ import org.opensearch.search.fetch.FetchSubPhaseProcessor;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -67,25 +68,69 @@ public final class MatchedQueriesPhase implements FetchSubPhase {
         if (namedQueries.isEmpty()) {
             return null;
         }
-        Map<String, Weight> weights = new HashMap<>();
-        for (Map.Entry<String, Query> entry : namedQueries.entrySet()) {
-            weights.put(
-                entry.getKey(),
-                context.searcher().createWeight(context.searcher().rewrite(entry.getValue()), ScoreMode.COMPLETE_NO_SCORES, 1)
-            );
-        }
-        return new FetchSubPhaseProcessor() {
 
-            final Map<String, Bits> matchingIterators = new HashMap<>();
+        Map<String, Weight> weights = prepareWeights(context, namedQueries);
+
+        return context.includeNamedQueriesScore() ? createScoringProcessor(weights) : createNonScoringProcessor(weights);
+    }
+
+    private Map<String, Weight> prepareWeights(FetchContext context, Map<String, Query> namedQueries) throws IOException {
+        Map<String, Weight> weights = new HashMap<>();
+        ScoreMode scoreMode = context.includeNamedQueriesScore() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
+        for (Map.Entry<String, Query> entry : namedQueries.entrySet()) {
+            weights.put(entry.getKey(), context.searcher().createWeight(context.searcher().rewrite(entry.getValue()), scoreMode, 1));
+        }
+        return weights;
+    }
+
+    private FetchSubPhaseProcessor createScoringProcessor(Map<String, Weight> weights) {
+        return new FetchSubPhaseProcessor() {
+            final Map<String, Scorer> matchingScorers = new HashMap<>();
 
             @Override
             public void setNextReader(LeafReaderContext readerContext) throws IOException {
-                matchingIterators.clear();
+                matchingScorers.clear();
                 for (Map.Entry<String, Weight> entry : weights.entrySet()) {
-                    ScorerSupplier ss = entry.getValue().scorerSupplier(readerContext);
-                    if (ss != null) {
-                        Bits matchingBits = Lucene.asSequentialAccessBits(readerContext.reader().maxDoc(), ss);
-                        matchingIterators.put(entry.getKey(), matchingBits);
+                    ScorerSupplier scorerSupplier = entry.getValue().scorerSupplier(readerContext);
+                    if (scorerSupplier != null) {
+                        Scorer scorer = scorerSupplier.get(0L);
+                        if (scorer != null) {
+                            matchingScorers.put(entry.getKey(), scorer);
+                        }
+                    }
+                }
+            }
+
+            @Override
+            public void process(HitContext hitContext) throws IOException {
+                Map<String, Float> matches = new LinkedHashMap<>();
+                int docId = hitContext.docId();
+                for (Map.Entry<String, Scorer> entry : matchingScorers.entrySet()) {
+                    Scorer scorer = entry.getValue();
+                    if (scorer.iterator().docID() < docId) {
+                        scorer.iterator().advance(docId);
+                    }
+                    if (scorer.iterator().docID() == docId) {
+                        matches.put(entry.getKey(), scorer.score());
+                    }
+                }
+                hitContext.hit().matchedQueriesWithScores(matches);
+            }
+        };
+    }
+
+    private FetchSubPhaseProcessor createNonScoringProcessor(Map<String, Weight> weights) {
+        return new FetchSubPhaseProcessor() {
+            final Map<String, Bits> matchingBits = new HashMap<>();
+
+            @Override
+            public void setNextReader(LeafReaderContext readerContext) throws IOException {
+                matchingBits.clear();
+                for (Map.Entry<String, Weight> entry : weights.entrySet()) {
+                    ScorerSupplier scorerSupplier = entry.getValue().scorerSupplier(readerContext);
+                    if (scorerSupplier != null) {
+                        Bits bits = Lucene.asSequentialAccessBits(readerContext.reader().maxDoc(), scorerSupplier);
+                        matchingBits.put(entry.getKey(), bits);
                     }
                 }
             }
@@ -93,15 +138,14 @@ public final class MatchedQueriesPhase implements FetchSubPhase {
             @Override
             public void process(HitContext hitContext) {
                 List<String> matches = new ArrayList<>();
-                int doc = hitContext.docId();
-                for (Map.Entry<String, Bits> iterator : matchingIterators.entrySet()) {
-                    if (iterator.getValue().get(doc)) {
-                        matches.add(iterator.getKey());
+                int docId = hitContext.docId();
+                for (Map.Entry<String, Bits> entry : matchingBits.entrySet()) {
+                    if (entry.getValue().get(docId)) {
+                        matches.add(entry.getKey());
                     }
                 }
                 hitContext.hit().matchedQueries(matches.toArray(new String[0]));
             }
         };
     }
-
 }

--- a/server/src/main/java/org/opensearch/search/internal/FilteredSearchContext.java
+++ b/server/src/main/java/org/opensearch/search/internal/FilteredSearchContext.java
@@ -340,6 +340,14 @@ public abstract class FilteredSearchContext extends SearchContext {
         return in.searchAfter();
     }
 
+    public SearchContext includeNamedQueriesScore(boolean includeNamedQueriesScore) {
+        return in.includeNamedQueriesScore(includeNamedQueriesScore);
+    }
+
+    public boolean includeNamedQueriesScore() {
+        return in.includeNamedQueriesScore();
+    }
+
     @Override
     public SearchContext parsedPostFilter(ParsedQuery postFilter) {
         return in.parsedPostFilter(postFilter);

--- a/server/src/main/java/org/opensearch/search/internal/SearchContext.java
+++ b/server/src/main/java/org/opensearch/search/internal/SearchContext.java
@@ -305,6 +305,29 @@ public abstract class SearchContext implements Releasable {
 
     public abstract boolean trackScores();
 
+    /**
+     * Determines whether named queries' scores should be included in the search results.
+     * By default, this is set to return false, indicating that scores from named queries are not included.
+     *
+     * @param includeNamedQueriesScore true to include scores from named queries, false otherwise.
+     */
+    public SearchContext includeNamedQueriesScore(boolean includeNamedQueriesScore) {
+        // Default implementation does nothing and returns this for chaining.
+        // Implementations of SearchContext should override this method to actually store the value.
+        return this;
+    }
+
+    /**
+     * Checks if scores from named queries are included in the search results.
+     *
+     * @return true if scores from named queries are included, false otherwise.
+     */
+    public boolean includeNamedQueriesScore() {
+        // Default implementation returns false.
+        // Implementations of SearchContext should override this method to return the actual value.
+        return false;
+    }
+
     public abstract SearchContext trackTotalHitsUpTo(int trackTotalHits);
 
     /**

--- a/server/src/main/java/org/opensearch/search/internal/SubSearchContext.java
+++ b/server/src/main/java/org/opensearch/search/internal/SubSearchContext.java
@@ -82,6 +82,8 @@ public class SubSearchContext extends FilteredSearchContext {
 
     private boolean explain;
     private boolean trackScores;
+
+    private boolean includeNamedQueriesScore;
     private boolean version;
     private boolean seqNoAndPrimaryTerm;
 
@@ -232,6 +234,17 @@ public class SubSearchContext extends FilteredSearchContext {
     @Override
     public boolean trackScores() {
         return trackScores;
+    }
+
+    @Override
+    public SearchContext includeNamedQueriesScore(boolean includeNamedQueriesScore) {
+        this.includeNamedQueriesScore = includeNamedQueriesScore;
+        return this;
+    }
+
+    @Override
+    public boolean includeNamedQueriesScore() {
+        return includeNamedQueriesScore;
     }
 
     @Override

--- a/server/src/test/java/org/opensearch/search/SearchHitTests.java
+++ b/server/src/test/java/org/opensearch/search/SearchHitTests.java
@@ -242,7 +242,7 @@ public class SearchHitTests extends AbstractWireSerializingTestCase<SearchHit> {
 
     public void testSerializationDeserializationWithMatchedQueriesScores() throws IOException {
         SearchHit searchHit = createTestItemWithMatchedQueriesScores(true, true);
-        SearchHit deserializedSearchHit = copyWriteable(searchHit, getNamedWriteableRegistry(), SearchHit::new, Version.V_3_0_0);
+        SearchHit deserializedSearchHit = copyWriteable(searchHit, getNamedWriteableRegistry(), SearchHit::new, Version.V_2_13_0);
         assertEquals(searchHit, deserializedSearchHit);
         assertEquals(searchHit.getMatchedQueriesAndScores(), deserializedSearchHit.getMatchedQueriesAndScores());
     }
@@ -313,7 +313,7 @@ public class SearchHitTests extends AbstractWireSerializingTestCase<SearchHit> {
 
         SearchHits hits = new SearchHits(new SearchHit[] { hit1, hit2 }, new TotalHits(2, TotalHits.Relation.EQUAL_TO), 1f);
 
-        SearchHits results = copyWriteable(hits, getNamedWriteableRegistry(), SearchHits::new, Version.V_3_0_0);
+        SearchHits results = copyWriteable(hits, getNamedWriteableRegistry(), SearchHits::new, Version.V_2_13_0);
         SearchShardTarget deserializedTarget = results.getAt(0).getShard();
         assertThat(deserializedTarget, equalTo(target));
         assertThat(results.getAt(0).getInnerHits().get("1").getAt(0).getShard(), notNullValue());
@@ -369,7 +369,7 @@ public class SearchHitTests extends AbstractWireSerializingTestCase<SearchHit> {
 
         SearchHits hits = new SearchHits(new SearchHit[] { hit1, hit2 }, new TotalHits(2, TotalHits.Relation.EQUAL_TO), 1f);
 
-        SearchHits results = copyWriteable(hits, getNamedWriteableRegistry(), SearchHits::new, Version.V_3_0_0);
+        SearchHits results = copyWriteable(hits, getNamedWriteableRegistry(), SearchHits::new, Version.V_2_13_0);
         SearchShardTarget deserializedTarget = results.getAt(0).getShard();
         assertThat(deserializedTarget, equalTo(target));
         assertThat(results.getAt(0).getInnerHits().get("1").getAt(0).getShard(), notNullValue());

--- a/test/framework/src/main/java/org/opensearch/test/TestSearchContext.java
+++ b/test/framework/src/main/java/org/opensearch/test/TestSearchContext.java
@@ -107,6 +107,7 @@ public class TestSearchContext extends SearchContext {
     SearchShardTask task;
     SortAndFormats sort;
     boolean trackScores = false;
+    boolean includeNamedQueriesScore = false;
     int trackTotalHitsUpTo = SearchContext.DEFAULT_TRACK_TOTAL_HITS_UP_TO;
 
     ContextIndexSearcher searcher;
@@ -413,6 +414,17 @@ public class TestSearchContext extends SearchContext {
     @Override
     public boolean trackScores() {
         return trackScores;
+    }
+
+    @Override
+    public SearchContext includeNamedQueriesScore(boolean includeNamedQueriesScore) {
+        this.includeNamedQueriesScore = includeNamedQueriesScore;
+        return this;
+    }
+
+    @Override
+    public boolean includeNamedQueriesScore() {
+        return includeNamedQueriesScore;
     }
 
     @Override

--- a/test/framework/src/main/java/org/opensearch/test/hamcrest/OpenSearchAssertions.java
+++ b/test/framework/src/main/java/org/opensearch/test/hamcrest/OpenSearchAssertions.java
@@ -547,6 +547,10 @@ public class OpenSearchAssertions {
         return new OpenSearchMatchers.SearchHitHasScoreMatcher(score);
     }
 
+    public static Matcher<SearchHit> hasMatchedQueries(final String[] matchedQueries) {
+        return new OpenSearchMatchers.SearchHitMatchedQueriesMatcher(matchedQueries);
+    }
+
     public static <T, V> CombinableMatcher<T> hasProperty(Function<? super T, ? extends V> property, Matcher<V> valueMatcher) {
         return OpenSearchMatchers.HasPropertyLambdaMatcher.hasProperty(property, valueMatcher);
     }

--- a/test/framework/src/main/java/org/opensearch/test/hamcrest/OpenSearchMatchers.java
+++ b/test/framework/src/main/java/org/opensearch/test/hamcrest/OpenSearchMatchers.java
@@ -38,6 +38,7 @@ import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.hamcrest.core.CombinableMatcher;
 
+import java.util.Arrays;
 import java.util.function.Function;
 
 public class OpenSearchMatchers {
@@ -108,6 +109,35 @@ public class OpenSearchMatchers {
         @Override
         public void describeTo(final Description description) {
             description.appendText("searchHit score should be ").appendValue(score);
+        }
+    }
+
+    public static class SearchHitMatchedQueriesMatcher extends TypeSafeMatcher<SearchHit> {
+        private String[] matchedQueries;
+
+        public SearchHitMatchedQueriesMatcher(String[] matchedQueries) {
+            this.matchedQueries = matchedQueries;
+        }
+
+        @Override
+        protected boolean matchesSafely(SearchHit searchHit) {
+            String[] searchHitQueries = searchHit.getMatchedQueries();
+            if (matchedQueries == null) {
+                return false;
+            }
+            Arrays.sort(searchHitQueries);
+            Arrays.sort(matchedQueries);
+            return Arrays.equals(searchHitQueries, matchedQueries);
+        }
+
+        @Override
+        public void describeMismatchSafely(final SearchHit searchHit, final Description mismatchDescription) {
+            mismatchDescription.appendText(" matched queries were ").appendValue(Arrays.toString(searchHit.getMatchedQueries()));
+        }
+
+        @Override
+        public void describeTo(final Description description) {
+            description.appendText("searchHit matched queries should be ").appendValue(Arrays.toString(matchedQueries));
         }
     }
 


### PR DESCRIPTION
Opensearch already support labelling the queries, that returns as a list in the returned results, of which query it matched. However one of the use case while doing hybrid search with query text and dense vector is to determine individual scores for each query type. This is very useful in further analysis and building offline model to generate better weights for ranking score. Hence adding this feature that sends the client to add the score for each matched query.

---------




(cherry picked from commit 52b27f47bca5b3ab52cab237542f32c307d203b4)

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
