### PR TITLE
Query-level resource usages instrumentation

### DIFF
--- a/libs/core/src/main/java/org/opensearch/core/tasks/resourcetracker/ResourceUsageInfo.java
+++ b/libs/core/src/main/java/org/opensearch/core/tasks/resourcetracker/ResourceUsageInfo.java
@@ -104,6 +104,10 @@ public class ResourceUsageInfo {
             return endValue.get() - startValue;
         }
 
+        public long getStartValue() {
+            return startValue;
+        }
+
         @Override
         public String toString() {
             return String.valueOf(getTotalValue());

--- a/libs/core/src/main/java/org/opensearch/core/tasks/resourcetracker/TaskResourceInfo.java
+++ b/libs/core/src/main/java/org/opensearch/core/tasks/resourcetracker/TaskResourceInfo.java
@@ -1,0 +1,104 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.core.tasks.resourcetracker;
+
+import org.opensearch.common.annotation.PublicApi;
+import org.opensearch.core.ParseField;
+import org.opensearch.core.common.Strings;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.tasks.TaskId;
+import org.opensearch.core.xcontent.ConstructingObjectParser;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import static org.opensearch.core.xcontent.ConstructingObjectParser.constructorArg;
+
+/**
+ * Task resource usage information with minimal information about the task
+ * <p>
+ * Writeable TaskResourceInfo objects are used to represent resource usage
+ * information of running tasks, which can be propagated to coordinator node
+ * to infer query-level resource usage
+ *
+ *  @opensearch.api
+ */
+@PublicApi(since = "2.1.0")
+public class TaskResourceInfo implements Writeable, ToXContentFragment {
+    public TaskResourceUsage taskResourceUsage;
+    public String action;
+    public long taskId;
+    public long parentTaskId;
+
+    public TaskResourceInfo() {
+        this.action = "";
+        this.taskId = -1L;
+        this.taskResourceUsage = new TaskResourceUsage(0, 0);
+    }
+
+    public TaskResourceInfo(String action, long taskId, long cpuTimeInNanos, long memoryInBytes) {
+        this.action = action;
+        this.taskId = taskId;
+        this.taskResourceUsage = new TaskResourceUsage(cpuTimeInNanos, memoryInBytes);
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public static TaskResourceInfo readFromStream(StreamInput in) throws IOException {
+        TaskResourceInfo info = new TaskResourceInfo();
+        info.action = in.readString();
+        info.taskId = in.readLong();
+        info.taskResourceUsage = TaskResourceUsage.readFromStream(in);
+        info.parentTaskId = in.readLong();
+        return info;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(action);
+        out.writeLong(taskId);
+        taskResourceUsage.writeTo(out);
+        out.writeLong(parentTaskId);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        // TODO: change to a constant
+        builder.field("Action", action);
+        taskResourceUsage.toXContent(builder, params);
+        return builder;
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(MediaTypeRegistry.JSON, this, false, true);
+    }
+
+    // Implements equals and hashcode for testing
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null || obj.getClass() != TaskResourceInfo.class) {
+            return false;
+        }
+        TaskResourceInfo other = (TaskResourceInfo) obj;
+        return action.equals(other.action) && taskId == other.taskId && taskResourceUsage.equals(other.taskResourceUsage);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(action, taskId, taskResourceUsage);
+    }
+}

--- a/libs/core/src/main/java/org/opensearch/core/tasks/resourcetracker/TaskResourceUsage.java
+++ b/libs/core/src/main/java/org/opensearch/core/tasks/resourcetracker/TaskResourceUsage.java
@@ -90,7 +90,7 @@ public class TaskResourceUsage implements Writeable, ToXContentFragment {
 
     @Override
     public String toString() {
-        return Strings.toString(MediaTypeRegistry.JSON, this, true, true);
+        return Strings.toString(MediaTypeRegistry.JSON, this, false, true);
     }
 
     // Implements equals and hashcode for testing

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/CommonAnalysisModulePlugin.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/CommonAnalysisModulePlugin.java
@@ -153,6 +153,7 @@ import org.opensearch.plugins.ScriptPlugin;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.script.ScriptContext;
 import org.opensearch.script.ScriptService;
+import org.opensearch.tasks.TaskResourceTrackingService;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.watcher.ResourceWatcherService;
 
@@ -187,7 +188,8 @@ public class CommonAnalysisModulePlugin extends Plugin implements AnalysisPlugin
         NodeEnvironment nodeEnvironment,
         NamedWriteableRegistry namedWriteableRegistry,
         IndexNameExpressionResolver expressionResolver,
-        Supplier<RepositoriesService> repositoriesServiceSupplier
+        Supplier<RepositoriesService> repositoriesServiceSupplier,
+        TaskResourceTrackingService taskResourceTrackingService
     ) {
         this.scriptService.set(scriptService);
         return Collections.emptyList();

--- a/modules/lang-painless/src/main/java/org/opensearch/painless/PainlessModulePlugin.java
+++ b/modules/lang-painless/src/main/java/org/opensearch/painless/PainlessModulePlugin.java
@@ -66,6 +66,7 @@ import org.opensearch.script.ScriptContext;
 import org.opensearch.script.ScriptEngine;
 import org.opensearch.script.ScriptService;
 import org.opensearch.search.aggregations.pipeline.MovingFunctionScript;
+import org.opensearch.tasks.TaskResourceTrackingService;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.watcher.ResourceWatcherService;
 
@@ -140,7 +141,8 @@ public final class PainlessModulePlugin extends Plugin implements ScriptPlugin, 
         NodeEnvironment nodeEnvironment,
         NamedWriteableRegistry namedWriteableRegistry,
         IndexNameExpressionResolver expressionResolver,
-        Supplier<RepositoriesService> repositoriesServiceSupplier
+        Supplier<RepositoriesService> repositoriesServiceSupplier,
+        TaskResourceTrackingService taskResourceTrackingService
     ) {
         // this is a hack to bind the painless script engine in guice (all components are added to guice), so that
         // the painless context api. this is a temporary measure until transport actions do no require guice

--- a/modules/reindex/src/main/java/org/opensearch/index/reindex/ReindexModulePlugin.java
+++ b/modules/reindex/src/main/java/org/opensearch/index/reindex/ReindexModulePlugin.java
@@ -58,6 +58,7 @@ import org.opensearch.rest.RestController;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.script.ScriptService;
 import org.opensearch.tasks.Task;
+import org.opensearch.tasks.TaskResourceTrackingService;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.watcher.ResourceWatcherService;
 
@@ -122,7 +123,8 @@ public class ReindexModulePlugin extends Plugin implements ActionPlugin, Extensi
         NodeEnvironment nodeEnvironment,
         NamedWriteableRegistry namedWriteableRegistry,
         IndexNameExpressionResolver expressionResolver,
-        Supplier<RepositoriesService> repositoriesServiceSupplier
+        Supplier<RepositoriesService> repositoriesServiceSupplier,
+        TaskResourceTrackingService taskResourceTrackingService
     ) {
         return Collections.singletonList(new ReindexSslConfig(environment.settings(), environment, resourceWatcherService));
     }

--- a/modules/systemd/src/main/java/org/opensearch/systemd/SystemdModulePlugin.java
+++ b/modules/systemd/src/main/java/org/opensearch/systemd/SystemdModulePlugin.java
@@ -47,6 +47,7 @@ import org.opensearch.plugins.ClusterPlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.script.ScriptService;
+import org.opensearch.tasks.TaskResourceTrackingService;
 import org.opensearch.threadpool.Scheduler;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.watcher.ResourceWatcherService;
@@ -100,7 +101,8 @@ public class SystemdModulePlugin extends Plugin implements ClusterPlugin {
         final NodeEnvironment nodeEnvironment,
         final NamedWriteableRegistry namedWriteableRegistry,
         final IndexNameExpressionResolver expressionResolver,
-        final Supplier<RepositoriesService> repositoriesServiceSupplier
+        final Supplier<RepositoriesService> repositoriesServiceSupplier,
+        TaskResourceTrackingService taskResourceTrackingService
     ) {
         if (enabled == false) {
             extender.set(null);

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/QueryInsightsPlugin.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/QueryInsightsPlugin.java
@@ -26,6 +26,7 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.env.Environment;
 import org.opensearch.env.NodeEnvironment;
 import org.opensearch.plugin.insights.core.listener.QueryInsightsListener;
+import org.opensearch.plugin.insights.core.listener.ResourceTrackingListener;
 import org.opensearch.plugin.insights.core.service.QueryInsightsService;
 import org.opensearch.plugin.insights.rules.action.top_queries.TopQueriesAction;
 import org.opensearch.plugin.insights.rules.resthandler.top_queries.RestTopQueriesAction;
@@ -37,6 +38,7 @@ import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.rest.RestController;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.script.ScriptService;
+import org.opensearch.tasks.TaskResourceTrackingService;
 import org.opensearch.threadpool.ExecutorBuilder;
 import org.opensearch.threadpool.ScalingExecutorBuilder;
 import org.opensearch.threadpool.ThreadPool;
@@ -67,11 +69,16 @@ public class QueryInsightsPlugin extends Plugin implements ActionPlugin {
         final NodeEnvironment nodeEnvironment,
         final NamedWriteableRegistry namedWriteableRegistry,
         final IndexNameExpressionResolver indexNameExpressionResolver,
-        final Supplier<RepositoriesService> repositoriesServiceSupplier
+        final Supplier<RepositoriesService> repositoriesServiceSupplier,
+        final TaskResourceTrackingService taskResourceTrackingService
     ) {
         // create top n queries service
         final QueryInsightsService queryInsightsService = new QueryInsightsService(threadPool);
-        return List.of(queryInsightsService, new QueryInsightsListener(clusterService, queryInsightsService));
+        return List.of(
+            queryInsightsService,
+            new QueryInsightsListener(clusterService, queryInsightsService),
+            new ResourceTrackingListener(queryInsightsService, taskResourceTrackingService)
+        );
     }
 
     @Override

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/core/listener/ResourceTrackingListener.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/core/listener/ResourceTrackingListener.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.core.listener;
+
+import org.opensearch.core.tasks.resourcetracker.TaskResourceInfo;
+import org.opensearch.plugin.insights.core.service.QueryInsightsService;
+import org.opensearch.tasks.Task;
+import org.opensearch.tasks.TaskResourceTrackingService;
+import org.opensearch.tasks.TaskResourceTrackingService.TaskCompletionListener;
+import org.opensearch.tasks.TaskResourceTrackingService.TaskStartListener;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ResourceTrackingListener implements TaskCompletionListener, TaskStartListener {
+
+    private final TaskResourceTrackingService taskResourceTrackingService;
+    private final QueryInsightsService queryInsightsService;
+
+    public ResourceTrackingListener (
+        QueryInsightsService queryInsightsService,
+        TaskResourceTrackingService taskResourceTrackingService
+    ) {
+        this.queryInsightsService = queryInsightsService;
+        this.taskResourceTrackingService = taskResourceTrackingService;
+        this.taskResourceTrackingService.addTaskCompletionListener(this);
+        this.taskResourceTrackingService.addTaskStartListener(this);
+    }
+    @Override
+    public void onTaskCompleted(Task task) {
+        TaskResourceInfo info = new TaskResourceInfo();
+        info.taskResourceUsage = task.getTotalResourceStats();
+        info.taskId = task.getId();
+        info.action = task.getAction();
+        info.parentTaskId = task.getParentTaskId().getId();
+        long parentTaskId = task.getParentTaskId().getId();
+        if (parentTaskId == -1) {
+            parentTaskId = task.getId();
+        }
+
+        this.queryInsightsService.taskStatusMap.get(parentTaskId).decrementAndGet();
+        queryInsightsService.taskRecordsQueue.add(info);
+//        System.out.println(String.format("id = %s, parent = %s, resource = %s, action = %s, total CPU and MEM: %s, %s", task.getId(), task.getParentTaskId(), task.getResourceStats(), task.getAction(),task.getTotalResourceUtilization(ResourceStats.CPU),task.getTotalResourceUtilization(ResourceStats.MEMORY) ));
+    }
+
+    @Override
+    public void onTaskStarts(Task task) {
+        long parentId = task.getParentTaskId().getId();
+        if (parentId == -1) {
+            parentId = task.getId();
+        }
+        this.queryInsightsService.taskStatusMap.putIfAbsent(parentId, new AtomicInteger(0));
+        this.queryInsightsService.taskStatusMap.get(parentId).incrementAndGet();
+    }
+}

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
@@ -28,8 +28,9 @@ import java.util.Objects;
  */
 public class SearchQueryRecord implements ToXContentObject, Writeable {
     private final long timestamp;
-    private final Map<MetricType, Number> measurements;
-    private final Map<Attribute, Object> attributes;
+    public long taskId;
+    public Map<MetricType, Number> measurements;
+    public Map<Attribute, Object> attributes;
 
     /**
      * Constructor of SearchQueryRecord

--- a/server/src/main/java/org/opensearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/opensearch/action/search/AbstractSearchAsyncAction.java
@@ -51,6 +51,7 @@ import org.opensearch.common.util.concurrent.AtomicArray;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ShardOperationFailedException;
 import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.core.tasks.resourcetracker.TaskResourceInfo;
 import org.opensearch.search.SearchPhaseResult;
 import org.opensearch.search.SearchShardTarget;
 import org.opensearch.search.internal.AliasFilter;
@@ -807,6 +808,10 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
         // Note that, we have to disable this shortcut for queries that create a context (scroll and search context).
         shardRequest.canReturnNullResponseIfMatchNoDocs(hasShardResponse.get() && shardRequest.scroll() == null);
         return shardRequest;
+    }
+    @Override
+    public List<TaskResourceInfo> getPhaseResourceUsageFromResults() {
+        return results.getAtomicArray().asList().stream().filter(a-> a.remoteAddress() != null).map(a -> a.resourceUsageInfo).collect(Collectors.toList());
     }
 
     /**

--- a/server/src/main/java/org/opensearch/action/search/DfsQueryPhase.java
+++ b/server/src/main/java/org/opensearch/action/search/DfsQueryPhase.java
@@ -32,6 +32,7 @@
 package org.opensearch.action.search;
 
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.opensearch.core.tasks.resourcetracker.TaskResourceInfo;
 import org.opensearch.search.SearchPhaseResult;
 import org.opensearch.search.SearchShardTarget;
 import org.opensearch.search.dfs.AggregatedDfs;
@@ -43,6 +44,7 @@ import org.opensearch.transport.Transport;
 import java.io.IOException;
 import java.util.List;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * This search phase fans out to every shards to execute a distributed search with a pre-collected distributed frequencies for all
@@ -81,6 +83,12 @@ final class DfsQueryPhase extends SearchPhase {
         // register the release of the query consumer to free up the circuit breaker memory
         // at the end of the search
         context.addReleasable(queryResult);
+    }
+
+    // TODO: Need to double check if should get from `searchResults`
+    @Override
+    public List<TaskResourceInfo> getPhaseResourceUsageFromResults() {
+        return searchResults.stream().filter(a-> a.remoteAddress() != null).map(a -> a.resourceUsageInfo).collect(Collectors.toList());
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/search/FetchSearchPhase.java
+++ b/server/src/main/java/org/opensearch/action/search/FetchSearchPhase.java
@@ -37,6 +37,7 @@ import org.apache.lucene.search.ScoreDoc;
 import org.opensearch.action.OriginalIndices;
 import org.opensearch.common.util.concurrent.AbstractRunnable;
 import org.opensearch.common.util.concurrent.AtomicArray;
+import org.opensearch.core.tasks.resourcetracker.TaskResourceInfo;
 import org.opensearch.search.RescoreDocIds;
 import org.opensearch.search.SearchPhaseResult;
 import org.opensearch.search.SearchShardTarget;
@@ -51,6 +52,7 @@ import org.opensearch.transport.Transport;
 
 import java.util.List;
 import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 
 /**
  * This search phase merges the query results from the previous phase together and calculates the topN hits for this search.
@@ -109,6 +111,11 @@ final class FetchSearchPhase extends SearchPhase {
         this.logger = context.getLogger();
         this.resultConsumer = resultConsumer;
         this.progressListener = context.getTask().getProgressListener();
+    }
+
+    @Override
+    public List<TaskResourceInfo> getPhaseResourceUsageFromResults() {
+        return fetchResults.getAtomicArray().asList().stream().filter(a-> a.remoteAddress() != null).map(a -> a.resourceUsageInfo).collect(Collectors.toList());
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/search/SearchPhase.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchPhase.java
@@ -33,8 +33,10 @@ package org.opensearch.action.search;
 
 import org.opensearch.common.CheckedRunnable;
 import org.opensearch.common.annotation.PublicApi;
+import org.opensearch.core.tasks.resourcetracker.TaskResourceInfo;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 
@@ -47,6 +49,10 @@ import java.util.Objects;
 public abstract class SearchPhase implements CheckedRunnable<IOException> {
     private final String name;
     private long startTimeInNanos;
+
+    public List<TaskResourceInfo> getPhaseResourceUsageFromResults() {
+        return List.of();
+    }
 
     protected SearchPhase(String name) {
         this.name = Objects.requireNonNull(name, "name must not be null");

--- a/server/src/main/java/org/opensearch/action/search/TransportCreatePitAction.java
+++ b/server/src/main/java/org/opensearch/action/search/TransportCreatePitAction.java
@@ -121,12 +121,14 @@ public class TransportCreatePitAction extends HandledTransportAction<CreatePitRe
         public CreateReaderContextResponse(StreamInput in) throws IOException {
             super(in);
             contextId = new ShardSearchContextId(in);
+            readResourceUsage(in);
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             contextId.writeTo(out);
+            writeResourceUsage(out);
         }
     }
 

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -864,36 +864,6 @@ public class Node implements Closeable {
                 metadataCreateIndexService
             );
 
-            Collection<Object> pluginComponents = pluginsService.filterPlugins(Plugin.class)
-                .stream()
-                .flatMap(
-                    p -> p.createComponents(
-                        client,
-                        clusterService,
-                        threadPool,
-                        resourceWatcherService,
-                        scriptService,
-                        xContentRegistry,
-                        environment,
-                        nodeEnvironment,
-                        namedWriteableRegistry,
-                        clusterModule.getIndexNameExpressionResolver(),
-                        repositoriesServiceReference::get
-                    ).stream()
-                )
-                .collect(Collectors.toList());
-
-            // register all standard SearchRequestOperationsCompositeListenerFactory to the SearchRequestOperationsCompositeListenerFactory
-            final SearchRequestOperationsCompositeListenerFactory searchRequestOperationsCompositeListenerFactory =
-                new SearchRequestOperationsCompositeListenerFactory(
-                    Stream.concat(
-                        Stream.of(searchRequestStats, searchRequestSlowLog),
-                        pluginComponents.stream()
-                            .filter(p -> p instanceof SearchRequestOperationsListener)
-                            .map(p -> (SearchRequestOperationsListener) p)
-                    ).toArray(SearchRequestOperationsListener[]::new)
-                );
-
             ActionModule actionModule = new ActionModule(
                 settings,
                 clusterModule.getIndexNameExpressionResolver(),
@@ -1024,6 +994,38 @@ public class Node implements Closeable {
                 threadPool,
                 transportService.getTaskManager()
             );
+
+            Collection<Object> pluginComponents = pluginsService.filterPlugins(Plugin.class)
+                .stream()
+                .flatMap(
+                    p -> p.createComponents(
+                        client,
+                        clusterService,
+                        threadPool,
+                        resourceWatcherService,
+                        scriptService,
+                        xContentRegistry,
+                        environment,
+                        nodeEnvironment,
+                        namedWriteableRegistry,
+                        clusterModule.getIndexNameExpressionResolver(),
+                        repositoriesServiceReference::get,
+                        taskResourceTrackingService
+                        ).stream()
+                )
+                .collect(Collectors.toList());
+
+            // register all standard SearchRequestOperationsCompositeListenerFactory to the SearchRequestOperationsCompositeListenerFactory
+            final SearchRequestOperationsCompositeListenerFactory searchRequestOperationsCompositeListenerFactory =
+                new SearchRequestOperationsCompositeListenerFactory(
+                    Stream.concat(
+                        Stream.of(searchRequestStats, searchRequestSlowLog),
+                        pluginComponents.stream()
+                            .filter(p -> p instanceof SearchRequestOperationsListener)
+                            .map(p -> (SearchRequestOperationsListener) p)
+                    ).toArray(SearchRequestOperationsListener[]::new)
+                );
+
 
             final SegmentReplicationStatsTracker segmentReplicationStatsTracker = new SegmentReplicationStatsTracker(indicesService);
             RepositoriesModule repositoriesModule = new RepositoriesModule(

--- a/server/src/main/java/org/opensearch/plugins/Plugin.java
+++ b/server/src/main/java/org/opensearch/plugins/Plugin.java
@@ -56,6 +56,7 @@ import org.opensearch.index.IndexModule;
 import org.opensearch.index.shard.IndexSettingProvider;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.script.ScriptService;
+import org.opensearch.tasks.TaskResourceTrackingService;
 import org.opensearch.threadpool.ExecutorBuilder;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.watcher.ResourceWatcherService;
@@ -150,7 +151,8 @@ public abstract class Plugin implements Closeable {
         NodeEnvironment nodeEnvironment,
         NamedWriteableRegistry namedWriteableRegistry,
         IndexNameExpressionResolver indexNameExpressionResolver,
-        Supplier<RepositoriesService> repositoriesServiceSupplier
+        Supplier<RepositoriesService> repositoriesServiceSupplier,
+        TaskResourceTrackingService taskResourceTrackingService
     ) {
         return Collections.emptyList();
     }

--- a/server/src/main/java/org/opensearch/search/SearchService.java
+++ b/server/src/main/java/org/opensearch/search/SearchService.java
@@ -73,6 +73,7 @@ import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.indices.breaker.CircuitBreakerService;
+import org.opensearch.core.tasks.resourcetracker.ResourceStatsType;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.IndexSettings;
@@ -621,6 +622,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                 final RescoreDocIds rescoreDocIds = context.rescoreDocIds();
                 context.queryResult().setRescoreDocIds(rescoreDocIds);
                 readerContext.setRescoreDocIds(rescoreDocIds);
+                context.queryResult().injectInitialResourceUsage(context);
                 return context.queryResult();
             }
         } catch (Exception e) {
@@ -645,7 +647,9 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             }
             executor.success();
         }
-        return new QueryFetchSearchResult(context.queryResult(), context.fetchResult());
+        QueryFetchSearchResult result = new QueryFetchSearchResult(context.queryResult(), context.fetchResult());
+        result.injectInitialResourceUsage(context);
+        return result;
     }
 
     public void executeQueryPhase(
@@ -784,6 +788,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                     }
                     executor.success();
                 }
+                searchContext.fetchResult().injectInitialResourceUsage(searchContext);
                 return searchContext.fetchResult();
             } catch (Exception e) {
                 assert TransportActions.isShardNotAvailableException(e) == false : new AssertionError(e);
@@ -1005,9 +1010,9 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                 context.size(DEFAULT_SIZE);
             }
             context.setTask(task);
-
             // pre process
             queryPhase.preProcess(context);
+            context.usageInfo = task.getActiveThreadResourceInfo(Thread.currentThread().getId(), ResourceStatsType.WORKER_STATS).getResourceUsageInfo().getStatsInfo();
         } catch (Exception e) {
             context.close();
             throw e;
@@ -1705,6 +1710,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             super(in);
             this.canMatch = in.readBoolean();
             this.estimatedMinAndMax = in.readOptionalWriteable(MinAndMax::new);
+            readResourceUsage(in);
         }
 
         public CanMatchResponse(boolean canMatch, MinAndMax<?> estimatedMinAndMax) {
@@ -1714,8 +1720,11 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
             out.writeBoolean(canMatch);
             out.writeOptionalWriteable(estimatedMinAndMax);
+
+            writeResourceUsage(out);
         }
 
         public boolean canMatch() {

--- a/server/src/main/java/org/opensearch/search/dfs/DfsSearchResult.java
+++ b/server/src/main/java/org/opensearch/search/dfs/DfsSearchResult.java
@@ -81,6 +81,7 @@ public class DfsSearchResult extends SearchPhaseResult {
 
         maxDoc = in.readVInt();
         setShardSearchRequest(in.readOptionalWriteable(ShardSearchRequest::new));
+        readResourceUsage(in);
     }
 
     public DfsSearchResult(ShardSearchContextId contextId, SearchShardTarget shardTarget, ShardSearchRequest shardSearchRequest) {
@@ -133,6 +134,7 @@ public class DfsSearchResult extends SearchPhaseResult {
         writeFieldStats(out, fieldStatistics);
         out.writeVInt(maxDoc);
         out.writeOptionalWriteable(getShardSearchRequest());
+        writeResourceUsage(out);
     }
 
     public static void writeFieldStats(StreamOutput out, final Map<String, CollectionStatistics> fieldStatistics) throws IOException {

--- a/server/src/main/java/org/opensearch/search/fetch/FetchSearchResult.java
+++ b/server/src/main/java/org/opensearch/search/fetch/FetchSearchResult.java
@@ -62,6 +62,7 @@ public final class FetchSearchResult extends SearchPhaseResult {
         super(in);
         contextId = new ShardSearchContextId(in);
         hits = new SearchHits(in);
+        readResourceUsage(in);
     }
 
     public FetchSearchResult(ShardSearchContextId id, SearchShardTarget shardTarget) {
@@ -108,5 +109,6 @@ public final class FetchSearchResult extends SearchPhaseResult {
     public void writeTo(StreamOutput out) throws IOException {
         contextId.writeTo(out);
         hits.writeTo(out);
+        writeResourceUsage(out);
     }
 }

--- a/server/src/main/java/org/opensearch/search/fetch/QueryFetchSearchResult.java
+++ b/server/src/main/java/org/opensearch/search/fetch/QueryFetchSearchResult.java
@@ -55,6 +55,7 @@ public final class QueryFetchSearchResult extends SearchPhaseResult {
         super(in);
         queryResult = new QuerySearchResult(in);
         fetchResult = new FetchSearchResult(in);
+        readResourceUsage(in);
     }
 
     public QueryFetchSearchResult(QuerySearchResult queryResult, FetchSearchResult fetchResult) {
@@ -100,5 +101,6 @@ public final class QueryFetchSearchResult extends SearchPhaseResult {
     public void writeTo(StreamOutput out) throws IOException {
         queryResult.writeTo(out);
         fetchResult.writeTo(out);
+        writeResourceUsage(out);
     }
 }

--- a/server/src/main/java/org/opensearch/search/fetch/ScrollQueryFetchSearchResult.java
+++ b/server/src/main/java/org/opensearch/search/fetch/ScrollQueryFetchSearchResult.java
@@ -54,6 +54,7 @@ public final class ScrollQueryFetchSearchResult extends SearchPhaseResult {
         SearchShardTarget searchShardTarget = new SearchShardTarget(in);
         result = new QueryFetchSearchResult(in);
         setSearchShardTarget(searchShardTarget);
+        readResourceUsage(in);
     }
 
     public ScrollQueryFetchSearchResult(QueryFetchSearchResult result, SearchShardTarget shardTarget) {
@@ -91,5 +92,6 @@ public final class ScrollQueryFetchSearchResult extends SearchPhaseResult {
     public void writeTo(StreamOutput out) throws IOException {
         getSearchShardTarget().writeTo(out);
         result.writeTo(out);
+        writeResourceUsage(out);
     }
 }

--- a/server/src/main/java/org/opensearch/search/internal/SearchContext.java
+++ b/server/src/main/java/org/opensearch/search/internal/SearchContext.java
@@ -43,6 +43,8 @@ import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.lease.Releasables;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.BigArrays;
+import org.opensearch.core.tasks.resourcetracker.ResourceStats;
+import org.opensearch.core.tasks.resourcetracker.ResourceUsageInfo;
 import org.opensearch.index.cache.bitset.BitsetFilterCache;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.MapperService;
@@ -79,6 +81,7 @@ import org.opensearch.search.sort.SortAndFormats;
 import org.opensearch.search.suggest.SuggestionSearchContext;
 
 import java.util.Collection;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -120,6 +123,8 @@ public abstract class SearchContext implements Releasable {
     private InnerHitsContext innerHitsContext;
 
     private volatile boolean searchTimedOut;
+
+    public Map<ResourceStats, ResourceUsageInfo.ResourceStatsInfo> usageInfo = new EnumMap<>(ResourceStats.class);
 
     protected SearchContext() {}
 

--- a/server/src/main/java/org/opensearch/search/query/QuerySearchResult.java
+++ b/server/src/main/java/org/opensearch/search/query/QuerySearchResult.java
@@ -101,6 +101,7 @@ public final class QuerySearchResult extends SearchPhaseResult {
             ShardSearchContextId id = new ShardSearchContextId(in);
             readFromWithId(id, in);
         }
+        readResourceUsage(in);
     }
 
     public QuerySearchResult(ShardSearchContextId contextId, SearchShardTarget shardTarget, ShardSearchRequest shardSearchRequest) {
@@ -375,6 +376,7 @@ public final class QuerySearchResult extends SearchPhaseResult {
             contextId.writeTo(out);
             writeToNoId(out);
         }
+        writeResourceUsage(out);
     }
 
     public void writeToNoId(StreamOutput out) throws IOException {

--- a/server/src/main/java/org/opensearch/search/query/ScrollQuerySearchResult.java
+++ b/server/src/main/java/org/opensearch/search/query/ScrollQuerySearchResult.java
@@ -53,6 +53,7 @@ public final class ScrollQuerySearchResult extends SearchPhaseResult {
         SearchShardTarget shardTarget = new SearchShardTarget(in);
         result = new QuerySearchResult(in);
         setSearchShardTarget(shardTarget);
+        readResourceUsage(in);
     }
 
     public ScrollQuerySearchResult(QuerySearchResult result, SearchShardTarget shardTarget) {
@@ -81,5 +82,6 @@ public final class ScrollQuerySearchResult extends SearchPhaseResult {
     public void writeTo(StreamOutput out) throws IOException {
         getSearchShardTarget().writeTo(out);
         result.writeTo(out);
+        writeResourceUsage(out);
     }
 }

--- a/server/src/main/java/org/opensearch/tasks/Task.java
+++ b/server/src/main/java/org/opensearch/tasks/Task.java
@@ -476,6 +476,18 @@ public class Task {
         throw new IllegalStateException("cannot update final values if active thread resource entry is not present");
     }
 
+    public ThreadResourceInfo getActiveThreadResourceInfo(long threadId, ResourceStatsType statsType) {
+        final List<ThreadResourceInfo> threadResourceInfoList = resourceStats.get(threadId);
+        if (threadResourceInfoList != null) {
+            for (ThreadResourceInfo threadResourceInfo : threadResourceInfoList) {
+                if (threadResourceInfo.getStatsType() == statsType && threadResourceInfo.isActive()) {
+                    return threadResourceInfo;
+                }
+            }
+        }
+        return null;
+    }
+
     /**
      * Individual tasks can override this if they want to support task resource tracking. We just need to make sure that
      * the ThreadPool on which the task runs on have runnable wrapper similar to


### PR DESCRIPTION
Bare minimum changes to:
- Instrument resource usages before a task finishes on a data node, more specifically, get resource usages at the last step (serialization) before a phase response is sent from query/fetch/.. phase.
- Piggyback the resource usages data with phase results.
- Gather resource usages for all shard search tasks on coordinator node (in query insights plugin) to get the query-level resource usage.

This draft only added instrumentation for query phase and fetch phase.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
