### PR TITLE
Accurate query-level resource usages instrumentation on Cluster Manager

### DIFF
--- a/libs/core/src/main/java/org/opensearch/core/tasks/resourcetracker/TaskResourceUsage.java
+++ b/libs/core/src/main/java/org/opensearch/core/tasks/resourcetracker/TaskResourceUsage.java
@@ -90,7 +90,8 @@ public class TaskResourceUsage implements Writeable, ToXContentFragment {
 
     @Override
     public String toString() {
-        return Strings.toString(MediaTypeRegistry.JSON, this, true, true);
+        // TODO revert after debugging
+        return Strings.toString(MediaTypeRegistry.JSON, this, false, true);
     }
 
     // Implements equals and hashcode for testing

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/CommonAnalysisModulePlugin.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/CommonAnalysisModulePlugin.java
@@ -153,6 +153,7 @@ import org.opensearch.plugins.ScriptPlugin;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.script.ScriptContext;
 import org.opensearch.script.ScriptService;
+import org.opensearch.tasks.TaskResourceTrackingService;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.watcher.ResourceWatcherService;
 
@@ -187,7 +188,8 @@ public class CommonAnalysisModulePlugin extends Plugin implements AnalysisPlugin
         NodeEnvironment nodeEnvironment,
         NamedWriteableRegistry namedWriteableRegistry,
         IndexNameExpressionResolver expressionResolver,
-        Supplier<RepositoriesService> repositoriesServiceSupplier
+        Supplier<RepositoriesService> repositoriesServiceSupplier,
+        TaskResourceTrackingService taskResourceTrackingService
     ) {
         this.scriptService.set(scriptService);
         return Collections.emptyList();

--- a/modules/lang-painless/src/main/java/org/opensearch/painless/PainlessModulePlugin.java
+++ b/modules/lang-painless/src/main/java/org/opensearch/painless/PainlessModulePlugin.java
@@ -66,6 +66,7 @@ import org.opensearch.script.ScriptContext;
 import org.opensearch.script.ScriptEngine;
 import org.opensearch.script.ScriptService;
 import org.opensearch.search.aggregations.pipeline.MovingFunctionScript;
+import org.opensearch.tasks.TaskResourceTrackingService;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.watcher.ResourceWatcherService;
 
@@ -140,7 +141,8 @@ public final class PainlessModulePlugin extends Plugin implements ScriptPlugin, 
         NodeEnvironment nodeEnvironment,
         NamedWriteableRegistry namedWriteableRegistry,
         IndexNameExpressionResolver expressionResolver,
-        Supplier<RepositoriesService> repositoriesServiceSupplier
+        Supplier<RepositoriesService> repositoriesServiceSupplier,
+        TaskResourceTrackingService taskResourceTrackingService
     ) {
         // this is a hack to bind the painless script engine in guice (all components are added to guice), so that
         // the painless context api. this is a temporary measure until transport actions do no require guice

--- a/modules/reindex/src/main/java/org/opensearch/index/reindex/ReindexModulePlugin.java
+++ b/modules/reindex/src/main/java/org/opensearch/index/reindex/ReindexModulePlugin.java
@@ -58,6 +58,7 @@ import org.opensearch.rest.RestController;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.script.ScriptService;
 import org.opensearch.tasks.Task;
+import org.opensearch.tasks.TaskResourceTrackingService;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.watcher.ResourceWatcherService;
 
@@ -122,7 +123,8 @@ public class ReindexModulePlugin extends Plugin implements ActionPlugin, Extensi
         NodeEnvironment nodeEnvironment,
         NamedWriteableRegistry namedWriteableRegistry,
         IndexNameExpressionResolver expressionResolver,
-        Supplier<RepositoriesService> repositoriesServiceSupplier
+        Supplier<RepositoriesService> repositoriesServiceSupplier,
+        TaskResourceTrackingService taskResourceTrackingService
     ) {
         return Collections.singletonList(new ReindexSslConfig(environment.settings(), environment, resourceWatcherService));
     }

--- a/modules/systemd/src/main/java/org/opensearch/systemd/SystemdModulePlugin.java
+++ b/modules/systemd/src/main/java/org/opensearch/systemd/SystemdModulePlugin.java
@@ -47,6 +47,7 @@ import org.opensearch.plugins.ClusterPlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.script.ScriptService;
+import org.opensearch.tasks.TaskResourceTrackingService;
 import org.opensearch.threadpool.Scheduler;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.watcher.ResourceWatcherService;
@@ -100,7 +101,8 @@ public class SystemdModulePlugin extends Plugin implements ClusterPlugin {
         final NodeEnvironment nodeEnvironment,
         final NamedWriteableRegistry namedWriteableRegistry,
         final IndexNameExpressionResolver expressionResolver,
-        final Supplier<RepositoriesService> repositoriesServiceSupplier
+        final Supplier<RepositoriesService> repositoriesServiceSupplier,
+        TaskResourceTrackingService taskResourceTrackingService
     ) {
         if (enabled == false) {
             extender.set(null);

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/core/listener/ResourceTrackingListener.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/core/listener/ResourceTrackingListener.java
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.core.listener;
+
+import org.opensearch.core.tasks.resourcetracker.ResourceStats;
+import org.opensearch.plugin.insights.core.service.QueryInsightsService;
+import org.opensearch.plugin.insights.rules.model.SearchTaskMetadata;
+import org.opensearch.tasks.Task;
+import org.opensearch.tasks.TaskResourceTrackingService;
+import org.opensearch.tasks.TaskResourceTrackingService.TaskCompletionListener;
+import org.opensearch.tasks.TaskResourceTrackingService.TaskStartListener;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ResourceTrackingListener implements TaskCompletionListener, TaskStartListener {
+
+    private final TaskResourceTrackingService taskResourceTrackingService;
+    private final QueryInsightsService queryInsightsService;
+
+    public ResourceTrackingListener (
+        QueryInsightsService queryInsightsService,
+        TaskResourceTrackingService taskResourceTrackingService
+    ) {
+        this.queryInsightsService = queryInsightsService;
+        this.taskResourceTrackingService = taskResourceTrackingService;
+        this.taskResourceTrackingService.addTaskCompletionListener(this);
+        this.taskResourceTrackingService.addTaskStartListener(this);
+    }
+    @Override
+    public void onTaskCompleted(Task task) {
+        long taskGroupId = task.getParentTaskId().getId();
+        if (taskGroupId == -1) {
+            taskGroupId = task.getId();
+        }
+        SearchTaskMetadata info = new SearchTaskMetadata(
+            task.getAction(), task.getId(), taskGroupId, task.getTotalResourceStats()
+        );
+
+        int pendingTaskCount = this.queryInsightsService.taskStatusMap.get(taskGroupId).decrementAndGet();
+        if (pendingTaskCount == 0) {
+            this.queryInsightsService.taskStatusMap.remove(taskGroupId);
+        }
+        queryInsightsService.taskRecordsQueue.add(info);
+        System.out.println(String.format("id = %s, parent = %s, resource = %s, action = %s, total CPU and MEM: %s, %s", task.getId(), task.getParentTaskId(), task.getResourceStats(), task.getAction(),task.getTotalResourceUtilization(ResourceStats.CPU),task.getTotalResourceUtilization(ResourceStats.MEMORY) ));
+    }
+
+    @Override
+    public void onTaskStarts(Task task) {
+        long taskGroupId = task.getParentTaskId().getId();
+        if (taskGroupId == -1) {
+            taskGroupId = task.getId();
+        }
+        this.queryInsightsService.taskStatusMap.putIfAbsent(taskGroupId, new AtomicInteger(0));
+        this.queryInsightsService.taskStatusMap.get(taskGroupId).incrementAndGet();
+    }
+}

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/SearchMetadata.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/SearchMetadata.java
@@ -1,0 +1,90 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.action.top_queries;
+
+import org.opensearch.action.support.nodes.BaseNodeResponse;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.annotation.PublicApi;
+import org.opensearch.core.common.Strings;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.tasks.resourcetracker.TaskResourceUsage;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
+import org.opensearch.plugin.insights.rules.model.SearchTaskMetadata;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Task resource usage information with minimal information about the task
+ * <p>
+ * Writeable TaskResourceInfo objects are used to represent resource usage
+ * information of running tasks, which can be propagated to coordinator node
+ * to infer query-level resource usage
+ *
+ *  @opensearch.api
+ */
+@PublicApi(since = "2.1.0")
+public class SearchMetadata extends BaseNodeResponse implements Writeable, ToXContentObject {
+    public List<SearchQueryRecord> queryRecordList;
+    public List<SearchTaskMetadata> taskMetadataList;
+    public Map<Long, Integer> taskStatusMap;
+
+    /**
+     * Create the TopQueries Object from StreamInput
+     * @param in A {@link StreamInput} object.
+     * @throws IOException IOException
+     */
+    public SearchMetadata(final StreamInput in) throws IOException {
+        super(in);
+        queryRecordList = in.readList(SearchQueryRecord::new);
+        taskMetadataList = in.readList(SearchTaskMetadata::new);
+        taskStatusMap = in.readMap(StreamInput::readLong, StreamInput::readInt);
+    }
+
+    /**
+     * Create the TopQueries Object
+     * @param node A node that is part of the cluster.
+     * @param taskMetadataList A list of SearchQueryRecord associated in this TopQueries.
+     */
+    public SearchMetadata(final DiscoveryNode node, List<SearchQueryRecord> queryRecordList, List<SearchTaskMetadata> taskMetadataList, Map<Long, Integer> taskStatusMap) {
+        super(node);
+        this.queryRecordList = queryRecordList;
+        this.taskMetadataList = taskMetadataList;
+        this.taskStatusMap = taskStatusMap;
+
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeList(queryRecordList);
+        out.writeList(taskMetadataList);
+        out.writeMap(taskStatusMap, StreamOutput::writeLong, StreamOutput::writeInt);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        if (taskMetadataList != null) {
+            for (SearchTaskMetadata metadata : taskMetadataList) {
+                metadata.toXContent(builder, params);
+            }
+        }
+        return builder.endObject();
+    }
+}

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/SearchMetadataAction.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/SearchMetadataAction.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.action.top_queries;
+
+import org.opensearch.action.ActionType;
+
+/**
+ * Transport action for cluster/node level top queries information.
+ *
+ * @opensearch.internal
+ */
+public class SearchMetadataAction extends ActionType<SearchMetadataResponse> {
+
+    /**
+     * The TopQueriesAction Instance.
+     */
+    public static final SearchMetadataAction INSTANCE = new SearchMetadataAction();
+    /**
+     * The name of this Action
+     */
+    public static final String NAME = "cluster:admin/opensearch/insights/search_metadata";
+
+    private SearchMetadataAction() {
+        super(NAME, SearchMetadataResponse::new);
+    }
+}

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/SearchMetadataRequest.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/SearchMetadataRequest.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.action.top_queries;
+
+import org.opensearch.action.support.nodes.BaseNodesRequest;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.plugin.insights.rules.model.MetricType;
+
+import java.io.IOException;
+
+/**
+ * A request to get cluster/node level top queries information.
+ *
+ * @opensearch.internal
+ */
+public class SearchMetadataRequest extends BaseNodesRequest<SearchMetadataRequest> {
+
+    /**
+     * Constructor for TopQueriesRequest
+     *
+     * @param in A {@link StreamInput} object.
+     * @throws IOException if the stream cannot be deserialized.
+     */
+    public SearchMetadataRequest(final StreamInput in) throws IOException {
+        super(in);
+    }
+
+    /**
+     * Get top queries from nodes based on the nodes ids specified.
+     * If none are passed, cluster level top queries will be returned.
+     *
+     * @param nodesIds the nodeIds specified in the request
+     */
+    // TODO remove this
+    public SearchMetadataRequest(final String... nodesIds) {
+        super(nodesIds);
+    }
+
+    @Override
+    public void writeTo(final StreamOutput out) throws IOException {
+        super.writeTo(out);
+    }
+}

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/MetricType.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/MetricType.java
@@ -110,10 +110,9 @@ public enum MetricType implements Comparator<Number> {
     Number parseValue(final Object o) {
         switch (this) {
             case LATENCY:
-                return (Long) o;
             case JVM:
             case CPU:
-                return (Double) o;
+                return (Long) o;
             default:
                 return (Number) o;
         }

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/SearchTaskMetadata.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/SearchTaskMetadata.java
@@ -1,0 +1,101 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.model;
+
+import org.opensearch.common.annotation.PublicApi;
+import org.opensearch.core.common.Strings;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.tasks.resourcetracker.TaskResourceUsage;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Task resource usage information with minimal information about the task
+ * <p>
+ * Writeable TaskResourceInfo objects are used to represent resource usage
+ * information of running tasks, which can be propagated to coordinator node
+ * to infer query-level resource usage
+ *
+ *  @opensearch.api
+ */
+@PublicApi(since = "2.1.0")
+public class SearchTaskMetadata implements Writeable, ToXContentObject {
+    public TaskResourceUsage taskResourceUsage;
+    public String action;
+    public long taskId;
+    public long parentTaskId;
+
+
+    /**
+     * Create the TopQueries Object from StreamInput
+     * @param in A {@link StreamInput} object.
+     * @throws IOException IOException
+     */
+    public SearchTaskMetadata(final StreamInput in) throws IOException {
+        action = in.readString();
+        taskId = in.readLong();
+        taskResourceUsage = TaskResourceUsage.readFromStream(in);
+        parentTaskId = in.readLong();
+    }
+
+    /**
+     * Create the TopQueries Object
+     */
+    public SearchTaskMetadata(String action, long taskId, long parentTaskId, TaskResourceUsage taskResourceUsage) {
+        this.action = action;
+        this.taskId = taskId;
+        this.taskResourceUsage = taskResourceUsage;
+        this.parentTaskId = parentTaskId;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(action);
+        out.writeLong(taskId);
+        taskResourceUsage.writeTo(out);
+        out.writeLong(parentTaskId);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        // TODO: change to a constant
+        builder.field("Action", action);
+        builder.field("TaskId", taskId);
+        builder.field("ParentTaskId", parentTaskId);
+        taskResourceUsage.toXContent(builder, params);
+        return builder.endObject();
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(MediaTypeRegistry.JSON, this, false, true);
+    }
+
+    // Implements equals and hashcode for testing
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null || obj.getClass() != SearchTaskMetadata.class) {
+            return false;
+        }
+        SearchTaskMetadata other = (SearchTaskMetadata) obj;
+        return action.equals(other.action) && taskId == other.taskId && taskResourceUsage.equals(other.taskResourceUsage);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(action, taskId, taskResourceUsage);
+    }
+}

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/transport/top_queries/TransportSearchMetadataAction.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/transport/top_queries/TransportSearchMetadataAction.java
@@ -1,0 +1,142 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.transport.top_queries;
+
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.nodes.TransportNodesAction;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.plugin.insights.core.service.QueryInsightsService;
+import org.opensearch.plugin.insights.rules.action.top_queries.SearchMetadata;
+import org.opensearch.plugin.insights.rules.action.top_queries.SearchMetadataAction;
+import org.opensearch.plugin.insights.rules.action.top_queries.SearchMetadataRequest;
+import org.opensearch.plugin.insights.rules.action.top_queries.SearchMetadataResponse;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportRequest;
+import org.opensearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Transport action for cluster/node level top queries information.
+ *
+ * @opensearch.internal
+ */
+public class TransportSearchMetadataAction extends TransportNodesAction<
+    SearchMetadataRequest,
+    SearchMetadataResponse,
+    TransportSearchMetadataAction.NodeRequest,
+    SearchMetadata> {
+
+    private final QueryInsightsService queryInsightsService;
+
+    /**
+     * Create the TransportTopQueriesAction Object
+
+     * @param threadPool The OpenSearch thread pool to run async tasks
+     * @param clusterService The clusterService of this node
+     * @param transportService The TransportService of this node
+     * @param queryInsightsService The topQueriesByLatencyService associated with this Transport Action
+     * @param actionFilters the action filters
+     */
+    @Inject
+    public TransportSearchMetadataAction(
+        final ThreadPool threadPool,
+        final ClusterService clusterService,
+        final TransportService transportService,
+        final QueryInsightsService queryInsightsService,
+        final ActionFilters actionFilters
+    ) {
+        super(
+            SearchMetadataAction.NAME,
+            threadPool,
+            clusterService,
+            transportService,
+            actionFilters,
+            SearchMetadataRequest::new,
+            NodeRequest::new,
+            ThreadPool.Names.GENERIC,
+            SearchMetadata.class
+        );
+        this.queryInsightsService = queryInsightsService;
+    }
+
+    @Override
+    protected SearchMetadataResponse newResponse(
+        final SearchMetadataRequest searchMetadataRequest,
+        final List<SearchMetadata> responses,
+        final List<FailedNodeException> failures
+    ) {
+        return new SearchMetadataResponse(
+            clusterService.getClusterName(),
+            responses,
+            failures
+        );
+    }
+
+    @Override
+    protected NodeRequest newNodeRequest(final SearchMetadataRequest request) {
+        return new NodeRequest(request);
+    }
+
+    @Override
+    protected SearchMetadata newNodeResponse(final StreamInput in) throws IOException {
+        return new SearchMetadata(in);
+    }
+
+    @Override
+    protected SearchMetadata nodeOperation(final NodeRequest nodeRequest) {
+        final SearchMetadataRequest request = nodeRequest.request;
+        return new SearchMetadata(
+            clusterService.localNode(),
+            queryInsightsService.getQueryRecordsList(),
+            queryInsightsService.getTaskRecordsList(),
+            queryInsightsService.getTaskStatusMap()
+        );
+    }
+
+    /**
+     * Inner Node Top Queries Request
+     *
+     * @opensearch.internal
+     */
+    public static class NodeRequest extends TransportRequest {
+
+        final SearchMetadataRequest request;
+
+        /**
+         * Create the NodeResponse object from StreamInput
+         *
+         * @param in the StreamInput to read the object
+         * @throws IOException IOException
+         */
+        public NodeRequest(StreamInput in) throws IOException {
+            super(in);
+            request = new SearchMetadataRequest(in);
+        }
+
+        /**
+         * Create the NodeResponse object from a TopQueriesRequest
+         * @param request the TopQueriesRequest object
+         */
+        public NodeRequest(final SearchMetadataRequest request) {
+            this.request = request;
+        }
+
+        @Override
+        public void writeTo(final StreamOutput out) throws IOException {
+            super.writeTo(out);
+            request.writeTo(out);
+        }
+    }
+}

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
@@ -38,7 +38,8 @@ public class QueryInsightsSettings {
     /**
      * Time interval for record queue consumer to run
      */
-    public static final TimeValue QUERY_RECORD_QUEUE_DRAIN_INTERVAL = new TimeValue(5, TimeUnit.SECONDS);
+    // TODO revert after debugging
+    public static final TimeValue QUERY_RECORD_QUEUE_DRAIN_INTERVAL = new TimeValue(10, TimeUnit.SECONDS);
     /**
      * Default Values and Settings
      */

--- a/server/src/main/java/org/opensearch/action/search/FetchSearchPhase.java
+++ b/server/src/main/java/org/opensearch/action/search/FetchSearchPhase.java
@@ -110,7 +110,6 @@ final class FetchSearchPhase extends SearchPhase {
         this.resultConsumer = resultConsumer;
         this.progressListener = context.getTask().getProgressListener();
     }
-
     @Override
     public void run() {
         context.execute(new AbstractRunnable() {

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -864,36 +864,6 @@ public class Node implements Closeable {
                 metadataCreateIndexService
             );
 
-            Collection<Object> pluginComponents = pluginsService.filterPlugins(Plugin.class)
-                .stream()
-                .flatMap(
-                    p -> p.createComponents(
-                        client,
-                        clusterService,
-                        threadPool,
-                        resourceWatcherService,
-                        scriptService,
-                        xContentRegistry,
-                        environment,
-                        nodeEnvironment,
-                        namedWriteableRegistry,
-                        clusterModule.getIndexNameExpressionResolver(),
-                        repositoriesServiceReference::get
-                    ).stream()
-                )
-                .collect(Collectors.toList());
-
-            // register all standard SearchRequestOperationsCompositeListenerFactory to the SearchRequestOperationsCompositeListenerFactory
-            final SearchRequestOperationsCompositeListenerFactory searchRequestOperationsCompositeListenerFactory =
-                new SearchRequestOperationsCompositeListenerFactory(
-                    Stream.concat(
-                        Stream.of(searchRequestStats, searchRequestSlowLog),
-                        pluginComponents.stream()
-                            .filter(p -> p instanceof SearchRequestOperationsListener)
-                            .map(p -> (SearchRequestOperationsListener) p)
-                    ).toArray(SearchRequestOperationsListener[]::new)
-                );
-
             ActionModule actionModule = new ActionModule(
                 settings,
                 clusterModule.getIndexNameExpressionResolver(),
@@ -1024,6 +994,38 @@ public class Node implements Closeable {
                 threadPool,
                 transportService.getTaskManager()
             );
+
+            Collection<Object> pluginComponents = pluginsService.filterPlugins(Plugin.class)
+                .stream()
+                .flatMap(
+                    p -> p.createComponents(
+                        client,
+                        clusterService,
+                        threadPool,
+                        resourceWatcherService,
+                        scriptService,
+                        xContentRegistry,
+                        environment,
+                        nodeEnvironment,
+                        namedWriteableRegistry,
+                        clusterModule.getIndexNameExpressionResolver(),
+                        repositoriesServiceReference::get,
+                        taskResourceTrackingService
+                        ).stream()
+                )
+                .collect(Collectors.toList());
+
+            // register all standard SearchRequestOperationsCompositeListenerFactory to the SearchRequestOperationsCompositeListenerFactory
+            final SearchRequestOperationsCompositeListenerFactory searchRequestOperationsCompositeListenerFactory =
+                new SearchRequestOperationsCompositeListenerFactory(
+                    Stream.concat(
+                        Stream.of(searchRequestStats, searchRequestSlowLog),
+                        pluginComponents.stream()
+                            .filter(p -> p instanceof SearchRequestOperationsListener)
+                            .map(p -> (SearchRequestOperationsListener) p)
+                    ).toArray(SearchRequestOperationsListener[]::new)
+                );
+
 
             final SegmentReplicationStatsTracker segmentReplicationStatsTracker = new SegmentReplicationStatsTracker(indicesService);
             RepositoriesModule repositoriesModule = new RepositoriesModule(

--- a/server/src/main/java/org/opensearch/plugins/Plugin.java
+++ b/server/src/main/java/org/opensearch/plugins/Plugin.java
@@ -56,6 +56,7 @@ import org.opensearch.index.IndexModule;
 import org.opensearch.index.shard.IndexSettingProvider;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.script.ScriptService;
+import org.opensearch.tasks.TaskResourceTrackingService;
 import org.opensearch.threadpool.ExecutorBuilder;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.watcher.ResourceWatcherService;
@@ -150,7 +151,8 @@ public abstract class Plugin implements Closeable {
         NodeEnvironment nodeEnvironment,
         NamedWriteableRegistry namedWriteableRegistry,
         IndexNameExpressionResolver indexNameExpressionResolver,
-        Supplier<RepositoriesService> repositoriesServiceSupplier
+        Supplier<RepositoriesService> repositoriesServiceSupplier,
+        TaskResourceTrackingService taskResourceTrackingService
     ) {
         return Collections.emptyList();
     }

--- a/server/src/main/java/org/opensearch/tasks/TaskResourceTrackingService.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskResourceTrackingService.java
@@ -56,6 +56,7 @@ public class TaskResourceTrackingService implements RunnableTaskExecutionListene
 
     private final ConcurrentMapLong<Task> resourceAwareTasks = ConcurrentCollections.newConcurrentMapLongWithAggressiveConcurrency();
     private final List<TaskCompletionListener> taskCompletionListeners = new ArrayList<>();
+    private final List<TaskStartListener> taskStartListeners = new ArrayList<>();
     private final ThreadPool threadPool;
     private volatile boolean taskResourceTrackingEnabled;
 
@@ -96,6 +97,17 @@ public class TaskResourceTrackingService implements RunnableTaskExecutionListene
 
         logger.debug("Starting resource tracking for task: {}", task.getId());
         resourceAwareTasks.put(task.getId(), task);
+
+        List<Exception> exceptions = new ArrayList<>();
+        for (TaskStartListener listener : taskStartListeners) {
+            try {
+                listener.onTaskStarts(task);
+            } catch (Exception e) {
+                exceptions.add(e);
+            }
+        }
+        ExceptionsHelper.maybeThrowRuntimeAndSuppress(exceptions);
+
         return addTaskIdToThreadContext(task);
     }
 
@@ -268,7 +280,17 @@ public class TaskResourceTrackingService implements RunnableTaskExecutionListene
         void onTaskCompleted(Task task);
     }
 
+    /**
+     * Listener that gets invoked when a task execution starts.
+     */
+    public interface TaskStartListener {
+        void onTaskStarts(Task task);
+    }
+
     public void addTaskCompletionListener(TaskCompletionListener listener) {
         this.taskCompletionListeners.add(listener);
+    }
+    public void addTaskStartListener(TaskStartListener listener) {
+        this.taskStartListeners.add(listener);
     }
 }


### PR DESCRIPTION
Accurate instrumentation: correlate queries and tasks results on cluster manager node. More specifically, this PR:
- Move the top N queries processing logic from each coordinator node to cluster manager node only
- Cluster manager node is now responsible for fetching query level information and task level resource usage information from each data node, and correlated them to calculate accurate query-level top n resource usage information
- Altered the Top N queries API to propergate `_insights/top_queries` api to cluser manager node only.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
