### PR TITLE
[Remote Store] Add support for randomizing Remote Store enabled testing.

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/index/engine/MaxDocsLimitIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/engine/MaxDocsLimitIT.java
@@ -80,6 +80,11 @@ public class MaxDocsLimitIT extends OpenSearchIntegTestCase {
     }
 
     @Override
+    public boolean useRemoteBackedStorageRandomly() {
+        return true;
+    }
+
+    @Override
     protected boolean addMockInternalEngine() {
         return false;
     }

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
@@ -371,6 +371,10 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
      */
     public static final String TESTS_CLUSTER_NAME = "tests.clustername";
 
+    protected static final String REMOTE_BACKED_STORAGE_REPOSITORY_NAME = "test-remote-store-repo";
+
+    private Path remoteStoreRepositoryPath;
+
     @BeforeClass
     public static void beforeClass() throws Exception {
         testClusterRule.beforeClass();
@@ -1896,6 +1900,17 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
             logger.info("Randomly using Replication Strategy as {}.", replicationType.toString());
             builder.put(CLUSTER_REPLICATION_TYPE_SETTING.getKey(), replicationType);
         }
+
+        if (useRemoteBackedStorageRandomly()) {
+            boolean remoteBackedStorageEnabled = randomBoolean();
+            logger.info("Remote Backed Storage (Remote Store) is set to {}.", remoteBackedStorageEnabled);
+            if (remoteBackedStorageEnabled) {
+                if (remoteStoreRepositoryPath == null) {
+                    remoteStoreRepositoryPath = randomRepoPath().toAbsolutePath();
+                }
+                 builder.put(remoteStoreClusterSettings(REMOTE_BACKED_STORAGE_REPOSITORY_NAME, remoteStoreRepositoryPath));
+            }
+        }
         return builder.build();
     }
 
@@ -1905,6 +1920,10 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
      * Should be used only on test classes where replication strategy is not critical for tests.
      */
     protected boolean useRandomReplicationStrategy() {
+        return false;
+    }
+
+    protected boolean useRemoteBackedStorageRandomly() {
         return false;
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR enables the support for randomizing Remote Store enabled testing. This helps to increase the Remote Store test coverage by randomly using remote backed storage for tests not critical of remote store.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
