### PR TITLE
Do not request "search_pipelines" metrics by default in NodesInfoRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add task completion count in search backpressure stats API ([#10028](https://github.com/opensearch-project/OpenSearch/pull/10028/))
 - Deprecate CamelCase `PathHierarchy` tokenizer name in favor to lowercase `path_hierarchy` ([#10894](https://github.com/opensearch-project/OpenSearch/pull/10894))
 - Switched to more reliable OpenSearch Lucene snapshot location([#11728](https://github.com/opensearch-project/OpenSearch/pull/11728))
+- Breaking change: Do not request "search_pipelines" metrics by default in NodesInfoRequest ([#12497](https://github.com/opensearch-project/OpenSearch/pull/12497))
 
 ### Deprecated
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/info/NodesInfoRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/info/NodesInfoRequest.java
@@ -53,7 +53,7 @@ import java.util.stream.Collectors;
 @PublicApi(since = "1.0.0")
 public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
 
-    private Set<String> requestedMetrics = Metric.allMetrics();
+    private Set<String> requestedMetrics = Metric.defaultMetrics();
 
     /**
      * Create a new NodeInfoRequest from a {@link StreamInput} object.
@@ -73,7 +73,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      */
     public NodesInfoRequest(String... nodesIds) {
         super(nodesIds);
-        all();
+        defaultMetrics();
     }
 
     /**
@@ -85,10 +85,21 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
     }
 
     /**
-     * Sets to return all the data.
+     * Sets to return data for all the metrics.
+     * See {@link Metric}
      */
     public NodesInfoRequest all() {
         requestedMetrics.addAll(Metric.allMetrics());
+        return this;
+    }
+
+    /**
+     * Sets to return data for default metrics only.
+     * See {@link Metric}
+     * See {@link Metric#defaultMetrics()}.
+     */
+    public NodesInfoRequest defaultMetrics() {
+        requestedMetrics.addAll(Metric.defaultMetrics());
         return this;
     }
 
@@ -156,7 +167,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
 
     /**
      * An enumeration of the "core" sections of metrics that may be requested
-     * from the nodes information endpoint. Eventually this list list will be
+     * from the nodes information endpoint. Eventually this list will be
      * pluggable.
      */
     public enum Metric {
@@ -187,8 +198,25 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
             return metricNames.contains(this.metricName());
         }
 
+        /**
+         * Return all available metrics.
+         * See {@link Metric}
+         */
         public static Set<String> allMetrics() {
             return Arrays.stream(values()).map(Metric::metricName).collect(Collectors.toSet());
+        }
+
+        /**
+         * Return "the default" set of metrics.
+         * Similar to {@link #allMetrics()} except {@link Metric#SEARCH_PIPELINES} metric is not included.
+         * <br>
+         * The motivation to define the default set of metrics was to keep the default response
+         * size at bay. Metrics that are NOT included in the default set were typically introduced later
+         * and are considered to contain specific type of information that is not usually useful unless you
+         * know that you really need it.
+         */
+        public static Set<String> defaultMetrics() {
+            return allMetrics().stream().filter(metric -> !(metric.equals(SEARCH_PIPELINES.metricName()))).collect(Collectors.toSet());
         }
     }
 }

--- a/server/src/main/java/org/opensearch/action/search/PutSearchPipelineTransportAction.java
+++ b/server/src/main/java/org/opensearch/action/search/PutSearchPipelineTransportAction.java
@@ -82,7 +82,7 @@ public class PutSearchPipelineTransportAction extends TransportClusterManagerNod
         ClusterState state,
         ActionListener<AcknowledgedResponse> listener
     ) throws Exception {
-        NodesInfoRequest nodesInfoRequest = new NodesInfoRequest();
+        NodesInfoRequest nodesInfoRequest = new NodesInfoRequest().clear().addMetric(NodesInfoRequest.Metric.SEARCH_PIPELINES.metricName());
         client.admin().cluster().nodesInfo(nodesInfoRequest, ActionListener.wrap(nodeInfos -> {
             Map<DiscoveryNode, SearchPipelineInfo> searchPipelineInfos = new HashMap<>();
             for (NodeInfo nodeInfo : nodeInfos.getNodes()) {

--- a/server/src/test/java/org/opensearch/action/admin/cluster/node/info/NodesInfoRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/node/info/NodesInfoRequestTests.java
@@ -86,15 +86,18 @@ public class NodesInfoRequestTests extends OpenSearchTestCase {
     }
 
     /**
-     * Test that a newly constructed NodesInfoRequestObject requests all of the
-     * possible metrics defined in {@link NodesInfoRequest.Metric}.
+     * Test that a newly constructed NodesInfoRequestObject does not request all the
+     * possible metrics defined in {@link NodesInfoRequest.Metric} but only the default metrics
+     * according to {@link NodesInfoRequest.Metric#defaultMetrics()}.
      */
     public void testNodesInfoRequestDefaults() {
-        NodesInfoRequest defaultNodesInfoRequest = new NodesInfoRequest(randomAlphaOfLength(8));
-        NodesInfoRequest allMetricsNodesInfoRequest = new NodesInfoRequest(randomAlphaOfLength(8));
-        allMetricsNodesInfoRequest.all();
+        NodesInfoRequest requestOOTB = new NodesInfoRequest(randomAlphaOfLength(8));
+        NodesInfoRequest requestAll = new NodesInfoRequest(randomAlphaOfLength(8)).all();
+        NodesInfoRequest requestDefault = new NodesInfoRequest(randomAlphaOfLength(8)).defaultMetrics();
 
-        assertThat(defaultNodesInfoRequest.requestedMetrics(), equalTo(allMetricsNodesInfoRequest.requestedMetrics()));
+        assertTrue(requestAll.requestedMetrics().size() > requestOOTB.requestedMetrics().size());
+        assertTrue(requestDefault.requestedMetrics().size() == requestOOTB.requestedMetrics().size());
+        assertThat(requestOOTB.requestedMetrics(), equalTo(requestDefault.requestedMetrics()));
     }
 
     /**
@@ -105,6 +108,21 @@ public class NodesInfoRequestTests extends OpenSearchTestCase {
         request.all();
 
         assertThat(request.requestedMetrics(), equalTo(NodesInfoRequest.Metric.allMetrics()));
+    }
+
+    /**
+     * Test that the {@link NodesInfoRequest#defaultMetrics()} method enables default metrics.
+     */
+    public void testNodesInfoRequestDefault() {
+        NodesInfoRequest request = new NodesInfoRequest("node");
+        request.defaultMetrics();
+
+        assertEquals(11, request.requestedMetrics().size());
+        assertThat(request.requestedMetrics(), equalTo(NodesInfoRequest.Metric.defaultMetrics()));
+        assertTrue(request.requestedMetrics().contains(NodesInfoRequest.Metric.JVM.metricName()));
+        assertTrue(request.requestedMetrics().contains(NodesInfoRequest.Metric.AGGREGATIONS.metricName()));
+        // search_pipelines metrics are not included
+        assertFalse(request.requestedMetrics().contains(NodesInfoRequest.Metric.SEARCH_PIPELINES.metricName()));
     }
 
     /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

This commit introduces a breaking change:

NodesInfoRequest does not request all metrics by default.

There are metrics there are not included in the default set of metrics. Right now "search_pipelines" metric is not included in the default set of metrics.

### Related Issues

Related issue: #10296

Originally, this change was part of above mentioned PR but during the review it was decided that it needs to be broken into several commits.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- ~[ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))~
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
