### PR TITLE
Fix PluginInfo bwc for opensearch_version field

### DIFF
--- a/server/src/main/java/org/opensearch/plugins/PluginInfo.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginInfo.java
@@ -445,7 +445,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
      */
     public String getOpenSearchVersionRangesString() {
         if (opensearchVersionRanges == null || opensearchVersionRanges.isEmpty()) {
-            return "";
+            throw new IllegalStateException("Opensearch version ranges list cannot be empty");
         }
         if (opensearchVersionRanges.size() == 1) {
             return opensearchVersionRanges.get(0).toString();

--- a/server/src/main/java/org/opensearch/plugins/PluginInfo.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginInfo.java
@@ -486,7 +486,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
         {
             builder.field("name", name);
             builder.field("version", version);
-            builder.field("opensearch_version", opensearchVersionRanges);
+            builder.field("opensearch_version", getOpenSearchVersionRangesString());
             builder.field("java_version", javaVersion);
             builder.field("description", description);
             builder.field("classname", classname);

--- a/server/src/test/java/org/opensearch/plugins/PluginInfoTests.java
+++ b/server/src/test/java/org/opensearch/plugins/PluginInfoTests.java
@@ -37,7 +37,10 @@ import com.fasterxml.jackson.core.JsonParseException;
 import org.opensearch.Version;
 import org.opensearch.action.admin.cluster.node.info.PluginsAndModules;
 import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.common.io.stream.ByteBufferStreamInput;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.semver.SemverRange;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -365,6 +368,31 @@ public class PluginInfoTests extends OpenSearchTestCase {
         ByteBufferStreamInput input = new ByteBufferStreamInput(buffer);
         PluginInfo info2 = new PluginInfo(input);
         assertThat(info2.toString(), equalTo(info.toString()));
+    }
+
+    public void testToXContent() throws Exception {
+        PluginInfo info = new PluginInfo(
+            "fake",
+            "foo",
+            "dummy",
+            Version.CURRENT,
+            "1.8",
+            "dummyClass",
+            "folder",
+            Collections.emptyList(),
+            false
+        );
+        XContentBuilder builder = JsonXContent.contentBuilder().prettyPrint();
+        String prettyPrint = info.toXContent(builder, ToXContent.EMPTY_PARAMS).prettyPrint().toString();
+        assertTrue(prettyPrint.contains("\"name\" : \"fake\""));
+        assertTrue(prettyPrint.contains("\"version\" : \"dummy\""));
+        assertTrue(prettyPrint.contains("\"opensearch_version\" : \"" + Version.CURRENT));
+        assertTrue(prettyPrint.contains("\"java_version\" : \"1.8\""));
+        assertTrue(prettyPrint.contains("\"description\" : \"foo\""));
+        assertTrue(prettyPrint.contains("\"classname\" : \"dummyClass\""));
+        assertTrue(prettyPrint.contains("\"custom_foldername\" : \"folder\""));
+        assertTrue(prettyPrint.contains("\"extended_plugins\" : [ ]"));
+        assertTrue(prettyPrint.contains("\"has_native_controller\" : false"));
     }
 
     public void testPluginListSorted() {


### PR DESCRIPTION
### Description
Updated opensearch_version field in PluginInfo json to represent a string of single version as opposed to a list of single version to ensure bwc.

Without this fix
```
/_cluster/stats

"plugins" : [
        {
          "name" : "analysis-icu",
          "version" : "3.0.0-SNAPSHOT",
          "opensearch_version" : [
            "3.0.0"
          ],
          "java_version" : "11",
          "description" : "The ICU Analysis plugin integrates the Lucene ICU module into OpenSearch, adding ICU-related analysis components.",
          "classname" : "org.opensearch.plugin.analysis.icu.AnalysisICUPlugin",
          "custom_foldername" : "",
          "extended_plugins" : [ ],
          "has_native_controller" : false
        }
      ],
```
With fix:
```
    "plugins" : [
      {
        "name" : "analysis-icu",
        "version" : "3.0.0-SNAPSHOT",
        "opensearch_version" : "3.0.0",
        "java_version" : "11",
        "description" : "The ICU Analysis plugin integrates the Lucene ICU module into OpenSearch, adding ICU-related analysis components.",
        "classname" : "org.opensearch.plugin.analysis.icu.AnalysisICUPlugin",
        "custom_foldername" : "",
        "extended_plugins" : [ ],
        "has_native_controller" : false
      }
    ],
```
### Related Issues
Resolves [#[12528]](https://github.com/opensearch-project/OpenSearch/issues/12528)

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [X] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
