### PR TITLE
[Backport 2.x] Fix for deserilization bug in weighted round robin metadata (#11679)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Prevent read beyond slice boundary in ByteArrayIndexInput ([#10481](https://github.com/opensearch-project/OpenSearch/issues/10481))
 - Fix the "highlight.max_analyzer_offset" request parameter with "plain" highlighter ([#10919](https://github.com/opensearch-project/OpenSearch/pull/10919))
 - Fix get task API does not refresh resource stats ([#11531](https://github.com/opensearch-project/OpenSearch/pull/11531))
+- Fix for deserilization bug in weighted round-robin metadata ([#11679](https://github.com/opensearch-project/OpenSearch/pull/11679))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/cluster/metadata/WeightedRoutingMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/WeightedRoutingMetadata.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Contains metadata for weighted routing
@@ -99,7 +100,7 @@ public class WeightedRoutingMetadata extends AbstractNamedDiffable<Metadata.Cust
     public static WeightedRoutingMetadata fromXContent(XContentParser parser) throws IOException {
         String attrKey = null;
         Double attrValue;
-        String attributeName = null;
+        String attributeName = "";
         Map<String, Double> weights = new HashMap<>();
         WeightedRouting weightedRouting;
         XContentParser.Token token;
@@ -162,12 +163,12 @@ public class WeightedRoutingMetadata extends AbstractNamedDiffable<Metadata.Cust
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         WeightedRoutingMetadata that = (WeightedRoutingMetadata) o;
-        return weightedRouting.equals(that.weightedRouting);
+        return weightedRouting.equals(that.weightedRouting) && version == that.version;
     }
 
     @Override
     public int hashCode() {
-        return weightedRouting.hashCode();
+        return Objects.hash(weightedRouting.hashCode(), version);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/cluster/routing/WeightedRouting.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/WeightedRouting.java
@@ -54,6 +54,7 @@ public class WeightedRouting implements Writeable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
+
         out.writeString(attributeName);
         out.writeGenericValue(weights);
     }

--- a/server/src/test/java/org/opensearch/cluster/metadata/WeightedRoutingMetadataTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/WeightedRoutingMetadataTests.java
@@ -8,20 +8,42 @@
 
 package org.opensearch.cluster.metadata;
 
+import org.opensearch.cluster.ClusterModule;
+import org.opensearch.cluster.Diff;
 import org.opensearch.cluster.routing.WeightedRouting;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.core.xcontent.XContentParser;
-import org.opensearch.test.AbstractXContentTestCase;
+import org.opensearch.test.AbstractDiffableSerializationTestCase;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
-public class WeightedRoutingMetadataTests extends AbstractXContentTestCase<WeightedRoutingMetadata> {
+public class WeightedRoutingMetadataTests extends AbstractDiffableSerializationTestCase<Metadata.Custom> {
+
+    @Override
+    protected Writeable.Reader<Metadata.Custom> instanceReader() {
+        return WeightedRoutingMetadata::new;
+    }
+
     @Override
     protected WeightedRoutingMetadata createTestInstance() {
+        String attributeName = "zone";
         Map<String, Double> weights = Map.of("a", 1.0, "b", 1.0, "c", 0.0);
-        WeightedRouting weightedRouting = new WeightedRouting("zone", weights);
+        if (randomBoolean()) {
+            weights = new HashMap<>();
+            attributeName = "";
+        }
+        WeightedRouting weightedRouting = new WeightedRouting(attributeName, weights);
         WeightedRoutingMetadata weightedRoutingMetadata = new WeightedRoutingMetadata(weightedRouting, -1);
+
         return weightedRoutingMetadata;
+    }
+
+    @Override
+    protected NamedWriteableRegistry getNamedWriteableRegistry() {
+        return new NamedWriteableRegistry(ClusterModule.getNamedWriteables());
     }
 
     @Override
@@ -30,7 +52,16 @@ public class WeightedRoutingMetadataTests extends AbstractXContentTestCase<Weigh
     }
 
     @Override
-    protected boolean supportsUnknownFields() {
-        return false;
+    protected Metadata.Custom makeTestChanges(Metadata.Custom testInstance) {
+
+        WeightedRouting weightedRouting = new WeightedRouting("", new HashMap<>());
+        WeightedRoutingMetadata weightedRoutingMetadata = new WeightedRoutingMetadata(weightedRouting, -1);
+        return weightedRoutingMetadata;
     }
+
+    @Override
+    protected Writeable.Reader<Diff<Metadata.Custom>> diffReader() {
+        return WeightedRoutingMetadata::readDiffFrom;
+    }
+
 }


### PR DESCRIPTION
---------

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[2.x Backport] Fix for deserialization bug in weighted round robin metadata
https://github.com/opensearch-project/OpenSearch/pull/11679

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
