### PR TITLE
Fix rest-api-spec test search.highlight/30_max_analyzed_offset[5]

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.highlight/30_max_analyzed_offset.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.highlight/30_max_analyzed_offset.yml
@@ -89,4 +89,4 @@ setup:
         rest_total_hits_as_int: true
         index: test1
         body: {"query" : {"match" : {"field1" : "quick"}}, "highlight" : {"type" : "plain", "fields" : {"field1" : {"max_analyzer_offset": 10}}}}
-  - match: {hits.hits.0.highlight.field1.0: "The <em>quick</em> "}
+  - match: {hits.hits.0.highlight.field1.0: "The <em>quick</em>"}


### PR DESCRIPTION
### Description
Fix rest-api-spec test search.highlight/30_max_analyzed_offset[5] to prevent https://github.com/opensearch-project/opensearch-py/actions/runs/8178214405/job/22361632385#step:10:2054

### Related Issues
https://github.com/opensearch-project/opensearch-py/issues/686
https://github.com/opensearch-project/opensearch-py/actions/runs/8178214405/job/22361632385#step:10:2054

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
