### PR TITLE
[Remote Store] Add check for byte lag in time lag calculation

### DIFF
--- a/server/src/main/java/org/opensearch/index/remote/RemoteSegmentTransferTracker.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteSegmentTransferTracker.java
@@ -260,7 +260,7 @@ public class RemoteSegmentTransferTracker extends RemoteTransferTracker {
     }
 
     public long getTimeMsLag() {
-        if (remoteRefreshTimeMs == localRefreshTimeMs) {
+        if (remoteRefreshTimeMs == localRefreshTimeMs || bytesLag == 0) {
             return 0;
         }
         return currentTimeMsUsingSystemNanos() - remoteRefreshStartTimeMs;

--- a/server/src/test/java/org/opensearch/index/remote/RemoteSegmentTransferTrackerTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteSegmentTransferTrackerTests.java
@@ -21,6 +21,7 @@ import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.opensearch.index.remote.RemoteSegmentTransferTracker.currentTimeMsUsingSystemNanos;
@@ -149,6 +150,7 @@ public class RemoteSegmentTransferTrackerTests extends OpenSearchTestCase {
         Thread.sleep(1);
         transferTracker.updateLocalRefreshTimeMs(currentTimeMsUsingSystemNanos());
 
+        transferTracker.updateLatestLocalFileNameLengthMap(List.of("test"), k -> 1L);
         // Sleep for 100ms and then the lag should be within 100ms +/- 20ms
         Thread.sleep(100);
         assertTrue(Math.abs(transferTracker.getTimeMsLag() - 100) <= 20);

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStorePressureServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStorePressureServiceTests.java
@@ -19,6 +19,7 @@ import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Matcher;
@@ -100,6 +101,7 @@ public class RemoteStorePressureServiceTests extends OpenSearchTestCase {
         while (currentTimeMsUsingSystemNanos() - localRefreshTimeMs <= 20 * avg) {
             Thread.sleep((long) (4 * avg));
         }
+        pressureTracker.updateLatestLocalFileNameLengthMap(List.of("test"), k -> 1L);
         Exception e = assertThrows(OpenSearchRejectedExecutionException.class, () -> pressureService.validateSegmentsUploadLag(shardId));
         String regex = "^rejected execution on primary shard:\\[index]\\[0] due to remote segments lagging behind "
             + "local segments.time_lag:[0-9]{2,3} ms dynamic_time_lag_threshold:95\\.0 ms$";


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
In this PR, we are adding a defensive check which is used for determining the time lag. The time lag can show erroneous value if there is a refresh without any additional data ingested as segments.

### Related Issues
No issue created.

### Check List
- ~[ ] New functionality includes testing.~
  - [x] All tests pass
- ~[ ] New functionality has been documented.~
  - ~[ ] New functionality has javadoc added~
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- ~[ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
