### PR TITLE
Fix Flaky SimpleQueryStringIT Tests

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/query/SimpleQueryStringIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/query/SimpleQueryStringIT.java
@@ -112,7 +112,7 @@ public class SimpleQueryStringIT extends ParameterizedStaticSettingsOpenSearchIn
 
     @BeforeClass
     public static void createRandomClusterSetting() {
-        CLUSTER_MAX_CLAUSE_COUNT = randomIntBetween(60, 100);
+        CLUSTER_MAX_CLAUSE_COUNT = randomIntBetween(80, 100);
     }
 
     @Override

--- a/server/src/internalClusterTest/java/org/opensearch/search/query/SimpleQueryStringIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/query/SimpleQueryStringIT.java
@@ -112,6 +112,9 @@ public class SimpleQueryStringIT extends ParameterizedStaticSettingsOpenSearchIn
 
     @BeforeClass
     public static void createRandomClusterSetting() {
+        // Lower bound can't be small(such as 60), simpleQueryStringQuery("foo Bar 19 127.0.0.1") in testDocWithAllTypes
+        // will create many clauses of BooleanClause, In that way, it will throw too_many_nested_clauses exception.
+        // So we need to set a higher bound(such as 80) to avoid failures.
         CLUSTER_MAX_CLAUSE_COUNT = randomIntBetween(80, 100);
     }
 


### PR DESCRIPTION
Signed-off-by: kkewwei [kkewwei@163.com](mailto:kkewwei@163.com)

### Description
org.opensearch.search.query.SimpleQueryStringIT.testDocWithAllTypes is flaky.

### Related Issues
Resolves #12574

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
