### PR TITLE
handle unexpected exception on success callback of translog upload

### DIFF
--- a/server/src/main/java/org/opensearch/index/translog/transfer/FileTransferTracker.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/FileTransferTracker.java
@@ -76,12 +76,7 @@ public class FileTransferTracker implements FileTransferListener {
             logger.error("Failure to update translog upload success stats", ex);
         }
 
-        try {
-            // add() gets a dedicated try/catch as its on the critical path
-            add(fileSnapshot.getName(), TransferState.SUCCESS);
-        } catch (IllegalStateException ex) {
-            throw new FileTransferException(fileSnapshot, ex);
-        }
+        add(fileSnapshot.getName(), TransferState.SUCCESS);
     }
 
     void add(String file, boolean success) {

--- a/server/src/main/java/org/opensearch/index/translog/transfer/FileTransferTracker.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/FileTransferTracker.java
@@ -64,10 +64,14 @@ public class FileTransferTracker implements FileTransferListener {
 
     @Override
     public void onSuccess(TransferFileSnapshot fileSnapshot) {
-        long durationInMillis = (System.nanoTime() - fileTransferStartTime) / 1_000_000L;
-        remoteTranslogTransferTracker.addUploadTimeInMillis(durationInMillis);
-        remoteTranslogTransferTracker.addUploadBytesSucceeded(bytesForTlogCkpFileToUpload.get(fileSnapshot.getName()));
-        add(fileSnapshot.getName(), TransferState.SUCCESS);
+        try {
+            long durationInMillis = (System.nanoTime() - fileTransferStartTime) / 1_000_000L;
+            remoteTranslogTransferTracker.addUploadTimeInMillis(durationInMillis);
+            remoteTranslogTransferTracker.addUploadBytesSucceeded(bytesForTlogCkpFileToUpload.get(fileSnapshot.getName()));
+            add(fileSnapshot.getName(), TransferState.SUCCESS);
+        } catch (Exception ex) {
+            throw new FileTransferException(fileSnapshot, ex);
+        }
     }
 
     void add(String file, boolean success) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
- Translog upload success callback can throw unexpected exceptions. 
- Since we are using ActionListener.wrap, we catch all exceptions in onSuccess and call the onFailure callback
- Currently, on failure callback only accepts FileTransferException. 
- if the exception is any other, we throw a ClassCastException and swallow the original exception trace.
- To be able to log the exceptions occurring in onSuccess callbacks, we wrap those exception as FileTransferException 

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/12544



### Check List
- ~~[ ] New functionality includes testing.~~
  - ~~[ ] All tests pass~~
- ~~[ ] New functionality has been documented.~~
  - ~~[ ] New functionality has javadoc added~~
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- ~~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
