### PR TITLE
The org.opensearch.bootstrap.Security should support codebase for JAR files with classifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Support for returning scores in matched queries ([#11626](https://github.com/opensearch-project/OpenSearch/pull/11626))
 - Add shard id property to SearchLookup for use in field types provided by plugins ([#1063](https://github.com/opensearch-project/OpenSearch/pull/1063))
 - Add kuromoji_completion analyzer and filter ([#4835](https://github.com/opensearch-project/OpenSearch/issues/4835))
+- The org.opensearch.bootstrap.Security should support codebase for JAR files with classifiers ([#12586](https://github.com/opensearch-project/OpenSearch/issues/12586))
 
 ### Dependencies
 - Bump `peter-evans/find-comment` from 2 to 3 ([#12288](https://github.com/opensearch-project/OpenSearch/pull/12288))

--- a/server/src/main/java/org/opensearch/bootstrap/Security.java
+++ b/server/src/main/java/org/opensearch/bootstrap/Security.java
@@ -66,6 +66,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.opensearch.bootstrap.FilePermissionUtils.addDirectoryPath;
 import static org.opensearch.bootstrap.FilePermissionUtils.addSingleFilePath;
@@ -121,6 +123,8 @@ import static org.opensearch.bootstrap.FilePermissionUtils.addSingleFilePath;
  */
 @SuppressWarnings("removal")
 final class Security {
+    private static final Pattern CODEBASE_JAR_WITH_CLASSIFIER = Pattern.compile("^(.+)-\\d+\\.\\d+[^-]*.*?[-]?([^-]+)?\\.jar$");
+
     /** no instantiation */
     private Security() {}
 
@@ -231,33 +235,45 @@ final class Security {
         try {
             List<String> propertiesSet = new ArrayList<>();
             try {
+                final Map<Map.Entry<String, URL>, String> jarsWithPossibleClassifiers = new HashMap<>();
                 // set codebase properties
                 for (Map.Entry<String, URL> codebase : codebases.entrySet()) {
-                    String name = codebase.getKey();
-                    URL url = codebase.getValue();
+                    final String name = codebase.getKey();
+                    final URL url = codebase.getValue();
 
                     // We attempt to use a versionless identifier for each codebase. This assumes a specific version
                     // format in the jar filename. While we cannot ensure all jars in all plugins use this format, nonconformity
                     // only means policy grants would need to include the entire jar filename as they always have before.
-                    String property = "codebase." + name;
-                    String aliasProperty = "codebase." + name.replaceFirst("-\\d+\\.\\d+.*\\.jar", "");
-                    if (aliasProperty.equals(property) == false) {
-                        propertiesSet.add(aliasProperty);
-                        String previous = System.setProperty(aliasProperty, url.toString());
-                        if (previous != null) {
-                            throw new IllegalStateException(
-                                "codebase property already set: " + aliasProperty + " -> " + previous + ", cannot set to " + url.toString()
-                            );
-                        }
-                    }
-                    propertiesSet.add(property);
-                    String previous = System.setProperty(property, url.toString());
-                    if (previous != null) {
-                        throw new IllegalStateException(
-                            "codebase property already set: " + property + " -> " + previous + ", cannot set to " + url.toString()
-                        );
+                    final Matcher matcher = CODEBASE_JAR_WITH_CLASSIFIER.matcher(name);
+                    if (matcher.matches() && matcher.group(2) != null) {
+                        // There is a JAR that, possibly, has a classifier or SNAPSHOT at the end, examples are:
+                        // - netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar
+                        // - kafka-server-common-3.6.1-test.jar
+                        // - lucene-core-9.11.0-snapshot-8a555eb.jar
+                        // - zstd-jni-1.5.5-5.jar
+                        jarsWithPossibleClassifiers.put(codebase, matcher.group(2));
+                    } else {
+                        String property = "codebase." + name;
+                        String aliasProperty = "codebase." + name.replaceFirst("-\\d+\\.\\d+.*\\.jar", "");
+                        addCodebaseToSystemProperties(propertiesSet, url, property, aliasProperty);
                     }
                 }
+
+                // set codebase properties for JARs that might present with classifiers
+                for (Map.Entry<Map.Entry<String, URL>, String> jarWithPossibleClassifier : jarsWithPossibleClassifiers.entrySet()) {
+                    final Map.Entry<String, URL> codebase = jarWithPossibleClassifier.getKey();
+                    final String name = codebase.getKey();
+                    final URL url = codebase.getValue();
+
+                    String property = "codebase." + name;
+                    String aliasProperty = "codebase." + name.replaceFirst("-\\d+\\.\\d+.*\\.jar", "");
+                    if (System.getProperties().containsKey(aliasProperty)) {
+                        aliasProperty = aliasProperty + "@" + jarWithPossibleClassifier.getValue();
+                    }
+
+                    addCodebaseToSystemProperties(propertiesSet, url, property, aliasProperty);
+                }
+
                 return Policy.getInstance("JavaPolicy", new URIParameter(policyFile.toURI()));
             } finally {
                 // clear codebase properties
@@ -267,6 +283,27 @@ final class Security {
             }
         } catch (NoSuchAlgorithmException | URISyntaxException e) {
             throw new IllegalArgumentException("unable to parse policy file `" + policyFile + "`", e);
+        }
+    }
+
+    /** adds the codebase to properties and System properties */
+    @SuppressForbidden(reason = "accesses System properties to configure codebases")
+    private static void addCodebaseToSystemProperties(List<String> propertiesSet, final URL url, String property, String aliasProperty) {
+        if (aliasProperty.equals(property) == false) {
+            propertiesSet.add(aliasProperty);
+            String previous = System.setProperty(aliasProperty, url.toString());
+            if (previous != null) {
+                throw new IllegalStateException(
+                    "codebase property already set: " + aliasProperty + " -> " + previous + ", cannot set to " + url.toString()
+                );
+            }
+        }
+        propertiesSet.add(property);
+        String previous = System.setProperty(property, url.toString());
+        if (previous != null) {
+            throw new IllegalStateException(
+                "codebase property already set: " + property + " -> " + previous + ", cannot set to " + url.toString()
+            );
         }
     }
 

--- a/server/src/test/java/org/opensearch/bootstrap/SecurityTests.java
+++ b/server/src/test/java/org/opensearch/bootstrap/SecurityTests.java
@@ -35,8 +35,12 @@ package org.opensearch.bootstrap;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Map;
 
 public class SecurityTests extends OpenSearchTestCase {
 
@@ -79,5 +83,24 @@ public class SecurityTests extends OpenSearchTestCase {
             Runtime.getRuntime().exec("ls");
             fail("didn't get expected exception");
         } catch (SecurityException expected) {}
+    }
+
+    public void testReadPolicyWithCodebases() throws IOException {
+        final Map<String, URL> codebases = Map.of(
+            "test-netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar",
+            new URL("file://test-netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar"),
+            "test-kafka-server-common-3.6.1.jar",
+            new URL("file://test-kafka-server-common-3.6.1.jar"),
+            "test-kafka-server-common-3.6.1-test.jar",
+            new URL("file://test-kafka-server-common-3.6.1-test.jar"),
+            "test-lucene-core-9.11.0-snapshot-8a555eb.jar",
+            new URL("file://test-lucene-core-9.11.0-snapshot-8a555eb.jar"),
+            "test-zstd-jni-1.5.5-5.jar",
+            new URL("file://test-zstd-jni-1.5.5-5.jar")
+        );
+
+        AccessController.doPrivileged(
+            (PrivilegedAction<?>) () -> Security.readPolicy(SecurityTests.class.getResource("test-codebases.policy"), codebases)
+        );
     }
 }

--- a/server/src/test/resources/org/opensearch/bootstrap/test-codebases.policy
+++ b/server/src/test/resources/org/opensearch/bootstrap/test-codebases.policy
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+//// additional test framework permissions.
+//// These are mock objects and test management that we allow test framework libs
+//// to provide on our behalf. But tests themselves cannot do this stuff!
+
+grant codeBase "${codebase.zstd-jni}" {
+};
+
+grant codeBase "${codebase.kafka-server-common}" {
+};
+
+grant codeBase "${codebase.kafka-server-common@test}" {
+};

--- a/server/src/test/resources/org/opensearch/bootstrap/test.policy
+++ b/server/src/test/resources/org/opensearch/bootstrap/test.policy
@@ -1,0 +1,13 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+grant {
+  // allow to test Security policy and codebases 
+  permission java.util.PropertyPermission "*", "read,write";
+  permission java.security.SecurityPermission "createPolicy.JavaPolicy";
+};


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The issue came out while integration OpenSearch test scaffolding with `security` plugin. The `org.opensearch.bootstrap.Security` analyzes the classpath and injects the `codebase.*` system property for each JAR entry found (so it could be referenced in security policy files), for example:

```
...

grant codeBase "${codebase.zstd-jni}" {
  permission java.lang.RuntimePermission "loadLibrary.*";
};

grant codeBase "${codebase.jna}" {
  // for registering native methods
  permission java.lang.RuntimePermission "accessDeclaredMembers";
};

...

```

The `codebase.*` suffix is constructed from the JAR file name by stripping the version (and `.jar` extension). However, it causes the issues when there same artifacts with classifiers referenced, for example:

- `netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar` and `netty-tcnative-boringssl-static-2.0.61.Final.jar`
- `kafka-server-common-3.6.1-test.jar` and `kafka-server-common-3.6.1.jar`

Although different, these artifacts are folded into same codebase suffix, causing the bootstrap process to fail.

The pull request adds support for artifacts (JARs) with classifiers so they could be distinguished (and also referenced in security policy): codebase.*@<classifier>. For example:

```
grant codeBase "${codebase.netty-tcnative-boringssl-static@linux-x86_64}" {
  ...
};

grant codeBase "${codebase.kafka-server-common@test}" {
  ...
};

```

### Related Issues
Closes https://github.com/opensearch-project/OpenSearch/issues/12581
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
