### PR TITLE
[Backport 2.x] onShardResult and onShardFailure are executed on one shard causes opensearch jvm crashed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix `terms` query on `float` field when `doc_values` are turned off by reverting back to `FloatPoint` from `FloatField` ([#12499](https://github.com/opensearch-project/OpenSearch/pull/12499))
 - Fix get task API does not refresh resource stats ([#11531](https://github.com/opensearch-project/OpenSearch/pull/11531))
 - Fix for deserilization bug in weighted round-robin metadata ([#11679](https://github.com/opensearch-project/OpenSearch/pull/11679))
+- onShardResult and onShardFailure are executed on one shard causes opensearch jvm crashed ([#12158](https://github.com/opensearch-project/OpenSearch/pull/12158))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/opensearch/action/search/AbstractSearchAsyncAction.java
@@ -306,7 +306,6 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
                                 } else {
                                     onShardFailure(shardIndex, shard, shardIt, t);
                                 }
-
                             } finally {
                                 executeNext(pendingExecutions, thread);
                             }

--- a/server/src/test/java/org/opensearch/action/search/AbstractSearchAsyncActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/AbstractSearchAsyncActionTests.java
@@ -163,7 +163,7 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
         ActionListener<SearchResponse> listener,
         final boolean controlled,
         final boolean failExecutePhaseOnShard,
-        final boolean catchExceptionInExecutePhaseOnShard,
+        final boolean catchExceptionWhenExecutePhaseOnShard,
         final AtomicLong expected,
         final SearchShardIterator... shards
     ) {
@@ -223,7 +223,7 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
                 if (failExecutePhaseOnShard) {
                     listener.onFailure(new ShardNotFoundException(shardIt.shardId()));
                 } else {
-                    if (catchExceptionInExecutePhaseOnShard) {
+                    if (catchExceptionWhenExecutePhaseOnShard) {
                         try {
                             listener.onResponse(new QuerySearchResult());
                         } catch (Exception e) {
@@ -582,7 +582,7 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
         assertThat(searchResponse.getSuccessfulShards(), equalTo(shards.length));
     }
 
-    private void innerTestExecutePhaseOnShardFailure(boolean catchExceptionInExecutePhaseOnShard) throws InterruptedException {
+    private void innerTestExecutePhaseOnShardFailure(boolean catchExceptionWhenExecutePhaseOnShard) throws InterruptedException {
         final Index index = new Index("test", UUID.randomUUID().toString());
 
         final SearchShardIterator[] shards = IntStream.range(0, 2 + randomInt(3))
@@ -618,7 +618,7 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
             },
             false,
             false,
-            catchExceptionInExecutePhaseOnShard,
+            catchExceptionWhenExecutePhaseOnShard,
             new AtomicLong(),
             shards
         );

--- a/server/src/test/java/org/opensearch/action/search/AbstractSearchAsyncActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/AbstractSearchAsyncActionTests.java
@@ -638,7 +638,7 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
         innerTestExecutePhaseOnShardFailure(false);
     }
 
-    public void testExecutePhaseOnShardFailureAndThrowException()  throws InterruptedException {
+    public void testExecutePhaseOnShardFailureAndThrowException() throws InterruptedException {
         innerTestExecutePhaseOnShardFailure(true);
     }
 

--- a/server/src/test/java/org/opensearch/action/search/AbstractSearchAsyncActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/AbstractSearchAsyncActionTests.java
@@ -221,7 +221,11 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
                 if (failExecutePhaseOnShard) {
                     listener.onFailure(new ShardNotFoundException(shardIt.shardId()));
                 } else {
-                    listener.onResponse(new QuerySearchResult());
+                    try {
+                        listener.onResponse(new QuerySearchResult());
+                    } catch (Exception e) {
+                        listener.onFailure(e);
+                    }
                 }
             }
 

--- a/server/src/test/java/org/opensearch/action/search/AbstractSearchAsyncActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/AbstractSearchAsyncActionTests.java
@@ -151,6 +151,7 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
             listener,
             controlled,
             false,
+            false,
             expected,
             new SearchShardIterator(null, null, Collections.emptyList(), null)
         );
@@ -162,6 +163,7 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
         ActionListener<SearchResponse> listener,
         final boolean controlled,
         final boolean failExecutePhaseOnShard,
+        final boolean catchExceptionInExecutePhaseOnShard,
         final AtomicLong expected,
         final SearchShardIterator... shards
     ) {
@@ -221,10 +223,14 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
                 if (failExecutePhaseOnShard) {
                     listener.onFailure(new ShardNotFoundException(shardIt.shardId()));
                 } else {
-                    try {
+                    if (catchExceptionInExecutePhaseOnShard) {
+                        try {
+                            listener.onResponse(new QuerySearchResult());
+                        } catch (Exception e) {
+                            listener.onFailure(e);
+                        }
+                    } else {
                         listener.onResponse(new QuerySearchResult());
-                    } catch (Exception e) {
-                        listener.onFailure(e);
                     }
                 }
             }
@@ -513,6 +519,7 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
             },
             false,
             true,
+            false,
             new AtomicLong(),
             shards
         );
@@ -559,6 +566,7 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
             },
             false,
             false,
+            false,
             new AtomicLong(),
             shards
         );
@@ -574,7 +582,7 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
         assertThat(searchResponse.getSuccessfulShards(), equalTo(shards.length));
     }
 
-    public void testExecutePhaseOnShardFailure() throws InterruptedException {
+    private void innerTestExecutePhaseOnShardFailure(boolean catchExceptionInExecutePhaseOnShard) throws InterruptedException {
         final Index index = new Index("test", UUID.randomUUID().toString());
 
         final SearchShardIterator[] shards = IntStream.range(0, 2 + randomInt(3))
@@ -610,6 +618,7 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
             },
             false,
             false,
+            catchExceptionInExecutePhaseOnShard,
             new AtomicLong(),
             shards
         );
@@ -623,6 +632,14 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
         assertSame(searchResponse.getProfileResults(), internalSearchResponse.profile());
         assertSame(searchResponse.getHits(), internalSearchResponse.hits());
         assertThat(searchResponse.getSuccessfulShards(), equalTo(shards.length));
+    }
+
+    public void testExecutePhaseOnShardFailure() throws InterruptedException {
+        innerTestExecutePhaseOnShardFailure(false);
+    }
+
+    public void testExecutePhaseOnShardFailureAndThrowException()  throws InterruptedException {
+        innerTestExecutePhaseOnShardFailure(true);
     }
 
     public void testOnPhaseListenersWithQueryAndThenFetchType() throws InterruptedException {


### PR DESCRIPTION
Backport from #12158