### PR TITLE
[Tiered Caching] Indices Request cache stalekey management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Metrics Framework] Adds support for asynchronous gauge metric type. ([#12642](https://github.com/opensearch-project/OpenSearch/issues/12642))
 - Make search query counters dynamic to support all query types ([#12601](https://github.com/opensearch-project/OpenSearch/pull/12601))
 - [Tiered caching] Add policies controlling which values can enter pluggable caches [EXPERIMENTAL] ([#12542](https://github.com/opensearch-project/OpenSearch/pull/12542))
+- [Tiered caching] Add Stale keys Management and CacheCleaner to IndicesRequestCache ([#12625](https://github.com/opensearch-project/OpenSearch/pull/12625))
 
 ### Dependencies
 - Bump `peter-evans/find-comment` from 2 to 3 ([#12288](https://github.com/opensearch-project/OpenSearch/pull/12288))
@@ -159,7 +160,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix `terms` query on `float` field when `doc_values` are turned off by reverting back to `FloatPoint` from `FloatField` ([#12499](https://github.com/opensearch-project/OpenSearch/pull/12499))
 - Fix get task API does not refresh resource stats ([#11531](https://github.com/opensearch-project/OpenSearch/pull/11531))
 - onShardResult and onShardFailure are executed on one shard causes opensearch jvm crashed ([#12158](https://github.com/opensearch-project/OpenSearch/pull/12158))
-- Avoid overflow when sorting missing last on `epoch_millis` datetime field ([#12676](https://github.com/opensearch-project/OpenSearch/pull/12676))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
@@ -577,13 +577,13 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
         /**
          * Cleans the cache based on the provided staleness threshold.
          * <p>If the percentage of stale keys in the cache is less than this threshold,the cache cleanup process is skipped.
-         * @param threshold The staleness threshold as a double.
+         * @param stalenessThreshold The staleness threshold as a double.
          */
-        private void cleanCache(double threshold) {
+        private void cleanCache(double stalenessThreshold) {
             if (logger.isDebugEnabled()) {
-                logger.debug("Cleaning Indices Request Cache with threshold : " + threshold);
+                logger.debug("Cleaning Indices Request Cache with threshold : " + stalenessThreshold);
             }
-            if (canSkipCacheCleanup(threshold)) {
+            if (canSkipCacheCleanup(stalenessThreshold)) {
                 return;
             }
             // Contains CleanupKey objects with open shard but invalidated readerCacheKeyId.

--- a/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
@@ -612,7 +612,7 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
                     iterator.remove();
                 } else {
                     CleanupKey cleanupKey = new CleanupKey(cacheEntityLookup.apply(key.shardId).orElse(null), key.readerCacheKeyId);
-                    if(cleanupKeysFromOutdatedReaders.contains(cleanupKey)) {
+                    if (cleanupKeysFromOutdatedReaders.contains(cleanupKey)) {
                         iterator.remove();
                     }
                 }

--- a/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
@@ -358,8 +358,10 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
 
         @Override
         public void onClose(IndexReader.CacheKey cacheKey) {
-            Boolean remove = registeredClosedListeners.remove(this);
-            if (remove != null) {
+            // Remove the current CleanupKey from the registeredClosedListeners map
+            // If the key was present, enqueue it for cleanup
+            Boolean wasRegistered = registeredClosedListeners.remove(this);
+            if (wasRegistered != null) {
                 cacheCleanupManager.enqueueCleanupKey(this);
             }
         }

--- a/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
@@ -555,7 +555,8 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
             });
         }
 
-        AtomicInteger getStaleKeysCountForTesting() {
+        // package private for testing
+        AtomicInteger getStaleKeysCount() {
             return staleKeysCount;
         }
 

--- a/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
@@ -197,6 +197,7 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
                     OpenSearchDirectoryReader.addReaderCloseListener(reader, cleanupKey);
                 }
             }
+            cacheCleanupManager.updateCleanupKeyToCountMap(cleanupKey);
         } else {
             cacheEntity.onHit();
         }

--- a/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
@@ -579,7 +579,7 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
             // Contains CleanupKey objects of a closed shard.
             final Set<Object> cleanupKeysFromClosedShards = new HashSet<>();
 
-            for (Iterator<CleanupKey> iterator = keysToClean.iterator(); iterator.hasNext(); ) {
+            for (Iterator<CleanupKey> iterator = keysToClean.iterator(); iterator.hasNext();) {
                 CleanupKey cleanupKey = iterator.next();
                 iterator.remove();
                 if (cleanupKey.readerCacheKeyId == null || !cleanupKey.entity.isOpen()) {
@@ -594,7 +594,7 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
                 return;
             }
 
-            for (Iterator<Key> iterator = cache.keys().iterator(); iterator.hasNext(); ) {
+            for (Iterator<Key> iterator = cache.keys().iterator(); iterator.hasNext();) {
                 Key key = iterator.next();
                 if (shouldRemoveKey(key, cleanupKeysFromOutdatedReaders, cleanupKeysFromClosedShards)) {
                     iterator.remove();
@@ -616,7 +616,11 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
          * @param cleanupKeysFromClosedShards A set of CleanupKeys of a closed shard.
          * @return true if the key should be removed, false otherwise.
          */
-        private synchronized boolean shouldRemoveKey(Key key, Set<CleanupKey> cleanupKeysFromOutdatedReaders, Set<Object> cleanupKeysFromClosedShards) {
+        private synchronized boolean shouldRemoveKey(
+            Key key,
+            Set<CleanupKey> cleanupKeysFromOutdatedReaders,
+            Set<Object> cleanupKeysFromClosedShards
+        ) {
             if (cleanupKeysFromClosedShards.contains(key.shardId)) {
                 return true;
             } else {
@@ -641,8 +645,7 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
             if (staleKeysInCachePercentage() < cleanThresholdPercent) {
                 if (logger.isDebugEnabled()) {
                     logger.debug(
-                        "Skipping cache cleanup since the percentage of stale keys is less than the threshold : "
-                            + stalenessThreshold
+                        "Skipping cache cleanup since the percentage of stale keys is less than the threshold : " + stalenessThreshold
                     );
                 }
                 return true;

--- a/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
@@ -556,6 +556,10 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
             });
         }
 
+        AtomicInteger getStaleKeysCountForTesting() {
+            return staleKeysCount;
+        }
+
         /**
          * Clean cache based on stalenessThreshold
          */

--- a/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
@@ -468,7 +468,7 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
          * @param cleanupKey the CleanupKey to be updated in the map
          */
         private void updateCleanupKeyToCountMapOnCacheInsertion(CleanupKey cleanupKey) {
-            if (stalenessThreshold == 0.0) {
+            if (stalenessThreshold == 0.0 || cleanupKey.entity == null) {
                 return;
             }
             IndexShard indexShard = (IndexShard) cleanupKey.entity.getCacheIdentity();
@@ -485,7 +485,7 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
         }
 
         private synchronized void updateCleanupKeyToCountMapOnCacheEviction(CleanupKey cleanupKey) {
-            if (stalenessThreshold == 0.0) {
+            if (stalenessThreshold == 0.0 || cleanupKey.entity == null) {
                 return;
             }
             IndexShard indexShard = (IndexShard) cleanupKey.entity.getCacheIdentity();
@@ -521,6 +521,7 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
          * @param cleanupKey the CleanupKey that has been marked for cleanup
          */
         private void incrementStaleKeysCount(CleanupKey cleanupKey) {
+            if (stalenessThreshold == 0.0 || cleanupKey.entity == null) {
                 return;
             }
             IndexShard indexShard = (IndexShard) cleanupKey.entity.getCacheIdentity();

--- a/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
@@ -497,13 +497,10 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
             // If the key doesn't exist, ignore
             ConcurrentMap<String, Integer> keyCountMap = cleanupKeyToCountMap.get(shardId);
             if (keyCountMap != null) {
-                keyCountMap.compute(cleanupKey.readerCacheKeyId, (key, currentValue) -> {
-                    // If the key is not present, no action is needed, return null.
-                    if (currentValue == null) return null;
-                    // Calculate the new value.
-                    int newValue = currentValue - 1;
+                keyCountMap.computeIfPresent(cleanupKey.readerCacheKeyId, (key, currentValue) -> {
                     // decrement the stale key count
                     staleKeysCount.decrementAndGet();
+                    int newValue = currentValue - 1;
                     // Remove the key if the new value is zero by returning null; otherwise, update with the new value.
                     return newValue == 0 ? null : newValue;
                 });

--- a/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
@@ -652,10 +652,14 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
             if (cleanThresholdPercent == 0.0) {
                 return false;
             }
-            if (staleKeysInCachePercentage() < cleanThresholdPercent) {
+            double staleKeysInCachePercentage = staleKeysInCachePercentage();
+            if (staleKeysInCachePercentage < cleanThresholdPercent) {
                 if (logger.isDebugEnabled()) {
                     logger.debug(
-                        "Skipping cache cleanup since the percentage of stale keys is less than the threshold : " + stalenessThreshold
+                        "Skipping Indices Request cache cleanup since the percentage of stale keys : "
+                            + staleKeysInCachePercentage
+                            + " is less than the threshold : "
+                            + stalenessThreshold
                     );
                 }
                 return true;

--- a/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
@@ -222,7 +222,7 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
         BytesReference value = cache.computeIfAbsent(key, cacheLoader);
         if (cacheLoader.isLoaded()) {
             cacheEntity.onMiss();
-            // see if its the first time we see this reader, and make sure to register a cleanup key
+            // see if it's the first time we see this reader, and make sure to register a cleanup key
             CleanupKey cleanupKey = new CleanupKey(cacheEntity, readerCacheKeyId);
             if (!registeredClosedListeners.containsKey(cleanupKey)) {
                 Boolean previous = registeredClosedListeners.putIfAbsent(cleanupKey, Boolean.TRUE);
@@ -639,7 +639,8 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
                 if (staleKeysInCachePercentage() < cleanThresholdPercent) {
                     if (logger.isDebugEnabled()) {
                         logger.debug(
-                            "Skipping disk cache keys cleanup since the percentage of stale keys in disk cache is less than the threshold"
+                            "Skipping cache cleanup since the percentage of stale keys is less than the threshold : "
+                                + stalenessThreshold
                         );
                     }
                     return true;

--- a/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
@@ -81,6 +81,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.ToLongBiFunction;
 
+import static org.opensearch.indices.IndicesService.INDICES_CACHE_CLEAN_INTERVAL_SETTING;
+
 /**
  * The indices request cache allows to cache a shard level request stage responses, helping with improving
  * similar requests that are potentially expensive (because of aggs for example). The cache is fully coherent
@@ -122,7 +124,7 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
     );
     public static final Setting<TimeValue> INDICES_REQUEST_CACHE_CLEAN_INTERVAL_SETTING = Setting.positiveTimeSetting(
         "indices.requests.cache.cleanup.interval",
-        TimeValue.timeValueMinutes(1),
+        INDICES_CACHE_CLEAN_INTERVAL_SETTING,
         Property.NodeScope
     );
     public static final Setting<String> INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING = new Setting<>(

--- a/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
@@ -579,7 +579,7 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
          * <p>If the percentage of stale keys in the cache is less than this threshold,the cache cleanup process is skipped.
          * @param stalenessThreshold The staleness threshold as a double.
          */
-        private void cleanCache(double stalenessThreshold) {
+        private synchronized void cleanCache(double stalenessThreshold) {
             if (logger.isDebugEnabled()) {
                 logger.debug("Cleaning Indices Request Cache with threshold : " + stalenessThreshold);
             }

--- a/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
@@ -452,7 +452,7 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
          */
         void enqueueCleanupKey(CleanupKey cleanupKey) {
             keysToClean.add(cleanupKey);
-            updateStaleKeysCount(cleanupKey);
+            incrementStaleKeysCount(cleanupKey);
         }
 
         /**
@@ -520,8 +520,7 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
          *
          * @param cleanupKey the CleanupKey that has been marked for cleanup
          */
-        private void updateStaleKeysCount(CleanupKey cleanupKey) {
-            if (stalenessThreshold == 0.0) {
+        private void incrementStaleKeysCount(CleanupKey cleanupKey) {
                 return;
             }
             IndexShard indexShard = (IndexShard) cleanupKey.entity.getCacheIdentity();

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -1611,6 +1611,10 @@ public class IndicesService extends AbstractLifecycleComponent
                     TimeValue.nsecToMSec(System.nanoTime() - startTimeNS)
                 );
             }
+            // Reschedule itself to run again if not closed
+            if (closed.get() == false) {
+                threadPool.scheduleUnlessShuttingDown(interval, ThreadPool.Names.SAME, this);
+            }
         }
 
         @Override

--- a/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
@@ -67,7 +67,9 @@ import org.opensearch.index.cache.request.ShardRequestCache;
 import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.shard.IndexShardState;
+import org.opensearch.node.Node;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
+import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -75,17 +77,23 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.UUID;
 
+import static org.opensearch.indices.IndicesRequestCache.INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
+    private ThreadPool getThreadPool() {
+        return new ThreadPool(Settings.builder().put(Node.NODE_NAME_SETTING.getKey(), "default tracer tests").build());
+    }
 
     public void testBasicOperationsCache() throws Exception {
         IndexShard indexShard = createIndex("test").getShard(0);
+        ThreadPool threadPool = getThreadPool();
         IndicesRequestCache cache = new IndicesRequestCache(
             Settings.EMPTY,
             (shardId -> Optional.of(new IndicesService.IndexShardCacheEntity(indexShard))),
-            new CacheModule(new ArrayList<>(), Settings.EMPTY).getCacheService()
+            new CacheModule(new ArrayList<>(), Settings.EMPTY).getCacheService(),
+            threadPool
         );
         Directory dir = newDirectory();
         IndexWriter writer = new IndexWriter(dir, newIndexWriterConfig());
@@ -128,7 +136,7 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
             indexShard.close("test", true, true); // closed shard but reader is still open
             cache.clear(entity);
         }
-        cache.cleanCache();
+        cache.cacheCleanupManager.cleanCache();
         assertEquals(1, requestCacheStats.stats().getHitCount());
         assertEquals(1, requestCacheStats.stats().getMissCount());
         assertEquals(0, requestCacheStats.stats().getEvictions());
@@ -137,16 +145,19 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
         assertEquals(0, requestCacheStats.stats().getMemorySize().bytesAsInt());
 
         IOUtils.close(reader, writer, dir, cache);
+        terminate(threadPool);
         assertEquals(0, cache.numRegisteredCloseListeners());
     }
 
     public void testBasicOperationsCacheWithFeatureFlag() throws Exception {
         IndexShard indexShard = createIndex("test").getShard(0);
         CacheService cacheService = new CacheModule(new ArrayList<>(), Settings.EMPTY).getCacheService();
+        ThreadPool threadPool = getThreadPool();
         IndicesRequestCache cache = new IndicesRequestCache(
             Settings.builder().put(super.featureFlagSettings()).put(FeatureFlags.PLUGGABLE_CACHE, "true").build(),
             (shardId -> Optional.of(new IndicesService.IndexShardCacheEntity(indexShard))),
-            cacheService
+            cacheService,
+            threadPool
         );
         Directory dir = newDirectory();
         IndexWriter writer = new IndexWriter(dir, newIndexWriterConfig());
@@ -189,7 +200,7 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
             indexShard.close("test", true, true); // closed shard but reader is still open
             cache.clear(entity);
         }
-        cache.cleanCache();
+        cache.cacheCleanupManager.cleanCache();
         assertEquals(1, requestCacheStats.stats().getHitCount());
         assertEquals(1, requestCacheStats.stats().getMissCount());
         assertEquals(0, requestCacheStats.stats().getEvictions());
@@ -198,12 +209,14 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
         assertEquals(0, requestCacheStats.stats().getMemorySize().bytesAsInt());
 
         IOUtils.close(reader, writer, dir, cache);
+        terminate(threadPool);
         assertEquals(0, cache.numRegisteredCloseListeners());
     }
 
     public void testCacheDifferentReaders() throws Exception {
         IndicesService indicesService = getInstanceFromNode(IndicesService.class);
         IndexShard indexShard = createIndex("test").getShard(0);
+        ThreadPool threadPool = getThreadPool();
         IndicesRequestCache cache = new IndicesRequestCache(Settings.EMPTY, (shardId -> {
             IndexService indexService = null;
             try {
@@ -212,7 +225,7 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
                 return Optional.empty();
             }
             return Optional.of(new IndicesService.IndexShardCacheEntity(indexService.getShard(shardId.id())));
-        }), new CacheModule(new ArrayList<>(), Settings.EMPTY).getCacheService());
+        }), new CacheModule(new ArrayList<>(), Settings.EMPTY).getCacheService(), threadPool);
         Directory dir = newDirectory();
         IndexWriter writer = new IndexWriter(dir, newIndexWriterConfig());
 
@@ -281,7 +294,7 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
 
         // Closing the cache doesn't change returned entities
         reader.close();
-        cache.cleanCache();
+        cache.cacheCleanupManager.cleanCache();
         assertEquals(2, requestCacheStats.stats().getMissCount());
         assertEquals(0, requestCacheStats.stats().getEvictions());
         assertTrue(loader.loadedFromCache);
@@ -296,7 +309,7 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
             indexShard.close("test", true, true); // closed shard but reader is still open
             cache.clear(secondEntity);
         }
-        cache.cleanCache();
+        cache.cacheCleanupManager.cleanCache();
         assertEquals(2, requestCacheStats.stats().getMissCount());
         assertEquals(0, requestCacheStats.stats().getEvictions());
         assertTrue(loader.loadedFromCache);
@@ -304,17 +317,290 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
         assertEquals(0, requestCacheStats.stats().getMemorySize().bytesAsInt());
 
         IOUtils.close(secondReader, writer, dir, cache);
+        terminate(threadPool);
         assertEquals(0, cache.numRegisteredCloseListeners());
+    }
+
+    public void testCacheCleanupThresholdSettingValidator_Valid_Percentage() {
+        String s = IndicesRequestCache.validateStalenessSetting("50%");
+        assertEquals("50%", s);
+    }
+
+    public void testCacheCleanupThresholdSettingValidator_Valid_Double() {
+        String s = IndicesRequestCache.validateStalenessSetting("0.5");
+        assertEquals("0.5", s);
+    }
+
+    public void testCacheCleanupThresholdSettingValidator_Valid_DecimalPercentage() {
+        String s = IndicesRequestCache.validateStalenessSetting("0.5%");
+        assertEquals("0.5%", s);
+    }
+
+    public void testCacheCleanupThresholdSettingValidator_InValid_MB() {
+        assertThrows(IllegalArgumentException.class, () -> { IndicesRequestCache.validateStalenessSetting("50mb"); });
+    }
+
+    public void testCacheCleanupThresholdSettingValidator_Invalid_Percentage() {
+        assertThrows(IllegalArgumentException.class, () -> { IndicesRequestCache.validateStalenessSetting("500%"); });
+    }
+
+    public void testCacheCleanupBasedOnZeroThreshold() throws Exception {
+        IndicesService indicesService = getInstanceFromNode(IndicesService.class);
+        IndexShard indexShard = createIndex("test").getShard(0);
+        ThreadPool threadPool = getThreadPool();
+        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0%").build();
+        IndicesRequestCache cache = new IndicesRequestCache(settings, (shardId -> {
+            IndexService indexService = null;
+            try {
+                indexService = indicesService.indexServiceSafe(shardId.getIndex());
+            } catch (IndexNotFoundException ex) {
+                return Optional.empty();
+            }
+            return Optional.of(new IndicesService.IndexShardCacheEntity(indexService.getShard(shardId.id())));
+        }), new CacheModule(new ArrayList<>(), settings).getCacheService(), threadPool);
+        Directory dir = newDirectory();
+        IndexWriter writer = new IndexWriter(dir, newIndexWriterConfig());
+
+        writer.addDocument(newDoc(0, "foo"));
+        DirectoryReader reader = OpenSearchDirectoryReader.wrap(DirectoryReader.open(writer), new ShardId("foo", "bar", 1));
+        TermQueryBuilder termQuery = new TermQueryBuilder("id", "0");
+        BytesReference termBytes = XContentHelper.toXContent(termQuery, MediaTypeRegistry.JSON, false);
+        if (randomBoolean()) {
+            writer.flush();
+            IOUtils.close(writer);
+            writer = new IndexWriter(dir, newIndexWriterConfig());
+        }
+        writer.updateDocument(new Term("id", "0"), newDoc(0, "bar"));
+        DirectoryReader secondReader = OpenSearchDirectoryReader.wrap(DirectoryReader.open(writer), new ShardId("foo", "bar", 1));
+
+        // Get 2 entries into the cache
+        IndicesService.IndexShardCacheEntity entity = new IndicesService.IndexShardCacheEntity(indexShard);
+        Loader loader = new Loader(reader, 0);
+        cache.getOrCompute(entity, loader, reader, termBytes);
+
+        entity = new IndicesService.IndexShardCacheEntity(indexShard);
+        loader = new Loader(reader, 0);
+        cache.getOrCompute(entity, loader, reader, termBytes);
+
+        IndicesService.IndexShardCacheEntity secondEntity = new IndicesService.IndexShardCacheEntity(indexShard);
+        loader = new Loader(secondReader, 0);
+        cache.getOrCompute(entity, loader, secondReader, termBytes);
+
+        secondEntity = new IndicesService.IndexShardCacheEntity(indexShard);
+        loader = new Loader(secondReader, 0);
+        cache.getOrCompute(secondEntity, loader, secondReader, termBytes);
+        assertEquals(2, cache.count());
+
+        // Close the reader, to be enqueued for cleanup
+        // 1 out of 2 keys ie 50% are now stale.
+        reader.close();
+        // cache count should not be affected
+        assertEquals(2, cache.count());
+        // clean cache with 0% staleness threshold
+        cache.cacheCleanupManager.cleanCache();
+        // cleanup should remove the stale-key
+        assertEquals(1, cache.count());
+
+        IOUtils.close(secondReader, writer, dir, cache);
+        terminate(threadPool);
+    }
+
+    public void testCacheCleanupBasedOnStaleThreshold_StalenessEqualToThreshold() throws Exception {
+        IndicesService indicesService = getInstanceFromNode(IndicesService.class);
+        IndexShard indexShard = createIndex("test").getShard(0);
+        ThreadPool threadPool = getThreadPool();
+        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.5").build();
+        IndicesRequestCache cache = new IndicesRequestCache(settings, (shardId -> {
+            IndexService indexService = null;
+            try {
+                indexService = indicesService.indexServiceSafe(shardId.getIndex());
+            } catch (IndexNotFoundException ex) {
+                return Optional.empty();
+            }
+            return Optional.of(new IndicesService.IndexShardCacheEntity(indexService.getShard(shardId.id())));
+        }), new CacheModule(new ArrayList<>(), settings).getCacheService(), threadPool);
+        Directory dir = newDirectory();
+        IndexWriter writer = new IndexWriter(dir, newIndexWriterConfig());
+
+        writer.addDocument(newDoc(0, "foo"));
+        DirectoryReader reader = OpenSearchDirectoryReader.wrap(DirectoryReader.open(writer), new ShardId("foo", "bar", 1));
+        TermQueryBuilder termQuery = new TermQueryBuilder("id", "0");
+        BytesReference termBytes = XContentHelper.toXContent(termQuery, MediaTypeRegistry.JSON, false);
+        if (randomBoolean()) {
+            writer.flush();
+            IOUtils.close(writer);
+            writer = new IndexWriter(dir, newIndexWriterConfig());
+        }
+        writer.updateDocument(new Term("id", "0"), newDoc(0, "bar"));
+        DirectoryReader secondReader = OpenSearchDirectoryReader.wrap(DirectoryReader.open(writer), new ShardId("foo", "bar", 1));
+
+        // Get 2 entries into the cache
+        IndicesService.IndexShardCacheEntity entity = new IndicesService.IndexShardCacheEntity(indexShard);
+        Loader loader = new Loader(reader, 0);
+        cache.getOrCompute(entity, loader, reader, termBytes);
+
+        entity = new IndicesService.IndexShardCacheEntity(indexShard);
+        loader = new Loader(reader, 0);
+        cache.getOrCompute(entity, loader, reader, termBytes);
+
+        IndicesService.IndexShardCacheEntity secondEntity = new IndicesService.IndexShardCacheEntity(indexShard);
+        loader = new Loader(secondReader, 0);
+        cache.getOrCompute(entity, loader, secondReader, termBytes);
+
+        secondEntity = new IndicesService.IndexShardCacheEntity(indexShard);
+        loader = new Loader(secondReader, 0);
+        cache.getOrCompute(secondEntity, loader, secondReader, termBytes);
+        assertEquals(2, cache.count());
+
+        // Close the reader, to be enqueued for cleanup
+        // 1 out of 2 keys ie 50% are now stale.
+        reader.close();
+        // cache count should not be affected
+        assertEquals(2, cache.count());
+
+        // clean cache with 50% staleness threshold
+        cache.cacheCleanupManager.cleanCache();
+        // cleanup should have taken effect
+        assertEquals(1, cache.count());
+
+        IOUtils.close(secondReader, writer, dir, cache);
+        terminate(threadPool);
+    }
+
+    public void testCacheCleanupBasedOnStaleThreshold_StalenessGreaterThanThreshold() throws Exception {
+        IndicesService indicesService = getInstanceFromNode(IndicesService.class);
+        IndexShard indexShard = createIndex("test").getShard(0);
+        ThreadPool threadPool = getThreadPool();
+        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.49").build();
+        IndicesRequestCache cache = new IndicesRequestCache(settings, (shardId -> {
+            IndexService indexService = null;
+            try {
+                indexService = indicesService.indexServiceSafe(shardId.getIndex());
+            } catch (IndexNotFoundException ex) {
+                return Optional.empty();
+            }
+            return Optional.of(new IndicesService.IndexShardCacheEntity(indexService.getShard(shardId.id())));
+        }), new CacheModule(new ArrayList<>(), settings).getCacheService(), threadPool);
+        Directory dir = newDirectory();
+        IndexWriter writer = new IndexWriter(dir, newIndexWriterConfig());
+
+        writer.addDocument(newDoc(0, "foo"));
+        DirectoryReader reader = OpenSearchDirectoryReader.wrap(DirectoryReader.open(writer), new ShardId("foo", "bar", 1));
+        TermQueryBuilder termQuery = new TermQueryBuilder("id", "0");
+        BytesReference termBytes = XContentHelper.toXContent(termQuery, MediaTypeRegistry.JSON, false);
+        if (randomBoolean()) {
+            writer.flush();
+            IOUtils.close(writer);
+            writer = new IndexWriter(dir, newIndexWriterConfig());
+        }
+        writer.updateDocument(new Term("id", "0"), newDoc(0, "bar"));
+        DirectoryReader secondReader = OpenSearchDirectoryReader.wrap(DirectoryReader.open(writer), new ShardId("foo", "bar", 1));
+
+        // Get 2 entries into the cache
+        IndicesService.IndexShardCacheEntity entity = new IndicesService.IndexShardCacheEntity(indexShard);
+        Loader loader = new Loader(reader, 0);
+        cache.getOrCompute(entity, loader, reader, termBytes);
+
+        entity = new IndicesService.IndexShardCacheEntity(indexShard);
+        loader = new Loader(reader, 0);
+        cache.getOrCompute(entity, loader, reader, termBytes);
+
+        IndicesService.IndexShardCacheEntity secondEntity = new IndicesService.IndexShardCacheEntity(indexShard);
+        loader = new Loader(secondReader, 0);
+        cache.getOrCompute(entity, loader, secondReader, termBytes);
+
+        secondEntity = new IndicesService.IndexShardCacheEntity(indexShard);
+        loader = new Loader(secondReader, 0);
+        cache.getOrCompute(secondEntity, loader, secondReader, termBytes);
+        assertEquals(2, cache.count());
+
+        // Close the reader, to be enqueued for cleanup
+        // 1 out of 2 keys ie 50% are now stale.
+        reader.close();
+        // cache count should not be affected
+        assertEquals(2, cache.count());
+
+        // clean cache with 49% staleness threshold
+        cache.cacheCleanupManager.cleanCache();
+        // cleanup should have taken effect with 49% threshold
+        assertEquals(1, cache.count());
+
+        IOUtils.close(secondReader, writer, dir, cache);
+        terminate(threadPool);
+    }
+
+    public void testCacheCleanupBasedOnStaleThreshold_StalenessLesserThanThreshold() throws Exception {
+        IndicesService indicesService = getInstanceFromNode(IndicesService.class);
+        IndexShard indexShard = createIndex("test").getShard(0);
+        ThreadPool threadPool = getThreadPool();
+        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "51%").build();
+        IndicesRequestCache cache = new IndicesRequestCache(settings, (shardId -> {
+            IndexService indexService = null;
+            try {
+                indexService = indicesService.indexServiceSafe(shardId.getIndex());
+            } catch (IndexNotFoundException ex) {
+                return Optional.empty();
+            }
+            return Optional.of(new IndicesService.IndexShardCacheEntity(indexService.getShard(shardId.id())));
+        }), new CacheModule(new ArrayList<>(), Settings.EMPTY).getCacheService(), threadPool);
+        Directory dir = newDirectory();
+        IndexWriter writer = new IndexWriter(dir, newIndexWriterConfig());
+
+        writer.addDocument(newDoc(0, "foo"));
+        DirectoryReader reader = OpenSearchDirectoryReader.wrap(DirectoryReader.open(writer), new ShardId("foo", "bar", 1));
+        TermQueryBuilder termQuery = new TermQueryBuilder("id", "0");
+        BytesReference termBytes = XContentHelper.toXContent(termQuery, MediaTypeRegistry.JSON, false);
+        if (randomBoolean()) {
+            writer.flush();
+            IOUtils.close(writer);
+            writer = new IndexWriter(dir, newIndexWriterConfig());
+        }
+        writer.updateDocument(new Term("id", "0"), newDoc(0, "bar"));
+        DirectoryReader secondReader = OpenSearchDirectoryReader.wrap(DirectoryReader.open(writer), new ShardId("foo", "bar", 1));
+
+        // Get 2 entries into the cache
+        IndicesService.IndexShardCacheEntity entity = new IndicesService.IndexShardCacheEntity(indexShard);
+        Loader loader = new Loader(reader, 0);
+        cache.getOrCompute(entity, loader, reader, termBytes);
+
+        entity = new IndicesService.IndexShardCacheEntity(indexShard);
+        loader = new Loader(reader, 0);
+        cache.getOrCompute(entity, loader, reader, termBytes);
+
+        IndicesService.IndexShardCacheEntity secondEntity = new IndicesService.IndexShardCacheEntity(indexShard);
+        loader = new Loader(secondReader, 0);
+        cache.getOrCompute(entity, loader, secondReader, termBytes);
+
+        secondEntity = new IndicesService.IndexShardCacheEntity(indexShard);
+        loader = new Loader(secondReader, 0);
+        cache.getOrCompute(secondEntity, loader, secondReader, termBytes);
+        assertEquals(2, cache.count());
+
+        // Close the reader, to be enqueued for cleanup
+        // 1 out of 2 keys ie 50% are now stale.
+        reader.close();
+        // cache count should not be affected
+        assertEquals(2, cache.count());
+
+        // clean cache with 51% staleness threshold
+        cache.cacheCleanupManager.cleanCache();
+        // cleanup should have been ignored
+        assertEquals(2, cache.count());
+
+        IOUtils.close(secondReader, writer, dir, cache);
+        terminate(threadPool);
     }
 
     public void testEviction() throws Exception {
         final ByteSizeValue size;
         {
             IndexShard indexShard = createIndex("test").getShard(0);
+            ThreadPool threadPool = getThreadPool();
             IndicesRequestCache cache = new IndicesRequestCache(
                 Settings.EMPTY,
                 (shardId -> Optional.of(new IndicesService.IndexShardCacheEntity(indexShard))),
-                new CacheModule(new ArrayList<>(), Settings.EMPTY).getCacheService()
+                new CacheModule(new ArrayList<>(), Settings.EMPTY).getCacheService(),
+                threadPool
             );
             Directory dir = newDirectory();
             IndexWriter writer = new IndexWriter(dir, newIndexWriterConfig());
@@ -337,12 +623,15 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
             assertEquals("bar", value2.streamInput().readString());
             size = indexShard.requestCache().stats().getMemorySize();
             IOUtils.close(reader, secondReader, writer, dir, cache);
+            terminate(threadPool);
         }
         IndexShard indexShard = createIndex("test1").getShard(0);
+        ThreadPool threadPool = getThreadPool();
         IndicesRequestCache cache = new IndicesRequestCache(
             Settings.builder().put(IndicesRequestCache.INDICES_CACHE_QUERY_SIZE.getKey(), size.getBytes() + 1 + "b").build(),
             (shardId -> Optional.of(new IndicesService.IndexShardCacheEntity(indexShard))),
-            new CacheModule(new ArrayList<>(), Settings.EMPTY).getCacheService()
+            new CacheModule(new ArrayList<>(), Settings.EMPTY).getCacheService(),
+            threadPool
         );
         Directory dir = newDirectory();
         IndexWriter writer = new IndexWriter(dir, newIndexWriterConfig());
@@ -374,11 +663,13 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
         assertEquals(2, cache.count());
         assertEquals(1, indexShard.requestCache().stats().getEvictions());
         IOUtils.close(reader, secondReader, thirdReader, writer, dir, cache);
+        terminate(threadPool);
     }
 
     public void testClearAllEntityIdentity() throws Exception {
         IndicesService indicesService = getInstanceFromNode(IndicesService.class);
         IndexShard indexShard = createIndex("test").getShard(0);
+        ThreadPool threadPool = getThreadPool();
         IndicesRequestCache cache = new IndicesRequestCache(Settings.EMPTY, (shardId -> {
             IndexService indexService = null;
             try {
@@ -387,7 +678,7 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
                 return Optional.empty();
             }
             return Optional.of(new IndicesService.IndexShardCacheEntity(indexService.getShard(shardId.id())));
-        }), new CacheModule(new ArrayList<>(), Settings.EMPTY).getCacheService());
+        }), new CacheModule(new ArrayList<>(), Settings.EMPTY).getCacheService(), threadPool);
 
         Directory dir = newDirectory();
         IndexWriter writer = new IndexWriter(dir, newIndexWriterConfig());
@@ -422,7 +713,7 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
         final long hitCount = requestCacheStats.getHitCount();
         // clear all for the indexShard Idendity even though is't still open
         cache.clear(randomFrom(entity, secondEntity));
-        cache.cleanCache();
+        cache.cacheCleanupManager.cleanCache();
         assertEquals(1, cache.count());
         // third has not been validated since it's a different identity
         value3 = cache.getOrCompute(thirddEntity, thirdLoader, thirdReader, termBytes);
@@ -432,7 +723,7 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
         assertEquals("baz", value3.streamInput().readString());
 
         IOUtils.close(reader, secondReader, thirdReader, writer, dir, cache);
-
+        terminate(threadPool);
     }
 
     public Iterable<Field> newDoc(int id, String value) {
@@ -474,6 +765,7 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
     public void testInvalidate() throws Exception {
         IndicesService indicesService = getInstanceFromNode(IndicesService.class);
         IndexShard indexShard = createIndex("test").getShard(0);
+        ThreadPool threadPool = getThreadPool();
         IndicesRequestCache cache = new IndicesRequestCache(Settings.EMPTY, (shardId -> {
             IndexService indexService = null;
             try {
@@ -482,7 +774,7 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
                 return Optional.empty();
             }
             return Optional.of(new IndicesService.IndexShardCacheEntity(indexService.getShard(shardId.id())));
-        }), new CacheModule(new ArrayList<>(), Settings.EMPTY).getCacheService());
+        }), new CacheModule(new ArrayList<>(), Settings.EMPTY).getCacheService(), threadPool);
         Directory dir = newDirectory();
         IndexWriter writer = new IndexWriter(dir, newIndexWriterConfig());
 
@@ -539,7 +831,7 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
             indexShard.close("test", true, true); // closed shard but reader is still open
             cache.clear(entity);
         }
-        cache.cleanCache();
+        cache.cacheCleanupManager.cleanCache();
         assertEquals(1, requestCacheStats.stats().getHitCount());
         assertEquals(2, requestCacheStats.stats().getMissCount());
         assertEquals(0, requestCacheStats.stats().getEvictions());
@@ -547,6 +839,7 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
         assertEquals(0, requestCacheStats.stats().getMemorySize().bytesAsInt());
 
         IOUtils.close(reader, writer, dir, cache);
+        terminate(threadPool);
         assertEquals(0, cache.numRegisteredCloseListeners());
     }
 

--- a/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
@@ -519,7 +519,7 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
 
         // Close the reader, to be enqueued for cleanup
         reader.close();
-        AtomicInteger staleKeysCount = cache.cacheCleanupManager.getStaleKeysCountForTesting();
+        AtomicInteger staleKeysCount = cache.cacheCleanupManager.getStaleKeysCount();
         // 1 out of 2 keys ie 50% are now stale.
         assertEquals(1, staleKeysCount.get());
         // cache count should not be affected
@@ -535,7 +535,7 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
         );
 
         cache.onRemoval(new RemovalNotification<IndicesRequestCache.Key, BytesReference>(key, termBytes, RemovalReason.EVICTED));
-        staleKeysCount = cache.cacheCleanupManager.getStaleKeysCountForTesting();
+        staleKeysCount = cache.cacheCleanupManager.getStaleKeysCount();
         // eviction of previous stale key from the cache should decrement staleKeysCount in iRC
         assertEquals(0, staleKeysCount.get());
 
@@ -592,7 +592,7 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
 
         // Close the reader, to be enqueued for cleanup
         reader.close();
-        AtomicInteger staleKeysCount = cache.cacheCleanupManager.getStaleKeysCountForTesting();
+        AtomicInteger staleKeysCount = cache.cacheCleanupManager.getStaleKeysCount();
         // 1 out of 2 keys ie 50% are now stale.
         assertEquals(1, staleKeysCount.get());
         // cache count should not be affected
@@ -608,7 +608,7 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
         );
 
         cache.onRemoval(new RemovalNotification<IndicesRequestCache.Key, BytesReference>(key, termBytes, RemovalReason.EVICTED));
-        staleKeysCount = cache.cacheCleanupManager.getStaleKeysCountForTesting();
+        staleKeysCount = cache.cacheCleanupManager.getStaleKeysCount();
         // eviction of NON-stale key from the cache should NOT decrement staleKeysCount in iRC
         assertEquals(1, staleKeysCount.get());
 


### PR DESCRIPTION
### Description
This PR introduces following changes
- Introduces IndicesRequestCacheCleanupManager, as a way of refactoring existing cleanup logic into a well structured class. This class also provides cleanup based on a staleness threshold setting.
- Provides IndicesRequestCache its own cleaner in the form of IndicesRequestCacheCleaner


### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/12540

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
