### PR TITLE
[Tiered caching] Supporting removal function on EhcacheDiskCache iterator

### DIFF
--- a/plugins/cache-ehcache/src/main/java/org/opensearch/cache/store/disk/EhcacheDiskCache.java
+++ b/plugins/cache-ehcache/src/main/java/org/opensearch/cache/store/disk/EhcacheDiskCache.java
@@ -407,6 +407,11 @@ public class EhcacheDiskCache<K, V> implements ICache<K, V> {
             }
             return iterator.next().getKey();
         }
+
+        @Override
+        public void remove() {
+            iterator.remove(); // Calls underlying ehcache iterator.remove()
+        }
     }
 
     /**

--- a/plugins/cache-ehcache/src/test/java/org/opensearch/cache/store/disk/EhCacheDiskCacheTests.java
+++ b/plugins/cache-ehcache/src/test/java/org/opensearch/cache/store/disk/EhCacheDiskCacheTests.java
@@ -22,6 +22,7 @@ import org.opensearch.env.NodeEnvironment;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -479,6 +480,53 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
             assertEquals(0, ((EhcacheDiskCache) ehcacheTest).getCompletableFutureMap().size());
             ehcacheTest.close();
         }
+    }
+
+    public void testEhcacheKeyIteratorWithRemove() throws IOException {
+        Settings settings = Settings.builder().build();
+        try (NodeEnvironment env = newNodeEnvironment(settings)) {
+            ICache<String, String> ehcacheTest = new EhcacheDiskCache.Builder<String, String>().setDiskCacheAlias("test1")
+                .setThreadPoolAlias("ehcacheTest")
+                .setStoragePath(env.nodePaths()[0].indicesPath.toString() + "/request_cache")
+                .setIsEventListenerModeSync(true)
+                .setKeyType(String.class)
+                .setValueType(String.class)
+                .setCacheType(CacheType.INDICES_REQUEST_CACHE)
+                .setSettings(settings)
+                .setExpireAfterAccess(TimeValue.MAX_VALUE)
+                .setMaximumWeightInBytes(CACHE_SIZE_IN_BYTES)
+                .setRemovalListener(new MockRemovalListener<>())
+                .build();
+
+            int randomKeys = randomIntBetween(2, 100);
+            Map<String, String> keyValueMap = new HashMap<>();
+            for (int i = 0; i < randomKeys; i++) {
+                keyValueMap.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+            }
+            for (Map.Entry<String, String> entry : keyValueMap.entrySet()) {
+                ehcacheTest.put(entry.getKey(), entry.getValue());
+            }
+            long originalSize = ehcacheTest.count();
+            assertEquals(randomKeys, originalSize);
+
+            // Now try removing subset of keys and verify
+            List<String> removedKeyList = new ArrayList<>();
+            for (Iterator<String> iterator = ehcacheTest.keys().iterator(); iterator.hasNext();) {
+                String key = iterator.next();
+                if (randomBoolean()) {
+                    removedKeyList.add(key);
+                    iterator.remove();
+                }
+            }
+            // Verify the removed key doesn't exist anymore.
+            for (String ehcacheKey : removedKeyList) {
+                assertNull(ehcacheTest.get(ehcacheKey));
+            }
+            // Verify ehcache entry size again.
+            assertEquals(originalSize - removedKeyList.size(), ehcacheTest.count());
+            ehcacheTest.close();
+        }
+
     }
 
     private static String generateRandomString(int length) {

--- a/plugins/cache-ehcache/src/test/java/org/opensearch/cache/store/disk/EhCacheDiskCacheTests.java
+++ b/plugins/cache-ehcache/src/test/java/org/opensearch/cache/store/disk/EhCacheDiskCacheTests.java
@@ -499,12 +499,8 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                 .build();
 
             int randomKeys = randomIntBetween(2, 100);
-            Map<String, String> keyValueMap = new HashMap<>();
             for (int i = 0; i < randomKeys; i++) {
-                keyValueMap.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
-            }
-            for (Map.Entry<String, String> entry : keyValueMap.entrySet()) {
-                ehcacheTest.put(entry.getKey(), entry.getValue());
+                ehcacheTest.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
             }
             long originalSize = ehcacheTest.count();
             assertEquals(randomKeys, originalSize);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Supports removal on ehcache disk cache key iterator.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/12652

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- ~[ ] New functionality has been documented.~
  - ~[ ] New functionality has javadoc added~
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- ~[ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
