### PR TITLE
[Backport 2.x] Removing unused fetch sub phase processor initialization during fetch…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add a system property to configure YamlParser codepoint limits ([#12298](https://github.com/opensearch-project/OpenSearch/pull/12298))
 - Prevent read beyond slice boundary in ByteArrayIndexInput ([#10481](https://github.com/opensearch-project/OpenSearch/issues/10481))
 - Fix the "highlight.max_analyzer_offset" request parameter with "plain" highlighter ([#10919](https://github.com/opensearch-project/OpenSearch/pull/10919))
+- Prevent unnecessary fetch sub phase processor initialization during fetch phase execution ([#12503](https://github.com/opensearch-project/OpenSearch/pull/12503))
+- Warn about deprecated and ignored index.mapper.dynamic index setting ([#11193](https://github.com/opensearch-project/OpenSearch/pull/11193))
 - Fix `terms` query on `float` field when `doc_values` are turned off by reverting back to `FloatPoint` from `FloatField` ([#12499](https://github.com/opensearch-project/OpenSearch/pull/12499))
 - Fix get task API does not refresh resource stats ([#11531](https://github.com/opensearch-project/OpenSearch/pull/11531))
 - Fix for deserilization bug in weighted round-robin metadata ([#11679](https://github.com/opensearch-project/OpenSearch/pull/11679))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Prevent read beyond slice boundary in ByteArrayIndexInput ([#10481](https://github.com/opensearch-project/OpenSearch/issues/10481))
 - Fix the "highlight.max_analyzer_offset" request parameter with "plain" highlighter ([#10919](https://github.com/opensearch-project/OpenSearch/pull/10919))
 - Prevent unnecessary fetch sub phase processor initialization during fetch phase execution ([#12503](https://github.com/opensearch-project/OpenSearch/pull/12503))
-- Warn about deprecated and ignored index.mapper.dynamic index setting ([#11193](https://github.com/opensearch-project/OpenSearch/pull/11193))
 - Fix `terms` query on `float` field when `doc_values` are turned off by reverting back to `FloatPoint` from `FloatField` ([#12499](https://github.com/opensearch-project/OpenSearch/pull/12499))
 - Fix get task API does not refresh resource stats ([#11531](https://github.com/opensearch-project/OpenSearch/pull/11531))
 - Fix for deserilization bug in weighted round-robin metadata ([#11679](https://github.com/opensearch-project/OpenSearch/pull/11679))

--- a/server/src/main/java/org/opensearch/search/fetch/FetchContext.java
+++ b/server/src/main/java/org/opensearch/search/fetch/FetchContext.java
@@ -192,6 +192,10 @@ public class FetchContext {
         return searchContext.includeNamedQueriesScore();
     }
 
+    public boolean hasInnerHits() {
+        return searchContext.hasInnerHits();
+    }
+
     /**
      * Configuration for returning inner hits
      */
@@ -211,6 +215,10 @@ public class FetchContext {
      */
     public FetchFieldsContext fetchFieldsContext() {
         return searchContext.fetchFieldsContext();
+    }
+
+    public boolean hasScriptFields() {
+        return searchContext.hasScriptFields();
     }
 
     /**

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/InnerHitsContext.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/InnerHitsContext.java
@@ -120,6 +120,11 @@ public final class InnerHitsContext {
         }
 
         @Override
+        public boolean hasInnerHits() {
+            return childInnerHits != null;
+        }
+
+        @Override
         public InnerHitsContext innerHits() {
             return childInnerHits;
         }

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/InnerHitsPhase.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/InnerHitsPhase.java
@@ -64,7 +64,7 @@ public final class InnerHitsPhase implements FetchSubPhase {
 
     @Override
     public FetchSubPhaseProcessor getProcessor(FetchContext searchContext) {
-        if (searchContext.innerHits() == null) {
+        if (searchContext.hasInnerHits() == false) {
             return null;
         }
         Map<String, InnerHitsContext.InnerHitSubContext> innerHits = searchContext.innerHits().getInnerHits();

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/ScriptFieldsPhase.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/ScriptFieldsPhase.java
@@ -54,7 +54,7 @@ public final class ScriptFieldsPhase implements FetchSubPhase {
 
     @Override
     public FetchSubPhaseProcessor getProcessor(FetchContext context) {
-        if (context.scriptFields() == null) {
+        if (context.hasScriptFields() == false) {
             return null;
         }
         List<ScriptFieldsContext.ScriptField> scriptFields = context.scriptFields().fields();

--- a/server/src/main/java/org/opensearch/search/internal/SearchContext.java
+++ b/server/src/main/java/org/opensearch/search/internal/SearchContext.java
@@ -188,6 +188,10 @@ public abstract class SearchContext implements Releasable {
 
     public abstract void highlight(SearchHighlightContext highlight);
 
+    public boolean hasInnerHits() {
+        return innerHitsContext != null;
+    }
+
     public InnerHitsContext innerHits() {
         if (innerHitsContext == null) {
             innerHitsContext = new InnerHitsContext();

--- a/server/src/test/java/org/opensearch/search/fetch/subphase/InnerHitsPhaseTests.java
+++ b/server/src/test/java/org/opensearch/search/fetch/subphase/InnerHitsPhaseTests.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.fetch.subphase;
+
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.search.fetch.FetchContext;
+import org.opensearch.search.internal.SearchContext;
+import org.opensearch.search.lookup.SearchLookup;
+import org.opensearch.test.OpenSearchTestCase;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class InnerHitsPhaseTests extends OpenSearchTestCase {
+
+    /*
+    Returns mock search context reused across test methods
+     */
+    private SearchContext getMockSearchContext(final boolean hasInnerHits) {
+        final QueryShardContext queryShardContext = mock(QueryShardContext.class);
+        when(queryShardContext.newFetchLookup()).thenReturn(mock(SearchLookup.class));
+
+        final SearchContext searchContext = mock(SearchContext.class);
+        when(searchContext.hasInnerHits()).thenReturn(hasInnerHits);
+        when(searchContext.getQueryShardContext()).thenReturn(queryShardContext);
+
+        return searchContext;
+    }
+
+    /*
+    Validates that InnerHitsPhase processor is not initialized when no inner hits
+     */
+    public void testInnerHitsNull() {
+        assertNull(new InnerHitsPhase(null).getProcessor(new FetchContext(getMockSearchContext(false))));
+    }
+
+    /*
+    Validates that InnerHitsPhase processor is initialized when inner hits are present
+     */
+    public void testInnerHitsNonNull() {
+        final SearchContext searchContext = getMockSearchContext(true);
+        when(searchContext.innerHits()).thenReturn(new InnerHitsContext());
+
+        assertNotNull(new InnerHitsPhase(null).getProcessor(new FetchContext(searchContext)));
+    }
+
+}

--- a/server/src/test/java/org/opensearch/search/fetch/subphase/ScriptFieldsPhaseTests.java
+++ b/server/src/test/java/org/opensearch/search/fetch/subphase/ScriptFieldsPhaseTests.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.fetch.subphase;
+
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.search.fetch.FetchContext;
+import org.opensearch.search.internal.SearchContext;
+import org.opensearch.search.lookup.SearchLookup;
+import org.opensearch.test.OpenSearchTestCase;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ScriptFieldsPhaseTests extends OpenSearchTestCase {
+
+    /*
+    Returns mock search context reused across test methods
+     */
+    private SearchContext getMockSearchContext(final boolean hasScriptFields) {
+        final QueryShardContext queryShardContext = mock(QueryShardContext.class);
+        when(queryShardContext.newFetchLookup()).thenReturn(mock(SearchLookup.class));
+
+        final SearchContext searchContext = mock(SearchContext.class);
+        when(searchContext.hasScriptFields()).thenReturn(hasScriptFields);
+        when(searchContext.getQueryShardContext()).thenReturn(queryShardContext);
+
+        return searchContext;
+    }
+
+    /*
+    Validates that ScriptFieldsPhase processor is not initialized when no script fields
+     */
+    public void testScriptFieldsNull() {
+        assertNull(new ScriptFieldsPhase().getProcessor(new FetchContext(getMockSearchContext(false))));
+    }
+
+    /*
+    Validates that ScriptFieldsPhase processor is initialized when script fields are present
+     */
+    public void testScriptFieldsNonNull() {
+        final SearchContext searchContext = getMockSearchContext(true);
+        when(searchContext.scriptFields()).thenReturn(new ScriptFieldsContext());
+
+        assertNotNull(new ScriptFieldsPhase().getProcessor(new FetchContext(searchContext)));
+    }
+
+}


### PR DESCRIPTION
### Description
Prevent initialization of unused fetch sub phase processor initialization during fetch phase execution

### Related Issues
Resolves #12502 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- ~[ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))~
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
