### PR TITLE
Simplify remote directory cleanup after snapshot delete to …

### DIFF
--- a/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
@@ -1153,11 +1153,12 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         logger.debug("Successfully released lock for shard {} of index with uuid {}", shardId, indexUUID);
         if (!isIndexPresent(clusterService, indexUUID)) {
             // Note: this is a temporary solution where snapshot deletion triggers remote store side cleanup if
-            // index is already deleted. shard cleanup will still happen asynchronously using REMOTE_PURGE
-            // threadpool. if it fails, it could leave some stale files in remote directory. this issue could
-            // even happen in cases of shard level remote store data cleanup which also happens asynchronously.
-            // in long term, we have plans to implement remote store GC poller mechanism which will take care of
-            // such stale data. related issue: https://github.com/opensearch-project/OpenSearch/issues/8469
+            // index is already deleted. this is the best effort at the moment since shard cleanup will still happen
+            // asynchronously using REMOTE_PURGE thread pool. if it fails, it could leave some stale files in remote
+            // directory. this issue could even happen in cases of shard level remote store data cleanup which also
+            // happens asynchronously. in long term, we have plans to implement remote store GC poller mechanism which
+            // will take care of such stale data.
+            // related issue: https://github.com/opensearch-project/OpenSearch/issues/8469
             RemoteSegmentStoreDirectoryFactory remoteDirectoryFactory = new RemoteSegmentStoreDirectoryFactory(
                 remoteStoreLockManagerFactory.getRepositoriesService(),
                 threadPool

--- a/server/src/main/java/org/opensearch/repositories/blobstore/RemoteStoreShardCleanupTask.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/RemoteStoreShardCleanupTask.java
@@ -12,10 +12,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.core.index.shard.ShardId;
 
-import java.util.Map;
 import java.util.Set;
 
-import static org.opensearch.common.util.concurrent.ConcurrentCollections.newConcurrentMap;
 import static org.opensearch.common.util.concurrent.ConcurrentCollections.newConcurrentSet;
 
 /**
@@ -25,7 +23,6 @@ public class RemoteStoreShardCleanupTask implements Runnable {
     private final Runnable task;
     private final String shardIdentifier;
     final static Set<String> ongoingRemoteDirectoryCleanups = newConcurrentSet();
-    final static Map<String, Runnable> pendingRemoteDirectoryCleanups = newConcurrentMap();
     private static final Logger staticLogger = LogManager.getLogger(RemoteStoreShardCleanupTask.class);
 
     public RemoteStoreShardCleanupTask(Runnable task, String indexUUID, ShardId shardId) {
@@ -39,25 +36,16 @@ public class RemoteStoreShardCleanupTask implements Runnable {
 
     @Override
     public void run() {
-        // TODO: this is the best effort at the moment since there is still a known race condition scenario in this
-        // method which needs to be handled where one of the thread just came out of while loop and removed the
-        // entry from ongoingRemoteDirectoryCleanup, and another thread added new pending task in the map.
-        // we need to introduce semaphores/locks to avoid that situation which introduces the overhead of lock object
-        // cleanups. however, there will be no scenario where two threads run cleanup for same shard at same time.
-        // <issue-link>
-        if (pendingRemoteDirectoryCleanups.put(shardIdentifier, task) == null) {
-            if (ongoingRemoteDirectoryCleanups.add(shardIdentifier)) {
-                while (pendingRemoteDirectoryCleanups.containsKey(shardIdentifier)) {
-                    Runnable newTask = pendingRemoteDirectoryCleanups.get(shardIdentifier);
-                    pendingRemoteDirectoryCleanups.remove(shardIdentifier);
-                    newTask.run();
-                }
+        // If there is already a same task ongoing for a shard, we need to skip the new task to avoid multiple
+        // concurrent cleanup of same shard.
+        if (ongoingRemoteDirectoryCleanups.add(shardIdentifier)) {
+            try {
+                task.run();
+            } finally {
                 ongoingRemoteDirectoryCleanups.remove(shardIdentifier);
-            } else {
-                staticLogger.debug("one task is already ongoing for shard {}, we can leave entry in pending", shardIdentifier);
             }
         } else {
-            staticLogger.debug("one cleanup task for shard {} is already in pending, we can skip this task", shardIdentifier);
+            staticLogger.warn("one cleanup task for shard {} is already ongoing, need to skip this task", shardIdentifier);
         }
     }
 }


### PR DESCRIPTION
…avoid concurrent cleanup task runs for same shard.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
During snapshot deletion, we need to trigger remote directory cleanup after every release lock operation for indices which are already deleted and removed from cluster state. We trigger cleanup task after every release lock operation. 
if there are multiple shard blobs of same shard we will trigger multiple async cleanup task for same shard directory. since remote store directory cleanup logic is not thread safe. we might end up into situations where both cleanup tasks were not able to trigger cleanup successfully.
So as part of this PR, if there is already an ongoing cleanup task for a shard, and another thread also tries to trigger the cleanup, we will just skip the next task. This might end up into some zombie data in remote store, but since the cleanup itself happens asynchronously if the cleanup fails in between it will also end up into zombie data in remote store which is needed to be handled separately.


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [ ] ~~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~~
- [ ] ~~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
