### PR TITLE
Avoid overflow when sorting missing last on epoch_millis datetime field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix `terms` query on `float` field when `doc_values` are turned off by reverting back to `FloatPoint` from `FloatField` ([#12499](https://github.com/opensearch-project/OpenSearch/pull/12499))
 - Fix get task API does not refresh resource stats ([#11531](https://github.com/opensearch-project/OpenSearch/pull/11531))
 - onShardResult and onShardFailure are executed on one shard causes opensearch jvm crashed ([#12158](https://github.com/opensearch-project/OpenSearch/pull/12158))
+- Avoid overflow when sorting missing last on `epoch_millis` datetime field ([#12676](https://github.com/opensearch-project/OpenSearch/pull/12676))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/common/time/EpochTime.java
+++ b/server/src/main/java/org/opensearch/common/time/EpochTime.java
@@ -126,7 +126,12 @@ class EpochTime {
 
         @Override
         public long getFrom(TemporalAccessor temporal) {
-            long instantSecondsInMillis = temporal.getLong(ChronoField.INSTANT_SECONDS) * 1_000;
+            long instantSeconds = temporal.getLong(ChronoField.INSTANT_SECONDS);
+            if (instantSeconds < Long.MIN_VALUE / 1000L || instantSeconds > Long.MAX_VALUE / 1000L) {
+                // Multiplying would yield integer overflow
+                return Long.MAX_VALUE;
+            }
+            long instantSecondsInMillis = instantSeconds * 1_000;
             if (instantSecondsInMillis >= 0) {
                 if (temporal.isSupported(ChronoField.NANO_OF_SECOND)) {
                     return instantSecondsInMillis + (temporal.getLong(ChronoField.NANO_OF_SECOND) / 1_000_000);

--- a/server/src/test/java/org/opensearch/common/time/DateFormattersTests.java
+++ b/server/src/test/java/org/opensearch/common/time/DateFormattersTests.java
@@ -211,6 +211,10 @@ public class DateFormattersTests extends OpenSearchTestCase {
             assertThat(formatter.format(instant), is("-0.12345"));
             assertThat(Instant.from(formatter.parse(formatter.format(instant))), is(instant));
         }
+        {
+            Instant instant = Instant.ofEpochMilli(Long.MIN_VALUE);
+            assertThat(formatter.format(instant), is("-" + Long.MAX_VALUE)); // We actually truncate to Long.MAX_VALUE to avoid overflow
+        }
     }
 
     public void testInvalidEpochMilliParser() {


### PR DESCRIPTION
Fixes https://github.com/opensearch-project/OpenSearch/issues/10253

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
When sorting a datetime field with `epoch_millis` formatting and putting missing values last (with a descending sort) or first (with ascending sort), the datetime value is `Long.MIN_VALUE`. 

When we try to render that, the formatter tries to emit the negative sign, followed by the absolute value of the original value. Since `Long.MIN_VALUE = -Long.MAX_VALUE - 1`, it is not possible to represent `-Long.MIN_VALUE` as a `long`.

To work around this, my proposed fix introduces an off-by-one error by truncating to `Long.MAX_VALUE`.

### Related Issues
Resolves #10253
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] ~~New functionality has been documented.~~
  - [ ] ~~New functionality has javadoc added~~
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] ~~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
