### PR TITLE
Fixed skip version in rest-api-spec test search.highlight/30_max_analyzed_offset

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.highlight/30_max_analyzed_offset.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.highlight/30_max_analyzed_offset.yml
@@ -82,8 +82,8 @@ setup:
 ---
 "Plain highlighter on a field WITHOUT OFFSETS using max_analyzer_offset should SUCCEED":
   - skip:
-      version: " - 2.1.99"
-      reason: only starting supporting the parameter max_analyzer_offset on version 2.2
+      version: " - 2.12.99"
+      reason: only starting supporting the parameter max_analyzer_offset with plain highlighter on version 2.13
   - do:
       search:
         rest_total_hits_as_int: true


### PR DESCRIPTION
### Description

- Adjusted skip version for test search.highlight/30_max_analyzed_offset from ' - 2.1.99' to ' - 2.12.99' as support for the '[max_analyzed_offset](https://github.com/opensearch-project/OpenSearch/pull/10919)' parameter with plain highlighter began in version 2.13.

- Note: The [2.x branch](https://github.com/opensearch-project/OpenSearch/blob/2.x/rest-api-spec/src/main/resources/rest-api-spec/test/search.highlight/30_max_analyzed_offset.yml#L85) already has the correct skip version for this test case.

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/10702, https://github.com/opensearch-project/opensearch-py/issues/686


### Check List
- [ ] All tests pass
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
