### PR TITLE
Fix flaky test SegmentReplicationWithNodeToNodeIndexShardTests#testReplicaClosesWhileReplicating_AfterGetCheckpoint

### DIFF
--- a/server/src/test/java/org/opensearch/index/shard/SegmentReplicationWithNodeToNodeIndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/SegmentReplicationWithNodeToNodeIndexShardTests.java
@@ -110,7 +110,6 @@ public class SegmentReplicationWithNodeToNodeIndexShardTests extends SegmentRepl
             IndexShard primary = shards.getPrimary();
             final IndexShard replica = shards.getReplicas().get(0);
 
-            final int numDocs = shards.indexDocs(randomInt(10));
             primary.refresh("Test");
 
             final SegmentReplicationSourceFactory sourceFactory = mock(SegmentReplicationSourceFactory.class);
@@ -124,7 +123,6 @@ public class SegmentReplicationWithNodeToNodeIndexShardTests extends SegmentRepl
                 ) {
                     // trigger a cancellation by closing the replica.
                     targetService.beforeIndexShardClosed(replica.shardId, replica, Settings.EMPTY);
-                    resolveCheckpointInfoResponseListener(listener, primary);
                 }
 
                 @Override
@@ -141,7 +139,6 @@ public class SegmentReplicationWithNodeToNodeIndexShardTests extends SegmentRepl
             };
             when(sourceFactory.get(any())).thenReturn(source);
             startReplicationAndAssertCancellation(replica, primary, targetService);
-
             shards.removeReplica(replica);
             closeShards(replica);
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This fixes a race condition in the test that leaves th eprimary with an open file ref while shutting down. This happens because we are acquiring file refs inside the resolveCheckpointInfoResponseListener method right after calling beforeIndexShardClosed. BeforeIndexShardClosed will resolve replication listeners immediately and leave a possibility of the test continuing & the primary attempting shut down before those refs are closed. We can resolve this using latches, but this test really doesn't need to simulate a primary response only that the replica is shutting down at this stage.

Also removed an unused variable.

### Related Issues
Resolves #12291 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
