### PR TITLE
[Backport 2.x] [Tiered Caching] Cache tier policies (#12542)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Remote reindex: Add support for configurable retry mechanism ([#12561](https://github.com/opensearch-project/OpenSearch/pull/12561))
 - Tracing for deep search path ([#12103](https://github.com/opensearch-project/OpenSearch/pull/12103))
 - [Metrics Framework] Adds support for asynchronous gauge metric type. ([#12642](https://github.com/opensearch-project/OpenSearch/issues/12642))
+- Make search query counters dynamic to support all query types ([#12601](https://github.com/opensearch-project/OpenSearch/pull/12601))
+- [Tiered caching] Add policies controlling which values can enter pluggable caches [EXPERIMENTAL] ([#12542](https://github.com/opensearch-project/OpenSearch/pull/12542))
 
 ### Dependencies
 - Bump `com.squareup.okio:okio` from 3.7.0 to 3.8.0 ([#12290](https://github.com/opensearch-project/OpenSearch/pull/12290))

--- a/modules/cache-common/src/main/java/org/opensearch/cache/common/policy/TookTimePolicy.java
+++ b/modules/cache-common/src/main/java/org/opensearch/cache/common/policy/TookTimePolicy.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.cache.common.policy;
+
+import org.opensearch.common.cache.policy.CachedQueryResult;
+import org.opensearch.common.unit.TimeValue;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * A cache tier policy which accepts queries whose took time is greater than some threshold.
+ * The threshold should be set to approximately the time it takes to get a result from the cache tier.
+ * The policy accepts values of type V and decodes them into CachedQueryResult.PolicyValues, which has the data needed
+ * to decide whether to admit the value.
+ * @param <V> The type of data consumed by test().
+ */
+public class TookTimePolicy<V> implements Predicate<V> {
+    /**
+     * The minimum took time to allow a query. Set to TimeValue.ZERO to let all data through.
+     */
+    private final TimeValue threshold;
+
+    /**
+     * Function which extracts the relevant PolicyValues from a serialized CachedQueryResult
+     */
+    private final Function<V, CachedQueryResult.PolicyValues> cachedResultParser;
+
+    /**
+     * Constructs a took time policy.
+     * @param threshold the threshold
+     * @param cachedResultParser the function providing policy values
+     */
+    public TookTimePolicy(TimeValue threshold, Function<V, CachedQueryResult.PolicyValues> cachedResultParser) {
+        if (threshold.compareTo(TimeValue.ZERO) < 0) {
+            throw new IllegalArgumentException("Threshold for TookTimePolicy must be >= 0ms but was " + threshold.getStringRep());
+        }
+        this.threshold = threshold;
+        this.cachedResultParser = cachedResultParser;
+    }
+
+    /**
+     * Check whether to admit data.
+     * @param data the input argument
+     * @return whether to admit the data
+     */
+    public boolean test(V data) {
+        long tookTimeNanos;
+        try {
+            tookTimeNanos = cachedResultParser.apply(data).getTookTimeNanos();
+        } catch (Exception e) {
+            // If we can't read a CachedQueryResult.PolicyValues from the BytesReference, reject the data
+            return false;
+        }
+
+        TimeValue tookTime = TimeValue.timeValueNanos(tookTimeNanos);
+        return tookTime.compareTo(threshold) >= 0;
+    }
+}

--- a/modules/cache-common/src/main/java/org/opensearch/cache/common/policy/package-info.java
+++ b/modules/cache-common/src/main/java/org/opensearch/cache/common/policy/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/** A package for policies controlling what can enter caches. */
+package org.opensearch.cache.common.policy;

--- a/modules/cache-common/src/main/java/org/opensearch/cache/common/tier/TieredSpilloverCache.java
+++ b/modules/cache-common/src/main/java/org/opensearch/cache/common/tier/TieredSpilloverCache.java
@@ -8,19 +8,23 @@
 
 package org.opensearch.cache.common.tier;
 
+import org.opensearch.cache.common.policy.TookTimePolicy;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.cache.CacheType;
 import org.opensearch.common.cache.ICache;
 import org.opensearch.common.cache.LoadAwareCacheLoader;
 import org.opensearch.common.cache.RemovalListener;
 import org.opensearch.common.cache.RemovalNotification;
+import org.opensearch.common.cache.policy.CachedQueryResult;
 import org.opensearch.common.cache.store.config.CacheConfig;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.ReleasableLock;
 import org.opensearch.common.util.iterable.Iterables;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +32,7 @@ import java.util.Objects;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * This cache spillover the evicted items from heap tier to disk tier. All the new items are first cached on heap
@@ -52,6 +57,7 @@ public class TieredSpilloverCache<K, V> implements ICache<K, V> {
      * Maintains caching tiers in ascending order of cache latency.
      */
     private final List<ICache<K, V>> cacheList;
+    private final List<Predicate<V>> policies;
 
     TieredSpilloverCache(Builder<K, V> builder) {
         Objects.requireNonNull(builder.onHeapCacheFactory, "onHeap cache builder can't be null");
@@ -63,7 +69,9 @@ public class TieredSpilloverCache<K, V> implements ICache<K, V> {
                 @Override
                 public void onRemoval(RemovalNotification<K, V> notification) {
                     try (ReleasableLock ignore = writeLock.acquire()) {
-                        diskCache.put(notification.getKey(), notification.getValue());
+                        if (evaluatePolicies(notification.getValue())) {
+                            diskCache.put(notification.getKey(), notification.getValue());
+                        }
                     }
                 }
             })
@@ -71,6 +79,8 @@ public class TieredSpilloverCache<K, V> implements ICache<K, V> {
                 .setValueType(builder.cacheConfig.getValueType())
                 .setSettings(builder.cacheConfig.getSettings())
                 .setWeigher(builder.cacheConfig.getWeigher())
+                .setMaxSizeInBytes(builder.cacheConfig.getMaxSizeInBytes()) // TODO: Part of a workaround for an issue in TSC. Overall fix
+                                                                            // coming soon
                 .build(),
             builder.cacheType,
             builder.cacheFactories
@@ -78,6 +88,8 @@ public class TieredSpilloverCache<K, V> implements ICache<K, V> {
         );
         this.diskCache = builder.diskCacheFactory.create(builder.cacheConfig, builder.cacheType, builder.cacheFactories);
         this.cacheList = Arrays.asList(onHeapCache, diskCache);
+
+        this.policies = builder.policies; // Will never be null; builder initializes it to an empty list
     }
 
     // Package private for testing
@@ -192,6 +204,15 @@ public class TieredSpilloverCache<K, V> implements ICache<K, V> {
         };
     }
 
+    boolean evaluatePolicies(V value) {
+        for (Predicate<V> policy : policies) {
+            if (!policy.test(value)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     /**
      * Factory to create TieredSpilloverCache objects.
      */
@@ -231,11 +252,21 @@ public class TieredSpilloverCache<K, V> implements ICache<K, V> {
                 );
             }
             ICache.Factory diskCacheFactory = cacheFactories.get(diskCacheStoreName);
+
+            TimeValue diskPolicyThreshold = TieredSpilloverCacheSettings.TIERED_SPILLOVER_DISK_TOOK_TIME_THRESHOLD
+                .getConcreteSettingForNamespace(cacheType.getSettingPrefix())
+                .get(settings);
+            Function<V, CachedQueryResult.PolicyValues> cachedResultParser = Objects.requireNonNull(
+                config.getCachedResultParser(),
+                "Cached result parser fn can't be null"
+            );
+
             return new Builder<K, V>().setDiskCacheFactory(diskCacheFactory)
                 .setOnHeapCacheFactory(onHeapCacheFactory)
                 .setRemovalListener(config.getRemovalListener())
                 .setCacheConfig(config)
                 .setCacheType(cacheType)
+                .addPolicy(new TookTimePolicy<V>(diskPolicyThreshold, cachedResultParser))
                 .build();
         }
 
@@ -257,6 +288,7 @@ public class TieredSpilloverCache<K, V> implements ICache<K, V> {
         private CacheConfig<K, V> cacheConfig;
         private CacheType cacheType;
         private Map<String, ICache.Factory> cacheFactories;
+        private final ArrayList<Predicate<V>> policies = new ArrayList<>();
 
         /**
          * Default constructor
@@ -320,6 +352,26 @@ public class TieredSpilloverCache<K, V> implements ICache<K, V> {
          */
         public Builder<K, V> setCacheFactories(Map<String, ICache.Factory> cacheFactories) {
             this.cacheFactories = cacheFactories;
+            return this;
+        }
+
+        /**
+         * Set a cache policy to be used to limit access to this cache's disk tier.
+         * @param policy the policy
+         * @return builder
+         */
+        public Builder<K, V> addPolicy(Predicate<V> policy) {
+            this.policies.add(policy);
+            return this;
+        }
+
+        /**
+         * Set multiple policies to be used to limit access to this cache's disk tier.
+         * @param policies the policies
+         * @return builder
+         */
+        public Builder<K, V> addPolicies(List<Predicate<V>> policies) {
+            this.policies.addAll(policies);
             return this;
         }
 

--- a/modules/cache-common/src/main/java/org/opensearch/cache/common/tier/TieredSpilloverCachePlugin.java
+++ b/modules/cache-common/src/main/java/org/opensearch/cache/common/tier/TieredSpilloverCachePlugin.java
@@ -51,6 +51,11 @@ public class TieredSpilloverCachePlugin extends Plugin implements CachePlugin {
             settingList.add(
                 TieredSpilloverCacheSettings.TIERED_SPILLOVER_DISK_STORE_NAME.getConcreteSettingForNamespace(cacheType.getSettingPrefix())
             );
+            settingList.add(
+                TieredSpilloverCacheSettings.TIERED_SPILLOVER_DISK_TOOK_TIME_THRESHOLD.getConcreteSettingForNamespace(
+                    cacheType.getSettingPrefix()
+                )
+            );
         }
         return settingList;
     }

--- a/modules/cache-common/src/main/java/org/opensearch/cache/common/tier/TieredSpilloverCacheSettings.java
+++ b/modules/cache-common/src/main/java/org/opensearch/cache/common/tier/TieredSpilloverCacheSettings.java
@@ -9,6 +9,9 @@
 package org.opensearch.cache.common.tier;
 
 import org.opensearch.common.settings.Setting;
+import org.opensearch.common.unit.TimeValue;
+
+import java.util.concurrent.TimeUnit;
 
 import static org.opensearch.common.settings.Setting.Property.NodeScope;
 
@@ -35,6 +38,21 @@ public class TieredSpilloverCacheSettings {
         TieredSpilloverCache.TieredSpilloverCacheFactory.TIERED_SPILLOVER_CACHE_NAME + ".disk.store.name",
         (key) -> Setting.simpleString(key, "", NodeScope)
     );
+
+    /**
+     * Setting defining the minimum took time for a query to be allowed into the disk cache.
+     */
+    public static final Setting.AffixSetting<TimeValue> TIERED_SPILLOVER_DISK_TOOK_TIME_THRESHOLD = Setting.suffixKeySetting(
+        TieredSpilloverCache.TieredSpilloverCacheFactory.TIERED_SPILLOVER_CACHE_NAME + ".disk.store.policies.took_time.threshold",
+        (key) -> Setting.timeSetting(
+            key,
+            new TimeValue(10, TimeUnit.MILLISECONDS), // Default value for this setting
+            TimeValue.ZERO, // Minimum value for this setting
+            NodeScope
+        )
+    );
+    // 10 ms was chosen as a safe value based on proof of concept, where we saw disk latencies in this range.
+    // Will be tuned further with future benchmarks.
 
     /**
      * Default constructor

--- a/modules/cache-common/src/test/java/org/opensearch/cache/common/policy/TookTimePolicyTests.java
+++ b/modules/cache-common/src/test/java/org/opensearch/cache/common/policy/TookTimePolicyTests.java
@@ -1,0 +1,103 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cache.common.policy;
+
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
+import org.opensearch.common.Randomness;
+import org.opensearch.common.cache.policy.CachedQueryResult;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.lucene.search.TopDocsAndMaxScore;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.query.QuerySearchResult;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.Random;
+import java.util.function.Function;
+
+public class TookTimePolicyTests extends OpenSearchTestCase {
+    private final Function<BytesReference, CachedQueryResult.PolicyValues> transformationFunction = (data) -> {
+        try {
+            return CachedQueryResult.getPolicyValues(data);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    };
+
+    private TookTimePolicy<BytesReference> getTookTimePolicy(TimeValue threshold) {
+        return new TookTimePolicy<>(threshold, transformationFunction);
+    }
+
+    public void testTookTimePolicy() throws Exception {
+        double threshMillis = 10;
+        long shortMillis = (long) (0.9 * threshMillis);
+        long longMillis = (long) (1.5 * threshMillis);
+        TookTimePolicy<BytesReference> tookTimePolicy = getTookTimePolicy(new TimeValue((long) threshMillis));
+        BytesReference shortTime = getValidPolicyInput(shortMillis * 1000000);
+        BytesReference longTime = getValidPolicyInput(longMillis * 1000000);
+
+        boolean shortResult = tookTimePolicy.test(shortTime);
+        assertFalse(shortResult);
+        boolean longResult = tookTimePolicy.test(longTime);
+        assertTrue(longResult);
+
+        TookTimePolicy<BytesReference> disabledPolicy = getTookTimePolicy(TimeValue.ZERO);
+        shortResult = disabledPolicy.test(shortTime);
+        assertTrue(shortResult);
+        longResult = disabledPolicy.test(longTime);
+        assertTrue(longResult);
+    }
+
+    public void testNegativeOneInput() throws Exception {
+        // PolicyValues with -1 took time can be passed to this policy if we shouldn't accept it for whatever reason
+        TookTimePolicy<BytesReference> tookTimePolicy = getTookTimePolicy(TimeValue.ZERO);
+        BytesReference minusOne = getValidPolicyInput(-1L);
+        assertFalse(tookTimePolicy.test(minusOne));
+    }
+
+    public void testInvalidThreshold() throws Exception {
+        assertThrows(IllegalArgumentException.class, () -> getTookTimePolicy(TimeValue.MINUS_ONE));
+    }
+
+    private BytesReference getValidPolicyInput(Long tookTimeNanos) throws IOException {
+        // When it's used in the cache, the policy will receive BytesReferences which come from
+        // serializing a CachedQueryResult.
+        CachedQueryResult cachedQueryResult = new CachedQueryResult(getQSR(), tookTimeNanos);
+        BytesStreamOutput out = new BytesStreamOutput();
+        cachedQueryResult.writeToNoId(out);
+        return out.bytes();
+    }
+
+    private QuerySearchResult getQSR() {
+        // We can't mock the QSR with mockito because the class is final. Construct a real one
+        QuerySearchResult mockQSR = new QuerySearchResult();
+
+        // duplicated from DfsQueryPhaseTests.java
+        mockQSR.topDocs(
+            new TopDocsAndMaxScore(
+                new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(42, 1.0F) }),
+                2.0F
+            ),
+            new DocValueFormat[0]
+        );
+        return mockQSR;
+    }
+
+    private void writeRandomBytes(StreamOutput out, int numBytes) throws IOException {
+        Random rand = Randomness.get();
+        byte[] bytes = new byte[numBytes];
+        rand.nextBytes(bytes);
+        out.writeBytes(bytes);
+    }
+}

--- a/server/src/main/java/org/opensearch/common/cache/policy/CachedQueryResult.java
+++ b/server/src/main/java/org/opensearch/common/cache/policy/CachedQueryResult.java
@@ -1,0 +1,87 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.cache.policy;
+
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.NamedWriteableAwareStreamInput;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.search.internal.ShardSearchContextId;
+import org.opensearch.search.query.QuerySearchResult;
+
+import java.io.IOException;
+
+/**
+ * A class containing a QuerySearchResult used in a cache, as well as information needed for all cache policies
+ * to decide whether to admit a given BytesReference. Also handles serialization/deserialization of the underlying QuerySearchResult,
+ * which is all that is needed outside the cache. At policy checking time, this spares us from having to create an entire
+ * short-lived QuerySearchResult object just to read a few values.
+ * @opensearch.internal
+ */
+public class CachedQueryResult {
+    private final PolicyValues policyValues;
+    private final QuerySearchResult qsr;
+
+    public CachedQueryResult(QuerySearchResult qsr, long tookTimeNanos) {
+        this.qsr = qsr;
+        this.policyValues = new PolicyValues(tookTimeNanos);
+    }
+
+    // Retrieve only took time from a serialized CQR, without creating a short-lived QuerySearchResult or CachedQueryResult object.
+    public static PolicyValues getPolicyValues(BytesReference serializedCQR) throws IOException {
+        StreamInput in = serializedCQR.streamInput();
+        return new PolicyValues(in);
+    }
+
+    // Retrieve only the QSR from a serialized CQR, and load it into an existing QSR object discarding the took time which isn't needed
+    // outside the cache
+    public static void loadQSR(
+        BytesReference serializedCQR,
+        QuerySearchResult qsr,
+        ShardSearchContextId id,
+        NamedWriteableRegistry registry
+    ) throws IOException {
+        StreamInput in = new NamedWriteableAwareStreamInput(serializedCQR.streamInput(), registry);
+        PolicyValues pv = new PolicyValues(in); // Read and discard PolicyValues
+        qsr.readFromWithId(id, in);
+    }
+
+    public void writeToNoId(StreamOutput out) throws IOException {
+        policyValues.writeTo(out);
+        qsr.writeToNoId(out);
+    }
+
+    /**
+     * A class containing information needed for all cache policies
+     *  to decide whether to admit a given value.
+     */
+    public static class PolicyValues implements Writeable {
+        final long tookTimeNanos;
+        // More values can be added here as they're needed for future policies
+
+        public PolicyValues(long tookTimeNanos) {
+            this.tookTimeNanos = tookTimeNanos;
+        }
+
+        public PolicyValues(StreamInput in) throws IOException {
+            this.tookTimeNanos = in.readZLong();
+        }
+
+        public long getTookTimeNanos() {
+            return tookTimeNanos;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeZLong(tookTimeNanos);
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/common/cache/policy/package-info.java
+++ b/server/src/main/java/org/opensearch/common/cache/policy/package-info.java
@@ -1,0 +1,9 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+/** A package for policies controlling what can enter caches. */
+package org.opensearch.common.cache.policy;

--- a/server/src/main/java/org/opensearch/common/cache/store/config/CacheConfig.java
+++ b/server/src/main/java/org/opensearch/common/cache/store/config/CacheConfig.java
@@ -10,9 +10,11 @@ package org.opensearch.common.cache.store.config;
 
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.cache.RemovalListener;
+import org.opensearch.common.cache.policy.CachedQueryResult;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 
+import java.util.function.Function;
 import java.util.function.ToLongBiFunction;
 
 /**
@@ -42,6 +44,8 @@ public class CacheConfig<K, V> {
 
     private final RemovalListener<K, V> removalListener;
 
+    /** A function which extracts policy-relevant information, such as took time, from values, to allow inspection by policies if present. */
+    private Function<V, CachedQueryResult.PolicyValues> cachedResultParser;
     /**
      * Max size in bytes for the cache. This is needed for backward compatibility.
      */
@@ -58,6 +62,7 @@ public class CacheConfig<K, V> {
         this.settings = builder.settings;
         this.removalListener = builder.removalListener;
         this.weigher = builder.weigher;
+        this.cachedResultParser = builder.cachedResultParser;
         this.maxSizeInBytes = builder.maxSizeInBytes;
         this.expireAfterAccess = builder.expireAfterAccess;
     }
@@ -80,6 +85,10 @@ public class CacheConfig<K, V> {
 
     public ToLongBiFunction<K, V> getWeigher() {
         return weigher;
+    }
+
+    public Function<V, CachedQueryResult.PolicyValues> getCachedResultParser() {
+        return cachedResultParser;
     }
 
     public Long getMaxSizeInBytes() {
@@ -106,6 +115,7 @@ public class CacheConfig<K, V> {
         private RemovalListener<K, V> removalListener;
 
         private ToLongBiFunction<K, V> weigher;
+        private Function<V, CachedQueryResult.PolicyValues> cachedResultParser;
 
         private long maxSizeInBytes;
 
@@ -135,6 +145,11 @@ public class CacheConfig<K, V> {
 
         public Builder<K, V> setWeigher(ToLongBiFunction<K, V> weigher) {
             this.weigher = weigher;
+            return this;
+        }
+
+        public Builder<K, V> setCachedResultParser(Function<V, CachedQueryResult.PolicyValues> function) {
+            this.cachedResultParser = function;
             return this;
         }
 

--- a/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
@@ -44,6 +44,7 @@ import org.opensearch.common.cache.ICache;
 import org.opensearch.common.cache.LoadAwareCacheLoader;
 import org.opensearch.common.cache.RemovalListener;
 import org.opensearch.common.cache.RemovalNotification;
+import org.opensearch.common.cache.policy.CachedQueryResult;
 import org.opensearch.common.cache.service.CacheService;
 import org.opensearch.common.cache.store.config.CacheConfig;
 import org.opensearch.common.lucene.index.OpenSearchDirectoryReader;
@@ -136,6 +137,14 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
                 .setRemovalListener(this)
                 .setMaxSizeInBytes(sizeInBytes) // for backward compatibility
                 .setExpireAfterAccess(expire) // for backward compatibility
+                .setCachedResultParser((bytesReference) -> {
+                    try {
+                        return CachedQueryResult.getPolicyValues(bytesReference);
+                    } catch (IOException e) {
+                        // Set took time to -1, which will always be rejected by the policy.
+                        return new CachedQueryResult.PolicyValues(-1);
+                    }
+                })
                 .build(),
             CacheType.INDICES_REQUEST_CACHE
         );

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -64,6 +64,7 @@ import org.opensearch.common.CheckedFunction;
 import org.opensearch.common.CheckedSupplier;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.annotation.PublicApi;
+import org.opensearch.common.cache.policy.CachedQueryResult;
 import org.opensearch.common.cache.service.CacheService;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.lease.Releasable;
@@ -84,9 +85,7 @@ import org.opensearch.common.util.set.Sets;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.core.common.breaker.CircuitBreaker;
 import org.opensearch.core.common.bytes.BytesReference;
-import org.opensearch.core.common.io.stream.NamedWriteableAwareStreamInput;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
-import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException;
@@ -1702,16 +1701,20 @@ public class IndicesService extends AbstractLifecycleComponent
 
         boolean[] loadedFromCache = new boolean[] { true };
         BytesReference bytesReference = cacheShardLevelResult(context.indexShard(), directoryReader, request.cacheKey(), out -> {
+            long beforeQueryPhase = System.nanoTime();
             queryPhase.execute(context);
-            context.queryResult().writeToNoId(out);
+            // Write relevant info for cache tier policies before the whole QuerySearchResult, so we don't have to read
+            // the whole QSR into memory when we decide whether to allow it into a particular cache tier based on took time/other info
+            CachedQueryResult cachedQueryResult = new CachedQueryResult(context.queryResult(), System.nanoTime() - beforeQueryPhase);
+            cachedQueryResult.writeToNoId(out);
             loadedFromCache[0] = false;
         });
 
         if (loadedFromCache[0]) {
             // restore the cached query result into the context
             final QuerySearchResult result = context.queryResult();
-            StreamInput in = new NamedWriteableAwareStreamInput(bytesReference.streamInput(), namedWriteableRegistry);
-            result.readFromWithId(context.id(), in);
+            // Load the cached QSR into result, discarding values used only in the cache
+            CachedQueryResult.loadQSR(bytesReference, result, context.id(), namedWriteableRegistry);
             result.setSearchShardTarget(context.shardTarget());
         } else if (context.queryResult().searchTimedOut()) {
             // we have to invalidate the cache entry if we cached a query result form a request that timed out.


### PR DESCRIPTION
Signed-off-by: Peter Alfonsi <petealft@amazon.com>
Co-authored-by: Peter Alfonsi <petealft@amazon.com>
(cherry picked from commit ccdf3ffb4c5cdce25db0b8c4b90f6a87dc0add95)

### Description

**Original PR: https://github.com/opensearch-project/OpenSearch/pull/12542**

This PR adds caching tier policies. In a tiered caching setup, or even for a single-tier cache, we might not want to allow all values into all tiers, so we want to define policies to allow or reject values. For example, we might not want to add values that took a very short time to compute to a disk tier, since the time to recompute them could be shorter than the time to get them back from the disk. 

This PR adds an interface for policies and integrates them to restrict access to the disk tier in the TieredSpilloverCache. Currently the only non-test implementation is the took time policy, but it should be easy to add more as they're needed.

When QuerySearchResult values are written into the IndicesRequestCache, we first write a CachePolicyInfoWrapper object, which has any values we might want to provide to policies. This way policies don't have to read the entire QSR (or other value type V). This wrapper is discarded when values come out of the cache.

CacheConfig<K, V> is modified to accept a generic Function<V, CachePolicyInfoWrapper>, which is used to get such a wrapper from cache values. It can be passed along to policies the cache will use. 

### Related Issues

This is part of the tiered caching feature (https://github.com/opensearch-project/OpenSearch/issues/10024).

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- ~[N/A] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

