### PR TITLE
[Backport 2.x] [Tiered Caching] Serializers for ehcache (#12709)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Metrics Framework] Adds support for asynchronous gauge metric type. ([#12642](https://github.com/opensearch-project/OpenSearch/issues/12642))
 - Make search query counters dynamic to support all query types ([#12601](https://github.com/opensearch-project/OpenSearch/pull/12601))
 - [Tiered caching] Add policies controlling which values can enter pluggable caches [EXPERIMENTAL] ([#12542](https://github.com/opensearch-project/OpenSearch/pull/12542))
-- [Tiered caching] Add Stale keys Management and CacheCleaner to IndicesRequestCache ([#12625](https://github.com/opensearch-project/OpenSearch/pull/12625))
 - [Tiered caching] Add serializer integration to allow ehcache disk cache to use non-primitive values ([#12709](https://github.com/opensearch-project/OpenSearch/pull/12709))
 - [Admission Control] Integrated IO Based AdmissionController to AdmissionControl Framework ([#12583](https://github.com/opensearch-project/OpenSearch/pull/12583))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Metrics Framework] Adds support for asynchronous gauge metric type. ([#12642](https://github.com/opensearch-project/OpenSearch/issues/12642))
 - Make search query counters dynamic to support all query types ([#12601](https://github.com/opensearch-project/OpenSearch/pull/12601))
 - [Tiered caching] Add policies controlling which values can enter pluggable caches [EXPERIMENTAL] ([#12542](https://github.com/opensearch-project/OpenSearch/pull/12542))
+- [Tiered caching] Add Stale keys Management and CacheCleaner to IndicesRequestCache ([#12625](https://github.com/opensearch-project/OpenSearch/pull/12625))
+- [Tiered caching] Add serializer integration to allow ehcache disk cache to use non-primitive values ([#12709](https://github.com/opensearch-project/OpenSearch/pull/12709))
 - [Admission Control] Integrated IO Based AdmissionController to AdmissionControl Framework ([#12583](https://github.com/opensearch-project/OpenSearch/pull/12583))
 
 ### Dependencies

--- a/modules/cache-common/src/test/java/org/opensearch/cache/common/tier/MockDiskCache.java
+++ b/modules/cache-common/src/test/java/org/opensearch/cache/common/tier/MockDiskCache.java
@@ -14,6 +14,7 @@ import org.opensearch.common.cache.LoadAwareCacheLoader;
 import org.opensearch.common.cache.RemovalListener;
 import org.opensearch.common.cache.RemovalNotification;
 import org.opensearch.common.cache.RemovalReason;
+import org.opensearch.common.cache.serializer.Serializer;
 import org.opensearch.common.cache.store.builders.ICacheBuilder;
 import org.opensearch.common.cache.store.config.CacheConfig;
 
@@ -106,8 +107,11 @@ public class MockDiskCache<K, V> implements ICache<K, V> {
         }
 
         @Override
+        @SuppressWarnings({ "unchecked" })
         public <K, V> ICache<K, V> create(CacheConfig<K, V> config, CacheType cacheType, Map<String, Factory> cacheFactories) {
-            return new Builder<K, V>().setMaxSize(maxSize)
+            return new Builder<K, V>().setKeySerializer((Serializer<K, byte[]>) config.getKeySerializer())
+                .setValueSerializer((Serializer<V, byte[]>) config.getValueSerializer())
+                .setMaxSize(maxSize)
                 .setDeliberateDelay(delay)
                 .setRemovalListener(config.getRemovalListener())
                 .build();
@@ -123,6 +127,8 @@ public class MockDiskCache<K, V> implements ICache<K, V> {
 
         int maxSize;
         long delay;
+        Serializer<K, byte[]> keySerializer;
+        Serializer<V, byte[]> valueSerializer;
 
         @Override
         public ICache<K, V> build() {
@@ -138,5 +144,16 @@ public class MockDiskCache<K, V> implements ICache<K, V> {
             this.delay = millis;
             return this;
         }
+
+        public Builder<K, V> setKeySerializer(Serializer<K, byte[]> keySerializer) {
+            this.keySerializer = keySerializer;
+            return this;
+        }
+
+        public Builder<K, V> setValueSerializer(Serializer<V, byte[]> valueSerializer) {
+            this.valueSerializer = valueSerializer;
+            return this;
+        }
+
     }
 }

--- a/plugins/cache-ehcache/src/test/java/org/opensearch/cache/store/disk/EhCacheDiskCacheTests.java
+++ b/plugins/cache-ehcache/src/test/java/org/opensearch/cache/store/disk/EhCacheDiskCacheTests.java
@@ -9,24 +9,33 @@
 package org.opensearch.cache.store.disk;
 
 import org.opensearch.cache.EhcacheDiskCacheSettings;
+import org.opensearch.common.Randomness;
 import org.opensearch.common.cache.CacheType;
 import org.opensearch.common.cache.ICache;
 import org.opensearch.common.cache.LoadAwareCacheLoader;
 import org.opensearch.common.cache.RemovalListener;
 import org.opensearch.common.cache.RemovalNotification;
+import org.opensearch.common.cache.serializer.BytesReferenceSerializer;
+import org.opensearch.common.cache.serializer.Serializer;
 import org.opensearch.common.cache.store.config.CacheConfig;
 import org.opensearch.common.metrics.CounterMetric;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.bytes.CompositeBytesReference;
 import org.opensearch.env.NodeEnvironment;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -51,6 +60,8 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                 .setIsEventListenerModeSync(true)
                 .setKeyType(String.class)
                 .setValueType(String.class)
+                .setKeySerializer(new StringSerializer())
+                .setValueSerializer(new StringSerializer())
                 .setCacheType(CacheType.INDICES_REQUEST_CACHE)
                 .setSettings(settings)
                 .setExpireAfterAccess(TimeValue.MAX_VALUE)
@@ -89,6 +100,8 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                 new CacheConfig.Builder<String, String>().setValueType(String.class)
                     .setKeyType(String.class)
                     .setRemovalListener(removalListener)
+                    .setKeySerializer(new StringSerializer())
+                    .setValueSerializer(new StringSerializer())
                     .setSettings(
                         Settings.builder()
                             .put(
@@ -149,6 +162,8 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                 .setIsEventListenerModeSync(true) // For accurate count
                 .setKeyType(String.class)
                 .setValueType(String.class)
+                .setKeySerializer(new StringSerializer())
+                .setValueSerializer(new StringSerializer())
                 .setCacheType(CacheType.INDICES_REQUEST_CACHE)
                 .setSettings(settings)
                 .setExpireAfterAccess(TimeValue.MAX_VALUE)
@@ -194,6 +209,8 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                 .setIsEventListenerModeSync(true) // For accurate count
                 .setKeyType(String.class)
                 .setValueType(String.class)
+                .setKeySerializer(new StringSerializer())
+                .setValueSerializer(new StringSerializer())
                 .setCacheType(CacheType.INDICES_REQUEST_CACHE)
                 .setSettings(settings)
                 .setExpireAfterAccess(TimeValue.MAX_VALUE)
@@ -237,6 +254,8 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                 .setIsEventListenerModeSync(true)
                 .setKeyType(String.class)
                 .setValueType(String.class)
+                .setKeySerializer(new StringSerializer())
+                .setValueSerializer(new StringSerializer())
                 .setCacheType(CacheType.INDICES_REQUEST_CACHE)
                 .setSettings(settings)
                 .setExpireAfterAccess(TimeValue.MAX_VALUE)
@@ -274,6 +293,8 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                 .setThreadPoolAlias("ehcacheTest")
                 .setKeyType(String.class)
                 .setValueType(String.class)
+                .setKeySerializer(new StringSerializer())
+                .setValueSerializer(new StringSerializer())
                 .setCacheType(CacheType.INDICES_REQUEST_CACHE)
                 .setSettings(settings)
                 .setExpireAfterAccess(TimeValue.MAX_VALUE)
@@ -304,6 +325,8 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                 .setThreadPoolAlias("ehcacheTest")
                 .setKeyType(String.class)
                 .setValueType(String.class)
+                .setKeySerializer(new StringSerializer())
+                .setValueSerializer(new StringSerializer())
                 .setCacheType(CacheType.INDICES_REQUEST_CACHE)
                 .setSettings(settings)
                 .setExpireAfterAccess(TimeValue.MAX_VALUE)
@@ -373,6 +396,8 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                 .setThreadPoolAlias("ehcacheTest")
                 .setKeyType(String.class)
                 .setValueType(String.class)
+                .setKeySerializer(new StringSerializer())
+                .setValueSerializer(new StringSerializer())
                 .setCacheType(CacheType.INDICES_REQUEST_CACHE)
                 .setSettings(settings)
                 .setExpireAfterAccess(TimeValue.MAX_VALUE)
@@ -430,6 +455,8 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                 .setStoragePath(env.nodePaths()[0].indicesPath.toString() + "/request_cache")
                 .setKeyType(String.class)
                 .setValueType(String.class)
+                .setKeySerializer(new StringSerializer())
+                .setValueSerializer(new StringSerializer())
                 .setCacheType(CacheType.INDICES_REQUEST_CACHE)
                 .setSettings(settings)
                 .setExpireAfterAccess(TimeValue.MAX_VALUE)
@@ -491,6 +518,8 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                 .setIsEventListenerModeSync(true)
                 .setKeyType(String.class)
                 .setValueType(String.class)
+                .setKeySerializer(new StringSerializer())
+                .setValueSerializer(new StringSerializer())
                 .setCacheType(CacheType.INDICES_REQUEST_CACHE)
                 .setSettings(settings)
                 .setExpireAfterAccess(TimeValue.MAX_VALUE)
@@ -525,6 +554,50 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
 
     }
 
+    public void testBasicGetAndPutBytesReference() throws Exception {
+        Settings settings = Settings.builder().build();
+        try (NodeEnvironment env = newNodeEnvironment(settings)) {
+            ICache<String, BytesReference> ehCacheDiskCachingTier = new EhcacheDiskCache.Builder<String, BytesReference>()
+                .setThreadPoolAlias("ehcacheTest")
+                .setStoragePath(env.nodePaths()[0].indicesPath.toString() + "/request_cache")
+                .setKeySerializer(new StringSerializer())
+                .setValueSerializer(new BytesReferenceSerializer())
+                .setKeyType(String.class)
+                .setValueType(BytesReference.class)
+                .setCacheType(CacheType.INDICES_REQUEST_CACHE)
+                .setSettings(settings)
+                .setMaximumWeightInBytes(CACHE_SIZE_IN_BYTES * 20) // bigger so no evictions happen
+                .setExpireAfterAccess(TimeValue.MAX_VALUE)
+                .setRemovalListener(new MockRemovalListener<>())
+                .build();
+            int randomKeys = randomIntBetween(10, 100);
+            int valueLength = 100;
+            Random rand = Randomness.get();
+            Map<String, BytesReference> keyValueMap = new HashMap<>();
+            for (int i = 0; i < randomKeys; i++) {
+                byte[] valueBytes = new byte[valueLength];
+                rand.nextBytes(valueBytes);
+                keyValueMap.put(UUID.randomUUID().toString(), new BytesArray(valueBytes));
+
+                // Test a non-BytesArray implementation of BytesReference.
+                byte[] compositeBytes1 = new byte[valueLength];
+                byte[] compositeBytes2 = new byte[valueLength];
+                rand.nextBytes(compositeBytes1);
+                rand.nextBytes(compositeBytes2);
+                BytesReference composite = CompositeBytesReference.of(new BytesArray(compositeBytes1), new BytesArray(compositeBytes2));
+                keyValueMap.put(UUID.randomUUID().toString(), composite);
+            }
+            for (Map.Entry<String, BytesReference> entry : keyValueMap.entrySet()) {
+                ehCacheDiskCachingTier.put(entry.getKey(), entry.getValue());
+            }
+            for (Map.Entry<String, BytesReference> entry : keyValueMap.entrySet()) {
+                BytesReference value = ehCacheDiskCachingTier.get(entry.getKey());
+                assertEquals(entry.getValue(), value);
+            }
+            ehCacheDiskCachingTier.close();
+        }
+    }
+
     private static String generateRandomString(int length) {
         String characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
         StringBuilder randomString = new StringBuilder(length);
@@ -544,6 +617,27 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
         @Override
         public void onRemoval(RemovalNotification<K, V> notification) {
             evictionMetric.inc();
+        }
+    }
+
+    static class StringSerializer implements Serializer<String, byte[]> {
+        private final Charset charset = StandardCharsets.UTF_8;
+
+        @Override
+        public byte[] serialize(String object) {
+            return object.getBytes(charset);
+        }
+
+        @Override
+        public String deserialize(byte[] bytes) {
+            if (bytes == null) {
+                return null;
+            }
+            return new String(bytes, charset);
+        }
+
+        public boolean equals(String object, byte[] bytes) {
+            return object.equals(deserialize(bytes));
         }
     }
 }

--- a/server/src/main/java/org/opensearch/common/cache/serializer/BytesReferenceSerializer.java
+++ b/server/src/main/java/org/opensearch/common/cache/serializer/BytesReferenceSerializer.java
@@ -1,0 +1,42 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.cache.serializer;
+
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.common.bytes.BytesReference;
+
+import java.util.Arrays;
+
+/**
+ * A serializer which transforms BytesReference to byte[].
+ * The type of BytesReference is NOT preserved after deserialization, but nothing in opensearch should care.
+ */
+public class BytesReferenceSerializer implements Serializer<BytesReference, byte[]> {
+    // This class does not get passed to ehcache itself, so it's not required that classes match after deserialization.
+
+    public BytesReferenceSerializer() {}
+
+    @Override
+    public byte[] serialize(BytesReference object) {
+        return BytesReference.toBytes(object);
+    }
+
+    @Override
+    public BytesReference deserialize(byte[] bytes) {
+        if (bytes == null) {
+            return null;
+        }
+        return new BytesArray(bytes);
+    }
+
+    @Override
+    public boolean equals(BytesReference object, byte[] bytes) {
+        return Arrays.equals(serialize(object), bytes);
+    }
+}

--- a/server/src/main/java/org/opensearch/common/cache/serializer/Serializer.java
+++ b/server/src/main/java/org/opensearch/common/cache/serializer/Serializer.java
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.cache.serializer;
+
+/**
+ * Defines an interface for serializers, to be used by pluggable caches.
+ * T is the class of the original object, and U is the serialized class.
+ */
+public interface Serializer<T, U> {
+    /**
+     * Serializes an object.
+     * @param object A non-serialized object.
+     * @return The serialized representation of the object.
+     */
+    U serialize(T object);
+
+    /**
+     * Deserializes bytes into an object.
+     * @param bytes The serialized representation.
+     * @return The original object.
+     */
+    T deserialize(U bytes);
+
+    /**
+     * Compares an object to a serialized representation of an object.
+     * @param object A non-serialized objet
+     * @param bytes Serialized representation of an object
+     * @return true if representing the same object, false if not
+     */
+    boolean equals(T object, U bytes);
+}

--- a/server/src/main/java/org/opensearch/common/cache/serializer/package-info.java
+++ b/server/src/main/java/org/opensearch/common/cache/serializer/package-info.java
@@ -1,0 +1,9 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+/** A package for serializers used in caches. */
+package org.opensearch.common.cache.serializer;

--- a/server/src/main/java/org/opensearch/common/cache/store/config/CacheConfig.java
+++ b/server/src/main/java/org/opensearch/common/cache/store/config/CacheConfig.java
@@ -11,6 +11,7 @@ package org.opensearch.common.cache.store.config;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.cache.RemovalListener;
 import org.opensearch.common.cache.policy.CachedQueryResult;
+import org.opensearch.common.cache.serializer.Serializer;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 
@@ -44,6 +45,10 @@ public class CacheConfig<K, V> {
 
     private final RemovalListener<K, V> removalListener;
 
+    // Serializers for keys and values. Not required for all caches.
+    private final Serializer<K, ?> keySerializer;
+    private final Serializer<V, ?> valueSerializer;
+
     /** A function which extracts policy-relevant information, such as took time, from values, to allow inspection by policies if present. */
     private Function<V, CachedQueryResult.PolicyValues> cachedResultParser;
     /**
@@ -62,6 +67,8 @@ public class CacheConfig<K, V> {
         this.settings = builder.settings;
         this.removalListener = builder.removalListener;
         this.weigher = builder.weigher;
+        this.keySerializer = builder.keySerializer;
+        this.valueSerializer = builder.valueSerializer;
         this.cachedResultParser = builder.cachedResultParser;
         this.maxSizeInBytes = builder.maxSizeInBytes;
         this.expireAfterAccess = builder.expireAfterAccess;
@@ -81,6 +88,14 @@ public class CacheConfig<K, V> {
 
     public RemovalListener<K, V> getRemovalListener() {
         return removalListener;
+    }
+
+    public Serializer<K, ?> getKeySerializer() {
+        return keySerializer;
+    }
+
+    public Serializer<V, ?> getValueSerializer() {
+        return valueSerializer;
     }
 
     public ToLongBiFunction<K, V> getWeigher() {
@@ -114,6 +129,9 @@ public class CacheConfig<K, V> {
 
         private RemovalListener<K, V> removalListener;
 
+        private Serializer<K, ?> keySerializer;
+        private Serializer<V, ?> valueSerializer;
+
         private ToLongBiFunction<K, V> weigher;
         private Function<V, CachedQueryResult.PolicyValues> cachedResultParser;
 
@@ -140,6 +158,16 @@ public class CacheConfig<K, V> {
 
         public Builder<K, V> setRemovalListener(RemovalListener<K, V> removalListener) {
             this.removalListener = removalListener;
+            return this;
+        }
+
+        public Builder<K, V> setKeySerializer(Serializer<K, ?> keySerializer) {
+            this.keySerializer = keySerializer;
+            return this;
+        }
+
+        public Builder<K, V> setValueSerializer(Serializer<V, ?> valueSerializer) {
+            this.valueSerializer = valueSerializer;
             return this;
         }
 

--- a/server/src/main/java/org/opensearch/indices/IRCKeyWriteableSerializer.java
+++ b/server/src/main/java/org/opensearch/indices/IRCKeyWriteableSerializer.java
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.indices;
+
+import org.opensearch.OpenSearchException;
+import org.opensearch.common.cache.serializer.Serializer;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.BytesStreamInput;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * This class serializes the IndicesRequestCache.Key using its writeTo method.
+ */
+public class IRCKeyWriteableSerializer implements Serializer<IndicesRequestCache.Key, byte[]> {
+
+    public IRCKeyWriteableSerializer() {}
+
+    @Override
+    public byte[] serialize(IndicesRequestCache.Key object) {
+        if (object == null) {
+            return null;
+        }
+        try {
+            BytesStreamOutput os = new BytesStreamOutput();
+            object.writeTo(os);
+            return BytesReference.toBytes(os.bytes());
+        } catch (IOException e) {
+            throw new OpenSearchException("Unable to serialize IndicesRequestCache.Key", e);
+        }
+    }
+
+    @Override
+    public IndicesRequestCache.Key deserialize(byte[] bytes) {
+        if (bytes == null) {
+            return null;
+        }
+        try {
+            BytesStreamInput is = new BytesStreamInput(bytes, 0, bytes.length);
+            return new IndicesRequestCache.Key(is);
+        } catch (IOException e) {
+            throw new OpenSearchException("Unable to deserialize byte[] to IndicesRequestCache.Key", e);
+        }
+    }
+
+    @Override
+    public boolean equals(IndicesRequestCache.Key object, byte[] bytes) {
+        // Deserialization is much slower than serialization for keys of order 1 KB,
+        // while time to serialize is fairly constant (per byte)
+        if (bytes.length < 5000) {
+            return Arrays.equals(serialize(object), bytes);
+        } else {
+            return object.equals(deserialize(bytes));
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
@@ -45,6 +45,7 @@ import org.opensearch.common.cache.LoadAwareCacheLoader;
 import org.opensearch.common.cache.RemovalListener;
 import org.opensearch.common.cache.RemovalNotification;
 import org.opensearch.common.cache.policy.CachedQueryResult;
+import org.opensearch.common.cache.serializer.BytesReferenceSerializer;
 import org.opensearch.common.cache.service.CacheService;
 import org.opensearch.common.cache.store.config.CacheConfig;
 import org.opensearch.common.lucene.index.OpenSearchDirectoryReader;
@@ -145,6 +146,8 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
                         return new CachedQueryResult.PolicyValues(-1);
                     }
                 })
+                .setKeySerializer(new IRCKeyWriteableSerializer())
+                .setValueSerializer(new BytesReferenceSerializer())
                 .build(),
             CacheType.INDICES_REQUEST_CACHE
         );

--- a/server/src/test/java/org/opensearch/common/cache/serializer/BytesReferenceSerializerTests.java
+++ b/server/src/test/java/org/opensearch/common/cache/serializer/BytesReferenceSerializerTests.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.cache.serializer;
+
+import org.opensearch.common.Randomness;
+import org.opensearch.common.bytes.ReleasableBytesReference;
+import org.opensearch.common.util.BigArrays;
+import org.opensearch.common.util.PageCacheRecycler;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.bytes.CompositeBytesReference;
+import org.opensearch.core.common.util.ByteArray;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Random;
+
+public class BytesReferenceSerializerTests extends OpenSearchTestCase {
+    public void testEquality() throws Exception {
+        BytesReferenceSerializer ser = new BytesReferenceSerializer();
+        // Test that values are equal before and after serialization, for each implementation of BytesReference.
+        byte[] bytesValue = new byte[1000];
+        Random rand = Randomness.get();
+        rand.nextBytes(bytesValue);
+
+        BytesReference ba = new BytesArray(bytesValue);
+        byte[] serialized = ser.serialize(ba);
+        assertTrue(ser.equals(ba, serialized));
+        BytesReference deserialized = ser.deserialize(serialized);
+        assertEquals(ba, deserialized);
+
+        ba = new BytesArray(new byte[] {});
+        serialized = ser.serialize(ba);
+        assertTrue(ser.equals(ba, serialized));
+        deserialized = ser.deserialize(serialized);
+        assertEquals(ba, deserialized);
+
+        BytesReference cbr = CompositeBytesReference.of(new BytesArray(bytesValue), new BytesArray(bytesValue));
+        serialized = ser.serialize(cbr);
+        assertTrue(ser.equals(cbr, serialized));
+        deserialized = ser.deserialize(serialized);
+        assertEquals(cbr, deserialized);
+
+        // We need the PagedBytesReference to be larger than the page size (16 KB) in order to actually create it
+        byte[] pbrValue = new byte[PageCacheRecycler.PAGE_SIZE_IN_BYTES * 2];
+        rand.nextBytes(pbrValue);
+        ByteArray arr = BigArrays.NON_RECYCLING_INSTANCE.newByteArray(pbrValue.length);
+        arr.set(0L, pbrValue, 0, pbrValue.length);
+        assert !arr.hasArray();
+        BytesReference pbr = BytesReference.fromByteArray(arr, pbrValue.length);
+        serialized = ser.serialize(pbr);
+        assertTrue(ser.equals(pbr, serialized));
+        deserialized = ser.deserialize(serialized);
+        assertEquals(pbr, deserialized);
+
+        BytesReference rbr = new ReleasableBytesReference(new BytesArray(bytesValue), ReleasableBytesReference.NO_OP);
+        serialized = ser.serialize(rbr);
+        assertTrue(ser.equals(rbr, serialized));
+        deserialized = ser.deserialize(serialized);
+        assertEquals(rbr, deserialized);
+    }
+}

--- a/server/src/test/java/org/opensearch/indices/IRCKeyWriteableSerializerTests.java
+++ b/server/src/test/java/org/opensearch/indices/IRCKeyWriteableSerializerTests.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.indices;
+
+import org.opensearch.common.Randomness;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.index.IndexService;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.test.OpenSearchSingleNodeTestCase;
+
+import java.util.Random;
+import java.util.UUID;
+
+public class IRCKeyWriteableSerializerTests extends OpenSearchSingleNodeTestCase {
+
+    public void testSerializer() throws Exception {
+        IndexService indexService = createIndex("test");
+        IndexShard indexShard = indexService.getShardOrNull(0);
+        IRCKeyWriteableSerializer ser = new IRCKeyWriteableSerializer();
+
+        int NUM_KEYS = 1000;
+        int[] valueLengths = new int[] { 1000, 6000 }; // test both branches in equals()
+        Random rand = Randomness.get();
+        for (int valueLength : valueLengths) {
+            for (int i = 0; i < NUM_KEYS; i++) {
+                IndicesRequestCache.Key key = getRandomIRCKey(valueLength, rand, indexShard.shardId());
+                byte[] serialized = ser.serialize(key);
+                assertTrue(ser.equals(key, serialized));
+                IndicesRequestCache.Key deserialized = ser.deserialize(serialized);
+                assertTrue(key.equals(deserialized));
+            }
+        }
+    }
+
+    private IndicesRequestCache.Key getRandomIRCKey(int valueLength, Random random, ShardId shard) {
+        byte[] value = new byte[valueLength];
+        for (int i = 0; i < valueLength; i++) {
+            value[i] = (byte) (random.nextInt(126 - 32) + 32);
+        }
+        BytesReference keyValue = new BytesArray(value);
+        return new IndicesRequestCache.Key(shard, keyValue, UUID.randomUUID().toString()); // same UUID source as used in real key
+    }
+}


### PR DESCRIPTION
**Original PR: https://github.com/opensearch-project/OpenSearch/pull/12709**

Signed-off-by: Peter Alfonsi <petealft@amazon.com>
Co-authored-by: Peter Alfonsi <petealft@amazon.com>
(cherry picked from commit 21b28f2a019a8ee538a763453366e6fd4943b768)

### Description
As part of tiered caching, adds a Serializer interface and implementations for BytesReference and IndicesRequestCache.Key. Also integrates these with EhcacheDiskCache. This is required for Ehcache to accept non-primitive keys or values. 

### Related Issues
Part of the [tiered caching feature. ](https://github.com/opensearch-project/OpenSearch/issues/10024)

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
~- [N/A] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
