### PR TITLE
Add a counter to node stat api to track shard going from idle to non-idle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add kuromoji_completion analyzer and filter ([#4835](https://github.com/opensearch-project/OpenSearch/issues/4835))
 - The org.opensearch.bootstrap.Security should support codebase for JAR files with classifiers ([#12586](https://github.com/opensearch-project/OpenSearch/issues/12586))
 - Make search query counters dynamic to support all query types ([#12601](https://github.com/opensearch-project/OpenSearch/pull/12601))
+- - [Tiered caching] Add policies controlling which values can enter pluggable caches [EXPERIMENTAL] ([#12542](https://github.com/opensearch-project/OpenSearch/pull/12542))
+- [Tiered caching] Add Stale keys Management and CacheCleaner to IndicesRequestCache ([#12625](https://github.com/opensearch-project/OpenSearch/pull/12625))
+- [Tiered caching] Add serializer integration to allow ehcache disk cache to use non-primitive values ([#12709](https://github.com/opensearch-project/OpenSearch/pull/12709))
+- [Admission Control] Integrated IO Based AdmissionController to AdmissionControl Framework ([#12583](https://github.com/opensearch-project/OpenSearch/pull/12583))
 - Add a counter to node stat api to track shard going from idle to non-idle ([#12737](https://github.com/opensearch-project/OpenSearch/pull/12737))
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Tiered caching] Make IndicesRequestCache implementation configurable [EXPERIMENTAL] ([#12533](https://github.com/opensearch-project/OpenSearch/pull/12533))
 - Add kuromoji_completion analyzer and filter ([#4835](https://github.com/opensearch-project/OpenSearch/issues/4835))
 - The org.opensearch.bootstrap.Security should support codebase for JAR files with classifiers ([#12586](https://github.com/opensearch-project/OpenSearch/issues/12586))
+- [Metrics Framework] Adds support for asynchronous gauge metric type. ([#12642](https://github.com/opensearch-project/OpenSearch/issues/12642))
 - Make search query counters dynamic to support all query types ([#12601](https://github.com/opensearch-project/OpenSearch/pull/12601))
 - [Tiered caching] Add policies controlling which values can enter pluggable caches [EXPERIMENTAL] ([#12542](https://github.com/opensearch-project/OpenSearch/pull/12542))
 - [Tiered caching] Add Stale keys Management and CacheCleaner to IndicesRequestCache ([#12625](https://github.com/opensearch-project/OpenSearch/pull/12625))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add kuromoji_completion analyzer and filter ([#4835](https://github.com/opensearch-project/OpenSearch/issues/4835))
 - The org.opensearch.bootstrap.Security should support codebase for JAR files with classifiers ([#12586](https://github.com/opensearch-project/OpenSearch/issues/12586))
 - Make search query counters dynamic to support all query types ([#12601](https://github.com/opensearch-project/OpenSearch/pull/12601))
+- Add a counter to node stat api to track shard going from idle to non-idle ([#12737](https://github.com/opensearch-project/OpenSearch/pull/12737))
 
 ### Dependencies
 - Bump `peter-evans/find-comment` from 2 to 3 ([#12288](https://github.com/opensearch-project/OpenSearch/pull/12288))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,7 +113,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add kuromoji_completion analyzer and filter ([#4835](https://github.com/opensearch-project/OpenSearch/issues/4835))
 - The org.opensearch.bootstrap.Security should support codebase for JAR files with classifiers ([#12586](https://github.com/opensearch-project/OpenSearch/issues/12586))
 - Make search query counters dynamic to support all query types ([#12601](https://github.com/opensearch-project/OpenSearch/pull/12601))
-- - [Tiered caching] Add policies controlling which values can enter pluggable caches [EXPERIMENTAL] ([#12542](https://github.com/opensearch-project/OpenSearch/pull/12542))
+- [Tiered caching] Add policies controlling which values can enter pluggable caches [EXPERIMENTAL] ([#12542](https://github.com/opensearch-project/OpenSearch/pull/12542))
 - [Tiered caching] Add Stale keys Management and CacheCleaner to IndicesRequestCache ([#12625](https://github.com/opensearch-project/OpenSearch/pull/12625))
 - [Tiered caching] Add serializer integration to allow ehcache disk cache to use non-primitive values ([#12709](https://github.com/opensearch-project/OpenSearch/pull/12709))
 - [Admission Control] Integrated IO Based AdmissionController to AdmissionControl Framework ([#12583](https://github.com/opensearch-project/OpenSearch/pull/12583))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Allow composite aggregation to run under a parent filter aggregation ([#11499](https://github.com/opensearch-project/OpenSearch/pull/11499))
 - Quickly compute terms aggregations when the top-level query is functionally match-all for a segment ([#11643](https://github.com/opensearch-project/OpenSearch/pull/11643))
+- Mark fuzzy filter GA and remove experimental setting ([12631](https://github.com/opensearch-project/OpenSearch/pull/12631))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix `terms` query on `float` field when `doc_values` are turned off by reverting back to `FloatPoint` from `FloatField` ([#12499](https://github.com/opensearch-project/OpenSearch/pull/12499))
 - Fix get task API does not refresh resource stats ([#11531](https://github.com/opensearch-project/OpenSearch/pull/11531))
 - onShardResult and onShardFailure are executed on one shard causes opensearch jvm crashed ([#12158](https://github.com/opensearch-project/OpenSearch/pull/12158))
+- Avoid overflow when sorting missing last on `epoch_millis` datetime field ([#12676](https://github.com/opensearch-project/OpenSearch/pull/12676))
 
 ### Security
 

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/metrics/DefaultMetricsRegistry.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/metrics/DefaultMetricsRegistry.java
@@ -8,7 +8,11 @@
 
 package org.opensearch.telemetry.metrics;
 
+import org.opensearch.telemetry.metrics.tags.Tags;
+
+import java.io.Closeable;
 import java.io.IOException;
+import java.util.function.Supplier;
 
 /**
  * Default implementation for {@link MetricsRegistry}
@@ -37,6 +41,11 @@ class DefaultMetricsRegistry implements MetricsRegistry {
     @Override
     public Histogram createHistogram(String name, String description, String unit) {
         return metricsTelemetry.createHistogram(name, description, unit);
+    }
+
+    @Override
+    public Closeable createGauge(String name, String description, String unit, Supplier<Double> valueProvider, Tags tags) {
+        return metricsTelemetry.createGauge(name, description, unit, valueProvider, tags);
     }
 
     @Override

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/metrics/MetricsRegistry.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/metrics/MetricsRegistry.java
@@ -9,8 +9,10 @@
 package org.opensearch.telemetry.metrics;
 
 import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.telemetry.metrics.tags.Tags;
 
 import java.io.Closeable;
+import java.util.function.Supplier;
 
 /**
  * MetricsRegistry helps in creating the metric instruments.
@@ -47,4 +49,18 @@ public interface MetricsRegistry extends Closeable {
      * @return histogram.
      */
     Histogram createHistogram(String name, String description, String unit);
+
+    /**
+     * Creates the Observable Gauge type of Metric. Where the value provider will be called at a certain frequency
+     * to capture the value.
+     *
+     * @param name          name of the observable gauge.
+     * @param description   any description about the metric.
+     * @param unit          unit of the metric.
+     * @param valueProvider value provider.
+     * @param tags          attributes/dimensions of the metric.
+     * @return closeable to dispose/close the Gauge metric.
+     */
+    Closeable createGauge(String name, String description, String unit, Supplier<Double> valueProvider, Tags tags);
+
 }

--- a/libs/telemetry/src/main/java/org/opensearch/telemetry/metrics/noop/NoopMetricsRegistry.java
+++ b/libs/telemetry/src/main/java/org/opensearch/telemetry/metrics/noop/NoopMetricsRegistry.java
@@ -12,8 +12,11 @@ import org.opensearch.common.annotation.InternalApi;
 import org.opensearch.telemetry.metrics.Counter;
 import org.opensearch.telemetry.metrics.Histogram;
 import org.opensearch.telemetry.metrics.MetricsRegistry;
+import org.opensearch.telemetry.metrics.tags.Tags;
 
+import java.io.Closeable;
 import java.io.IOException;
+import java.util.function.Supplier;
 
 /**
  *No-op {@link MetricsRegistry}
@@ -42,6 +45,11 @@ public class NoopMetricsRegistry implements MetricsRegistry {
     @Override
     public Histogram createHistogram(String name, String description, String unit) {
         return NoopHistogram.INSTANCE;
+    }
+
+    @Override
+    public Closeable createGauge(String name, String description, String unit, Supplier<Double> valueProvider, Tags tags) {
+        return () -> {};
     }
 
     @Override

--- a/libs/telemetry/src/test/java/org/opensearch/telemetry/metrics/DefaultMetricsRegistryTests.java
+++ b/libs/telemetry/src/test/java/org/opensearch/telemetry/metrics/DefaultMetricsRegistryTests.java
@@ -8,7 +8,11 @@
 
 package org.opensearch.telemetry.metrics;
 
+import org.opensearch.telemetry.metrics.tags.Tags;
 import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.Closeable;
+import java.util.function.Supplier;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -57,6 +61,22 @@ public class DefaultMetricsRegistryTests extends OpenSearchTestCase {
             "ms"
         );
         assertSame(mockHistogram, histogram);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testGauge() {
+        Closeable mockCloseable = mock(Closeable.class);
+        when(
+            defaultMeterRegistry.createGauge(any(String.class), any(String.class), any(String.class), any(Supplier.class), any(Tags.class))
+        ).thenReturn(mockCloseable);
+        Closeable closeable = defaultMeterRegistry.createGauge(
+            "org.opensearch.telemetry.metrics.DefaultMeterRegistryTests.testObservableGauge",
+            "test observable gauge",
+            "ms",
+            () -> 1.0,
+            Tags.EMPTY
+        );
+        assertSame(mockCloseable, closeable);
     }
 
 }

--- a/plugins/cache-ehcache/src/main/java/org/opensearch/cache/store/disk/EhcacheDiskCache.java
+++ b/plugins/cache-ehcache/src/main/java/org/opensearch/cache/store/disk/EhcacheDiskCache.java
@@ -407,6 +407,11 @@ public class EhcacheDiskCache<K, V> implements ICache<K, V> {
             }
             return iterator.next().getKey();
         }
+
+        @Override
+        public void remove() {
+            iterator.remove(); // Calls underlying ehcache iterator.remove()
+        }
     }
 
     /**

--- a/plugins/telemetry-otel/src/internalClusterTest/java/org/opensearch/telemetry/metrics/TelemetryMetricsEnabledSanityIT.java
+++ b/plugins/telemetry-otel/src/internalClusterTest/java/org/opensearch/telemetry/metrics/TelemetryMetricsEnabledSanityIT.java
@@ -14,15 +14,21 @@ import org.opensearch.plugins.Plugin;
 import org.opensearch.telemetry.IntegrationTestOTelTelemetryPlugin;
 import org.opensearch.telemetry.OTelTelemetrySettings;
 import org.opensearch.telemetry.TelemetrySettings;
+import org.opensearch.telemetry.metrics.tags.Tags;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.junit.After;
 
+import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import io.opentelemetry.sdk.metrics.data.DoublePointData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableExponentialHistogramPointData;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, minNumDataNodes = 1)
@@ -116,6 +122,41 @@ public class TelemetryMetricsEnabledSanityIT extends OpenSearchIntegTestCase {
         assertEquals(1.0, histogramPointData.getSum(), 6.0);
         assertEquals(1.0, histogramPointData.getMax(), 3.0);
         assertEquals(1.0, histogramPointData.getMin(), 1.0);
+    }
+
+    public void testObservableGauge() throws Exception {
+        String metricName = "test-observable-gauge";
+        MetricsRegistry metricsRegistry = internalCluster().getInstance(MetricsRegistry.class);
+        InMemorySingletonMetricsExporter.INSTANCE.reset();
+        Tags tags = Tags.create().addTag("test", "integ-test");
+        final AtomicInteger testValue = new AtomicInteger(0);
+        Supplier<Double> valueProvider = () -> { return Double.valueOf(testValue.incrementAndGet()); };
+        Closeable gaugeCloseable = metricsRegistry.createGauge(metricName, "test", "ms", valueProvider, tags);
+        // Sleep for about 2.2s to wait for metrics to be published.
+        Thread.sleep(2200);
+
+        InMemorySingletonMetricsExporter exporter = InMemorySingletonMetricsExporter.INSTANCE;
+
+        assertEquals(2.0, getMaxObservableGaugeValue(exporter, metricName), 0.0);
+        gaugeCloseable.close();
+        double observableGaugeValueAfterStop = getMaxObservableGaugeValue(exporter, metricName);
+
+        // Sleep for about 1.2s to wait for metrics to see that closed observableGauge shouldn't execute the callable.
+        Thread.sleep(1200);
+        assertEquals(observableGaugeValueAfterStop, getMaxObservableGaugeValue(exporter, metricName), 0.0);
+
+    }
+
+    private static double getMaxObservableGaugeValue(InMemorySingletonMetricsExporter exporter, String metricName) {
+        List<MetricData> dataPoints = exporter.getFinishedMetricItems()
+            .stream()
+            .filter(a -> a.getName().contains(metricName))
+            .collect(Collectors.toList());
+        double totalValue = 0;
+        for (MetricData metricData : dataPoints) {
+            totalValue = Math.max(totalValue, ((DoublePointData) metricData.getDoubleGaugeData().getPoints().toArray()[0]).getValue());
+        }
+        return totalValue;
     }
 
     @After

--- a/plugins/telemetry-otel/src/main/java/org/opensearch/telemetry/metrics/OTelMetricsTelemetry.java
+++ b/plugins/telemetry-otel/src/main/java/org/opensearch/telemetry/metrics/OTelMetricsTelemetry.java
@@ -9,18 +9,22 @@
 package org.opensearch.telemetry.metrics;
 
 import org.opensearch.common.concurrent.RefCountedReleasable;
+import org.opensearch.telemetry.OTelAttributesConverter;
 import org.opensearch.telemetry.OTelTelemetryPlugin;
+import org.opensearch.telemetry.metrics.tags.Tags;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.function.Supplier;
 
 import io.opentelemetry.api.metrics.DoubleCounter;
 import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.DoubleUpDownCounter;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.MeterProvider;
+import io.opentelemetry.api.metrics.ObservableDoubleGauge;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 
 /**
@@ -84,6 +88,17 @@ public class OTelMetricsTelemetry<T extends MeterProvider & Closeable> implement
             (PrivilegedAction<DoubleHistogram>) () -> otelMeter.histogramBuilder(name).setUnit(unit).setDescription(description).build()
         );
         return new OTelHistogram(doubleHistogram);
+    }
+
+    @Override
+    public Closeable createGauge(String name, String description, String unit, Supplier<Double> valueProvider, Tags tags) {
+        ObservableDoubleGauge doubleObservableGauge = AccessController.doPrivileged(
+            (PrivilegedAction<ObservableDoubleGauge>) () -> otelMeter.gaugeBuilder(name)
+                .setUnit(unit)
+                .setDescription(description)
+                .buildWithCallback(record -> record.record(valueProvider.get(), OTelAttributesConverter.convert(tags)))
+        );
+        return () -> doubleObservableGauge.close();
     }
 
     @Override

--- a/plugins/telemetry-otel/src/test/java/org/opensearch/telemetry/metrics/OTelMetricsTelemetryTests.java
+++ b/plugins/telemetry-otel/src/test/java/org/opensearch/telemetry/metrics/OTelMetricsTelemetryTests.java
@@ -14,9 +14,13 @@ import org.opensearch.telemetry.OTelTelemetryPlugin;
 import org.opensearch.telemetry.metrics.tags.Tags;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.io.Closeable;
+import java.util.function.Consumer;
+
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.metrics.DoubleCounter;
 import io.opentelemetry.api.metrics.DoubleCounterBuilder;
+import io.opentelemetry.api.metrics.DoubleGaugeBuilder;
 import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
 import io.opentelemetry.api.metrics.DoubleUpDownCounter;
@@ -25,8 +29,10 @@ import io.opentelemetry.api.metrics.LongCounterBuilder;
 import io.opentelemetry.api.metrics.LongUpDownCounterBuilder;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.MeterProvider;
+import io.opentelemetry.api.metrics.ObservableDoubleGauge;
 import org.mockito.Mockito;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -148,5 +154,30 @@ public class OTelMetricsTelemetryTests extends OpenSearchTestCase {
         Tags tags = Tags.create().addTag("test", "test");
         histogram.record(2.0, tags);
         verify(mockOTelDoubleHistogram).record(2.0, OTelAttributesConverter.convert(tags));
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public void testGauge() throws Exception {
+        String observableGaugeName = "test-gauge";
+        String description = "test";
+        String unit = "1";
+        Meter mockMeter = mock(Meter.class);
+        OpenTelemetry mockOpenTelemetry = mock(OpenTelemetry.class);
+        ObservableDoubleGauge observableDoubleGauge = mock(ObservableDoubleGauge.class);
+        DoubleGaugeBuilder mockOTelDoubleGaugeBuilder = mock(DoubleGaugeBuilder.class);
+        MeterProvider meterProvider = mock(MeterProvider.class);
+        when(meterProvider.get(OTelTelemetryPlugin.INSTRUMENTATION_SCOPE_NAME)).thenReturn(mockMeter);
+        MetricsTelemetry metricsTelemetry = new OTelMetricsTelemetry(
+            new RefCountedReleasable("telemetry", mockOpenTelemetry, () -> {}),
+            meterProvider
+        );
+        when(mockMeter.gaugeBuilder(Mockito.contains(observableGaugeName))).thenReturn(mockOTelDoubleGaugeBuilder);
+        when(mockOTelDoubleGaugeBuilder.setDescription(description)).thenReturn(mockOTelDoubleGaugeBuilder);
+        when(mockOTelDoubleGaugeBuilder.setUnit(unit)).thenReturn(mockOTelDoubleGaugeBuilder);
+        when(mockOTelDoubleGaugeBuilder.buildWithCallback(any(Consumer.class))).thenReturn(observableDoubleGauge);
+
+        Closeable closeable = metricsTelemetry.createGauge(observableGaugeName, description, unit, () -> 1.0, Tags.EMPTY);
+        closeable.close();
+        verify(observableDoubleGauge).close();
     }
 }

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -62,7 +62,6 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
       setting 'repositories.url.allowed_urls', 'http://snapshot.test*'
       setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
       setting 'http.content_type.required', 'true'
-      systemProperty 'opensearch.experimental.optimize_doc_id_lookup.fuzzy_set.enabled', 'true'
     }
   }
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.highlight/30_max_analyzed_offset.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.highlight/30_max_analyzed_offset.yml
@@ -82,8 +82,8 @@ setup:
 ---
 "Plain highlighter on a field WITHOUT OFFSETS using max_analyzer_offset should SUCCEED":
   - skip:
-      version: " - 2.1.99"
-      reason: only starting supporting the parameter max_analyzer_offset on version 2.2
+      version: " - 2.12.99"
+      reason: only starting supporting the parameter max_analyzer_offset with plain highlighter on version 2.13
   - do:
       search:
         rest_total_hits_as_int: true

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/DeleteSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/DeleteSnapshotIT.java
@@ -304,7 +304,8 @@ public class DeleteSnapshotIT extends AbstractSnapshotIntegTestCase {
             .getSetting(remoteStoreEnabledIndexName, IndexMetadata.SETTING_INDEX_UUID);
 
         logger.info("--> create two remote index shallow snapshots");
-        List<String> shallowCopySnapshots = createNSnapshots(snapshotRepoName, 2);
+        SnapshotInfo snapshotInfo1 = createFullSnapshot(snapshotRepoName, "snap1");
+        SnapshotInfo snapshotInfo2 = createFullSnapshot(snapshotRepoName, "snap2");
 
         String[] lockFiles = getLockFilesInRemoteStore(remoteStoreEnabledIndexName, REMOTE_REPO_NAME);
         assert (lockFiles.length == 2) : "lock files are " + Arrays.toString(lockFiles);
@@ -315,17 +316,18 @@ public class DeleteSnapshotIT extends AbstractSnapshotIntegTestCase {
         logger.info("--> delete snapshot 1");
         AcknowledgedResponse deleteSnapshotResponse = clusterManagerClient.admin()
             .cluster()
-            .prepareDeleteSnapshot(snapshotRepoName, shallowCopySnapshots.get(0))
+            .prepareDeleteSnapshot(snapshotRepoName, snapshotInfo1.snapshotId().getName())
             .get();
         assertAcked(deleteSnapshotResponse);
 
         lockFiles = getLockFilesInRemoteStore(remoteStoreEnabledIndexName, REMOTE_REPO_NAME, indexUUID);
         assert (lockFiles.length == 1) : "lock files are " + Arrays.toString(lockFiles);
+        assertTrue(lockFiles[0].contains(snapshotInfo2.snapshotId().getUUID()));
 
         logger.info("--> delete snapshot 2");
         deleteSnapshotResponse = clusterManagerClient.admin()
             .cluster()
-            .prepareDeleteSnapshot(snapshotRepoName, shallowCopySnapshots.get(1))
+            .prepareDeleteSnapshot(snapshotRepoName, snapshotInfo2.snapshotId().getName())
             .get();
         assertAcked(deleteSnapshotResponse);
 

--- a/server/src/main/java/org/opensearch/cluster/ClusterModule.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterModule.java
@@ -69,6 +69,7 @@ import org.opensearch.cluster.routing.allocation.decider.MaxRetryAllocationDecid
 import org.opensearch.cluster.routing.allocation.decider.NodeLoadAwareAllocationDecider;
 import org.opensearch.cluster.routing.allocation.decider.NodeVersionAllocationDecider;
 import org.opensearch.cluster.routing.allocation.decider.RebalanceOnlyWhenActiveAllocationDecider;
+import org.opensearch.cluster.routing.allocation.decider.RemoteStoreMigrationAllocationDecider;
 import org.opensearch.cluster.routing.allocation.decider.ReplicaAfterPrimaryActiveAllocationDecider;
 import org.opensearch.cluster.routing.allocation.decider.ResizeAllocationDecider;
 import org.opensearch.cluster.routing.allocation.decider.RestoreInProgressAllocationDecider;
@@ -83,6 +84,7 @@ import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.util.set.Sets;
 import org.opensearch.core.ParseField;
@@ -373,6 +375,9 @@ public class ClusterModule extends AbstractModule {
         addAllocationDecider(deciders, new AwarenessAllocationDecider(settings, clusterSettings));
         addAllocationDecider(deciders, new NodeLoadAwareAllocationDecider(settings, clusterSettings));
         addAllocationDecider(deciders, new TargetPoolAllocationDecider());
+        if (FeatureFlags.isEnabled(FeatureFlags.REMOTE_STORE_MIGRATION_EXPERIMENTAL_SETTING)) {
+            addAllocationDecider(deciders, new RemoteStoreMigrationAllocationDecider(settings, clusterSettings));
+        }
 
         clusterPlugins.stream()
             .flatMap(p -> p.createAllocationDeciders(settings, clusterSettings).stream())

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -138,7 +138,7 @@ import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REPLICATION_
 import static org.opensearch.cluster.metadata.Metadata.DEFAULT_REPLICA_COUNT_SETTING;
 import static org.opensearch.index.IndexModule.INDEX_STORE_TYPE_SETTING;
 import static org.opensearch.indices.IndicesService.CLUSTER_REPLICATION_TYPE_SETTING;
-import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.isRemoteStoreAttributePresent;
+import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.isRemoteDataAttributePresent;
 
 /**
  * Service responsible for submitting create index requests
@@ -971,7 +971,7 @@ public class MetadataCreateIndexService {
             indexReplicationType = INDEX_REPLICATION_TYPE_SETTING.get(combinedTemplateSettings);
         } else if (CLUSTER_REPLICATION_TYPE_SETTING.exists(clusterSettings)) {
             indexReplicationType = CLUSTER_REPLICATION_TYPE_SETTING.get(clusterSettings);
-        } else if (isRemoteStoreAttributePresent(clusterSettings)) {
+        } else if (isRemoteDataAttributePresent(clusterSettings)) {
             indexReplicationType = ReplicationType.SEGMENT;
         } else {
             indexReplicationType = CLUSTER_REPLICATION_TYPE_SETTING.getDefault(clusterSettings);
@@ -985,7 +985,7 @@ public class MetadataCreateIndexService {
      * @param clusterSettings cluster level settings
      */
     private static void updateRemoteStoreSettings(Settings.Builder settingsBuilder, Settings clusterSettings) {
-        if (isRemoteStoreAttributePresent(clusterSettings)) {
+        if (isRemoteDataAttributePresent(clusterSettings)) {
             settingsBuilder.put(SETTING_REMOTE_STORE_ENABLED, true)
                 .put(
                     SETTING_REMOTE_SEGMENT_STORE_REPOSITORY,
@@ -1577,7 +1577,7 @@ public class MetadataCreateIndexService {
      * @param clusterSettings cluster setting
      */
     static void validateTranslogDurabilitySettings(Settings requestSettings, ClusterSettings clusterSettings, Settings settings) {
-        if (isRemoteStoreAttributePresent(settings) == false
+        if (isRemoteDataAttributePresent(settings) == false
             || IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING.exists(requestSettings) == false
             || clusterSettings.get(IndicesService.CLUSTER_REMOTE_INDEX_RESTRICT_ASYNC_DURABILITY_SETTING) == false) {
             return;

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/RemoteStoreMigrationAllocationDecider.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/RemoteStoreMigrationAllocationDecider.java
@@ -1,0 +1,174 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.cluster.routing.allocation.decider;
+
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.routing.RoutingNode;
+import org.opensearch.cluster.routing.ShardRouting;
+import org.opensearch.cluster.routing.allocation.RoutingAllocation;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.node.remotestore.RemoteStoreNodeService;
+import org.opensearch.node.remotestore.RemoteStoreNodeService.CompatibilityMode;
+import org.opensearch.node.remotestore.RemoteStoreNodeService.Direction;
+
+import java.util.Locale;
+
+/**
+ * A new allocation decider for migration of document replication clusters to remote store backed clusters:
+ * - For STRICT compatibility mode, the decision is always YES
+ * - For remote store backed indices, relocation or allocation/relocation can only be towards a remote node
+ * - For "REMOTE_STORE" migration direction:
+ *      - New primary shards can only be allocated to a remote node
+ *      - New replica shards can be allocated to a remote node iff the primary has been migrated/allocated to a remote node
+ * - For other directions ("DOCREP", "NONE"), the decision is always YES
+ *
+ * @opensearch.internal
+ */
+public class RemoteStoreMigrationAllocationDecider extends AllocationDecider {
+
+    public static final String NAME = "remote_store_migration";
+
+    private Direction migrationDirection;
+    private CompatibilityMode compatibilityMode;
+    private boolean remoteStoreBackedIndex;
+
+    public RemoteStoreMigrationAllocationDecider(Settings settings, ClusterSettings clusterSettings) {
+        this.migrationDirection = RemoteStoreNodeService.MIGRATION_DIRECTION_SETTING.get(settings);
+        this.compatibilityMode = RemoteStoreNodeService.REMOTE_STORE_COMPATIBILITY_MODE_SETTING.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(RemoteStoreNodeService.MIGRATION_DIRECTION_SETTING, this::setMigrationDirection);
+        clusterSettings.addSettingsUpdateConsumer(
+            RemoteStoreNodeService.REMOTE_STORE_COMPATIBILITY_MODE_SETTING,
+            this::setCompatibilityMode
+        );
+    }
+
+    private void setMigrationDirection(Direction migrationDirection) {
+        this.migrationDirection = migrationDirection;
+    }
+
+    private void setCompatibilityMode(CompatibilityMode compatibilityMode) {
+        this.compatibilityMode = compatibilityMode;
+    }
+
+    @Override
+    public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+        DiscoveryNode targetNode = node.node();
+
+        if (compatibilityMode.equals(CompatibilityMode.STRICT)) {
+            // assuming all nodes are of the same type (all remote or all non-remote)
+            return allocation.decision(
+                Decision.YES,
+                NAME,
+                getDecisionDetails(true, shardRouting, targetNode, " for strict compatibility mode")
+            );
+        }
+
+        if (migrationDirection.equals(Direction.REMOTE_STORE) == false) {
+            // docrep migration direction is currently not supported
+            return allocation.decision(
+                Decision.YES,
+                NAME,
+                getDecisionDetails(true, shardRouting, targetNode, " for non remote_store direction")
+            );
+        }
+
+        // check for remote store backed indices
+        IndexMetadata indexMetadata = allocation.metadata().getIndexSafe(shardRouting.index());
+        if (IndexMetadata.INDEX_REMOTE_STORE_ENABLED_SETTING.exists(indexMetadata.getSettings())) {
+            remoteStoreBackedIndex = IndexMetadata.INDEX_REMOTE_STORE_ENABLED_SETTING.get(indexMetadata.getSettings());
+        }
+        if (remoteStoreBackedIndex && targetNode.isRemoteStoreNode() == false) {
+            // allocations and relocations must be to a remote node
+            String reason = String.format(
+                Locale.ROOT,
+                " because a remote store backed index's shard copy can only be %s to a remote node",
+                ((shardRouting.assignedToNode() == false) ? "allocated" : "relocated")
+            );
+            return allocation.decision(Decision.NO, NAME, getDecisionDetails(false, shardRouting, targetNode, reason));
+        }
+
+        if (shardRouting.primary()) {
+            return primaryShardDecision(shardRouting, targetNode, allocation);
+        }
+        return replicaShardDecision(shardRouting, targetNode, allocation);
+    }
+
+    // handle scenarios for allocation of a new shard's primary copy
+    private Decision primaryShardDecision(ShardRouting primaryShardRouting, DiscoveryNode targetNode, RoutingAllocation allocation) {
+        if (targetNode.isRemoteStoreNode() == false) {
+            return allocation.decision(Decision.NO, NAME, getDecisionDetails(false, primaryShardRouting, targetNode, ""));
+        }
+        return allocation.decision(Decision.YES, NAME, getDecisionDetails(true, primaryShardRouting, targetNode, ""));
+    }
+
+    private Decision replicaShardDecision(ShardRouting replicaShardRouting, DiscoveryNode targetNode, RoutingAllocation allocation) {
+        if (targetNode.isRemoteStoreNode()) {
+            ShardRouting primaryShardRouting = allocation.routingNodes().activePrimary(replicaShardRouting.shardId());
+            boolean primaryHasMigratedToRemote = false;
+            if (primaryShardRouting != null) {
+                DiscoveryNode primaryShardNode = allocation.nodes().getNodes().get(primaryShardRouting.currentNodeId());
+                primaryHasMigratedToRemote = primaryShardNode.isRemoteStoreNode();
+            }
+            if (primaryHasMigratedToRemote == false) {
+                return allocation.decision(
+                    Decision.NO,
+                    NAME,
+                    getDecisionDetails(false, replicaShardRouting, targetNode, " since primary shard copy is not yet migrated to remote")
+                );
+            }
+            return allocation.decision(
+                Decision.YES,
+                NAME,
+                getDecisionDetails(true, replicaShardRouting, targetNode, " since primary shard copy has been migrated to remote")
+            );
+        }
+        return allocation.decision(Decision.YES, NAME, getDecisionDetails(true, replicaShardRouting, targetNode, ""));
+    }
+
+    // get detailed reason for the decision
+    private String getDecisionDetails(boolean isYes, ShardRouting shardRouting, DiscoveryNode targetNode, String reason) {
+        return String.format(
+            Locale.ROOT,
+            "[%s migration_direction]: %s shard copy %s be %s to a %s node%s",
+            migrationDirection.direction,
+            (shardRouting.primary() ? "primary" : "replica"),
+            (isYes ? "can" : "can not"),
+            ((shardRouting.assignedToNode() == false) ? "allocated" : "relocated"),
+            (targetNode.isRemoteStoreNode() ? "remote" : "non-remote"),
+            reason
+        );
+    }
+
+}

--- a/server/src/main/java/org/opensearch/common/settings/FeatureFlagSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/FeatureFlagSettings.java
@@ -35,7 +35,6 @@ public class FeatureFlagSettings extends AbstractScopedSettings {
         FeatureFlags.TELEMETRY_SETTING,
         FeatureFlags.DATETIME_FORMATTER_CACHING_SETTING,
         FeatureFlags.WRITEABLE_REMOTE_INDEX_SETTING,
-        FeatureFlags.DOC_ID_FUZZY_SET_SETTING,
         FeatureFlags.REMOTE_STORE_MIGRATION_EXPERIMENTAL_SETTING,
         FeatureFlags.PLUGGABLE_CACHE_SETTING
     );

--- a/server/src/main/java/org/opensearch/common/time/EpochTime.java
+++ b/server/src/main/java/org/opensearch/common/time/EpochTime.java
@@ -126,7 +126,12 @@ class EpochTime {
 
         @Override
         public long getFrom(TemporalAccessor temporal) {
-            long instantSecondsInMillis = temporal.getLong(ChronoField.INSTANT_SECONDS) * 1_000;
+            long instantSeconds = temporal.getLong(ChronoField.INSTANT_SECONDS);
+            if (instantSeconds < Long.MIN_VALUE / 1000L || instantSeconds > Long.MAX_VALUE / 1000L) {
+                // Multiplying would yield integer overflow
+                return Long.MAX_VALUE;
+            }
+            long instantSecondsInMillis = instantSeconds * 1_000;
             if (instantSecondsInMillis >= 0) {
                 if (temporal.isSupported(ChronoField.NANO_OF_SECOND)) {
                     return instantSecondsInMillis + (temporal.getLong(ChronoField.NANO_OF_SECOND) / 1_000_000);

--- a/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
+++ b/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
@@ -60,11 +60,6 @@ public class FeatureFlags {
     public static final String WRITEABLE_REMOTE_INDEX = "opensearch.experimental.feature.writeable_remote_index.enabled";
 
     /**
-     * Gates the optimization to enable bloom filters for doc id lookup.
-     */
-    public static final String DOC_ID_FUZZY_SET = "opensearch.experimental.optimize_doc_id_lookup.fuzzy_set.enabled";
-
-    /**
      * Gates the functionality of pluggable cache.
      * Enables OpenSearch to use pluggable caches with respective store names via setting.
      */
@@ -132,8 +127,6 @@ public class FeatureFlags {
         false,
         Property.NodeScope
     );
-
-    public static final Setting<Boolean> DOC_ID_FUZZY_SET_SETTING = Setting.boolSetting(DOC_ID_FUZZY_SET, false, Property.NodeScope);
 
     public static final Setting<Boolean> PLUGGABLE_CACHE_SETTING = Setting.boolSetting(PLUGGABLE_CACHE, false, Property.NodeScope);
 }

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -65,7 +65,6 @@ import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
 import static org.opensearch.Version.V_2_7_0;
-import static org.opensearch.common.util.FeatureFlags.DOC_ID_FUZZY_SET_SETTING;
 import static org.opensearch.common.util.FeatureFlags.SEARCHABLE_SNAPSHOT_EXTENDED_COMPATIBILITY;
 import static org.opensearch.index.codec.fuzzy.FuzzySetParameters.DEFAULT_FALSE_POSITIVE_PROBABILITY;
 import static org.opensearch.index.mapper.MapperService.INDEX_MAPPING_DEPTH_LIMIT_SETTING;
@@ -969,11 +968,8 @@ public final class IndexSettings {
          */
         widenIndexSortType = IndexMetadata.SETTING_INDEX_VERSION_CREATED.get(settings).before(V_2_7_0);
 
-        boolean isOptimizeDocIdLookupUsingFuzzySetFeatureEnabled = FeatureFlags.isEnabled(DOC_ID_FUZZY_SET_SETTING);
-        if (isOptimizeDocIdLookupUsingFuzzySetFeatureEnabled) {
-            enableFuzzySetForDocId = scopedSettings.get(INDEX_DOC_ID_FUZZY_SET_ENABLED_SETTING);
-            docIdFuzzySetFalsePositiveProbability = scopedSettings.get(INDEX_DOC_ID_FUZZY_SET_FALSE_POSITIVE_PROBABILITY_SETTING);
-        }
+        setEnableFuzzySetForDocId(scopedSettings.get(INDEX_DOC_ID_FUZZY_SET_ENABLED_SETTING));
+        setDocIdFuzzySetFalsePositiveProbability(scopedSettings.get(INDEX_DOC_ID_FUZZY_SET_FALSE_POSITIVE_PROBABILITY_SETTING));
 
         scopedSettings.addSettingsUpdateConsumer(
             TieredMergePolicyProvider.INDEX_COMPOUND_FORMAT_SETTING,
@@ -1873,7 +1869,7 @@ public final class IndexSettings {
     }
 
     public void setEnableFuzzySetForDocId(boolean enableFuzzySetForDocId) {
-        verifyFeatureToSetDocIdFuzzySetSetting(enabled -> this.enableFuzzySetForDocId = enabled, enableFuzzySetForDocId);
+        this.enableFuzzySetForDocId = enableFuzzySetForDocId;
     }
 
     public double getDocIdFuzzySetFalsePositiveProbability() {
@@ -1881,22 +1877,6 @@ public final class IndexSettings {
     }
 
     public void setDocIdFuzzySetFalsePositiveProbability(double docIdFuzzySetFalsePositiveProbability) {
-        verifyFeatureToSetDocIdFuzzySetSetting(
-            fpp -> this.docIdFuzzySetFalsePositiveProbability = fpp,
-            docIdFuzzySetFalsePositiveProbability
-        );
-    }
-
-    private static <T> void verifyFeatureToSetDocIdFuzzySetSetting(Consumer<T> settingUpdater, T val) {
-        if (FeatureFlags.isEnabled(DOC_ID_FUZZY_SET_SETTING)) {
-            settingUpdater.accept(val);
-        } else {
-            throw new IllegalArgumentException(
-                "Fuzzy set for optimizing doc id lookup "
-                    + "cannot be enabled with feature flag ["
-                    + FeatureFlags.DOC_ID_FUZZY_SET
-                    + "] set to false"
-            );
-        }
+        this.docIdFuzzySetFalsePositiveProbability = docIdFuzzySetFalsePositiveProbability;
     }
 }

--- a/server/src/main/java/org/opensearch/index/search/stats/SearchStats.java
+++ b/server/src/main/java/org/opensearch/index/search/stats/SearchStats.java
@@ -244,8 +244,6 @@ public class SearchStats implements Writeable, ToXContentFragment {
             suggestTimeInMillis = in.readVLong();
             suggestCurrent = in.readVLong();
 
-            searchIdleWakenUpCount = in.readVLong();
-
             if (in.getVersion().onOrAfter(Version.V_2_4_0)) {
                 pitCount = in.readVLong();
                 pitTimeInMillis = in.readVLong();
@@ -261,6 +259,10 @@ public class SearchStats implements Writeable, ToXContentFragment {
                 concurrentQueryTimeInMillis = in.readVLong();
                 concurrentQueryCurrent = in.readVLong();
                 queryConcurrency = in.readVLong();
+            }
+
+            if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+                searchIdleWakenUpCount = in.readVLong();
             }
         }
 
@@ -449,8 +451,6 @@ public class SearchStats implements Writeable, ToXContentFragment {
             out.writeVLong(suggestTimeInMillis);
             out.writeVLong(suggestCurrent);
 
-            out.writeVLong(searchIdleWakenUpCount);
-
             if (out.getVersion().onOrAfter(Version.V_2_4_0)) {
                 out.writeVLong(pitCount);
                 out.writeVLong(pitTimeInMillis);
@@ -473,6 +473,10 @@ public class SearchStats implements Writeable, ToXContentFragment {
                 out.writeVLong(concurrentQueryTimeInMillis);
                 out.writeVLong(concurrentQueryCurrent);
                 out.writeVLong(queryConcurrency);
+            }
+
+            if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+                out.writeVLong(searchIdleWakenUpCount);
             }
 
         }
@@ -667,7 +671,6 @@ public class SearchStats implements Writeable, ToXContentFragment {
         static final String PIT_CURRENT = "point_in_time_current";
         static final String SUGGEST_TOTAL = "suggest_total";
         static final String SUGGEST_TIME = "suggest_time";
-        static final String SEARCH_IDLE_WAKEN_UP_TOTAL = "search_idle_waken_up_total";
         static final String SUGGEST_TIME_IN_MILLIS = "suggest_time_in_millis";
         static final String SUGGEST_CURRENT = "suggest_current";
         static final String REQUEST = "request";
@@ -675,7 +678,7 @@ public class SearchStats implements Writeable, ToXContentFragment {
         static final String TIME = "time";
         static final String CURRENT = "current";
         static final String TOTAL = "total";
-
+        static final String SEARCH_IDLE_WAKEN_UP_TOTAL = "search_idle_waken_up_total";
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/search/stats/SearchStats.java
+++ b/server/src/main/java/org/opensearch/index/search/stats/SearchStats.java
@@ -163,6 +163,8 @@ public class SearchStats implements Writeable, ToXContentFragment {
         private long pitTimeInMillis;
         private long pitCurrent;
 
+        private long searchIdleWakenUpCount;
+
         @Nullable
         private RequestStatsLongHolder requestStatsLongHolder;
 
@@ -193,7 +195,8 @@ public class SearchStats implements Writeable, ToXContentFragment {
             long pitCurrent,
             long suggestCount,
             long suggestTimeInMillis,
-            long suggestCurrent
+            long suggestCurrent,
+            long searchIdleWakenUpCount
         ) {
             this.requestStatsLongHolder = new RequestStatsLongHolder();
             this.queryCount = queryCount;
@@ -220,6 +223,8 @@ public class SearchStats implements Writeable, ToXContentFragment {
             this.pitCount = pitCount;
             this.pitTimeInMillis = pitTimeInMillis;
             this.pitCurrent = pitCurrent;
+
+            this.searchIdleWakenUpCount = searchIdleWakenUpCount;
         }
 
         private Stats(StreamInput in) throws IOException {
@@ -238,6 +243,8 @@ public class SearchStats implements Writeable, ToXContentFragment {
             suggestCount = in.readVLong();
             suggestTimeInMillis = in.readVLong();
             suggestCurrent = in.readVLong();
+
+            searchIdleWakenUpCount = in.readVLong();
 
             if (in.getVersion().onOrAfter(Version.V_2_4_0)) {
                 pitCount = in.readVLong();
@@ -282,6 +289,8 @@ public class SearchStats implements Writeable, ToXContentFragment {
             pitCount += stats.pitCount;
             pitTimeInMillis += stats.pitTimeInMillis;
             pitCurrent += stats.pitCurrent;
+
+            searchIdleWakenUpCount += stats.searchIdleWakenUpCount;
         }
 
         public void addForClosingShard(Stats stats) {
@@ -306,6 +315,8 @@ public class SearchStats implements Writeable, ToXContentFragment {
             pitTimeInMillis += stats.pitTimeInMillis;
             pitCurrent += stats.pitCurrent;
             queryConcurrency += stats.queryConcurrency;
+
+            searchIdleWakenUpCount += stats.searchIdleWakenUpCount;
         }
 
         public long getQueryCount() {
@@ -412,6 +423,10 @@ public class SearchStats implements Writeable, ToXContentFragment {
             return suggestCurrent;
         }
 
+        public long getSearchIdleWakenUpCount() {
+            return searchIdleWakenUpCount;
+        }
+
         public static Stats readStats(StreamInput in) throws IOException {
             return new Stats(in);
         }
@@ -433,6 +448,8 @@ public class SearchStats implements Writeable, ToXContentFragment {
             out.writeVLong(suggestCount);
             out.writeVLong(suggestTimeInMillis);
             out.writeVLong(suggestCurrent);
+
+            out.writeVLong(searchIdleWakenUpCount);
 
             if (out.getVersion().onOrAfter(Version.V_2_4_0)) {
                 out.writeVLong(pitCount);
@@ -457,6 +474,7 @@ public class SearchStats implements Writeable, ToXContentFragment {
                 out.writeVLong(concurrentQueryCurrent);
                 out.writeVLong(queryConcurrency);
             }
+
         }
 
         @Override
@@ -485,6 +503,8 @@ public class SearchStats implements Writeable, ToXContentFragment {
             builder.field(Fields.SUGGEST_TOTAL, suggestCount);
             builder.humanReadableField(Fields.SUGGEST_TIME_IN_MILLIS, Fields.SUGGEST_TIME, getSuggestTime());
             builder.field(Fields.SUGGEST_CURRENT, suggestCurrent);
+
+            builder.field(Fields.SEARCH_IDLE_WAKEN_UP_TOTAL, searchIdleWakenUpCount);
 
             if (requestStatsLongHolder != null) {
                 builder.startObject(Fields.REQUEST);
@@ -647,6 +667,7 @@ public class SearchStats implements Writeable, ToXContentFragment {
         static final String PIT_CURRENT = "point_in_time_current";
         static final String SUGGEST_TOTAL = "suggest_total";
         static final String SUGGEST_TIME = "suggest_time";
+        static final String SEARCH_IDLE_WAKEN_UP_TOTAL = "search_idle_waken_up_total";
         static final String SUGGEST_TIME_IN_MILLIS = "suggest_time_in_millis";
         static final String SUGGEST_CURRENT = "suggest_current";
         static final String REQUEST = "request";

--- a/server/src/main/java/org/opensearch/index/search/stats/ShardSearchStats.java
+++ b/server/src/main/java/org/opensearch/index/search/stats/ShardSearchStats.java
@@ -195,6 +195,11 @@ public final class ShardSearchStats implements SearchOperationListener {
     }
 
     @Override
+    public void onNewSearchIdleWakenUp() {
+        totalStats.searchIdleMetric.inc();
+    }
+
+    @Override
     public void onFreeScrollContext(ReaderContext readerContext) {
         totalStats.scrollCurrent.dec();
         assert totalStats.scrollCurrent.count() >= 0;
@@ -220,6 +225,7 @@ public final class ShardSearchStats implements SearchOperationListener {
      */
     static final class StatsHolder {
         final MeanMetric queryMetric = new MeanMetric();
+        final CounterMetric searchIdleMetric = new CounterMetric();
         final MeanMetric concurrentQueryMetric = new MeanMetric();
         final CounterMetric queryConcurrencyMetric = new CounterMetric();
         final MeanMetric fetchMetric = new MeanMetric();
@@ -260,7 +266,8 @@ public final class ShardSearchStats implements SearchOperationListener {
                 pitCurrent.count(),
                 suggestMetric.count(),
                 TimeUnit.NANOSECONDS.toMillis(suggestMetric.sum()),
-                suggestCurrent.count()
+                suggestCurrent.count(),
+                searchIdleMetric.count()
             );
         }
     }

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1859,6 +1859,10 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     }
 
     private void markSearcherAccessed() {
+        if (isSearchIdle()) {
+            SearchOperationListener searchOperationListener = getSearchOperationListener();
+            searchOperationListener.onNewSearchIdleWakenUp();
+        }
         lastSearcherAccess.lazySet(threadPool.relativeTimeInMillis());
     }
 

--- a/server/src/main/java/org/opensearch/index/shard/SearchOperationListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/SearchOperationListener.java
@@ -115,6 +115,11 @@ public interface SearchOperationListener {
     default void onNewScrollContext(ReaderContext readerContext) {}
 
     /**
+     * Executed when a shard goes from idle to non-idle state
+     */
+    default void onNewSearchIdleWakenUp() {}
+
+    /**
      * Executed when a scroll search {@link SearchContext} is freed.
      * This happens either when the scroll search execution finishes, if the
      * execution failed or if the search context as idle for and needs to be
@@ -252,6 +257,17 @@ public interface SearchOperationListener {
                     listener.onNewScrollContext(readerContext);
                 } catch (Exception e) {
                     logger.warn(() -> new ParameterizedMessage("onNewScrollContext listener [{}] failed", listener), e);
+                }
+            }
+        }
+
+        @Override
+        public void onNewSearchIdleWakenUp() {
+            for (SearchOperationListener listener : listeners) {
+                try {
+                    listener.onNewSearchIdleWakenUp();
+                } catch (Exception e) {
+                    logger.warn(() -> new ParameterizedMessage("onNewSearchIdleWakenUp listener [{}] failed", listener), e);
                 }
             }
         }

--- a/server/src/main/java/org/opensearch/index/translog/transfer/FileTransferTracker.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/FileTransferTracker.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.index.translog.transfer;
 
+import org.apache.logging.log4j.Logger;
+import org.opensearch.common.logging.Loggers;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.remote.RemoteTranslogTransferTracker;
 import org.opensearch.index.translog.transfer.FileSnapshot.TransferFileSnapshot;
@@ -33,11 +35,13 @@ public class FileTransferTracker implements FileTransferListener {
     private final RemoteTranslogTransferTracker remoteTranslogTransferTracker;
     private Map<String, Long> bytesForTlogCkpFileToUpload;
     private long fileTransferStartTime = -1;
+    private final Logger logger;
 
     public FileTransferTracker(ShardId shardId, RemoteTranslogTransferTracker remoteTranslogTransferTracker) {
         this.shardId = shardId;
         this.fileTransferTracker = new ConcurrentHashMap<>();
         this.remoteTranslogTransferTracker = remoteTranslogTransferTracker;
+        this.logger = Loggers.getLogger(getClass(), shardId);
     }
 
     void recordFileTransferStartTime(long uploadStartTime) {
@@ -64,9 +68,14 @@ public class FileTransferTracker implements FileTransferListener {
 
     @Override
     public void onSuccess(TransferFileSnapshot fileSnapshot) {
-        long durationInMillis = (System.nanoTime() - fileTransferStartTime) / 1_000_000L;
-        remoteTranslogTransferTracker.addUploadTimeInMillis(durationInMillis);
-        remoteTranslogTransferTracker.addUploadBytesSucceeded(bytesForTlogCkpFileToUpload.get(fileSnapshot.getName()));
+        try {
+            long durationInMillis = (System.nanoTime() - fileTransferStartTime) / 1_000_000L;
+            remoteTranslogTransferTracker.addUploadTimeInMillis(durationInMillis);
+            remoteTranslogTransferTracker.addUploadBytesSucceeded(bytesForTlogCkpFileToUpload.get(fileSnapshot.getName()));
+        } catch (Exception ex) {
+            logger.error("Failure to update translog upload success stats", ex);
+        }
+
         add(fileSnapshot.getName(), TransferState.SUCCESS);
     }
 

--- a/server/src/main/java/org/opensearch/node/remotestore/RemoteStoreNodeAttribute.java
+++ b/server/src/main/java/org/opensearch/node/remotestore/RemoteStoreNodeAttribute.java
@@ -131,12 +131,8 @@ public class RemoteStoreNodeAttribute {
     }
 
     private RepositoriesMetadata buildRepositoriesMetadata(DiscoveryNode node) {
+        Set<String> repositoryNames = getValidatedRepositoryNames(node);
         List<RepositoryMetadata> repositoryMetadataList = new ArrayList<>();
-        Set<String> repositoryNames = new HashSet<>();
-
-        repositoryNames.add(validateAttributeNonNull(node, REMOTE_STORE_SEGMENT_REPOSITORY_NAME_ATTRIBUTE_KEY));
-        repositoryNames.add(validateAttributeNonNull(node, REMOTE_STORE_TRANSLOG_REPOSITORY_NAME_ATTRIBUTE_KEY));
-        repositoryNames.add(validateAttributeNonNull(node, REMOTE_STORE_CLUSTER_STATE_REPOSITORY_NAME_ATTRIBUTE_KEY));
 
         for (String repositoryName : repositoryNames) {
             repositoryMetadataList.add(buildRepositoryMetadata(node, repositoryName));
@@ -145,12 +141,36 @@ public class RemoteStoreNodeAttribute {
         return new RepositoriesMetadata(repositoryMetadataList);
     }
 
+    private Set<String> getValidatedRepositoryNames(DiscoveryNode node) {
+        Set<String> repositoryNames = new HashSet<>();
+        if (node.getAttributes().containsKey(REMOTE_STORE_SEGMENT_REPOSITORY_NAME_ATTRIBUTE_KEY)
+            || node.getAttributes().containsKey(REMOTE_STORE_TRANSLOG_REPOSITORY_NAME_ATTRIBUTE_KEY)) {
+            repositoryNames.add(validateAttributeNonNull(node, REMOTE_STORE_SEGMENT_REPOSITORY_NAME_ATTRIBUTE_KEY));
+            repositoryNames.add(validateAttributeNonNull(node, REMOTE_STORE_TRANSLOG_REPOSITORY_NAME_ATTRIBUTE_KEY));
+            repositoryNames.add(validateAttributeNonNull(node, REMOTE_STORE_CLUSTER_STATE_REPOSITORY_NAME_ATTRIBUTE_KEY));
+        } else if (node.getAttributes().containsKey(REMOTE_STORE_CLUSTER_STATE_REPOSITORY_NAME_ATTRIBUTE_KEY)) {
+            repositoryNames.add(validateAttributeNonNull(node, REMOTE_STORE_CLUSTER_STATE_REPOSITORY_NAME_ATTRIBUTE_KEY));
+        }
+        return repositoryNames;
+    }
+
     public static boolean isRemoteStoreAttributePresent(Settings settings) {
         return settings.getByPrefix(Node.NODE_ATTRIBUTES.getKey() + REMOTE_STORE_NODE_ATTRIBUTE_KEY_PREFIX).isEmpty() == false;
     }
 
+    public static boolean isRemoteDataAttributePresent(Settings settings) {
+        return settings.getByPrefix(Node.NODE_ATTRIBUTES.getKey() + REMOTE_STORE_SEGMENT_REPOSITORY_NAME_ATTRIBUTE_KEY).isEmpty() == false
+            || settings.getByPrefix(Node.NODE_ATTRIBUTES.getKey() + REMOTE_STORE_TRANSLOG_REPOSITORY_NAME_ATTRIBUTE_KEY).isEmpty() == false;
+    }
+
+    public static boolean isRemoteClusterStateAttributePresent(Settings settings) {
+        return settings.getByPrefix(Node.NODE_ATTRIBUTES.getKey() + REMOTE_STORE_CLUSTER_STATE_REPOSITORY_NAME_ATTRIBUTE_KEY)
+            .isEmpty() == false;
+    }
+
     public static boolean isRemoteStoreClusterStateEnabled(Settings settings) {
-        return RemoteClusterStateService.REMOTE_CLUSTER_STATE_ENABLED_SETTING.get(settings) && isRemoteStoreAttributePresent(settings);
+        return RemoteClusterStateService.REMOTE_CLUSTER_STATE_ENABLED_SETTING.get(settings)
+            && isRemoteClusterStateAttributePresent(settings);
     }
 
     public RepositoriesMetadata getRepositoriesMetadata() {

--- a/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
@@ -3388,7 +3388,8 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                             blob.substring(SNAPSHOT_PREFIX.length(), blob.length() - ".dat".length())
                         ) == false)
                     || (remoteStoreLockManagerFactory != null
-                        && extractShallowSnapshotUUID(blob).map(survivingSnapshotUUIDs::contains).orElse(false))
+                        && extractShallowSnapshotUUID(blob).map(snapshotUUID -> !survivingSnapshotUUIDs.contains(snapshotUUID))
+                            .orElse(false))
                     || (blob.startsWith(UPLOADED_DATA_BLOB_PREFIX) && updatedSnapshots.findNameFile(canonicalName(blob)) == null)
                     || FsBlobContainer.isTempBlobName(blob)
             )

--- a/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
@@ -1153,11 +1153,12 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         logger.debug("Successfully released lock for shard {} of index with uuid {}", shardId, indexUUID);
         if (!isIndexPresent(clusterService, indexUUID)) {
             // Note: this is a temporary solution where snapshot deletion triggers remote store side cleanup if
-            // index is already deleted. shard cleanup will still happen asynchronously using REMOTE_PURGE
-            // threadpool. if it fails, it could leave some stale files in remote directory. this issue could
-            // even happen in cases of shard level remote store data cleanup which also happens asynchronously.
-            // in long term, we have plans to implement remote store GC poller mechanism which will take care of
-            // such stale data. related issue: https://github.com/opensearch-project/OpenSearch/issues/8469
+            // index is already deleted. this is the best effort at the moment since shard cleanup will still happen
+            // asynchronously using REMOTE_PURGE thread pool. if it fails, it could leave some stale files in remote
+            // directory. this issue could even happen in cases of shard level remote store data cleanup which also
+            // happens asynchronously. in long term, we have plans to implement remote store GC poller mechanism which
+            // will take care of such stale data.
+            // related issue: https://github.com/opensearch-project/OpenSearch/issues/8469
             RemoteSegmentStoreDirectoryFactory remoteDirectoryFactory = new RemoteSegmentStoreDirectoryFactory(
                 remoteStoreLockManagerFactory.getRepositoriesService(),
                 threadPool

--- a/server/src/main/java/org/opensearch/repositories/blobstore/RemoteStoreShardCleanupTask.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/RemoteStoreShardCleanupTask.java
@@ -12,10 +12,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.core.index.shard.ShardId;
 
-import java.util.Map;
 import java.util.Set;
 
-import static org.opensearch.common.util.concurrent.ConcurrentCollections.newConcurrentMap;
 import static org.opensearch.common.util.concurrent.ConcurrentCollections.newConcurrentSet;
 
 /**
@@ -25,7 +23,6 @@ public class RemoteStoreShardCleanupTask implements Runnable {
     private final Runnable task;
     private final String shardIdentifier;
     final static Set<String> ongoingRemoteDirectoryCleanups = newConcurrentSet();
-    final static Map<String, Runnable> pendingRemoteDirectoryCleanups = newConcurrentMap();
     private static final Logger staticLogger = LogManager.getLogger(RemoteStoreShardCleanupTask.class);
 
     public RemoteStoreShardCleanupTask(Runnable task, String indexUUID, ShardId shardId) {
@@ -39,25 +36,16 @@ public class RemoteStoreShardCleanupTask implements Runnable {
 
     @Override
     public void run() {
-        // TODO: this is the best effort at the moment since there is still a known race condition scenario in this
-        // method which needs to be handled where one of the thread just came out of while loop and removed the
-        // entry from ongoingRemoteDirectoryCleanup, and another thread added new pending task in the map.
-        // we need to introduce semaphores/locks to avoid that situation which introduces the overhead of lock object
-        // cleanups. however, there will be no scenario where two threads run cleanup for same shard at same time.
-        // <issue-link>
-        if (pendingRemoteDirectoryCleanups.put(shardIdentifier, task) == null) {
-            if (ongoingRemoteDirectoryCleanups.add(shardIdentifier)) {
-                while (pendingRemoteDirectoryCleanups.containsKey(shardIdentifier)) {
-                    Runnable newTask = pendingRemoteDirectoryCleanups.get(shardIdentifier);
-                    pendingRemoteDirectoryCleanups.remove(shardIdentifier);
-                    newTask.run();
-                }
+        // If there is already a same task ongoing for a shard, we need to skip the new task to avoid multiple
+        // concurrent cleanup of same shard.
+        if (ongoingRemoteDirectoryCleanups.add(shardIdentifier)) {
+            try {
+                task.run();
+            } finally {
                 ongoingRemoteDirectoryCleanups.remove(shardIdentifier);
-            } else {
-                staticLogger.debug("one task is already ongoing for shard {}, we can leave entry in pending", shardIdentifier);
             }
         } else {
-            staticLogger.debug("one cleanup task for shard {} is already in pending, we can skip this task", shardIdentifier);
+            staticLogger.warn("one cleanup task for shard {} is already ongoing, need to skip this task", shardIdentifier);
         }
     }
 }

--- a/server/src/test/java/org/opensearch/cluster/ClusterModuleTests.java
+++ b/server/src/test/java/org/opensearch/cluster/ClusterModuleTests.java
@@ -51,6 +51,7 @@ import org.opensearch.cluster.routing.allocation.decider.MaxRetryAllocationDecid
 import org.opensearch.cluster.routing.allocation.decider.NodeLoadAwareAllocationDecider;
 import org.opensearch.cluster.routing.allocation.decider.NodeVersionAllocationDecider;
 import org.opensearch.cluster.routing.allocation.decider.RebalanceOnlyWhenActiveAllocationDecider;
+import org.opensearch.cluster.routing.allocation.decider.RemoteStoreMigrationAllocationDecider;
 import org.opensearch.cluster.routing.allocation.decider.ReplicaAfterPrimaryActiveAllocationDecider;
 import org.opensearch.cluster.routing.allocation.decider.ResizeAllocationDecider;
 import org.opensearch.cluster.routing.allocation.decider.RestoreInProgressAllocationDecider;
@@ -67,6 +68,7 @@ import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.settings.SettingsModule;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.gateway.GatewayAllocator;
 import org.opensearch.plugins.ClusterPlugin;
@@ -242,6 +244,9 @@ public class ClusterModuleTests extends ModuleTestCase {
             NodeLoadAwareAllocationDecider.class,
             TargetPoolAllocationDecider.class
         );
+        if (FeatureFlags.isEnabled(FeatureFlags.REMOTE_STORE_MIGRATION_EXPERIMENTAL_SETTING)) {
+            expectedDeciders.add(RemoteStoreMigrationAllocationDecider.class);
+        }
         Collection<AllocationDecider> deciders = ClusterModule.createAllocationDeciders(
             Settings.EMPTY,
             new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -1901,7 +1901,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
                 request,
                 Settings.EMPTY,
                 null,
-                Settings.builder().put("node.attr.remote_store.setting", "test").build(),
+                Settings.builder().put("node.attr.remote_store.segment.repository", "test").build(),
                 IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
                 randomShardLimitService(),
                 Collections.emptySet(),

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/RemoteStoreMigrationAllocationDeciderTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/RemoteStoreMigrationAllocationDeciderTests.java
@@ -1,0 +1,681 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.cluster.routing.allocation;
+
+import org.opensearch.Version;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.OpenSearchAllocationTestCase;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.node.DiscoveryNodeRole;
+import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.cluster.routing.IndexRoutingTable;
+import org.opensearch.cluster.routing.IndexShardRoutingTable;
+import org.opensearch.cluster.routing.RoutingNode;
+import org.opensearch.cluster.routing.RoutingTable;
+import org.opensearch.cluster.routing.ShardRouting;
+import org.opensearch.cluster.routing.ShardRoutingState;
+import org.opensearch.cluster.routing.TestShardRouting;
+import org.opensearch.cluster.routing.allocation.decider.AllocationDeciders;
+import org.opensearch.cluster.routing.allocation.decider.Decision;
+import org.opensearch.cluster.routing.allocation.decider.RemoteStoreMigrationAllocationDecider;
+import org.opensearch.common.UUIDs;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.indices.replication.common.ReplicationType;
+import org.opensearch.node.remotestore.RemoteStoreNodeService;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REMOTE_SEGMENT_STORE_REPOSITORY;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REMOTE_STORE_ENABLED;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REMOTE_TRANSLOG_STORE_REPOSITORY;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REPLICATION_TYPE;
+import static org.opensearch.common.util.FeatureFlags.REMOTE_STORE_MIGRATION_EXPERIMENTAL;
+import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.REMOTE_STORE_CLUSTER_STATE_REPOSITORY_NAME_ATTRIBUTE_KEY;
+import static org.opensearch.node.remotestore.RemoteStoreNodeService.MIGRATION_DIRECTION_SETTING;
+import static org.opensearch.node.remotestore.RemoteStoreNodeService.REMOTE_STORE_COMPATIBILITY_MODE_SETTING;
+import static org.hamcrest.core.Is.is;
+
+public class RemoteStoreMigrationAllocationDeciderTests extends OpenSearchAllocationTestCase {
+
+    private final static String TEST_INDEX = "test_index";
+    private final static String TEST_REPO = "test_repo";
+
+    private final Settings directionEnabledNodeSettings = Settings.builder().put(REMOTE_STORE_MIGRATION_EXPERIMENTAL, "true").build();
+
+    private final Settings strictModeCompatibilitySettings = Settings.builder()
+        .put(REMOTE_STORE_COMPATIBILITY_MODE_SETTING.getKey(), RemoteStoreNodeService.CompatibilityMode.STRICT)
+        .build();
+    private final Settings mixedModeCompatibilitySettings = Settings.builder()
+        .put(REMOTE_STORE_COMPATIBILITY_MODE_SETTING.getKey(), RemoteStoreNodeService.CompatibilityMode.MIXED)
+        .build();
+
+    private final Settings remoteStoreDirectionSettings = Settings.builder()
+        .put(MIGRATION_DIRECTION_SETTING.getKey(), RemoteStoreNodeService.Direction.REMOTE_STORE)
+        .build();
+    private final Settings docrepDirectionSettings = Settings.builder()
+        .put(MIGRATION_DIRECTION_SETTING.getKey(), RemoteStoreNodeService.Direction.DOCREP)
+        .build();
+
+    private Boolean isRemoteStoreBackedIndex = null, isMixedMode;
+    private int shardCount, replicaCount;
+    private IndexMetadata.Builder indexMetadataBuilder;
+    private Settings customSettings;
+    private DiscoveryNodes discoveryNodes;
+    private ClusterState clusterState;
+    private RemoteStoreMigrationAllocationDecider remoteStoreMigrationAllocationDecider;
+    private RoutingAllocation routingAllocation;
+    private Metadata metadata;
+    private RoutingTable routingTable = null;
+
+    private void beforeAllocation() {
+        FeatureFlags.initializeFeatureFlags(directionEnabledNodeSettings);
+        if (isRemoteStoreBackedIndex == null) {
+            isRemoteStoreBackedIndex = randomBoolean();
+        }
+        indexMetadataBuilder = getIndexMetadataBuilder(isRemoteStoreBackedIndex, shardCount, replicaCount);
+
+        String compatibilityMode = isMixedMode
+            ? RemoteStoreNodeService.CompatibilityMode.MIXED.mode
+            : RemoteStoreNodeService.CompatibilityMode.STRICT.mode;
+        customSettings = getCustomSettings(
+            RemoteStoreNodeService.Direction.REMOTE_STORE.direction,
+            compatibilityMode,
+            indexMetadataBuilder
+        );
+
+        if (routingTable != null) {
+            metadata = Metadata.builder().put(indexMetadataBuilder).build();
+            clusterState = ClusterState.builder(ClusterName.DEFAULT)
+                .metadata(metadata)
+                .routingTable(routingTable)
+                .nodes(discoveryNodes)
+                .build();
+        } else {
+            clusterState = getInitialClusterState(customSettings, indexMetadataBuilder, discoveryNodes);
+        }
+
+        remoteStoreMigrationAllocationDecider = new RemoteStoreMigrationAllocationDecider(
+            customSettings,
+            getClusterSettings(customSettings)
+        );
+
+        routingAllocation = new RoutingAllocation(
+            new AllocationDeciders(Collections.singleton(remoteStoreMigrationAllocationDecider)),
+            clusterState.getRoutingNodes(),
+            clusterState,
+            null,
+            null,
+            0L
+        );
+        routingAllocation.debugDecision(true);
+    }
+
+    // tests for primary shard copy allocation with MIXED mode and REMOTE_STORE direction
+
+    public void testDontAllocateNewPrimaryShardOnNonRemoteNodeForMixedModeAndRemoteStoreDirection() {
+        shardCount = 1;
+        replicaCount = 0;
+        isMixedMode = true;
+
+        DiscoveryNode remoteNode = getRemoteNode();
+        DiscoveryNode nonRemoteNode = getNonRemoteNode();
+
+        discoveryNodes = DiscoveryNodes.builder()
+            .add(nonRemoteNode)
+            .localNodeId(nonRemoteNode.getId())
+            .add(remoteNode)
+            .localNodeId(remoteNode.getId())
+            .build();
+
+        beforeAllocation();
+
+        ShardRouting primaryShardRouting = clusterState.getRoutingTable().shardRoutingTable(TEST_INDEX, 0).primaryShard();
+        RoutingNode nonRemoteRoutingNode = clusterState.getRoutingNodes().node(nonRemoteNode.getId());
+
+        Decision decision = remoteStoreMigrationAllocationDecider.canAllocate(primaryShardRouting, nonRemoteRoutingNode, routingAllocation);
+        assertThat(decision.type(), is(Decision.Type.NO));
+        String reason = "[remote_store migration_direction]: primary shard copy can not be allocated to a non-remote node";
+        if (isRemoteStoreBackedIndex) {
+            reason =
+                "[remote_store migration_direction]: primary shard copy can not be allocated to a non-remote node because a remote store backed index's shard copy can only be allocated to a remote node";
+        }
+        assertThat(decision.getExplanation().toLowerCase(Locale.ROOT), is(reason));
+    }
+
+    public void testAllocateNewPrimaryShardOnRemoteNodeForMixedModeAndRemoteStoreDirection() {
+        shardCount = 1;
+        replicaCount = 0;
+        isMixedMode = true;
+
+        DiscoveryNode remoteNode = getRemoteNode();
+        DiscoveryNode nonRemoteNode = getNonRemoteNode();
+
+        discoveryNodes = DiscoveryNodes.builder()
+            .add(nonRemoteNode)
+            .localNodeId(nonRemoteNode.getId())
+            .add(remoteNode)
+            .localNodeId(remoteNode.getId())
+            .build();
+
+        beforeAllocation();
+
+        ShardRouting primaryShardRouting = clusterState.getRoutingTable().shardRoutingTable(TEST_INDEX, 0).primaryShard();
+        RoutingNode remoteRoutingNode = clusterState.getRoutingNodes().node(remoteNode.getId());
+
+        Decision decision = remoteStoreMigrationAllocationDecider.canAllocate(primaryShardRouting, remoteRoutingNode, routingAllocation);
+        assertThat(decision.type(), is(Decision.Type.YES));
+        assertThat(
+            decision.getExplanation().toLowerCase(Locale.ROOT),
+            is("[remote_store migration_direction]: primary shard copy can be allocated to a remote node")
+        );
+    }
+
+    // tests for replica shard copy allocation with MIXED mode and REMOTE_STORE direction
+
+    public void testDontAllocateNewReplicaShardOnRemoteNodeIfPrimaryShardOnNonRemoteNodeForMixedModeAndRemoteStoreDirection() {
+        shardCount = 1;
+        replicaCount = 1;
+        isMixedMode = true;
+
+        ShardId shardId = new ShardId(TEST_INDEX, "_na_", 0);
+
+        DiscoveryNode nonRemoteNode = getNonRemoteNode();
+        DiscoveryNode remoteNode = getRemoteNode();
+
+        routingTable = RoutingTable.builder()
+            .add(
+                IndexRoutingTable.builder(shardId.getIndex())
+                    .addIndexShard(
+                        new IndexShardRoutingTable.Builder(shardId).addShard(
+                            // primary on non-remote node
+                            TestShardRouting.newShardRouting(
+                                shardId.getIndexName(),
+                                shardId.getId(),
+                                nonRemoteNode.getId(),
+                                true,
+                                ShardRoutingState.STARTED
+                            )
+                        )
+                            .addShard(
+                                // new replica's allocation
+                                TestShardRouting.newShardRouting(
+                                    shardId.getIndexName(),
+                                    shardId.getId(),
+                                    null,
+                                    false,
+                                    ShardRoutingState.UNASSIGNED
+                                )
+                            )
+                            .build()
+                    )
+            )
+            .build();
+
+        discoveryNodes = DiscoveryNodes.builder()
+            .add(nonRemoteNode)
+            .localNodeId(nonRemoteNode.getId())
+            .add(remoteNode)
+            .localNodeId(remoteNode.getId())
+            .build();
+
+        beforeAllocation();
+
+        assertEquals(2, clusterState.getRoutingTable().allShards().size());
+        ShardRouting replicaShardRouting = clusterState.getRoutingTable().shardRoutingTable(TEST_INDEX, 0).replicaShards().get(0);
+        RoutingNode remoteRoutingNode = clusterState.getRoutingNodes().node(remoteNode.getId());
+
+        Decision decision = remoteStoreMigrationAllocationDecider.canAllocate(replicaShardRouting, remoteRoutingNode, routingAllocation);
+        assertThat(decision.type(), is(Decision.Type.NO));
+        assertThat(
+            decision.getExplanation().toLowerCase(Locale.ROOT),
+            is(
+                "[remote_store migration_direction]: replica shard copy can not be allocated to a remote node since primary shard copy is not yet migrated to remote"
+            )
+        );
+    }
+
+    public void testAllocateNewReplicaShardOnRemoteNodeIfPrimaryShardOnRemoteNodeForMixedModeAndRemoteStoreDirection() {
+        shardCount = 1;
+        replicaCount = 1;
+        isMixedMode = true;
+
+        ShardId shardId = new ShardId(TEST_INDEX, "_na_", 0);
+
+        DiscoveryNode remoteNode1 = getRemoteNode();
+        DiscoveryNode remoteNode2 = getRemoteNode();
+        DiscoveryNode nonRemoteNode = getNonRemoteNode();
+
+        routingTable = RoutingTable.builder()
+            .add(
+                IndexRoutingTable.builder(shardId.getIndex())
+                    .addIndexShard(
+                        new IndexShardRoutingTable.Builder(shardId).addShard(
+                            // primary on remote node
+                            TestShardRouting.newShardRouting(
+                                shardId.getIndexName(),
+                                shardId.getId(),
+                                remoteNode1.getId(),
+                                true,
+                                ShardRoutingState.STARTED
+                            )
+                        )
+                            .addShard(
+                                // new replica's allocation
+                                TestShardRouting.newShardRouting(
+                                    shardId.getIndexName(),
+                                    shardId.getId(),
+                                    null,
+                                    false,
+                                    ShardRoutingState.UNASSIGNED
+                                )
+                            )
+                            .build()
+                    )
+            )
+            .build();
+
+        discoveryNodes = DiscoveryNodes.builder()
+            .add(remoteNode1)
+            .localNodeId(remoteNode1.getId())
+            .add(remoteNode2)
+            .localNodeId(remoteNode2.getId())
+            .add(nonRemoteNode)
+            .localNodeId(nonRemoteNode.getId())
+            .build();
+
+        beforeAllocation();
+
+        assertEquals(2, clusterState.getRoutingTable().allShards().size());
+        ShardRouting replicaShardRouting = clusterState.getRoutingTable().shardRoutingTable(TEST_INDEX, 0).replicaShards().get(0);
+        RoutingNode remoteRoutingNode = clusterState.getRoutingNodes().node(remoteNode2.getId());
+
+        Decision decision = remoteStoreMigrationAllocationDecider.canAllocate(replicaShardRouting, remoteRoutingNode, routingAllocation);
+        assertThat(decision.type(), is(Decision.Type.YES));
+        assertThat(
+            decision.getExplanation().toLowerCase(Locale.ROOT),
+            is(
+                "[remote_store migration_direction]: replica shard copy can be allocated to a remote node since primary shard copy has been migrated to remote"
+            )
+        );
+    }
+
+    public void testAllocateNewReplicaShardOnNonRemoteNodeIfPrimaryShardOnNonRemoteNodeForMixedModeAndRemoteStoreDirection() {
+        shardCount = 1;
+        replicaCount = 1;
+        isMixedMode = true;
+
+        ShardId shardId = new ShardId(TEST_INDEX, "_na_", 0);
+
+        DiscoveryNode remoteNode = getRemoteNode();
+        DiscoveryNode nonRemoteNode1 = getNonRemoteNode();
+        DiscoveryNode nonRemoteNode2 = getNonRemoteNode();
+
+        routingTable = RoutingTable.builder()
+            .add(
+                IndexRoutingTable.builder(shardId.getIndex())
+                    .addIndexShard(
+                        new IndexShardRoutingTable.Builder(shardId).addShard(
+                            // primary shard on non-remote node
+                            TestShardRouting.newShardRouting(
+                                shardId.getIndexName(),
+                                shardId.getId(),
+                                nonRemoteNode1.getId(),
+                                true,
+                                ShardRoutingState.STARTED
+                            )
+                        )
+                            .addShard(
+                                // new replica's allocation
+                                TestShardRouting.newShardRouting(
+                                    shardId.getIndexName(),
+                                    shardId.getId(),
+                                    null,
+                                    false,
+                                    ShardRoutingState.UNASSIGNED
+                                )
+                            )
+                            .build()
+                    )
+            )
+            .build();
+
+        discoveryNodes = DiscoveryNodes.builder()
+            .add(remoteNode)
+            .localNodeId(remoteNode.getId())
+            .add(nonRemoteNode1)
+            .localNodeId(nonRemoteNode1.getId())
+            .add(nonRemoteNode2)
+            .localNodeId(nonRemoteNode2.getId())
+            .build();
+
+        beforeAllocation();
+
+        assertEquals(2, clusterState.getRoutingTable().allShards().size());
+
+        ShardRouting replicaShardRouting = clusterState.getRoutingTable().shardRoutingTable(TEST_INDEX, 0).replicaShards().get(0);
+        RoutingNode nonRemoteRoutingNode = clusterState.getRoutingNodes().node(nonRemoteNode2.getId());
+
+        Decision decision = remoteStoreMigrationAllocationDecider.canAllocate(replicaShardRouting, nonRemoteRoutingNode, routingAllocation);
+        Decision.Type type = Decision.Type.YES;
+        String reason = "[remote_store migration_direction]: replica shard copy can be allocated to a non-remote node";
+        if (isRemoteStoreBackedIndex) {
+            type = Decision.Type.NO;
+            reason =
+                "[remote_store migration_direction]: replica shard copy can not be allocated to a non-remote node because a remote store backed index's shard copy can only be allocated to a remote node";
+        }
+        assertThat(decision.type(), is(type));
+        assertThat(decision.getExplanation().toLowerCase(Locale.ROOT), is(reason));
+    }
+
+    public void testAllocateNewReplicaShardOnNonRemoteNodeIfPrimaryShardOnRemoteNodeForRemoteStoreDirection() {
+        shardCount = 1;
+        replicaCount = 1;
+        isMixedMode = true;
+
+        ShardId shardId = new ShardId(TEST_INDEX, "_na_", 0);
+
+        DiscoveryNode nonRemoteNode = getNonRemoteNode();
+        DiscoveryNode remoteNode = getRemoteNode();
+
+        routingTable = RoutingTable.builder()
+            .add(
+                IndexRoutingTable.builder(shardId.getIndex())
+                    .addIndexShard(
+                        new IndexShardRoutingTable.Builder(shardId).addShard(
+                            // primary shard on non-remote node
+                            TestShardRouting.newShardRouting(
+                                shardId.getIndexName(),
+                                shardId.getId(),
+                                remoteNode.getId(),
+                                true,
+                                ShardRoutingState.STARTED
+                            )
+                        )
+                            .addShard(
+                                // new replica's allocation
+                                TestShardRouting.newShardRouting(
+                                    shardId.getIndexName(),
+                                    shardId.getId(),
+                                    null,
+                                    false,
+                                    ShardRoutingState.UNASSIGNED
+                                )
+                            )
+                            .build()
+                    )
+            )
+            .build();
+
+        discoveryNodes = DiscoveryNodes.builder()
+            .add(nonRemoteNode)
+            .localNodeId(nonRemoteNode.getId())
+            .add(remoteNode)
+            .localNodeId(remoteNode.getId())
+            .build();
+
+        beforeAllocation();
+
+        assertEquals(2, clusterState.getRoutingTable().allShards().size());
+        ShardRouting replicaShardRouting = clusterState.getRoutingTable().shardRoutingTable(TEST_INDEX, 0).replicaShards().get(0);
+        RoutingNode nonRemoteRoutingNode = clusterState.getRoutingNodes().node(nonRemoteNode.getId());
+
+        Decision decision = remoteStoreMigrationAllocationDecider.canAllocate(replicaShardRouting, nonRemoteRoutingNode, routingAllocation);
+        Decision.Type type = Decision.Type.YES;
+        String reason = "[remote_store migration_direction]: replica shard copy can be allocated to a non-remote node";
+        if (isRemoteStoreBackedIndex) {
+            type = Decision.Type.NO;
+            reason =
+                "[remote_store migration_direction]: replica shard copy can not be allocated to a non-remote node because a remote store backed index's shard copy can only be allocated to a remote node";
+        }
+        assertThat(decision.type(), is(type));
+        assertThat(decision.getExplanation().toLowerCase(Locale.ROOT), is(reason));
+    }
+
+    // test for STRICT mode
+
+    public void testAlwaysAllocateNewShardForStrictMode() {
+        shardCount = 1;
+        replicaCount = 1;
+        isMixedMode = false;
+        isRemoteStoreBackedIndex = false;
+
+        ShardId shardId = new ShardId(TEST_INDEX, "_na_", 0);
+
+        DiscoveryNode nonRemoteNode1 = getNonRemoteNode();
+        DiscoveryNode nonRemoteNode2 = getNonRemoteNode();
+
+        boolean isReplicaAllocation = randomBoolean();
+
+        routingTable = RoutingTable.builder()
+            .add(
+                IndexRoutingTable.builder(shardId.getIndex())
+                    .addIndexShard(
+                        new IndexShardRoutingTable.Builder(shardId).addShard(
+                            TestShardRouting.newShardRouting(
+                                shardId.getIndexName(),
+                                shardId.getId(),
+                                (isReplicaAllocation ? nonRemoteNode1.getId() : null),
+                                true,
+                                (isReplicaAllocation ? ShardRoutingState.STARTED : ShardRoutingState.UNASSIGNED)
+                            )
+                        )
+                            .addShard(
+                                TestShardRouting.newShardRouting(
+                                    shardId.getIndexName(),
+                                    shardId.getId(),
+                                    null,
+                                    false,
+                                    ShardRoutingState.UNASSIGNED
+                                )
+                            )
+                            .build()
+                    )
+            )
+            .build();
+
+        discoveryNodes = DiscoveryNodes.builder()
+            .add(nonRemoteNode1)
+            .localNodeId(nonRemoteNode1.getId())
+            .add(nonRemoteNode2)
+            .localNodeId(nonRemoteNode2.getId())
+            .build();
+
+        beforeAllocation();
+
+        assertEquals(2, clusterState.getRoutingTable().allShards().size());
+
+        ShardRouting shardRouting = clusterState.getRoutingTable().shardRoutingTable(TEST_INDEX, 0).primaryShard();
+        if (isReplicaAllocation) {
+            shardRouting = clusterState.getRoutingTable().shardRoutingTable(TEST_INDEX, 0).replicaShards().get(0);
+        }
+        RoutingNode nonRemoteRoutingNode = clusterState.getRoutingNodes().node(nonRemoteNode2.getId());
+
+        Decision decision = remoteStoreMigrationAllocationDecider.canAllocate(shardRouting, nonRemoteRoutingNode, routingAllocation);
+        assertThat(decision.type(), is(Decision.Type.YES));
+        String reason = String.format(
+            Locale.ROOT,
+            "[remote_store migration_direction]: %s shard copy can be allocated to a non-remote node for strict compatibility mode",
+            (isReplicaAllocation ? "replica" : "primary")
+        );
+        assertThat(decision.getExplanation().toLowerCase(Locale.ROOT), is(reason));
+
+        isRemoteStoreBackedIndex = true;
+
+        DiscoveryNode remoteNode1 = getRemoteNode();
+        DiscoveryNode remoteNode2 = getRemoteNode();
+
+        routingTable = RoutingTable.builder()
+            .add(
+                IndexRoutingTable.builder(shardId.getIndex())
+                    .addIndexShard(
+                        new IndexShardRoutingTable.Builder(shardId).addShard(
+                            TestShardRouting.newShardRouting(
+                                shardId.getIndexName(),
+                                shardId.getId(),
+                                (isReplicaAllocation ? remoteNode1.getId() : null),
+                                true,
+                                (isReplicaAllocation ? ShardRoutingState.STARTED : ShardRoutingState.UNASSIGNED)
+                            )
+                        )
+                            .addShard(
+                                // new replica's allocation
+                                TestShardRouting.newShardRouting(
+                                    shardId.getIndexName(),
+                                    shardId.getId(),
+                                    null,
+                                    false,
+                                    ShardRoutingState.UNASSIGNED
+                                )
+                            )
+                            .build()
+                    )
+            )
+            .build();
+
+        discoveryNodes = DiscoveryNodes.builder()
+            .add(remoteNode1)
+            .localNodeId(remoteNode1.getId())
+            .add(remoteNode2)
+            .localNodeId(remoteNode2.getId())
+            .build();
+
+        beforeAllocation();
+
+        assertEquals(2, clusterState.getRoutingTable().allShards().size());
+
+        shardRouting = clusterState.getRoutingTable().shardRoutingTable(TEST_INDEX, 0).primaryShard();
+        if (isReplicaAllocation) {
+            shardRouting = clusterState.getRoutingTable().shardRoutingTable(TEST_INDEX, 0).replicaShards().get(0);
+        }
+        RoutingNode remoteRoutingNode = clusterState.getRoutingNodes().node(remoteNode2.getId());
+
+        decision = remoteStoreMigrationAllocationDecider.canAllocate(shardRouting, remoteRoutingNode, routingAllocation);
+        assertThat(decision.type(), is(Decision.Type.YES));
+        reason = String.format(
+            Locale.ROOT,
+            "[remote_store migration_direction]: %s shard copy can be allocated to a remote node for strict compatibility mode",
+            (isReplicaAllocation ? "replica" : "primary")
+        );
+        assertThat(decision.getExplanation().toLowerCase(Locale.ROOT), is(reason));
+    }
+
+    // prepare index metadata for test-index
+    private IndexMetadata.Builder getIndexMetadataBuilder(boolean isRemoteStoreBackedIndex, int shardCount, int replicaCount) {
+        Settings.Builder builder = settings(Version.CURRENT);
+        if (isRemoteStoreBackedIndex) {
+            builder.put(SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+                .put(SETTING_REMOTE_SEGMENT_STORE_REPOSITORY, TEST_REPO)
+                .put(SETTING_REMOTE_TRANSLOG_STORE_REPOSITORY, TEST_REPO)
+                .put(SETTING_REMOTE_STORE_ENABLED, true);
+        }
+        return IndexMetadata.builder(TEST_INDEX).settings(builder).numberOfShards(shardCount).numberOfReplicas(replicaCount);
+    }
+
+    // get node-level settings
+    private Settings getCustomSettings(String direction, String compatibilityMode, IndexMetadata.Builder indexMetadataBuilder) {
+        Settings.Builder builder = Settings.builder();
+        // direction settings
+        if (direction.toLowerCase(Locale.ROOT).equals(RemoteStoreNodeService.Direction.REMOTE_STORE.direction)) {
+            builder.put(remoteStoreDirectionSettings);
+        } else if (direction.toLowerCase(Locale.ROOT).equals(RemoteStoreNodeService.Direction.DOCREP.direction)) {
+            builder.put(docrepDirectionSettings);
+        }
+
+        // compatibility mode settings
+        if (compatibilityMode.toLowerCase(Locale.ROOT).equals(RemoteStoreNodeService.CompatibilityMode.STRICT.mode)) {
+            builder.put(strictModeCompatibilitySettings);
+        } else if (compatibilityMode.toLowerCase(Locale.ROOT).equals(RemoteStoreNodeService.CompatibilityMode.MIXED.mode)) {
+            builder.put(mixedModeCompatibilitySettings);
+        }
+
+        // index metadata settings
+        builder.put(indexMetadataBuilder.build().getSettings());
+
+        builder.put(directionEnabledNodeSettings);
+
+        return builder.build();
+    }
+
+    private String getRandomCompatibilityMode() {
+        return randomFrom(RemoteStoreNodeService.CompatibilityMode.STRICT.mode, RemoteStoreNodeService.CompatibilityMode.MIXED.mode);
+    }
+
+    private ClusterSettings getClusterSettings(Settings settings) {
+        return new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+    }
+
+    private ClusterState getInitialClusterState(
+        Settings settings,
+        IndexMetadata.Builder indexMetadataBuilder,
+        DiscoveryNodes discoveryNodes
+    ) {
+        Metadata metadata = Metadata.builder().persistentSettings(settings).put(indexMetadataBuilder).build();
+
+        RoutingTable routingTable = RoutingTable.builder()
+            .addAsNew(indexMetadataBuilder.build())
+            .addAsNew(metadata.index(TEST_INDEX))
+            .build();
+
+        return ClusterState.builder(ClusterName.DEFAULT).metadata(metadata).routingTable(routingTable).nodes(discoveryNodes).build();
+    }
+
+    // get a dummy non-remote node
+    private DiscoveryNode getNonRemoteNode() {
+        return new DiscoveryNode(UUIDs.base64UUID(), buildNewFakeTransportAddress(), Version.CURRENT);
+    }
+
+    // get a dummy remote node
+    public DiscoveryNode getRemoteNode() {
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(
+            REMOTE_STORE_CLUSTER_STATE_REPOSITORY_NAME_ATTRIBUTE_KEY,
+            "REMOTE_STORE_CLUSTER_STATE_REPOSITORY_NAME_ATTRIBUTE_VALUE"
+        );
+        return new DiscoveryNode(
+            UUIDs.base64UUID(),
+            buildNewFakeTransportAddress(),
+            attributes,
+            DiscoveryNodeRole.BUILT_IN_ROLES,
+            Version.CURRENT
+        );
+    }
+}

--- a/server/src/test/java/org/opensearch/common/time/DateFormattersTests.java
+++ b/server/src/test/java/org/opensearch/common/time/DateFormattersTests.java
@@ -211,6 +211,10 @@ public class DateFormattersTests extends OpenSearchTestCase {
             assertThat(formatter.format(instant), is("-0.12345"));
             assertThat(Instant.from(formatter.parse(formatter.format(instant))), is(instant));
         }
+        {
+            Instant instant = Instant.ofEpochMilli(Long.MIN_VALUE);
+            assertThat(formatter.format(instant), is("-" + Long.MAX_VALUE)); // We actually truncate to Long.MAX_VALUE to avoid overflow
+        }
     }
 
     public void testInvalidEpochMilliParser() {

--- a/server/src/test/java/org/opensearch/index/search/stats/SearchStatsTests.java
+++ b/server/src/test/java/org/opensearch/index/search/stats/SearchStatsTests.java
@@ -57,9 +57,9 @@ public class SearchStatsTests extends OpenSearchTestCase implements SearchReques
         // let's create two dummy search stats with groups
         Map<String, Stats> groupStats1 = new HashMap<>();
         Map<String, Stats> groupStats2 = new HashMap<>();
-        groupStats2.put("group1", new Stats(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1));
-        SearchStats searchStats1 = new SearchStats(new Stats(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1), 0, groupStats1);
-        SearchStats searchStats2 = new SearchStats(new Stats(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1), 0, groupStats2);
+        groupStats2.put("group1", new Stats(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1));
+        SearchStats searchStats1 = new SearchStats(new Stats(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1), 0, groupStats1);
+        SearchStats searchStats2 = new SearchStats(new Stats(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1), 0, groupStats2);
 
         // adding these two search stats and checking group stats are correct
         searchStats1.add(searchStats2);
@@ -128,6 +128,7 @@ public class SearchStatsTests extends OpenSearchTestCase implements SearchReques
         assertEquals(equalTo, stats.getSuggestCount());
         assertEquals(equalTo, stats.getSuggestTimeInMillis());
         assertEquals(equalTo, stats.getSuggestCurrent());
+        assertEquals(equalTo, stats.getSearchIdleWakenUpCount());
         // avg_concurrency is not summed up across stats
         assertEquals(1, stats.getConcurrentAvgSliceCount(), 0);
     }

--- a/server/src/test/java/org/opensearch/index/shard/SearchOperationListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/SearchOperationListenerTests.java
@@ -64,6 +64,7 @@ public class SearchOperationListenerTests extends OpenSearchTestCase {
         AtomicInteger newScrollContext = new AtomicInteger();
         AtomicInteger freeScrollContext = new AtomicInteger();
         AtomicInteger validateSearchContext = new AtomicInteger();
+        AtomicInteger searchIdleWakenUp = new AtomicInteger();
         AtomicInteger timeInNanos = new AtomicInteger(randomIntBetween(0, 10));
         SearchOperationListener listener = new SearchOperationListener() {
             @Override
@@ -133,6 +134,11 @@ public class SearchOperationListenerTests extends OpenSearchTestCase {
                 assertNotNull(readerContext);
                 validateSearchContext.incrementAndGet();
             }
+
+            @Override
+            public void onNewSearchIdleWakenUp() {
+                searchIdleWakenUp.incrementAndGet();
+            }
         };
 
         SearchOperationListener throwingListener = (SearchOperationListener) Proxy.newProxyInstance(
@@ -169,6 +175,7 @@ public class SearchOperationListenerTests extends OpenSearchTestCase {
         assertEquals(0, newScrollContext.get());
         assertEquals(0, freeContext.get());
         assertEquals(0, freeScrollContext.get());
+        assertEquals(0, searchIdleWakenUp.get());
         assertEquals(0, validateSearchContext.get());
 
         compositeListener.onFetchPhase(ctx, timeInNanos.get());
@@ -182,6 +189,7 @@ public class SearchOperationListenerTests extends OpenSearchTestCase {
         assertEquals(0, newScrollContext.get());
         assertEquals(0, freeContext.get());
         assertEquals(0, freeScrollContext.get());
+        assertEquals(0, searchIdleWakenUp.get());
         assertEquals(0, validateSearchContext.get());
 
         compositeListener.onPreQueryPhase(ctx);
@@ -195,6 +203,7 @@ public class SearchOperationListenerTests extends OpenSearchTestCase {
         assertEquals(0, newScrollContext.get());
         assertEquals(0, freeContext.get());
         assertEquals(0, freeScrollContext.get());
+        assertEquals(0, searchIdleWakenUp.get());
         assertEquals(0, validateSearchContext.get());
 
         compositeListener.onPreFetchPhase(ctx);
@@ -208,6 +217,7 @@ public class SearchOperationListenerTests extends OpenSearchTestCase {
         assertEquals(0, newScrollContext.get());
         assertEquals(0, freeContext.get());
         assertEquals(0, freeScrollContext.get());
+        assertEquals(0, searchIdleWakenUp.get());
         assertEquals(0, validateSearchContext.get());
 
         compositeListener.onFailedFetchPhase(ctx);
@@ -221,6 +231,7 @@ public class SearchOperationListenerTests extends OpenSearchTestCase {
         assertEquals(0, newScrollContext.get());
         assertEquals(0, freeContext.get());
         assertEquals(0, freeScrollContext.get());
+        assertEquals(0, searchIdleWakenUp.get());
         assertEquals(0, validateSearchContext.get());
 
         compositeListener.onFailedQueryPhase(ctx);
@@ -234,6 +245,7 @@ public class SearchOperationListenerTests extends OpenSearchTestCase {
         assertEquals(0, newScrollContext.get());
         assertEquals(0, freeContext.get());
         assertEquals(0, freeScrollContext.get());
+        assertEquals(0, searchIdleWakenUp.get());
         assertEquals(0, validateSearchContext.get());
 
         compositeListener.onNewReaderContext(mock(ReaderContext.class));
@@ -247,6 +259,7 @@ public class SearchOperationListenerTests extends OpenSearchTestCase {
         assertEquals(0, newScrollContext.get());
         assertEquals(0, freeContext.get());
         assertEquals(0, freeScrollContext.get());
+        assertEquals(0, searchIdleWakenUp.get());
         assertEquals(0, validateSearchContext.get());
 
         compositeListener.onNewScrollContext(mock(ReaderContext.class));
@@ -260,6 +273,7 @@ public class SearchOperationListenerTests extends OpenSearchTestCase {
         assertEquals(2, newScrollContext.get());
         assertEquals(0, freeContext.get());
         assertEquals(0, freeScrollContext.get());
+        assertEquals(0, searchIdleWakenUp.get());
         assertEquals(0, validateSearchContext.get());
 
         compositeListener.onFreeReaderContext(mock(ReaderContext.class));
@@ -273,6 +287,7 @@ public class SearchOperationListenerTests extends OpenSearchTestCase {
         assertEquals(2, newScrollContext.get());
         assertEquals(2, freeContext.get());
         assertEquals(0, freeScrollContext.get());
+        assertEquals(0, searchIdleWakenUp.get());
         assertEquals(0, validateSearchContext.get());
 
         compositeListener.onFreeScrollContext(mock(ReaderContext.class));
@@ -286,6 +301,21 @@ public class SearchOperationListenerTests extends OpenSearchTestCase {
         assertEquals(2, newScrollContext.get());
         assertEquals(2, freeContext.get());
         assertEquals(2, freeScrollContext.get());
+        assertEquals(0, searchIdleWakenUp.get());
+        assertEquals(0, validateSearchContext.get());
+
+        compositeListener.onNewSearchIdleWakenUp();
+        assertEquals(2, preFetch.get());
+        assertEquals(2, preQuery.get());
+        assertEquals(2, failedFetch.get());
+        assertEquals(2, failedQuery.get());
+        assertEquals(2, onQuery.get());
+        assertEquals(2, onFetch.get());
+        assertEquals(2, newContext.get());
+        assertEquals(2, newScrollContext.get());
+        assertEquals(2, freeContext.get());
+        assertEquals(2, freeScrollContext.get());
+        assertEquals(2, searchIdleWakenUp.get());
         assertEquals(0, validateSearchContext.get());
 
         if (throwingListeners == 0) {
@@ -311,6 +341,7 @@ public class SearchOperationListenerTests extends OpenSearchTestCase {
         assertEquals(2, newScrollContext.get());
         assertEquals(2, freeContext.get());
         assertEquals(2, freeScrollContext.get());
+        assertEquals(2, searchIdleWakenUp.get());
         assertEquals(2, validateSearchContext.get());
     }
 }

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
@@ -669,8 +669,6 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
         // Enabling Telemetry setting by default
         featureSettings.put(FeatureFlags.TELEMETRY_SETTING.getKey(), true);
 
-        // Enabling fuzzy set for tests by default
-        featureSettings.put(FeatureFlags.DOC_ID_FUZZY_SET_SETTING.getKey(), true);
         return featureSettings.build();
     }
 

--- a/test/framework/src/main/java/org/opensearch/test/telemetry/MockTelemetry.java
+++ b/test/framework/src/main/java/org/opensearch/test/telemetry/MockTelemetry.java
@@ -15,8 +15,12 @@ import org.opensearch.telemetry.metrics.Histogram;
 import org.opensearch.telemetry.metrics.MetricsTelemetry;
 import org.opensearch.telemetry.metrics.noop.NoopCounter;
 import org.opensearch.telemetry.metrics.noop.NoopHistogram;
+import org.opensearch.telemetry.metrics.tags.Tags;
 import org.opensearch.telemetry.tracing.TracingTelemetry;
 import org.opensearch.test.telemetry.tracing.MockTracingTelemetry;
+
+import java.io.Closeable;
+import java.util.function.Supplier;
 
 /**
  * Mock {@link Telemetry} implementation for testing.
@@ -51,6 +55,11 @@ public class MockTelemetry implements Telemetry {
             @Override
             public Histogram createHistogram(String name, String description, String unit) {
                 return NoopHistogram.INSTANCE;
+            }
+
+            @Override
+            public Closeable createGauge(String name, String description, String unit, Supplier<Double> valueProvider, Tags tags) {
+                return () -> {};
             }
 
             @Override


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Shards automatically refresh every second, but when a shard doesn't receive search requests for over 30 seconds, it goes into an idle state to improve performance by suspending the implicit index refresh (Mode information on search idle feature [here](https://github.com/elastic/elasticsearch/pull/27500)). However, this introduces a problem: After a shard does idle, the next search request must force a refresh to reflect the latest data. This extra step increases latency. 

We want to monitor how often idle shards are reactivated. This PR introduces a counter called `search_idle_waken_up_total` and exports it in the [node stat api](https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-stats/). 

### Related Issues
Resolves #12678 

### Check List
- [x] New functionality includes testing.
- [x] All tests pass
- [x] New functionality has been documented.
- [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
