### PR TITLE
Fixes flaky test org.opensearch.telemetry.metrics.TelemetryMetricsEna…

### DIFF
--- a/plugins/telemetry-otel/src/internalClusterTest/java/org/opensearch/telemetry/metrics/TelemetryMetricsEnabledSanityIT.java
+++ b/plugins/telemetry-otel/src/internalClusterTest/java/org/opensearch/telemetry/metrics/TelemetryMetricsEnabledSanityIT.java
@@ -124,8 +124,8 @@ public class TelemetryMetricsEnabledSanityIT extends OpenSearchIntegTestCase {
         assertEquals(1.0, histogramPointData.getMin(), 1.0);
     }
 
-    public void testObservableGauge() throws Exception {
-        String metricName = "test-observable-gauge";
+    public void testGauge() throws Exception {
+        String metricName = "test-gauge";
         MetricsRegistry metricsRegistry = internalCluster().getInstance(MetricsRegistry.class);
         InMemorySingletonMetricsExporter.INSTANCE.reset();
         Tags tags = Tags.create().addTag("test", "integ-test");
@@ -137,7 +137,7 @@ public class TelemetryMetricsEnabledSanityIT extends OpenSearchIntegTestCase {
 
         InMemorySingletonMetricsExporter exporter = InMemorySingletonMetricsExporter.INSTANCE;
 
-        assertEquals(2.0, getMaxObservableGaugeValue(exporter, metricName), 0.0);
+        assertTrue(getMaxObservableGaugeValue(exporter, metricName) >= 2.0);
         gaugeCloseable.close();
         double observableGaugeValueAfterStop = getMaxObservableGaugeValue(exporter, metricName);
 


### PR DESCRIPTION
### Description 

This fixes the exact check to avoid failure in the scenario where the test execution thread is experiencing some delay.

### Related Issues
Resolves #12717

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
