### PR TITLE
Fixing ehcache flaky test

### DIFF
--- a/plugins/cache-ehcache/src/test/java/org/opensearch/cache/store/disk/EhcacheThreadLeakFilter.java
+++ b/plugins/cache-ehcache/src/test/java/org/opensearch/cache/store/disk/EhcacheThreadLeakFilter.java
@@ -11,10 +11,12 @@ package org.opensearch.cache.store.disk;
 import com.carrotsearch.randomizedtesting.ThreadFilter;
 
 /**
- * In Ehcache(as of 3.8.0), while calling remove/invalidate() on entries causes to start a daemon thread in the
+ * In Ehcache(as of 3.10.8), while calling remove/invalidate() on entries causes to start a daemon thread in the
  * background to clean up the stale offheap memory associated with the disk cache. And this thread is not closed even
  * after we try to close the cache or cache manager. Considering that it requires a node restart to switch between
  * different cache plugins, this shouldn't be a problem for now. Will be following up with ehcache on this.
+ *
+ * See: https://github.com/ehcache/ehcache3/issues/3204
  */
 public class EhcacheThreadLeakFilter implements ThreadFilter {
 

--- a/plugins/cache-ehcache/src/test/java/org/opensearch/cache/store/disk/EhcacheThreadLeakFilter.java
+++ b/plugins/cache-ehcache/src/test/java/org/opensearch/cache/store/disk/EhcacheThreadLeakFilter.java
@@ -1,0 +1,27 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cache.store.disk;
+
+import com.carrotsearch.randomizedtesting.ThreadFilter;
+
+/**
+ * In Ehcache(as of 3.8.0), while calling remove/invalidate() on entries causes to start a daemon thread in the
+ * background to clean up the stale offheap memory associated with the disk cache. And this thread is not closed even
+ * after we try to close the cache or cache manager. Considering that it requires a node restart to switch between
+ * different cache plugins, this shouldn't be a problem for now. Will be following up with ehcache on this.
+ */
+public class EhcacheThreadLeakFilter implements ThreadFilter {
+
+    private static final String OFFENDING_THREAD_NAME = "MappedByteBufferSource";
+
+    @Override
+    public boolean reject(Thread t) {
+        return t.getName().startsWith(OFFENDING_THREAD_NAME);
+    }
+}

--- a/plugins/cache-ehcache/src/test/java/org/opensearch/cache/store/disk/EhcacheThreadLeakFilter.java
+++ b/plugins/cache-ehcache/src/test/java/org/opensearch/cache/store/disk/EhcacheThreadLeakFilter.java
@@ -14,7 +14,7 @@ import com.carrotsearch.randomizedtesting.ThreadFilter;
  * In Ehcache(as of 3.10.8), while calling remove/invalidate() on entries causes to start a daemon thread in the
  * background to clean up the stale offheap memory associated with the disk cache. And this thread is not closed even
  * after we try to close the cache or cache manager. Considering that it requires a node restart to switch between
- * different cache plugins, this shouldn't be a problem for now. Will be following up with ehcache on this.
+ * different cache plugins, this shouldn't be a problem for now.
  *
  * See: https://github.com/ehcache/ehcache3/issues/3204
  */


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fixing flaky test within EhcacheDiskCacheTests

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/12758

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- ~[ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
