### PR TITLE
Fix SimpleNestedExplainIT.testExplainMultipleDocs flakiness

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/nested/SimpleNestedExplainIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/nested/SimpleNestedExplainIT.java
@@ -30,6 +30,11 @@ import static org.hamcrest.Matchers.equalTo;
  */
 public class SimpleNestedExplainIT extends OpenSearchIntegTestCase {
 
+    @Override
+    protected int numberOfShards() {
+        return 1;
+    }
+
     /*
      * Tests the explain output for multiple docs. Concurrent search with multiple slices is tested
      * here as call to indexRandomForMultipleSlices is made and compared with explain output for
@@ -70,7 +75,23 @@ public class SimpleNestedExplainIT extends OpenSearchIntegTestCase {
             .setRefreshPolicy(IMMEDIATE)
             .get();
 
-        indexRandomForMultipleSlices("test");
+        client().prepareIndex("test")
+            .setId("2")
+            .setSource(
+                jsonBuilder().startObject()
+                    .field("field1", "value2")
+                    .startArray("nested1")
+                    .startObject()
+                    .field("n_field1", "n_value2")
+                    .endObject()
+                    .startObject()
+                    .field("n_field1", "n_value2")
+                    .endObject()
+                    .endArray()
+                    .endObject()
+            )
+            .setRefreshPolicy(IMMEDIATE)
+            .get();
 
         // Turn off the concurrent search setting to test search with non-concurrent search
         client().admin()


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The explain itself is coming from Lucene: https://github.com/apache/lucene/blob/a6f70ad2bb0b682eb65feb522358ee6d16cad766/lucene/join/src/java/org/apache/lucene/search/join/ToParentBlockJoinQuery.java#L432-L440

Here's some info on the docIds in lucene:
- A DocId in lucene is not actually unique to the Index but is unique to a Segment. Lucene does this mainly to optimize writing and compression. Since it is only unique to a Segment, how can a Doc be uniquely identified at the Index level? The solution is simple. The segments are ordered. To take a simple example, an Index has two segments and each segment has 100 docs respectively. The DocId's in the Segment are 0-100 but when they are converted to the Index level, the range of the DocId's in the second Segment is converted to 100-200.

- DocId's are unique within a Segment, numbered progressively from zero. But this does not mean that the DocId's are continuous. When a Doc is deleted, there is a gap.

- The DocId corresponding to a document can change, usually when Segments are merged.

The test fails on the validation of range of the docIds in the assertion, the range changes as with indexRandomForMultipleSlices function there are several bogus documents ingested and deleted which could trigger background merges and cause the range of the docIds matched with the search query to change.

One of the solutions is to not the delete the bogus documents as part of the indexRandomForMultipleSlices, perform search for concurrent search and non-concurrent search and delete the bogus docs at the end. This is done as part of this PR.

Validated the success of the tests for 500 times.

Relates: #11681

### Related Issues
Resolves #12318

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
