### PR TITLE
Fixing flaky test GeoPointShapeQueryTests.testQueryLinearRing

### DIFF
--- a/server/src/test/java/org/opensearch/search/geo/GeoPointShapeQueryTests.java
+++ b/server/src/test/java/org/opensearch/search/geo/GeoPointShapeQueryTests.java
@@ -143,6 +143,8 @@ public class GeoPointShapeQueryTests extends GeoQueryTests {
                 e.getCause().getMessage(),
                 containsString("Field [" + defaultGeoFieldName + "] does not support LINEARRING queries")
             );
+        } catch (UnsupportedOperationException e) {
+            assertThat(e.getMessage(), containsString("line ring cannot be serialized using GeoJson"));
         }
     }
 


### PR DESCRIPTION

### Description
It fixes the GeoPointShapeQueryTests.testQueryLinearRing which has been failing across multiple PR during gradle-check

### Related Issues
Resolves [11688](https://github.com/opensearch-project/OpenSearch/issues/11688)
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
