### PR TITLE
Fix Flaky TaskBatcherTests Tests

### DIFF
--- a/server/src/test/java/org/opensearch/cluster/service/TaskBatcherTests.java
+++ b/server/src/test/java/org/opensearch/cluster/service/TaskBatcherTests.java
@@ -218,7 +218,8 @@ public class TaskBatcherTests extends TaskExecutorTests {
             executors[i] = new TaskExecutor();
         }
 
-        int tasksSubmittedPerThread = randomIntBetween(2, 1024);
+        // it will create at most 8192 threads, which will cause native memory oom. so we limit the number of created threads.
+        int tasksSubmittedPerThread = randomIntBetween(2, 128);
 
         CopyOnWriteArrayList<Tuple<String, Throwable>> failures = new CopyOnWriteArrayList<>();
         CountDownLatch updateLatch = new CountDownLatch(numberOfThreads * tasksSubmittedPerThread);
@@ -286,7 +287,7 @@ public class TaskBatcherTests extends TaskExecutorTests {
             executors[i] = new TaskExecutor();
         }
 
-        int tasksSubmittedPerThread = randomIntBetween(2, 1024);
+        int tasksSubmittedPerThread = randomIntBetween(2, 128);
 
         CopyOnWriteArrayList<Tuple<String, Throwable>> failures = new CopyOnWriteArrayList<>();
         CountDownLatch updateLatch = new CountDownLatch(numberOfThreads * tasksSubmittedPerThread);


### PR DESCRIPTION
Signed-off-by: kkewwei [kkewwei@163.com]

### Description
org.opensearch.cluster.service.TaskBatcherTests.testNoTasksAreDroppedInParallelSubmission is flaky

### Related Issues
Resolves #12815

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
