### PR TITLE
Update supported version for the wait_for_completion parameter in open&clone&shrink&split APIs

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.clone/40_wait_for_completion.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.clone/40_wait_for_completion.yml
@@ -4,8 +4,8 @@
   # will return a task immediately and the clone operation will run in background.
 
   - skip:
-      version: " - 2.99.99"
-      reason: "only available in 3.0+"
+      version: " - 2.6.99"
+      reason: "wait_for_completion was introduced in 2.7.0"
       features: allowed_warnings
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.open/30_wait_for_completion.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.open/30_wait_for_completion.yml
@@ -4,8 +4,8 @@
   # will return a task immediately and the open operation will run in background.
 
   - skip:
-      version: " - 2.99.99"
-      reason: "only available in 3.0+"
+      version: " - 2.6.99"
+      reason: "wait_for_completion was introduced in 2.7.0"
       features: allowed_warnings
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/50_wait_for_completion.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/50_wait_for_completion.yml
@@ -4,8 +4,8 @@
   # will return a task immediately and the shrink operation will run in background.
 
   - skip:
-      version: " - 2.99.99"
-      reason: "only available in 3.0+"
+      version: " - 2.6.99"
+      reason: "wait_for_completion was introduced in 2.7.0"
       features: allowed_warnings
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/40_wait_for_completion.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/40_wait_for_completion.yml
@@ -4,8 +4,8 @@
   # will return a task immediately and the split operation will run in background.
 
   - skip:
-      version: " - 2.99.99"
-      reason: "only available in 3.0+"
+      version: " - 2.6.99"
+      reason: "wait_for_completion was introduced in 2.7.0"
       features: allowed_warnings
 
   - do:


### PR DESCRIPTION
### Description
In the PR https://github.com/opensearch-project/OpenSearch/pull/6434, we've added `wait_for_completion` parameter for open&clone&shrink&split&forcemerge APIs, after the PR was merged and backported to 2.x branch, we need to update the supported version in the yaml test file to ensure that change can be covered by yaml test.

The supported version in the [yaml test file](https://github.com/opensearch-project/OpenSearch/blob/f3d2beee637f63e38c8f26dbcee9f2a82f9c87b6/rest-api-spec/src/main/resources/rest-api-spec/test/indices.forcemerge/20_wait_for_completion.yml#L7) of forcemerge API has been changed by other PR, this PR only change the version for the remaining APIs.

The wait_for_completion parameter is not serialized/deserialized, so no java code change.

Backport  and changelog is not needed.

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/6228

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
