### PR TITLE
Implement serialization for LinearRing.

### DIFF
--- a/server/src/main/java/org/opensearch/action/search/SearchTask.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchTask.java
@@ -80,7 +80,11 @@ public class SearchTask extends CancellableTask implements SearchBackpressureTas
 
     @Override
     public final String getDescription() {
-        return descriptionSupplier.get();
+        try {
+            return descriptionSupplier.get();
+        } catch(UnsupportedOperationException e) {
+            return e.getMessage();
+        }
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/search/SearchTask.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchTask.java
@@ -80,11 +80,7 @@ public class SearchTask extends CancellableTask implements SearchBackpressureTas
 
     @Override
     public final String getDescription() {
-        try {
-            return descriptionSupplier.get();
-        } catch(UnsupportedOperationException e) {
-            return e.getMessage();
-        }
+        return descriptionSupplier.get();
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/common/geo/GeoJson.java
+++ b/server/src/main/java/org/opensearch/common/geo/GeoJson.java
@@ -125,8 +125,13 @@ public final class GeoJson {
             }
 
             @Override
-            public XContentBuilder visit(LinearRing ring) {
-                throw new UnsupportedOperationException("linearRing cannot be serialized using GeoJson");
+            public XContentBuilder visit(LinearRing ring) throws IOException {
+                builder.field(ShapeParser.FIELD_COORDINATES.getPreferredName());
+                builder.startArray();
+                for (int i = 0; i < ring.length(); i++) {
+                    coordinatesToXContent(ring.getLat(i), ring.getLon(i), ring.getAlt(i));
+                }
+                return builder.endArray();
             }
 
             @Override
@@ -254,7 +259,18 @@ public final class GeoJson {
 
             @Override
             public Void visit(LinearRing ring) {
-                throw new UnsupportedOperationException("linearRing cannot be serialized using GeoJson");
+                List<Object> points = new ArrayList<>(ring.length());
+                for (int i = 0; i < ring.length(); i++) {
+                    List<Object> point = new ArrayList<>();
+                    point.add(ring.getX(i));
+                    point.add(ring.getY(i));
+                    if (ring.hasZ()) {
+                        point.add(ring.getZ(i));
+                    }
+                    points.add(point);
+                }
+                root.put(ShapeParser.FIELD_COORDINATES.getPreferredName(), points);
+                return null;
             }
 
             @Override
@@ -428,6 +444,9 @@ public final class GeoJson {
             case LINESTRING:
                 verifyNulls(type, geometries, orientation, radius);
                 return coordinates.asLineString(coerce);
+            case LINEARRING:
+                verifyNulls(type, geometries, orientation, radius);
+                return coordinates.asLinearRing(orientation != null ? orientation : defaultOrientation, coerce);
             case MULTILINESTRING:
                 verifyNulls(type, geometries, orientation, radius);
                 return coordinates.asMultiLineString(coerce);
@@ -558,7 +577,7 @@ public final class GeoJson {
 
             @Override
             public String visit(LinearRing ring) {
-                throw new UnsupportedOperationException("line ring cannot be serialized using GeoJson");
+                return "LinearRing";
             }
 
             @Override

--- a/server/src/test/java/org/opensearch/common/geo/GeoJsonSerializationTests.java
+++ b/server/src/test/java/org/opensearch/common/geo/GeoJsonSerializationTests.java
@@ -56,6 +56,7 @@ import java.util.function.Supplier;
 import static org.opensearch.geo.GeometryTestUtils.randomCircle;
 import static org.opensearch.geo.GeometryTestUtils.randomGeometryCollection;
 import static org.opensearch.geo.GeometryTestUtils.randomLine;
+import static org.opensearch.geo.GeometryTestUtils.randomLinearRing;
 import static org.opensearch.geo.GeometryTestUtils.randomMultiLine;
 import static org.opensearch.geo.GeometryTestUtils.randomMultiPoint;
 import static org.opensearch.geo.GeometryTestUtils.randomMultiPolygon;
@@ -119,6 +120,10 @@ public class GeoJsonSerializationTests extends OpenSearchTestCase {
 
     public void testLineString() throws IOException {
         xContentTest(() -> randomLine(randomBoolean()));
+    }
+
+    public void testLinearRing() throws IOException {
+        xContentTest(() -> randomLinearRing(randomBoolean()));
     }
 
     public void testMultiLineString() throws IOException {

--- a/server/src/test/java/org/opensearch/search/geo/GeoPointShapeQueryTests.java
+++ b/server/src/test/java/org/opensearch/search/geo/GeoPointShapeQueryTests.java
@@ -100,6 +100,7 @@ public class GeoPointShapeQueryTests extends GeoQueryTests {
                     client().prepareSearch("test")
                         .setQuery(QueryBuilders.geoShapeQuery(defaultGeoFieldName, rectangle).relation(shapeRelation))
                         .get();
+                    fail("Expected " + shapeRelation + " query relation not supported for Field [" + defaultGeoFieldName + "]");
                 } catch (SearchPhaseExecutionException e) {
                     assertThat(
                         e.getCause().getMessage(),
@@ -119,6 +120,7 @@ public class GeoPointShapeQueryTests extends GeoQueryTests {
 
         try {
             client().prepareSearch("test").setQuery(QueryBuilders.geoShapeQuery(defaultGeoFieldName, line)).get();
+            fail("Expected field [" + defaultGeoFieldName + "] does not support LINEARRING queries");
         } catch (SearchPhaseExecutionException e) {
             assertThat(e.getCause().getMessage(), containsString("does not support " + GeoShapeType.LINESTRING + " queries"));
         }
@@ -138,6 +140,7 @@ public class GeoPointShapeQueryTests extends GeoQueryTests {
             searchRequestBuilder.setQuery(queryBuilder);
             searchRequestBuilder.setIndices("test");
             searchRequestBuilder.get();
+            fail("Expected field [" + defaultGeoFieldName + "] does not support LINEARRING queries");
         } catch (SearchPhaseExecutionException e) {
             assertThat(
                 e.getCause().getMessage(),
@@ -160,6 +163,7 @@ public class GeoPointShapeQueryTests extends GeoQueryTests {
 
         try {
             client().prepareSearch("test").setQuery(QueryBuilders.geoShapeQuery(defaultGeoFieldName, multiline)).get();
+            fail("Expected field [" + defaultGeoFieldName + "] does not support " + GeoShapeType.MULTILINESTRING + " queries");
         } catch (Exception e) {
             assertThat(e.getCause().getMessage(), containsString("does not support " + GeoShapeType.MULTILINESTRING + " queries"));
         }
@@ -175,6 +179,7 @@ public class GeoPointShapeQueryTests extends GeoQueryTests {
 
         try {
             client().prepareSearch("test").setQuery(QueryBuilders.geoShapeQuery(defaultGeoFieldName, multiPoint)).get();
+            fail("Expected field [" + defaultGeoFieldName + "] does not support " + GeoShapeType.MULTIPOINT + " queries");
         } catch (Exception e) {
             assertThat(e.getCause().getMessage(), containsString("does not support " + GeoShapeType.MULTIPOINT + " queries"));
         }
@@ -190,6 +195,7 @@ public class GeoPointShapeQueryTests extends GeoQueryTests {
 
         try {
             client().prepareSearch("test").setQuery(QueryBuilders.geoShapeQuery(defaultGeoFieldName, point)).get();
+            fail("Expected field [" + defaultGeoFieldName + "] does not support " + GeoShapeType.POINT + " queries");
         } catch (Exception e) {
             assertThat(e.getCause().getMessage(), containsString("does not support " + GeoShapeType.POINT + " queries"));
         }

--- a/server/src/test/java/org/opensearch/search/geo/GeoPointShapeQueryTests.java
+++ b/server/src/test/java/org/opensearch/search/geo/GeoPointShapeQueryTests.java
@@ -143,8 +143,6 @@ public class GeoPointShapeQueryTests extends GeoQueryTests {
                 e.getCause().getMessage(),
                 containsString("Field [" + defaultGeoFieldName + "] does not support LINEARRING queries")
             );
-        } catch (UnsupportedOperationException e) {
-            assertThat(e.getMessage(), containsString("line ring cannot be serialized using GeoJson"));
         }
     }
 

--- a/test/framework/src/main/java/org/opensearch/geo/GeometryTestUtils.java
+++ b/test/framework/src/main/java/org/opensearch/geo/GeometryTestUtils.java
@@ -102,6 +102,30 @@ public class GeometryTestUtils {
         return new Line(lons, lats);
     }
 
+    public static LinearRing randomLinearRing(boolean hasAlts) {
+        // we use nextPolygon because it guarantees no duplicate points
+        org.apache.lucene.geo.Polygon lucenePolygon = GeoTestUtil.nextPolygon();
+        int size = lucenePolygon.numPoints() - 1;
+        double[] lats = new double[size + 1];
+        double[] lons = new double[size + 1];
+        double[] alts = hasAlts ? new double[size + 1] : null;
+        for (int i = 0; i < size; i++) {
+            lats[i] = lucenePolygon.getPolyLat(i);
+            lons[i] = lucenePolygon.getPolyLon(i);
+            if (hasAlts) {
+                alts[i] = randomAlt();
+            }
+        }
+        // first and last points of the linear ring must be the same
+        lats[size] = lats[0];
+        lons[size] = lons[0];
+        if (hasAlts) {
+            alts[size] = alts[0];
+            return new LinearRing(lons, lats, alts);
+        }
+        return new LinearRing(lons, lats);
+    }
+
     public static Point randomPoint() {
         return randomPoint(OpenSearchTestCase.randomBoolean());
     }


### PR DESCRIPTION
### Description

A user that enables trace-level logging with OpenSearch will run into a serialization error on geo tasks that they otherwise would not run into. It comes from [here](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/common/geo/GeoJson.java#L129). This also happens in a test, and https://github.com/opensearch-project/OpenSearch/pull/12783 attempts to ignore the failed serialization error. This PR implements JSON serialization for `LinearRing`.

Reproduce with

```
./gradlew ':server:test' --tests "org.opensearch.search.geo.GeoPointShapeQueryTests.testQueryLinearRing" -Dtests.opensearch.logger.level=TRACE
``` 

### Related Issues

Closes https://github.com/opensearch-project/OpenSearch/issues/11688.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
