### PR TITLE
Catch task description error

### DIFF
--- a/server/src/main/java/org/opensearch/action/search/SearchRequest.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequest.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.action.search;
 
+import org.opensearch.OpenSearchException;
 import org.opensearch.Version;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
@@ -712,7 +713,13 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
             sb.append("scroll[").append(scroll.keepAlive()).append("], ");
         }
         if (source != null) {
-            sb.append("source[").append(source.toString(FORMAT_PARAMS)).append("]");
+            sb.append("source[");
+            try {
+                sb.append(source.toString(FORMAT_PARAMS));
+            } catch (final OpenSearchException ex) {
+                sb.append(ex.getMessage());
+            }
+            sb.append("]");
         } else {
             sb.append("source[]");
         }

--- a/server/src/main/java/org/opensearch/action/search/SearchRequest.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequest.java
@@ -717,7 +717,7 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
             try {
                 sb.append(source.toString(FORMAT_PARAMS));
             } catch (final OpenSearchException ex) {
-                sb.append(ex.getMessage());
+                sb.append("<error: ").append(ex.getMessage()).append(">");
             }
             sb.append("]");
         } else {

--- a/server/src/main/java/org/opensearch/action/search/SearchTask.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchTask.java
@@ -80,7 +80,11 @@ public class SearchTask extends CancellableTask implements SearchBackpressureTas
 
     @Override
     public final String getDescription() {
-        return descriptionSupplier.get();
+        try {
+            return descriptionSupplier.get();
+        } catch(UnsupportedOperationException e) {
+            return e.getMessage();
+        }
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/search/SearchTask.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchTask.java
@@ -80,11 +80,7 @@ public class SearchTask extends CancellableTask implements SearchBackpressureTas
 
     @Override
     public final String getDescription() {
-        try {
-            return descriptionSupplier.get();
-        } catch (UnsupportedOperationException e) {
-            return e.getMessage();
-        }
+        return descriptionSupplier.get();
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/search/SearchTask.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchTask.java
@@ -82,7 +82,7 @@ public class SearchTask extends CancellableTask implements SearchBackpressureTas
     public final String getDescription() {
         try {
             return descriptionSupplier.get();
-        } catch(UnsupportedOperationException e) {
+        } catch (UnsupportedOperationException e) {
             return e.getMessage();
         }
     }

--- a/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
@@ -1842,7 +1842,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
     public String toString(Params params) {
         try {
             return XContentHelper.toXContent(this, MediaTypeRegistry.JSON, params, true).utf8ToString();
-        } catch (IOException e) {
+        } catch (IOException | UnsupportedOperationException e) {
             throw new OpenSearchException(e);
         }
     }

--- a/server/src/test/java/org/opensearch/action/search/SearchRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchRequestTests.java
@@ -279,7 +279,7 @@ public class SearchRequestTests extends AbstractSearchTestCase {
         assertThat(
             toDescription(request),
             equalTo(
-                "indices[], search_type[QUERY_THEN_FETCH], source[java.lang.UnsupportedOperationException: line ring cannot be serialized using GeoJson]"
+                "indices[], search_type[QUERY_THEN_FETCH], source[<error: java.lang.UnsupportedOperationException: line ring cannot be serialized using GeoJson>]"
             )
         );
     }

--- a/server/src/test/java/org/opensearch/action/search/SearchRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchRequestTests.java
@@ -39,6 +39,8 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.ArrayUtils;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.tasks.TaskId;
+import org.opensearch.geometry.LinearRing;
+import org.opensearch.index.query.GeoShapeQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.AbstractSearchTestCase;
 import org.opensearch.search.Scroll;
@@ -266,6 +268,19 @@ public class SearchRequestTests extends AbstractSearchTestCase {
         assertThat(
             toDescription(new SearchRequest().scroll(TimeValue.timeValueMinutes(5))),
             equalTo("indices[], search_type[QUERY_THEN_FETCH], scroll[5m], source[]")
+        );
+    }
+
+    public void testDescriptionOnSourceError() {
+        LinearRing linearRing = new LinearRing(new double[] { -25, -35, -25 }, new double[] { -25, -35, -25 });
+        GeoShapeQueryBuilder queryBuilder = new GeoShapeQueryBuilder("geo", linearRing);
+        SearchRequest request = new SearchRequest();
+        request.source(new SearchSourceBuilder().query(queryBuilder));
+        assertThat(
+            toDescription(request),
+            equalTo(
+                "indices[], search_type[QUERY_THEN_FETCH], source[java.lang.UnsupportedOperationException: line ring cannot be serialized using GeoJson]"
+            )
         );
     }
 

--- a/server/src/test/java/org/opensearch/search/geo/GeoPointShapeQueryTests.java
+++ b/server/src/test/java/org/opensearch/search/geo/GeoPointShapeQueryTests.java
@@ -100,6 +100,7 @@ public class GeoPointShapeQueryTests extends GeoQueryTests {
                     client().prepareSearch("test")
                         .setQuery(QueryBuilders.geoShapeQuery(defaultGeoFieldName, rectangle).relation(shapeRelation))
                         .get();
+                    fail("Expected " + shapeRelation + " query relation not supported for Field [" + defaultGeoFieldName + "]");
                 } catch (SearchPhaseExecutionException e) {
                     assertThat(
                         e.getCause().getMessage(),
@@ -119,6 +120,7 @@ public class GeoPointShapeQueryTests extends GeoQueryTests {
 
         try {
             client().prepareSearch("test").setQuery(QueryBuilders.geoShapeQuery(defaultGeoFieldName, line)).get();
+            fail("Expected field [" + defaultGeoFieldName + "] does not support LINEARRING queries");
         } catch (SearchPhaseExecutionException e) {
             assertThat(e.getCause().getMessage(), containsString("does not support " + GeoShapeType.LINESTRING + " queries"));
         }
@@ -138,6 +140,7 @@ public class GeoPointShapeQueryTests extends GeoQueryTests {
             searchRequestBuilder.setQuery(queryBuilder);
             searchRequestBuilder.setIndices("test");
             searchRequestBuilder.get();
+            fail("Expected field [" + defaultGeoFieldName + "] does not support LINEARRING queries");
         } catch (SearchPhaseExecutionException e) {
             assertThat(
                 e.getCause().getMessage(),
@@ -160,6 +163,7 @@ public class GeoPointShapeQueryTests extends GeoQueryTests {
 
         try {
             client().prepareSearch("test").setQuery(QueryBuilders.geoShapeQuery(defaultGeoFieldName, multiline)).get();
+            fail("Expected field [" + defaultGeoFieldName + "] does not support " + GeoShapeType.MULTILINESTRING + " queries");
         } catch (Exception e) {
             assertThat(e.getCause().getMessage(), containsString("does not support " + GeoShapeType.MULTILINESTRING + " queries"));
         }
@@ -175,6 +179,7 @@ public class GeoPointShapeQueryTests extends GeoQueryTests {
 
         try {
             client().prepareSearch("test").setQuery(QueryBuilders.geoShapeQuery(defaultGeoFieldName, multiPoint)).get();
+            fail("Expected field [" + defaultGeoFieldName + "] does not support " + GeoShapeType.MULTIPOINT + " queries");
         } catch (Exception e) {
             assertThat(e.getCause().getMessage(), containsString("does not support " + GeoShapeType.MULTIPOINT + " queries"));
         }
@@ -190,6 +195,7 @@ public class GeoPointShapeQueryTests extends GeoQueryTests {
 
         try {
             client().prepareSearch("test").setQuery(QueryBuilders.geoShapeQuery(defaultGeoFieldName, point)).get();
+            fail("Expected field [" + defaultGeoFieldName + "] does not support " + GeoShapeType.POINT + " queries");
         } catch (Exception e) {
             assertThat(e.getCause().getMessage(), containsString("does not support " + GeoShapeType.POINT + " queries"));
         }

--- a/server/src/test/java/org/opensearch/search/geo/GeoPointShapeQueryTests.java
+++ b/server/src/test/java/org/opensearch/search/geo/GeoPointShapeQueryTests.java
@@ -143,8 +143,6 @@ public class GeoPointShapeQueryTests extends GeoQueryTests {
                 e.getCause().getMessage(),
                 containsString("Field [" + defaultGeoFieldName + "] does not support LINEARRING queries")
             );
-        } catch (UnsupportedOperationException e) {
-            assertThat(e.getMessage(), containsString("line ring cannot be serialized using GeoJson"));
         }
     }
 


### PR DESCRIPTION
### Description

Alternative to (just the first two commits) to https://github.com/opensearch-project/OpenSearch/pull/12831.

A user that enables trace-level logging with OpenSearch will run into a serialization error on geo tasks that they otherwise would not run into. It comes from [here](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/common/geo/GeoJson.java#L129). This also happens in a test, and https://github.com/opensearch-project/OpenSearch/pull/12783 attempts to ignore the failed serialization error. This PR always returns a task description.

Reproduce with

```
./gradlew ':server:test' --tests "org.opensearch.search.geo.GeoPointShapeQueryTests.testQueryLinearRing" -Dtests.opensearch.logger.level=TRACE
``` 
### Related Issues

Closes https://github.com/opensearch-project/OpenSearch/issues/11688
Closes #12324

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
