### PR TITLE
Fix issue with feature flags where default value may not be honored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 ### Fixed
+- Fix issue with feature flags where default value may not be honored ([#12849](https://github.com/opensearch-project/OpenSearch/pull/12849))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
+++ b/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
@@ -124,7 +124,10 @@ public class FeatureFlags {
     public static void initializeFeatureFlags(Settings openSearchSettings) {
         Settings.Builder settingsBuilder = Settings.builder();
         for (Setting<Boolean> ffSetting : ALL_FEATURE_FLAG_SETTINGS) {
-            settingsBuilder = settingsBuilder.put(ffSetting.getKey(), ffSetting.getDefault(openSearchSettings));
+            settingsBuilder = settingsBuilder.put(
+                ffSetting.getKey(),
+                openSearchSettings.getAsBoolean(ffSetting.getKey(), ffSetting.getDefault(openSearchSettings))
+            );
         }
         settings = settingsBuilder.build();
     }

--- a/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
+++ b/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
@@ -102,7 +102,7 @@ public class FeatureFlags {
         .put(DATETIME_FORMATTER_CACHING_SETTING.getKey(), DATETIME_FORMATTER_CACHING_SETTING.getDefault(Settings.EMPTY))
         .put(WRITEABLE_REMOTE_INDEX_SETTING.getKey(), WRITEABLE_REMOTE_INDEX_SETTING.getDefault(Settings.EMPTY))
         .put(PLUGGABLE_CACHE_SETTING.getKey(), PLUGGABLE_CACHE_SETTING.getDefault(Settings.EMPTY))
-        .build();;
+        .build();
 
     /**
      * This method is responsible to map settings from opensearch.yml to local stored

--- a/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
+++ b/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
@@ -65,10 +65,44 @@ public class FeatureFlags {
      */
     public static final String PLUGGABLE_CACHE = "opensearch.experimental.feature.pluggable.caching.enabled";
 
+    public static final Setting<Boolean> REMOTE_STORE_MIGRATION_EXPERIMENTAL_SETTING = Setting.boolSetting(
+        REMOTE_STORE_MIGRATION_EXPERIMENTAL,
+        false,
+        Property.NodeScope
+    );
+
+    public static final Setting<Boolean> EXTENSIONS_SETTING = Setting.boolSetting(EXTENSIONS, false, Property.NodeScope);
+
+    public static final Setting<Boolean> IDENTITY_SETTING = Setting.boolSetting(IDENTITY, false, Property.NodeScope);
+
+    public static final Setting<Boolean> TELEMETRY_SETTING = Setting.boolSetting(TELEMETRY, false, Property.NodeScope);
+
+    public static final Setting<Boolean> DATETIME_FORMATTER_CACHING_SETTING = Setting.boolSetting(
+        DATETIME_FORMATTER_CACHING,
+        true,
+        Property.NodeScope
+    );
+
+    public static final Setting<Boolean> WRITEABLE_REMOTE_INDEX_SETTING = Setting.boolSetting(
+        WRITEABLE_REMOTE_INDEX,
+        false,
+        Property.NodeScope
+    );
+
+    public static final Setting<Boolean> PLUGGABLE_CACHE_SETTING = Setting.boolSetting(PLUGGABLE_CACHE, false, Property.NodeScope);
+
     /**
      * Should store the settings from opensearch.yml.
      */
-    private static Settings settings;
+    private static Settings settings = Settings.builder()
+        .put(REMOTE_STORE_MIGRATION_EXPERIMENTAL_SETTING.getKey(), REMOTE_STORE_MIGRATION_EXPERIMENTAL_SETTING.getDefault(Settings.EMPTY))
+        .put(EXTENSIONS_SETTING.getKey(), EXTENSIONS_SETTING.getDefault(Settings.EMPTY))
+        .put(IDENTITY_SETTING.getKey(), IDENTITY_SETTING.getDefault(Settings.EMPTY))
+        .put(TELEMETRY_SETTING.getKey(), TELEMETRY_SETTING.getDefault(Settings.EMPTY))
+        .put(DATETIME_FORMATTER_CACHING_SETTING.getKey(), DATETIME_FORMATTER_CACHING_SETTING.getDefault(Settings.EMPTY))
+        .put(WRITEABLE_REMOTE_INDEX_SETTING.getKey(), WRITEABLE_REMOTE_INDEX_SETTING.getDefault(Settings.EMPTY))
+        .put(PLUGGABLE_CACHE_SETTING.getKey(), PLUGGABLE_CACHE_SETTING.getDefault(Settings.EMPTY))
+        .build();;
 
     /**
      * This method is responsible to map settings from opensearch.yml to local stored
@@ -103,30 +137,4 @@ public class FeatureFlags {
             return featureFlag.getDefault(Settings.EMPTY);
         }
     }
-
-    public static final Setting<Boolean> REMOTE_STORE_MIGRATION_EXPERIMENTAL_SETTING = Setting.boolSetting(
-        REMOTE_STORE_MIGRATION_EXPERIMENTAL,
-        false,
-        Property.NodeScope
-    );
-
-    public static final Setting<Boolean> EXTENSIONS_SETTING = Setting.boolSetting(EXTENSIONS, false, Property.NodeScope);
-
-    public static final Setting<Boolean> IDENTITY_SETTING = Setting.boolSetting(IDENTITY, false, Property.NodeScope);
-
-    public static final Setting<Boolean> TELEMETRY_SETTING = Setting.boolSetting(TELEMETRY, false, Property.NodeScope);
-
-    public static final Setting<Boolean> DATETIME_FORMATTER_CACHING_SETTING = Setting.boolSetting(
-        DATETIME_FORMATTER_CACHING,
-        true,
-        Property.NodeScope
-    );
-
-    public static final Setting<Boolean> WRITEABLE_REMOTE_INDEX_SETTING = Setting.boolSetting(
-        WRITEABLE_REMOTE_INDEX,
-        false,
-        Property.NodeScope
-    );
-
-    public static final Setting<Boolean> PLUGGABLE_CACHE_SETTING = Setting.boolSetting(PLUGGABLE_CACHE, false, Property.NodeScope);
 }

--- a/server/src/test/java/org/opensearch/common/util/FeatureFlagTests.java
+++ b/server/src/test/java/org/opensearch/common/util/FeatureFlagTests.java
@@ -13,6 +13,7 @@ import org.opensearch.test.FeatureFlagSetter;
 import org.opensearch.test.OpenSearchTestCase;
 
 import static org.opensearch.common.util.FeatureFlags.DATETIME_FORMATTER_CACHING;
+import static org.opensearch.common.util.FeatureFlags.EXTENSIONS;
 import static org.opensearch.common.util.FeatureFlags.IDENTITY;
 
 public class FeatureFlagTests extends OpenSearchTestCase {
@@ -56,5 +57,14 @@ public class FeatureFlagTests extends OpenSearchTestCase {
         FeatureFlags.initializeFeatureFlags(Settings.EMPTY);
         assertNotNull(testFlag);
         assertTrue(FeatureFlags.isEnabled(testFlag));
+    }
+
+    public void testInitializeFeatureFlagsWithExperimentalSettings() {
+        FeatureFlags.initializeFeatureFlags(Settings.builder().put(IDENTITY, true).build());
+        assertTrue(FeatureFlags.isEnabled(IDENTITY));
+        assertTrue(FeatureFlags.isEnabled(DATETIME_FORMATTER_CACHING));
+        assertFalse(FeatureFlags.isEnabled(EXTENSIONS));
+        // reset FeatureFlags to defaults
+        FeatureFlags.initializeFeatureFlags(Settings.EMPTY);
     }
 }

--- a/server/src/test/java/org/opensearch/common/util/FeatureFlagTests.java
+++ b/server/src/test/java/org/opensearch/common/util/FeatureFlagTests.java
@@ -12,6 +12,7 @@ import org.opensearch.test.FeatureFlagSetter;
 import org.opensearch.test.OpenSearchTestCase;
 
 import static org.opensearch.common.util.FeatureFlags.DATETIME_FORMATTER_CACHING;
+import static org.opensearch.common.util.FeatureFlags.IDENTITY;
 
 public class FeatureFlagTests extends OpenSearchTestCase {
 
@@ -40,5 +41,11 @@ public class FeatureFlagTests extends OpenSearchTestCase {
         final String testFlag = DATETIME_FORMATTER_CACHING;
         assertNotNull(testFlag);
         assertTrue(FeatureFlags.isEnabled(testFlag));
+    }
+
+    public void testBooleanFeatureFlagWithDefaultSetToFalse() {
+        final String testFlag = IDENTITY;
+        assertNotNull(testFlag);
+        assertFalse(FeatureFlags.isEnabled(testFlag));
     }
 }

--- a/server/src/test/java/org/opensearch/common/util/FeatureFlagTests.java
+++ b/server/src/test/java/org/opensearch/common/util/FeatureFlagTests.java
@@ -11,6 +11,8 @@ package org.opensearch.common.util;
 import org.opensearch.test.FeatureFlagSetter;
 import org.opensearch.test.OpenSearchTestCase;
 
+import static org.opensearch.common.util.FeatureFlags.DATETIME_FORMATTER_CACHING;
+
 public class FeatureFlagTests extends OpenSearchTestCase {
 
     private final String FLAG_PREFIX = "opensearch.experimental.feature.";
@@ -32,5 +34,11 @@ public class FeatureFlagTests extends OpenSearchTestCase {
         String javaVersionProperty = "java.version";
         assertNotNull(System.getProperty(javaVersionProperty));
         assertFalse(FeatureFlags.isEnabled(javaVersionProperty));
+    }
+
+    public void testBooleanFeatureFlagWithDefaultSetToTrue() {
+        final String testFlag = DATETIME_FORMATTER_CACHING;
+        assertNotNull(testFlag);
+        assertTrue(FeatureFlags.isEnabled(testFlag));
     }
 }

--- a/server/src/test/java/org/opensearch/common/util/FeatureFlagTests.java
+++ b/server/src/test/java/org/opensearch/common/util/FeatureFlagTests.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.common.util;
 
+import org.opensearch.common.settings.Settings;
 import org.opensearch.test.FeatureFlagSetter;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -45,7 +46,15 @@ public class FeatureFlagTests extends OpenSearchTestCase {
 
     public void testBooleanFeatureFlagWithDefaultSetToFalse() {
         final String testFlag = IDENTITY;
+        FeatureFlags.initializeFeatureFlags(Settings.EMPTY);
         assertNotNull(testFlag);
         assertFalse(FeatureFlags.isEnabled(testFlag));
+    }
+
+    public void testBooleanFeatureFlagInitializedWithEmptySettingsAndDefaultSetToTrue() {
+        final String testFlag = DATETIME_FORMATTER_CACHING;
+        FeatureFlags.initializeFeatureFlags(Settings.EMPTY);
+        assertNotNull(testFlag);
+        assertTrue(FeatureFlags.isEnabled(testFlag));
     }
 }


### PR DESCRIPTION
### Description

Fixes an issue where FeatureFlags is not honoring the default value of the feature flag setting when calling `isEnabled`. 

The bug exists because the settings object in the FeatureFlags class is not initialized until initializeFeatureFlags is called and will return false from this [line](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/common/util/FeatureFlags.java#L93) instead of honoring the default value. While a feature guarded by a feature flag should not be enabled by default, this is a bug in the way the feature flags logic is implemented. 

### Related Issues

- https://github.com/opensearch-project/OpenSearch/issues/9564

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
