### PR TITLE
[Derived Fields] PR4: Capability to define derived fields in search request

### DIFF
--- a/client/rest-high-level/src/test/java/org/opensearch/client/SearchIT.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/SearchIT.java
@@ -54,15 +54,19 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchScrollRequest;
 import org.opensearch.client.core.CountRequest;
 import org.opensearch.client.core.CountResponse;
+import org.opensearch.common.geo.ShapeRelation;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.geometry.Rectangle;
+import org.opensearch.index.query.GeoShapeQueryBuilder;
 import org.opensearch.index.query.MatchQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.query.RangeQueryBuilder;
 import org.opensearch.index.query.ScriptQueryBuilder;
 import org.opensearch.index.query.TermsQueryBuilder;
 import org.opensearch.join.aggregations.Children;
@@ -102,6 +106,8 @@ import org.opensearch.search.sort.SortOrder;
 import org.opensearch.search.suggest.Suggest;
 import org.opensearch.search.suggest.SuggestBuilder;
 import org.opensearch.search.suggest.phrase.PhraseSuggestionBuilder;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 
@@ -116,6 +122,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.opensearch.index.query.QueryBuilders.geoShapeQuery;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertToXContentEquivalent;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.both;
@@ -762,6 +769,228 @@ public class SearchIT extends OpenSearchRestHighLevelClientTestCase {
             List<?> list = (List<?>) values.get(0);
             assertEquals(0, list.size());
         }
+    }
+
+    public void testSearchWithDerivedFields() throws Exception {
+        // Just testing DerivedField definition from SearchSourceBuilder derivedField()
+        // We are not testing the full functionality here
+        Request doc = new Request("PUT", "test/_doc/1");
+        doc.setJsonEntity("{\"field\":\"value\"}");
+        client().performRequest(doc);
+        client().performRequest(new Request("POST", "/test/_refresh"));
+        // Keyword field
+        {
+            SearchRequest searchRequest = new SearchRequest("test").source(
+                SearchSourceBuilder.searchSource()
+                    .derivedField("result", "keyword", new Script("emit(params._source[\"field\"])"))
+                    .fetchField("result")
+                    .query(new TermsQueryBuilder("result", "value"))
+            );
+            SearchResponse searchResponse = execute(searchRequest, highLevelClient()::search, highLevelClient()::searchAsync);
+            SearchHit searchHit = searchResponse.getHits().getAt(0);
+            List<Object> values = searchHit.getFields().get("result").getValues();
+            assertNotNull(values);
+            assertEquals(1, values.size());
+            assertEquals("value", values.get(0));
+
+            // multi valued
+            searchRequest = new SearchRequest("test").source(
+                SearchSourceBuilder.searchSource()
+                    .derivedField(
+                        "result",
+                        "keyword",
+                        new Script("emit(params._source[\"field\"]);emit(params._source[\"field\"] + \"_2\")")
+                    )
+                    .query(new TermsQueryBuilder("result", "value_2"))
+                    .fetchField("result")
+            );
+            searchResponse = execute(searchRequest, highLevelClient()::search, highLevelClient()::searchAsync);
+            searchHit = searchResponse.getHits().getAt(0);
+            values = searchHit.getFields().get("result").getValues();
+            assertNotNull(values);
+            assertEquals(2, values.size());
+            assertEquals("value", values.get(0));
+            assertEquals("value_2", values.get(1));
+        }
+        // Boolean field
+        {
+            SearchRequest searchRequest = new SearchRequest("test").source(
+                SearchSourceBuilder.searchSource()
+                    .derivedField("result", "boolean", new Script("emit(((String)params._source[\"field\"]).equals(\"value\"))"))
+                    .query(new TermsQueryBuilder("result", "true"))
+                    .fetchField("result")
+            );
+            SearchResponse searchResponse = execute(searchRequest, highLevelClient()::search, highLevelClient()::searchAsync);
+            SearchHit searchHit = searchResponse.getHits().getAt(0);
+            List<Object> values = searchHit.getFields().get("result").getValues();
+            assertNotNull(values);
+            assertEquals(1, values.size());
+            assertEquals(true, values.get(0));
+        }
+        // Long field
+        {
+            SearchRequest searchRequest = new SearchRequest("test").source(
+                SearchSourceBuilder.searchSource()
+                    .derivedField("result", "long", new Script("emit(Long.MAX_VALUE)"))
+                    .query(new RangeQueryBuilder("result").from(Long.MAX_VALUE - 1).to(Long.MAX_VALUE))
+                    .fetchField("result")
+            );
+
+            SearchResponse searchResponse = execute(searchRequest, highLevelClient()::search, highLevelClient()::searchAsync);
+            SearchHit searchHit = searchResponse.getHits().getAt(0);
+            List<Object> values = searchHit.getFields().get("result").getValues();
+            assertNotNull(values);
+            assertEquals(1, values.size());
+            assertEquals(Long.MAX_VALUE, values.get(0));
+
+            // multi-valued
+            searchRequest = new SearchRequest("test").source(
+                SearchSourceBuilder.searchSource()
+                    .derivedField("result", "long", new Script("emit(Long.MAX_VALUE); emit(Long.MIN_VALUE);"))
+                    .query(new RangeQueryBuilder("result").from(Long.MIN_VALUE).to(Long.MIN_VALUE + 1))
+                    .fetchField("result")
+            );
+
+            searchResponse = execute(searchRequest, highLevelClient()::search, highLevelClient()::searchAsync);
+            searchHit = searchResponse.getHits().getAt(0);
+            values = searchHit.getFields().get("result").getValues();
+            assertNotNull(values);
+            assertEquals(2, values.size());
+            assertEquals(Long.MAX_VALUE, values.get(0));
+            assertEquals(Long.MIN_VALUE, values.get(1));
+        }
+        // Double field
+        {
+            SearchRequest searchRequest = new SearchRequest("test").source(
+                SearchSourceBuilder.searchSource()
+                    .derivedField("result", "double", new Script("emit(Double.MAX_VALUE)"))
+                    .query(new RangeQueryBuilder("result").from(Double.MAX_VALUE - 1).to(Double.MAX_VALUE))
+                    .fetchField("result")
+            );
+            SearchResponse searchResponse = execute(searchRequest, highLevelClient()::search, highLevelClient()::searchAsync);
+            SearchHit searchHit = searchResponse.getHits().getAt(0);
+            List<Object> values = searchHit.getFields().get("result").getValues();
+            assertNotNull(values);
+            assertEquals(1, values.size());
+            assertEquals(Double.MAX_VALUE, values.get(0));
+
+            // multi-valued
+            searchRequest = new SearchRequest("test").source(
+                SearchSourceBuilder.searchSource()
+                    .derivedField("result", "double", new Script("emit(Double.MAX_VALUE); emit(Double.MIN_VALUE);"))
+                    .query(new RangeQueryBuilder("result").from(Double.MIN_VALUE).to(Double.MIN_VALUE + 1))
+                    .fetchField("result")
+            );
+
+            searchResponse = execute(searchRequest, highLevelClient()::search, highLevelClient()::searchAsync);
+            searchHit = searchResponse.getHits().getAt(0);
+            values = searchHit.getFields().get("result").getValues();
+            assertNotNull(values);
+            assertEquals(2, values.size());
+            assertEquals(Double.MAX_VALUE, values.get(0));
+            assertEquals(Double.MIN_VALUE, values.get(1));
+        }
+        // Date field
+        {
+            DateTime date1 = new DateTime(1990, 12, 29, 0, 0, DateTimeZone.UTC);
+            DateTime date2 = new DateTime(1990, 12, 30, 0, 0, DateTimeZone.UTC);
+            SearchRequest searchRequest = new SearchRequest("test").source(
+                SearchSourceBuilder.searchSource()
+                    .derivedField("result", "date", new Script("emit(" + date1.getMillis() + "L)"))
+                    .query(new RangeQueryBuilder("result").from(date1.toString()).to(date2.toString()))
+                    .fetchField("result")
+            );
+
+            SearchResponse searchResponse = execute(searchRequest, highLevelClient()::search, highLevelClient()::searchAsync);
+            SearchHit searchHit = searchResponse.getHits().getAt(0);
+            List<Object> values = searchHit.getFields().get("result").getValues();
+            assertNotNull(values);
+            assertEquals(1, values.size());
+            assertEquals(date1.toString(), values.get(0));
+
+            // multi-valued
+            searchRequest = new SearchRequest("test").source(
+                SearchSourceBuilder.searchSource()
+                    .derivedField("result", "date", new Script("emit(" + date1.getMillis() + "L); " + "emit(" + date2.getMillis() + "L)"))
+                    .query(new RangeQueryBuilder("result").from(date1.toString()).to(date2.toString()))
+                    .fetchField("result")
+            );
+
+            searchResponse = execute(searchRequest, highLevelClient()::search, highLevelClient()::searchAsync);
+            searchHit = searchResponse.getHits().getAt(0);
+            values = searchHit.getFields().get("result").getValues();
+            assertNotNull(values);
+            assertEquals(2, values.size());
+            assertEquals(date1.toString(), values.get(0));
+            assertEquals(date2.toString(), values.get(1));
+        }
+        // Geo field
+        {
+            GeoShapeQueryBuilder qb = geoShapeQuery("result", new Rectangle(-35, 35, 35, -35));
+            qb.relation(ShapeRelation.INTERSECTS);
+            SearchRequest searchRequest = new SearchRequest("test").source(
+                SearchSourceBuilder.searchSource()
+                    .derivedField("result", "geo_point", new Script("emit(10.0, 20.0)"))
+                    .query(qb)
+                    .fetchField("result")
+            );
+
+            SearchResponse searchResponse = execute(searchRequest, highLevelClient()::search, highLevelClient()::searchAsync);
+            SearchHit searchHit = searchResponse.getHits().getAt(0);
+            List<Object> values = searchHit.getFields().get("result").getValues();
+            assertNotNull(values);
+            assertEquals(1, values.size());
+            assertEquals(10.0, ((HashMap) values.get(0)).get("lat"));
+            assertEquals(20.0, ((HashMap) values.get(0)).get("lon"));
+
+            // multi-valued
+            searchRequest = new SearchRequest("test").source(
+                SearchSourceBuilder.searchSource()
+                    .derivedField("result", "geo_point", new Script("emit(10.0, 20.0); emit(20.0, 30.0);"))
+                    .query(qb)
+                    .fetchField("result")
+            );
+
+            searchResponse = execute(searchRequest, highLevelClient()::search, highLevelClient()::searchAsync);
+            searchHit = searchResponse.getHits().getAt(0);
+            values = searchHit.getFields().get("result").getValues();
+            assertNotNull(values);
+            assertEquals(2, values.size());
+            assertEquals(10.0, ((HashMap) values.get(0)).get("lat"));
+            assertEquals(20.0, ((HashMap) values.get(0)).get("lon"));
+            assertEquals(20.0, ((HashMap) values.get(1)).get("lat"));
+            assertEquals(30.0, ((HashMap) values.get(1)).get("lon"));
+        }
+        // IP field
+        {
+            SearchRequest searchRequest = new SearchRequest("test").source(
+                SearchSourceBuilder.searchSource().derivedField("result", "ip", new Script("emit(\"10.0.0.1\")")).fetchField("result")
+            );
+
+            SearchResponse searchResponse = execute(searchRequest, highLevelClient()::search, highLevelClient()::searchAsync);
+            SearchHit searchHit = searchResponse.getHits().getAt(0);
+            List<Object> values = searchHit.getFields().get("result").getValues();
+            assertNotNull(values);
+            assertEquals(1, values.size());
+            assertEquals("10.0.0.1", values.get(0));
+
+            // multi-valued
+            searchRequest = new SearchRequest("test").source(
+                SearchSourceBuilder.searchSource()
+                    .derivedField("result", "ip", new Script("emit(\"10.0.0.1\"); emit(\"10.0.0.2\");"))
+                    .fetchField("result")
+            );
+
+            searchResponse = execute(searchRequest, highLevelClient()::search, highLevelClient()::searchAsync);
+            searchHit = searchResponse.getHits().getAt(0);
+            values = searchHit.getFields().get("result").getValues();
+            assertNotNull(values);
+            assertEquals(2, values.size());
+            assertEquals("10.0.0.1", values.get(0));
+            assertEquals("10.0.0.2", values.get(1));
+
+        }
+
     }
 
     public void testSearchScroll() throws Exception {

--- a/server/src/internalClusterTest/java/org/opensearch/search/fields/SearchFieldsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/fields/SearchFieldsIT.java
@@ -40,6 +40,7 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.common.Numbers;
 import org.opensearch.common.collect.MapBuilder;
 import org.opensearch.common.document.DocumentField;
+import org.opensearch.common.geo.GeoPoint;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.time.DateFormatter;
 import org.opensearch.common.time.DateUtils;
@@ -51,6 +52,7 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.fielddata.ScriptDocValues;
+import org.opensearch.index.mapper.DateFieldMapper;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.plugins.Plugin;
@@ -188,6 +190,27 @@ public class SearchFieldsIT extends ParameterizedStaticSettingsOpenSearchIntegTe
             scripts.put("doc['md']", vars -> docScript(vars, "md"));
             scripts.put("doc['s']", vars -> docScript(vars, "s"));
             scripts.put("doc['ms']", vars -> docScript(vars, "ms"));
+
+            scripts.put("doc['l']", vars -> docScript(vars, "l"));
+            scripts.put("doc['ml']", vars -> docScript(vars, "ml"));
+            scripts.put("doc['d']", vars -> docScript(vars, "d"));
+            scripts.put("doc['md']", vars -> docScript(vars, "md"));
+            scripts.put("doc['s']", vars -> docScript(vars, "s"));
+            scripts.put("doc['ms']", vars -> docScript(vars, "ms"));
+
+            scripts.put("doc['keyword_field']", vars -> sourceScript(vars, "keyword_field"));
+            scripts.put("doc['multi_keyword_field']", vars -> sourceScript(vars, "multi_keyword_field"));
+            scripts.put("doc['long_field']", vars -> sourceScript(vars, "long_field"));
+            scripts.put("doc['multi_long_field']", vars -> sourceScript(vars, "multi_long_field"));
+            scripts.put("doc['double_field']", vars -> sourceScript(vars, "double_field"));
+            scripts.put("doc['multi_double_field']", vars -> sourceScript(vars, "multi_double_field"));
+            scripts.put("doc['date_field']", vars -> sourceScript(vars, "date_field"));
+            scripts.put("doc['multi_date_field']", vars -> sourceScript(vars, "multi_date_field"));
+            scripts.put("doc['ip_field']", vars -> sourceScript(vars, "ip_field"));
+            scripts.put("doc['multi_ip_field']", vars -> sourceScript(vars, "multi_ip_field"));
+            scripts.put("doc['boolean_field']", vars -> sourceScript(vars, "boolean_field"));
+            scripts.put("doc['geo_field']", vars -> sourceScript(vars, "geo_field"));
+            scripts.put("doc['multi_geo_field']", vars -> sourceScript(vars, "multi_geo_field"));
 
             return scripts;
         }
@@ -1296,6 +1319,147 @@ public class SearchFieldsIT extends ParameterizedStaticSettingsOpenSearchIntegTe
             assertThat(fields.get("ms").getValues(), equalTo(Arrays.<Object>asList(Integer.toString(id), Integer.toString(id + 1))));
             assertThat(fields.get("ml").getValues(), equalTo(Arrays.<Object>asList((long) id, id + 1L)));
             assertThat(fields.get("md").getValues(), equalTo(Arrays.<Object>asList((double) id, id + 1d)));
+        }
+    }
+
+    public void testDerivedFields() throws Exception {
+        assertAcked(
+            prepareCreate("index").setMapping(
+                "keyword_field",
+                "type=keyword",
+                "multi_keyword_field",
+                "type=keyword",
+                "long_field",
+                "type=long",
+                "multi_long_field",
+                "type=long",
+                "double_field",
+                "type=double",
+                "multi_double_field",
+                "type=double",
+                "date_field",
+                "type=date",
+                "multi_date_field",
+                "type=date",
+                "ip_field",
+                "type=ip",
+                "multi_ip_field",
+                "type=ip",
+                "boolean_field",
+                "type=boolean",
+                "geo_field",
+                "type=geo_point",
+                "multi_geo_field",
+                "type=geo_point"
+            ).get()
+        );
+        final int numDocs = randomIntBetween(3, 8);
+        List<IndexRequestBuilder> reqs = new ArrayList<>();
+
+        DateTime date1 = new DateTime(1990, 12, 29, 0, 0, DateTimeZone.UTC);
+        DateTime date2 = new DateTime(1990, 12, 30, 0, 0, DateTimeZone.UTC);
+
+        for (int i = 0; i < numDocs; ++i) {
+            reqs.add(
+                client().prepareIndex("index")
+                    .setId(Integer.toString(i))
+                    .setSource(
+                        "keyword_field",
+                        Integer.toString(i),
+                        "multi_keyword_field",
+                        new String[] { Integer.toString(i), Integer.toString(i + 1) },
+                        "long_field",
+                        (long) i,
+                        "multi_long_field",
+                        new long[] { i, i + 1 },
+                        "double_field",
+                        (double) i,
+                        "multi_double_field",
+                        new double[] { i, i + 1 },
+                        "date_field",
+                        date1.getMillis(),
+                        "multi_date_field",
+                        new Long[] { date1.getMillis(), date2.getMillis() },
+                        "ip_field",
+                        "172.16.1.10",
+                        "multi_ip_field",
+                        new String[] { "172.16.1.10", "172.16.1.11" },
+                        "boolean_field",
+                        true,
+                        "geo_field",
+                        new GeoPoint(12.0, 10.0),
+                        "multi_geo_field",
+                        new GeoPoint[] { new GeoPoint(12.0, 10.0), new GeoPoint(13.0, 10.0) }
+                    )
+            );
+        }
+        indexRandom(true, reqs);
+        indexRandomForConcurrentSearch("index");
+        ensureSearchable();
+        SearchRequestBuilder req = client().prepareSearch("index");
+        String[][] fieldLookup = new String[][] {
+            { "keyword_field", "keyword" },
+            { "multi_keyword_field", "keyword" },
+            { "long_field", "long" },
+            { "multi_long_field", "long" },
+            { "double_field", "double" },
+            { "multi_double_field", "double" },
+            { "date_field", "date" },
+            { "multi_date_field", "date" },
+            { "ip_field", "ip" },
+            { "multi_ip_field", "ip" },
+            { "boolean_field", "boolean" },
+            { "geo_field", "geo_point" },
+            { "multi_geo_field", "geo_point" } };
+        for (String[] field : fieldLookup) {
+            req.addDerivedField(
+                "derived_" + field[0],
+                field[1],
+                new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "doc['" + field[0] + "']", Collections.emptyMap())
+            );
+        }
+        req.addFetchField("derived_*");
+        SearchResponse resp = req.get();
+        assertSearchResponse(resp);
+        for (SearchHit hit : resp.getHits().getHits()) {
+            final int id = Integer.parseInt(hit.getId());
+            Map<String, DocumentField> fields = hit.getFields();
+
+            assertEquals(fields.get("derived_keyword_field").getValues().get(0), Integer.toString(id));
+            assertEquals(fields.get("derived_multi_keyword_field").getValues().get(0), Integer.toString(id));
+            assertEquals(fields.get("derived_multi_keyword_field").getValues().get(1), Integer.toString(id + 1));
+
+            assertEquals(fields.get("derived_long_field").getValues().get(0), id);
+            assertEquals(fields.get("derived_multi_long_field").getValues().get(0), id);
+            assertEquals(fields.get("derived_multi_long_field").getValues().get(1), (id + 1));
+
+            assertEquals(fields.get("derived_double_field").getValues().get(0), (double) id);
+            assertEquals(fields.get("derived_multi_double_field").getValues().get(0), (double) id);
+            assertEquals(fields.get("derived_multi_double_field").getValues().get(1), (double) (id + 1));
+
+            assertEquals(
+                fields.get("derived_date_field").getValues().get(0),
+                DateFieldMapper.getDefaultDateTimeFormatter().formatJoda(date1)
+            );
+            assertEquals(
+                fields.get("derived_multi_date_field").getValues().get(0),
+                DateFieldMapper.getDefaultDateTimeFormatter().formatJoda(date1)
+            );
+            assertEquals(
+                fields.get("derived_multi_date_field").getValues().get(1),
+                DateFieldMapper.getDefaultDateTimeFormatter().formatJoda(date2)
+            );
+
+            assertEquals(fields.get("derived_ip_field").getValues().get(0), "172.16.1.10");
+            assertEquals(fields.get("derived_multi_ip_field").getValues().get(0), "172.16.1.10");
+            assertEquals(fields.get("derived_multi_ip_field").getValues().get(1), "172.16.1.11");
+
+            assertEquals(fields.get("derived_boolean_field").getValues().get(0), true);
+
+            assertEquals(fields.get("derived_geo_field").getValues().get(0), new GeoPoint(12.0, 10.0));
+            assertEquals(fields.get("derived_multi_geo_field").getValues().get(0), new GeoPoint(12.0, 10.0));
+            assertEquals(fields.get("derived_multi_geo_field").getValues().get(1), new GeoPoint(13.0, 10.0));
+
         }
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/fields/SearchFieldsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/fields/SearchFieldsIT.java
@@ -191,13 +191,6 @@ public class SearchFieldsIT extends ParameterizedStaticSettingsOpenSearchIntegTe
             scripts.put("doc['s']", vars -> docScript(vars, "s"));
             scripts.put("doc['ms']", vars -> docScript(vars, "ms"));
 
-            scripts.put("doc['l']", vars -> docScript(vars, "l"));
-            scripts.put("doc['ml']", vars -> docScript(vars, "ml"));
-            scripts.put("doc['d']", vars -> docScript(vars, "d"));
-            scripts.put("doc['md']", vars -> docScript(vars, "md"));
-            scripts.put("doc['s']", vars -> docScript(vars, "s"));
-            scripts.put("doc['ms']", vars -> docScript(vars, "ms"));
-
             scripts.put("doc['keyword_field']", vars -> sourceScript(vars, "keyword_field"));
             scripts.put("doc['multi_keyword_field']", vars -> sourceScript(vars, "multi_keyword_field"));
             scripts.put("doc['long_field']", vars -> sourceScript(vars, "long_field"));

--- a/server/src/main/java/org/opensearch/action/search/SearchRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequestBuilder.java
@@ -364,6 +364,21 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
     }
 
     /**
+     * Adds a derived field of a given type. The script provided will be used to derive the value
+     * of a given type. Thereafter, it can be treated as regular field of a given type to perform
+     * query on them.
+     *
+     * @param name   The name of the field to be used in various parts of the query. The name will also represent
+     *               the field value in the return hit.
+     * @param type   The type of derived field. All values emitted by script must be of this type
+     * @param script The script to use
+     */
+    public SearchRequestBuilder addDerivedField(String name, String type, Script script) {
+        sourceBuilder().derivedField(name, type, script);
+        return this;
+    }
+
+    /**
      * Adds a sort against the given field name and the sort ordering.
      *
      * @param field The name of the field

--- a/server/src/main/java/org/opensearch/index/mapper/DerivedField.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DerivedField.java
@@ -52,7 +52,7 @@ public class DerivedField implements Writeable, ToXContentFragment {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
         builder.startObject(name);
-        builder.field(type);
+        builder.field("type", type);
         builder.field("script", script);
         builder.endObject();
         return builder;

--- a/server/src/main/java/org/opensearch/index/mapper/DerivedField.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DerivedField.java
@@ -18,6 +18,7 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.script.Script;
 
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * DerivedField representation: expects a name, type and script.
@@ -67,6 +68,23 @@ public class DerivedField implements Writeable, ToXContentFragment {
 
     public Script getScript() {
         return script;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, type, script);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        DerivedField other = (DerivedField) obj;
+        return Objects.equals(name, other.name) && Objects.equals(type, other.type) && Objects.equals(script, other.script);
     }
 
 }

--- a/server/src/main/java/org/opensearch/index/mapper/DerivedField.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DerivedField.java
@@ -1,0 +1,72 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.mapper;
+
+import org.opensearch.common.annotation.PublicApi;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.script.Script;
+
+import java.io.IOException;
+
+/**
+ * DerivedField representation: expects a name, type and script.
+ */
+@PublicApi(since = "2.14.0")
+public class DerivedField implements Writeable, ToXContentFragment {
+
+    private final String name;
+    private final String type;
+    private final Script script;
+
+    public DerivedField(String name, String type, Script script) {
+        this.name = name;
+        this.type = type;
+        this.script = script;
+    }
+
+    public DerivedField(StreamInput in) throws IOException {
+        name = in.readString();
+        type = in.readString();
+        script = new Script(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(name);
+        out.writeString(type);
+        script.writeTo(out);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        builder.startObject(name);
+        builder.field(type);
+        builder.field("script", script);
+        builder.endObject();
+        return builder;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public Script getScript() {
+        return script;
+    }
+
+}

--- a/server/src/main/java/org/opensearch/index/mapper/DerivedFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DerivedFieldMapper.java
@@ -39,7 +39,7 @@ public class DerivedFieldMapper extends ParametrizedFieldMapper {
      */
     public static class Builder extends ParametrizedFieldMapper.Builder {
         // TODO: The type of parameter may change here if the actual underlying FieldType object is needed
-        private final Parameter<String> type = Parameter.stringParam("type", false, m -> toType(m).type, "keyword");
+        private final Parameter<String> type = Parameter.stringParam("type", false, m -> toType(m).type, "");
 
         private final Parameter<Script> script = new Parameter<>(
             "script",

--- a/server/src/main/java/org/opensearch/index/mapper/DerivedFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DerivedFieldMapper.java
@@ -37,7 +37,7 @@ public class DerivedFieldMapper extends ParametrizedFieldMapper {
      */
     public static class Builder extends ParametrizedFieldMapper.Builder {
         // TODO: The type of parameter may change here if the actual underlying FieldType object is needed
-        private final Parameter<String> type = Parameter.stringParam("type", false, m -> toType(m).type, "text");
+        private final Parameter<String> type = Parameter.stringParam("type", false, m -> toType(m).type, "keyword");
 
         private final Parameter<Script> script = new Parameter<>(
             "script",

--- a/server/src/main/java/org/opensearch/index/mapper/DerivedFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DerivedFieldMapper.java
@@ -14,7 +14,9 @@ import org.opensearch.script.Script;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 /**
@@ -49,6 +51,12 @@ public class DerivedFieldMapper extends ParametrizedFieldMapper {
 
         public Builder(String name) {
             super(name);
+        }
+
+        public Builder(DerivedField derivedField) {
+            super(derivedField.getName());
+            this.type.setValue(derivedField.getType());
+            this.script.setValue(derivedField.getScript());
         }
 
         @Override
@@ -125,5 +133,28 @@ public class DerivedFieldMapper extends ParametrizedFieldMapper {
 
     public Script getScript() {
         return script;
+    }
+
+    public static Map<String, DerivedFieldType> getAllDerivedFieldTypeFromObject(
+        Map<String, Object> derivedFieldObject,
+        MapperService mapperService
+    ) {
+        Map<String, DerivedFieldType> derivedFieldTypes = new HashMap<>();
+        DocumentMapper documentMapper = mapperService.documentMapperParser().parse(DerivedFieldMapper.CONTENT_TYPE, derivedFieldObject);
+        if (documentMapper != null && documentMapper.mappers() != null) {
+            for (Mapper mapper : documentMapper.mappers()) {
+                if (mapper instanceof DerivedFieldMapper) {
+                    DerivedFieldType derivedFieldType = ((DerivedFieldMapper) mapper).fieldType();
+                    derivedFieldTypes.put(derivedFieldType.name(), derivedFieldType);
+                }
+            }
+        }
+        return derivedFieldTypes;
+    }
+
+    public static DerivedFieldType getDerivedFieldType(DerivedField derivedField, MapperService mapperService) {
+        BuilderContext builderContext = new Mapper.BuilderContext(mapperService.getIndexSettings().getSettings(), new ContentPath(1));
+        Builder builder = new Builder(derivedField);
+        return builder.build(builderContext).fieldType();
     }
 }

--- a/server/src/main/java/org/opensearch/index/mapper/DerivedFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DerivedFieldMapper.java
@@ -72,9 +72,7 @@ public class DerivedFieldMapper extends ParametrizedFieldMapper {
                 name
             );
             DerivedFieldType ft = new DerivedFieldType(
-                buildFullName(context),
-                type.getValue(),
-                script.getValue(),
+                new DerivedField(buildFullName(context), type.getValue(), script.getValue()),
                 fieldMapper,
                 fieldFunction
             );

--- a/server/src/main/java/org/opensearch/index/mapper/DerivedFieldSupportedTypes.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DerivedFieldSupportedTypes.java
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
  * it is used to create an IndexableField for the provided type and object. It is useful when indexing into
  * lucene MemoryIndex in {@link org.opensearch.index.query.DerivedFieldQuery}.
  */
-enum DerivedFieldSupportedTypes {
+public enum DerivedFieldSupportedTypes {
 
     BOOLEAN("boolean", (name, context) -> {
         BooleanFieldMapper.Builder builder = new BooleanFieldMapper.Builder(name);

--- a/server/src/main/java/org/opensearch/index/mapper/DerivedFieldSupportedTypes.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DerivedFieldSupportedTypes.java
@@ -20,12 +20,13 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.opensearch.Version;
 import org.opensearch.common.Booleans;
+import org.opensearch.common.collect.Tuple;
+import org.opensearch.common.geo.GeoPoint;
 import org.opensearch.common.lucene.Lucene;
 import org.opensearch.common.network.InetAddresses;
 
 import java.net.InetAddress;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -51,7 +52,7 @@ public enum DerivedFieldSupportedTypes {
             value = Booleans.parseBooleanStrict(textValue, false);
         }
         return new Field(name, value ? "T" : "F", BooleanFieldMapper.Defaults.FIELD_TYPE);
-    }),
+    }, o -> o),
     DATE("date", (name, context) -> {
         // TODO: should we support mapping settings exposed by a given field type from derived fields too?
         // for example, support `format` for date type?
@@ -63,17 +64,17 @@ public enum DerivedFieldSupportedTypes {
             Version.CURRENT
         );
         return builder.build(context);
-    }, name -> o -> new LongPoint(name, (long) o)),
+    }, name -> o -> new LongPoint(name, (long) o), o -> DateFieldMapper.getDefaultDateTimeFormatter().formatMillis((long) o)),
     GEO_POINT("geo_point", (name, context) -> {
         GeoPointFieldMapper.Builder builder = new GeoPointFieldMapper.Builder(name);
         return builder.build(context);
     }, name -> o -> {
         // convert o to array of double
-        if (!(o instanceof List) || ((List<?>) o).size() != 2 || !(((List<?>) o).get(0) instanceof Double)) {
+        if (!(o instanceof Tuple) || !(((Tuple<?, ?>) o).v1() instanceof Double || !(((Tuple<?, ?>) o).v2() instanceof Double))) {
             throw new ClassCastException("geo_point should be in format emit(double lat, double lon) for derived fields");
         }
-        return new LatLonPoint(name, (Double) ((List<?>) o).get(0), (Double) ((List<?>) o).get(1));
-    }),
+        return new LatLonPoint(name, (double) ((Tuple<?, ?>) o).v1(), (double) ((Tuple<?, ?>) o).v2());
+    }, o -> new GeoPoint((double) ((Tuple) o).v1(), (double) ((Tuple) o).v2())),
     IP("ip", (name, context) -> {
         IpFieldMapper.Builder builder = new IpFieldMapper.Builder(name, false, Version.CURRENT);
         return builder.build(context);
@@ -85,7 +86,7 @@ public enum DerivedFieldSupportedTypes {
             address = InetAddresses.forString(o.toString());
         }
         return new InetAddressPoint(name, address);
-    }),
+    }, o -> o),
     KEYWORD("keyword", (name, context) -> {
         FieldType dummyFieldType = new FieldType();
         dummyFieldType.setIndexOptions(IndexOptions.DOCS_AND_FREQS);
@@ -100,29 +101,33 @@ public enum DerivedFieldSupportedTypes {
             keywordBuilder.copyTo.build(),
             keywordBuilder
         );
-    }, name -> o -> new KeywordField(name, (String) o, Field.Store.NO)),
+    }, name -> o -> new KeywordField(name, (String) o, Field.Store.NO), o -> o),
     LONG("long", (name, context) -> {
         NumberFieldMapper.Builder longBuilder = new NumberFieldMapper.Builder(name, NumberFieldMapper.NumberType.LONG, false, false);
         return longBuilder.build(context);
-    }, name -> o -> new LongField(name, Long.parseLong(o.toString()), Field.Store.NO)),
+    }, name -> o -> new LongField(name, Long.parseLong(o.toString()), Field.Store.NO), o -> o),
     DOUBLE("double", (name, context) -> {
         NumberFieldMapper.Builder doubleBuilder = new NumberFieldMapper.Builder(name, NumberFieldMapper.NumberType.DOUBLE, false, false);
         return doubleBuilder.build(context);
-    }, name -> o -> new DoubleField(name, Double.parseDouble(o.toString()), Field.Store.NO));
+    }, name -> o -> new DoubleField(name, Double.parseDouble(o.toString()), Field.Store.NO), o -> o);
 
     final String name;
     private final BiFunction<String, Mapper.BuilderContext, FieldMapper> builder;
 
     private final Function<String, Function<Object, IndexableField>> indexableFieldBuilder;
 
+    private final Function<Object, Object> valueForDisplay;
+
     DerivedFieldSupportedTypes(
         String name,
         BiFunction<String, Mapper.BuilderContext, FieldMapper> builder,
-        Function<String, Function<Object, IndexableField>> indexableFieldBuilder
+        Function<String, Function<Object, IndexableField>> indexableFieldBuilder,
+        Function<Object, Object> valueForDisplay
     ) {
         this.name = name;
         this.builder = builder;
         this.indexableFieldBuilder = indexableFieldBuilder;
+        this.valueForDisplay = valueForDisplay;
     }
 
     public String getName() {
@@ -135,6 +140,10 @@ public enum DerivedFieldSupportedTypes {
 
     private Function<Object, IndexableField> getIndexableFieldGenerator(String name) {
         return indexableFieldBuilder.apply(name);
+    }
+
+    private Function<Object, Object> getValueForDisplayGenerator() {
+        return valueForDisplay;
     }
 
     private static final Map<String, DerivedFieldSupportedTypes> enumMap = Arrays.stream(DerivedFieldSupportedTypes.values())
@@ -152,5 +161,12 @@ public enum DerivedFieldSupportedTypes {
             throw new IllegalArgumentException("Type [" + type + "] isn't supported in Derived field context.");
         }
         return enumMap.get(type).getIndexableFieldGenerator(name);
+    }
+
+    public static Function<Object, Object> getValueForDisplayGenerator(String type) {
+        if (!enumMap.containsKey(type)) {
+            throw new IllegalArgumentException("Type [" + type + "] isn't supported in Derived field context.");
+        }
+        return enumMap.get(type).getValueForDisplayGenerator();
     }
 }

--- a/server/src/main/java/org/opensearch/index/mapper/DerivedFieldType.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DerivedFieldType.java
@@ -83,27 +83,27 @@ public final class DerivedFieldType extends MappedFieldType {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
-        return new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
+        return new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context, searchLookup));
     }
 
     @Override
     public Query termQuery(Object value, QueryShardContext context) {
         Query query = typeFieldMapper.mappedFieldType.termQuery(value, context);
-        DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
+        DerivedFieldValueFetcher valueFetcher = valueFetcher(context, context.lookup(), null);
         return new DerivedFieldQuery(query, valueFetcher, context.lookup(), indexableFieldGenerator, getIndexAnalyzer());
     }
 
     @Override
     public Query termQueryCaseInsensitive(Object value, @Nullable QueryShardContext context) {
         Query query = typeFieldMapper.mappedFieldType.termQueryCaseInsensitive(value, context);
-        DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
+        DerivedFieldValueFetcher valueFetcher = valueFetcher(context, context.lookup(), null);
         return new DerivedFieldQuery(query, valueFetcher, context.lookup(), indexableFieldGenerator, getIndexAnalyzer());
     }
 
     @Override
     public Query termsQuery(List<?> values, @Nullable QueryShardContext context) {
         Query query = typeFieldMapper.mappedFieldType.termsQuery(values, context);
-        DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
+        DerivedFieldValueFetcher valueFetcher = valueFetcher(context, context.lookup(), null);
         return new DerivedFieldQuery(query, valueFetcher, context.lookup(), indexableFieldGenerator, getIndexAnalyzer());
     }
 
@@ -128,7 +128,7 @@ public final class DerivedFieldType extends MappedFieldType {
             parser,
             context
         );
-        DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
+        DerivedFieldValueFetcher valueFetcher = valueFetcher(context, context.lookup(), null);
         return new DerivedFieldQuery(query, valueFetcher, context.lookup(), indexableFieldGenerator, getIndexAnalyzer());
     }
 
@@ -142,7 +142,7 @@ public final class DerivedFieldType extends MappedFieldType {
         QueryShardContext context
     ) {
         Query query = typeFieldMapper.mappedFieldType.fuzzyQuery(value, fuzziness, prefixLength, maxExpansions, transpositions, context);
-        DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
+        DerivedFieldValueFetcher valueFetcher = valueFetcher(context, context.lookup(), null);
         return new DerivedFieldQuery(query, valueFetcher, context.lookup(), indexableFieldGenerator, getIndexAnalyzer());
     }
 
@@ -165,7 +165,7 @@ public final class DerivedFieldType extends MappedFieldType {
             method,
             context
         );
-        DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
+        DerivedFieldValueFetcher valueFetcher = valueFetcher(context, context.lookup(), null);
         return new DerivedFieldQuery(query, valueFetcher, context.lookup(), indexableFieldGenerator, getIndexAnalyzer());
     }
 
@@ -177,7 +177,7 @@ public final class DerivedFieldType extends MappedFieldType {
         QueryShardContext context
     ) {
         Query query = typeFieldMapper.mappedFieldType.prefixQuery(value, method, caseInsensitive, context);
-        DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
+        DerivedFieldValueFetcher valueFetcher = valueFetcher(context, context.lookup(), null);
         return new DerivedFieldQuery(query, valueFetcher, context.lookup(), indexableFieldGenerator, getIndexAnalyzer());
     }
 
@@ -189,14 +189,14 @@ public final class DerivedFieldType extends MappedFieldType {
         QueryShardContext context
     ) {
         Query query = typeFieldMapper.mappedFieldType.wildcardQuery(value, method, caseInsensitive, context);
-        DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
+        DerivedFieldValueFetcher valueFetcher = valueFetcher(context, context.lookup(), null);
         return new DerivedFieldQuery(query, valueFetcher, context.lookup(), indexableFieldGenerator, getIndexAnalyzer());
     }
 
     @Override
     public Query normalizedWildcardQuery(String value, @Nullable MultiTermQuery.RewriteMethod method, QueryShardContext context) {
         Query query = typeFieldMapper.mappedFieldType.normalizedWildcardQuery(value, method, context);
-        DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
+        DerivedFieldValueFetcher valueFetcher = valueFetcher(context, context.lookup(), null);
         return new DerivedFieldQuery(query, valueFetcher, context.lookup(), indexableFieldGenerator, getIndexAnalyzer());
     }
 
@@ -210,14 +210,14 @@ public final class DerivedFieldType extends MappedFieldType {
         QueryShardContext context
     ) {
         Query query = typeFieldMapper.mappedFieldType.regexpQuery(value, syntaxFlags, matchFlags, maxDeterminizedStates, method, context);
-        DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
+        DerivedFieldValueFetcher valueFetcher = valueFetcher(context, context.lookup(), null);
         return new DerivedFieldQuery(query, valueFetcher, context.lookup(), indexableFieldGenerator, getIndexAnalyzer());
     }
 
     @Override
     public Query phraseQuery(TokenStream stream, int slop, boolean enablePositionIncrements, QueryShardContext context) throws IOException {
         Query query = typeFieldMapper.mappedFieldType.phraseQuery(stream, slop, enablePositionIncrements, context);
-        DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
+        DerivedFieldValueFetcher valueFetcher = valueFetcher(context, context.lookup(), null);
         return new DerivedFieldQuery(query, valueFetcher, context.lookup(), indexableFieldGenerator, getIndexAnalyzer());
     }
 
@@ -225,14 +225,14 @@ public final class DerivedFieldType extends MappedFieldType {
     public Query multiPhraseQuery(TokenStream stream, int slop, boolean enablePositionIncrements, QueryShardContext context)
         throws IOException {
         Query query = typeFieldMapper.mappedFieldType.multiPhraseQuery(stream, slop, enablePositionIncrements, context);
-        DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
+        DerivedFieldValueFetcher valueFetcher = valueFetcher(context, context.lookup(), null);
         return new DerivedFieldQuery(query, valueFetcher, context.lookup(), indexableFieldGenerator, getIndexAnalyzer());
     }
 
     @Override
     public Query phrasePrefixQuery(TokenStream stream, int slop, int maxExpansions, QueryShardContext context) throws IOException {
         Query query = typeFieldMapper.mappedFieldType.phrasePrefixQuery(stream, slop, maxExpansions, context);
-        DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
+        DerivedFieldValueFetcher valueFetcher = valueFetcher(context, context.lookup(), null);
         return new DerivedFieldQuery(query, valueFetcher, context.lookup(), indexableFieldGenerator, getIndexAnalyzer());
     }
 
@@ -246,7 +246,7 @@ public final class DerivedFieldType extends MappedFieldType {
     @Override
     public Query distanceFeatureQuery(Object origin, String pivot, float boost, QueryShardContext context) {
         Query query = typeFieldMapper.mappedFieldType.distanceFeatureQuery(origin, pivot, boost, context);
-        DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
+        DerivedFieldValueFetcher valueFetcher = valueFetcher(context, context.lookup(), null);
         return new DerivedFieldQuery(query, valueFetcher, context.lookup(), indexableFieldGenerator, getIndexAnalyzer());
     }
 
@@ -260,7 +260,7 @@ public final class DerivedFieldType extends MappedFieldType {
         return false;
     }
 
-    private DerivedFieldScript.LeafFactory getDerivedFieldLeafFactory(QueryShardContext context) {
+    private DerivedFieldScript.LeafFactory getDerivedFieldLeafFactory(QueryShardContext context, SearchLookup searchLookup) {
         if (!context.documentMapper("").sourceMapper().enabled()) {
             throw new IllegalArgumentException(
                 "DerivedFieldQuery error: unable to fetch fields from _source field: _source is disabled in the mappings "
@@ -270,6 +270,6 @@ public final class DerivedFieldType extends MappedFieldType {
             );
         }
         DerivedFieldScript.Factory factory = context.compile(derivedField.getScript(), DerivedFieldScript.CONTEXT);
-        return factory.newFactory(derivedField.getScript().getParams(), context.lookup());
+        return factory.newFactory(derivedField.getScript().getParams(), searchLookup);
     }
 }

--- a/server/src/main/java/org/opensearch/index/mapper/DerivedFieldType.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DerivedFieldType.java
@@ -15,9 +15,11 @@ import org.apache.lucene.queries.spans.SpanQuery;
 import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.Query;
 import org.opensearch.common.Nullable;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.geo.ShapeRelation;
 import org.opensearch.common.time.DateMathParser;
 import org.opensearch.common.unit.Fuzziness;
+import org.opensearch.index.analysis.NamedAnalyzer;
 import org.opensearch.index.query.DerivedFieldQuery;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.script.DerivedFieldScript;
@@ -36,6 +38,7 @@ import java.util.function.Function;
  * Contains logic to execute different type of queries on a derived field of given type.
  * @opensearch.internal
  */
+@PublicApi(since = "2.14.0")
 public final class DerivedFieldType extends MappedFieldType {
     private final String type;
 
@@ -82,6 +85,10 @@ public final class DerivedFieldType extends MappedFieldType {
         return type;
     }
 
+    public NamedAnalyzer getIndexAnalyzer() {
+        return typeFieldMapper.mappedFieldType.indexAnalyzer();
+    }
+
     @Override
     public DerivedFieldValueFetcher valueFetcher(QueryShardContext context, SearchLookup searchLookup, String format) {
         if (format != null) {
@@ -94,39 +101,21 @@ public final class DerivedFieldType extends MappedFieldType {
     public Query termQuery(Object value, QueryShardContext context) {
         Query query = typeFieldMapper.mappedFieldType.termQuery(value, context);
         DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
-        return new DerivedFieldQuery(
-            query,
-            valueFetcher,
-            context.lookup(),
-            indexableFieldGenerator,
-            typeFieldMapper.mappedFieldType.indexAnalyzer()
-        );
+        return new DerivedFieldQuery(query, valueFetcher, context.lookup(), indexableFieldGenerator, getIndexAnalyzer());
     }
 
     @Override
     public Query termQueryCaseInsensitive(Object value, @Nullable QueryShardContext context) {
         Query query = typeFieldMapper.mappedFieldType.termQueryCaseInsensitive(value, context);
         DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
-        return new DerivedFieldQuery(
-            query,
-            valueFetcher,
-            context.lookup(),
-            indexableFieldGenerator,
-            typeFieldMapper.mappedFieldType.indexAnalyzer()
-        );
+        return new DerivedFieldQuery(query, valueFetcher, context.lookup(), indexableFieldGenerator, getIndexAnalyzer());
     }
 
     @Override
     public Query termsQuery(List<?> values, @Nullable QueryShardContext context) {
         Query query = typeFieldMapper.mappedFieldType.termsQuery(values, context);
         DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
-        return new DerivedFieldQuery(
-            query,
-            valueFetcher,
-            context.lookup(),
-            indexableFieldGenerator,
-            typeFieldMapper.mappedFieldType.indexAnalyzer()
-        );
+        return new DerivedFieldQuery(query, valueFetcher, context.lookup(), indexableFieldGenerator, getIndexAnalyzer());
     }
 
     @Override
@@ -151,13 +140,7 @@ public final class DerivedFieldType extends MappedFieldType {
             context
         );
         DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
-        return new DerivedFieldQuery(
-            query,
-            valueFetcher,
-            context.lookup(),
-            indexableFieldGenerator,
-            typeFieldMapper.mappedFieldType.indexAnalyzer()
-        );
+        return new DerivedFieldQuery(query, valueFetcher, context.lookup(), indexableFieldGenerator, getIndexAnalyzer());
     }
 
     @Override
@@ -171,13 +154,7 @@ public final class DerivedFieldType extends MappedFieldType {
     ) {
         Query query = typeFieldMapper.mappedFieldType.fuzzyQuery(value, fuzziness, prefixLength, maxExpansions, transpositions, context);
         DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
-        return new DerivedFieldQuery(
-            query,
-            valueFetcher,
-            context.lookup(),
-            indexableFieldGenerator,
-            typeFieldMapper.mappedFieldType.indexAnalyzer()
-        );
+        return new DerivedFieldQuery(query, valueFetcher, context.lookup(), indexableFieldGenerator, getIndexAnalyzer());
     }
 
     @Override
@@ -200,13 +177,7 @@ public final class DerivedFieldType extends MappedFieldType {
             context
         );
         DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
-        return new DerivedFieldQuery(
-            query,
-            valueFetcher,
-            context.lookup(),
-            indexableFieldGenerator,
-            typeFieldMapper.mappedFieldType.indexAnalyzer()
-        );
+        return new DerivedFieldQuery(query, valueFetcher, context.lookup(), indexableFieldGenerator, getIndexAnalyzer());
     }
 
     @Override
@@ -218,13 +189,7 @@ public final class DerivedFieldType extends MappedFieldType {
     ) {
         Query query = typeFieldMapper.mappedFieldType.prefixQuery(value, method, caseInsensitive, context);
         DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
-        return new DerivedFieldQuery(
-            query,
-            valueFetcher,
-            context.lookup(),
-            indexableFieldGenerator,
-            typeFieldMapper.mappedFieldType.indexAnalyzer()
-        );
+        return new DerivedFieldQuery(query, valueFetcher, context.lookup(), indexableFieldGenerator, getIndexAnalyzer());
     }
 
     @Override
@@ -236,26 +201,14 @@ public final class DerivedFieldType extends MappedFieldType {
     ) {
         Query query = typeFieldMapper.mappedFieldType.wildcardQuery(value, method, caseInsensitive, context);
         DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
-        return new DerivedFieldQuery(
-            query,
-            valueFetcher,
-            context.lookup(),
-            indexableFieldGenerator,
-            typeFieldMapper.mappedFieldType.indexAnalyzer()
-        );
+        return new DerivedFieldQuery(query, valueFetcher, context.lookup(), indexableFieldGenerator, getIndexAnalyzer());
     }
 
     @Override
     public Query normalizedWildcardQuery(String value, @Nullable MultiTermQuery.RewriteMethod method, QueryShardContext context) {
         Query query = typeFieldMapper.mappedFieldType.normalizedWildcardQuery(value, method, context);
         DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
-        return new DerivedFieldQuery(
-            query,
-            valueFetcher,
-            context.lookup(),
-            indexableFieldGenerator,
-            typeFieldMapper.mappedFieldType.indexAnalyzer()
-        );
+        return new DerivedFieldQuery(query, valueFetcher, context.lookup(), indexableFieldGenerator, getIndexAnalyzer());
     }
 
     @Override
@@ -269,26 +222,14 @@ public final class DerivedFieldType extends MappedFieldType {
     ) {
         Query query = typeFieldMapper.mappedFieldType.regexpQuery(value, syntaxFlags, matchFlags, maxDeterminizedStates, method, context);
         DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
-        return new DerivedFieldQuery(
-            query,
-            valueFetcher,
-            context.lookup(),
-            indexableFieldGenerator,
-            typeFieldMapper.mappedFieldType.indexAnalyzer()
-        );
+        return new DerivedFieldQuery(query, valueFetcher, context.lookup(), indexableFieldGenerator, getIndexAnalyzer());
     }
 
     @Override
     public Query phraseQuery(TokenStream stream, int slop, boolean enablePositionIncrements, QueryShardContext context) throws IOException {
         Query query = typeFieldMapper.mappedFieldType.phraseQuery(stream, slop, enablePositionIncrements, context);
         DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
-        return new DerivedFieldQuery(
-            query,
-            valueFetcher,
-            context.lookup(),
-            indexableFieldGenerator,
-            typeFieldMapper.mappedFieldType.indexAnalyzer()
-        );
+        return new DerivedFieldQuery(query, valueFetcher, context.lookup(), indexableFieldGenerator, getIndexAnalyzer());
     }
 
     @Override
@@ -296,26 +237,14 @@ public final class DerivedFieldType extends MappedFieldType {
         throws IOException {
         Query query = typeFieldMapper.mappedFieldType.multiPhraseQuery(stream, slop, enablePositionIncrements, context);
         DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
-        return new DerivedFieldQuery(
-            query,
-            valueFetcher,
-            context.lookup(),
-            indexableFieldGenerator,
-            typeFieldMapper.mappedFieldType.indexAnalyzer()
-        );
+        return new DerivedFieldQuery(query, valueFetcher, context.lookup(), indexableFieldGenerator, getIndexAnalyzer());
     }
 
     @Override
     public Query phrasePrefixQuery(TokenStream stream, int slop, int maxExpansions, QueryShardContext context) throws IOException {
         Query query = typeFieldMapper.mappedFieldType.phrasePrefixQuery(stream, slop, maxExpansions, context);
         DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
-        return new DerivedFieldQuery(
-            query,
-            valueFetcher,
-            context.lookup(),
-            indexableFieldGenerator,
-            typeFieldMapper.mappedFieldType.indexAnalyzer()
-        );
+        return new DerivedFieldQuery(query, valueFetcher, context.lookup(), indexableFieldGenerator, getIndexAnalyzer());
     }
 
     @Override
@@ -329,13 +258,7 @@ public final class DerivedFieldType extends MappedFieldType {
     public Query distanceFeatureQuery(Object origin, String pivot, float boost, QueryShardContext context) {
         Query query = typeFieldMapper.mappedFieldType.distanceFeatureQuery(origin, pivot, boost, context);
         DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
-        return new DerivedFieldQuery(
-            query,
-            valueFetcher,
-            context.lookup(),
-            indexableFieldGenerator,
-            typeFieldMapper.mappedFieldType.indexAnalyzer()
-        );
+        return new DerivedFieldQuery(query, valueFetcher, context.lookup(), indexableFieldGenerator, getIndexAnalyzer());
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/mapper/DerivedFieldType.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DerivedFieldType.java
@@ -83,7 +83,7 @@ public final class DerivedFieldType extends MappedFieldType {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
         }
-        return new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context, searchLookup));
+        return new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context, searchLookup == null ? context.lookup() : searchLookup));
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/mapper/DerivedFieldValueFetcher.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DerivedFieldValueFetcher.java
@@ -9,6 +9,7 @@
 package org.opensearch.index.mapper;
 
 import org.apache.lucene.index.LeafReaderContext;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.script.DerivedFieldScript;
 import org.opensearch.search.lookup.SourceLookup;
 
@@ -20,6 +21,7 @@ import java.util.List;
  * It expects DerivedFieldScript.LeafFactory as an input and sets the contract with consumer to call
  * {@link #setNextReader(LeafReaderContext)} whenever a segment is switched.
  */
+@PublicApi(since = "2.14.0")
 public final class DerivedFieldValueFetcher implements ValueFetcher {
     private DerivedFieldScript derivedFieldScript;
     private final DerivedFieldScript.LeafFactory derivedFieldScriptFactory;

--- a/server/src/main/java/org/opensearch/index/mapper/DerivedFieldValueFetcher.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DerivedFieldValueFetcher.java
@@ -37,6 +37,7 @@ public final class DerivedFieldValueFetcher implements ValueFetcher {
         return derivedFieldScript.getEmittedValues();
     }
 
+    @Override
     public void setNextReader(LeafReaderContext context) {
         try {
             derivedFieldScript = derivedFieldScriptFactory.newInstance(context);

--- a/server/src/main/java/org/opensearch/index/mapper/DerivedFieldValueFetcher.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DerivedFieldValueFetcher.java
@@ -8,13 +8,16 @@
 
 package org.opensearch.index.mapper;
 
+import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.LeafReaderContext;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.script.DerivedFieldScript;
 import org.opensearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * The value fetcher contains logic to execute script and fetch the value in form of list of object.
@@ -26,15 +29,45 @@ public final class DerivedFieldValueFetcher implements ValueFetcher {
     private DerivedFieldScript derivedFieldScript;
     private final DerivedFieldScript.LeafFactory derivedFieldScriptFactory;
 
-    public DerivedFieldValueFetcher(DerivedFieldScript.LeafFactory derivedFieldScriptFactory) {
+    private final Function<Object, Object> valueForDisplay;
+    private final Function<Object, IndexableField> indexableFieldFunction;
+
+    public DerivedFieldValueFetcher(
+        DerivedFieldScript.LeafFactory derivedFieldScriptFactory,
+        Function<Object, Object> valueForDisplay,
+        Function<Object, IndexableField> indexableFieldFunction
+    ) {
         this.derivedFieldScriptFactory = derivedFieldScriptFactory;
+        this.valueForDisplay = valueForDisplay;
+        this.indexableFieldFunction = indexableFieldFunction;
     }
 
     @Override
     public List<Object> fetchValues(SourceLookup lookup) {
+        List<Object> values = fetchValuesInternal(lookup);
+        if (values.isEmpty()) {
+            return values;
+        }
+        List<Object> result = new ArrayList<>();
+        for (Object v : values) {
+            result.add(valueForDisplay.apply(v));
+        }
+        return result;
+    }
+
+    private List<Object> fetchValuesInternal(SourceLookup lookup) {
         derivedFieldScript.setDocument(lookup.docId());
         derivedFieldScript.execute();
         return derivedFieldScript.getEmittedValues();
+    }
+
+    public List<IndexableField> getIndexableField(SourceLookup lookup) {
+        List<Object> values = fetchValuesInternal(lookup);
+        List<IndexableField> indexableFields = new ArrayList<>();
+        for (Object v : values) {
+            indexableFields.add(indexableFieldFunction.apply(v));
+        }
+        return indexableFields;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/mapper/DocumentMapperParser.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocumentMapperParser.java
@@ -133,7 +133,7 @@ public class DocumentMapperParser {
     }
 
     @SuppressWarnings({ "unchecked" })
-    private DocumentMapper parse(String type, Map<String, Object> mapping) throws MapperParsingException {
+    public DocumentMapper parse(String type, Map<String, Object> mapping) throws MapperParsingException {
         if (type == null) {
             throw new MapperParsingException("Failed to derive type");
         }

--- a/server/src/main/java/org/opensearch/index/query/DerivedFieldQuery.java
+++ b/server/src/main/java/org/opensearch/index/query/DerivedFieldQuery.java
@@ -127,16 +127,12 @@ public final class DerivedFieldQuery extends Query {
             return false;
         }
         DerivedFieldQuery other = (DerivedFieldQuery) o;
-        return Objects.equals(this.query, other.query)
-            && Objects.equals(this.valueFetcher, other.valueFetcher)
-            && Objects.equals(this.searchLookup, other.searchLookup)
-            && Objects.equals(this.indexableFieldGenerator, other.indexableFieldGenerator)
-            && Objects.equals(this.indexAnalyzer, other.indexAnalyzer);
+        return Objects.equals(this.query, other.query) && Objects.equals(this.indexAnalyzer, other.indexAnalyzer);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(classHash(), query, valueFetcher, searchLookup, indexableFieldGenerator, indexableFieldGenerator);
+        return Objects.hash(classHash(), query, indexAnalyzer);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/query/QueryShardContext.java
+++ b/server/src/main/java/org/opensearch/index/query/QueryShardContext.java
@@ -45,6 +45,7 @@ import org.opensearch.common.SetOnce;
 import org.opensearch.common.TriFunction;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.lucene.search.Queries;
+import org.opensearch.common.regex.Regex;
 import org.opensearch.common.util.BigArrays;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.ParsingException;
@@ -332,7 +333,15 @@ public class QueryShardContext extends QueryRewriteContext {
      * type then the fields will be returned with a type prefix.
      */
     public Set<String> simpleMatchToIndexNames(String pattern) {
-        return mapperService.simpleMatchToFullName(pattern);
+        Set<String> matchingFields = mapperService.simpleMatchToFullName(pattern);
+        if (derivedFieldTypeMap != null && !derivedFieldTypeMap.isEmpty()) {
+            for (String fieldName : derivedFieldTypeMap.keySet()) {
+                if (Regex.simpleMatch(pattern, fieldName)) {
+                    matchingFields.add(fieldName);
+                }
+            }
+        }
+        return matchingFields;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/query/QueryShardContext.java
+++ b/server/src/main/java/org/opensearch/index/query/QueryShardContext.java
@@ -58,7 +58,7 @@ import org.opensearch.index.analysis.IndexAnalyzers;
 import org.opensearch.index.cache.bitset.BitsetFilterCache;
 import org.opensearch.index.fielddata.IndexFieldData;
 import org.opensearch.index.mapper.ContentPath;
-import org.opensearch.index.mapper.DerivedFieldMapper;
+import org.opensearch.index.mapper.DerivedFieldType;
 import org.opensearch.index.mapper.DocumentMapper;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.Mapper;
@@ -120,7 +120,7 @@ public class QueryShardContext extends QueryRewriteContext {
     private final ValuesSourceRegistry valuesSourceRegistry;
     private BitSetProducer parentFilter;
 
-    private DocumentMapper derivedFieldMappers;
+    private Map<String, DerivedFieldType> derivedFieldTypeMap = new HashMap<>();
 
     public QueryShardContext(
         int shardId,
@@ -267,7 +267,6 @@ public class QueryShardContext extends QueryRewriteContext {
         this.fullyQualifiedIndex = fullyQualifiedIndex;
         this.allowExpensiveQueries = allowExpensiveQueries;
         this.valuesSourceRegistry = valuesSourceRegistry;
-        derivedFieldMappers = null;
     }
 
     private void reset() {
@@ -399,12 +398,12 @@ public class QueryShardContext extends QueryRewriteContext {
         return valuesSourceRegistry;
     }
 
-    public void setDerivedFieldMappers(DocumentMapper derivedFieldMappers) {
-        this.derivedFieldMappers = derivedFieldMappers;
+    public void setDerivedFieldTypes(Map<String, DerivedFieldType> derivedFieldTypeMap) {
+        this.derivedFieldTypeMap = derivedFieldTypeMap;
     }
 
-    public DocumentMapper getDerivedFieldsMapper() {
-        return derivedFieldMappers;
+    public DerivedFieldType getDerivedFieldType(String fieldName) {
+        return derivedFieldTypeMap == null ? null : derivedFieldTypeMap.get(fieldName);
     }
 
     public void setAllowUnmappedFields(boolean allowUnmappedFields) {
@@ -418,18 +417,16 @@ public class QueryShardContext extends QueryRewriteContext {
     MappedFieldType failIfFieldMappingNotFound(String name, MappedFieldType fieldMapping) {
         if (fieldMapping != null) {
             return fieldMapping;
-        } else if (derivedFieldMappers != null
-            && derivedFieldMappers.mappers() != null
-            && derivedFieldMappers.mappers().getMapper(name) != null) {
-                return ((DerivedFieldMapper) derivedFieldMappers.mappers().getMapper(name)).fieldType();
-            } else if (allowUnmappedFields) {
-                return fieldMapping;
-            } else if (mapUnmappedFieldAsString) {
-                TextFieldMapper.Builder builder = new TextFieldMapper.Builder(name, mapperService.getIndexAnalyzers());
-                return builder.build(new Mapper.BuilderContext(indexSettings.getSettings(), new ContentPath(1))).fieldType();
-            } else {
-                throw new QueryShardException(this, "No field mapping can be found for the field with name [{}]", name);
-            }
+        } else if (getDerivedFieldType(name) != null) {
+            return getDerivedFieldType(name);
+        } else if (allowUnmappedFields) {
+            return fieldMapping;
+        } else if (mapUnmappedFieldAsString) {
+            TextFieldMapper.Builder builder = new TextFieldMapper.Builder(name, mapperService.getIndexAnalyzers());
+            return builder.build(new Mapper.BuilderContext(indexSettings.getSettings(), new ContentPath(1))).fieldType();
+        } else {
+            throw new QueryShardException(this, "No field mapping can be found for the field with name [{}]", name);
+        }
     }
 
     private SearchLookup lookup = null;

--- a/server/src/main/java/org/opensearch/index/query/VectorGeoPointShapeQueryProcessor.java
+++ b/server/src/main/java/org/opensearch/index/query/VectorGeoPointShapeQueryProcessor.java
@@ -54,6 +54,7 @@ import org.opensearch.geometry.Point;
 import org.opensearch.geometry.Polygon;
 import org.opensearch.geometry.Rectangle;
 import org.opensearch.geometry.ShapeType;
+import org.opensearch.index.mapper.DerivedFieldType;
 import org.opensearch.index.mapper.GeoPointFieldMapper;
 import org.opensearch.index.mapper.MappedFieldType;
 
@@ -78,7 +79,9 @@ public class VectorGeoPointShapeQueryProcessor {
 
     private void validateIsGeoPointFieldType(String fieldName, QueryShardContext context) {
         MappedFieldType fieldType = context.fieldMapper(fieldName);
-        if (fieldType instanceof GeoPointFieldMapper.GeoPointFieldType == false) {
+        if (fieldType instanceof GeoPointFieldMapper.GeoPointFieldType == false
+            && !(fieldType instanceof DerivedFieldType
+                && (((DerivedFieldType) fieldType).getTypeMappedFieldType() instanceof GeoPointFieldMapper.GeoPointFieldType))) {
             throw new QueryShardException(
                 context,
                 "Expected "

--- a/server/src/main/java/org/opensearch/script/DerivedFieldScript.java
+++ b/server/src/main/java/org/opensearch/script/DerivedFieldScript.java
@@ -68,13 +68,6 @@ public abstract class DerivedFieldScript {
         this.totalByteSize = 0;
     }
 
-    public DerivedFieldScript() {
-        this.params = null;
-        this.leafLookup = null;
-        this.emittedValues = new ArrayList<>();
-        this.totalByteSize = 0;
-    }
-
     /**
      * Return the parameters for this script.
      */

--- a/server/src/main/java/org/opensearch/search/SearchService.java
+++ b/server/src/main/java/org/opensearch/search/SearchService.java
@@ -79,7 +79,7 @@ import org.opensearch.index.IndexSettings;
 import org.opensearch.index.engine.Engine;
 import org.opensearch.index.mapper.DerivedField;
 import org.opensearch.index.mapper.DerivedFieldMapper;
-import org.opensearch.index.mapper.DerivedFieldType;
+import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.query.InnerHitContextBuilder;
 import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.query.MatchNoneQueryBuilder;
@@ -1072,7 +1072,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             if (request.source() != null
                 && request.source().size() != 0
                 && (request.source().getDerivedFieldsObject() != null || request.source().getDerivedFields() != null)) {
-                Map<String, DerivedFieldType> derivedFieldTypeMap = new HashMap<>();
+                Map<String, MappedFieldType> derivedFieldTypeMap = new HashMap<>();
                 if (request.source().getDerivedFieldsObject() != null) {
                     Map<String, Object> derivedFieldObject = new HashMap<>();
                     derivedFieldObject.put(DerivedFieldMapper.CONTENT_TYPE, request.source().getDerivedFieldsObject());

--- a/server/src/main/java/org/opensearch/search/SearchService.java
+++ b/server/src/main/java/org/opensearch/search/SearchService.java
@@ -77,8 +77,9 @@ import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.engine.Engine;
+import org.opensearch.index.mapper.DerivedField;
 import org.opensearch.index.mapper.DerivedFieldMapper;
-import org.opensearch.index.mapper.DocumentMapper;
+import org.opensearch.index.mapper.DerivedFieldType;
 import org.opensearch.index.query.InnerHitContextBuilder;
 import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.query.MatchNoneQueryBuilder;
@@ -1068,14 +1069,27 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             // might end up with incorrect state since we are using now() or script services
             // during rewrite and normalized / evaluate templates etc.
             QueryShardContext context = new QueryShardContext(searchContext.getQueryShardContext());
-            if (request.source().derivedFields() != null && request.source().size() != 0) {
-                Map<String, Object> derivedFieldObject = new HashMap<>();
-                derivedFieldObject.put(DerivedFieldMapper.CONTENT_TYPE, request.source().derivedFields());
-                DocumentMapper documentMapper = searchContext.mapperService()
-                    .documentMapperParser()
-                    .parse(DerivedFieldMapper.CONTENT_TYPE, derivedFieldObject);
-                context.setDerivedFieldMappers(documentMapper);
-                searchContext.getQueryShardContext().setDerivedFieldMappers(documentMapper);
+            if (request.source() != null
+                && request.source().size() != 0
+                && (request.source().getDerivedFieldsObject() != null || request.source().getDerivedFields() != null)) {
+                Map<String, DerivedFieldType> derivedFieldTypeMap = new HashMap<>();
+                if (request.source().getDerivedFieldsObject() != null) {
+                    Map<String, Object> derivedFieldObject = new HashMap<>();
+                    derivedFieldObject.put(DerivedFieldMapper.CONTENT_TYPE, request.source().getDerivedFieldsObject());
+                    derivedFieldTypeMap.putAll(
+                        DerivedFieldMapper.getAllDerivedFieldTypeFromObject(derivedFieldObject, searchContext.mapperService())
+                    );
+                }
+                if (request.source().getDerivedFields() != null) {
+                    for (DerivedField derivedField : request.source().getDerivedFields()) {
+                        derivedFieldTypeMap.put(
+                            derivedField.getName(),
+                            DerivedFieldMapper.getDerivedFieldType(derivedField, searchContext.mapperService())
+                        );
+                    }
+                }
+                context.setDerivedFieldTypes(derivedFieldTypeMap);
+                searchContext.getQueryShardContext().setDerivedFieldTypes(derivedFieldTypeMap);
             }
             Rewriteable.rewrite(request.getRewriteable(), context, true);
             assert searchContext.getQueryShardContext().isCacheable();

--- a/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
@@ -289,7 +289,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         if (in.getVersion().onOrAfter(Version.V_2_13_0)) {
             includeNamedQueriesScore = in.readOptionalBoolean();
         }
-        if (in.getVersion().onOrAfter(Version.V_2_13_1)) {
+        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
             if (in.readBoolean()) {
                 derivedFieldsObject = in.readMap();
             }
@@ -365,7 +365,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         if (out.getVersion().onOrAfter(Version.V_2_13_0)) {
             out.writeOptionalBoolean(includeNamedQueriesScore);
         }
-        if (out.getVersion().onOrAfter(Version.V_2_13_1)) {
+        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
             boolean hasDerivedFieldsObject = derivedFieldsObject != null;
             out.writeBoolean(hasDerivedFieldsObject);
             if (hasDerivedFieldsObject) {

--- a/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
@@ -1570,7 +1570,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         if (derivedFieldsObject != null || derivedFields != null) {
             builder.startObject(DERIVED_FIELDS_FIELD.getPreferredName());
             if (derivedFieldsObject != null) {
-                builder.map(derivedFieldsObject);
+                builder.mapContents(derivedFieldsObject);
             }
             if (derivedFields != null) {
                 for (DerivedField derivedField : derivedFields) {
@@ -1578,6 +1578,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
                 }
             }
             builder.endObject();
+
         }
 
         return builder;

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/highlight/HighlightPhase.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/highlight/HighlightPhase.java
@@ -35,8 +35,6 @@ package org.opensearch.search.fetch.subphase.highlight;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Query;
 import org.opensearch.common.regex.Regex;
-import org.opensearch.index.mapper.DerivedFieldMapper;
-import org.opensearch.index.mapper.DocumentMapper;
 import org.opensearch.index.mapper.KeywordFieldMapper;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.SourceFieldMapper;
@@ -147,11 +145,8 @@ public class HighlightPhase implements FetchSubPhase {
             boolean fieldNameContainsWildcards = field.field().contains("*");
             for (String fieldName : fieldNamesToHighlight) {
                 MappedFieldType fieldType = context.mapperService().fieldType(fieldName);
-                if (fieldType == null && context.getQueryShardContext().getDerivedFieldsMapper() != null) {
-                    DocumentMapper derivedFieldsMapper = context.getQueryShardContext().getDerivedFieldsMapper();
-                    if (derivedFieldsMapper.mappers() != null && derivedFieldsMapper.mappers().getMapper(fieldName) != null) {
-                        fieldType = ((DerivedFieldMapper) derivedFieldsMapper.mappers().getMapper(fieldName)).fieldType();
-                    }
+                if (fieldType == null && context.getQueryShardContext().getDerivedFieldType(fieldName) != null) {
+                    fieldType = context.getQueryShardContext().getDerivedFieldType(fieldName);
                 }
                 if (fieldType == null) {
                     continue;

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/highlight/HighlightUtils.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/highlight/HighlightUtils.java
@@ -35,6 +35,7 @@ import org.apache.lucene.search.highlight.DefaultEncoder;
 import org.apache.lucene.search.highlight.Encoder;
 import org.apache.lucene.search.highlight.SimpleHTMLEncoder;
 import org.opensearch.index.fieldvisitor.CustomFieldsVisitor;
+import org.opensearch.index.mapper.DerivedFieldValueFetcher;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.ValueFetcher;
 import org.opensearch.index.query.QueryShardContext;
@@ -77,6 +78,9 @@ public final class HighlightUtils {
             return textsToHighlight != null ? textsToHighlight : Collections.emptyList();
         }
         ValueFetcher fetcher = fieldType.valueFetcher(context, null, null);
+        if (fetcher instanceof DerivedFieldValueFetcher) {
+            fetcher.setNextReader(hitContext.reader().getContext());
+        }
         return fetcher.fetchValues(hitContext.sourceLookup());
     }
 

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/highlight/UnifiedHighlighter.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/highlight/UnifiedHighlighter.java
@@ -159,6 +159,12 @@ public class UnifiedHighlighter implements Highlighter {
         Integer fieldMaxAnalyzedOffset = fieldContext.field.fieldOptions().maxAnalyzerOffset();
         int numberOfFragments = fieldContext.field.fieldOptions().numberOfFragments();
         Analyzer analyzer = getAnalyzer(fieldContext.context.mapperService().documentMapper());
+        if (fieldContext.context.getQueryShardContext().getDerivedFieldsMapper() != null) {
+            DocumentMapper derivedFieldsMapper = fieldContext.context.getQueryShardContext().getDerivedFieldsMapper();
+            if (derivedFieldsMapper != null) {
+                analyzer = getAnalyzer(derivedFieldsMapper);
+            }
+        }
         if (fieldMaxAnalyzedOffset != null) {
             analyzer = getLimitedOffsetAnalyzer(analyzer, fieldMaxAnalyzedOffset);
         }

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/highlight/UnifiedHighlighter.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/highlight/UnifiedHighlighter.java
@@ -159,11 +159,8 @@ public class UnifiedHighlighter implements Highlighter {
         Integer fieldMaxAnalyzedOffset = fieldContext.field.fieldOptions().maxAnalyzerOffset();
         int numberOfFragments = fieldContext.field.fieldOptions().numberOfFragments();
         Analyzer analyzer = getAnalyzer(fieldContext.context.mapperService().documentMapper());
-        if (fieldContext.context.getQueryShardContext().getDerivedFieldsMapper() != null) {
-            DocumentMapper derivedFieldsMapper = fieldContext.context.getQueryShardContext().getDerivedFieldsMapper();
-            if (derivedFieldsMapper != null) {
-                analyzer = getAnalyzer(derivedFieldsMapper);
-            }
+        if (fieldContext.context.getQueryShardContext().getDerivedFieldType(fieldContext.fieldName) != null) {
+            analyzer = fieldContext.context.getQueryShardContext().getDerivedFieldType(fieldContext.fieldName).getIndexAnalyzer();
         }
         if (fieldMaxAnalyzedOffset != null) {
             analyzer = getLimitedOffsetAnalyzer(analyzer, fieldMaxAnalyzedOffset);

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/highlight/UnifiedHighlighter.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/highlight/UnifiedHighlighter.java
@@ -48,6 +48,7 @@ import org.apache.lucene.util.CollectionUtil;
 import org.opensearch.common.CheckedSupplier;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.text.Text;
+import org.opensearch.index.mapper.DerivedFieldType;
 import org.opensearch.index.mapper.DocumentMapper;
 import org.opensearch.index.mapper.IdFieldMapper;
 import org.opensearch.index.mapper.MappedFieldType;
@@ -160,7 +161,8 @@ public class UnifiedHighlighter implements Highlighter {
         int numberOfFragments = fieldContext.field.fieldOptions().numberOfFragments();
         Analyzer analyzer = getAnalyzer(fieldContext.context.mapperService().documentMapper());
         if (fieldContext.context.getQueryShardContext().getDerivedFieldType(fieldContext.fieldName) != null) {
-            analyzer = fieldContext.context.getQueryShardContext().getDerivedFieldType(fieldContext.fieldName).getIndexAnalyzer();
+            analyzer = ((DerivedFieldType) fieldContext.context.getQueryShardContext().getDerivedFieldType(fieldContext.fieldName))
+                .getIndexAnalyzer();
         }
         if (fieldMaxAnalyzedOffset != null) {
             analyzer = getLimitedOffsetAnalyzer(analyzer, fieldMaxAnalyzedOffset);

--- a/server/src/test/java/org/opensearch/index/mapper/DerivedFieldTypeTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/DerivedFieldTypeTests.java
@@ -15,6 +15,7 @@ import org.apache.lucene.document.KeywordField;
 import org.apache.lucene.document.LatLonPoint;
 import org.apache.lucene.document.LongField;
 import org.apache.lucene.document.LongPoint;
+import org.opensearch.common.collect.Tuple;
 import org.opensearch.script.Script;
 
 import java.util.List;
@@ -51,7 +52,7 @@ public class DerivedFieldTypeTests extends FieldTypeTestCase {
     public void testGeoPointType() {
         DerivedFieldType dft = createDerivedFieldType("geo_point");
         assertTrue(dft.typeFieldMapper instanceof GeoPointFieldMapper);
-        assertTrue(dft.indexableFieldGenerator.apply(List.of(10.0, 20.0)) instanceof LatLonPoint);
+        assertTrue(dft.indexableFieldGenerator.apply(new Tuple<>(10.0, 20.0)) instanceof LatLonPoint);
         expectThrows(ClassCastException.class, () -> dft.indexableFieldGenerator.apply(List.of(10.0)));
         expectThrows(ClassCastException.class, () -> dft.indexableFieldGenerator.apply(List.of()));
         expectThrows(ClassCastException.class, () -> dft.indexableFieldGenerator.apply(List.of("10")));

--- a/server/src/test/java/org/opensearch/index/mapper/DerivedFieldTypeTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/DerivedFieldTypeTests.java
@@ -28,9 +28,7 @@ public class DerivedFieldTypeTests extends FieldTypeTestCase {
         Mapper.BuilderContext context = mock(Mapper.BuilderContext.class);
         when(context.path()).thenReturn(new ContentPath());
         return new DerivedFieldType(
-            type + " _derived_field",
-            type,
-            new Script(""),
+            new DerivedField(type + " _derived_field", type, new Script("")),
             DerivedFieldSupportedTypes.getFieldMapperFromType(type, type + "_derived_field", context),
             DerivedFieldSupportedTypes.getIndexableFieldGeneratorType(type, type + "_derived_field")
         );

--- a/server/src/test/java/org/opensearch/index/query/DerivedFieldQueryTests.java
+++ b/server/src/test/java/org/opensearch/index/query/DerivedFieldQueryTests.java
@@ -22,6 +22,7 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
 import org.opensearch.common.lucene.Lucene;
+import org.opensearch.index.mapper.DerivedFieldSupportedTypes;
 import org.opensearch.index.mapper.DerivedFieldValueFetcher;
 import org.opensearch.script.DerivedFieldScript;
 import org.opensearch.script.Script;
@@ -75,14 +76,17 @@ public class DerivedFieldQueryTests extends OpenSearchTestCase {
 
         // Create ValueFetcher from mocked DerivedFieldScript.Factory
         DerivedFieldScript.LeafFactory leafFactory = factory.newFactory((new Script("")).getParams(), searchLookup);
-        DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(leafFactory);
+        DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(
+            leafFactory,
+            null,
+            DerivedFieldSupportedTypes.getIndexableFieldGeneratorType("keyword", "ip_from_raw_request")
+        );
 
         // Create DerivedFieldQuery
         DerivedFieldQuery derivedFieldQuery = new DerivedFieldQuery(
             new TermQuery(new Term("ip_from_raw_request", "247.37.0.0")),
             valueFetcher,
             searchLookup,
-            (o -> new KeywordField("ip_from_raw_request", (String) o, Field.Store.NO)),
             Lucene.STANDARD_ANALYZER
         );
 

--- a/server/src/test/java/org/opensearch/index/query/QueryShardContextTests.java
+++ b/server/src/test/java/org/opensearch/index/query/QueryShardContextTests.java
@@ -83,6 +83,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
@@ -127,6 +128,8 @@ public class QueryShardContextTests extends OpenSearchTestCase {
     public void testDerivedFieldMapping() {
         QueryShardContext context = createQueryShardContext(IndexMetadata.INDEX_UUID_NA_VALUE, null);
         assertNull(context.failIfFieldMappingNotFound("test_derived", null));
+        context.setDerivedFieldTypes(null);
+        assertNull(context.failIfFieldMappingNotFound("test_derived", null));
         DocumentMapper documentMapper = mock(DocumentMapper.class);
         Mapper.BuilderContext builderContext = new Mapper.BuilderContext(Settings.EMPTY, new ContentPath(0));
         DerivedFieldMapper derivedFieldMapper = new DerivedFieldMapper.Builder("test_derived").build(builderContext);
@@ -138,7 +141,7 @@ public class QueryShardContextTests extends OpenSearchTestCase {
             new StandardAnalyzer()
         );
         when(documentMapper.mappers()).thenReturn(mappingLookup);
-        context.setDerivedFieldMappers(documentMapper);
+        context.setDerivedFieldTypes(Map.of("test_derived", derivedFieldMapper.fieldType()));
         context.setAllowUnmappedFields(false);
         assertEquals(derivedFieldMapper.fieldType(), context.failIfFieldMappingNotFound("test_derived", null));
     }

--- a/server/src/test/java/org/opensearch/index/query/QueryShardContextTests.java
+++ b/server/src/test/java/org/opensearch/index/query/QueryShardContextTests.java
@@ -65,6 +65,7 @@ import org.opensearch.index.fielddata.LeafFieldData;
 import org.opensearch.index.fielddata.ScriptDocValues;
 import org.opensearch.index.fielddata.plain.AbstractLeafOrdinalsFieldData;
 import org.opensearch.index.mapper.ContentPath;
+import org.opensearch.index.mapper.DerivedField;
 import org.opensearch.index.mapper.DerivedFieldMapper;
 import org.opensearch.index.mapper.DocumentMapper;
 import org.opensearch.index.mapper.IndexFieldMapper;
@@ -73,6 +74,7 @@ import org.opensearch.index.mapper.Mapper;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.MappingLookup;
 import org.opensearch.index.mapper.TextFieldMapper;
+import org.opensearch.script.Script;
 import org.opensearch.search.lookup.LeafDocLookup;
 import org.opensearch.search.lookup.LeafSearchLookup;
 import org.opensearch.search.lookup.SearchLookup;
@@ -132,7 +134,8 @@ public class QueryShardContextTests extends OpenSearchTestCase {
         assertNull(context.failIfFieldMappingNotFound("test_derived", null));
         DocumentMapper documentMapper = mock(DocumentMapper.class);
         Mapper.BuilderContext builderContext = new Mapper.BuilderContext(Settings.EMPTY, new ContentPath(0));
-        DerivedFieldMapper derivedFieldMapper = new DerivedFieldMapper.Builder("test_derived").build(builderContext);
+        DerivedFieldMapper derivedFieldMapper = new DerivedFieldMapper.Builder(new DerivedField("test_derived", "keyword", new Script("")))
+            .build(builderContext);
         MappingLookup mappingLookup = new MappingLookup(
             Collections.singletonList(derivedFieldMapper),
             Collections.emptyList(),

--- a/server/src/test/java/org/opensearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/opensearch/search/SearchServiceTests.java
@@ -71,6 +71,7 @@ import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.engine.Engine;
+import org.opensearch.index.mapper.DerivedFieldType;
 import org.opensearch.index.query.AbstractQueryBuilder;
 import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.query.MatchNoneQueryBuilder;
@@ -544,6 +545,49 @@ public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
                     + "This limit can be set by changing the [index.max_docvalue_fields_search] index level setting.",
                 ex.getMessage()
             );
+        }
+    }
+
+    public void testDerivedFieldsSearch() throws IOException {
+        createIndex("index");
+        final SearchService service = getInstanceFromNode(SearchService.class);
+        final IndicesService indicesService = getInstanceFromNode(IndicesService.class);
+        final IndexService indexService = indicesService.indexServiceSafe(resolveIndex("index"));
+        final IndexShard indexShard = indexService.getShard(0);
+
+        SearchRequest searchRequest = new SearchRequest().allowPartialSearchResults(true);
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        searchRequest.source(searchSourceBuilder);
+
+        for (int i = 0; i < 5; i++) {
+            searchSourceBuilder.derivedField(
+                "field" + i,
+                "date",
+                new Script(ScriptType.INLINE, MockScriptEngine.NAME, CustomScriptPlugin.DUMMY_SCRIPT, Collections.emptyMap())
+            );
+        }
+        final ShardSearchRequest request = new ShardSearchRequest(
+            OriginalIndices.NONE,
+            searchRequest,
+            indexShard.shardId(),
+            1,
+            new AliasFilter(null, Strings.EMPTY_ARRAY),
+            1.0f,
+            -1,
+            null,
+            null
+        );
+
+        try (ReaderContext reader = createReaderContext(indexService, indexShard)) {
+            try (SearchContext context = service.createContext(reader, request, null, randomBoolean())) {
+                assertNotNull(context);
+                for (int i = 0; i < 5; i++) {
+                    DerivedFieldType derivedFieldType = context.getQueryShardContext().getDerivedFieldType("field" + i);
+                    assertEquals("field" + i, derivedFieldType.name());
+                    assertEquals("date", derivedFieldType.getType());
+                }
+                assertNull(context.getQueryShardContext().getDerivedFieldType("field" + 5));
+            }
         }
     }
 

--- a/server/src/test/java/org/opensearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/opensearch/search/SearchServiceTests.java
@@ -582,7 +582,7 @@ public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
             try (SearchContext context = service.createContext(reader, request, null, randomBoolean())) {
                 assertNotNull(context);
                 for (int i = 0; i < 5; i++) {
-                    DerivedFieldType derivedFieldType = context.getQueryShardContext().getDerivedFieldType("field" + i);
+                    DerivedFieldType derivedFieldType = (DerivedFieldType) context.getQueryShardContext().getDerivedFieldType("field" + i);
                     assertEquals("field" + i, derivedFieldType.name());
                     assertEquals("date", derivedFieldType.getType());
                 }

--- a/server/src/test/java/org/opensearch/search/builder/SearchSourceBuilderTests.java
+++ b/server/src/test/java/org/opensearch/search/builder/SearchSourceBuilderTests.java
@@ -53,6 +53,7 @@ import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.QueryRewriteContext;
 import org.opensearch.index.query.RandomQueryBuilder;
 import org.opensearch.index.query.Rewriteable;
+import org.opensearch.script.Script;
 import org.opensearch.search.AbstractSearchTestCase;
 import org.opensearch.search.rescore.QueryRescorerBuilder;
 import org.opensearch.search.sort.FieldSortBuilder;
@@ -311,7 +312,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
         }
     }
 
-    public void testDerivedFieldsParsing() throws IOException {
+    public void testDerivedFieldsParsingAndSerialization() throws IOException {
         {
             String restContent = "{\n"
                 + "  \"derived\": {\n"
@@ -328,10 +329,29 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
                 + "        \"match\": { \"content\": { \"query\": \"foo bar\" }}\n"
                 + "     }\n"
                 + "}";
+
+            String expectedContent =
+                "{\"query\":{\"match\":{\"content\":{\"query\":\"foo bar\",\"operator\":\"OR\",\"prefix_length\":0,\"max_expansions\":50,\"fuzzy_transpositions\":true,\"lenient\":false,\"zero_terms_query\":\"NONE\",\"auto_generate_synonyms_phrase_query\":true,\"boost\":1.0}}},"
+                    + "\"derived\":{"
+                    + "\"duration\":{\"type\":\"long\",\"script\":\"emit(doc['test'])\"},\"ip_from_message\":{\"type\":\"keyword\",\"script\":\"emit(doc['message'])\"},\"derived_field\":{\"type\":\"keyword\",\"script\":{\"source\":\"emit(doc['message']\",\"lang\":\"painless\"}}}}";
+
             try (XContentParser parser = createParser(JsonXContent.jsonXContent, restContent)) {
                 SearchSourceBuilder searchSourceBuilder = SearchSourceBuilder.fromXContent(parser);
+                searchSourceBuilder.derivedField("derived_field", "keyword", new Script("emit(doc['message']"));
                 searchSourceBuilder = rewrite(searchSourceBuilder);
                 assertEquals(2, searchSourceBuilder.getDerivedFieldsObject().size());
+                assertEquals(1, searchSourceBuilder.getDerivedFields().size());
+
+                try (BytesStreamOutput output = new BytesStreamOutput()) {
+                    searchSourceBuilder.writeTo(output);
+                    try (StreamInput in = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), namedWriteableRegistry)) {
+                        SearchSourceBuilder deserializedBuilder = new SearchSourceBuilder(in);
+                        String actualContent = deserializedBuilder.toString();
+                        assertEquals(expectedContent, actualContent);
+                        assertEquals(searchSourceBuilder.hashCode(), deserializedBuilder.hashCode());
+                        assertNotSame(searchSourceBuilder, deserializedBuilder);
+                    }
+                }
             }
         }
 

--- a/server/src/test/java/org/opensearch/search/builder/SearchSourceBuilderTests.java
+++ b/server/src/test/java/org/opensearch/search/builder/SearchSourceBuilderTests.java
@@ -311,6 +311,32 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
         }
     }
 
+    public void testDerivedFieldsParsing() throws IOException {
+        {
+            String restContent = "{\n"
+                + "  \"derived\": {\n"
+                + "    \"duration\": {\n"
+                + "      \"type\": \"long\",\n"
+                + "      \"script\": \"emit(doc['test'])\"\n"
+                + "    },\n"
+                + "    \"ip_from_message\": {\n"
+                + "      \"type\": \"keyword\",\n"
+                + "      \"script\": \"emit(doc['message'])\"\n"
+                + "    }\n"
+                + "  },\n"
+                + "    \"query\" : {\n"
+                + "        \"match\": { \"content\": { \"query\": \"foo bar\" }}\n"
+                + "     }\n"
+                + "}";
+            try (XContentParser parser = createParser(JsonXContent.jsonXContent, restContent)) {
+                SearchSourceBuilder searchSourceBuilder = SearchSourceBuilder.fromXContent(parser);
+                searchSourceBuilder = rewrite(searchSourceBuilder);
+                assertEquals(2, searchSourceBuilder.getDerivedFieldsObject().size());
+            }
+        }
+
+    }
+
     public void testAggsParsing() throws IOException {
         {
             String restContent = "{\n"

--- a/server/src/test/java/org/opensearch/search/fetch/subphase/FieldFetcherTests.java
+++ b/server/src/test/java/org/opensearch/search/fetch/subphase/FieldFetcherTests.java
@@ -43,33 +43,19 @@ import org.opensearch.index.IndexService;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.query.QueryShardContext;
-import org.opensearch.script.MockScriptEngine;
-import org.opensearch.script.ScriptEngine;
-import org.opensearch.script.ScriptModule;
-import org.opensearch.script.ScriptService;
-import org.opensearch.search.lookup.LeafSearchLookup;
-import org.opensearch.search.lookup.SearchLookup;
 import org.opensearch.search.lookup.SourceLookup;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static java.util.Collections.singletonMap;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class FieldFetcherTests extends OpenSearchSingleNodeTestCase {
-
-    private static String DERIVED_FIELD_SCRIPT_1 = "derived_field_script_1";
-    private static String DERIVED_FIELD_SCRIPT_2 = "derived_field_script_2";
 
     public void testLeafValues() throws IOException {
         MapperService mapperService = createMapperService();
@@ -449,45 +435,6 @@ public class FieldFetcherTests extends OpenSearchSingleNodeTestCase {
         }
     }
 
-    public void testDerivedFields() throws IOException {
-        XContentBuilder mapping = XContentFactory.jsonBuilder()
-            .startObject()
-            .startObject("derived")
-            .startObject("derived_1")
-            .field("type", "keyword")
-            .startObject("script")
-            .field("source", DERIVED_FIELD_SCRIPT_1)
-            .field("lang", "mockscript")
-            .endObject()
-            .endObject()
-            .startObject("derived_2")
-            .field("type", "keyword")
-            .startObject("script")
-            .field("source", DERIVED_FIELD_SCRIPT_2)
-            .field("lang", "mockscript")
-            .endObject()
-            .endObject()
-            .endObject()
-            .endObject();
-
-        IndexService indexService = createIndex("index", Settings.EMPTY, MapperService.SINGLE_MAPPING_NAME, mapping);
-        MapperService mapperService = indexService.mapperService();
-
-        XContentBuilder source = XContentFactory.jsonBuilder()
-            .startObject()
-            .field("field1", "some text 1")
-            .field("field2", "some text 2")
-            .endObject();
-
-        Map<String, DocumentField> fields = fetchFields(mapperService, source, "*");
-        assertThat(fields.size(), equalTo(2));
-        assertThat(fields.keySet(), containsInAnyOrder("derived_1", "derived_2"));
-        assertThat(fields.get("derived_1").getValues().size(), equalTo(1));
-        assertThat(fields.get("derived_2").getValues().size(), equalTo(1));
-        assertThat(fields.get("derived_1").getValue(), equalTo("some text 1"));
-        assertThat(fields.get("derived_2").getValue(), equalTo("some text 2"));
-    }
-
     private static Map<String, DocumentField> fetchFields(MapperService mapperService, XContentBuilder source, String fieldPattern)
         throws IOException {
 
@@ -501,13 +448,7 @@ public class FieldFetcherTests extends OpenSearchSingleNodeTestCase {
         SourceLookup sourceLookup = new SourceLookup();
         sourceLookup.setSource(BytesReference.bytes(source));
 
-        SearchLookup searchLookup = mock(SearchLookup.class);
-        LeafSearchLookup leafSearchLookup = mock(LeafSearchLookup.class);
-        when(searchLookup.source()).thenReturn(sourceLookup);
-        when(searchLookup.getLeafSearchLookup(any())).thenReturn(leafSearchLookup);
-        when(leafSearchLookup.source()).thenReturn(sourceLookup);
-        FieldFetcher fieldFetcher = FieldFetcher.create(createQueryShardContext(mapperService), searchLookup, fields);
-        fieldFetcher.setNextReader(null);
+        FieldFetcher fieldFetcher = FieldFetcher.create(createQueryShardContext(mapperService), null, fields);
         return fieldFetcher.fetch(sourceLookup, Set.of());
     }
 
@@ -556,19 +497,6 @@ public class FieldFetcherTests extends OpenSearchSingleNodeTestCase {
             .build();
         IndexMetadata indexMetadata = new IndexMetadata.Builder("index").settings(settings).build();
         IndexSettings indexSettings = new IndexSettings(indexMetadata, settings);
-
-        final MockScriptEngine engine = new MockScriptEngine(
-            MockScriptEngine.NAME,
-            Map.of(
-                DERIVED_FIELD_SCRIPT_1,
-                (script) -> ((Map<String, Object>) script.get("_source")).get("field1"),
-                DERIVED_FIELD_SCRIPT_2,
-                (script) -> ((Map<String, Object>) script.get("_source")).get("field2")
-            ),
-            Collections.emptyMap()
-        );
-        final Map<String, ScriptEngine> engines = singletonMap(engine.getType(), engine);
-        ScriptService scriptService = new ScriptService(Settings.EMPTY, engines, ScriptModule.CORE_CONTEXTS);
         return new QueryShardContext(
             0,
             indexSettings,
@@ -577,7 +505,7 @@ public class FieldFetcherTests extends OpenSearchSingleNodeTestCase {
             null,
             mapperService,
             null,
-            scriptService,
+            null,
             null,
             null,
             null,

--- a/server/src/test/java/org/opensearch/search/fetch/subphase/highlight/DerivedFieldFetchAndHighlightTests.java
+++ b/server/src/test/java/org/opensearch/search/fetch/subphase/highlight/DerivedFieldFetchAndHighlightTests.java
@@ -1,0 +1,366 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.fetch.subphase.highlight;
+
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.opensearch.Version;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.document.DocumentField;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.IndexService;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.mapper.ContentPath;
+import org.opensearch.index.mapper.DerivedField;
+import org.opensearch.index.mapper.DerivedFieldSupportedTypes;
+import org.opensearch.index.mapper.DerivedFieldType;
+import org.opensearch.index.mapper.Mapper;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.index.mapper.SourceToParse;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.index.query.Rewriteable;
+import org.opensearch.script.MockScriptEngine;
+import org.opensearch.script.Script;
+import org.opensearch.script.ScriptEngine;
+import org.opensearch.script.ScriptModule;
+import org.opensearch.script.ScriptService;
+import org.opensearch.script.ScriptType;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.fetch.FetchContext;
+import org.opensearch.search.fetch.FetchSubPhase;
+import org.opensearch.search.fetch.FetchSubPhaseProcessor;
+import org.opensearch.search.fetch.subphase.FieldAndFormat;
+import org.opensearch.search.fetch.subphase.FieldFetcher;
+import org.opensearch.search.internal.ContextIndexSearcher;
+import org.opensearch.test.OpenSearchSingleNodeTestCase;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DerivedFieldFetchAndHighlightTests extends OpenSearchSingleNodeTestCase {
+    private static String DERIVED_FIELD_SCRIPT_1 = "derived_field_script_1";
+    private static String DERIVED_FIELD_SCRIPT_2 = "derived_field_script_2";
+
+    private static String DERIVED_FIELD_1 = "derived_1";
+    private static String DERIVED_FIELD_2 = "derived_2";
+
+    public void testDerivedFieldFromIndexMapping() throws IOException {
+        // Create index and mapper service
+        // Define mapping for derived fields, create 2 derived fields derived_1 and derived_2
+        XContentBuilder mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("derived")
+            .startObject(DERIVED_FIELD_1)
+            .field("type", "keyword")
+            .startObject("script")
+            .field("source", DERIVED_FIELD_SCRIPT_1)
+            .field("lang", "mockscript")
+            .endObject()
+            .endObject()
+            .startObject(DERIVED_FIELD_2)
+            .field("type", "keyword")
+            .startObject("script")
+            .field("source", DERIVED_FIELD_SCRIPT_2)
+            .field("lang", "mockscript")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        // Create source document with 2 fields field1 and field2.
+        // derived_1 will act on field1 and derived_2 will act on derived_2. DERIVED_FIELD_SCRIPT_1 substitutes whitespaces with _
+        XContentBuilder source = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("field1", "some_text_1")
+            .field("field2", "some_text_2")
+            .endObject();
+
+        int docId = 0;
+        IndexService indexService = createIndex("test_index", Settings.EMPTY, MapperService.SINGLE_MAPPING_NAME, mapping);
+        MapperService mapperService = indexService.mapperService();
+
+        try (
+            Directory dir = newDirectory();
+            RandomIndexWriter iw = new RandomIndexWriter(random(), dir, new IndexWriterConfig(mapperService.indexAnalyzer()));
+        ) {
+            iw.addDocument(
+                mapperService.documentMapper()
+                    .parse(new SourceToParse("test_index", "0", BytesReference.bytes(source), MediaTypeRegistry.JSON))
+                    .rootDoc()
+            );
+            try (IndexReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                LeafReaderContext context = searcher.getIndexReader().leaves().get(0);
+                QueryShardContext mockShardContext = createQueryShardContext(mapperService, searcher);
+                mockShardContext.lookup().source().setSegmentAndDocument(context, docId);
+                // mockShardContext.setDerivedFieldTypes(Map.of("derived_2", createDerivedFieldType("derived_1", "keyword"), "derived_1",
+
+                // Assert the fetch phase works for both of the derived fields
+                Map<String, DocumentField> fields = fetchFields(mockShardContext, context, "*");
+
+                // Validate FetchPhase
+                {
+                    assertEquals(fields.size(), 2);
+                    assertEquals(1, fields.get(DERIVED_FIELD_1).getValues().size());
+                    assertEquals(1, fields.get(DERIVED_FIELD_2).getValues().size());
+                    assertEquals("some_text_1", fields.get(DERIVED_FIELD_1).getValue());
+                    assertEquals("some_text_2", fields.get(DERIVED_FIELD_2).getValue());
+                }
+
+                // Create a HighlightBuilder of type unified, set its fields as derived_1 and derived_2
+                HighlightBuilder highlightBuilder = new HighlightBuilder();
+                highlightBuilder.highlighterType("unified");
+                highlightBuilder.field(DERIVED_FIELD_1);
+                highlightBuilder.field(DERIVED_FIELD_2);
+                highlightBuilder = Rewriteable.rewrite(highlightBuilder, mockShardContext);
+                SearchHighlightContext searchHighlightContext = highlightBuilder.build(mockShardContext);
+
+                // Create a HighlightPhase with highlighter defined above
+                HighlightPhase highlightPhase = new HighlightPhase(Collections.singletonMap("unified", new UnifiedHighlighter()));
+
+                // create a fetch context to be used by HighlightPhase processor
+                FetchContext fetchContext = mock(FetchContext.class);
+                when(fetchContext.mapperService()).thenReturn(mockShardContext.getMapperService());
+                when(fetchContext.getQueryShardContext()).thenReturn(mockShardContext);
+                when(fetchContext.getIndexSettings()).thenReturn(indexService.getIndexSettings());
+                when(fetchContext.searcher()).thenReturn(
+                    new ContextIndexSearcher(
+                        searcher.getIndexReader(),
+                        searcher.getSimilarity(),
+                        searcher.getQueryCache(),
+                        searcher.getQueryCachingPolicy(),
+                        true,
+                        searcher.getExecutor(),
+                        null
+                    )
+                );
+
+                // The query used by FetchSubPhaseProcessor to highlight is a term query on DERIVED_FIELD_1
+                FetchSubPhaseProcessor subPhaseProcessor = highlightPhase.getProcessor(
+                    fetchContext,
+                    searchHighlightContext,
+                    new TermQuery(new Term(DERIVED_FIELD_1, "some_text_1"))
+                );
+
+                // Create a search hit using the derived fields fetched above in fetch phase
+                SearchHit searchHit = new SearchHit(docId, "0", null, fields, null);
+
+                // Create a HitContext of search hit
+                FetchSubPhase.HitContext hitContext = new FetchSubPhase.HitContext(
+                    searchHit,
+                    context,
+                    docId,
+                    mockShardContext.lookup().source()
+                );
+                hitContext.sourceLookup().loadSourceIfNeeded();
+                // process the HitContext using the highlightPhase subPhaseProcessor
+                subPhaseProcessor.process(hitContext);
+
+                // Validate that 1 highlight field is present
+                assertEquals(hitContext.hit().getHighlightFields().size(), 1);
+            }
+        }
+    }
+
+    public void testDerivedFieldFromSearchMapping() throws IOException {
+        // Create source document with 2 fields field1 and field2.
+        // derived_1 will act on field1 and derived_2 will act on derived_2. DERIVED_FIELD_SCRIPT_1 substitutes whitespaces with _
+        XContentBuilder source = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("field1", "some_text_1")
+            .field("field2", "some_text_2")
+            .endObject();
+
+        int docId = 0;
+
+        // Create index and mapper service
+        // We are not defining derived fields in index mapping here
+        XContentBuilder mapping = XContentFactory.jsonBuilder().startObject().endObject();
+        IndexService indexService = createIndex("test_index", Settings.EMPTY, MapperService.SINGLE_MAPPING_NAME, mapping);
+        MapperService mapperService = indexService.mapperService();
+
+        try (
+            Directory dir = newDirectory();
+            RandomIndexWriter iw = new RandomIndexWriter(random(), dir, new IndexWriterConfig(mapperService.indexAnalyzer()));
+        ) {
+            iw.addDocument(
+                mapperService.documentMapper()
+                    .parse(new SourceToParse("test_index", "0", BytesReference.bytes(source), MediaTypeRegistry.JSON))
+                    .rootDoc()
+            );
+            try (IndexReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                LeafReaderContext context = searcher.getIndexReader().leaves().get(0);
+                QueryShardContext mockShardContext = createQueryShardContext(mapperService, searcher);
+                mockShardContext.lookup().source().setSegmentAndDocument(context, docId);
+
+                // This mock behavior is similar to adding derived fields in search request
+                mockShardContext.setDerivedFieldTypes(
+                    Map.of(
+                        DERIVED_FIELD_1,
+                        createDerivedFieldType(DERIVED_FIELD_1, "keyword", DERIVED_FIELD_SCRIPT_1),
+                        DERIVED_FIELD_2,
+                        createDerivedFieldType(DERIVED_FIELD_2, "keyword", DERIVED_FIELD_SCRIPT_2)
+                    )
+                );
+
+                // Assert the fetch phase works for both of the derived fields
+                Map<String, DocumentField> fields = fetchFields(mockShardContext, context, "derived_*");
+
+                // Validate FetchPhase
+                {
+                    assertEquals(fields.size(), 2);
+                    assertEquals(1, fields.get(DERIVED_FIELD_1).getValues().size());
+                    assertEquals(1, fields.get(DERIVED_FIELD_2).getValues().size());
+                    assertEquals("some_text_1", fields.get(DERIVED_FIELD_1).getValue());
+                    assertEquals("some_text_2", fields.get(DERIVED_FIELD_2).getValue());
+                }
+
+                // Create a HighlightBuilder of type unified, set its fields as derived_1 and derived_2
+                HighlightBuilder highlightBuilder = new HighlightBuilder();
+                highlightBuilder.highlighterType("unified");
+                highlightBuilder.field(DERIVED_FIELD_1);
+                highlightBuilder.field(DERIVED_FIELD_2);
+                highlightBuilder = Rewriteable.rewrite(highlightBuilder, mockShardContext);
+                SearchHighlightContext searchHighlightContext = highlightBuilder.build(mockShardContext);
+
+                // Create a HighlightPhase with highlighter defined above
+                HighlightPhase highlightPhase = new HighlightPhase(Collections.singletonMap("unified", new UnifiedHighlighter()));
+
+                // create a fetch context to be used by HighlightPhase processor
+                FetchContext fetchContext = mock(FetchContext.class);
+                when(fetchContext.mapperService()).thenReturn(mockShardContext.getMapperService());
+                when(fetchContext.getQueryShardContext()).thenReturn(mockShardContext);
+                when(fetchContext.getIndexSettings()).thenReturn(indexService.getIndexSettings());
+                when(fetchContext.searcher()).thenReturn(
+                    new ContextIndexSearcher(
+                        searcher.getIndexReader(),
+                        searcher.getSimilarity(),
+                        searcher.getQueryCache(),
+                        searcher.getQueryCachingPolicy(),
+                        true,
+                        searcher.getExecutor(),
+                        null
+                    )
+                );
+
+                // The query used by FetchSubPhaseProcessor to highlight is a term query on DERIVED_FIELD_1
+                FetchSubPhaseProcessor subPhaseProcessor = highlightPhase.getProcessor(
+                    fetchContext,
+                    searchHighlightContext,
+                    new TermQuery(new Term(DERIVED_FIELD_1, "some_text_1"))
+                );
+
+                // Create a search hit using the derived fields fetched above in fetch phase
+                SearchHit searchHit = new SearchHit(docId, "0", null, fields, null);
+
+                // Create a HitContext of search hit
+                FetchSubPhase.HitContext hitContext = new FetchSubPhase.HitContext(
+                    searchHit,
+                    context,
+                    docId,
+                    mockShardContext.lookup().source()
+                );
+                hitContext.sourceLookup().loadSourceIfNeeded();
+                // process the HitContext using the highlightPhase subPhaseProcessor
+                subPhaseProcessor.process(hitContext);
+
+                // Validate that 1 highlight field is present
+                assertEquals(hitContext.hit().getHighlightFields().size(), 1);
+            }
+        }
+    }
+
+    public static Map<String, DocumentField> fetchFields(
+        QueryShardContext queryShardContext,
+        LeafReaderContext context,
+        String fieldPattern
+    ) throws IOException {
+        List<FieldAndFormat> fields = List.of(new FieldAndFormat(fieldPattern, null));
+        FieldFetcher fieldFetcher = FieldFetcher.create(queryShardContext, queryShardContext.lookup(), fields);
+        fieldFetcher.setNextReader(context);
+        return fieldFetcher.fetch(queryShardContext.lookup().source(), Set.of());
+    }
+
+    private static QueryShardContext createQueryShardContext(MapperService mapperService, IndexSearcher indexSearcher) {
+        Settings settings = Settings.builder()
+            .put("index.version.created", Version.CURRENT)
+            .put("index.number_of_shards", 1)
+            .put("index.number_of_replicas", 0)
+            .put(IndexMetadata.SETTING_INDEX_UUID, "uuid")
+            .build();
+        IndexMetadata indexMetadata = new IndexMetadata.Builder("index").settings(settings).build();
+        IndexSettings indexSettings = new IndexSettings(indexMetadata, settings);
+
+        ScriptService scriptService = getScriptService();
+        return new QueryShardContext(
+            0,
+            indexSettings,
+            null,
+            null,
+            null,
+            mapperService,
+            null,
+            scriptService,
+            null,
+            null,
+            null,
+            indexSearcher,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+    }
+
+    private static ScriptService getScriptService() {
+        final MockScriptEngine engine = new MockScriptEngine(
+            MockScriptEngine.NAME,
+            Map.of(
+                DERIVED_FIELD_SCRIPT_1,
+                (script) -> ((String) ((Map<String, Object>) script.get("_source")).get("field1")).replace(" ", "_"),
+                DERIVED_FIELD_SCRIPT_2,
+                (script) -> ((String) ((Map<String, Object>) script.get("_source")).get("field2")).replace(" ", "_")
+            ),
+            Collections.emptyMap()
+        );
+        final Map<String, ScriptEngine> engines = singletonMap(engine.getType(), engine);
+        ScriptService scriptService = new ScriptService(Settings.EMPTY, engines, ScriptModule.CORE_CONTEXTS);
+        return scriptService;
+    }
+
+    private DerivedFieldType createDerivedFieldType(String name, String type, String script) {
+        Mapper.BuilderContext context = mock(Mapper.BuilderContext.class);
+        when(context.path()).thenReturn(new ContentPath());
+        return new DerivedFieldType(
+            new DerivedField(name, type, new Script(ScriptType.INLINE, "mockscript", script, emptyMap())),
+            DerivedFieldSupportedTypes.getFieldMapperFromType(type, name, context),
+            DerivedFieldSupportedTypes.getIndexableFieldGeneratorType(type, name)
+        );
+    }
+}

--- a/test/framework/src/main/java/org/opensearch/script/MockScriptEngine.java
+++ b/test/framework/src/main/java/org/opensearch/script/MockScriptEngine.java
@@ -35,6 +35,7 @@ package org.opensearch.script;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Scorable;
+import org.opensearch.common.collect.Tuple;
 import org.opensearch.index.query.IntervalFilterScript;
 import org.opensearch.index.similarity.ScriptedSimilarity.Doc;
 import org.opensearch.index.similarity.ScriptedSimilarity.Field;
@@ -46,6 +47,7 @@ import org.opensearch.search.lookup.SearchLookup;
 import org.opensearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -283,22 +285,39 @@ public class MockScriptEngine implements ScriptEngine {
             IntervalFilterScript.Factory factory = mockCompiled::createIntervalFilterScript;
             return context.factoryClazz.cast(factory);
         } else if (context.instanceClazz.equals(DerivedFieldScript.class)) {
-            DerivedFieldScript.Factory factory = (derivedFieldParams, lookup) -> ctx -> new DerivedFieldScript(
-                derivedFieldParams,
-                lookup,
-                ctx
-            ) {
+            DerivedFieldScript.Factory factory = new DerivedFieldScript.Factory() {
                 @Override
-                public void setDocument(int docid) {}
+                public boolean isResultDeterministic() {
+                    return true;
+                }
 
                 @Override
-                public void execute() {
-                    Map<String, Object> vars = new HashMap<>(derivedFieldParams);
-                    SourceLookup sourceLookup = lookup.source();
-                    vars.put("params", derivedFieldParams);
-                    vars.put("_source", sourceLookup.loadSourceIfNeeded());
-                    // currently supports adding one value, can be extended to emit multiple values too.
-                    addEmittedValue(script.apply(vars));
+                public DerivedFieldScript.LeafFactory newFactory(Map<String, Object> derivedFieldParams, SearchLookup lookup) {
+                    return ctx -> new DerivedFieldScript(derivedFieldParams, lookup, ctx) {
+                        @Override
+                        public void execute() {
+                            Map<String, Object> vars = new HashMap<>(derivedFieldParams);
+                            SourceLookup sourceLookup = lookup.source();
+                            vars.put("params", derivedFieldParams);
+                            vars.put("_source", sourceLookup.loadSourceIfNeeded());
+                            Object result = script.apply(vars);
+                            if (result instanceof ArrayList) {
+                                for (Object v : ((ArrayList<?>) result)) {
+                                    if (v instanceof HashMap) {
+                                        addEmittedValue(new Tuple(((HashMap<?, ?>) v).get("lat"), ((HashMap<?, ?>) v).get("lon")));
+                                    } else {
+                                        addEmittedValue(v);
+                                    }
+                                }
+                            } else {
+                                if (result instanceof HashMap) {
+                                    addEmittedValue(new Tuple(((HashMap<?, ?>) result).get("lat"), ((HashMap<?, ?>) result).get("lon")));
+                                } else {
+                                    addEmittedValue(result);
+                                }
+                            }
+                        }
+                    };
                 }
             };
             return context.factoryClazz.cast(factory);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Adds following capability to derived fields - 

1. Define derived fields in search request - 
There are 2 ways to add derived fields to search path - a) Programatically using a rest client (which makes use of `DerivedField` class and adding to it `SearchSourceBuilder` ) b) through http request, which relies on document parsing. Thus you will see logic for both in `SearchSourceBuilder`. Given, we don't have access to mapper service in these classes, its not possible to create a derived field mapper and type in `SearchSourceBuilder`, thus they are used and are created in `SearchService` and injected into `QueryShardContext`. Once available in `QueryShardContext`, these derived fields mappers from search request can be used in different phases of the query. 
2. Support in fetch phase.
3. Support highlighting on derived fields.
4. Fixes the bug for `geo_point` related to geo shape query execution failure. 
5. Add integration tests for all supported types for both single and multi-valued case. 
6. Code refactor such as `DerivedFieldValueFetcher` now exposes 2 methods to fetch value - valueForDisplay (used by fetch and highlight phase) and value used by lucene memory index for querying purpose. 

This PR is on top of - https://github.com/opensearch-project/OpenSearch/pull/12746, https://github.com/opensearch-project/OpenSearch/pull/12808, https://github.com/opensearch-project/OpenSearch/pull/12569, https://github.com/opensearch-project/OpenSearch/pull/12837

TODO
- add support in inner hits

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/12508
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [ ] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
