### PR TITLE
Added missed API visibility annotations for public / experimental APIs

### DIFF
--- a/libs/core/src/main/java/org/opensearch/OpenSearchException.java
+++ b/libs/core/src/main/java/org/opensearch/OpenSearchException.java
@@ -33,6 +33,7 @@ package org.opensearch;
 
 import org.opensearch.common.CheckedFunction;
 import org.opensearch.common.Nullable;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.core.ParseField;
 import org.opensearch.core.common.Strings;
@@ -69,8 +70,9 @@ import static org.opensearch.core.xcontent.XContentParserUtils.ensureFieldName;
 /**
  * A core library base class for all opensearch exceptions.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public class OpenSearchException extends RuntimeException implements Writeable, ToXContentFragment {
 
     protected static final Version UNKNOWN_VERSION_ADDED = Version.fromId(0);

--- a/libs/core/src/main/java/org/opensearch/core/common/breaker/CircuitBreaker.java
+++ b/libs/core/src/main/java/org/opensearch/core/common/breaker/CircuitBreaker.java
@@ -32,14 +32,17 @@
 
 package org.opensearch.core.common.breaker;
 
+import org.opensearch.common.annotation.PublicApi;
+
 import java.util.Locale;
 
 /**
  * Interface for an object that can be incremented, breaking after some
  * configured limit has been reached.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public interface CircuitBreaker {
 
     /**
@@ -72,8 +75,10 @@ public interface CircuitBreaker {
     /**
      * The type of breaker
      * can be {@link #MEMORY}, {@link #PARENT}, or {@link #NOOP}
-     * @opensearch.internal
+     *
+     * @opensearch.api
      */
+    @PublicApi(since = "1.0.0")
     enum Type {
         /** A regular or ChildMemoryCircuitBreaker */
         MEMORY,

--- a/libs/core/src/main/java/org/opensearch/core/common/transport/BoundTransportAddress.java
+++ b/libs/core/src/main/java/org/opensearch/core/common/transport/BoundTransportAddress.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.core.common.transport;
 
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.network.InetAddresses;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -44,8 +45,9 @@ import java.io.IOException;
  * the addresses the transport is bound to, and the other is the published one that represents the address clients
  * should communicate on.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public class BoundTransportAddress implements Writeable {
 
     private TransportAddress[] boundAddresses;

--- a/libs/core/src/main/java/org/opensearch/core/transport/TransportResponse.java
+++ b/libs/core/src/main/java/org/opensearch/core/transport/TransportResponse.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.core.transport;
 
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 
@@ -40,8 +41,9 @@ import java.io.IOException;
 /**
  * Response over the transport interface
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public abstract class TransportResponse extends TransportMessage {
 
     /**

--- a/libs/core/src/main/java/org/opensearch/semver/SemverRange.java
+++ b/libs/core/src/main/java/org/opensearch/semver/SemverRange.java
@@ -10,6 +10,7 @@ package org.opensearch.semver;
 
 import org.opensearch.Version;
 import org.opensearch.common.Nullable;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.xcontent.ToXContentFragment;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.semver.expr.Caret;
@@ -31,7 +32,10 @@ import static java.util.Arrays.stream;
  *     <li>'~' Allows for patch version variability starting from the range version. For example, ~1.2.3 range would match versions greater than or equal to 1.2.3 but less than 1.3.0</li>
  *     <li>'^' Allows for patch and minor version variability starting from the range version. For example, ^1.2.3 range would match versions greater than or equal to 1.2.3 but less than 2.0.0</li>
  * </ul>
+ *
+ * @opensearch.api
  */
+@PublicApi(since = "2.13.0")
 public class SemverRange implements ToXContentFragment {
 
     private final Version rangeVersion;

--- a/server/src/main/java/org/opensearch/action/support/clustermanager/ClusterManagerNodeRequest.java
+++ b/server/src/main/java/org/opensearch/action/support/clustermanager/ClusterManagerNodeRequest.java
@@ -33,6 +33,7 @@
 package org.opensearch.action.support.clustermanager;
 
 import org.opensearch.action.ActionRequest;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -42,8 +43,9 @@ import java.io.IOException;
 /**
  * A based request for cluster-manager based operation.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public abstract class ClusterManagerNodeRequest<Request extends ClusterManagerNodeRequest<Request>> extends ActionRequest {
 
     public static final TimeValue DEFAULT_CLUSTER_MANAGER_NODE_TIMEOUT = TimeValue.timeValueSeconds(30);

--- a/server/src/main/java/org/opensearch/common/cache/RemovalListener.java
+++ b/server/src/main/java/org/opensearch/common/cache/RemovalListener.java
@@ -32,11 +32,14 @@
 
 package org.opensearch.common.cache;
 
+import org.opensearch.common.annotation.ExperimentalApi;
+
 /**
  * Listener for removing an element from the cache
  *
- * @opensearch.internal
+ * @opensearch.experimental
  */
+@ExperimentalApi
 @FunctionalInterface
 public interface RemovalListener<K, V> {
     void onRemoval(RemovalNotification<K, V> notification);

--- a/server/src/main/java/org/opensearch/common/cache/policy/CachedQueryResult.java
+++ b/server/src/main/java/org/opensearch/common/cache/policy/CachedQueryResult.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.common.cache.policy;
 
+import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.common.io.stream.NamedWriteableAwareStreamInput;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
@@ -62,7 +63,10 @@ public class CachedQueryResult {
     /**
      * A class containing information needed for all cache policies
      *  to decide whether to admit a given value.
+     *
+     *  @opensearch.experimental
      */
+    @ExperimentalApi
     public static class PolicyValues implements Writeable {
         final long tookTimeNanos;
         // More values can be added here as they're needed for future policies

--- a/server/src/main/java/org/opensearch/common/cache/serializer/Serializer.java
+++ b/server/src/main/java/org/opensearch/common/cache/serializer/Serializer.java
@@ -8,10 +8,15 @@
 
 package org.opensearch.common.cache.serializer;
 
+import org.opensearch.common.annotation.ExperimentalApi;
+
 /**
  * Defines an interface for serializers, to be used by pluggable caches.
  * T is the class of the original object, and U is the serialized class.
+ *
+ * @opensearch.experimental
  */
+@ExperimentalApi
 public interface Serializer<T, U> {
     /**
      * Serializes an object.

--- a/server/src/main/java/org/opensearch/common/lucene/index/OpenSearchDirectoryReader.java
+++ b/server/src/main/java/org/opensearch/common/lucene/index/OpenSearchDirectoryReader.java
@@ -84,8 +84,10 @@ public final class OpenSearchDirectoryReader extends FilterDirectoryReader {
 
     /**
      * Wraps existing IndexReader cache helper which internally provides a way to wrap CacheKey.
-     * @opensearch.internal
+     *
+     * @opensearch.api
      */
+    @PublicApi(since = "2.13.0")
     public class DelegatingCacheHelper implements CacheHelper {
         private final CacheHelper cacheHelper;
         private final DelegatingCacheKey serializableCacheKey;
@@ -113,7 +115,10 @@ public final class OpenSearchDirectoryReader extends FilterDirectoryReader {
     /**
      *  Wraps internal IndexReader.CacheKey and attaches a uniqueId to it which can be eventually be used instead of
      *  object itself for serialization purposes.
+     *
+     *  @opensearch.api
      */
+    @PublicApi(since = "2.13.0")
     public class DelegatingCacheKey {
         private final CacheKey cacheKey;
         private final String uniqueId;

--- a/server/src/main/java/org/opensearch/common/metrics/MeanMetric.java
+++ b/server/src/main/java/org/opensearch/common/metrics/MeanMetric.java
@@ -32,13 +32,16 @@
 
 package org.opensearch.common.metrics;
 
+import org.opensearch.common.annotation.PublicApi;
+
 import java.util.concurrent.atomic.LongAdder;
 
 /**
  * An average metric for tracking.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public class MeanMetric implements Metric {
 
     private final LongAdder counter = new LongAdder();

--- a/server/src/main/java/org/opensearch/http/HttpInfo.java
+++ b/server/src/main/java/org/opensearch/http/HttpInfo.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.http;
 
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.network.InetAddresses;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -47,8 +48,9 @@ import java.io.IOException;
 /**
  * Information about an http connection
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public class HttpInfo implements ReportingService.Info {
 
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(HttpInfo.class);

--- a/server/src/main/java/org/opensearch/http/HttpServerTransport.java
+++ b/server/src/main/java/org/opensearch/http/HttpServerTransport.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.http;
 
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.lifecycle.LifecycleComponent;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.common.transport.BoundTransportAddress;
@@ -42,8 +43,9 @@ import org.opensearch.rest.RestRequest;
 /**
  * HTTP Transport server
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public interface HttpServerTransport extends LifecycleComponent, ReportingService<HttpInfo> {
 
     String HTTP_SERVER_WORKER_THREAD_NAME_PREFIX = "http_server_worker";

--- a/server/src/main/java/org/opensearch/http/HttpStats.java
+++ b/server/src/main/java/org/opensearch/http/HttpStats.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.http;
 
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
@@ -43,8 +44,9 @@ import java.io.IOException;
 /**
  * Stats for HTTP connections
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public class HttpStats implements Writeable, ToXContentFragment {
 
     private final long serverOpen;

--- a/server/src/main/java/org/opensearch/index/codec/fuzzy/LongArrayBackedBitSet.java
+++ b/server/src/main/java/org/opensearch/index/codec/fuzzy/LongArrayBackedBitSet.java
@@ -39,7 +39,7 @@ class LongArrayBackedBitSet implements Accountable, Closeable {
     /**
      * Constructor which uses Lucene's IndexInput to read the bitset into a read-only buffer.
      * @param in IndexInput containing the serialized bitset.
-     * @throws IOException
+     * @throws IOException I/O exception
      */
     LongArrayBackedBitSet(IndexInput in) throws IOException {
         underlyingArrayLength = in.readLong();

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryFactory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryFactory.java
@@ -9,6 +9,7 @@
 package org.opensearch.index.store;
 
 import org.apache.lucene.store.Directory;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.IndexSettings;
@@ -28,8 +29,9 @@ import java.util.function.Supplier;
 /**
  * Factory for a remote store directory
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "2.3.0")
 public class RemoteSegmentStoreDirectoryFactory implements IndexStorePlugin.DirectoryFactory {
     private static final String SEGMENTS = "segments";
 

--- a/server/src/main/java/org/opensearch/rest/BaseRestHandler.java
+++ b/server/src/main/java/org/opensearch/rest/BaseRestHandler.java
@@ -40,6 +40,7 @@ import org.opensearch.OpenSearchParseException;
 import org.opensearch.action.support.clustermanager.ClusterManagerNodeRequest;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.common.CheckedConsumer;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.settings.Setting;
@@ -73,6 +74,7 @@ import java.util.stream.Collectors;
  *
  * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public abstract class BaseRestHandler implements RestHandler {
 
     public static final Setting<Boolean> MULTI_ALLOW_EXPLICIT_INDEX = Setting.boolSetting(
@@ -195,8 +197,11 @@ public abstract class BaseRestHandler implements RestHandler {
     /**
      * REST requests are handled by preparing a channel consumer that represents the execution of
      * the request against a channel.
+     *
+     * @opensearch.api
      */
     @FunctionalInterface
+    @PublicApi(since = "1.0.0")
     protected interface RestChannelConsumer extends CheckedConsumer<RestChannel, Exception> {}
 
     /**

--- a/server/src/main/java/org/opensearch/rest/RestChannel.java
+++ b/server/src/main/java/org/opensearch/rest/RestChannel.java
@@ -33,6 +33,7 @@
 package org.opensearch.rest;
 
 import org.opensearch.common.Nullable;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.xcontent.MediaType;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -44,6 +45,7 @@ import java.io.IOException;
  *
  * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public interface RestChannel {
 
     XContentBuilder newBuilder() throws IOException;

--- a/server/src/main/java/org/opensearch/rest/RestHandler.java
+++ b/server/src/main/java/org/opensearch/rest/RestHandler.java
@@ -33,6 +33,7 @@
 package org.opensearch.rest;
 
 import org.opensearch.client.node.NodeClient;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.xcontent.XContent;
 import org.opensearch.rest.RestRequest.Method;
 
@@ -180,8 +181,9 @@ public interface RestHandler {
     /**
      * Route for the request.
      *
-     * @opensearch.internal
+     * @opensearch.api
      */
+    @PublicApi(since = "1.0.0")
     class Route {
 
         protected final String path;

--- a/server/src/main/java/org/opensearch/rest/RestResponse.java
+++ b/server/src/main/java/org/opensearch/rest/RestResponse.java
@@ -33,6 +33,7 @@
 package org.opensearch.rest;
 
 import org.opensearch.OpenSearchException;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.rest.RestStatus;
@@ -49,6 +50,7 @@ import java.util.Set;
  *
  * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public abstract class RestResponse {
 
     private Map<String, List<String>> customHeaders;

--- a/server/src/main/java/org/opensearch/transport/ConnectionProfile.java
+++ b/server/src/main/java/org/opensearch/transport/ConnectionProfile.java
@@ -33,6 +33,7 @@ package org.opensearch.transport;
 
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.Nullable;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 
@@ -49,8 +50,9 @@ import java.util.concurrent.atomic.AtomicInteger;
  * A connection profile describes how many connection are established to specific node for each of the available request types.
  * ({@link org.opensearch.transport.TransportRequestOptions.Type}). This allows to tailor a connection towards a specific usage.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public final class ConnectionProfile {
 
     /**

--- a/server/src/main/java/org/opensearch/transport/Header.java
+++ b/server/src/main/java/org/opensearch/transport/Header.java
@@ -33,6 +33,7 @@
 package org.opensearch.transport;
 
 import org.opensearch.Version;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -47,8 +48,9 @@ import java.util.TreeSet;
 /**
  * Transport Header
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public class Header {
 
     private static final String RESPONSE_NAME = "NO_ACTION_NAME_FOR_RESPONSES";

--- a/server/src/main/java/org/opensearch/transport/InboundMessage.java
+++ b/server/src/main/java/org/opensearch/transport/InboundMessage.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.transport;
 
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.bytes.ReleasableBytesReference;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.lease.Releasables;
@@ -43,8 +44,9 @@ import java.io.IOException;
 /**
  * Inbound data as a message
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public class InboundMessage implements Releasable {
 
     private final Header header;

--- a/server/src/main/java/org/opensearch/transport/RequestHandlerRegistry.java
+++ b/server/src/main/java/org/opensearch/transport/RequestHandlerRegistry.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.transport;
 
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.lease.Releasables;
 import org.opensearch.common.util.concurrent.ThreadContext;
@@ -47,8 +48,9 @@ import java.io.IOException;
 /**
  * Registry for OpenSearch RequestHandlers
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public final class RequestHandlerRegistry<Request extends TransportRequest> {
 
     private final String action;

--- a/server/src/main/java/org/opensearch/transport/StatsTracker.java
+++ b/server/src/main/java/org/opensearch/transport/StatsTracker.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.transport;
 
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.metrics.MeanMetric;
 
 import java.util.concurrent.atomic.LongAdder;
@@ -39,8 +40,9 @@ import java.util.concurrent.atomic.LongAdder;
 /**
  * Tracks transport statistics
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public final class StatsTracker {
 
     private final LongAdder bytesRead = new LongAdder();

--- a/server/src/main/java/org/opensearch/transport/TcpChannel.java
+++ b/server/src/main/java/org/opensearch/transport/TcpChannel.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.transport;
 
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.network.CloseableChannel;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
@@ -45,8 +46,9 @@ import java.util.Optional;
  * abstraction used by the {@link TcpTransport} and {@link TransportService}. All tcp transport
  * implementations must return channels that adhere to the required method contracts.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public interface TcpChannel extends CloseableChannel {
 
     /**
@@ -114,8 +116,9 @@ public interface TcpChannel extends CloseableChannel {
     /**
      * Channel statistics
      *
-     * @opensearch.internal
+     * @opensearch.api
      */
+    @PublicApi(since = "1.0.0")
     class ChannelStats {
 
         private volatile long lastAccessedTime;

--- a/server/src/main/java/org/opensearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/opensearch/transport/TcpTransport.java
@@ -39,6 +39,7 @@ import org.opensearch.Version;
 import org.opensearch.action.support.ThreadedActionListener;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.Booleans;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.lifecycle.AbstractLifecycleComponent;
 import org.opensearch.common.lifecycle.Lifecycle;
 import org.opensearch.common.metrics.MeanMetric;
@@ -111,8 +112,9 @@ import static org.opensearch.common.util.concurrent.ConcurrentCollections.newCon
 /**
  * The TCP Transport layer
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public abstract class TcpTransport extends AbstractLifecycleComponent implements Transport {
     private static final Logger logger = LogManager.getLogger(TcpTransport.class);
 
@@ -966,7 +968,10 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
 
     /**
      * Representation of a transport profile settings for a {@code transport.profiles.$profilename.*}
+     *
+     * @opensearch.api
      */
+    @PublicApi(since = "1.0.0")
     public static final class ProfileSettings {
         public final String profileName;
         public final boolean tcpNoDelay;

--- a/server/src/main/java/org/opensearch/transport/Transport.java
+++ b/server/src/main/java/org/opensearch/transport/Transport.java
@@ -58,8 +58,9 @@ import java.util.function.Predicate;
 /**
  * OpenSearch Transport Interface
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public interface Transport extends LifecycleComponent {
 
     /**
@@ -166,7 +167,10 @@ public interface Transport extends LifecycleComponent {
     /**
      * This class represents a response context that encapsulates the actual response handler, the action and the connection it was
      * executed on.
+     *
+     * @opensearch.api
      */
+    @PublicApi(since = "1.0.0")
     final class ResponseContext<T extends TransportResponse> {
 
         private final TransportResponseHandler<T> handler;
@@ -196,7 +200,10 @@ public interface Transport extends LifecycleComponent {
 
     /**
      * This class is a registry that allows
+     *
+     * @opensearch.api
      */
+    @PublicApi(since = "1.0.0")
     final class ResponseHandlers {
         private final ConcurrentMapLong<ResponseContext<? extends TransportResponse>> handlers = ConcurrentCollections
             .newConcurrentMapLongWithAggressiveConcurrency();
@@ -276,8 +283,9 @@ public interface Transport extends LifecycleComponent {
     /**
      * Request handler implementations
      *
-     * @opensearch.internal
+     * @opensearch.api
      */
+    @PublicApi(since = "1.0.0")
     final class RequestHandlers {
 
         private volatile Map<String, RequestHandlerRegistry<? extends TransportRequest>> requestHandlers = Collections.emptyMap();

--- a/server/src/main/java/org/opensearch/transport/TransportChannel.java
+++ b/server/src/main/java/org/opensearch/transport/TransportChannel.java
@@ -36,6 +36,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.Version;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.transport.TransportResponse;
 
 import java.io.IOException;
@@ -46,6 +47,7 @@ import java.util.Optional;
  *
  * @opensearch.internal
  */
+@PublicApi(since = "1.0.0")
 public interface TransportChannel {
 
     Logger logger = LogManager.getLogger(TransportChannel.class);

--- a/server/src/main/java/org/opensearch/transport/TransportMessageListener.java
+++ b/server/src/main/java/org/opensearch/transport/TransportMessageListener.java
@@ -32,13 +32,15 @@
 package org.opensearch.transport;
 
 import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.transport.TransportResponse;
 
 /**
  * Listens for transport messages
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public interface TransportMessageListener {
 
     TransportMessageListener NOOP_LISTENER = new TransportMessageListener() {

--- a/server/src/main/java/org/opensearch/transport/TransportRequestHandler.java
+++ b/server/src/main/java/org/opensearch/transport/TransportRequestHandler.java
@@ -32,13 +32,15 @@
 
 package org.opensearch.transport;
 
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.tasks.Task;
 
 /**
  * Handles transport requests
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public interface TransportRequestHandler<T extends TransportRequest> {
 
     void messageReceived(T request, TransportChannel channel, Task task) throws Exception;

--- a/server/src/main/java/org/opensearch/transport/TransportResponseHandler.java
+++ b/server/src/main/java/org/opensearch/transport/TransportResponseHandler.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.transport;
 
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.core.transport.TransportResponse;
@@ -42,8 +43,9 @@ import java.util.function.Function;
 /**
  * Handles transport responses
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public interface TransportResponseHandler<T extends TransportResponse> extends Writeable.Reader<T> {
 
     void handleResponse(T response);

--- a/server/src/main/java/org/opensearch/transport/TransportStats.java
+++ b/server/src/main/java/org/opensearch/transport/TransportStats.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.transport;
 
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
@@ -44,8 +45,9 @@ import java.io.IOException;
 /**
  * Stats for transport activity
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "1.0.0")
 public class TransportStats implements Writeable, ToXContentFragment {
 
     private final long serverOpen;


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Added missed API visibility annotations for public / experimental APIs

### Related Issues
Fixing warnings from OpenSearch API annotation processor:

```
Note: The element org.opensearch.http.HttpServerTransport is part of the public APIs but is not marked as @PublicApi, @ExperimentalApi or @DeprecatedApi (referenced by org.opensearch.plugins.SecureTransportSettingsProvider)                                                                              
Note: The element org.opensearch.transport.TcpTransport is part of the public APIs but is not marked as @PublicApi, @ExperimentalApi or @DeprecatedApi (referenced by org.opensearch.plugins.SecureTransportSettingsProvider)   
Note: The element org.opensearch.semver.SemverRange is part of the public APIs but is not marked as @PublicApi, @ExperimentalApi or @DeprecatedApi (referenced by org.opensearch.plugins.PluginInfo)                                   
Note: The element org.opensearch.rest.RestHandler.Route is part of the public APIs but is not marked as @PublicApi, @ExperimentalApi or @DeprecatedApi (referenced by org.opensearch.rest.action.admin.indices.RestViewAction.CreateViewHandler) 
Note: The element org.opensearch.rest.BaseRestHandler.RestChannelConsumer is part of the public APIs but is not marked as @PublicApi, @ExperimentalApi or @DeprecatedApi (referenced by org.opensearch.rest.action.admin.indices.RestViewAction.SearchViewHandler) 
Note: The element org.opensearch.common.cache.RemovalListener is part of the public APIs but is not marked as @PublicApi, @ExperimentalApi or @DeprecatedApi (referenced by org.opensearch.common.cache.store.config.CacheConfig) 
Note: The element org.opensearch.common.cache.serializer.Serializer is part of the public APIs but is not marked as @PublicApi, @ExperimentalApi or @DeprecatedApi (referenced by org.opensearch.common.cache.store.config.CacheConfig) 
Note: The element org.opensearch.common.cache.policy.CachedQueryResult.PolicyValues is part of the public APIs but is not marked as @PublicApi, @ExperimentalApi or @DeprecatedApi (referenced by org.opensearch.common.cache.store.config.CacheConfig) 
Note: The element org.opensearch.common.lucene.index.OpenSearchDirectoryReader.DelegatingCacheHelper is part of the public APIs but is not marked as @PublicApi, @ExperimentalApi or @DeprecatedApi (referenced by org.opensearch.common.lucene.index.OpenSearchDirectoryReader) 
Note: The element org.opensearch.index.store.RemoteSegmentStoreDirectoryFactory is part of the public APIs but is not marked as @PublicApi, @ExperimentalApi or @DeprecatedApi (referenced by org.opensearch.index.store.RemoteSegmentStoreDirectory)
```

<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
