### PR TITLE
Replace configureEach with all for publication iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Remote reindex: Add support for configurable retry mechanism ([#12561](https://github.com/opensearch-project/OpenSearch/pull/12561))
 - [Admission Control] Integrate IO Usage Tracker to the Resource Usage Collector Service and Emit IO Usage Stats ([#11880](https://github.com/opensearch-project/OpenSearch/pull/11880))
 - Tracing for deep search path ([#12103](https://github.com/opensearch-project/OpenSearch/pull/12103))
-- Add explicit dependency to validatePom and generatePom tasks ([#12103](https://github.com/opensearch-project/OpenSearch/pull/12807))
+- Add explicit dependency to validatePom and generatePom tasks ([#12807](https://github.com/opensearch-project/OpenSearch/pull/12807))
+- Replace configureEach with all for publication iteration ([#12876](https://github.com/opensearch-project/OpenSearch/pull/12876))
 
 ### Dependencies
 - Bump `log4j-core` from 2.18.0 to 2.19.0

--- a/buildSrc/src/main/java/org/opensearch/gradle/precommit/PomValidationPrecommitPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/precommit/PomValidationPrecommitPlugin.java
@@ -48,7 +48,7 @@ public class PomValidationPrecommitPlugin extends PrecommitPlugin {
     public TaskProvider<? extends Task> createTask(Project project) {
         TaskProvider<Task> validatePom = project.getTasks().register("validatePom");
         PublishingExtension publishing = project.getExtensions().getByType(PublishingExtension.class);
-        publishing.getPublications().configureEach(publication -> {
+        publishing.getPublications().all(publication -> {
             String publicationName = Util.capitalize(publication.getName());
             TaskProvider<PomValidationTask> validateTask = project.getTasks()
                 .register("validate" + publicationName + "Pom", PomValidationTask.class);
@@ -59,7 +59,7 @@ public class PomValidationPrecommitPlugin extends PrecommitPlugin {
             validateTask.configure(task -> {
                 task.dependsOn(generateMavenPom);
                 task.getPomFile().fileProvider(generateMavenPom.map(GenerateMavenPom::getDestination));
-                publishing.getPublications().configureEach(publicationForPomGen -> {
+                publishing.getPublications().all(publicationForPomGen -> {
                     task.mustRunAfter(
                         project.getTasks()
                             .withType(GenerateMavenPom.class)


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Change the publication iteration to all to resolve incompatibility on security plugin. 

I tested locally and it built successfully. 

```
☁  ~/workplace/security[main] ./gradlew assemble
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 8.5
  OS Info               : Mac OS X 14.3 (x86_64)
  JDK Version           : 21 (Oracle JDK)
  JAVA_HOME             : /Library/Java/JavaVirtualMachines/jdk-21.jdk/Contents/Home
  Random Testing Seed   : C82B0FF391C689CE
  In FIPS 140 mode      : false
=======================================

> Task :compileJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.5/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 44s
11 actionable tasks: 11 executed
```
and the Pom validation tasks are executed successfully as well.
```
☁  ~/workplace/security[main] ./gradlew validatePom --info
Initialized native services in: /Users/zelinhao/.gradle/native
Initialized jansi services in: /Users/zelinhao/.gradle/native
Received JVM installation metadata from '/Library/Java/JavaVirtualMachines/jdk-21.jdk/Contents/Home': {JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-21.jdk/Contents/Home, JAVA_VERSION=21.0.2, JAVA_VENDOR=Oracle Corporation, RUNTIME_NAME=Java(TM) SE Runtime Environment, RUNTIME_VERSION=21.0.2+13-LTS-58, VM_NAME=Java HotSpot(TM) 64-Bit Server VM, VM_VERSION=21.0.2+13-LTS-58, VM_VENDOR=Oracle Corporation, OS_ARCH=x86_64}
The client will now receive all logging from the daemon (pid: 64282). The daemon log file: /Users/zelinhao/.gradle/daemon/8.5/daemon-64282.out.log
Starting 3rd build in daemon [uptime: 13 mins 49.216 secs, performance: 99%, GC rate: 0.00/s, heap usage: 0% of 512 MiB, non-heap usage: 26% of 384 MiB]
Using 12 worker leases.
Now considering [/Users/zelinhao/workplace/security] as hierarchies to watch
Watching the file system is configured to be enabled if available
File system watching is active
Starting Build
Settings evaluated using settings file '/Users/zelinhao/workplace/security/settings.gradle'.
Projects loaded. Root project using build file '/Users/zelinhao/workplace/security/build.gradle'.
Included projects: [root project 'opensearch-security']

> Configure project :
Evaluating root project 'opensearch-security' using build file '/Users/zelinhao/workplace/security/build.gradle'.
Invalidating in-memory cache of /Users/zelinhao/.gradle/caches/journal-1/file-access.bin
------------------------------------------------------------------------
Detecting the operating system and CPU architecture
------------------------------------------------------------------------
os.detected.name=osx
os.detected.arch=x86_64
os.detected.bitness=64
os.detected.version=14.3
os.detected.version.major=14
os.detected.version.minor=3
os.detected.classifier=osx-x86_64
All projects evaluated.
Task name matched 'validatePom'
Selected primary task 'validatePom' from project :
Tasks to be executed: [task ':generatePomFileForMavenPublication', task ':generatePomFileForNebulaPublication', task ':generatePomFileForPluginZipPublication', task ':validateMavenPom', task ':validateNebulaPom', task ':validatePluginZipPom', task ':validatePom']
Tasks that were excluded: []
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 8.5
  OS Info               : Mac OS X 14.3 (x86_64)
  JDK Version           : 21 (Oracle JDK)
  JAVA_HOME             : /Library/Java/JavaVirtualMachines/jdk-21.jdk/Contents/Home
  Random Testing Seed   : 7B7B1C62ACD616C6
  In FIPS 140 mode      : false
=======================================
Resolve mutations for :generatePomFileForMavenPublication (Thread[#310,Execution worker,5,main]) started.
:generatePomFileForMavenPublication (Thread[#314,Execution worker Thread 5,5,main]) started.

> Task :generatePomFileForMavenPublication
Caching disabled for task ':generatePomFileForMavenPublication' because:
  Build cache is disabled
Task ':generatePomFileForMavenPublication' is not up-to-date because:
  Task is untracked because: Gradle doesn't understand the data structures used to configure this task
Resolve mutations for :generatePomFileForNebulaPublication (Thread[#314,Execution worker Thread 5,5,main]) started.
:generatePomFileForNebulaPublication (Thread[#314,Execution worker Thread 5,5,main]) started.

> Task :generatePomFileForNebulaPublication
Caching disabled for task ':generatePomFileForNebulaPublication' because:
  Build cache is disabled
Task ':generatePomFileForNebulaPublication' is not up-to-date because:
  Task is untracked because: Gradle doesn't understand the data structures used to configure this task
Resolve mutations for :generatePomFileForPluginZipPublication (Thread[#314,Execution worker Thread 5,5,main]) started.
:generatePomFileForPluginZipPublication (Thread[#314,Execution worker Thread 5,5,main]) started.

> Task :generatePomFileForPluginZipPublication
Caching disabled for task ':generatePomFileForPluginZipPublication' because:
  Build cache is disabled
Task ':generatePomFileForPluginZipPublication' is not up-to-date because:
  Task is untracked because: Gradle doesn't understand the data structures used to configure this task
Resolve mutations for :validateMavenPom (Thread[#309,included builds,5,main]) started.
:validateMavenPom (Thread[#309,included builds,5,main]) started.

> Task :validateMavenPom
Caching disabled for task ':validateMavenPom' because:
  Build cache is disabled
Task ':validateMavenPom' is not up-to-date because:
  No history is available.
groupId with value org.opensearch.plugin is validated.
artifactId with value opensearch-security is validated.
version with value 3.0.0.0-SNAPSHOT is validated.
name with value opensearch-security is validated.
description with value Provide access control related features for OpenSearch is validated.
url with value https://github.com/opensearch-project/security is validated.
licenses.name with value The Apache License, Version 2.0 is validated.
licenses.url with value http://www.apache.org/licenses/LICENSE-2.0.txt is validated.
developers.name with value OpenSearch is validated.
developers.url with value https://github.com/opensearch-project/security is validated.
scm.url with value https://github.com/opensearch-project/security is validated.
Resolve mutations for :validateNebulaPom (Thread[#309,included builds,5,main]) started.
:validateNebulaPom (Thread[#309,included builds,5,main]) started.

> Task :validateNebulaPom
Caching disabled for task ':validateNebulaPom' because:
  Build cache is disabled
Task ':validateNebulaPom' is not up-to-date because:
  No history is available.
groupId with value org.opensearch.plugin is validated.
artifactId with value opensearch-security is validated.
version with value 3.0.0.0-SNAPSHOT is validated.
name with value opensearch-security is validated.
description with value Provide access control related features for OpenSearch is validated.
url with value https://github.com/opensearch-project/security is validated.
licenses.name with value The Apache License, Version 2.0 is validated.
licenses.url with value http://www.apache.org/licenses/LICENSE-2.0.txt is validated.
developers.name with value OpenSearch is validated.
developers.url with value https://github.com/opensearch-project/security is validated.
scm.url with value https://github.com/opensearch-project/security is validated.
Resolve mutations for :validatePluginZipPom (Thread[#309,included builds,5,main]) started.
:validatePluginZipPom (Thread[#309,included builds,5,main]) started.

> Task :validatePluginZipPom
Caching disabled for task ':validatePluginZipPom' because:
  Build cache is disabled
Task ':validatePluginZipPom' is not up-to-date because:
  No history is available.
groupId with value org.opensearch.plugin is validated.
artifactId with value opensearch-security is validated.
version with value 3.0.0.0-SNAPSHOT is validated.
name with value opensearch-security is validated.
description with value Provide access control related features for OpenSearch is validated.
url with value https://github.com/opensearch-project/security is validated.
licenses.name with value The Apache License, Version 2.0 is validated.
licenses.url with value http://www.apache.org/licenses/LICENSE-2.0.txt is validated.
developers.name with value OpenSearch is validated.
developers.url with value https://github.com/opensearch-project/security is validated.
scm.url with value https://github.com/opensearch-project/security is validated.
Resolve mutations for :validatePom (Thread[#309,included builds,5,main]) started.
:validatePom (Thread[#309,included builds,5,main]) started.

> Task :validatePom
Skipping task ':validatePom' as it has no actions.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.5/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 7s
6 actionable tasks: 6 executed
Watched directory hierarchies: [/Users/zelinhao/workplace/security]
```

### Related Issues
Regarding of the breaking change to security plugin. 
https://github.com/opensearch-project/OpenSearch/pull/12807#issuecomment-2015266673

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
