### PR TITLE
Disable MockTelemetryPlugin by default for integ tests

### DIFF
--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
@@ -2070,7 +2070,8 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
      * @return boolean.
      */
     protected boolean addMockTelemetryPlugin() {
-        return true;
+        // setting to false until https://github.com/opensearch-project/OpenSearch/issues/12615 is resolved
+        return false;
     }
 
     /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
With this plugin enabled I see significant increase in memory usage during ITs. This is due to a [static map](https://github.com/opensearch-project/OpenSearch/blob/4e1022e2e85ce16c8772e76c1e1d857e89b6c08c/test/telemetry/src/main/java/org/opensearch/test/telemetry/tracing/StrictCheckSpanProcessor.java#L30) that collects Span entries per write/replication request and is not [cleared](https://github.com/opensearch-project/OpenSearch/blob/b1f8b169c2f195012a08cfc6d79ef5e5a3c7f885/test/framework/src/main/java/org/opensearch/test/OpenSearchTestClusterRule.java#L99) until after the test execution. Tests with higher counts of independent writes are at risk of running oom or experiencing slow down / warnings related to this.

I've run two reported flaky tests on repeat with this disabled #12801 and #12836 and do not see failures.

Disabled the plugin by default until this is resolved given it is still under FeatureFlag.

### Related Issues
related to https://github.com/opensearch-project/OpenSearch/issues/12615
Resolves https://github.com/opensearch-project/OpenSearch/issues/12801
Resolves https://github.com/opensearch-project/OpenSearch/issues/12836

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
