### PR TITLE
Fix flaky tests in CopyProcessorTests

### DIFF
--- a/modules/ingest-common/src/test/java/org/opensearch/ingest/common/CopyProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/opensearch/ingest/common/CopyProcessorTests.java
@@ -23,8 +23,10 @@ public class CopyProcessorTests extends OpenSearchTestCase {
 
     public void testCopyExistingField() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
+        String targetFieldName = RandomDocumentPicks.randomExistingFieldName(random(), ingestDocument);
+        // remove the target field to ensure that we get a non-existing field name
+        ingestDocument.removeField(targetFieldName);
         String sourceFieldName = RandomDocumentPicks.randomExistingFieldName(random(), ingestDocument);
-        String targetFieldName = sourceFieldName + "_" + randomAlphaOfLength(10);
         Processor processor = createCopyProcessor(sourceFieldName, targetFieldName, false, false, false);
         processor.execute(ingestDocument);
         assertThat(ingestDocument.hasField(targetFieldName), equalTo(true));
@@ -70,8 +72,11 @@ public class CopyProcessorTests extends OpenSearchTestCase {
 
     public void testCopyWithRemoveSource() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
+        String targetFieldName = RandomDocumentPicks.randomExistingFieldName(random(), ingestDocument);
+        // remove the target field to ensure that we get a non-existing field name
+        ingestDocument.removeField(targetFieldName);
         String sourceFieldName = RandomDocumentPicks.randomExistingFieldName(random(), ingestDocument);
-        String targetFieldName = sourceFieldName + "_" + randomAlphaOfLength(10);
+
         Object sourceValue = ingestDocument.getFieldValue(sourceFieldName, Object.class);
 
         Processor processor = createCopyProcessor(sourceFieldName, targetFieldName, false, true, false);

--- a/modules/ingest-common/src/test/java/org/opensearch/ingest/common/CopyProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/opensearch/ingest/common/CopyProcessorTests.java
@@ -24,7 +24,7 @@ public class CopyProcessorTests extends OpenSearchTestCase {
     public void testCopyExistingField() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
         String sourceFieldName = RandomDocumentPicks.randomExistingFieldName(random(), ingestDocument);
-        String targetFieldName = RandomDocumentPicks.randomFieldName(random());
+        String targetFieldName = sourceFieldName + "_" + randomAlphaOfLength(10);
         Processor processor = createCopyProcessor(sourceFieldName, targetFieldName, false, false, false);
         processor.execute(ingestDocument);
         assertThat(ingestDocument.hasField(targetFieldName), equalTo(true));
@@ -71,7 +71,7 @@ public class CopyProcessorTests extends OpenSearchTestCase {
     public void testCopyWithRemoveSource() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
         String sourceFieldName = RandomDocumentPicks.randomExistingFieldName(random(), ingestDocument);
-        String targetFieldName = RandomDocumentPicks.randomFieldName(random());
+        String targetFieldName = sourceFieldName + "_" + randomAlphaOfLength(10);
         Object sourceValue = ingestDocument.getFieldValue(sourceFieldName, Object.class);
 
         Processor processor = createCopyProcessor(sourceFieldName, targetFieldName, false, true, false);

--- a/modules/ingest-common/src/test/java/org/opensearch/ingest/common/CopyProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/opensearch/ingest/common/CopyProcessorTests.java
@@ -23,10 +23,8 @@ public class CopyProcessorTests extends OpenSearchTestCase {
 
     public void testCopyExistingField() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
-        String targetFieldName = RandomDocumentPicks.randomExistingFieldName(random(), ingestDocument);
-        // remove the target field to ensure that we get a non-existing field name
-        ingestDocument.removeField(targetFieldName);
         String sourceFieldName = RandomDocumentPicks.randomExistingFieldName(random(), ingestDocument);
+        String targetFieldName = RandomDocumentPicks.randomNonExistingFieldName(random(), ingestDocument);
         Processor processor = createCopyProcessor(sourceFieldName, targetFieldName, false, false, false);
         processor.execute(ingestDocument);
         assertThat(ingestDocument.hasField(targetFieldName), equalTo(true));
@@ -72,10 +70,8 @@ public class CopyProcessorTests extends OpenSearchTestCase {
 
     public void testCopyWithRemoveSource() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
-        String targetFieldName = RandomDocumentPicks.randomExistingFieldName(random(), ingestDocument);
-        // remove the target field to ensure that we get a non-existing field name
-        ingestDocument.removeField(targetFieldName);
         String sourceFieldName = RandomDocumentPicks.randomExistingFieldName(random(), ingestDocument);
+        String targetFieldName = RandomDocumentPicks.randomNonExistingFieldName(random(), ingestDocument);
 
         Object sourceValue = ingestDocument.getFieldValue(sourceFieldName, Object.class);
 

--- a/test/framework/src/main/java/org/opensearch/ingest/RandomDocumentPicks.java
+++ b/test/framework/src/main/java/org/opensearch/ingest/RandomDocumentPicks.java
@@ -72,6 +72,17 @@ public final class RandomDocumentPicks {
     }
 
     /**
+     * Returns a random field name that doesn't exist in the document.
+     */
+    public static String randomNonExistingFieldName(Random random, IngestDocument ingestDocument) {
+        String fieldName;
+        do {
+            fieldName = randomFieldName(random);
+        } while (canAddField(fieldName, ingestDocument) == false);
+        return fieldName;
+    }
+
+    /**
      * Returns a random leaf field name.
      */
     public static String randomLeafFieldName(Random random) {


### PR DESCRIPTION
### Description
When testing CopyProcessorTests#testCopyWithRemoveSource(), even though we use random() to generate field names, but there's a probability that the target field's name conflicts with the existing fields(then the error `target field [] already exists` will be thrown), we need to have a better way to make sure that the target field's name never exists in the document.

Another method `testCopyExistingField()` also has the same issue.

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/12884

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
