### PR TITLE
[2.x] Add README to version increment automation

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -108,6 +108,7 @@ jobs:
       - name: Add bwc version to main branch
         run: |
           echo Adding bwc version $NEXT_VERSION after $CURRENT_VERSION
+          sed -i "s/$CURRENT_VERSION/$NEXT_VERSION/g" README.md
           sed -i "s/- \"$CURRENT_VERSION\"/\0\n  - \"$NEXT_VERSION\"/g" .ci/bwcVersions
           echo Adding $NEXT_VERSION_UNDERSCORE after $CURRENT_VERSION_UNDERSCORE
           sed -i "s/public static final Version $CURRENT_VERSION_UNDERSCORE = new Version(\([[:digit:]]\+\)\(.*\));/\0\n    public static final Version $NEXT_VERSION_UNDERSCORE = new Version($NEXT_VERSION_ID\2);/g" libs/core/src/main/java/org/opensearch/Version.java


### PR DESCRIPTION
### Description

Adds the README to the git workflow for version increment automation to update the tag on the top of the README that contains the number of open issues for the next unreleased minor version.

See companion PR in core that updates the currently outdated tag from 2.10.0 -> 2.14.0: https://github.com/opensearch-project/OpenSearch/pull/12895

Tested on my fork here: https://github.com/cwperks/OpenSearch/pull/148

### Related Issues

- https://github.com/opensearch-project/OpenSearch/issues/8851

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
