### PR TITLE
Fix detect-breaking-change Github action configuration

### DIFF
--- a/.github/workflows/detect-breaking-change.yml
+++ b/.github/workflows/detect-breaking-change.yml
@@ -1,5 +1,7 @@
 name: "Detect Breaking Changes"
-on: [push, pull_request]
+on:
+  pull_request
+
 jobs:
   detect-breaking-change:
     runs-on: ubuntu-latest
@@ -11,6 +13,7 @@ jobs:
         java-version: 21
     - uses: gradle/gradle-build-action@v3
       with:
+        cache-disabled: true
         arguments: japicmp
         gradle-version: 8.7
         build-root-directory: server


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fix triggers and disable Gradle build cache (it seems to be problematic)

![Screenshot from 2024-04-02 11-43-16](https://github.com/opensearch-project/OpenSearch/assets/509855/fe1f8e6f-8042-47a3-b6b7-7234337e518e)


### Related Issues
Closes https://github.com/opensearch-project/OpenSearch/issues/13029

<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
