### PR TITLE
[Backport 2.x] [DerivedFields] PR2 - Implementation for all supported types, DerivedFieldType and DerivedFieldMapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add additional handling in SearchTemplateRequest when simulate is set to true ([#11591](https://github.com/opensearch-project/OpenSearch/pull/11591))
 - Introduce cluster level setting `cluster.index.restrict.replication.type` to prevent replication type setting override during index creations([#11583](https://github.com/opensearch-project/OpenSearch/pull/11583))
 - Add match_only_text field that is optimized for storage by trading off positional queries performance ([#6836](https://github.com/opensearch-project/OpenSearch/pull/11039))
+- Derived fields support to derive field values at query time without indexing ([#12569](https://github.com/opensearch-project/OpenSearch/pull/12569))
 
 ### Dependencies
 - Bumps jetty version to 9.4.52.v20230823 to fix GMS-2023-1857 ([#9822](https://github.com/opensearch-project/OpenSearch/pull/9822))

--- a/server/src/main/java/org/opensearch/index/mapper/DerivedFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DerivedFieldMapper.java
@@ -1,0 +1,129 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.mapper;
+
+import org.apache.lucene.index.IndexableField;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.script.Script;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * A field mapper for derived fields
+ *
+ * @opensearch.internal
+ */
+public class DerivedFieldMapper extends ParametrizedFieldMapper {
+
+    public static final String CONTENT_TYPE = "derived";
+
+    private static DerivedFieldMapper toType(FieldMapper in) {
+        return (DerivedFieldMapper) in;
+    }
+
+    /**
+     * Builder for this field mapper
+     *
+     * @opensearch.internal
+     */
+    public static class Builder extends ParametrizedFieldMapper.Builder {
+        // TODO: The type of parameter may change here if the actual underlying FieldType object is needed
+        private final Parameter<String> type = Parameter.stringParam("type", false, m -> toType(m).type, "text");
+
+        private final Parameter<Script> script = new Parameter<>(
+            "script",
+            false,
+            () -> null,
+            (n, c, o) -> o == null ? null : Script.parse(o),
+            m -> toType(m).script
+        ).setSerializerCheck((id, ic, value) -> value != null);
+
+        public Builder(String name) {
+            super(name);
+        }
+
+        @Override
+        protected List<Parameter<?>> getParameters() {
+            return Arrays.asList(type, script);
+        }
+
+        @Override
+        public DerivedFieldMapper build(BuilderContext context) {
+            FieldMapper fieldMapper = DerivedFieldSupportedTypes.getFieldMapperFromType(type.getValue(), name, context);
+            Function<Object, IndexableField> fieldFunction = DerivedFieldSupportedTypes.getIndexableFieldGeneratorType(
+                type.getValue(),
+                name
+            );
+            DerivedFieldType ft = new DerivedFieldType(
+                buildFullName(context),
+                type.getValue(),
+                script.getValue(),
+                fieldMapper,
+                fieldFunction
+            );
+            return new DerivedFieldMapper(name, ft, multiFieldsBuilder.build(this, context), copyTo.build(), this);
+        }
+    }
+
+    public static final TypeParser PARSER = new TypeParser((n, c) -> new Builder(n));
+    private final String type;
+    private final Script script;
+
+    protected DerivedFieldMapper(
+        String simpleName,
+        MappedFieldType mappedFieldType,
+        MultiFields multiFields,
+        CopyTo copyTo,
+        Builder builder
+    ) {
+        super(simpleName, mappedFieldType, multiFields, copyTo);
+        this.type = builder.type.getValue();
+        this.script = builder.script.getValue();
+    }
+
+    @Override
+    public DerivedFieldType fieldType() {
+        return (DerivedFieldType) super.fieldType();
+    }
+
+    @Override
+    protected void parseCreateField(ParseContext context) throws IOException {
+        // Leaving this empty as the parsing should be handled via the Builder when root object is parsed.
+        // The context would not contain anything in this case since the DerivedFieldMapper is not indexed or stored.
+        throw new UnsupportedOperationException("should not be invoked");
+    }
+
+    @Override
+    public ParametrizedFieldMapper.Builder getMergeBuilder() {
+        return new Builder(simpleName()).init(this);
+    }
+
+    @Override
+    protected String contentType() {
+        return CONTENT_TYPE;
+    }
+
+    @Override
+    protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
+        getMergeBuilder().toXContent(builder, includeDefaults);
+        multiFields.toXContent(builder, params);
+        copyTo.toXContent(builder, params);
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public Script getScript() {
+        return script;
+    }
+}

--- a/server/src/main/java/org/opensearch/index/mapper/DerivedFieldSupportedTypes.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DerivedFieldSupportedTypes.java
@@ -1,0 +1,156 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.mapper;
+
+import org.apache.lucene.document.DoubleField;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.InetAddressPoint;
+import org.apache.lucene.document.KeywordField;
+import org.apache.lucene.document.LatLonPoint;
+import org.apache.lucene.document.LongField;
+import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexableField;
+import org.opensearch.Version;
+import org.opensearch.common.Booleans;
+import org.opensearch.common.lucene.Lucene;
+import org.opensearch.common.network.InetAddresses;
+
+import java.net.InetAddress;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Contains logic to get the FieldMapper for a given type of derived field. Also, for a given type of derived field,
+ * it is used to create an IndexableField for the provided type and object. It is useful when indexing into
+ * lucene MemoryIndex in {@link org.opensearch.index.query.DerivedFieldQuery}.
+ */
+enum DerivedFieldSupportedTypes {
+
+    BOOLEAN("boolean", (name, context) -> {
+        BooleanFieldMapper.Builder builder = new BooleanFieldMapper.Builder(name);
+        return builder.build(context);
+    }, name -> o -> {
+        // Trying to mimic the logic for parsing source value as used in BooleanFieldMapper valueFetcher
+        Boolean value;
+        if (o instanceof Boolean) {
+            value = (Boolean) o;
+        } else {
+            String textValue = o.toString();
+            value = Booleans.parseBooleanStrict(textValue, false);
+        }
+        return new Field(name, value ? "T" : "F", BooleanFieldMapper.Defaults.FIELD_TYPE);
+    }),
+    DATE("date", (name, context) -> {
+        // TODO: should we support mapping settings exposed by a given field type from derived fields too?
+        // for example, support `format` for date type?
+        DateFieldMapper.Builder builder = new DateFieldMapper.Builder(
+            name,
+            DateFieldMapper.Resolution.MILLISECONDS,
+            DateFieldMapper.getDefaultDateTimeFormatter(),
+            false,
+            Version.CURRENT
+        );
+        return builder.build(context);
+    }, name -> o -> new LongPoint(name, (long) o)),
+    GEO_POINT("geo_point", (name, context) -> {
+        GeoPointFieldMapper.Builder builder = new GeoPointFieldMapper.Builder(name);
+        return builder.build(context);
+    }, name -> o -> {
+        // convert o to array of double
+        if (!(o instanceof List) || ((List<?>) o).size() != 2 || !(((List<?>) o).get(0) instanceof Double)) {
+            throw new ClassCastException("geo_point should be in format emit(double lat, double lon) for derived fields");
+        }
+        return new LatLonPoint(name, (Double) ((List<?>) o).get(0), (Double) ((List<?>) o).get(1));
+    }),
+    IP("ip", (name, context) -> {
+        IpFieldMapper.Builder builder = new IpFieldMapper.Builder(name, false, Version.CURRENT);
+        return builder.build(context);
+    }, name -> o -> {
+        InetAddress address;
+        if (o instanceof InetAddress) {
+            address = (InetAddress) o;
+        } else {
+            address = InetAddresses.forString(o.toString());
+        }
+        return new InetAddressPoint(name, address);
+    }),
+    KEYWORD("keyword", (name, context) -> {
+        FieldType dummyFieldType = new FieldType();
+        dummyFieldType.setIndexOptions(IndexOptions.DOCS_AND_FREQS);
+        KeywordFieldMapper.Builder keywordBuilder = new KeywordFieldMapper.Builder(name);
+        KeywordFieldMapper.KeywordFieldType keywordFieldType = keywordBuilder.buildFieldType(context, dummyFieldType);
+        keywordFieldType.setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
+        return new KeywordFieldMapper(
+            name,
+            dummyFieldType,
+            keywordFieldType,
+            keywordBuilder.multiFieldsBuilder.build(keywordBuilder, context),
+            keywordBuilder.copyTo.build(),
+            keywordBuilder
+        );
+    }, name -> o -> new KeywordField(name, (String) o, Field.Store.NO)),
+    LONG("long", (name, context) -> {
+        NumberFieldMapper.Builder longBuilder = new NumberFieldMapper.Builder(name, NumberFieldMapper.NumberType.LONG, false, false);
+        return longBuilder.build(context);
+    }, name -> o -> new LongField(name, Long.parseLong(o.toString()), Field.Store.NO)),
+    DOUBLE("double", (name, context) -> {
+        NumberFieldMapper.Builder doubleBuilder = new NumberFieldMapper.Builder(name, NumberFieldMapper.NumberType.DOUBLE, false, false);
+        return doubleBuilder.build(context);
+    }, name -> o -> new DoubleField(name, Double.parseDouble(o.toString()), Field.Store.NO));
+
+    final String name;
+    private final BiFunction<String, Mapper.BuilderContext, FieldMapper> builder;
+
+    private final Function<String, Function<Object, IndexableField>> indexableFieldBuilder;
+
+    DerivedFieldSupportedTypes(
+        String name,
+        BiFunction<String, Mapper.BuilderContext, FieldMapper> builder,
+        Function<String, Function<Object, IndexableField>> indexableFieldBuilder
+    ) {
+        this.name = name;
+        this.builder = builder;
+        this.indexableFieldBuilder = indexableFieldBuilder;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    private FieldMapper getFieldMapper(String name, Mapper.BuilderContext context) {
+        return builder.apply(name, context);
+    }
+
+    private Function<Object, IndexableField> getIndexableFieldGenerator(String name) {
+        return indexableFieldBuilder.apply(name);
+    }
+
+    private static final Map<String, DerivedFieldSupportedTypes> enumMap = Arrays.stream(DerivedFieldSupportedTypes.values())
+        .collect(Collectors.toMap(DerivedFieldSupportedTypes::getName, enumValue -> enumValue));
+
+    public static FieldMapper getFieldMapperFromType(String type, String name, Mapper.BuilderContext context) {
+        if (!enumMap.containsKey(type)) {
+            throw new IllegalArgumentException("Type [" + type + "] isn't supported in Derived field context.");
+        }
+        return enumMap.get(type).getFieldMapper(name, context);
+    }
+
+    public static Function<Object, IndexableField> getIndexableFieldGeneratorType(String type, String name) {
+        if (!enumMap.containsKey(type)) {
+            throw new IllegalArgumentException("Type [" + type + "] isn't supported in Derived field context.");
+        }
+        return enumMap.get(type).getIndexableFieldGenerator(name);
+    }
+}

--- a/server/src/main/java/org/opensearch/index/mapper/DerivedFieldType.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DerivedFieldType.java
@@ -1,0 +1,363 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.mapper;
+
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.queries.spans.SpanMultiTermQueryWrapper;
+import org.apache.lucene.queries.spans.SpanQuery;
+import org.apache.lucene.search.MultiTermQuery;
+import org.apache.lucene.search.Query;
+import org.opensearch.common.Nullable;
+import org.opensearch.common.geo.ShapeRelation;
+import org.opensearch.common.time.DateMathParser;
+import org.opensearch.common.unit.Fuzziness;
+import org.opensearch.index.query.DerivedFieldQuery;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.script.DerivedFieldScript;
+import org.opensearch.script.Script;
+import org.opensearch.search.lookup.SearchLookup;
+
+import java.io.IOException;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * MappedFieldType for Derived Fields
+ * Contains logic to execute different type of queries on a derived field of given type.
+ * @opensearch.internal
+ */
+public final class DerivedFieldType extends MappedFieldType {
+    private final String type;
+
+    private final Script script;
+
+    FieldMapper typeFieldMapper;
+
+    final Function<Object, IndexableField> indexableFieldGenerator;
+
+    public DerivedFieldType(
+        String name,
+        String type,
+        Script script,
+        boolean isIndexed,
+        boolean isStored,
+        boolean hasDocValues,
+        Map<String, String> meta,
+        FieldMapper typeFieldMapper,
+        Function<Object, IndexableField> fieldFunction
+    ) {
+        super(name, isIndexed, isStored, hasDocValues, typeFieldMapper.fieldType().getTextSearchInfo(), meta);
+        this.type = type;
+        this.script = script;
+        this.typeFieldMapper = typeFieldMapper;
+        this.indexableFieldGenerator = fieldFunction;
+    }
+
+    public DerivedFieldType(
+        String name,
+        String type,
+        Script script,
+        FieldMapper typeFieldMapper,
+        Function<Object, IndexableField> fieldFunction
+    ) {
+        this(name, type, script, false, false, false, Collections.emptyMap(), typeFieldMapper, fieldFunction);
+    }
+
+    @Override
+    public String typeName() {
+        return "derived";
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    @Override
+    public DerivedFieldValueFetcher valueFetcher(QueryShardContext context, SearchLookup searchLookup, String format) {
+        if (format != null) {
+            throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
+        }
+        return new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
+    }
+
+    @Override
+    public Query termQuery(Object value, QueryShardContext context) {
+        Query query = typeFieldMapper.mappedFieldType.termQuery(value, context);
+        DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
+        return new DerivedFieldQuery(
+            query,
+            valueFetcher,
+            context.lookup(),
+            indexableFieldGenerator,
+            typeFieldMapper.mappedFieldType.indexAnalyzer()
+        );
+    }
+
+    @Override
+    public Query termQueryCaseInsensitive(Object value, @Nullable QueryShardContext context) {
+        Query query = typeFieldMapper.mappedFieldType.termQueryCaseInsensitive(value, context);
+        DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
+        return new DerivedFieldQuery(
+            query,
+            valueFetcher,
+            context.lookup(),
+            indexableFieldGenerator,
+            typeFieldMapper.mappedFieldType.indexAnalyzer()
+        );
+    }
+
+    @Override
+    public Query termsQuery(List<?> values, @Nullable QueryShardContext context) {
+        Query query = typeFieldMapper.mappedFieldType.termsQuery(values, context);
+        DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
+        return new DerivedFieldQuery(
+            query,
+            valueFetcher,
+            context.lookup(),
+            indexableFieldGenerator,
+            typeFieldMapper.mappedFieldType.indexAnalyzer()
+        );
+    }
+
+    @Override
+    public Query rangeQuery(
+        Object lowerTerm,
+        Object upperTerm,
+        boolean includeLower,
+        boolean includeUpper,
+        ShapeRelation relation,
+        ZoneId timeZone,
+        DateMathParser parser,
+        QueryShardContext context
+    ) {
+        Query query = typeFieldMapper.mappedFieldType.rangeQuery(
+            lowerTerm,
+            upperTerm,
+            includeLower,
+            includeUpper,
+            relation,
+            timeZone,
+            parser,
+            context
+        );
+        DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
+        return new DerivedFieldQuery(
+            query,
+            valueFetcher,
+            context.lookup(),
+            indexableFieldGenerator,
+            typeFieldMapper.mappedFieldType.indexAnalyzer()
+        );
+    }
+
+    @Override
+    public Query fuzzyQuery(
+        Object value,
+        Fuzziness fuzziness,
+        int prefixLength,
+        int maxExpansions,
+        boolean transpositions,
+        QueryShardContext context
+    ) {
+        Query query = typeFieldMapper.mappedFieldType.fuzzyQuery(value, fuzziness, prefixLength, maxExpansions, transpositions, context);
+        DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
+        return new DerivedFieldQuery(
+            query,
+            valueFetcher,
+            context.lookup(),
+            indexableFieldGenerator,
+            typeFieldMapper.mappedFieldType.indexAnalyzer()
+        );
+    }
+
+    @Override
+    public Query fuzzyQuery(
+        Object value,
+        Fuzziness fuzziness,
+        int prefixLength,
+        int maxExpansions,
+        boolean transpositions,
+        @Nullable MultiTermQuery.RewriteMethod method,
+        QueryShardContext context
+    ) {
+        Query query = typeFieldMapper.mappedFieldType.fuzzyQuery(
+            value,
+            fuzziness,
+            prefixLength,
+            maxExpansions,
+            transpositions,
+            method,
+            context
+        );
+        DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
+        return new DerivedFieldQuery(
+            query,
+            valueFetcher,
+            context.lookup(),
+            indexableFieldGenerator,
+            typeFieldMapper.mappedFieldType.indexAnalyzer()
+        );
+    }
+
+    @Override
+    public Query prefixQuery(
+        String value,
+        @Nullable MultiTermQuery.RewriteMethod method,
+        boolean caseInsensitive,
+        QueryShardContext context
+    ) {
+        Query query = typeFieldMapper.mappedFieldType.prefixQuery(value, method, caseInsensitive, context);
+        DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
+        return new DerivedFieldQuery(
+            query,
+            valueFetcher,
+            context.lookup(),
+            indexableFieldGenerator,
+            typeFieldMapper.mappedFieldType.indexAnalyzer()
+        );
+    }
+
+    @Override
+    public Query wildcardQuery(
+        String value,
+        @Nullable MultiTermQuery.RewriteMethod method,
+        boolean caseInsensitive,
+        QueryShardContext context
+    ) {
+        Query query = typeFieldMapper.mappedFieldType.wildcardQuery(value, method, caseInsensitive, context);
+        DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
+        return new DerivedFieldQuery(
+            query,
+            valueFetcher,
+            context.lookup(),
+            indexableFieldGenerator,
+            typeFieldMapper.mappedFieldType.indexAnalyzer()
+        );
+    }
+
+    @Override
+    public Query normalizedWildcardQuery(String value, @Nullable MultiTermQuery.RewriteMethod method, QueryShardContext context) {
+        Query query = typeFieldMapper.mappedFieldType.normalizedWildcardQuery(value, method, context);
+        DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
+        return new DerivedFieldQuery(
+            query,
+            valueFetcher,
+            context.lookup(),
+            indexableFieldGenerator,
+            typeFieldMapper.mappedFieldType.indexAnalyzer()
+        );
+    }
+
+    @Override
+    public Query regexpQuery(
+        String value,
+        int syntaxFlags,
+        int matchFlags,
+        int maxDeterminizedStates,
+        @Nullable MultiTermQuery.RewriteMethod method,
+        QueryShardContext context
+    ) {
+        Query query = typeFieldMapper.mappedFieldType.regexpQuery(value, syntaxFlags, matchFlags, maxDeterminizedStates, method, context);
+        DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
+        return new DerivedFieldQuery(
+            query,
+            valueFetcher,
+            context.lookup(),
+            indexableFieldGenerator,
+            typeFieldMapper.mappedFieldType.indexAnalyzer()
+        );
+    }
+
+    @Override
+    public Query phraseQuery(TokenStream stream, int slop, boolean enablePositionIncrements, QueryShardContext context) throws IOException {
+        Query query = typeFieldMapper.mappedFieldType.phraseQuery(stream, slop, enablePositionIncrements, context);
+        DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
+        return new DerivedFieldQuery(
+            query,
+            valueFetcher,
+            context.lookup(),
+            indexableFieldGenerator,
+            typeFieldMapper.mappedFieldType.indexAnalyzer()
+        );
+    }
+
+    @Override
+    public Query multiPhraseQuery(TokenStream stream, int slop, boolean enablePositionIncrements, QueryShardContext context)
+        throws IOException {
+        Query query = typeFieldMapper.mappedFieldType.multiPhraseQuery(stream, slop, enablePositionIncrements, context);
+        DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
+        return new DerivedFieldQuery(
+            query,
+            valueFetcher,
+            context.lookup(),
+            indexableFieldGenerator,
+            typeFieldMapper.mappedFieldType.indexAnalyzer()
+        );
+    }
+
+    @Override
+    public Query phrasePrefixQuery(TokenStream stream, int slop, int maxExpansions, QueryShardContext context) throws IOException {
+        Query query = typeFieldMapper.mappedFieldType.phrasePrefixQuery(stream, slop, maxExpansions, context);
+        DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
+        return new DerivedFieldQuery(
+            query,
+            valueFetcher,
+            context.lookup(),
+            indexableFieldGenerator,
+            typeFieldMapper.mappedFieldType.indexAnalyzer()
+        );
+    }
+
+    @Override
+    public SpanQuery spanPrefixQuery(String value, SpanMultiTermQueryWrapper.SpanRewriteMethod method, QueryShardContext context) {
+        throw new IllegalArgumentException(
+            "Can only use span prefix queries on text fields - not on [" + name() + "] which is of type [" + typeName() + "]"
+        );
+    }
+
+    @Override
+    public Query distanceFeatureQuery(Object origin, String pivot, float boost, QueryShardContext context) {
+        Query query = typeFieldMapper.mappedFieldType.distanceFeatureQuery(origin, pivot, boost, context);
+        DerivedFieldValueFetcher valueFetcher = new DerivedFieldValueFetcher(getDerivedFieldLeafFactory(context));
+        return new DerivedFieldQuery(
+            query,
+            valueFetcher,
+            context.lookup(),
+            indexableFieldGenerator,
+            typeFieldMapper.mappedFieldType.indexAnalyzer()
+        );
+    }
+
+    @Override
+    public Query existsQuery(QueryShardContext context) {
+        throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] does not support exist queries");
+    }
+
+    @Override
+    public boolean isAggregatable() {
+        return false;
+    }
+
+    private DerivedFieldScript.LeafFactory getDerivedFieldLeafFactory(QueryShardContext context) {
+        if (!context.documentMapper("").sourceMapper().enabled()) {
+            throw new IllegalArgumentException(
+                "DerivedFieldQuery error: unable to fetch fields from _source field: _source is disabled in the mappings "
+                    + "for index ["
+                    + context.index().getName()
+                    + "]"
+            );
+        }
+        DerivedFieldScript.Factory factory = context.compile(script, DerivedFieldScript.CONTEXT);
+        return factory.newFactory(script.getParams(), context.lookup());
+    }
+}

--- a/server/src/main/java/org/opensearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/KeywordFieldMapper.java
@@ -218,7 +218,7 @@ public final class KeywordFieldMapper extends ParametrizedFieldMapper {
             );
         }
 
-        private KeywordFieldType buildFieldType(BuilderContext context, FieldType fieldType) {
+        protected KeywordFieldType buildFieldType(BuilderContext context, FieldType fieldType) {
             NamedAnalyzer normalizer = Lucene.KEYWORD_ANALYZER;
             NamedAnalyzer searchAnalyzer = Lucene.KEYWORD_ANALYZER;
             String normalizerName = this.normalizer.getValue();

--- a/server/src/main/java/org/opensearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ObjectMapper.java
@@ -291,6 +291,15 @@ public class ObjectMapper extends Mapper implements Cloneable {
             } else if (fieldName.equals("enabled")) {
                 builder.enabled(XContentMapValues.nodeBooleanValue(fieldNode, fieldName + ".enabled"));
                 return true;
+            } else if (fieldName.equals("derived")) {
+                if (fieldNode instanceof Collection && ((Collection) fieldNode).isEmpty()) {
+                    // nothing to do here, empty (to support "derived: []" case)
+                } else if (fieldNode instanceof Map) {
+                    parseDerived(builder, (Map<String, Object>) fieldNode, parserContext);
+                } else {
+                    throw new OpenSearchParseException("derived must be a map type");
+                }
+                return true;
             } else if (fieldName.equals("properties")) {
                 if (fieldNode instanceof Collection && ((Collection) fieldNode).isEmpty()) {
                     // nothing to do here, empty (to support "properties: []" case)
@@ -347,6 +356,55 @@ public class ObjectMapper extends Mapper implements Cloneable {
             if (nested) {
                 builder.nested = Nested.newNested(nestedIncludeInParent, nestedIncludeInRoot);
             }
+        }
+
+        protected static void parseDerived(ObjectMapper.Builder objBuilder, Map<String, Object> derivedNode, ParserContext parserContext) {
+            Iterator<Map.Entry<String, Object>> iterator = derivedNode.entrySet().iterator();
+            while (iterator.hasNext()) {
+                Map.Entry<String, Object> entry = iterator.next();
+                String fieldName = entry.getKey();
+                // Should accept empty arrays, as a work around for when the
+                // user can't provide an empty Map. (PHP for example)
+                boolean isEmptyList = entry.getValue() instanceof List && ((List<?>) entry.getValue()).isEmpty();
+
+                if (entry.getValue() instanceof Map) {
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> node = (Map<String, Object>) entry.getValue();
+
+                    // Derived fields are a bit unique in that the 'type' attribute does not map to the TypeParser
+                    // like it would for traditional fields in properties.
+                    // So in this case, the DerivedFieldMapper's TypeParser will explicitly be used
+                    Mapper.TypeParser typeParser = parserContext.typeParser(DerivedFieldMapper.CONTENT_TYPE);
+                    String[] fieldNameParts = fieldName.split("\\.");
+                    // field name is just ".", which is invalid
+                    if (fieldNameParts.length < 1) {
+                        throw new MapperParsingException("Invalid field name " + fieldName);
+                    }
+                    String realFieldName = fieldNameParts[fieldNameParts.length - 1];
+                    Mapper.Builder<?> fieldBuilder = typeParser.parse(realFieldName, node, parserContext);
+                    for (int i = fieldNameParts.length - 2; i >= 0; --i) {
+                        ObjectMapper.Builder<?> intermediate = new ObjectMapper.Builder<>(fieldNameParts[i]);
+                        intermediate.add(fieldBuilder);
+                        fieldBuilder = intermediate;
+                    }
+                    objBuilder.add(fieldBuilder);
+                    node.remove("type");
+                    DocumentMapperParser.checkNoRemainingFields(fieldName, node, parserContext.indexVersionCreated());
+                    iterator.remove();
+                } else if (isEmptyList) {
+                    iterator.remove();
+                } else {
+                    throw new MapperParsingException(
+                        "Expected map for property [derived_fields] on field [" + fieldName + "] but got a " + fieldName.getClass()
+                    );
+                }
+            }
+
+            DocumentMapperParser.checkNoRemainingFields(
+                derivedNode,
+                parserContext.indexVersionCreated(),
+                "DocType mapping definition has unsupported parameters: "
+            );
         }
 
         protected static void parseProperties(ObjectMapper.Builder objBuilder, Map<String, Object> propsNode, ParserContext parserContext) {
@@ -663,7 +721,21 @@ public class ObjectMapper extends Mapper implements Cloneable {
         doXContent(builder, params);
 
         // sort the mappers so we get consistent serialization format
-        Mapper[] sortedMappers = mappers.values().stream().toArray(size -> new Mapper[size]);
+        Mapper[] derivedSortedMappers = mappers.values()
+            .stream()
+            .filter(m -> m instanceof DerivedFieldMapper)
+            .toArray(size -> new Mapper[size]);
+        Arrays.sort(derivedSortedMappers, new Comparator<Mapper>() {
+            @Override
+            public int compare(Mapper o1, Mapper o2) {
+                return o1.name().compareTo(o2.name());
+            }
+        });
+
+        Mapper[] sortedMappers = mappers.values()
+            .stream()
+            .filter(m -> !(m instanceof DerivedFieldMapper))
+            .toArray(size -> new Mapper[size]);
         Arrays.sort(sortedMappers, new Comparator<Mapper>() {
             @Override
             public int compare(Mapper o1, Mapper o2) {
@@ -672,6 +744,17 @@ public class ObjectMapper extends Mapper implements Cloneable {
         });
 
         int count = 0;
+        for (Mapper mapper : derivedSortedMappers) {
+            if (count++ == 0) {
+                builder.startObject("derived");
+            }
+            mapper.toXContent(builder, params);
+        }
+        if (count > 0) {
+            builder.endObject();
+        }
+
+        count = 0;
         for (Mapper mapper : sortedMappers) {
             if (!(mapper instanceof MetadataFieldMapper)) {
                 if (count++ == 0) {

--- a/server/src/main/java/org/opensearch/index/mapper/ParametrizedFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ParametrizedFieldMapper.java
@@ -670,7 +670,11 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
                     deprecatedParamsMap.put(deprecatedName, param);
                 }
             }
-            String type = (String) fieldNode.remove("type");
+            String type = (String) fieldNode.get("type");
+            if (paramsMap.get("type") == null) {
+                fieldNode.remove("type");
+            }
+
             for (Iterator<Map.Entry<String, Object>> iterator = fieldNode.entrySet().iterator(); iterator.hasNext();) {
                 Map.Entry<String, Object> entry = iterator.next();
                 final String propName = entry.getKey();

--- a/server/src/main/java/org/opensearch/indices/IndicesModule.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesModule.java
@@ -48,6 +48,7 @@ import org.opensearch.index.mapper.BooleanFieldMapper;
 import org.opensearch.index.mapper.CompletionFieldMapper;
 import org.opensearch.index.mapper.DataStreamFieldMapper;
 import org.opensearch.index.mapper.DateFieldMapper;
+import org.opensearch.index.mapper.DerivedFieldMapper;
 import org.opensearch.index.mapper.DocCountFieldMapper;
 import org.opensearch.index.mapper.FieldAliasMapper;
 import org.opensearch.index.mapper.FieldNamesFieldMapper;
@@ -167,6 +168,7 @@ public class IndicesModule extends AbstractModule {
         mappers.put(FieldAliasMapper.CONTENT_TYPE, new FieldAliasMapper.TypeParser());
         mappers.put(GeoPointFieldMapper.CONTENT_TYPE, new GeoPointFieldMapper.TypeParser());
         mappers.put(FlatObjectFieldMapper.CONTENT_TYPE, FlatObjectFieldMapper.PARSER);
+        mappers.put(DerivedFieldMapper.CONTENT_TYPE, DerivedFieldMapper.PARSER);
 
         for (MapperPlugin mapperPlugin : mapperPlugins) {
             for (Map.Entry<String, Mapper.TypeParser> entry : mapperPlugin.getMappers().entrySet()) {

--- a/server/src/test/java/org/opensearch/index/mapper/DerivedFieldMapperQueryTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/DerivedFieldMapperQueryTests.java
@@ -1,0 +1,279 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.mapper;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.Directory;
+import org.opensearch.common.lucene.Lucene;
+import org.opensearch.core.index.Index;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.script.DerivedFieldScript;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.when;
+
+public class DerivedFieldMapperQueryTests extends MapperServiceTestCase {
+
+    // First element is the document ingested, other elements corresponds to value returned against a given derived field script
+    // Raw Message, Request Succeeded (boolean), Timestamp (long), Client IP, Method, Request Size (double), Duration (long)
+    private static final Object[][] raw_requests = new Object[][] {
+        {
+            "40.135.0.0 GET /images/hm_bg.jpg?size=1.5KB HTTP/1.0 200 2024-03-20T08:30:45 1500",
+            true,
+            1710923445000L,
+            "40.135.0.0",
+            "GET",
+            1.5,
+            1500L },
+        {
+            "232.0.0.0 GET /images/hm_bg.jpg?size=2.3KB HTTP/1.0 400 2024-03-20T09:15:20 2300",
+            false,
+            1710926120000L,
+            "232.0.0.0",
+            "GET",
+            2.3,
+            2300L },
+        {
+            "26.1.0.0 DELETE /images/hm_bg.jpg?size=3.7KB HTTP/1.0 200 2024-03-20T10:05:55 3700",
+            true,
+            1710929155000L,
+            "26.1.0.0",
+            "DELETE",
+            3.7,
+            3700L },
+        {
+            "247.37.0.0 GET /french/splash_inet.html?size=4.1KB HTTP/1.0 400 2024-03-20T11:20:10 4100",
+            false,
+            1710933610000L,
+            "247.37.0.0",
+            "GET",
+            4.1,
+            4100L },
+        {
+            "247.37.0.0 DELETE /french/splash_inet.html?size=5.8KB HTTP/1.0 400 2024-03-20T12:45:30 5800",
+            false,
+            1710938730000L,
+            "247.37.0.0",
+            "DELETE",
+            5.8,
+            5800L },
+        {
+            "10.20.30.40 GET /path/to/resource?size=6.3KB HTTP/1.0 200 2024-03-20T13:10:15 6300",
+            true,
+            1710940215000L,
+            "10.20.30.40",
+            "GET",
+            6.3,
+            6300L },
+        {
+            "50.60.70.80 GET /path/to/resource?size=7.2KB HTTP/1.0 404 2024-03-20T14:20:50 7200",
+            false,
+            1710944450000L,
+            "50.60.70.80",
+            "GET",
+            7.2,
+            7200L },
+        {
+            "127.0.0.1 PUT /path/to/resource?size=8.9KB HTTP/1.0 500 2024-03-20T15:30:25 8900",
+            false,
+            1710948625000L,
+            "127.0.0.1",
+            "PUT",
+            8.9,
+            8900L },
+        {
+            "127.0.0.1 GET /path/to/resource?size=9.4KB HTTP/1.0 200 2024-03-20T16:40:15 9400",
+            true,
+            1710952815000L,
+            "127.0.0.1",
+            "GET",
+            9.4,
+            9400L },
+        {
+            "192.168.1.1 GET /path/to/resource?size=10.7KB HTTP/1.0 400 2024-03-20T17:50:40 10700",
+            false,
+            1710957040000L,
+            "192.168.1.1",
+            "GET",
+            10.7,
+            10700L } };
+
+    public void testAllPossibleQueriesOnDerivedFields() throws IOException {
+        MapperService mapperService = createMapperService(topMapping(b -> {
+            b.startObject("properties");
+            {
+                b.startObject("raw_message");
+                {
+                    b.field("type", "text");
+                }
+                b.endObject();
+            }
+            b.endObject();
+            b.startObject("derived");
+            {
+                b.startObject("request_succeeded");
+                {
+                    b.field("type", "boolean");
+                    b.field("script", "");
+                }
+                b.endObject();
+                b.startObject("@timestamp");
+                {
+                    b.field("type", "date");
+                    b.field("script", "");
+                }
+                b.endObject();
+                b.startObject("client_ip");
+                {
+                    b.field("type", "ip");
+                    b.field("script", "");
+                }
+                b.endObject();
+                b.startObject("method");
+                {
+                    b.field("type", "keyword");
+                    b.field("script", "");
+                }
+                b.endObject();
+                b.startObject("request_size");
+                {
+                    b.field("type", "double");
+                    b.field("script", "");
+                }
+                b.endObject();
+                b.startObject("duration");
+                {
+                    b.field("type", "long");
+                    b.field("script", "");
+                }
+                b.endObject();
+            }
+            b.endObject();
+        }));
+
+        List<Document> docs = new ArrayList<>();
+        for (Object[] request : raw_requests) {
+            Document document = new Document();
+            document.add(new TextField("raw_message", (String) request[0], Field.Store.YES));
+            docs.add(document);
+        }
+
+        int[] scriptIndex = { 1 };
+
+        // Mock DerivedFieldScript.Factory
+        DerivedFieldScript.Factory factory = (params, lookup) -> (DerivedFieldScript.LeafFactory) ctx -> new DerivedFieldScript(
+            params,
+            lookup,
+            ctx
+        ) {
+            int docId = 0;
+
+            @Override
+            public void setDocument(int docId) {
+                super.setDocument(docId);
+                this.docId = docId;
+            }
+
+            @Override
+            public Object execute() {
+                return raw_requests[docId][scriptIndex[0]];
+            }
+        };
+
+        QueryShardContext queryShardContext = createQueryShardContext(mapperService);
+        when(queryShardContext.compile(Mockito.any(), Mockito.any())).thenReturn(factory);
+        when(queryShardContext.sourcePath("raw_message")).thenReturn(Set.of("raw_message"));
+        when(queryShardContext.index()).thenReturn(new Index("test_index", "uuid"));
+
+        // Index and Search
+        try (Directory dir = newDirectory()) {
+            IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig(Lucene.STANDARD_ANALYZER));
+            for (Document d : docs) {
+                iw.addDocument(d);
+            }
+            try (IndexReader reader = DirectoryReader.open(iw)) {
+                iw.close();
+
+                IndexSearcher searcher = new IndexSearcher(reader);
+                Query query = QueryBuilders.termQuery("request_succeeded", "true").toQuery(queryShardContext);
+                TopDocs topDocs = searcher.search(query, 10);
+                assertEquals(4, topDocs.totalHits.value);
+
+                // IP Field Term Query
+                scriptIndex[0] = 3;
+                query = QueryBuilders.termQuery("client_ip", "192.168.0.0/16").toQuery(queryShardContext);
+                topDocs = searcher.search(query, 10);
+                assertEquals(1, topDocs.totalHits.value);
+
+                scriptIndex[0] = 4;
+                query = QueryBuilders.termsQuery("method", "DELETE", "PUT").toQuery(queryShardContext);
+                topDocs = searcher.search(query, 10);
+                assertEquals(3, topDocs.totalHits.value);
+
+                query = QueryBuilders.termsQuery("method", "delete").toQuery(queryShardContext);
+                topDocs = searcher.search(query, 10);
+                assertEquals(0, topDocs.totalHits.value);
+
+                query = QueryBuilders.termQuery("method", "delete").caseInsensitive(true).toQuery(queryShardContext);
+                topDocs = searcher.search(query, 10);
+                assertEquals(2, topDocs.totalHits.value);
+
+                // Range queries of types - date, long and double
+                scriptIndex[0] = 2;
+                query = QueryBuilders.rangeQuery("@timestamp").from("2024-03-20T14:20:50").toQuery(queryShardContext);
+                topDocs = searcher.search(query, 10);
+                assertEquals(4, topDocs.totalHits.value);
+
+                scriptIndex[0] = 5;
+                query = QueryBuilders.rangeQuery("request_size").from("4.1").toQuery(queryShardContext);
+                topDocs = searcher.search(query, 10);
+                assertEquals(7, topDocs.totalHits.value);
+
+                scriptIndex[0] = 6;
+                query = QueryBuilders.rangeQuery("duration").from("5800").toQuery(queryShardContext);
+                topDocs = searcher.search(query, 10);
+                assertEquals(6, topDocs.totalHits.value);
+
+                scriptIndex[0] = 4;
+
+                // Prefix Query
+                query = QueryBuilders.prefixQuery("method", "DE").toQuery(queryShardContext);
+                topDocs = searcher.search(query, 10);
+                assertEquals(2, topDocs.totalHits.value);
+
+                scriptIndex[0] = 4;
+                query = QueryBuilders.wildcardQuery("method", "G*").toQuery(queryShardContext);
+                topDocs = searcher.search(query, 10);
+                assertEquals(7, topDocs.totalHits.value);
+
+                // Regexp Query
+                scriptIndex[0] = 4;
+                query = QueryBuilders.regexpQuery("method", ".*LET.*").toQuery(queryShardContext);
+                topDocs = searcher.search(query, 10);
+                assertEquals(2, topDocs.totalHits.value);
+            }
+        }
+    }
+}

--- a/server/src/test/java/org/opensearch/index/mapper/DerivedFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/DerivedFieldMapperTests.java
@@ -1,0 +1,117 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.mapper;
+
+import org.opensearch.common.CheckedConsumer;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.script.Script;
+
+import java.io.IOException;
+
+public class DerivedFieldMapperTests extends MapperTestCase {
+
+    protected boolean supportsOrIgnoresBoost() {
+        return false;
+    }
+
+    protected boolean supportsMeta() {
+        return false;
+    }
+
+    // Overriding fieldMapping to make it create derived mappings by default.
+    // This way, the parent tests are checking the right behavior for this Mapper.
+    @Override
+    protected final XContentBuilder fieldMapping(CheckedConsumer<XContentBuilder, IOException> buildField) throws IOException {
+        return fieldMapping(buildField, true);
+    }
+
+    // Overriding this to do nothing since derived fields are not written in the documents
+    @Override
+    protected void writeFieldValue(XContentBuilder builder) throws IOException {}
+
+    @Override
+    protected void minimalMapping(XContentBuilder b) throws IOException {
+        b.field("type", "keyword");
+    }
+
+    protected void registerParameters(ParameterChecker checker) throws IOException {
+        // TODO Any conflicts or updates to check for here? Parameters index, store, doc_values and boost are not
+        // supported for DerivedFieldMapper (we explicitly set these values on initialization)
+    }
+
+    // TODO: Can update this once the query implementation is completed
+    // This is also being left blank because the super assertExistsQuery is trying to parse
+    // an empty source and fails.
+    @Override
+    protected void assertExistsQuery(MapperService mapperService) {}
+
+    public void testSerialization() throws IOException {
+
+        DocumentMapper defaultMapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        Mapper mapper = defaultMapper.mappers().getMapper("field");
+        assertTrue(mapper instanceof DerivedFieldMapper);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+        mapper.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+        assertEquals("{\"field\":{\"type\":\"keyword\"}}", builder.toString());
+    }
+
+    public void testParsesScript() throws IOException {
+
+        String scriptString = "doc['test'].value";
+        DocumentMapper defaultMapper = createDocumentMapper(fieldMapping(b -> {
+            b.field("type", "keyword");
+            b.startObject("script");
+            b.field("source", scriptString);
+            b.endObject();
+        }));
+        Mapper mapper = defaultMapper.mappers().getMapper("field");
+        assertTrue(mapper instanceof DerivedFieldMapper);
+        DerivedFieldMapper derivedFieldMapper = (DerivedFieldMapper) mapper;
+        assertEquals(Script.parse(scriptString), derivedFieldMapper.getScript());
+
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+        mapper.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+        assertEquals(
+            "{\"field\":{\"type\":\"keyword\",\"script\":{\"source\":\"doc['test'].value\",\"lang\":\"painless\"}}}",
+            builder.toString()
+        );
+    }
+
+    // TODO: Is there a case where we want to allow the field to be defined in both 'derived' and 'properties'?
+    // If the user wants to move a field they were testing as derived to be indexed, they should be able to update
+    // the mappings in index template to move the field from 'derived' to 'properties' and it should take affect
+    // during the next index rollover (so even in this case, the field is only defined in one or the other).
+    public void testFieldInDerivedAndProperties() throws IOException {
+        MapperParsingException ex = expectThrows(MapperParsingException.class, () -> createDocumentMapper(topMapping(b -> {
+            b.startObject("derived");
+            b.startObject("field");
+            b.field("type", "keyword");
+            b.endObject();
+            b.endObject();
+            b.startObject("properties");
+            b.startObject("field");
+            b.field("type", "keyword");
+            b.endObject();
+            b.endObject();
+        })));
+        // TODO: Do we want to handle this as a different error? As it stands, it fails as a merge conflict which makes sense.
+        // If it didn't fail here, it would hit the MapperParsingException for the field being defined more than once
+        // when MappingLookup is initialized
+        assertEquals("Failed to parse mapping [_doc]: mapper [field] cannot be changed from type [derived] to [keyword]", ex.getMessage());
+    }
+
+    // TODO TESTCASE: testWithFieldInSource() (derived field with that field present in source)
+    // This is more checking search behavior so may need to revisit this after query implementation
+
+}

--- a/server/src/test/java/org/opensearch/index/mapper/DerivedFieldTypeTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/DerivedFieldTypeTests.java
@@ -1,0 +1,94 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.mapper;
+
+import org.apache.lucene.document.DoubleField;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.InetAddressPoint;
+import org.apache.lucene.document.KeywordField;
+import org.apache.lucene.document.LatLonPoint;
+import org.apache.lucene.document.LongField;
+import org.apache.lucene.document.LongPoint;
+import org.opensearch.script.Script;
+
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DerivedFieldTypeTests extends FieldTypeTestCase {
+
+    private DerivedFieldType createDerivedFieldType(String type) {
+        Mapper.BuilderContext context = mock(Mapper.BuilderContext.class);
+        when(context.path()).thenReturn(new ContentPath());
+        return new DerivedFieldType(
+            type + " _derived_field",
+            type,
+            new Script(""),
+            DerivedFieldSupportedTypes.getFieldMapperFromType(type, type + "_derived_field", context),
+            DerivedFieldSupportedTypes.getIndexableFieldGeneratorType(type, type + "_derived_field")
+        );
+    }
+
+    public void testBooleanType() {
+        DerivedFieldType dft = createDerivedFieldType("boolean");
+        assertTrue(dft.typeFieldMapper instanceof BooleanFieldMapper);
+        assertTrue(dft.indexableFieldGenerator.apply(true) instanceof Field);
+        assertTrue(dft.indexableFieldGenerator.apply(false) instanceof Field);
+    }
+
+    public void testDateType() {
+        DerivedFieldType dft = createDerivedFieldType("date");
+        assertTrue(dft.typeFieldMapper instanceof DateFieldMapper);
+        assertTrue(dft.indexableFieldGenerator.apply(System.currentTimeMillis()) instanceof LongPoint);
+        expectThrows(Exception.class, () -> dft.indexableFieldGenerator.apply("blah"));
+    }
+
+    public void testGeoPointType() {
+        DerivedFieldType dft = createDerivedFieldType("geo_point");
+        assertTrue(dft.typeFieldMapper instanceof GeoPointFieldMapper);
+        assertTrue(dft.indexableFieldGenerator.apply(List.of(10.0, 20.0)) instanceof LatLonPoint);
+        expectThrows(ClassCastException.class, () -> dft.indexableFieldGenerator.apply(List.of(10.0)));
+        expectThrows(ClassCastException.class, () -> dft.indexableFieldGenerator.apply(List.of()));
+        expectThrows(ClassCastException.class, () -> dft.indexableFieldGenerator.apply(List.of("10")));
+        expectThrows(ClassCastException.class, () -> dft.indexableFieldGenerator.apply(List.of(10.0, 20.0, 30.0)));
+    }
+
+    public void testIPType() {
+        DerivedFieldType dft = createDerivedFieldType("ip");
+        assertTrue(dft.typeFieldMapper instanceof IpFieldMapper);
+        assertTrue(dft.indexableFieldGenerator.apply("127.0.0.1") instanceof InetAddressPoint);
+        expectThrows(Exception.class, () -> dft.indexableFieldGenerator.apply("blah"));
+    }
+
+    public void testKeywordType() {
+        DerivedFieldType dft = createDerivedFieldType("keyword");
+        assertTrue(dft.typeFieldMapper instanceof KeywordFieldMapper);
+        assertTrue(dft.indexableFieldGenerator.apply("test_keyword") instanceof KeywordField);
+        expectThrows(Exception.class, () -> dft.indexableFieldGenerator.apply(10));
+    }
+
+    public void testLongType() {
+        DerivedFieldType dft = createDerivedFieldType("long");
+        assertTrue(dft.typeFieldMapper instanceof NumberFieldMapper);
+        assertTrue(dft.indexableFieldGenerator.apply(10) instanceof LongField);
+        expectThrows(Exception.class, () -> dft.indexableFieldGenerator.apply(10.0));
+    }
+
+    public void testDoubleType() {
+        DerivedFieldType dft = createDerivedFieldType("double");
+        assertTrue(dft.typeFieldMapper instanceof NumberFieldMapper);
+        assertTrue(dft.indexableFieldGenerator.apply(10.0) instanceof DoubleField);
+        expectThrows(Exception.class, () -> dft.indexableFieldGenerator.apply(""));
+    }
+
+    public void testUnsupportedType() {
+        expectThrows(IllegalArgumentException.class, () -> createDerivedFieldType("match_only_text"));
+    }
+}

--- a/test/framework/src/main/java/org/opensearch/index/mapper/MapperServiceTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/mapper/MapperServiceTestCase.java
@@ -225,13 +225,32 @@ public abstract class MapperServiceTestCase extends OpenSearchTestCase {
         return builder.endObject().endObject().endObject();
     }
 
+    protected final XContentBuilder derivedMapping(CheckedConsumer<XContentBuilder, IOException> buildFields) throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("_doc").startObject("derived");
+        buildFields.accept(builder);
+        return builder.endObject().endObject().endObject();
+    }
+
     protected final XContentBuilder dynamicMapping(Mapping dynamicMapping) throws IOException {
         XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
         dynamicMapping.toXContent(builder, ToXContent.EMPTY_PARAMS);
         return builder.endObject();
     }
 
-    protected final XContentBuilder fieldMapping(CheckedConsumer<XContentBuilder, IOException> buildField) throws IOException {
+    protected XContentBuilder fieldMapping(CheckedConsumer<XContentBuilder, IOException> buildField) throws IOException {
+        return fieldMapping(buildField, false);
+    }
+
+    protected final XContentBuilder fieldMapping(CheckedConsumer<XContentBuilder, IOException> buildField, Boolean isDerived)
+        throws IOException {
+        if (isDerived) {
+            return derivedMapping(b -> {
+                b.startObject("field");
+                buildField.accept(b);
+                b.endObject();
+            });
+        }
+
         return mapping(b -> {
             b.startObject("field");
             buildField.accept(b);

--- a/test/framework/src/main/java/org/opensearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/search/aggregations/AggregatorTestCase.java
@@ -94,6 +94,7 @@ import org.opensearch.index.mapper.BinaryFieldMapper;
 import org.opensearch.index.mapper.CompletionFieldMapper;
 import org.opensearch.index.mapper.ContentPath;
 import org.opensearch.index.mapper.DateFieldMapper;
+import org.opensearch.index.mapper.DerivedFieldMapper;
 import org.opensearch.index.mapper.FieldAliasMapper;
 import org.opensearch.index.mapper.FieldMapper;
 import org.opensearch.index.mapper.GeoPointFieldMapper;
@@ -185,6 +186,7 @@ public abstract class AggregatorTestCase extends OpenSearchTestCase {
         denylist.add(ObjectMapper.NESTED_CONTENT_TYPE); // TODO support for nested
         denylist.add(CompletionFieldMapper.CONTENT_TYPE); // TODO support completion
         denylist.add(FieldAliasMapper.CONTENT_TYPE); // TODO support alias
+        denylist.add(DerivedFieldMapper.CONTENT_TYPE); // TODO support derived fields
         TYPE_TEST_DENYLIST = denylist;
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This is a backport PR for https://github.com/opensearch-project/OpenSearch/pull/12808 and https://github.com/opensearch-project/OpenSearch/pull/12569

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [] New functionality has javadoc added
- [] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
~~- [] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
