### PR TITLE
[Backport 1.x] Update links to documentation in rest-api-spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="https://opensearch.org/assets/img/opensearch-logo-themed.svg" height="64px">
 
 [![Chat](https://img.shields.io/badge/chat-on%20forums-blue)](https://forum.opensearch.org/c/opensearch/)
-[![Documentation](https://img.shields.io/badge/documentation-reference-blue)](https://opensearch.org/docs/latest/opensearch/index/)
+[![Documentation](https://img.shields.io/badge/documentation-reference-blue)](https://opensearch.org/docs/1.3/opensearch/index/)
 [![codecov](https://codecov.io/gh/opensearch-project/OpenSearch/branch/1.x/graph/badge.svg)](https://codecov.io/gh/opensearch-project/OpenSearch)
 [![GHA gradle check](https://github.com/opensearch-project/OpenSearch/actions/workflows/gradle-check.yml/badge.svg)](https://github.com/opensearch-project/OpenSearch/actions/workflows/gradle-check.yml)
 [![GHA validate pull request](https://github.com/opensearch-project/OpenSearch/actions/workflows/wrapper.yml/badge.svg)](https://github.com/opensearch-project/OpenSearch/actions/workflows/wrapper.yml)

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.aliases.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.aliases.json
@@ -1,7 +1,7 @@
 {
   "cat.aliases":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/cat/cat-aliases/",
       "description":"Shows information about currently configured aliases to indices including filter and routing infos."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.allocation.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.allocation.json
@@ -1,7 +1,7 @@
 {
   "cat.allocation":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/cat/cat-allocation/",
       "description":"Provides a snapshot of how many shards are allocated to each data node and how much disk space they are using."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.count.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.count.json
@@ -1,7 +1,7 @@
 {
   "cat.count":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/cat/cat-count/",
       "description":"Provides quick access to the document count of the entire cluster, or individual indices."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.fielddata.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.fielddata.json
@@ -1,7 +1,7 @@
 {
   "cat.fielddata":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/cat/cat-field-data/",
       "description":"Shows how much heap memory is currently being used by fielddata on every data node in the cluster."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.help.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.help.json
@@ -1,7 +1,7 @@
 {
   "cat.help":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/cat/index/",
       "description":"Returns help for the Cat APIs."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.indices.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.indices.json
@@ -1,7 +1,7 @@
 {
   "cat.indices":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/cat/cat-indices/",
       "description":"Returns information about indices: number of primaries and replicas, document counts, disk size, ..."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.master.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.master.json
@@ -1,7 +1,7 @@
 {
   "cat.master":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/cat/cat-cluster_manager/",
       "description":"Returns information about the master node."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodeattrs.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodeattrs.json
@@ -1,7 +1,7 @@
 {
   "cat.nodeattrs":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/cat/cat-nodeattrs/",
       "description":"Returns information about custom node attributes."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodes.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodes.json
@@ -1,7 +1,7 @@
 {
   "cat.nodes":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/cat/cat-nodes/",
       "description":"Returns basic statistics about performance of cluster nodes."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.pending_tasks.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.pending_tasks.json
@@ -1,7 +1,7 @@
 {
   "cat.pending_tasks":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/cat/cat-pending-tasks/",
       "description":"Returns a concise representation of the cluster pending tasks."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.plugins.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.plugins.json
@@ -1,7 +1,7 @@
 {
   "cat.plugins":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/cat/cat-plugins/",
       "description":"Returns information about installed plugins across nodes node."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.recovery.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.recovery.json
@@ -1,7 +1,7 @@
 {
   "cat.recovery":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/cat/cat-recovery/",
       "description":"Returns information about index shard recoveries, both on-going completed."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.repositories.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.repositories.json
@@ -1,7 +1,7 @@
 {
   "cat.repositories":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/cat/cat-repositories/",
       "description":"Returns information about snapshot repositories registered in the cluster."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json
@@ -1,7 +1,7 @@
 {
   "cat.segments":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/cat/cat-segments/",
       "description":"Provides low-level information about the segments in the shards of an index."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.shards.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.shards.json
@@ -1,7 +1,7 @@
 {
   "cat.shards":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/cat/cat-shards/",
       "description":"Provides a detailed view of shard allocation on nodes."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.snapshots.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.snapshots.json
@@ -1,7 +1,7 @@
 {
   "cat.snapshots":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/cat/cat-snapshots/",
       "description":"Returns all snapshots in a specific repository."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.tasks.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.tasks.json
@@ -1,7 +1,7 @@
 {
   "cat.tasks":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/cat/cat-tasks/",
       "description":"Returns information about the tasks currently executing on one or more nodes in the cluster."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.templates.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.templates.json
@@ -1,7 +1,7 @@
 {
   "cat.templates":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/cat/cat-templates/",
       "description":"Returns information about existing templates."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.thread_pool.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.thread_pool.json
@@ -1,7 +1,7 @@
 {
   "cat.thread_pool":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/cat/cat-thread-pool/",
       "description":"Returns cluster-wide thread pool statistics per node.\nBy default the active, queue and rejected statistics are returned for all thread pools."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/clear_scroll.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/clear_scroll.json
@@ -1,7 +1,7 @@
 {
   "clear_scroll":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/clear-scroll-api.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/scroll/",
       "description":"Explicitly clears the search context for a scroll."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.allocation_explain.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.allocation_explain.json
@@ -1,7 +1,7 @@
 {
   "cluster.allocation_explain":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/cluster-api/cluster-allocation/",
       "description":"Provides explanations for shard allocations in the cluster."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.delete_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.delete_component_template.json
@@ -1,7 +1,7 @@
 {
   "cluster.delete_component_template":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html",
+      "url":"https://opensearch.org/docs/1.3/im-plugin/index-templates/#create-a-component-template",
       "description":"Deletes a component template"
     },
     "stability":"experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_settings.json
@@ -1,7 +1,7 @@
 {
   "cluster.get_settings":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/cluster-api/cluster-settings/",
       "description":"Returns cluster settings."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.health.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.health.json
@@ -1,7 +1,7 @@
 {
   "cluster.health":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/cluster-api/cluster-health/",
       "description":"Returns basic information about the health of the cluster."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_component_template.json
@@ -1,7 +1,7 @@
 {
   "cluster.put_component_template":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html",
+      "url":"https://opensearch.org/docs/1.3/im-plugin/index-templates/#create-a-component-template",
       "description":"Creates or updates a component template"
     },
     "stability":"experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_settings.json
@@ -1,7 +1,7 @@
 {
   "cluster.put_settings":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/cluster-api/cluster-settings/",
       "description":"Updates the cluster settings."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.remote_info.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.remote_info.json
@@ -1,7 +1,7 @@
 {
   "cluster.remote_info":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/remote-info/",
       "description":"Returns the information about configured remote clusters."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.state.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.state.json
@@ -1,7 +1,7 @@
 {
   "cluster.state":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/count/",
       "description":"Returns a comprehensive information about the state of the cluster."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.stats.json
@@ -1,7 +1,7 @@
 {
   "cluster.stats":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/cluster-api/cluster-stats/",
       "description":"Returns high-level overview of cluster statistics."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/count.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/count.json
@@ -1,7 +1,7 @@
 {
   "count":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/count/",
       "description":"Returns number of documents matching a query."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/create.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/create.json
@@ -1,7 +1,7 @@
 {
   "create":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/document-apis/index-document/",
       "description":"Creates a new document in the index.\n\nReturns a 409 response when a document with a same ID already exists in the index."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/dangling_indices.delete_dangling_index.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/dangling_indices.delete_dangling_index.json
@@ -1,7 +1,7 @@
 {
   "dangling_indices.delete_dangling_index": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html",
+      "url": "https://opensearch.org/docs/1.3/api-reference/index-apis/dangling-index/",
       "description": "Deletes the specified dangling index"
     },
     "stability": "stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/dangling_indices.import_dangling_index.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/dangling_indices.import_dangling_index.json
@@ -1,7 +1,7 @@
 {
   "dangling_indices.import_dangling_index": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html",
+      "url": "https://opensearch.org/docs/1.3/api-reference/index-apis/dangling-index/",
       "description": "Imports the specified dangling index"
     },
     "stability": "stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/dangling_indices.list_dangling_indices.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/dangling_indices.list_dangling_indices.json
@@ -1,7 +1,7 @@
 {
   "dangling_indices.list_dangling_indices": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html",
+      "url": "https://opensearch.org/docs/1.3/api-reference/index-apis/dangling-index/",
       "description": "Returns all dangling indices."
     },
     "stability": "stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete.json
@@ -1,7 +1,7 @@
 {
   "delete":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/document-apis/delete-document/",
       "description":"Removes a document from the index."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
@@ -1,7 +1,7 @@
 {
   "delete_by_query":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/document-apis/delete-by-query/",
       "description":"Deletes documents matching the provided query."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query_rethrottle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query_rethrottle.json
@@ -1,7 +1,7 @@
 {
   "delete_by_query_rethrottle":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/document-apis/delete-by-query/",
       "description":"Changes the number of requests per second for a particular Delete By Query operation."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_script.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_script.json
@@ -1,7 +1,7 @@
 {
   "delete_script":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/script-apis/delete-script/",
       "description":"Deletes a script."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/exists.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/exists.json
@@ -1,7 +1,7 @@
 {
   "exists":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/document-apis/get-documents/",
       "description":"Returns information about whether a document exists in an index."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/exists_source.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/exists_source.json
@@ -1,7 +1,7 @@
 {
   "exists_source":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/document-apis/get-documents/",
       "description":"Returns information about whether a document source exists in an index."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/explain.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/explain.json
@@ -1,7 +1,7 @@
 {
   "explain":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/explain/",
       "description":"Returns information about why a specific matches (or doesn't match) a query."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get.json
@@ -1,7 +1,7 @@
 {
   "get":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/document-apis/get-documents/",
       "description":"Returns a document."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get_script_context.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get_script_context.json
@@ -1,7 +1,7 @@
 {
   "get_script_context":{
     "documentation":{
-      "url": "https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-contexts.html",
+      "url": "https://opensearch.org/docs/1.3/api-reference/script-apis/get-script-language/",
       "description":"Returns all script contexts."
     },
     "stability":"experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get_script_languages.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get_script_languages.json
@@ -1,7 +1,7 @@
 {
   "get_script_languages":{
     "documentation":{
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html",
+      "url": "https://opensearch.org/docs/1.3/api-reference/script-apis/get-script-language/",
       "description":"Returns available script types, languages and contexts"
     },
     "stability":"experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get_source.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get_source.json
@@ -1,7 +1,7 @@
 {
   "get_source":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/document-apis/get-documents/",
       "description":"Returns the source of a document."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/index.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/index.json
@@ -1,7 +1,7 @@
 {
   "index":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/document-apis/index-document/",
       "description":"Creates or updates a document in an index."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.analyze.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.analyze.json
@@ -1,7 +1,7 @@
 {
   "indices.analyze":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/analyze-apis/",
       "description":"Performs the analysis process on a text and return the tokens breakdown of the text."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.clear_cache.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.clear_cache.json
@@ -1,7 +1,7 @@
 {
   "indices.clear_cache":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/index-apis/clear-index-cache/",
       "description":"Clears all or specific caches for one or more indices."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.clone.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.clone.json
@@ -1,7 +1,7 @@
 {
   "indices.clone": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html",
+      "url": "https://opensearch.org/docs/1.3/api-reference/index-apis/clone/",
       "description": "Clones an index"
     },
     "stability": "stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.close.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.close.json
@@ -1,7 +1,7 @@
 {
   "indices.close":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/index-apis/close-index/",
       "description":"Closes an index."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create.json
@@ -1,7 +1,7 @@
 {
   "indices.create":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/index-apis/create-index/",
       "description":"Creates an index with optional settings and mappings."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.data_streams_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.data_streams_stats.json
@@ -1,7 +1,7 @@
 {
   "indices.data_streams_stats":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html",
+      "url":"https://opensearch.org/docs/1.3/im-plugin/data-streams/",
       "description":"Provides statistics on operations happening in a data stream."
     },
     "stability":"experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete.json
@@ -1,7 +1,7 @@
 {
   "indices.delete":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/index-apis/delete-index/",
       "description":"Deletes an index."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_alias.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_alias.json
@@ -1,7 +1,7 @@
 {
   "indices.delete_alias":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html",
+      "url":"https://opensearch.org/docs/1.3/im-plugin/index-alias/",
       "description":"Deletes an alias."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_data_stream.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_data_stream.json
@@ -1,7 +1,7 @@
 {
   "indices.delete_data_stream":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html",
+      "url":"https://opensearch.org/docs/1.3/im-plugin/data-streams/",
       "description":"Deletes a data stream."
     },
     "stability":"experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_template.json
@@ -1,7 +1,7 @@
 {
   "indices.delete_template":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
+      "url":"https://opensearch.org/docs/1.3/im-plugin/index-templates",
       "description":"Deletes an index template."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists.json
@@ -1,7 +1,7 @@
 {
   "indices.exists":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/index-apis/exists/",
       "description":"Returns information about whether a particular index exists."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_alias.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_alias.json
@@ -1,7 +1,7 @@
 {
   "indices.exists_alias":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html",
+      "url":"https://opensearch.org/docs/1.3/im-plugin/index-alias/",
       "description":"Returns information about whether a particular alias exists."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_index_template.json
@@ -1,7 +1,7 @@
 {
   "indices.exists_index_template":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
+      "url":"https://opensearch.org/docs/1.3/im-plugin/index-templates",
       "description":"Returns information about whether a particular index template exists."
     },
     "stability":"experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_template.json
@@ -1,7 +1,7 @@
 {
   "indices.exists_template":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
+      "url":"https://opensearch.org/docs/1.3/im-plugin/index-templates",
       "description":"Returns information about whether a particular index template exists."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.forcemerge.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.forcemerge.json
@@ -1,7 +1,7 @@
 {
   "indices.forcemerge":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/index-apis/force-merge/",
       "description":"Performs the force merge operation on one or more indices."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get.json
@@ -1,7 +1,7 @@
 {
   "indices.get":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/index-apis/get-index/",
       "description":"Returns information about one or more indices."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_alias.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_alias.json
@@ -1,7 +1,7 @@
 {
   "indices.get_alias":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html",
+      "url":"https://opensearch.org/docs/1.3/im-plugin/index-alias/",
       "description":"Returns an alias."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_stream.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_stream.json
@@ -1,7 +1,7 @@
 {
   "indices.get_data_stream":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html",
+      "url":"https://opensearch.org/docs/1.3/im-plugin/data-streams/",
       "description":"Returns data streams."
     },
     "stability":"experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_field_mapping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_field_mapping.json
@@ -1,7 +1,7 @@
 {
   "indices.get_field_mapping":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/index-apis/put-mapping/",
       "description":"Returns mapping for one or more fields."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_index_template.json
@@ -1,7 +1,7 @@
 {
   "indices.get_index_template":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
+      "url":"https://opensearch.org/docs/1.3/im-plugin/index-templates",
       "description":"Returns an index template."
     },
     "stability":"experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_mapping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_mapping.json
@@ -1,7 +1,7 @@
 {
   "indices.get_mapping":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/index-apis/put-mapping/",
       "description":"Returns mappings for one or more indices."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_settings.json
@@ -1,7 +1,7 @@
 {
   "indices.get_settings":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/index-apis/get-settings/",
       "description":"Returns settings for one or more indices."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_template.json
@@ -1,7 +1,7 @@
 {
   "indices.get_template":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
+      "url":"https://opensearch.org/docs/1.3/im-plugin/index-templates",
       "description":"Returns an index template."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.open.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.open.json
@@ -1,7 +1,7 @@
 {
   "indices.open":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/index-apis/open-index/",
       "description":"Opens an index."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_alias.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_alias.json
@@ -1,7 +1,7 @@
 {
   "indices.put_alias":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html",
+      "url":"https://opensearch.org/docs/1.3/im-plugin/index-alias/",
       "description":"Creates or updates an alias."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_index_template.json
@@ -1,7 +1,7 @@
 {
   "indices.put_index_template":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
+      "url":"https://opensearch.org/docs/1.3/im-plugin/index-templates",
       "description":"Creates or updates an index template."
     },
     "stability":"experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_mapping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_mapping.json
@@ -1,7 +1,7 @@
 {
   "indices.put_mapping":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/index-apis/put-mapping/",
       "description":"Updates the index mappings."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json
@@ -1,7 +1,7 @@
 {
   "indices.put_template":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
+      "url":"https://opensearch.org/docs/1.3/im-plugin/index-templates",
       "description":"Creates or updates an index template."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.shrink.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.shrink.json
@@ -1,7 +1,7 @@
 {
   "indices.shrink":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/index-apis/shrink-index/",
       "description":"Allow to shrink an existing index into a new index with fewer primary shards."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.simulate_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.simulate_index_template.json
@@ -1,7 +1,7 @@
 {
   "indices.simulate_index_template":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
+      "url":"https://opensearch.org/docs/1.3/im-plugin/index-templates",
       "description": "Simulate matching the given index name against the index templates in the system"
     },
     "stability":"experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.simulate_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.simulate_template.json
@@ -1,7 +1,7 @@
 {
   "indices.simulate_template":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
+      "url":"https://opensearch.org/docs/1.3/im-plugin/index-templates",
       "description": "Simulate resolving the given template name or body"
     },
     "stability":"experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.split.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.split.json
@@ -1,7 +1,7 @@
 {
   "indices.split":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/index-apis/split/",
       "description":"Allows you to split an existing index into a new index with more primary shards."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.stats.json
@@ -1,7 +1,7 @@
 {
   "indices.stats":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/index-apis/stats/",
       "description":"Provides statistics on operations happening in an index."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.update_aliases.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.update_aliases.json
@@ -1,7 +1,7 @@
 {
   "indices.update_aliases":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html",
+      "url":"https://opensearch.org/docs/1.3/im-plugin/index-alias/",
       "description":"Updates index aliases."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.delete_pipeline.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.delete_pipeline.json
@@ -1,7 +1,7 @@
 {
   "ingest.delete_pipeline":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-pipeline-api.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/ingest-apis/delete-ingest/",
       "description":"Deletes a pipeline."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.get_pipeline.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.get_pipeline.json
@@ -1,7 +1,7 @@
 {
   "ingest.get_pipeline":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/get-pipeline-api.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/ingest-apis/get-ingest/",
       "description":"Returns a pipeline."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_pipeline.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_pipeline.json
@@ -1,7 +1,7 @@
 {
   "ingest.put_pipeline":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/put-pipeline-api.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/ingest-apis/create-update-ingest/",
       "description":"Creates or updates a pipeline."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.simulate.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.simulate.json
@@ -1,7 +1,7 @@
 {
   "ingest.simulate":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/ingest-apis/simulate-ingest/",
       "description":"Allows to simulate a pipeline with example documents."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/msearch.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/msearch.json
@@ -1,7 +1,7 @@
 {
   "msearch":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/multi-search/",
       "description":"Allows to execute several search operations in one request."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/msearch_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/msearch_template.json
@@ -1,7 +1,7 @@
 {
   "msearch_template":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/search-template/",
       "description":"Allows to execute several search template operations in one request."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.hot_threads.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.hot_threads.json
@@ -1,7 +1,7 @@
 {
   "nodes.hot_threads":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/nodes-apis/nodes-hot-threads/",
       "description":"Returns information about hot threads on each node in the cluster."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.info.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.info.json
@@ -1,7 +1,7 @@
 {
   "nodes.info":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/nodes-apis/nodes-info/",
       "description":"Returns information about nodes in the cluster."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.reload_secure_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.reload_secure_settings.json
@@ -1,7 +1,7 @@
 {
   "nodes.reload_secure_settings":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings",
+      "url":"https://opensearch.org/docs/1.3/api-reference/nodes-apis/nodes-reload-secure/",
       "description":"Reloads secure settings."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.stats.json
@@ -1,7 +1,7 @@
 {
   "nodes.stats":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/nodes-apis/nodes-stats/",
       "description":"Returns statistical information about nodes in the cluster."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.usage.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.usage.json
@@ -1,7 +1,7 @@
 {
   "nodes.usage":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/nodes-apis/nodes-usage/",
       "description":"Returns low-level information about REST actions usage on nodes."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/put_script.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/put_script.json
@@ -1,7 +1,7 @@
 {
   "put_script":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/nodes-apis/nodes-usage/",
       "description":"Creates or updates a script."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rank_eval.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rank_eval.json
@@ -1,7 +1,7 @@
 {
   "rank_eval":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/search-rank-eval.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/rank-eval/",
       "description":"Allows to evaluate the quality of ranked search results over a set of typical search queries"
     },
     "stability":"experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/reindex.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/reindex.json
@@ -1,7 +1,7 @@
 {
   "reindex":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html",
+      "url":"https://opensearch.org/docs/1.3/im-plugin/reindex-data/",
       "description":"Allows to copy documents from one index to another, optionally filtering the source\ndocuments by a query, changing the destination index settings, or fetching the\ndocuments from a remote cluster."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/reindex_rethrottle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/reindex_rethrottle.json
@@ -1,7 +1,7 @@
 {
   "reindex_rethrottle":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html",
+      "url":"https://opensearch.org/docs/1.3/im-plugin/reindex-data/",
       "description":"Changes the number of requests per second for a particular Reindex operation."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/render_search_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/render_search_template.json
@@ -1,7 +1,7 @@
 {
   "render_search_template":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html#_validating_templates",
+      "url":"https://opensearch.org/docs/1.3/api-reference/search-template/",
       "description":"Allows to use the Mustache language to pre-render a search definition."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/scripts_painless_execute.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/scripts_painless_execute.json
@@ -1,7 +1,7 @@
 {
   "scripts_painless_execute":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/script-apis/exec-stored-script/",
       "description":"Allows an arbitrary script to be executed and a result to be returned"
     },
     "stability":"experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/scroll.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/scroll.json
@@ -1,7 +1,7 @@
 {
   "scroll":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#request-body-search-scroll",
+      "url":"https://opensearch.org/docs/1.3/api-reference/scroll/",
       "description":"Allows to retrieve a large numbers of results from a single search request."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
@@ -1,7 +1,7 @@
 {
   "search":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/search/",
       "description":"Returns results matching a query."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_template.json
@@ -1,7 +1,7 @@
 {
   "search_template":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/search-template/",
       "description":"Allows to use the Mustache language to pre-render a search definition."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.cleanup_repository.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.cleanup_repository.json
@@ -1,7 +1,7 @@
 {
   "snapshot.cleanup_repository": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/clean-up-snapshot-repo-api.html",
+      "url": "https://opensearch.org/docs/1.3/api-reference/snapshots/index/",
       "description": "Removes stale data from repository."
     },
     "stability": "stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.clone.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.clone.json
@@ -1,7 +1,7 @@
 {
   "snapshot.clone":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/snapshots/index/",
       "description":"Clones indices from one snapshot into another snapshot in the same repository."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.create.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.create.json
@@ -1,7 +1,7 @@
 {
   "snapshot.create":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/snapshots/create-snapshot/",
       "description":"Creates a snapshot in a repository."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.create_repository.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.create_repository.json
@@ -1,7 +1,7 @@
 {
   "snapshot.create_repository":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/snapshots/create-repository/",
       "description":"Creates a repository."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete.json
@@ -1,7 +1,7 @@
 {
   "snapshot.delete":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/snapshots/delete-snapshot/",
       "description":"Deletes a snapshot."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete_repository.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete_repository.json
@@ -1,7 +1,7 @@
 {
   "snapshot.delete_repository":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/snapshots/delete-snapshot-repository/",
       "description":"Deletes a repository."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.get.json
@@ -1,7 +1,7 @@
 {
   "snapshot.get":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/snapshots/get-snapshot/",
       "description":"Returns information about a snapshot."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.get_repository.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.get_repository.json
@@ -1,7 +1,7 @@
 {
   "snapshot.get_repository":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/snapshots/get-snapshot-repository/",
       "description":"Returns information about a repository."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.restore.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.restore.json
@@ -1,7 +1,7 @@
 {
   "snapshot.restore":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/snapshots/restore-snapshot/",
       "description":"Restores a snapshot."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.status.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.status.json
@@ -1,7 +1,7 @@
 {
   "snapshot.status":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/snapshots/get-snapshot-status/",
       "description":"Returns information about the status of a snapshot."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.verify_repository.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.verify_repository.json
@@ -1,7 +1,7 @@
 {
   "snapshot.verify_repository":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/snapshots/verify-snapshot-repository/",
       "description":"Verifies a repository."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.cancel.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.cancel.json
@@ -1,7 +1,7 @@
 {
   "tasks.cancel":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/tasks/",
       "description":"Cancels a task, if it can be cancelled through an API."
     },
     "stability":"experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.get.json
@@ -1,7 +1,7 @@
 {
   "tasks.get":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/tasks/",
       "description":"Returns information about a task."
     },
     "stability":"experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.list.json
@@ -1,7 +1,7 @@
 {
   "tasks.list":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/tasks/",
       "description":"Returns a list of tasks."
     },
     "stability":"experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update.json
@@ -1,7 +1,7 @@
 {
   "update":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/document-apis/update-document/",
       "description":"Updates a document with a script or partial document."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
@@ -1,7 +1,7 @@
 {
   "update_by_query":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/document-apis/update-by-query/",
       "description":"Performs an update on every document in the index without changing the source,\nfor example to pick up a mapping change."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query_rethrottle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query_rethrottle.json
@@ -1,7 +1,7 @@
 {
   "update_by_query_rethrottle":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html",
+      "url":"https://opensearch.org/docs/1.3/api-reference/document-apis/update-by-query/",
       "description":"Changes the number of requests per second for a particular Update By Query operation."
     },
     "stability":"stable",


### PR DESCRIPTION
### Description

Backports #13043 to 1.x

This updates all of the links to make them version-specific to the 1.x line. Some of the links had changed on the documentation website, but most links remain the same and only replace `latest` with `1.3`. The ingest API routes are different on the documentation website between 1.3 and latest.

i.e.

https://opensearch.org/docs/latest/ingest-pipelines/create-ingest/ on main

vs

https://opensearch.org/docs/1.3/api-reference/ingest-apis/create-update-ingest/ on 1.3

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/1339

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
