### PR TITLE
Fix ClassCastException when using dynamic template with flat_object mapping and dots in field names

### DIFF
--- a/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
@@ -936,7 +936,13 @@ final class DocumentParser {
                             context.indexSettings().getSettings(),
                             context.path()
                         );
-                        mapper = (ObjectMapper) builder.build(builderContext);
+                        Mapper tmp = builder.build(builderContext);
+                        if (tmp instanceof FlatObjectFieldMapper) {
+                            throw new MapperParsingException(
+                                "It is forbidden to create dynamic flat_object ([" + String.join(".", paths) + "]) with dots in field names"
+                            );
+                        }
+                        mapper = (ObjectMapper) tmp;
                         if (mapper.nested() != ObjectMapper.Nested.NO) {
                             throw new MapperParsingException(
                                 "It is forbidden to create dynamic nested objects (["

--- a/server/src/test/java/org/opensearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/DocumentParserTests.java
@@ -217,6 +217,28 @@ public class DocumentParserTests extends MapperServiceTestCase {
         assertEquals("It is forbidden to create dynamic nested objects ([foo]) through `copy_to` or dots in field names", e.getMessage());
     }
 
+    public void testDotsWithDynamicFlatObjectMapper() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(topMapping(b -> {
+            b.startArray("dynamic_templates");
+            {
+                b.startObject();
+                {
+                    b.startObject("nested_object_fields");
+                    {
+                        b.field("match_mapping_type", "object");
+                        b.startObject("mapping").field("type", "flat_object").endObject();
+                    }
+                    b.endObject();
+                }
+                b.endObject();
+            }
+            b.endArray();
+        }));
+
+        MapperParsingException e = expectThrows(MapperParsingException.class, () -> mapper.parse(source(b -> b.field("foo.bar", 42))));
+        assertEquals("It is forbidden to create dynamic flat_object ([foo.bar]) with dots in field names", e.getMessage());
+    }
+
     public void testNestedHaveIdAndTypeFields() throws Exception {
 
         DocumentMapper mapper = createDocumentMapper(mapping(b -> {


### PR DESCRIPTION
### Description

Opening a draft PR to solicit feedback. This fixes an issue that can cause the DocumentParser to throw a ClassCastException when there is a dynamic template with a `flat_object` mapping and trying to index a document that contains field names with dots.

Instead of the ClassCastException, this PR will still fail the request but with a more descriptive error message saying that dots in field names is forbidden using a dynamic template with `flat_object` mapping. This is similar to existing behavior with dynamic templates with a `nested` mapping. See [similar test](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/test/java/org/opensearch/index/mapper/DocumentParserTests.java#L198-L218).

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/12298

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
