### PR TITLE
Ensure javadocs are published for plugin CLI command classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [BWC and API enforcement] Enforcing the presence of API annotations at build time ([#12872](https://github.com/opensearch-project/OpenSearch/pull/12872))
 - Improve built-in secure transports support ([#12907](https://github.com/opensearch-project/OpenSearch/pull/12907))
 - Update links to documentation in rest-api-spec ([#13043](https://github.com/opensearch-project/OpenSearch/pull/13043))
+- Ensure javadocs are published for plugin CLI command classes ([#13086](https://github.com/opensearch-project/OpenSearch/pull/13086))
 
 ### Deprecated
 

--- a/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/InstallPluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/InstallPluginCommand.java
@@ -106,11 +106,11 @@ import java.util.stream.Collectors;
 import static org.opensearch.cli.Terminal.Verbosity.VERBOSE;
 
 /**
- * A command for the plugin cli to install a plugin into opensearch.
+ * A command for the plugin CLI to install a plugin into OpenSearch.
  * <p>
  * The install command takes a plugin id, which may be any of the following:
  * <ul>
- * <li>An official opensearch plugin name</li>
+ * <li>An official OpenSearch plugin name</li>
  * <li>Maven coordinates to a plugin zip</li>
  * <li>A URL to a plugin zip</li>
  * </ul>
@@ -121,21 +121,21 @@ import static org.opensearch.cli.Terminal.Verbosity.VERBOSE;
  * The installation process first extracts the plugin files into a temporary
  * directory in order to verify the plugin satisfies the following requirements:
  * <ul>
- * <li>Jar hell does not exist, either between the plugin's own jars, or with opensearch</li>
- * <li>The plugin is not a module already provided with opensearch</li>
+ * <li>Jar hell does not exist, either between the plugin's own jars, or with OpenSearch</li>
+ * <li>The plugin is not a module already provided with OpenSearch</li>
  * <li>If the plugin contains extra security permissions, the policy file is validated</li>
  * </ul>
  * <p>
  * A plugin may also contain an optional {@code bin} directory which contains scripts. The
- * scripts will be installed into a subdirectory of the opensearch bin directory, using
+ * scripts will be installed into a subdirectory of the OpenSearch bin directory, using
  * the name of the plugin, and the scripts will be marked executable.
  * <p>
  * A plugin may also contain an optional {@code config} directory which contains configuration
  * files specific to the plugin. The config files be installed into a subdirectory of the
- * opensearch config directory, using the name of the plugin. If any files to be installed
+ * OpenSearch config directory, using the name of the plugin. If any files to be installed
  * already exist, they will be skipped.
  */
-class InstallPluginCommand extends EnvironmentAwareCommand {
+public class InstallPluginCommand extends EnvironmentAwareCommand {
 
     private static final String PROPERTY_STAGING_ID = "opensearch.plugins.staging";
 

--- a/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/ListPluginsCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/ListPluginsCommand.java
@@ -47,9 +47,9 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * A command for the plugin cli to list plugins installed in opensearch.
+ * A command for the plugin CLI to list plugins installed in OpenSearch.
  */
-class ListPluginsCommand extends EnvironmentAwareCommand {
+public class ListPluginsCommand extends EnvironmentAwareCommand {
 
     ListPluginsCommand() {
         super("Lists installed opensearch plugins");

--- a/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/ProgressInputStream.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/ProgressInputStream.java
@@ -38,13 +38,21 @@ import java.io.InputStream;
 
 /**
  * An input stream that allows to add a listener to monitor progress
+ * <ul>
+ * <li>
  * The listener is triggered whenever a full percent is increased
+ * </li>
+ * <li>
  * The listener is never triggered twice on the same percentage
+ * </li>
+ * <li>
  * The listener will always return 99 percent, if the expectedTotalSize is exceeded, until it is finished
+ * </li>
+ * </ul>
  * <p>
- * Only used by the InstallPluginCommand, thus package private here
+ * Only used by the InstallPluginCommand
  */
-abstract class ProgressInputStream extends FilterInputStream {
+public abstract class ProgressInputStream extends FilterInputStream {
 
     private final int expectedTotalSize;
     private int currentPercent;
@@ -92,5 +100,10 @@ abstract class ProgressInputStream extends FilterInputStream {
         }
     }
 
+    /**
+     * Listener to react to progress updates
+     *
+     * @param percent percent complete
+     */
     public void onProgress(int percent) {}
 }

--- a/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/RemovePluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/RemovePluginCommand.java
@@ -58,7 +58,7 @@ import static org.opensearch.cli.Terminal.Verbosity.VERBOSE;
 /**
  * A command for the plugin CLI to remove a plugin from OpenSearch.
  */
-class RemovePluginCommand extends EnvironmentAwareCommand {
+public class RemovePluginCommand extends EnvironmentAwareCommand {
 
     // exit codes for remove
     /** A plugin cannot be removed because it is extended by another plugin. */


### PR DESCRIPTION
### Description

Ensures that javadocs are published for the classes in `:distribution:tools:plugin-cli`. The reason the javadocs were not published for InstallPluginCommand, ListPluginsCommand and RemovePlugin command is that the classes were package-private. This PR makes the classes public to ensure the javadoc is published when running `./gradlew :distribution:tools:plugin-cli:javadoc`.

After generating javadocs, open the `build/docs/javadoc` directory and open `index.html` in a browser to see that the docs have been generated.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/11336

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
