### PR TITLE
Pre computing hash code for WeightedRouting to avoid recomputing it

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/WeightedRouting.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/WeightedRouting.java
@@ -14,6 +14,7 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -25,27 +26,26 @@ import java.util.Objects;
  */
 @PublicApi(since = "2.4.0")
 public class WeightedRouting implements Writeable {
-    private String attributeName;
-    private Map<String, Double> weights;
+    private final String attributeName;
+    private final Map<String, Double> weights;
+    private final int hashCode;
 
     public WeightedRouting() {
-        this.attributeName = "";
-        this.weights = new HashMap<>(3);
+        this("", new HashMap<>(3));
     }
 
     public WeightedRouting(String attributeName, Map<String, Double> weights) {
         this.attributeName = attributeName;
-        this.weights = weights;
+        this.weights = Collections.unmodifiableMap(weights);
+        this.hashCode = Objects.hash(this.attributeName, this.weights);
     }
 
     public WeightedRouting(WeightedRouting weightedRouting) {
-        this.attributeName = weightedRouting.attributeName();
-        this.weights = weightedRouting.weights;
+        this(weightedRouting.attributeName(), weightedRouting.weights);
     }
 
     public WeightedRouting(StreamInput in) throws IOException {
-        attributeName = in.readString();
-        weights = (Map<String, Double>) in.readGenericValue();
+        this(in.readString(), (Map<String, Double>) in.readGenericValue());
     }
 
     public boolean isSet() {
@@ -70,7 +70,7 @@ public class WeightedRouting implements Writeable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(attributeName, weights);
+        return hashCode;
     }
 
     @Override


### PR DESCRIPTION

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
WeightedRoutingKey is used as key in the HashMap to retreive the shard routings, for every usage the hash key is computed. WeightedRoutingKey internally uses WeightedRouting. As the number of the shards getting queried increases, the computation cost goes high.

Computing the hash key during object creation as the object is immutable and using it through out the object thus saving on the additional computation.

### Check List
- ~[ ] New functionality includes testing.~
  - [x] All tests pass
- ~[ ] New functionality has been documented.~
  - ~[ ] New functionality has javadoc added~
- ~[ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))~
- [x] Commits are signed per the DCO using --signoff
- ~[ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
