### PR TITLE
Add implementation for remote store path types

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
@@ -23,6 +23,7 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.routing.RecoverySource;
 import org.opensearch.cluster.routing.allocation.command.MoveAllocationCommand;
 import org.opensearch.common.Priority;
+import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.BufferedAsyncIOProcessor;
@@ -57,7 +58,11 @@ import java.util.stream.Stream;
 
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
+import static org.opensearch.index.remote.RemoteStoreEnums.DataCategory.SEGMENTS;
+import static org.opensearch.index.remote.RemoteStoreEnums.DataType.DATA;
+import static org.opensearch.index.remote.RemoteStoreEnums.DataType.METADATA;
 import static org.opensearch.indices.RemoteStoreSettings.CLUSTER_REMOTE_TRANSLOG_BUFFER_INTERVAL_SETTING;
+import static org.opensearch.test.OpenSearchTestCase.getShardLevelBlobPath;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.comparesEqualTo;
@@ -182,13 +187,9 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
         createIndex(INDEX_NAME, remoteStoreIndexSettings(1, 10000l, -1));
         int numberOfIterations = randomIntBetween(5, 15);
         indexData(numberOfIterations, true, INDEX_NAME);
-        String indexUUID = client().admin()
-            .indices()
-            .prepareGetSettings(INDEX_NAME)
-            .get()
-            .getSetting(INDEX_NAME, IndexMetadata.SETTING_INDEX_UUID);
-        Path indexPath = Path.of(String.valueOf(segmentRepoPath), indexUUID, "/0/segments/metadata");
-
+        String shardPath = getShardLevelBlobPath(client(), INDEX_NAME, BlobPath.cleanPath(), "0", SEGMENTS, METADATA).buildAsString();
+        Path indexPath = Path.of(segmentRepoPath + "/" + shardPath);
+        ;
         IndexShard indexShard = getIndexShard(dataNode, INDEX_NAME);
         int lastNMetadataFilesToKeep = indexShard.getRemoteStoreSettings().getMinRemoteSegmentMetadataFiles();
         // Delete is async.
@@ -212,12 +213,8 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
         createIndex(INDEX_NAME, remoteStoreIndexSettings(1, 10000l, -1));
         int numberOfIterations = randomIntBetween(5, 15);
         indexData(numberOfIterations, false, INDEX_NAME);
-        String indexUUID = client().admin()
-            .indices()
-            .prepareGetSettings(INDEX_NAME)
-            .get()
-            .getSetting(INDEX_NAME, IndexMetadata.SETTING_INDEX_UUID);
-        Path indexPath = Path.of(String.valueOf(segmentRepoPath), indexUUID, "/0/segments/metadata");
+        String shardPath = getShardLevelBlobPath(client(), INDEX_NAME, BlobPath.cleanPath(), "0", SEGMENTS, METADATA).buildAsString();
+        Path indexPath = Path.of(segmentRepoPath + "/" + shardPath);
         int actualFileCount = getFileCount(indexPath);
         // We also allow (numberOfIterations + 1) as index creation also triggers refresh.
         MatcherAssert.assertThat(actualFileCount, is(oneOf(numberOfIterations - 1, numberOfIterations, numberOfIterations + 1)));
@@ -231,12 +228,8 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
         createIndex(INDEX_NAME, remoteStoreIndexSettings(1, 10000l, -1));
         int numberOfIterations = randomIntBetween(5, 15);
         indexData(numberOfIterations, true, INDEX_NAME);
-        String indexUUID = client().admin()
-            .indices()
-            .prepareGetSettings(INDEX_NAME)
-            .get()
-            .getSetting(INDEX_NAME, IndexMetadata.SETTING_INDEX_UUID);
-        Path indexPath = Path.of(String.valueOf(segmentRepoPath), indexUUID, "/0/segments/metadata");
+        String shardPath = getShardLevelBlobPath(client(), INDEX_NAME, BlobPath.cleanPath(), "0", SEGMENTS, METADATA).buildAsString();
+        Path indexPath = Path.of(segmentRepoPath + "/" + shardPath);
         int actualFileCount = getFileCount(indexPath);
         // We also allow (numberOfIterations + 1) as index creation also triggers refresh.
         MatcherAssert.assertThat(actualFileCount, is(oneOf(4)));
@@ -250,12 +243,9 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
         createIndex(INDEX_NAME, remoteStoreIndexSettings(1, 10000l, -1));
         int numberOfIterations = randomIntBetween(12, 18);
         indexData(numberOfIterations, true, INDEX_NAME);
-        String indexUUID = client().admin()
-            .indices()
-            .prepareGetSettings(INDEX_NAME)
-            .get()
-            .getSetting(INDEX_NAME, IndexMetadata.SETTING_INDEX_UUID);
-        Path indexPath = Path.of(String.valueOf(segmentRepoPath), indexUUID, "/0/segments/metadata");
+        String shardPath = getShardLevelBlobPath(client(), INDEX_NAME, BlobPath.cleanPath(), "0", SEGMENTS, METADATA).buildAsString();
+        Path indexPath = Path.of(segmentRepoPath + "/" + shardPath);
+        ;
         int actualFileCount = getFileCount(indexPath);
         // We also allow (numberOfIterations + 1) as index creation also triggers refresh.
         MatcherAssert.assertThat(actualFileCount, is(oneOf(numberOfIterations + 1)));
@@ -589,12 +579,8 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
         flushAndRefresh(INDEX_NAME);
 
         // 3. Delete data from remote segment store
-        String indexUUID = client().admin()
-            .indices()
-            .prepareGetSettings(INDEX_NAME)
-            .get()
-            .getSetting(INDEX_NAME, IndexMetadata.SETTING_INDEX_UUID);
-        Path segmentDataPath = Path.of(String.valueOf(segmentRepoPath), indexUUID, "/0/segments/data");
+        String shardPath = getShardLevelBlobPath(client(), INDEX_NAME, BlobPath.cleanPath(), "0", SEGMENTS, DATA).buildAsString();
+        Path segmentDataPath = Path.of(segmentRepoPath + "/" + shardPath);
 
         try (Stream<Path> files = Files.list(segmentDataPath)) {
             files.forEach(p -> {

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreRefreshListenerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreRefreshListenerIT.java
@@ -11,6 +11,7 @@ package org.opensearch.remotestore;
 import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsResponse;
 import org.opensearch.action.admin.indices.stats.IndicesStatsRequest;
 import org.opensearch.action.admin.indices.stats.IndicesStatsResponse;
+import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
@@ -22,7 +23,10 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static org.opensearch.index.remote.RemoteStoreEnums.DataCategory.SEGMENTS;
+import static org.opensearch.index.remote.RemoteStoreEnums.DataType.DATA;
 import static org.opensearch.index.remote.RemoteStorePressureSettings.REMOTE_REFRESH_SEGMENT_PRESSURE_ENABLED;
+import static org.opensearch.test.OpenSearchTestCase.getShardLevelBlobPath;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
 public class RemoteStoreRefreshListenerIT extends AbstractRemoteStoreMockRepositoryIntegTestCase {
@@ -45,8 +49,10 @@ public class RemoteStoreRefreshListenerIT extends AbstractRemoteStoreMockReposit
         IndicesStatsResponse response = client().admin().indices().stats(new IndicesStatsRequest()).get();
         assertEquals(1, response.getShards().length);
 
+        String indexName = response.getShards()[0].getShardRouting().index().getName();
         String indexUuid = response.getShards()[0].getShardRouting().index().getUUID();
-        Path segmentDataRepoPath = location.resolve(String.format(Locale.ROOT, "%s/0/segments/data", indexUuid));
+        String shardPath = getShardLevelBlobPath(client(), indexName, new BlobPath(), "0", SEGMENTS, DATA).buildAsString();
+        Path segmentDataRepoPath = location.resolve(shardPath);
         String segmentDataLocalPath = String.format(Locale.ROOT, "%s/indices/%s/0/index", response.getShards()[0].getDataPath(), indexUuid);
 
         logger.info("--> Verify that the segment files are same on local and repository eventually");

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/DeleteSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/DeleteSnapshotIT.java
@@ -14,9 +14,14 @@ import org.opensearch.client.Client;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.action.ActionFuture;
+import org.opensearch.common.blobstore.BlobContainer;
+import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.index.store.RemoteBufferedOutputDirectory;
 import org.opensearch.remotestore.RemoteStoreBaseIntegTestCase;
+import org.opensearch.repositories.RepositoriesService;
+import org.opensearch.repositories.blobstore.BlobStoreRepository;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
 import java.nio.file.Path;
@@ -27,6 +32,8 @@ import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
+import static org.opensearch.index.remote.RemoteStoreEnums.DataCategory.SEGMENTS;
+import static org.opensearch.index.remote.RemoteStoreEnums.DataType.LOCK_FILES;
 import static org.opensearch.remotestore.RemoteStoreBaseIntegTestCase.remoteStoreClusterSettings;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.comparesEqualTo;
@@ -307,7 +314,21 @@ public class DeleteSnapshotIT extends AbstractSnapshotIntegTestCase {
         SnapshotInfo snapshotInfo1 = createFullSnapshot(snapshotRepoName, "snap1");
         SnapshotInfo snapshotInfo2 = createFullSnapshot(snapshotRepoName, "snap2");
 
-        String[] lockFiles = getLockFilesInRemoteStore(remoteStoreEnabledIndexName, REMOTE_REPO_NAME);
+        final RepositoriesService repositoriesService = internalCluster().getCurrentClusterManagerNodeInstance(RepositoriesService.class);
+        final BlobStoreRepository remoteStoreRepository = (BlobStoreRepository) repositoriesService.repository(REMOTE_REPO_NAME);
+        BlobPath shardLevelBlobPath = getShardLevelBlobPath(
+            client(),
+            remoteStoreEnabledIndexName,
+            remoteStoreRepository.basePath(),
+            "0",
+            SEGMENTS,
+            LOCK_FILES
+        );
+        BlobContainer blobContainer = remoteStoreRepository.blobStore().blobContainer(shardLevelBlobPath);
+        String[] lockFiles;
+        try (RemoteBufferedOutputDirectory lockDirectory = new RemoteBufferedOutputDirectory(blobContainer)) {
+            lockFiles = lockDirectory.listAll();
+        }
         assert (lockFiles.length == 2) : "lock files are " + Arrays.toString(lockFiles);
 
         // delete remote store index
@@ -320,7 +341,9 @@ public class DeleteSnapshotIT extends AbstractSnapshotIntegTestCase {
             .get();
         assertAcked(deleteSnapshotResponse);
 
-        lockFiles = getLockFilesInRemoteStore(remoteStoreEnabledIndexName, REMOTE_REPO_NAME, indexUUID);
+        try (RemoteBufferedOutputDirectory lockDirectory = new RemoteBufferedOutputDirectory(blobContainer)) {
+            lockFiles = lockDirectory.listAll();
+        }
         assert (lockFiles.length == 1) : "lock files are " + Arrays.toString(lockFiles);
         assertTrue(lockFiles[0].contains(snapshotInfo2.snapshotId().getUUID()));
 

--- a/server/src/main/java/org/opensearch/common/blobstore/BlobPath.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/BlobPath.java
@@ -79,6 +79,15 @@ public class BlobPath implements Iterable<String> {
         return new BlobPath(Collections.unmodifiableList(paths));
     }
 
+    /**
+     * Add additional level of paths to the existing path and returns new {@link BlobPath} with the updated paths.
+     */
+    public BlobPath add(Iterable<String> paths) {
+        List<String> updatedPaths = new ArrayList<>(this.paths);
+        paths.iterator().forEachRemaining(updatedPaths::add);
+        return new BlobPath(Collections.unmodifiableList(updatedPaths));
+    }
+
     public String buildAsString() {
         String p = String.join(SEPARATOR, paths);
         if (p.isEmpty() || p.endsWith(SEPARATOR)) {

--- a/server/src/main/java/org/opensearch/index/remote/RemoteStoreEnums.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStoreEnums.java
@@ -219,7 +219,7 @@ public class RemoteStoreEnums {
                 String input = pathInput.indexUUID() + pathInput.shardId() + pathInput.dataCategory().getName() + pathInput.dataType()
                     .getName();
                 long hash = FNV1a.hash64(input);
-                return RemoteStoreUtils.longToBase64(hash);
+                return RemoteStoreUtils.longToUrlBase64(hash);
             }
         };
 

--- a/server/src/main/java/org/opensearch/index/remote/RemoteStoreEnums.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStoreEnums.java
@@ -104,7 +104,10 @@ public class RemoteStoreEnums {
             @Override
             public BlobPath generatePath(PathInput pathInput, PathHashAlgorithm hashAlgorithm) {
                 assert Objects.nonNull(hashAlgorithm) : "hashAlgorithm is expected to be non-null";
-                return addPrefix(pathInput.basePath(), hashAlgorithm.hash(pathInput)).add(pathInput.indexUUID())
+                return BlobPath.cleanPath()
+                    .add(hashAlgorithm.hash(pathInput))
+                    .add(pathInput.basePath())
+                    .add(pathInput.indexUUID())
                     .add(pathInput.shardId())
                     .add(pathInput.dataCategory().getName())
                     .add(pathInput.dataType().getName());
@@ -273,14 +276,5 @@ public class RemoteStoreEnums {
          * This string is used as key for storing information in the custom data in index settings.
          */
         public static final String NAME = "path_hash_algorithm";
-    }
-
-    static BlobPath addPrefix(BlobPath blobPath, String prefix) {
-        BlobPath updatedPath = BlobPath.cleanPath();
-        updatedPath = updatedPath.add(prefix);
-        for (String path : blobPath) {
-            updatedPath = updatedPath.add(path);
-        }
-        return updatedPath;
     }
 }

--- a/server/src/main/java/org/opensearch/index/remote/RemoteStoreUtils.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStoreUtils.java
@@ -10,7 +10,9 @@ package org.opensearch.index.remote;
 
 import org.opensearch.common.collect.Tuple;
 
+import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -101,4 +103,26 @@ public class RemoteStoreUtils {
         });
     }
 
+    /**
+     * Converts an input hash which occupies 64 bits of space into Base64 (6 bits per character) String. This must not
+     * be changed as it is used for creating path for storing remote store data on the remote store.
+     */
+    static String longToBase64(long value) {
+        byte[] hashBytes = ByteBuffer.allocate(Long.BYTES).putLong(value).array();
+        return base64(hashBytes);
+    }
+
+    /**
+     * This converts the byte array to base 64 string. `/` is replaced with `_`, `+` is replaced with `-` and `=`
+     * which is padded at the last is also removed. These characters are either used as delimiter or special character
+     * requiring special handling in some vendors. The characters present in this base64 version are [A-Za-z0-9_-].
+     * This must not be changed as it is used for creating path for storing remote store data on the remote store.
+     *
+     * @param bytes byte array
+     * @return base 64 string.
+     */
+    private static String base64(byte[] bytes) {
+        String base64 = Base64.getEncoder().encodeToString(bytes);
+        return base64.substring(0, base64.length() - 1).replace('/', '_').replace('+', '-');
+    }
 }

--- a/server/src/main/java/org/opensearch/index/remote/RemoteStoreUtils.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStoreUtils.java
@@ -106,23 +106,14 @@ public class RemoteStoreUtils {
     /**
      * Converts an input hash which occupies 64 bits of space into Base64 (6 bits per character) String. This must not
      * be changed as it is used for creating path for storing remote store data on the remote store.
-     */
-    static String longToBase64(long value) {
-        byte[] hashBytes = ByteBuffer.allocate(Long.BYTES).putLong(value).array();
-        return base64(hashBytes);
-    }
-
-    /**
      * This converts the byte array to base 64 string. `/` is replaced with `_`, `+` is replaced with `-` and `=`
      * which is padded at the last is also removed. These characters are either used as delimiter or special character
      * requiring special handling in some vendors. The characters present in this base64 version are [A-Za-z0-9_-].
      * This must not be changed as it is used for creating path for storing remote store data on the remote store.
-     *
-     * @param bytes byte array
-     * @return base 64 string.
      */
-    private static String base64(byte[] bytes) {
-        String base64 = Base64.getEncoder().encodeToString(bytes);
-        return base64.substring(0, base64.length() - 1).replace('/', '_').replace('+', '-');
+    static String longToUrlBase64(long value) {
+        byte[] hashBytes = ByteBuffer.allocate(Long.BYTES).putLong(value).array();
+        String base64Str = Base64.getUrlEncoder().encodeToString(hashBytes);
+        return base64Str.substring(0, base64Str.length() - 1);
     }
 }

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -312,7 +312,7 @@ public class IndicesService extends AbstractLifecycleComponent
      */
     public static final Setting<PathType> CLUSTER_REMOTE_STORE_PATH_PREFIX_TYPE_SETTING = new Setting<>(
         "cluster.remote_store.index.path.prefix.type",
-        PathType.FIXED.toString(),
+        PathType.HASHED_PREFIX.toString(),
         PathType::parseString,
         Property.NodeScope,
         Property.Dynamic

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -312,7 +312,7 @@ public class IndicesService extends AbstractLifecycleComponent
      */
     public static final Setting<PathType> CLUSTER_REMOTE_STORE_PATH_PREFIX_TYPE_SETTING = new Setting<>(
         "cluster.remote_store.index.path.prefix.type",
-        PathType.HASHED_PREFIX.toString(),
+        PathType.FIXED.toString(),
         PathType::parseString,
         Property.NodeScope,
         Property.Dynamic

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStoreEnumsTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStoreEnumsTests.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.index.remote;
 
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.index.remote.RemoteStoreEnums.DataCategory;
 import org.opensearch.index.remote.RemoteStoreEnums.DataType;
@@ -24,7 +25,10 @@ import static org.opensearch.index.remote.RemoteStoreEnums.DataCategory.TRANSLOG
 import static org.opensearch.index.remote.RemoteStoreEnums.DataType.DATA;
 import static org.opensearch.index.remote.RemoteStoreEnums.DataType.LOCK_FILES;
 import static org.opensearch.index.remote.RemoteStoreEnums.DataType.METADATA;
+import static org.opensearch.index.remote.RemoteStoreEnums.PathHashAlgorithm.FNV_1A;
 import static org.opensearch.index.remote.RemoteStoreEnums.PathType.FIXED;
+import static org.opensearch.index.remote.RemoteStoreEnums.PathType.HASHED_INFIX;
+import static org.opensearch.index.remote.RemoteStoreEnums.PathType.HASHED_PREFIX;
 import static org.opensearch.index.remote.RemoteStoreEnums.PathType.parseString;
 
 public class RemoteStoreEnumsTests extends OpenSearchTestCase {
@@ -136,6 +140,370 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
         assertEquals(basePath + dataCategory.getName() + SEPARATOR + dataType.getName() + SEPARATOR, result.buildAsString());
     }
 
+    public void testGeneratePathForHashedPrefixType() {
+        BlobPath blobPath = new BlobPath();
+        List<String> pathList = getPathList();
+        for (String path : pathList) {
+            blobPath = blobPath.add(path);
+        }
+
+        String indexUUID = randomAlphaOfLength(10);
+        String shardId = String.valueOf(randomInt(100));
+        DataCategory dataCategory = TRANSLOG;
+        DataType dataType = DATA;
+
+        String basePath = getPath(pathList) + indexUUID + SEPARATOR + shardId;
+        // Translog Data
+        PathInput pathInput = PathInput.builder()
+            .basePath(blobPath)
+            .indexUUID(indexUUID)
+            .shardId(shardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        BlobPath result = HASHED_PREFIX.path(pathInput, FNV_1A);
+        assertTrue(
+            result.buildAsString()
+                .startsWith(String.join(SEPARATOR, FNV_1A.hash(pathInput), basePath, dataCategory.getName(), dataType.getName()))
+        );
+
+        // assert with exact value for known base path
+        BlobPath fixedBlobPath = BlobPath.cleanPath().add("xjsdhj").add("ddjsha").add("yudy7sd").add("32hdhua7").add("89jdij");
+        String fixedIndexUUID = "k2ijhe877d7yuhx7";
+        String fixedShardId = "10";
+        pathInput = PathInput.builder()
+            .basePath(fixedBlobPath)
+            .indexUUID(fixedIndexUUID)
+            .shardId(fixedShardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        result = HASHED_PREFIX.path(pathInput, FNV_1A);
+        assertEquals("DgSI70IciXs/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/translog/data/", result.buildAsString());
+
+        // Translog Metadata
+        dataType = METADATA;
+        pathInput = PathInput.builder()
+            .basePath(blobPath)
+            .indexUUID(indexUUID)
+            .shardId(shardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        result = HASHED_PREFIX.path(pathInput, FNV_1A);
+        assertTrue(
+            result.buildAsString()
+                .startsWith(String.join(SEPARATOR, FNV_1A.hash(pathInput), basePath, dataCategory.getName(), dataType.getName()))
+        );
+
+        // assert with exact value for known base path
+        pathInput = PathInput.builder()
+            .basePath(fixedBlobPath)
+            .indexUUID(fixedIndexUUID)
+            .shardId(fixedShardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        result = HASHED_PREFIX.path(pathInput, FNV_1A);
+        assertEquals("oKU5SjILiy4/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/translog/metadata/", result.buildAsString());
+
+        // Translog Lock files - This is a negative case where the assertion will trip.
+        dataType = LOCK_FILES;
+        PathInput finalPathInput = PathInput.builder()
+            .basePath(blobPath)
+            .indexUUID(indexUUID)
+            .shardId(shardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        assertThrows(AssertionError.class, () -> HASHED_PREFIX.path(finalPathInput, null));
+
+        // assert with exact value for known base path
+        pathInput = PathInput.builder()
+            .basePath(fixedBlobPath)
+            .indexUUID(fixedIndexUUID)
+            .shardId(fixedShardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        assertThrows(AssertionError.class, () -> HASHED_PREFIX.path(finalPathInput, null));
+
+        // Segment Data
+        dataCategory = SEGMENTS;
+        dataType = DATA;
+        pathInput = PathInput.builder()
+            .basePath(blobPath)
+            .indexUUID(indexUUID)
+            .shardId(shardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        result = HASHED_PREFIX.path(pathInput, FNV_1A);
+        assertTrue(
+            result.buildAsString()
+                .startsWith(String.join(SEPARATOR, FNV_1A.hash(pathInput), basePath, dataCategory.getName(), dataType.getName()))
+        );
+
+        // assert with exact value for known base path
+        pathInput = PathInput.builder()
+            .basePath(fixedBlobPath)
+            .indexUUID(fixedIndexUUID)
+            .shardId(fixedShardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        result = HASHED_PREFIX.path(pathInput, FNV_1A);
+        assertEquals("AUBRfCIuWdk/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/segments/data/", result.buildAsString());
+
+        // Segment Metadata
+        dataType = METADATA;
+        pathInput = PathInput.builder()
+            .basePath(blobPath)
+            .indexUUID(indexUUID)
+            .shardId(shardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        result = HASHED_PREFIX.path(pathInput, FNV_1A);
+        assertTrue(
+            result.buildAsString()
+                .startsWith(String.join(SEPARATOR, FNV_1A.hash(pathInput), basePath, dataCategory.getName(), dataType.getName()))
+        );
+
+        // assert with exact value for known base path
+        pathInput = PathInput.builder()
+            .basePath(fixedBlobPath)
+            .indexUUID(fixedIndexUUID)
+            .shardId(fixedShardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        result = HASHED_PREFIX.path(pathInput, FNV_1A);
+        assertEquals("erwR-G735Uw/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/segments/metadata/", result.buildAsString());
+
+        // Segment Lockfiles
+        dataType = LOCK_FILES;
+        pathInput = PathInput.builder()
+            .basePath(blobPath)
+            .indexUUID(indexUUID)
+            .shardId(shardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        result = HASHED_PREFIX.path(pathInput, FNV_1A);
+        assertTrue(
+            result.buildAsString()
+                .startsWith(String.join(SEPARATOR, FNV_1A.hash(pathInput), basePath, dataCategory.getName(), dataType.getName()))
+        );
+
+        // assert with exact value for known base path
+        pathInput = PathInput.builder()
+            .basePath(fixedBlobPath)
+            .indexUUID(fixedIndexUUID)
+            .shardId(fixedShardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        result = HASHED_PREFIX.path(pathInput, FNV_1A);
+        assertEquals("KeYDIk0mJXI/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/segments/lock_files/", result.buildAsString());
+    }
+
+    public void testGeneratePathForHashedInfixType() {
+        BlobPath blobPath = new BlobPath();
+        List<String> pathList = getPathList();
+        for (String path : pathList) {
+            blobPath = blobPath.add(path);
+        }
+
+        String indexUUID = randomAlphaOfLength(10);
+        String shardId = String.valueOf(randomInt(100));
+        DataCategory dataCategory = TRANSLOG;
+        DataType dataType = DATA;
+
+        String basePath = getPath(pathList);
+        basePath = basePath.length() == 0 ? basePath : basePath.substring(0, basePath.length() - 1);
+        // Translog Data
+        PathInput pathInput = PathInput.builder()
+            .basePath(blobPath)
+            .indexUUID(indexUUID)
+            .shardId(shardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        BlobPath result = HASHED_INFIX.path(pathInput, FNV_1A);
+        String expected = derivePath(basePath, pathInput);
+        String actual = result.buildAsString();
+        assertTrue(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual.startsWith(expected));
+
+        // assert with exact value for known base path
+        BlobPath fixedBlobPath = BlobPath.cleanPath().add("xjsdhj").add("ddjsha").add("yudy7sd").add("32hdhua7").add("89jdij");
+        String fixedIndexUUID = "k2ijhe877d7yuhx7";
+        String fixedShardId = "10";
+        pathInput = PathInput.builder()
+            .basePath(fixedBlobPath)
+            .indexUUID(fixedIndexUUID)
+            .shardId(fixedShardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        result = HASHED_INFIX.path(pathInput, FNV_1A);
+        expected = "xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/DgSI70IciXs/k2ijhe877d7yuhx7/10/translog/data/";
+        actual = result.buildAsString();
+        assertTrue(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual.startsWith(expected));
+
+        // Translog Metadata
+        dataType = METADATA;
+        pathInput = PathInput.builder()
+            .basePath(blobPath)
+            .indexUUID(indexUUID)
+            .shardId(shardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+
+        result = HASHED_INFIX.path(pathInput, FNV_1A);
+        expected = derivePath(basePath, pathInput);
+        actual = result.buildAsString();
+        assertTrue(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual.startsWith(expected));
+
+        // assert with exact value for known base path
+        pathInput = PathInput.builder()
+            .basePath(fixedBlobPath)
+            .indexUUID(fixedIndexUUID)
+            .shardId(fixedShardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        result = HASHED_INFIX.path(pathInput, FNV_1A);
+        expected = "xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/oKU5SjILiy4/k2ijhe877d7yuhx7/10/translog/metadata/";
+        actual = result.buildAsString();
+        assertTrue(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual.startsWith(expected));
+
+        // Translog Lock files - This is a negative case where the assertion will trip.
+        dataType = LOCK_FILES;
+        PathInput finalPathInput = PathInput.builder()
+            .basePath(blobPath)
+            .indexUUID(indexUUID)
+            .shardId(shardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        assertThrows(AssertionError.class, () -> HASHED_INFIX.path(finalPathInput, null));
+
+        // assert with exact value for known base path
+        pathInput = PathInput.builder()
+            .basePath(fixedBlobPath)
+            .indexUUID(fixedIndexUUID)
+            .shardId(fixedShardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        assertThrows(AssertionError.class, () -> HASHED_INFIX.path(finalPathInput, null));
+
+        // Segment Data
+        dataCategory = SEGMENTS;
+        dataType = DATA;
+        pathInput = PathInput.builder()
+            .basePath(blobPath)
+            .indexUUID(indexUUID)
+            .shardId(shardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        result = HASHED_INFIX.path(pathInput, FNV_1A);
+        expected = derivePath(basePath, pathInput);
+        actual = result.buildAsString();
+        assertTrue(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual.startsWith(expected));
+
+        // assert with exact value for known base path
+        pathInput = PathInput.builder()
+            .basePath(fixedBlobPath)
+            .indexUUID(fixedIndexUUID)
+            .shardId(fixedShardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        result = HASHED_INFIX.path(pathInput, FNV_1A);
+        expected = "xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/AUBRfCIuWdk/k2ijhe877d7yuhx7/10/segments/data/";
+        actual = result.buildAsString();
+        assertTrue(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual.startsWith(expected));
+
+        // Segment Metadata
+        dataType = METADATA;
+        pathInput = PathInput.builder()
+            .basePath(blobPath)
+            .indexUUID(indexUUID)
+            .shardId(shardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        result = HASHED_INFIX.path(pathInput, FNV_1A);
+        expected = derivePath(basePath, pathInput);
+        actual = result.buildAsString();
+        assertTrue(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual.startsWith(expected));
+
+        // assert with exact value for known base path
+        pathInput = PathInput.builder()
+            .basePath(fixedBlobPath)
+            .indexUUID(fixedIndexUUID)
+            .shardId(fixedShardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        result = HASHED_INFIX.path(pathInput, FNV_1A);
+        expected = "xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/erwR-G735Uw/k2ijhe877d7yuhx7/10/segments/metadata/";
+        actual = result.buildAsString();
+        assertTrue(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual.startsWith(expected));
+
+        // Segment Lockfiles
+        dataType = LOCK_FILES;
+        pathInput = PathInput.builder()
+            .basePath(blobPath)
+            .indexUUID(indexUUID)
+            .shardId(shardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        result = HASHED_INFIX.path(pathInput, FNV_1A);
+        expected = derivePath(basePath, pathInput);
+        actual = result.buildAsString();
+        assertTrue(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual.startsWith(expected));
+
+        // assert with exact value for known base path
+        pathInput = PathInput.builder()
+            .basePath(fixedBlobPath)
+            .indexUUID(fixedIndexUUID)
+            .shardId(fixedShardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        result = HASHED_INFIX.path(pathInput, FNV_1A);
+        expected = "xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/KeYDIk0mJXI/k2ijhe877d7yuhx7/10/segments/lock_files/";
+        actual = result.buildAsString();
+        assertTrue(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual.startsWith(expected));
+    }
+
+    private String derivePath(String basePath, PathInput pathInput) {
+        return "".equals(basePath)
+            ? String.join(
+                SEPARATOR,
+                FNV_1A.hash(pathInput),
+                pathInput.indexUUID(),
+                pathInput.shardId(),
+                pathInput.dataCategory().getName(),
+                pathInput.dataType().getName()
+            )
+            : String.join(
+                SEPARATOR,
+                basePath,
+                FNV_1A.hash(pathInput),
+                pathInput.indexUUID(),
+                pathInput.shardId(),
+                pathInput.dataCategory().getName(),
+                pathInput.dataType().getName()
+            );
+    }
+
     private List<String> getPathList() {
         List<String> pathList = new ArrayList<>();
         int length = randomIntBetween(0, 5);
@@ -152,5 +520,4 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
         }
         return p + SEPARATOR;
     }
-
 }

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStorePathStrategyResolverTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStorePathStrategyResolverTests.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.remote;
+
+import org.opensearch.Version;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.remote.RemoteStoreEnums.PathType;
+import org.opensearch.test.OpenSearchTestCase;
+
+import static org.opensearch.indices.IndicesService.CLUSTER_REMOTE_STORE_PATH_PREFIX_TYPE_SETTING;
+
+public class RemoteStorePathStrategyResolverTests extends OpenSearchTestCase {
+
+    public void testGetMinVersionOlder() {
+        Settings settings = Settings.builder()
+            .put(CLUSTER_REMOTE_STORE_PATH_PREFIX_TYPE_SETTING.getKey(), randomFrom(PathType.values()))
+            .build();
+        ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        RemoteStorePathStrategyResolver resolver = new RemoteStorePathStrategyResolver(clusterSettings, () -> Version.V_2_13_0);
+        assertEquals(PathType.FIXED, resolver.get().getType());
+        assertNull(resolver.get().getHashAlgorithm());
+    }
+
+    public void testGetMinVersionNewer() {
+        PathType pathType = randomFrom(PathType.values());
+        Settings settings = Settings.builder().put(CLUSTER_REMOTE_STORE_PATH_PREFIX_TYPE_SETTING.getKey(), pathType).build();
+        ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        RemoteStorePathStrategyResolver resolver = new RemoteStorePathStrategyResolver(clusterSettings, () -> Version.CURRENT);
+        assertEquals(pathType, resolver.get().getType());
+        if (pathType.requiresHashAlgorithm()) {
+            assertNotNull(resolver.get().getHashAlgorithm());
+        } else {
+            assertNull(resolver.get().getHashAlgorithm());
+        }
+
+    }
+
+}

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStoreUtilsTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStoreUtilsTests.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.opensearch.index.remote.RemoteStoreUtils.longToBase64;
+import static org.opensearch.index.remote.RemoteStoreUtils.longToUrlBase64;
 import static org.opensearch.index.remote.RemoteStoreUtils.verifyNoMultipleWriters;
 import static org.opensearch.index.store.RemoteSegmentStoreDirectory.MetadataFilenameUtils.METADATA_PREFIX;
 import static org.opensearch.index.store.RemoteSegmentStoreDirectory.MetadataFilenameUtils.SEPARATOR;
@@ -205,7 +205,7 @@ public class RemoteStoreUtilsTests extends OpenSearchTestCase {
             "6kv3yZNv9kY"
         );
         for (Map.Entry<Long, String> entry : longToExpectedBase64String.entrySet()) {
-            assertEquals(entry.getValue(), longToBase64(entry.getKey()));
+            assertEquals(entry.getValue(), longToUrlBase64(entry.getKey()));
             assertEquals(11, entry.getValue().length());
         }
     }

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStoreUtilsTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStoreUtilsTests.java
@@ -17,8 +17,10 @@ import org.opensearch.test.OpenSearchTestCase;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.opensearch.index.remote.RemoteStoreUtils.longToBase64;
 import static org.opensearch.index.remote.RemoteStoreUtils.verifyNoMultipleWriters;
 import static org.opensearch.index.store.RemoteSegmentStoreDirectory.MetadataFilenameUtils.METADATA_PREFIX;
 import static org.opensearch.index.store.RemoteSegmentStoreDirectory.MetadataFilenameUtils.SEPARATOR;
@@ -179,4 +181,32 @@ public class RemoteStoreUtilsTests extends OpenSearchTestCase {
         );
     }
 
+    public void testLongToBase64() {
+        Map<Long, String> longToExpectedBase64String = Map.of(
+            -5537941589147079860L,
+            "syVHd0gGq0w",
+            -5878421770170594047L,
+            "rmumi5UPDQE",
+            -5147010836697060622L,
+            "uJIk6f-V6vI",
+            937096430362711837L,
+            "DQE8PQwOVx0",
+            8422273604115462710L,
+            "dOHtOEZzejY",
+            -2528761975013221124L,
+            "3OgIYbXSXPw",
+            -5512387536280560513L,
+            "s4AQvdu03H8",
+            -5749656451579835857L,
+            "sDUd65cNCi8",
+            5569654857969679538L,
+            "TUtjlYLPvLI",
+            -1563884000447039930L,
+            "6kv3yZNv9kY"
+        );
+        for (Map.Entry<Long, String> entry : longToExpectedBase64String.entrySet()) {
+            assertEquals(entry.getValue(), longToBase64(entry.getKey()));
+            assertEquals(11, entry.getValue().length());
+        }
+    }
 }

--- a/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryHelperTests.java
+++ b/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryHelperTests.java
@@ -43,6 +43,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static org.opensearch.index.remote.RemoteStoreEnums.DataCategory.SEGMENTS;
+import static org.opensearch.index.remote.RemoteStoreEnums.DataType.LOCK_FILES;
+import static org.opensearch.test.OpenSearchTestCase.getShardLevelBlobPath;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
@@ -56,14 +59,16 @@ public class BlobStoreRepositoryHelperTests extends OpenSearchSingleNodeTestCase
     }
 
     protected String[] getLockFilesInRemoteStore(String remoteStoreIndex, String remoteStoreRepository) throws IOException {
-        String indexUUID = client().admin()
-            .indices()
-            .prepareGetSettings(remoteStoreIndex)
-            .get()
-            .getSetting(remoteStoreIndex, IndexMetadata.SETTING_INDEX_UUID);
         final RepositoriesService repositoriesService = getInstanceFromNode(RepositoriesService.class);
         final BlobStoreRepository remoteStorerepository = (BlobStoreRepository) repositoriesService.repository(remoteStoreRepository);
-        BlobPath shardLevelBlobPath = remoteStorerepository.basePath().add(indexUUID).add("0").add("segments").add("lock_files");
+        BlobPath shardLevelBlobPath = getShardLevelBlobPath(
+            client(),
+            remoteStoreIndex,
+            remoteStorerepository.basePath(),
+            "0",
+            SEGMENTS,
+            LOCK_FILES
+        );
         BlobContainer blobContainer = remoteStorerepository.blobStore().blobContainer(shardLevelBlobPath);
         try (RemoteBufferedOutputDirectory lockDirectory = new RemoteBufferedOutputDirectory(blobContainer)) {
             return Arrays.stream(lockDirectory.listAll())

--- a/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryHelperTests.java
+++ b/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryHelperTests.java
@@ -45,7 +45,6 @@ import java.util.Map;
 
 import static org.opensearch.index.remote.RemoteStoreEnums.DataCategory.SEGMENTS;
 import static org.opensearch.index.remote.RemoteStoreEnums.DataType.LOCK_FILES;
-import static org.opensearch.test.OpenSearchTestCase.getShardLevelBlobPath;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;

--- a/test/framework/src/main/java/org/opensearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -101,6 +101,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import static org.opensearch.index.remote.RemoteStoreEnums.DataCategory.SEGMENTS;
+import static org.opensearch.index.remote.RemoteStoreEnums.DataType.LOCK_FILES;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -559,19 +561,16 @@ public abstract class AbstractSnapshotIntegTestCase extends OpenSearchIntegTestC
     }
 
     protected String[] getLockFilesInRemoteStore(String remoteStoreIndex, String remoteStoreRepositoryName) throws IOException {
-        String indexUUID = client().admin()
-            .indices()
-            .prepareGetSettings(remoteStoreIndex)
-            .get()
-            .getSetting(remoteStoreIndex, IndexMetadata.SETTING_INDEX_UUID);
-        return getLockFilesInRemoteStore(remoteStoreIndex, remoteStoreRepositoryName, indexUUID);
-    }
-
-    protected String[] getLockFilesInRemoteStore(String remoteStoreIndex, String remoteStoreRepositoryName, String indexUUID)
-        throws IOException {
         final RepositoriesService repositoriesService = internalCluster().getCurrentClusterManagerNodeInstance(RepositoriesService.class);
         final BlobStoreRepository remoteStoreRepository = (BlobStoreRepository) repositoriesService.repository(remoteStoreRepositoryName);
-        BlobPath shardLevelBlobPath = remoteStoreRepository.basePath().add(indexUUID).add("0").add("segments").add("lock_files");
+        BlobPath shardLevelBlobPath = getShardLevelBlobPath(
+            client(),
+            remoteStoreIndex,
+            remoteStoreRepository.basePath(),
+            "0",
+            SEGMENTS,
+            LOCK_FILES
+        );
         BlobContainer blobContainer = remoteStoreRepository.blobStore().blobContainer(shardLevelBlobPath);
         try (RemoteBufferedOutputDirectory lockDirectory = new RemoteBufferedOutputDirectory(blobContainer)) {
             return lockDirectory.listAll();

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
@@ -135,6 +135,7 @@ import org.opensearch.index.codec.CodecService;
 import org.opensearch.index.engine.Segment;
 import org.opensearch.index.mapper.CompletionFieldMapper;
 import org.opensearch.index.mapper.MockFieldFilterPlugin;
+import org.opensearch.index.remote.RemoteStoreEnums.PathType;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.store.Store;
 import org.opensearch.index.translog.Translog;
@@ -210,6 +211,7 @@ import static org.opensearch.index.IndexSettings.INDEX_DOC_ID_FUZZY_SET_ENABLED_
 import static org.opensearch.index.IndexSettings.INDEX_DOC_ID_FUZZY_SET_FALSE_POSITIVE_PROBABILITY_SETTING;
 import static org.opensearch.index.IndexSettings.INDEX_SOFT_DELETES_RETENTION_LEASE_PERIOD_SETTING;
 import static org.opensearch.index.query.QueryBuilders.matchAllQuery;
+import static org.opensearch.indices.IndicesService.CLUSTER_REMOTE_STORE_PATH_PREFIX_TYPE_SETTING;
 import static org.opensearch.indices.IndicesService.CLUSTER_REPLICATION_TYPE_SETTING;
 import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.REMOTE_STORE_CLUSTER_STATE_REPOSITORY_NAME_ATTRIBUTE_KEY;
 import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_SETTINGS_ATTRIBUTE_KEY_PREFIX;
@@ -2593,6 +2595,7 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
             settings.put(segmentRepoSettingsAttributeKeyPrefix + "compress", randomBoolean())
                 .put(segmentRepoSettingsAttributeKeyPrefix + "chunk_size", 200, ByteSizeUnit.BYTES);
         }
+        settings.put(CLUSTER_REMOTE_STORE_PATH_PREFIX_TYPE_SETTING.getKey(), randomFrom(PathType.values()));
         return settings.build();
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This is one of the tasks to achieve https://github.com/opensearch-project/OpenSearch/issues/12589 as part of the feature request https://github.com/opensearch-project/OpenSearch/issues/12567. This is only an increment step to conclude the optimised prefix path work proposed in the feature request.

In this PR, we are getting following things done -
1. Implement hash functions for the path generation based on the custom data in the index metadata.
2. Made the `hashed_prefix` as the default path type.
3. Added another path type `hashed_infix`. This can be used to keep the data confined for a cluster within the base path supplied by the user.
4. Added multiple tests, updated multiple UTs and ITs.

### Related Issues
Resolves #13074
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- ~[ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
