### PR TITLE
Changing minimum number of required connections to 0 for bulk,state,rec…

### DIFF
--- a/server/src/main/java/org/opensearch/transport/TransportSettings.java
+++ b/server/src/main/java/org/opensearch/transport/TransportSettings.java
@@ -272,13 +272,13 @@ public final class TransportSettings {
     public static final Setting<Integer> CONNECTIONS_PER_NODE_RECOVERY = intSetting(
         "transport.connections_per_node.recovery",
         2,
-        1,
+        0,
         Setting.Property.NodeScope
     );
     public static final Setting<Integer> CONNECTIONS_PER_NODE_BULK = intSetting(
         "transport.connections_per_node.bulk",
         3,
-        1,
+        0,
         Setting.Property.NodeScope
     );
     public static final Setting<Integer> CONNECTIONS_PER_NODE_REG = intSetting(
@@ -290,7 +290,7 @@ public final class TransportSettings {
     public static final Setting<Integer> CONNECTIONS_PER_NODE_STATE = intSetting(
         "transport.connections_per_node.state",
         1,
-        1,
+        0,
         Setting.Property.NodeScope
     );
     public static final Setting<Integer> CONNECTIONS_PER_NODE_PING = intSetting(


### PR DESCRIPTION
### Description
We need to allow particular channels/connections to be `0` in some cases. 
Like,
1. For dedicated coordinator node set up, coordinator nodes doesn;t require `recovery` channels
2. Data/coordinator nodes doesn't have to initialize for `state` channels.
3. Dedicated master nodes doesn't require `bulk` in case they are not put up for coordinator nodes.

But other channels like `regular` & `ping` requres at least a connection/channel so not modifying them.


### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
