### PR TITLE
Skip Pull Request Checks / Verify Description Checklist for dependabot

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: peternied/check-pull-request-description-checklist@v1.1
+        if: github.actor != 'dependabot[bot]'
         with:
           checklist-items: |
             New functionality includes testing.


### PR DESCRIPTION
### Description

Skips the CI check `Pull Request Checks / Verify Description Checklist` for PRs from dependabot.

See the CI checks on a dependabot PR like [this](https://github.com/opensearch-project/OpenSearch/pull/13117) where the check fails since it doesn't contain the checklist on the PR template.

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
