### PR TITLE
[BUG] Fix missing javadocs error for nested generated types

### DIFF
--- a/doc-tools/missing-doclet/src/main/java/org/opensearch/missingdoclet/MissingDoclet.java
+++ b/doc-tools/missing-doclet/src/main/java/org/opensearch/missingdoclet/MissingDoclet.java
@@ -332,13 +332,20 @@ public class MissingDoclet extends StandardDoclet {
 
     // Ignore classes annotated with @Generated and all enclosed elements in them.
     private boolean isGenerated(Element element) {
-        return element
+        final boolean isGenerated = element
             .getAnnotationMirrors()
             .stream()
             .anyMatch(m -> m
                 .getAnnotationType()
                 .toString() /* ClassSymbol.toString() returns class name */
                 .equalsIgnoreCase("javax.annotation.Generated"));
+
+        if (!isGenerated && element.getEnclosingElement() != null) {
+            // check if enclosing element is generated
+            return isGenerated(element.getEnclosingElement());
+        } 
+
+        return isGenerated;
     }
 
     private boolean hasInheritedJavadocs(Element element) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
There are generators (like `protobuf`) which add `@javax.annotation.Generated` to top level classes only. The missing javadoc verification does not support that and fails with the error.

```
@javax.annotation.Generated(value="protoc", comments="annotations:FetchSearchResultProto.java.pb.meta")
public final class FetchSearchResultProto {
  public interface FetchSearchResultOrBuilder extends
  // ...
  }
}
```

### Related Issues
Closes https://github.com/opensearch-project/OpenSearch/issues/11913

<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
