### PR TITLE
Bump `joda-time` from 2.12.2 to 2.12.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump Apache Tika from 2.6.0 to 2.9.2 ([#12627](https://github.com/opensearch-project/OpenSearch/pull/12627))
 - Bump `com.gradle.enterprise` from 3.16.2 to 3.17.1 ([#13116](https://github.com/opensearch-project/OpenSearch/pull/13116), [#13191](https://github.com/opensearch-project/OpenSearch/pull/13191))
 - Bump `gradle/wrapper-validation-action` from 2 to 3 ([#13192](https://github.com/opensearch-project/OpenSearch/pull/13192))
+- Bump `joda-time` from 2.12.2 to 2.12.7 ([#](https://github.com/opensearch-project/OpenSearch/pull/))
 
 ### Changed
 - [BWC and API enforcement] Enforcing the presence of API annotations at build time ([#12872](https://github.com/opensearch-project/OpenSearch/pull/12872))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump Apache Tika from 2.6.0 to 2.9.2 ([#12627](https://github.com/opensearch-project/OpenSearch/pull/12627))
 - Bump `com.gradle.enterprise` from 3.16.2 to 3.17.1 ([#13116](https://github.com/opensearch-project/OpenSearch/pull/13116), [#13191](https://github.com/opensearch-project/OpenSearch/pull/13191))
 - Bump `gradle/wrapper-validation-action` from 2 to 3 ([#13192](https://github.com/opensearch-project/OpenSearch/pull/13192))
-- Bump `joda-time` from 2.12.2 to 2.12.7 ([#](https://github.com/opensearch-project/OpenSearch/pull/))
+- Bump `joda-time` from 2.12.2 to 2.12.7 ([#13203](https://github.com/opensearch-project/OpenSearch/pull/13203))
 
 ### Changed
 - [BWC and API enforcement] Enforcing the presence of API annotations at build time ([#12872](https://github.com/opensearch-project/OpenSearch/pull/12872))

--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -27,7 +27,7 @@ jakarta_annotation = 1.3.5
 jna               = 5.13.0
 
 netty             = 4.1.108.Final
-joda              = 2.12.2
+joda              = 2.12.7
 
 # project reactor
 reactor_netty     = 1.1.17


### PR DESCRIPTION
### Description
Bump `joda-time` from 2.12.2 to 2.12.7
Addresses CVE-2024-23080

### Related Issues
- Resolves https://github.com/opensearch-project/security/issues/4249
- Resolves https://github.com/opensearch-project/security-analytics/issues/983
- Resolves https://github.com/opensearch-project/spring-data-opensearch/issues/262

### Check List
- [ ] ~New functionality includes testing.~
  - [] ~All tests pass~
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [X] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
