### PR TITLE
[Remote Store] Abstract out remote segment garbage collection logic

### DIFF
--- a/server/src/main/java/org/opensearch/index/shard/CommitTriggeredRemoteSegmentGarbageCollector.java
+++ b/server/src/main/java/org/opensearch/index/shard/CommitTriggeredRemoteSegmentGarbageCollector.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.shard;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.store.Directory;
+import org.opensearch.common.logging.Loggers;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.index.remote.RemoteStoreUtils;
+import org.opensearch.index.store.RemoteSegmentStoreDirectory;
+import org.opensearch.indices.RemoteStoreSettings;
+
+public class CommitTriggeredRemoteSegmentGarbageCollector implements RemoteSegmentGarbageCollector {
+    private final Logger logger;
+    private final Directory storeDirectory;
+    private final RemoteSegmentStoreDirectory remoteDirectory;
+
+    private final RemoteStoreSettings remoteStoreSettings;
+
+    public CommitTriggeredRemoteSegmentGarbageCollector(
+        ShardId shardId,
+        Directory storeDirectory,
+        RemoteSegmentStoreDirectory remoteDirectory,
+        RemoteStoreSettings remoteStoreSettings
+    ) {
+        logger = Loggers.getLogger(getClass(), shardId);
+        this.storeDirectory = storeDirectory;
+        this.remoteDirectory = remoteDirectory;
+        this.remoteStoreSettings = remoteStoreSettings;
+    }
+
+    @Override
+    public void deleteStaleSegments(Listener listener) {
+        // if a new segments_N file is present in local that is not uploaded to remote store yet, it
+        // is considered as a first refresh post commit. A cleanup of stale commit files is triggered.
+        // This is done to avoid triggering delete post each refresh.
+        if (RemoteStoreUtils.isLatestSegmentInfosUploadedToRemote(storeDirectory, remoteDirectory) == false) {
+            remoteDirectory.deleteStaleSegmentsAsync(remoteStoreSettings.getMinRemoteSegmentMetadataFiles(), new ActionListener<Void>() {
+                @Override
+                public void onResponse(Void unused) {
+                    listener.onSuccess(unused);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    listener.onFailure(e);
+                }
+            });
+        } else {
+            String skipReason =
+                "Skipping garbage collection, CommitTriggeredRemoteSegmentGarbageCollector only triggers deletion on commit";
+            logger.debug(skipReason);
+            listener.onSkip(skipReason);
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/index/shard/RemoteSegmentGarbageCollector.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteSegmentGarbageCollector.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.shard;
+
+public interface RemoteSegmentGarbageCollector {
+
+    interface Listener {
+
+        /**
+         * Called after the successful deletion of stale segments from remote store
+         */
+        void onSuccess(Void response);
+
+        /**
+         * Called on exception while deleting stale segments from remote store
+         */
+        void onFailure(Exception e);
+
+        /**
+         * Called on skipping the garbage collection
+         */
+        void onSkip(String reason);
+    }
+
+    Listener DEFAULT_NOOP_LISTENER = new Listener() {
+        @Override
+        public void onSuccess(Void response) {}
+
+        @Override
+        public void onFailure(Exception e) {}
+
+        @Override
+        public void onSkip(String reason) {}
+    };
+
+    /**
+     * Deletes stale segments from remote store and notifies the listener.
+     */
+    void deleteStaleSegments(Listener listener);
+}


### PR DESCRIPTION
### Description
- Currently, remote segment garbage collection is tightly coupled with `RemoteStoreRefreshListener` and has a fixed logic where the deletion is triggered post commit.
- Ideally, garbage collection should be a separate flow and should not be coupled with RemoteStoreRefreshListener.
- It is also possible to have different triggers to the garbage collection like time based, size based etc.
- It shold also be possible to turn off the garbage collection completely where user wants to control it externally.
- In this PR, logic for remote segment garbage collection is abstracted out from `RemoteStoreRefreshListener`.

### Related Issues
- https://github.com/opensearch-project/OpenSearch/issues/13223

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
