### PR TITLE
[Backport 2.x] [Tiered Caching] Stats rework (1/3): Interfaces and implementations for individual tiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add cluster primary balance contraint for rebalancing with buffer ([#12656](https://github.com/opensearch-project/OpenSearch/pull/12656))
 - Derived fields support to derive field values at query time without indexing ([#12569](https://github.com/opensearch-project/OpenSearch/pull/12569))
 - Add support for more than one protocol for transport ([#12967](https://github.com/opensearch-project/OpenSearch/pull/12967))
+- [Tiered Caching] Add dimension-based stats to ICache implementations. ([#12531](https://github.com/opensearch-project/OpenSearch/pull/12531))
 - Add changes for overriding remote store and replication settings during snapshot restore. ([#11868](https://github.com/opensearch-project/OpenSearch/pull/11868))
 - Reject Resize index requests (i.e, split, shrink and clone), While DocRep to SegRep migration is in progress.([#12686](https://github.com/opensearch-project/OpenSearch/pull/12686))
 - Add an individual setting of rate limiter for segment replication ([#12959](https://github.com/opensearch-project/OpenSearch/pull/12959))

--- a/modules/cache-common/src/test/java/org/opensearch/cache/common/tier/MockDiskCache.java
+++ b/modules/cache-common/src/test/java/org/opensearch/cache/common/tier/MockDiskCache.java
@@ -10,11 +10,13 @@ package org.opensearch.cache.common.tier;
 
 import org.opensearch.common.cache.CacheType;
 import org.opensearch.common.cache.ICache;
+import org.opensearch.common.cache.ICacheKey;
 import org.opensearch.common.cache.LoadAwareCacheLoader;
 import org.opensearch.common.cache.RemovalListener;
 import org.opensearch.common.cache.RemovalNotification;
 import org.opensearch.common.cache.RemovalReason;
 import org.opensearch.common.cache.serializer.Serializer;
+import org.opensearch.common.cache.stats.ImmutableCacheStatsHolder;
 import org.opensearch.common.cache.store.builders.ICacheBuilder;
 import org.opensearch.common.cache.store.config.CacheConfig;
 
@@ -25,27 +27,27 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class MockDiskCache<K, V> implements ICache<K, V> {
 
-    Map<K, V> cache;
+    Map<ICacheKey<K>, V> cache;
     int maxSize;
     long delay;
 
-    private final RemovalListener<K, V> removalListener;
+    private final RemovalListener<ICacheKey<K>, V> removalListener;
 
-    public MockDiskCache(int maxSize, long delay, RemovalListener<K, V> removalListener) {
+    public MockDiskCache(int maxSize, long delay, RemovalListener<ICacheKey<K>, V> removalListener) {
         this.maxSize = maxSize;
         this.delay = delay;
         this.removalListener = removalListener;
-        this.cache = new ConcurrentHashMap<K, V>();
+        this.cache = new ConcurrentHashMap<ICacheKey<K>, V>();
     }
 
     @Override
-    public V get(K key) {
+    public V get(ICacheKey<K> key) {
         V value = cache.get(key);
         return value;
     }
 
     @Override
-    public void put(K key, V value) {
+    public void put(ICacheKey<K> key, V value) {
         if (this.cache.size() >= maxSize) { // For simplification
             this.removalListener.onRemoval(new RemovalNotification<>(key, value, RemovalReason.EVICTED));
         }
@@ -58,7 +60,7 @@ public class MockDiskCache<K, V> implements ICache<K, V> {
     }
 
     @Override
-    public V computeIfAbsent(K key, LoadAwareCacheLoader<K, V> loader) {
+    public V computeIfAbsent(ICacheKey<K> key, LoadAwareCacheLoader<ICacheKey<K>, V> loader) {
         V value = cache.computeIfAbsent(key, key1 -> {
             try {
                 return loader.load(key);
@@ -70,7 +72,7 @@ public class MockDiskCache<K, V> implements ICache<K, V> {
     }
 
     @Override
-    public void invalidate(K key) {
+    public void invalidate(ICacheKey<K> key) {
         this.cache.remove(key);
     }
 
@@ -80,7 +82,7 @@ public class MockDiskCache<K, V> implements ICache<K, V> {
     }
 
     @Override
-    public Iterable<K> keys() {
+    public Iterable<ICacheKey<K>> keys() {
         return () -> new CacheKeyIterator<>(cache, removalListener);
     }
 
@@ -91,6 +93,11 @@ public class MockDiskCache<K, V> implements ICache<K, V> {
 
     @Override
     public void refresh() {}
+
+    @Override
+    public ImmutableCacheStatsHolder stats() {
+        return null;
+    }
 
     @Override
     public void close() {

--- a/plugins/cache-ehcache/src/test/java/org/opensearch/cache/store/disk/EhCacheDiskCacheTests.java
+++ b/plugins/cache-ehcache/src/test/java/org/opensearch/cache/store/disk/EhCacheDiskCacheTests.java
@@ -14,11 +14,13 @@ import org.opensearch.cache.EhcacheDiskCacheSettings;
 import org.opensearch.common.Randomness;
 import org.opensearch.common.cache.CacheType;
 import org.opensearch.common.cache.ICache;
+import org.opensearch.common.cache.ICacheKey;
 import org.opensearch.common.cache.LoadAwareCacheLoader;
 import org.opensearch.common.cache.RemovalListener;
 import org.opensearch.common.cache.RemovalNotification;
 import org.opensearch.common.cache.serializer.BytesReferenceSerializer;
 import org.opensearch.common.cache.serializer.Serializer;
+import org.opensearch.common.cache.stats.ImmutableCacheStats;
 import org.opensearch.common.cache.store.config.CacheConfig;
 import org.opensearch.common.metrics.CounterMetric;
 import org.opensearch.common.settings.Settings;
@@ -43,6 +45,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Phaser;
+import java.util.function.ToLongBiFunction;
 
 import static org.opensearch.cache.EhcacheDiskCacheSettings.DISK_LISTENER_MODE_SYNC_KEY;
 import static org.opensearch.cache.EhcacheDiskCacheSettings.DISK_MAX_SIZE_IN_BYTES_KEY;
@@ -53,10 +56,12 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
 
     private static final int CACHE_SIZE_IN_BYTES = 1024 * 101;
+    private final String dimensionName = "shardId";
 
     public void testBasicGetAndPut() throws IOException {
         Settings settings = Settings.builder().build();
         MockRemovalListener<String, String> removalListener = new MockRemovalListener<>();
+        ToLongBiFunction<ICacheKey<String>, String> weigher = getWeigher();
         try (NodeEnvironment env = newNodeEnvironment(settings)) {
             ICache<String, String> ehcacheTest = new EhcacheDiskCache.Builder<String, String>().setThreadPoolAlias("ehcacheTest")
                 .setStoragePath(env.nodePaths()[0].indicesPath.toString() + "/request_cache")
@@ -65,31 +70,41 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                 .setValueType(String.class)
                 .setKeySerializer(new StringSerializer())
                 .setValueSerializer(new StringSerializer())
+                .setDimensionNames(List.of(dimensionName))
                 .setCacheType(CacheType.INDICES_REQUEST_CACHE)
                 .setSettings(settings)
                 .setExpireAfterAccess(TimeValue.MAX_VALUE)
                 .setMaximumWeightInBytes(CACHE_SIZE_IN_BYTES)
                 .setRemovalListener(removalListener)
+                .setWeigher(weigher)
                 .build();
             int randomKeys = randomIntBetween(10, 100);
+            long expectedSize = 0;
             Map<String, String> keyValueMap = new HashMap<>();
             for (int i = 0; i < randomKeys; i++) {
                 keyValueMap.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
             }
             for (Map.Entry<String, String> entry : keyValueMap.entrySet()) {
-                ehcacheTest.put(entry.getKey(), entry.getValue());
+                ICacheKey<String> iCacheKey = getICacheKey(entry.getKey());
+                ehcacheTest.put(iCacheKey, entry.getValue());
+                expectedSize += weigher.applyAsLong(iCacheKey, entry.getValue());
             }
             for (Map.Entry<String, String> entry : keyValueMap.entrySet()) {
-                String value = ehcacheTest.get(entry.getKey());
+                String value = ehcacheTest.get(getICacheKey(entry.getKey()));
                 assertEquals(entry.getValue(), value);
             }
+            assertEquals(randomKeys, ehcacheTest.stats().getTotalEntries());
+            assertEquals(randomKeys, ehcacheTest.stats().getTotalHits());
+            assertEquals(expectedSize, ehcacheTest.stats().getTotalSizeInBytes());
             assertEquals(randomKeys, ehcacheTest.count());
 
             // Validate misses
             int expectedNumberOfMisses = randomIntBetween(10, 200);
             for (int i = 0; i < expectedNumberOfMisses; i++) {
-                ehcacheTest.get(UUID.randomUUID().toString());
+                ehcacheTest.get(getICacheKey(UUID.randomUUID().toString()));
             }
+
+            assertEquals(expectedNumberOfMisses, ehcacheTest.stats().getTotalMisses());
 
             ehcacheTest.close();
         }
@@ -105,6 +120,8 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                     .setRemovalListener(removalListener)
                     .setKeySerializer(new StringSerializer())
                     .setValueSerializer(new StringSerializer())
+                    .setDimensionNames(List.of(dimensionName))
+                    .setWeigher(getWeigher())
                     .setSettings(
                         Settings.builder()
                             .put(
@@ -132,14 +149,14 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                 Map.of()
             );
             int randomKeys = randomIntBetween(10, 100);
-            Map<String, String> keyValueMap = new HashMap<>();
+            Map<ICacheKey<String>, String> keyValueMap = new HashMap<>();
             for (int i = 0; i < randomKeys; i++) {
-                keyValueMap.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+                keyValueMap.put(getICacheKey(UUID.randomUUID().toString()), UUID.randomUUID().toString());
             }
-            for (Map.Entry<String, String> entry : keyValueMap.entrySet()) {
+            for (Map.Entry<ICacheKey<String>, String> entry : keyValueMap.entrySet()) {
                 ehcacheTest.put(entry.getKey(), entry.getValue());
             }
-            for (Map.Entry<String, String> entry : keyValueMap.entrySet()) {
+            for (Map.Entry<ICacheKey<String>, String> entry : keyValueMap.entrySet()) {
                 String value = ehcacheTest.get(entry.getKey());
                 assertEquals(entry.getValue(), value);
             }
@@ -148,7 +165,7 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
             // Validate misses
             int expectedNumberOfMisses = randomIntBetween(10, 200);
             for (int i = 0; i < expectedNumberOfMisses; i++) {
-                ehcacheTest.get(UUID.randomUUID().toString());
+                ehcacheTest.get(getICacheKey(UUID.randomUUID().toString()));
             }
 
             ehcacheTest.close();
@@ -167,22 +184,24 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                 .setValueType(String.class)
                 .setKeySerializer(new StringSerializer())
                 .setValueSerializer(new StringSerializer())
+                .setDimensionNames(List.of(dimensionName))
                 .setCacheType(CacheType.INDICES_REQUEST_CACHE)
                 .setSettings(settings)
                 .setExpireAfterAccess(TimeValue.MAX_VALUE)
                 .setMaximumWeightInBytes(CACHE_SIZE_IN_BYTES)
                 .setRemovalListener(removalListener)
+                .setWeigher(getWeigher())
                 .build();
             int randomKeys = randomIntBetween(20, 100);
             Thread[] threads = new Thread[randomKeys];
             Phaser phaser = new Phaser(randomKeys + 1);
             CountDownLatch countDownLatch = new CountDownLatch(randomKeys);
-            Map<String, String> keyValueMap = new HashMap<>();
+            Map<ICacheKey<String>, String> keyValueMap = new HashMap<>();
             int j = 0;
             for (int i = 0; i < randomKeys; i++) {
-                keyValueMap.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+                keyValueMap.put(getICacheKey(UUID.randomUUID().toString()), UUID.randomUUID().toString());
             }
-            for (Map.Entry<String, String> entry : keyValueMap.entrySet()) {
+            for (Map.Entry<ICacheKey<String>, String> entry : keyValueMap.entrySet()) {
                 threads[j] = new Thread(() -> {
                     phaser.arriveAndAwaitAdvance();
                     ehcacheTest.put(entry.getKey(), entry.getValue());
@@ -193,11 +212,12 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
             }
             phaser.arriveAndAwaitAdvance(); // Will trigger parallel puts above.
             countDownLatch.await(); // Wait for all threads to finish
-            for (Map.Entry<String, String> entry : keyValueMap.entrySet()) {
+            for (Map.Entry<ICacheKey<String>, String> entry : keyValueMap.entrySet()) {
                 String value = ehcacheTest.get(entry.getKey());
                 assertEquals(entry.getValue(), value);
             }
             assertEquals(randomKeys, ehcacheTest.count());
+            assertEquals(randomKeys, ehcacheTest.stats().getTotalEntries());
             ehcacheTest.close();
         }
     }
@@ -214,11 +234,13 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                 .setValueType(String.class)
                 .setKeySerializer(new StringSerializer())
                 .setValueSerializer(new StringSerializer())
+                .setDimensionNames(List.of(dimensionName))
                 .setCacheType(CacheType.INDICES_REQUEST_CACHE)
                 .setSettings(settings)
                 .setExpireAfterAccess(TimeValue.MAX_VALUE)
                 .setMaximumWeightInBytes(CACHE_SIZE_IN_BYTES)
                 .setRemovalListener(removalListener)
+                .setWeigher(getWeigher())
                 .build();
             int randomKeys = randomIntBetween(20, 100);
             Thread[] threads = new Thread[randomKeys];
@@ -230,13 +252,13 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                 keyValueMap.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
             }
             for (Map.Entry<String, String> entry : keyValueMap.entrySet()) {
-                ehcacheTest.put(entry.getKey(), entry.getValue());
+                ehcacheTest.put(getICacheKey(entry.getKey()), entry.getValue());
             }
             assertEquals(keyValueMap.size(), ehcacheTest.count());
             for (Map.Entry<String, String> entry : keyValueMap.entrySet()) {
                 threads[j] = new Thread(() -> {
                     phaser.arriveAndAwaitAdvance();
-                    assertEquals(entry.getValue(), ehcacheTest.get(entry.getKey()));
+                    assertEquals(entry.getValue(), ehcacheTest.get(getICacheKey(entry.getKey())));
                     countDownLatch.countDown();
                 });
                 threads[j].start();
@@ -244,6 +266,7 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
             }
             phaser.arriveAndAwaitAdvance(); // Will trigger parallel puts above.
             countDownLatch.await(); // Wait for all threads to finish
+            assertEquals(randomKeys, ehcacheTest.stats().getTotalHits());
             ehcacheTest.close();
         }
     }
@@ -259,11 +282,13 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                 .setValueType(String.class)
                 .setKeySerializer(new StringSerializer())
                 .setValueSerializer(new StringSerializer())
+                .setDimensionNames(List.of(dimensionName))
                 .setCacheType(CacheType.INDICES_REQUEST_CACHE)
                 .setSettings(settings)
                 .setExpireAfterAccess(TimeValue.MAX_VALUE)
                 .setMaximumWeightInBytes(CACHE_SIZE_IN_BYTES)
                 .setRemovalListener(new MockRemovalListener<>())
+                .setWeigher(getWeigher())
                 .build();
 
             int randomKeys = randomIntBetween(2, 100);
@@ -272,12 +297,12 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                 keyValueMap.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
             }
             for (Map.Entry<String, String> entry : keyValueMap.entrySet()) {
-                ehcacheTest.put(entry.getKey(), entry.getValue());
+                ehcacheTest.put(getICacheKey(entry.getKey()), entry.getValue());
             }
-            Iterator<String> keys = ehcacheTest.keys().iterator();
+            Iterator<ICacheKey<String>> keys = ehcacheTest.keys().iterator();
             int keysCount = 0;
             while (keys.hasNext()) {
-                String key = keys.next();
+                ICacheKey<String> key = keys.next();
                 keysCount++;
                 assertNotNull(ehcacheTest.get(key));
             }
@@ -289,6 +314,7 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
     public void testEvictions() throws Exception {
         Settings settings = Settings.builder().build();
         MockRemovalListener<String, String> removalListener = new MockRemovalListener<>();
+        ToLongBiFunction<ICacheKey<String>, String> weigher = getWeigher();
         try (NodeEnvironment env = newNodeEnvironment(settings)) {
             ICache<String, String> ehcacheTest = new EhcacheDiskCache.Builder<String, String>().setDiskCacheAlias("test1")
                 .setStoragePath(env.nodePaths()[0].indicesPath.toString() + "/request_cache")
@@ -298,11 +324,13 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                 .setValueType(String.class)
                 .setKeySerializer(new StringSerializer())
                 .setValueSerializer(new StringSerializer())
+                .setDimensionNames(List.of(dimensionName))
                 .setCacheType(CacheType.INDICES_REQUEST_CACHE)
                 .setSettings(settings)
                 .setExpireAfterAccess(TimeValue.MAX_VALUE)
                 .setMaximumWeightInBytes(CACHE_SIZE_IN_BYTES)
                 .setRemovalListener(removalListener)
+                .setWeigher(weigher)
                 .build();
 
             // Generate a string with 100 characters
@@ -311,9 +339,10 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
             // Trying to generate more than 100kb to cause evictions.
             for (int i = 0; i < 1000; i++) {
                 String key = "Key" + i;
-                ehcacheTest.put(key, value);
+                ehcacheTest.put(getICacheKey(key), value);
             }
             assertEquals(660, removalListener.evictionMetric.count());
+            assertEquals(660, ehcacheTest.stats().getTotalEvictions());
             ehcacheTest.close();
         }
     }
@@ -330,11 +359,13 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                 .setValueType(String.class)
                 .setKeySerializer(new StringSerializer())
                 .setValueSerializer(new StringSerializer())
+                .setDimensionNames(List.of(dimensionName))
                 .setCacheType(CacheType.INDICES_REQUEST_CACHE)
                 .setSettings(settings)
                 .setExpireAfterAccess(TimeValue.MAX_VALUE)
                 .setMaximumWeightInBytes(CACHE_SIZE_IN_BYTES)
                 .setRemovalListener(removalListener)
+                .setWeigher(getWeigher())
                 .build();
 
             int numberOfRequest = 2;// randomIntBetween(200, 400);
@@ -344,12 +375,12 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
             Phaser phaser = new Phaser(numberOfRequest + 1);
             CountDownLatch countDownLatch = new CountDownLatch(numberOfRequest);
 
-            List<LoadAwareCacheLoader<String, String>> loadAwareCacheLoaderList = new CopyOnWriteArrayList<>();
+            List<LoadAwareCacheLoader<ICacheKey<String>, String>> loadAwareCacheLoaderList = new CopyOnWriteArrayList<>();
 
             // Try to hit different request with the same key concurrently. Verify value is only loaded once.
             for (int i = 0; i < numberOfRequest; i++) {
                 threads[i] = new Thread(() -> {
-                    LoadAwareCacheLoader<String, String> loadAwareCacheLoader = new LoadAwareCacheLoader<>() {
+                    LoadAwareCacheLoader<ICacheKey<String>, String> loadAwareCacheLoader = new LoadAwareCacheLoader<>() {
                         boolean isLoaded;
 
                         @Override
@@ -358,7 +389,7 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                         }
 
                         @Override
-                        public String load(String key) {
+                        public String load(ICacheKey<String> key) {
                             isLoaded = true;
                             return value;
                         }
@@ -366,7 +397,7 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                     loadAwareCacheLoaderList.add(loadAwareCacheLoader);
                     phaser.arriveAndAwaitAdvance();
                     try {
-                        assertEquals(value, ehcacheTest.computeIfAbsent(key, loadAwareCacheLoader));
+                        assertEquals(value, ehcacheTest.computeIfAbsent(getICacheKey(key), loadAwareCacheLoader));
                     } catch (Exception e) {
                         throw new RuntimeException(e);
                     }
@@ -384,6 +415,9 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
             }
             assertEquals(1, numberOfTimesValueLoaded);
             assertEquals(0, ((EhcacheDiskCache) ehcacheTest).getCompletableFutureMap().size());
+            assertEquals(1, ehcacheTest.stats().getTotalMisses());
+            assertEquals(1, ehcacheTest.stats().getTotalEntries());
+            assertEquals(numberOfRequest - 1, ehcacheTest.stats().getTotalHits());
             assertEquals(1, ehcacheTest.count());
             ehcacheTest.close();
         }
@@ -401,11 +435,13 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                 .setValueType(String.class)
                 .setKeySerializer(new StringSerializer())
                 .setValueSerializer(new StringSerializer())
+                .setDimensionNames(List.of(dimensionName))
                 .setCacheType(CacheType.INDICES_REQUEST_CACHE)
                 .setSettings(settings)
                 .setExpireAfterAccess(TimeValue.MAX_VALUE)
                 .setMaximumWeightInBytes(CACHE_SIZE_IN_BYTES)
                 .setRemovalListener(removalListener)
+                .setWeigher(getWeigher())
                 .build();
 
             int numberOfRequest = randomIntBetween(200, 400);
@@ -414,12 +450,12 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
             Phaser phaser = new Phaser(numberOfRequest + 1);
             CountDownLatch countDownLatch = new CountDownLatch(numberOfRequest);
 
-            List<LoadAwareCacheLoader<String, String>> loadAwareCacheLoaderList = new CopyOnWriteArrayList<>();
+            List<LoadAwareCacheLoader<ICacheKey<String>, String>> loadAwareCacheLoaderList = new CopyOnWriteArrayList<>();
 
             // Try to hit different request with the same key concurrently. Loader throws exception.
             for (int i = 0; i < numberOfRequest; i++) {
                 threads[i] = new Thread(() -> {
-                    LoadAwareCacheLoader<String, String> loadAwareCacheLoader = new LoadAwareCacheLoader<>() {
+                    LoadAwareCacheLoader<ICacheKey<String>, String> loadAwareCacheLoader = new LoadAwareCacheLoader<>() {
                         boolean isLoaded;
 
                         @Override
@@ -428,14 +464,14 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                         }
 
                         @Override
-                        public String load(String key) throws Exception {
+                        public String load(ICacheKey<String> key) throws Exception {
                             isLoaded = true;
                             throw new RuntimeException("Exception");
                         }
                     };
                     loadAwareCacheLoaderList.add(loadAwareCacheLoader);
                     phaser.arriveAndAwaitAdvance();
-                    assertThrows(ExecutionException.class, () -> ehcacheTest.computeIfAbsent(key, loadAwareCacheLoader));
+                    assertThrows(ExecutionException.class, () -> ehcacheTest.computeIfAbsent(getICacheKey(key), loadAwareCacheLoader));
                     countDownLatch.countDown();
                 });
                 threads[i].start();
@@ -460,11 +496,13 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                 .setValueType(String.class)
                 .setKeySerializer(new StringSerializer())
                 .setValueSerializer(new StringSerializer())
+                .setDimensionNames(List.of(dimensionName))
                 .setCacheType(CacheType.INDICES_REQUEST_CACHE)
                 .setSettings(settings)
                 .setExpireAfterAccess(TimeValue.MAX_VALUE)
                 .setMaximumWeightInBytes(CACHE_SIZE_IN_BYTES)
                 .setRemovalListener(removalListener)
+                .setWeigher(getWeigher())
                 .build();
 
             int numberOfRequest = randomIntBetween(200, 400);
@@ -473,12 +511,12 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
             Phaser phaser = new Phaser(numberOfRequest + 1);
             CountDownLatch countDownLatch = new CountDownLatch(numberOfRequest);
 
-            List<LoadAwareCacheLoader<String, String>> loadAwareCacheLoaderList = new CopyOnWriteArrayList<>();
+            List<LoadAwareCacheLoader<ICacheKey<String>, String>> loadAwareCacheLoaderList = new CopyOnWriteArrayList<>();
 
             // Try to hit different request with the same key concurrently. Loader throws exception.
             for (int i = 0; i < numberOfRequest; i++) {
                 threads[i] = new Thread(() -> {
-                    LoadAwareCacheLoader<String, String> loadAwareCacheLoader = new LoadAwareCacheLoader<>() {
+                    LoadAwareCacheLoader<ICacheKey<String>, String> loadAwareCacheLoader = new LoadAwareCacheLoader<>() {
                         boolean isLoaded;
 
                         @Override
@@ -487,7 +525,7 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                         }
 
                         @Override
-                        public String load(String key) throws Exception {
+                        public String load(ICacheKey<String> key) throws Exception {
                             isLoaded = true;
                             return null;
                         }
@@ -495,11 +533,11 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                     loadAwareCacheLoaderList.add(loadAwareCacheLoader);
                     phaser.arriveAndAwaitAdvance();
                     try {
-                        ehcacheTest.computeIfAbsent(key, loadAwareCacheLoader);
+                        ehcacheTest.computeIfAbsent(getICacheKey(key), loadAwareCacheLoader);
                     } catch (Exception ex) {
                         assertThat(ex.getCause(), instanceOf(NullPointerException.class));
                     }
-                    assertThrows(ExecutionException.class, () -> ehcacheTest.computeIfAbsent(key, loadAwareCacheLoader));
+                    assertThrows(ExecutionException.class, () -> ehcacheTest.computeIfAbsent(getICacheKey(key), loadAwareCacheLoader));
                     countDownLatch.countDown();
                 });
                 threads[i].start();
@@ -512,6 +550,81 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
         }
     }
 
+    public void testMemoryTracking() throws Exception {
+        // Test all cases for EhCacheEventListener.onEvent and check stats memory usage is updated correctly
+        Settings settings = Settings.builder().build();
+        ToLongBiFunction<ICacheKey<String>, String> weigher = getWeigher();
+        int initialKeyLength = 40;
+        int initialValueLength = 40;
+        long sizeForOneInitialEntry = weigher.applyAsLong(
+            new ICacheKey<>(generateRandomString(initialKeyLength), getMockDimensions()),
+            generateRandomString(initialValueLength)
+        );
+        int maxEntries = 2000;
+        try (NodeEnvironment env = newNodeEnvironment(settings)) {
+            ICache<String, String> ehcacheTest = new EhcacheDiskCache.Builder<String, String>().setDiskCacheAlias("test1")
+                .setThreadPoolAlias("ehcacheTest")
+                .setStoragePath(env.nodePaths()[0].indicesPath.toString() + "/request_cache")
+                .setKeyType(String.class)
+                .setValueType(String.class)
+                .setKeySerializer(new StringSerializer())
+                .setValueSerializer(new StringSerializer())
+                .setDimensionNames(List.of(dimensionName))
+                .setIsEventListenerModeSync(true) // Test fails if async; probably not all updates happen before checking stats
+                .setCacheType(CacheType.INDICES_REQUEST_CACHE)
+                .setSettings(settings)
+                .setExpireAfterAccess(TimeValue.MAX_VALUE)
+                .setMaximumWeightInBytes(maxEntries * sizeForOneInitialEntry)
+                .setRemovalListener(new MockRemovalListener<>())
+                .setWeigher(weigher)
+                .build();
+            long expectedSize = 0;
+
+            // Test CREATED case
+            int numInitialKeys = randomIntBetween(10, 100);
+            ArrayList<ICacheKey<String>> initialKeys = new ArrayList<>();
+            for (int i = 0; i < numInitialKeys; i++) {
+                ICacheKey<String> key = new ICacheKey<>(generateRandomString(initialKeyLength), getMockDimensions());
+                String value = generateRandomString(initialValueLength);
+                ehcacheTest.put(key, value);
+                initialKeys.add(key);
+                expectedSize += weigher.applyAsLong(key, value);
+                assertEquals(expectedSize, ehcacheTest.stats().getTotalStats().getSizeInBytes());
+            }
+
+            // Test UPDATED case
+            HashMap<ICacheKey<String>, String> updatedValues = new HashMap<>();
+            for (int i = 0; i < numInitialKeys * 0.5; i++) {
+                int newLengthDifference = randomIntBetween(-20, 20);
+                String newValue = generateRandomString(initialValueLength + newLengthDifference);
+                ehcacheTest.put(initialKeys.get(i), newValue);
+                updatedValues.put(initialKeys.get(i), newValue);
+                expectedSize += newLengthDifference;
+                assertEquals(expectedSize, ehcacheTest.stats().getTotalStats().getSizeInBytes());
+            }
+
+            // Test REMOVED case by removing all updated keys
+            for (int i = 0; i < numInitialKeys * 0.5; i++) {
+                ICacheKey<String> removedKey = initialKeys.get(i);
+                ehcacheTest.invalidate(removedKey);
+                expectedSize -= weigher.applyAsLong(removedKey, updatedValues.get(removedKey));
+                assertEquals(expectedSize, ehcacheTest.stats().getTotalStats().getSizeInBytes());
+            }
+
+            // Test EVICTED case by adding entries past the cap and ensuring memory size stays as what we expect
+            for (int i = 0; i < maxEntries - ehcacheTest.count(); i++) {
+                ICacheKey<String> key = new ICacheKey<>(generateRandomString(initialKeyLength), getMockDimensions());
+                String value = generateRandomString(initialValueLength);
+                ehcacheTest.put(key, value);
+            }
+            // TODO: Ehcache incorrectly evicts at 30-40% of max size. Fix this test once we figure out why.
+            // Since the EVICTED and EXPIRED cases use the same code as REMOVED, we should be ok on testing them for now.
+            // assertEquals(maxEntries * sizeForOneInitialEntry, ehcacheTest.stats().getTotalMemorySize());
+
+            ehcacheTest.close();
+        }
+    }
+
     public void testEhcacheKeyIteratorWithRemove() throws IOException {
         Settings settings = Settings.builder().build();
         try (NodeEnvironment env = newNodeEnvironment(settings)) {
@@ -519,35 +632,37 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                 .setThreadPoolAlias("ehcacheTest")
                 .setStoragePath(env.nodePaths()[0].indicesPath.toString() + "/request_cache")
                 .setIsEventListenerModeSync(true)
-                .setKeyType(String.class)
-                .setValueType(String.class)
                 .setKeySerializer(new StringSerializer())
                 .setValueSerializer(new StringSerializer())
+                .setDimensionNames(List.of(dimensionName))
                 .setCacheType(CacheType.INDICES_REQUEST_CACHE)
+                .setKeyType(String.class)
+                .setValueType(String.class)
                 .setSettings(settings)
                 .setExpireAfterAccess(TimeValue.MAX_VALUE)
                 .setMaximumWeightInBytes(CACHE_SIZE_IN_BYTES)
                 .setRemovalListener(new MockRemovalListener<>())
+                .setWeigher(getWeigher())
                 .build();
 
             int randomKeys = randomIntBetween(2, 100);
             for (int i = 0; i < randomKeys; i++) {
-                ehcacheTest.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+                ehcacheTest.put(getICacheKey(UUID.randomUUID().toString()), UUID.randomUUID().toString());
             }
             long originalSize = ehcacheTest.count();
             assertEquals(randomKeys, originalSize);
 
             // Now try removing subset of keys and verify
-            List<String> removedKeyList = new ArrayList<>();
-            for (Iterator<String> iterator = ehcacheTest.keys().iterator(); iterator.hasNext();) {
-                String key = iterator.next();
+            List<ICacheKey<String>> removedKeyList = new ArrayList<>();
+            for (Iterator<ICacheKey<String>> iterator = ehcacheTest.keys().iterator(); iterator.hasNext();) {
+                ICacheKey<String> key = iterator.next();
                 if (randomBoolean()) {
                     removedKeyList.add(key);
                     iterator.remove();
                 }
             }
             // Verify the removed key doesn't exist anymore.
-            for (String ehcacheKey : removedKeyList) {
+            for (ICacheKey<String> ehcacheKey : removedKeyList) {
                 assertNull(ehcacheTest.get(ehcacheKey));
             }
             // Verify ehcache entry size again.
@@ -568,22 +683,24 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                 .setValueType(String.class)
                 .setKeySerializer(new StringSerializer())
                 .setValueSerializer(new StringSerializer())
+                .setDimensionNames(List.of(dimensionName))
                 .setCacheType(CacheType.INDICES_REQUEST_CACHE)
                 .setSettings(settings)
                 .setExpireAfterAccess(TimeValue.MAX_VALUE)
                 .setMaximumWeightInBytes(CACHE_SIZE_IN_BYTES)
                 .setRemovalListener(removalListener)
+                .setWeigher(getWeigher())
                 .build();
             int randomKeys = randomIntBetween(10, 100);
-            Map<String, String> keyValueMap = new HashMap<>();
+            Map<ICacheKey<String>, String> keyValueMap = new HashMap<>();
             for (int i = 0; i < randomKeys; i++) {
-                keyValueMap.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+                keyValueMap.put(getICacheKey(UUID.randomUUID().toString()), UUID.randomUUID().toString());
             }
-            for (Map.Entry<String, String> entry : keyValueMap.entrySet()) {
+            for (Map.Entry<ICacheKey<String>, String> entry : keyValueMap.entrySet()) {
                 ehcacheTest.put(entry.getKey(), entry.getValue());
             }
             ehcacheTest.invalidateAll(); // clear all the entries.
-            for (Map.Entry<String, String> entry : keyValueMap.entrySet()) {
+            for (Map.Entry<ICacheKey<String>, String> entry : keyValueMap.entrySet()) {
                 // Verify that value is null for a removed entry.
                 assertNull(ehcacheTest.get(entry.getKey()));
             }
@@ -600,6 +717,7 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                 .setStoragePath(env.nodePaths()[0].indicesPath.toString() + "/request_cache")
                 .setKeySerializer(new StringSerializer())
                 .setValueSerializer(new BytesReferenceSerializer())
+                .setDimensionNames(List.of(dimensionName))
                 .setKeyType(String.class)
                 .setValueType(BytesReference.class)
                 .setCacheType(CacheType.INDICES_REQUEST_CACHE)
@@ -607,15 +725,16 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                 .setMaximumWeightInBytes(CACHE_SIZE_IN_BYTES * 20) // bigger so no evictions happen
                 .setExpireAfterAccess(TimeValue.MAX_VALUE)
                 .setRemovalListener(new MockRemovalListener<>())
+                .setWeigher((key, value) -> 1)
                 .build();
             int randomKeys = randomIntBetween(10, 100);
             int valueLength = 100;
             Random rand = Randomness.get();
-            Map<String, BytesReference> keyValueMap = new HashMap<>();
+            Map<ICacheKey<String>, BytesReference> keyValueMap = new HashMap<>();
             for (int i = 0; i < randomKeys; i++) {
                 byte[] valueBytes = new byte[valueLength];
                 rand.nextBytes(valueBytes);
-                keyValueMap.put(UUID.randomUUID().toString(), new BytesArray(valueBytes));
+                keyValueMap.put(getICacheKey(UUID.randomUUID().toString()), new BytesArray(valueBytes));
 
                 // Test a non-BytesArray implementation of BytesReference.
                 byte[] compositeBytes1 = new byte[valueLength];
@@ -623,12 +742,12 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                 rand.nextBytes(compositeBytes1);
                 rand.nextBytes(compositeBytes2);
                 BytesReference composite = CompositeBytesReference.of(new BytesArray(compositeBytes1), new BytesArray(compositeBytes2));
-                keyValueMap.put(UUID.randomUUID().toString(), composite);
+                keyValueMap.put(getICacheKey(UUID.randomUUID().toString()), composite);
             }
-            for (Map.Entry<String, BytesReference> entry : keyValueMap.entrySet()) {
+            for (Map.Entry<ICacheKey<String>, BytesReference> entry : keyValueMap.entrySet()) {
                 ehCacheDiskCachingTier.put(entry.getKey(), entry.getValue());
             }
-            for (Map.Entry<String, BytesReference> entry : keyValueMap.entrySet()) {
+            for (Map.Entry<ICacheKey<String>, BytesReference> entry : keyValueMap.entrySet()) {
                 BytesReference value = ehCacheDiskCachingTier.get(entry.getKey());
                 assertEquals(entry.getValue(), value);
             }
@@ -647,34 +766,97 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
                 .setKeySerializer(new StringSerializer())
                 .setValueSerializer(new StringSerializer())
                 .setValueType(String.class)
+                .setDimensionNames(List.of(dimensionName))
                 .setCacheType(CacheType.INDICES_REQUEST_CACHE)
                 .setSettings(settings)
                 .setExpireAfterAccess(TimeValue.MAX_VALUE)
                 .setMaximumWeightInBytes(CACHE_SIZE_IN_BYTES)
                 .setRemovalListener(removalListener)
+                .setWeigher(getWeigher())
                 .build();
             int randomKeys = randomIntBetween(10, 100);
-            Map<String, String> keyValueMap = new HashMap<>();
+            Map<ICacheKey<String>, String> keyValueMap = new HashMap<>();
             for (int i = 0; i < randomKeys; i++) {
-                keyValueMap.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+                keyValueMap.put(getICacheKey(UUID.randomUUID().toString()), UUID.randomUUID().toString());
             }
-            for (Map.Entry<String, String> entry : keyValueMap.entrySet()) {
+            for (Map.Entry<ICacheKey<String>, String> entry : keyValueMap.entrySet()) {
                 ehcacheTest.put(entry.getKey(), entry.getValue());
             }
             assertEquals(keyValueMap.size(), ehcacheTest.count());
-            List<String> removedKeyList = new ArrayList<>();
-            for (Map.Entry<String, String> entry : keyValueMap.entrySet()) {
+            List<ICacheKey<String>> removedKeyList = new ArrayList<>();
+            for (Map.Entry<ICacheKey<String>, String> entry : keyValueMap.entrySet()) {
                 if (randomBoolean()) {
                     removedKeyList.add(entry.getKey());
                     ehcacheTest.invalidate(entry.getKey());
                 }
             }
-            for (String removedKey : removedKeyList) {
+            for (ICacheKey<String> removedKey : removedKeyList) {
                 assertNull(ehcacheTest.get(removedKey));
             }
             assertEquals(keyValueMap.size() - removedKeyList.size(), ehcacheTest.count());
             ehcacheTest.close();
         }
+    }
+
+    // Modified from OpenSearchOnHeapCacheTests.java
+    public void testInvalidateWithDropDimensions() throws Exception {
+        Settings settings = Settings.builder().build();
+        List<String> dimensionNames = List.of("dim1", "dim2");
+        try (NodeEnvironment env = newNodeEnvironment(settings)) {
+            ICache<String, String> ehCacheDiskCachingTier = new EhcacheDiskCache.Builder<String, String>().setThreadPoolAlias("ehcacheTest")
+                .setStoragePath(env.nodePaths()[0].indicesPath.toString() + "/request_cache")
+                .setKeySerializer(new StringSerializer())
+                .setValueSerializer(new StringSerializer())
+                .setIsEventListenerModeSync(true)
+                .setDimensionNames(dimensionNames)
+                .setKeyType(String.class)
+                .setValueType(String.class)
+                .setCacheType(CacheType.INDICES_REQUEST_CACHE)
+                .setSettings(settings)
+                .setMaximumWeightInBytes(CACHE_SIZE_IN_BYTES * 20) // bigger so no evictions happen
+                .setExpireAfterAccess(TimeValue.MAX_VALUE)
+                .setRemovalListener(new MockRemovalListener<>())
+                .setWeigher((key, value) -> 1)
+                .build();
+
+            List<ICacheKey<String>> keysAdded = new ArrayList<>();
+
+            for (int i = 0; i < 20; i++) {
+                ICacheKey<String> key = new ICacheKey<>(UUID.randomUUID().toString(), getRandomDimensions(dimensionNames));
+                keysAdded.add(key);
+                ehCacheDiskCachingTier.put(key, UUID.randomUUID().toString());
+            }
+
+            ICacheKey<String> keyToDrop = keysAdded.get(0);
+
+            ImmutableCacheStats snapshot = ehCacheDiskCachingTier.stats().getStatsForDimensionValues(keyToDrop.dimensions);
+            assertNotNull(snapshot);
+
+            keyToDrop.setDropStatsForDimensions(true);
+            ehCacheDiskCachingTier.invalidate(keyToDrop);
+
+            // Now assert the stats are gone for any key that has this combination of dimensions, but still there otherwise
+            for (ICacheKey<String> keyAdded : keysAdded) {
+                snapshot = ehCacheDiskCachingTier.stats().getStatsForDimensionValues(keyAdded.dimensions);
+                if (keyAdded.dimensions.equals(keyToDrop.dimensions)) {
+                    assertNull(snapshot);
+                } else {
+                    assertNotNull(snapshot);
+                }
+            }
+
+            ehCacheDiskCachingTier.close();
+        }
+    }
+
+    private List<String> getRandomDimensions(List<String> dimensionNames) {
+        Random rand = Randomness.get();
+        int bound = 3;
+        List<String> result = new ArrayList<>();
+        for (String dimName : dimensionNames) {
+            result.add(String.valueOf(rand.nextInt(bound)));
+        }
+        return result;
     }
 
     private static String generateRandomString(int length) {
@@ -689,12 +871,34 @@ public class EhCacheDiskCacheTests extends OpenSearchSingleNodeTestCase {
         return randomString.toString();
     }
 
-    static class MockRemovalListener<K, V> implements RemovalListener<K, V> {
+    private List<String> getMockDimensions() {
+        return List.of("0");
+    }
+
+    private ICacheKey<String> getICacheKey(String key) {
+        return new ICacheKey<>(key, getMockDimensions());
+    }
+
+    private ToLongBiFunction<ICacheKey<String>, String> getWeigher() {
+        return (iCacheKey, value) -> {
+            // Size consumed by key
+            long totalSize = iCacheKey.key.length();
+            for (String dim : iCacheKey.dimensions) {
+                totalSize += dim.length();
+            }
+            totalSize += 10; // The ICacheKeySerializer writes 2 VInts to record array lengths, which can be 1-5 bytes each
+            // Size consumed by value
+            totalSize += value.length();
+            return totalSize;
+        };
+    }
+
+    static class MockRemovalListener<K, V> implements RemovalListener<ICacheKey<K>, V> {
 
         CounterMetric evictionMetric = new CounterMetric();
 
         @Override
-        public void onRemoval(RemovalNotification<K, V> notification) {
+        public void onRemoval(RemovalNotification<ICacheKey<K>, V> notification) {
             evictionMetric.inc();
         }
     }

--- a/server/src/main/java/org/opensearch/common/cache/Cache.java
+++ b/server/src/main/java/org/opensearch/common/cache/Cache.java
@@ -896,6 +896,10 @@ public class Cache<K, V> {
         }
     }
 
+    public ToLongBiFunction<K, V> getWeigher() {
+        return weigher;
+    }
+
     private CacheSegment<K, V> getCacheSegment(K key) {
         return segments[key.hashCode() & 0xff];
     }

--- a/server/src/main/java/org/opensearch/common/cache/ICache.java
+++ b/server/src/main/java/org/opensearch/common/cache/ICache.java
@@ -9,6 +9,7 @@
 package org.opensearch.common.cache;
 
 import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.common.cache.stats.ImmutableCacheStatsHolder;
 import org.opensearch.common.cache.store.config.CacheConfig;
 
 import java.io.Closeable;
@@ -23,21 +24,28 @@ import java.util.Map;
  */
 @ExperimentalApi
 public interface ICache<K, V> extends Closeable {
-    V get(K key);
+    V get(ICacheKey<K> key);
 
-    void put(K key, V value);
+    void put(ICacheKey<K> key, V value);
 
-    V computeIfAbsent(K key, LoadAwareCacheLoader<K, V> loader) throws Exception;
+    V computeIfAbsent(ICacheKey<K> key, LoadAwareCacheLoader<ICacheKey<K>, V> loader) throws Exception;
 
-    void invalidate(K key);
+    /**
+     * Invalidates the key. If a dimension in the key has dropStatsOnInvalidation set to true, the cache also completely
+     * resets stats for that dimension value. It's the caller's responsibility to make sure all keys with that dimension value are
+     * actually invalidated.
+     */
+    void invalidate(ICacheKey<K> key);
 
     void invalidateAll();
 
-    Iterable<K> keys();
+    Iterable<ICacheKey<K>> keys();
 
     long count();
 
     void refresh();
+
+    ImmutableCacheStatsHolder stats();
 
     /**
      * Factory to create objects.

--- a/server/src/main/java/org/opensearch/common/cache/ICacheKey.java
+++ b/server/src/main/java/org/opensearch/common/cache/ICacheKey.java
@@ -1,0 +1,96 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.cache;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+
+import java.util.List;
+
+/**
+ * A key wrapper used for ICache implementations, which carries dimensions with it.
+ * @param <K> the type of the underlying key. K must implement equals(), or else ICacheKey.equals()
+ *           won't work properly and cache behavior may be incorrect!
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class ICacheKey<K> {
+    public final K key; // K must implement equals()
+    public final List<String> dimensions; // Dimension values. The dimension names are implied.
+    /**
+     * If this key is invalidated and dropDimensions is true, the ICache implementation will also drop all stats,
+     * including hits/misses/evictions, with this combination of dimension values.
+     */
+    private boolean dropStatsForDimensions;
+
+    /**
+     * Constructor to use when specifying dimensions.
+     */
+    public ICacheKey(K key, List<String> dimensions) {
+        this.key = key;
+        this.dimensions = dimensions;
+    }
+
+    /**
+     * Constructor to use when no dimensions are needed.
+     */
+    public ICacheKey(K key) {
+        this.key = key;
+        this.dimensions = List.of();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (o == null) {
+            return false;
+        }
+        if (o.getClass() != ICacheKey.class) {
+            return false;
+        }
+        ICacheKey other = (ICacheKey) o;
+        if (!dimensions.equals(other.dimensions)) {
+            return false;
+        }
+        if (this.key == null && other.key == null) {
+            return true;
+        }
+        if (this.key == null || other.key == null) {
+            return false;
+        }
+        return this.key.equals(other.key);
+    }
+
+    @Override
+    public int hashCode() {
+        if (key == null) {
+            return dimensions.hashCode();
+        }
+        return 31 * key.hashCode() + dimensions.hashCode();
+    }
+
+    // As K might not be Accountable, directly pass in its memory usage to be added.
+    public long ramBytesUsed(long underlyingKeyRamBytes) {
+        long estimate = underlyingKeyRamBytes;
+        for (String dim : dimensions) {
+            estimate += dim.length();
+        }
+        return estimate;
+    }
+
+    public boolean getDropStatsForDimensions() {
+        return dropStatsForDimensions;
+    }
+
+    public void setDropStatsForDimensions(boolean newValue) {
+        dropStatsForDimensions = newValue;
+    }
+}

--- a/server/src/main/java/org/opensearch/common/cache/serializer/ICacheKeySerializer.java
+++ b/server/src/main/java/org/opensearch/common/cache/serializer/ICacheKeySerializer.java
@@ -1,0 +1,87 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.cache.serializer;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.OpenSearchException;
+import org.opensearch.common.cache.ICacheKey;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.BytesStreamInput;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A serializer for ICacheKey.
+ * @param <K> the type of the underlying key in ICacheKey
+ */
+public class ICacheKeySerializer<K> implements Serializer<ICacheKey<K>, byte[]> {
+
+    public final Serializer<K, byte[]> keySerializer;
+    private final Logger logger = LogManager.getLogger(ICacheKeySerializer.class);
+
+    public ICacheKeySerializer(Serializer<K, byte[]> serializer) {
+        this.keySerializer = serializer;
+    }
+
+    @Override
+    public byte[] serialize(ICacheKey<K> object) {
+        if (object == null || object.key == null || object.dimensions == null) {
+            return null;
+        }
+        byte[] serializedKey = keySerializer.serialize(object.key);
+        try {
+            BytesStreamOutput os = new BytesStreamOutput();
+            // First write the number of dimensions
+            os.writeVInt(object.dimensions.size());
+            for (String dimValue : object.dimensions) {
+                os.writeString(dimValue);
+            }
+            os.writeVInt(serializedKey.length); // The read byte[] fn seems to not work as expected
+            os.writeBytes(serializedKey);
+            byte[] finalBytes = BytesReference.toBytes(os.bytes());
+            return finalBytes;
+        } catch (IOException e) {
+            logger.debug("Could not write ICacheKey to byte[]");
+            throw new OpenSearchException(e);
+        }
+    }
+
+    @Override
+    public ICacheKey<K> deserialize(byte[] bytes) {
+        if (bytes == null) {
+            return null;
+        }
+        List<String> dimensionList = new ArrayList<>();
+        try {
+            BytesStreamInput is = new BytesStreamInput(bytes, 0, bytes.length);
+            int numDimensions = is.readVInt();
+            for (int i = 0; i < numDimensions; i++) {
+                dimensionList.add(is.readString());
+            }
+
+            int length = is.readVInt();
+            byte[] serializedKey = new byte[length];
+            is.readBytes(serializedKey, 0, length);
+            return new ICacheKey<>(keySerializer.deserialize(serializedKey), dimensionList);
+        } catch (IOException e) {
+            logger.debug("Could not write byte[] to ICacheKey");
+            throw new OpenSearchException(e);
+        }
+    }
+
+    @Override
+    public boolean equals(ICacheKey<K> object, byte[] bytes) {
+        return Arrays.equals(serialize(object), bytes);
+    }
+}

--- a/server/src/main/java/org/opensearch/common/cache/stats/CacheStats.java
+++ b/server/src/main/java/org/opensearch/common/cache/stats/CacheStats.java
@@ -1,0 +1,132 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.cache.stats;
+
+import org.opensearch.common.metrics.CounterMetric;
+
+import java.util.Objects;
+
+/**
+ * A mutable class containing the 5 live metrics tracked by a StatsHolder object.
+ */
+public class CacheStats {
+    CounterMetric hits;
+    CounterMetric misses;
+    CounterMetric evictions;
+    CounterMetric sizeInBytes;
+    CounterMetric entries;
+
+    public CacheStats(long hits, long misses, long evictions, long sizeInBytes, long entries) {
+        this.hits = new CounterMetric();
+        this.hits.inc(hits);
+        this.misses = new CounterMetric();
+        this.misses.inc(misses);
+        this.evictions = new CounterMetric();
+        this.evictions.inc(evictions);
+        this.sizeInBytes = new CounterMetric();
+        this.sizeInBytes.inc(sizeInBytes);
+        this.entries = new CounterMetric();
+        this.entries.inc(entries);
+    }
+
+    public CacheStats() {
+        this(0, 0, 0, 0, 0);
+    }
+
+    private void internalAdd(long otherHits, long otherMisses, long otherEvictions, long otherSizeInBytes, long otherEntries) {
+        this.hits.inc(otherHits);
+        this.misses.inc(otherMisses);
+        this.evictions.inc(otherEvictions);
+        this.sizeInBytes.inc(otherSizeInBytes);
+        this.entries.inc(otherEntries);
+    }
+
+    public void add(CacheStats other) {
+        if (other == null) {
+            return;
+        }
+        internalAdd(other.getHits(), other.getMisses(), other.getEvictions(), other.getSizeInBytes(), other.getEntries());
+    }
+
+    public void add(ImmutableCacheStats snapshot) {
+        if (snapshot == null) {
+            return;
+        }
+        internalAdd(snapshot.getHits(), snapshot.getMisses(), snapshot.getEvictions(), snapshot.getSizeInBytes(), snapshot.getEntries());
+    }
+
+    public void subtract(ImmutableCacheStats other) {
+        if (other == null) {
+            return;
+        }
+        internalAdd(-other.getHits(), -other.getMisses(), -other.getEvictions(), -other.getSizeInBytes(), -other.getEntries());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(hits.count(), misses.count(), evictions.count(), sizeInBytes.count(), entries.count());
+    }
+
+    public void incrementHits() {
+        hits.inc();
+    }
+
+    public void incrementMisses() {
+        misses.inc();
+    }
+
+    public void incrementEvictions() {
+        evictions.inc();
+    }
+
+    public void incrementSizeInBytes(long amount) {
+        sizeInBytes.inc(amount);
+    }
+
+    public void decrementSizeInBytes(long amount) {
+        sizeInBytes.dec(amount);
+    }
+
+    public void incrementEntries() {
+        entries.inc();
+    }
+
+    public void decrementEntries() {
+        entries.dec();
+    }
+
+    public long getHits() {
+        return hits.count();
+    }
+
+    public long getMisses() {
+        return misses.count();
+    }
+
+    public long getEvictions() {
+        return evictions.count();
+    }
+
+    public long getSizeInBytes() {
+        return sizeInBytes.count();
+    }
+
+    public long getEntries() {
+        return entries.count();
+    }
+
+    public void resetSizeAndEntries() {
+        sizeInBytes = new CounterMetric();
+        entries = new CounterMetric();
+    }
+
+    public ImmutableCacheStats immutableSnapshot() {
+        return new ImmutableCacheStats(hits.count(), misses.count(), evictions.count(), sizeInBytes.count(), entries.count());
+    }
+}

--- a/server/src/main/java/org/opensearch/common/cache/stats/CacheStatsHolder.java
+++ b/server/src/main/java/org/opensearch/common/cache/stats/CacheStatsHolder.java
@@ -1,0 +1,295 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.cache.stats;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
+
+/**
+ * A class ICache implementations use to internally keep track of their stats across multiple dimensions.
+ * Not intended to be exposed outside the cache; for this, caches use getImmutableCacheStatsHolder() to create an immutable
+ * copy of the current state of the stats.
+ * Currently, in the IRC, the stats tracked in a CacheStatsHolder will not appear for empty shards that have had no cache
+ * operations done on them yet. This might be changed in the future, by exposing a method to add empty nodes to the
+ * tree in CacheStatsHolder in the ICache interface.
+ *
+ * @opensearch.experimental
+ */
+public class CacheStatsHolder {
+
+    // The list of permitted dimensions. Should be ordered from "outermost" to "innermost", as you would like to
+    // aggregate them in an API response.
+    private final List<String> dimensionNames;
+    // A tree structure based on dimension values, which stores stats values in its leaf nodes.
+    // Non-leaf nodes have stats matching the sum of their children.
+    // We use a tree structure, rather than a map with concatenated keys, to save on memory usage. If there are many leaf
+    // nodes that share a parent, that parent's dimension value will only be stored once, not many times.
+    private final Node statsRoot;
+    // To avoid sync problems, obtain a lock before creating or removing nodes in the stats tree.
+    // No lock is needed to edit stats on existing nodes.
+    private final Lock lock = new ReentrantLock();
+
+    public CacheStatsHolder(List<String> dimensionNames) {
+        this.dimensionNames = Collections.unmodifiableList(dimensionNames);
+        this.statsRoot = new Node("", true); // The root node has the empty string as its dimension value
+    }
+
+    public List<String> getDimensionNames() {
+        return dimensionNames;
+    }
+
+    // For all these increment functions, the dimensions list comes from the key, and contains all dimensions present in dimensionNames.
+    // The order has to match the order given in dimensionNames.
+    public void incrementHits(List<String> dimensionValues) {
+        internalIncrement(dimensionValues, Node::incrementHits, true);
+    }
+
+    public void incrementMisses(List<String> dimensionValues) {
+        internalIncrement(dimensionValues, Node::incrementMisses, true);
+    }
+
+    public void incrementEvictions(List<String> dimensionValues) {
+        internalIncrement(dimensionValues, Node::incrementEvictions, true);
+    }
+
+    public void incrementSizeInBytes(List<String> dimensionValues, long amountBytes) {
+        internalIncrement(dimensionValues, (node) -> node.incrementSizeInBytes(amountBytes), true);
+    }
+
+    // For decrements, we should not create nodes if they are absent. This protects us from erroneously decrementing values for keys
+    // which have been entirely deleted, for example in an async removal listener.
+    public void decrementSizeInBytes(List<String> dimensionValues, long amountBytes) {
+        internalIncrement(dimensionValues, (node) -> node.decrementSizeInBytes(amountBytes), false);
+    }
+
+    public void incrementEntries(List<String> dimensionValues) {
+        internalIncrement(dimensionValues, Node::incrementEntries, true);
+    }
+
+    public void decrementEntries(List<String> dimensionValues) {
+        internalIncrement(dimensionValues, Node::decrementEntries, false);
+    }
+
+    /**
+     * Reset number of entries and memory size when all keys leave the cache, but don't reset hit/miss/eviction numbers.
+     * This is in line with the behavior of the existing API when caches are cleared.
+     */
+    public void reset() {
+        resetHelper(statsRoot);
+    }
+
+    private void resetHelper(Node current) {
+        current.resetSizeAndEntries();
+        for (Node child : current.children.values()) {
+            resetHelper(child);
+        }
+    }
+
+    public long count() {
+        // Include this here so caches don't have to create an entire CacheStats object to run count().
+        return statsRoot.getEntries();
+    }
+
+    private void internalIncrement(List<String> dimensionValues, Consumer<Node> adder, boolean createNodesIfAbsent) {
+        assert dimensionValues.size() == dimensionNames.size();
+        // First try to increment without creating nodes
+        boolean didIncrement = internalIncrementHelper(dimensionValues, statsRoot, 0, adder, false);
+        // If we failed to increment, because nodes had to be created, obtain the lock and run again while creating nodes if needed
+        if (!didIncrement && createNodesIfAbsent) {
+            try {
+                lock.lock();
+                internalIncrementHelper(dimensionValues, statsRoot, 0, adder, true);
+            } finally {
+                lock.unlock();
+            }
+        }
+    }
+
+    /**
+     * Use the incrementer function to increment/decrement a value in the stats for a set of dimensions.
+     * If createNodesIfAbsent is true, and there is no stats for this set of dimensions, create one.
+     * Returns true if the increment was applied, false if not.
+     */
+    private boolean internalIncrementHelper(
+        List<String> dimensionValues,
+        Node node,
+        int depth, // Pass in the depth to avoid having to slice the list for each node.
+        Consumer<Node> adder,
+        boolean createNodesIfAbsent
+    ) {
+        if (depth == dimensionValues.size()) {
+            // This is the leaf node we are trying to reach
+            adder.accept(node);
+            return true;
+        }
+
+        Node child = node.getChild(dimensionValues.get(depth));
+        if (child == null) {
+            if (createNodesIfAbsent) {
+                boolean createMapInChild = depth < dimensionValues.size() - 1;
+                child = node.createChild(dimensionValues.get(depth), createMapInChild);
+            } else {
+                return false;
+            }
+        }
+        if (internalIncrementHelper(dimensionValues, child, depth + 1, adder, createNodesIfAbsent)) {
+            // Function returns true if the next node down was incremented
+            adder.accept(node);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Produce an immutable version of these stats.
+     */
+    public ImmutableCacheStatsHolder getImmutableCacheStatsHolder() {
+        return new ImmutableCacheStatsHolder(statsRoot.snapshot(), dimensionNames);
+    }
+
+    public void removeDimensions(List<String> dimensionValues) {
+        assert dimensionValues.size() == dimensionNames.size() : "Must specify a value for every dimension when removing from StatsHolder";
+        // As we are removing nodes from the tree, obtain the lock
+        lock.lock();
+        try {
+            removeDimensionsHelper(dimensionValues, statsRoot, 0);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    // Returns a CacheStatsCounterSnapshot object for the stats to decrement if the removal happened, null otherwise.
+    private ImmutableCacheStats removeDimensionsHelper(List<String> dimensionValues, Node node, int depth) {
+        if (depth == dimensionValues.size()) {
+            // Pass up a snapshot of the original stats to avoid issues when the original is decremented by other fn invocations
+            return node.getImmutableStats();
+        }
+        Node child = node.getChild(dimensionValues.get(depth));
+        if (child == null) {
+            return null;
+        }
+        ImmutableCacheStats statsToDecrement = removeDimensionsHelper(dimensionValues, child, depth + 1);
+        if (statsToDecrement != null) {
+            // The removal took place, decrement values and remove this node from its parent if it's now empty
+            node.decrementBySnapshot(statsToDecrement);
+            if (child.getChildren().isEmpty()) {
+                node.children.remove(child.getDimensionValue());
+            }
+        }
+        return statsToDecrement;
+    }
+
+    // pkg-private for testing
+    Node getStatsRoot() {
+        return statsRoot;
+    }
+
+    static class Node {
+        private final String dimensionValue;
+        // Map from dimensionValue to the DimensionNode for that dimension value.
+        final Map<String, Node> children;
+        // The stats for this node. If a leaf node, corresponds to the stats for this combination of dimensions; if not,
+        // contains the sum of its children's stats.
+        private CacheStats stats;
+
+        // Used for leaf nodes to avoid allocating many unnecessary maps
+        private static final Map<String, Node> EMPTY_CHILDREN_MAP = new HashMap<>();
+
+        Node(String dimensionValue, boolean createChildrenMap) {
+            this.dimensionValue = dimensionValue;
+            if (createChildrenMap) {
+                this.children = new ConcurrentHashMap<>();
+            } else {
+                this.children = EMPTY_CHILDREN_MAP;
+            }
+            this.stats = new CacheStats();
+        }
+
+        public String getDimensionValue() {
+            return dimensionValue;
+        }
+
+        protected Map<String, Node> getChildren() {
+            // We can safely iterate over ConcurrentHashMap without worrying about thread issues.
+            return children;
+        }
+
+        // Functions for modifying internal CacheStatsCounter without callers having to be aware of CacheStatsCounter
+
+        void incrementHits() {
+            this.stats.incrementHits();
+        }
+
+        void incrementMisses() {
+            this.stats.incrementMisses();
+        }
+
+        void incrementEvictions() {
+            this.stats.incrementEvictions();
+        }
+
+        void incrementSizeInBytes(long amountBytes) {
+            this.stats.incrementSizeInBytes(amountBytes);
+        }
+
+        void decrementSizeInBytes(long amountBytes) {
+            this.stats.decrementSizeInBytes(amountBytes);
+        }
+
+        void incrementEntries() {
+            this.stats.incrementEntries();
+        }
+
+        void decrementEntries() {
+            this.stats.decrementEntries();
+        }
+
+        long getEntries() {
+            return this.stats.getEntries();
+        }
+
+        ImmutableCacheStats getImmutableStats() {
+            return this.stats.immutableSnapshot();
+        }
+
+        void decrementBySnapshot(ImmutableCacheStats snapshot) {
+            this.stats.subtract(snapshot);
+        }
+
+        void resetSizeAndEntries() {
+            this.stats.resetSizeAndEntries();
+        }
+
+        Node getChild(String dimensionValue) {
+            return children.get(dimensionValue);
+        }
+
+        Node createChild(String dimensionValue, boolean createMapInChild) {
+            return children.computeIfAbsent(dimensionValue, (key) -> new Node(dimensionValue, createMapInChild));
+        }
+
+        ImmutableCacheStatsHolder.Node snapshot() {
+            TreeMap<String, ImmutableCacheStatsHolder.Node> snapshotChildren = null;
+            if (!children.isEmpty()) {
+                snapshotChildren = new TreeMap<>();
+                for (Node child : children.values()) {
+                    snapshotChildren.put(child.getDimensionValue(), child.snapshot());
+                }
+            }
+            return new ImmutableCacheStatsHolder.Node(dimensionValue, snapshotChildren, getImmutableStats());
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/common/cache/stats/ImmutableCacheStats.java
+++ b/server/src/main/java/org/opensearch/common/cache/stats/ImmutableCacheStats.java
@@ -1,0 +1,103 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.cache.stats;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * An immutable snapshot of CacheStats.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class ImmutableCacheStats implements Writeable { // TODO: Make this extend ToXContent (in API PR)
+    private final long hits;
+    private final long misses;
+    private final long evictions;
+    private final long sizeInBytes;
+    private final long entries;
+
+    public ImmutableCacheStats(long hits, long misses, long evictions, long sizeInBytes, long entries) {
+        this.hits = hits;
+        this.misses = misses;
+        this.evictions = evictions;
+        this.sizeInBytes = sizeInBytes;
+        this.entries = entries;
+    }
+
+    public ImmutableCacheStats(StreamInput in) throws IOException {
+        this(in.readVLong(), in.readVLong(), in.readVLong(), in.readVLong(), in.readVLong());
+    }
+
+    public static ImmutableCacheStats addSnapshots(ImmutableCacheStats s1, ImmutableCacheStats s2) {
+        return new ImmutableCacheStats(
+            s1.hits + s2.hits,
+            s1.misses + s2.misses,
+            s1.evictions + s2.evictions,
+            s1.sizeInBytes + s2.sizeInBytes,
+            s1.entries + s2.entries
+        );
+    }
+
+    public long getHits() {
+        return hits;
+    }
+
+    public long getMisses() {
+        return misses;
+    }
+
+    public long getEvictions() {
+        return evictions;
+    }
+
+    public long getSizeInBytes() {
+        return sizeInBytes;
+    }
+
+    public long getEntries() {
+        return entries;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVLong(hits);
+        out.writeVLong(misses);
+        out.writeVLong(evictions);
+        out.writeVLong(sizeInBytes);
+        out.writeVLong(entries);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null) {
+            return false;
+        }
+        if (o.getClass() != ImmutableCacheStats.class) {
+            return false;
+        }
+        ImmutableCacheStats other = (ImmutableCacheStats) o;
+        return (hits == other.hits)
+            && (misses == other.misses)
+            && (evictions == other.evictions)
+            && (sizeInBytes == other.sizeInBytes)
+            && (entries == other.entries);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(hits, misses, evictions, sizeInBytes, entries);
+    }
+}

--- a/server/src/main/java/org/opensearch/common/cache/stats/ImmutableCacheStatsHolder.java
+++ b/server/src/main/java/org/opensearch/common/cache/stats/ImmutableCacheStatsHolder.java
@@ -1,0 +1,111 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.cache.stats;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * An object storing an immutable snapshot of an entire cache's stats. Accessible outside the cache itself.
+ *
+ * @opensearch.experimental
+ */
+
+@ExperimentalApi
+public class ImmutableCacheStatsHolder { // TODO: extends Writeable, ToXContent
+    // An immutable snapshot of a stats within a CacheStatsHolder, containing all the stats maintained by the cache.
+    // Pkg-private for testing.
+    final Node statsRoot;
+    final List<String> dimensionNames;
+
+    public ImmutableCacheStatsHolder(Node statsRoot, List<String> dimensionNames) {
+        this.statsRoot = statsRoot;
+        this.dimensionNames = dimensionNames;
+    }
+
+    public ImmutableCacheStats getTotalStats() {
+        return statsRoot.getStats();
+    }
+
+    public long getTotalHits() {
+        return getTotalStats().getHits();
+    }
+
+    public long getTotalMisses() {
+        return getTotalStats().getMisses();
+    }
+
+    public long getTotalEvictions() {
+        return getTotalStats().getEvictions();
+    }
+
+    public long getTotalSizeInBytes() {
+        return getTotalStats().getSizeInBytes();
+    }
+
+    public long getTotalEntries() {
+        return getTotalStats().getEntries();
+    }
+
+    public ImmutableCacheStats getStatsForDimensionValues(List<String> dimensionValues) {
+        Node current = statsRoot;
+        for (String dimensionValue : dimensionValues) {
+            current = current.children.get(dimensionValue);
+            if (current == null) {
+                return null;
+            }
+        }
+        return current.stats;
+    }
+
+    // A similar class to CacheStatsHolder.Node, which uses an ordered TreeMap and holds immutable CacheStatsSnapshot as its stats.
+    static class Node {
+        private final String dimensionValue;
+        final Map<String, Node> children; // Map from dimensionValue to the Node for that dimension value
+
+        // The stats for this node. If a leaf node, corresponds to the stats for this combination of dimensions; if not,
+        // contains the sum of its children's stats.
+        private final ImmutableCacheStats stats;
+        private static final Map<String, Node> EMPTY_CHILDREN_MAP = new HashMap<>();
+
+        Node(String dimensionValue, TreeMap<String, Node> snapshotChildren, ImmutableCacheStats stats) {
+            this.dimensionValue = dimensionValue;
+            this.stats = stats;
+            if (snapshotChildren == null) {
+                this.children = EMPTY_CHILDREN_MAP;
+            } else {
+                this.children = Collections.unmodifiableMap(snapshotChildren);
+            }
+        }
+
+        Map<String, Node> getChildren() {
+            return children;
+        }
+
+        public ImmutableCacheStats getStats() {
+            return stats;
+        }
+
+        public String getDimensionValue() {
+            return dimensionValue;
+        }
+    }
+
+    // pkg-private for testing
+    Node getStatsRoot() {
+        return statsRoot;
+    }
+
+    // TODO (in API PR): Produce XContent based on aggregateByLevels()
+}

--- a/server/src/main/java/org/opensearch/common/cache/stats/package-info.java
+++ b/server/src/main/java/org/opensearch/common/cache/stats/package-info.java
@@ -1,0 +1,9 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+/** A package for cache stats. */
+package org.opensearch.common.cache.stats;

--- a/server/src/main/java/org/opensearch/common/cache/store/builders/ICacheBuilder.java
+++ b/server/src/main/java/org/opensearch/common/cache/store/builders/ICacheBuilder.java
@@ -10,6 +10,7 @@ package org.opensearch.common.cache.store.builders;
 
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.cache.ICache;
+import org.opensearch.common.cache.ICacheKey;
 import org.opensearch.common.cache.RemovalListener;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
@@ -28,13 +29,13 @@ public abstract class ICacheBuilder<K, V> {
 
     private long maxWeightInBytes;
 
-    private ToLongBiFunction<K, V> weigher;
+    private ToLongBiFunction<ICacheKey<K>, V> weigher;
 
     private TimeValue expireAfterAcess;
 
     private Settings settings;
 
-    private RemovalListener<K, V> removalListener;
+    private RemovalListener<ICacheKey<K>, V> removalListener;
 
     public ICacheBuilder() {}
 
@@ -43,7 +44,7 @@ public abstract class ICacheBuilder<K, V> {
         return this;
     }
 
-    public ICacheBuilder<K, V> setWeigher(ToLongBiFunction<K, V> weigher) {
+    public ICacheBuilder<K, V> setWeigher(ToLongBiFunction<ICacheKey<K>, V> weigher) {
         this.weigher = weigher;
         return this;
     }
@@ -58,7 +59,7 @@ public abstract class ICacheBuilder<K, V> {
         return this;
     }
 
-    public ICacheBuilder<K, V> setRemovalListener(RemovalListener<K, V> removalListener) {
+    public ICacheBuilder<K, V> setRemovalListener(RemovalListener<ICacheKey<K>, V> removalListener) {
         this.removalListener = removalListener;
         return this;
     }
@@ -71,11 +72,11 @@ public abstract class ICacheBuilder<K, V> {
         return expireAfterAcess;
     }
 
-    public ToLongBiFunction<K, V> getWeigher() {
+    public ToLongBiFunction<ICacheKey<K>, V> getWeigher() {
         return weigher;
     }
 
-    public RemovalListener<K, V> getRemovalListener() {
+    public RemovalListener<ICacheKey<K>, V> getRemovalListener() {
         return this.removalListener;
     }
 

--- a/server/src/test/java/org/opensearch/common/cache/serializer/ICacheKeySerializerTests.java
+++ b/server/src/test/java/org/opensearch/common/cache/serializer/ICacheKeySerializerTests.java
@@ -1,0 +1,107 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.cache.serializer;
+
+import org.opensearch.OpenSearchException;
+import org.opensearch.common.Randomness;
+import org.opensearch.common.cache.ICacheKey;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+
+public class ICacheKeySerializerTests extends OpenSearchTestCase {
+    // For these tests, we use BytesReference as K, since we already have a Serializer<BytesReference, byte[]> implementation
+    public void testEquality() throws Exception {
+        BytesReferenceSerializer keySer = new BytesReferenceSerializer();
+        ICacheKeySerializer<BytesReference> serializer = new ICacheKeySerializer<>(keySer);
+
+        int numDimensionsTested = 100;
+        for (int i = 0; i < numDimensionsTested; i++) {
+            String dim = getRandomDimValue();
+            ICacheKey<BytesReference> key = new ICacheKey<>(getRandomBytesReference(), List.of(dim));
+            byte[] serialized = serializer.serialize(key);
+            assertTrue(serializer.equals(key, serialized));
+            ICacheKey<BytesReference> deserialized = serializer.deserialize(serialized);
+            assertEquals(key, deserialized);
+            assertTrue(serializer.equals(deserialized, serialized));
+        }
+    }
+
+    public void testInvalidInput() throws Exception {
+        BytesReferenceSerializer keySer = new BytesReferenceSerializer();
+        ICacheKeySerializer<BytesReference> serializer = new ICacheKeySerializer<>(keySer);
+
+        Random rand = Randomness.get();
+        byte[] randomInput = new byte[1000];
+        rand.nextBytes(randomInput);
+
+        assertThrows(OpenSearchException.class, () -> serializer.deserialize(randomInput));
+    }
+
+    public void testDimNumbers() throws Exception {
+        BytesReferenceSerializer keySer = new BytesReferenceSerializer();
+        ICacheKeySerializer<BytesReference> serializer = new ICacheKeySerializer<>(keySer);
+
+        for (int numDims : new int[] { 0, 5, 1000 }) {
+            List<String> dims = new ArrayList<>();
+            for (int j = 0; j < numDims; j++) {
+                dims.add(getRandomDimValue());
+            }
+            ICacheKey<BytesReference> key = new ICacheKey<>(getRandomBytesReference(), dims);
+            byte[] serialized = serializer.serialize(key);
+            assertTrue(serializer.equals(key, serialized));
+            ICacheKey<BytesReference> deserialized = serializer.deserialize(serialized);
+            assertEquals(key, deserialized);
+        }
+    }
+
+    public void testHashCodes() throws Exception {
+        ICacheKey<String> key1 = new ICacheKey<>("key", List.of("dimension_value"));
+        ICacheKey<String> key2 = new ICacheKey<>("key", List.of("dimension_value"));
+
+        ICacheKey<String> key3 = new ICacheKey<>(null, List.of("dimension_value"));
+        ICacheKey<String> key4 = new ICacheKey<>(null, List.of("dimension_value"));
+
+        assertEquals(key1, key2);
+        assertEquals(key1.hashCode(), key2.hashCode());
+
+        assertEquals(key3, key4);
+        assertEquals(key3.hashCode(), key4.hashCode());
+
+        assertNotEquals(key1, key3);
+        assertNotEquals("string", key3);
+    }
+
+    public void testNullInputs() throws Exception {
+        BytesReferenceSerializer keySer = new BytesReferenceSerializer();
+        ICacheKeySerializer<BytesReference> serializer = new ICacheKeySerializer<>(keySer);
+
+        assertNull(serializer.deserialize(null));
+        ICacheKey<BytesReference> nullKey = new ICacheKey<>(null, List.of(getRandomDimValue()));
+        assertNull(serializer.serialize(nullKey));
+        assertNull(serializer.serialize(null));
+        assertNull(serializer.serialize(new ICacheKey<>(getRandomBytesReference(), null)));
+    }
+
+    private String getRandomDimValue() {
+        return UUID.randomUUID().toString();
+    }
+
+    private BytesReference getRandomBytesReference() {
+        byte[] bytesValue = new byte[1000];
+        Random rand = Randomness.get();
+        rand.nextBytes(bytesValue);
+        return new BytesArray(bytesValue);
+    }
+}

--- a/server/src/test/java/org/opensearch/common/cache/stats/CacheStatsHolderTests.java
+++ b/server/src/test/java/org/opensearch/common/cache/stats/CacheStatsHolderTests.java
@@ -1,0 +1,287 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.cache.stats;
+
+import org.opensearch.common.Randomness;
+import org.opensearch.common.metrics.CounterMetric;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+
+public class CacheStatsHolderTests extends OpenSearchTestCase {
+    public void testAddAndGet() throws Exception {
+        List<String> dimensionNames = List.of("dim1", "dim2", "dim3", "dim4");
+        CacheStatsHolder cacheStatsHolder = new CacheStatsHolder(dimensionNames);
+        Map<String, List<String>> usedDimensionValues = CacheStatsHolderTests.getUsedDimensionValues(cacheStatsHolder, 10);
+        Map<List<String>, CacheStats> expected = CacheStatsHolderTests.populateStats(cacheStatsHolder, usedDimensionValues, 1000, 10);
+
+        // test the value in the map is as expected for each distinct combination of values
+        for (List<String> dimensionValues : expected.keySet()) {
+            CacheStats expectedCounter = expected.get(dimensionValues);
+
+            ImmutableCacheStats actualStatsHolder = CacheStatsHolderTests.getNode(dimensionValues, cacheStatsHolder.getStatsRoot())
+                .getImmutableStats();
+            ImmutableCacheStats actualCacheStats = getNode(dimensionValues, cacheStatsHolder.getStatsRoot()).getImmutableStats();
+
+            assertEquals(expectedCounter.immutableSnapshot(), actualStatsHolder);
+            assertEquals(expectedCounter.immutableSnapshot(), actualCacheStats);
+        }
+
+        // Check overall total matches
+        CacheStats expectedTotal = new CacheStats();
+        for (List<String> dims : expected.keySet()) {
+            expectedTotal.add(expected.get(dims));
+        }
+        assertEquals(expectedTotal.immutableSnapshot(), cacheStatsHolder.getStatsRoot().getImmutableStats());
+
+        // Check sum of children stats are correct
+        assertSumOfChildrenStats(cacheStatsHolder.getStatsRoot());
+    }
+
+    public void testReset() throws Exception {
+        List<String> dimensionNames = List.of("dim1", "dim2");
+        CacheStatsHolder cacheStatsHolder = new CacheStatsHolder(dimensionNames);
+        Map<String, List<String>> usedDimensionValues = getUsedDimensionValues(cacheStatsHolder, 10);
+        Map<List<String>, CacheStats> expected = populateStats(cacheStatsHolder, usedDimensionValues, 100, 10);
+
+        cacheStatsHolder.reset();
+
+        for (List<String> dimensionValues : expected.keySet()) {
+            CacheStats originalCounter = expected.get(dimensionValues);
+            originalCounter.sizeInBytes = new CounterMetric();
+            originalCounter.entries = new CounterMetric();
+
+            CacheStatsHolder.Node node = getNode(dimensionValues, cacheStatsHolder.getStatsRoot());
+            ImmutableCacheStats actual = node.getImmutableStats();
+            assertEquals(originalCounter.immutableSnapshot(), actual);
+        }
+    }
+
+    public void testDropStatsForDimensions() throws Exception {
+        List<String> dimensionNames = List.of("dim1", "dim2");
+        CacheStatsHolder cacheStatsHolder = new CacheStatsHolder(dimensionNames);
+
+        // Create stats for the following dimension sets
+        List<List<String>> populatedStats = List.of(List.of("A1", "B1"), List.of("A2", "B2"), List.of("A2", "B3"));
+        for (List<String> dims : populatedStats) {
+            cacheStatsHolder.incrementHits(dims);
+        }
+
+        assertEquals(3, cacheStatsHolder.getStatsRoot().getImmutableStats().getHits());
+
+        // When we invalidate A2, B2, we should lose the node for B2, but not B3 or A2.
+
+        cacheStatsHolder.removeDimensions(List.of("A2", "B2"));
+
+        assertEquals(2, cacheStatsHolder.getStatsRoot().getImmutableStats().getHits());
+        assertNull(getNode(List.of("A2", "B2"), cacheStatsHolder.getStatsRoot()));
+        assertNotNull(getNode(List.of("A2"), cacheStatsHolder.getStatsRoot()));
+        assertNotNull(getNode(List.of("A2", "B3"), cacheStatsHolder.getStatsRoot()));
+
+        // When we invalidate A1, B1, we should lose the nodes for B1 and also A1, as it has no more children.
+
+        cacheStatsHolder.removeDimensions(List.of("A1", "B1"));
+
+        assertEquals(1, cacheStatsHolder.getStatsRoot().getImmutableStats().getHits());
+        assertNull(getNode(List.of("A1", "B1"), cacheStatsHolder.getStatsRoot()));
+        assertNull(getNode(List.of("A1"), cacheStatsHolder.getStatsRoot()));
+
+        // When we invalidate the last node, all nodes should be deleted except the root node
+
+        cacheStatsHolder.removeDimensions(List.of("A2", "B3"));
+        assertEquals(0, cacheStatsHolder.getStatsRoot().getImmutableStats().getHits());
+        assertEquals(0, cacheStatsHolder.getStatsRoot().children.size());
+    }
+
+    public void testCount() throws Exception {
+        List<String> dimensionNames = List.of("dim1", "dim2");
+        CacheStatsHolder cacheStatsHolder = new CacheStatsHolder(dimensionNames);
+        Map<String, List<String>> usedDimensionValues = getUsedDimensionValues(cacheStatsHolder, 10);
+        Map<List<String>, CacheStats> expected = populateStats(cacheStatsHolder, usedDimensionValues, 100, 10);
+
+        long expectedCount = 0L;
+        for (CacheStats counter : expected.values()) {
+            expectedCount += counter.getEntries();
+        }
+        assertEquals(expectedCount, cacheStatsHolder.count());
+    }
+
+    public void testConcurrentRemoval() throws Exception {
+        List<String> dimensionNames = List.of("dim1", "dim2");
+        CacheStatsHolder cacheStatsHolder = new CacheStatsHolder(dimensionNames);
+
+        // Create stats for the following dimension sets
+        List<List<String>> populatedStats = List.of(List.of("A1", "B1"), List.of("A2", "B2"), List.of("A2", "B3"));
+        for (List<String> dims : populatedStats) {
+            cacheStatsHolder.incrementHits(dims);
+        }
+
+        // Remove (A2, B2) and (A1, B1), before re-adding (A2, B2). At the end we should have stats for (A2, B2) but not (A1, B1).
+
+        Thread[] threads = new Thread[3];
+        CountDownLatch countDownLatch = new CountDownLatch(3);
+        threads[0] = new Thread(() -> {
+            cacheStatsHolder.removeDimensions(List.of("A2", "B2"));
+            countDownLatch.countDown();
+        });
+        threads[1] = new Thread(() -> {
+            cacheStatsHolder.removeDimensions(List.of("A1", "B1"));
+            countDownLatch.countDown();
+        });
+        threads[2] = new Thread(() -> {
+            cacheStatsHolder.incrementMisses(List.of("A2", "B2"));
+            cacheStatsHolder.incrementMisses(List.of("A2", "B3"));
+            countDownLatch.countDown();
+        });
+        for (Thread thread : threads) {
+            thread.start();
+            // Add short sleep to ensure threads start their functions in order (so that incrementing doesn't happen before removal)
+            Thread.sleep(1);
+        }
+        countDownLatch.await();
+        assertNull(getNode(List.of("A1", "B1"), cacheStatsHolder.getStatsRoot()));
+        assertNull(getNode(List.of("A1"), cacheStatsHolder.getStatsRoot()));
+        assertNotNull(getNode(List.of("A2", "B2"), cacheStatsHolder.getStatsRoot()));
+        assertEquals(
+            new ImmutableCacheStats(0, 1, 0, 0, 0),
+            getNode(List.of("A2", "B2"), cacheStatsHolder.getStatsRoot()).getImmutableStats()
+        );
+        assertEquals(
+            new ImmutableCacheStats(1, 1, 0, 0, 0),
+            getNode(List.of("A2", "B3"), cacheStatsHolder.getStatsRoot()).getImmutableStats()
+        );
+    }
+
+    /**
+     * Returns the node found by following these dimension values down from the root node.
+     * Returns null if no such node exists.
+     */
+    static CacheStatsHolder.Node getNode(List<String> dimensionValues, CacheStatsHolder.Node root) {
+        CacheStatsHolder.Node current = root;
+        for (String dimensionValue : dimensionValues) {
+            current = current.getChildren().get(dimensionValue);
+            if (current == null) {
+                return null;
+            }
+        }
+        return current;
+    }
+
+    static Map<List<String>, CacheStats> populateStats(
+        CacheStatsHolder cacheStatsHolder,
+        Map<String, List<String>> usedDimensionValues,
+        int numDistinctValuePairs,
+        int numRepetitionsPerValue
+    ) throws InterruptedException {
+        Map<List<String>, CacheStats> expected = new ConcurrentHashMap<>();
+        Thread[] threads = new Thread[numDistinctValuePairs];
+        CountDownLatch countDownLatch = new CountDownLatch(numDistinctValuePairs);
+        Random rand = Randomness.get();
+        List<List<String>> dimensionsForThreads = new ArrayList<>();
+        for (int i = 0; i < numDistinctValuePairs; i++) {
+            dimensionsForThreads.add(getRandomDimList(cacheStatsHolder.getDimensionNames(), usedDimensionValues, true, rand));
+            int finalI = i;
+            threads[i] = new Thread(() -> {
+                Random threadRand = Randomness.get();
+                List<String> dimensions = dimensionsForThreads.get(finalI);
+                expected.computeIfAbsent(dimensions, (key) -> new CacheStats());
+                for (int j = 0; j < numRepetitionsPerValue; j++) {
+                    CacheStats statsToInc = new CacheStats(
+                        threadRand.nextInt(10),
+                        threadRand.nextInt(10),
+                        threadRand.nextInt(10),
+                        threadRand.nextInt(5000),
+                        threadRand.nextInt(10)
+                    );
+                    expected.get(dimensions).hits.inc(statsToInc.getHits());
+                    expected.get(dimensions).misses.inc(statsToInc.getMisses());
+                    expected.get(dimensions).evictions.inc(statsToInc.getEvictions());
+                    expected.get(dimensions).sizeInBytes.inc(statsToInc.getSizeInBytes());
+                    expected.get(dimensions).entries.inc(statsToInc.getEntries());
+                    CacheStatsHolderTests.populateStatsHolderFromStatsValueMap(cacheStatsHolder, Map.of(dimensions, statsToInc));
+                }
+                countDownLatch.countDown();
+            });
+        }
+        for (Thread thread : threads) {
+            thread.start();
+        }
+        countDownLatch.await();
+        return expected;
+    }
+
+    private static List<String> getRandomDimList(
+        List<String> dimensionNames,
+        Map<String, List<String>> usedDimensionValues,
+        boolean pickValueForAllDims,
+        Random rand
+    ) {
+        List<String> result = new ArrayList<>();
+        for (String dimName : dimensionNames) {
+            if (pickValueForAllDims || rand.nextBoolean()) { // if pickValueForAllDims, always pick a value for each dimension, otherwise do
+                // so 50% of the time
+                int index = between(0, usedDimensionValues.get(dimName).size() - 1);
+                result.add(usedDimensionValues.get(dimName).get(index));
+            }
+        }
+        return result;
+    }
+
+    static Map<String, List<String>> getUsedDimensionValues(CacheStatsHolder cacheStatsHolder, int numValuesPerDim) {
+        Map<String, List<String>> usedDimensionValues = new HashMap<>();
+        for (int i = 0; i < cacheStatsHolder.getDimensionNames().size(); i++) {
+            List<String> values = new ArrayList<>();
+            for (int j = 0; j < numValuesPerDim; j++) {
+                values.add(UUID.randomUUID().toString());
+            }
+            usedDimensionValues.put(cacheStatsHolder.getDimensionNames().get(i), values);
+        }
+        return usedDimensionValues;
+    }
+
+    private void assertSumOfChildrenStats(CacheStatsHolder.Node current) {
+        if (!current.children.isEmpty()) {
+            CacheStats expectedTotal = new CacheStats();
+            for (CacheStatsHolder.Node child : current.children.values()) {
+                expectedTotal.add(child.getImmutableStats());
+            }
+            assertEquals(expectedTotal.immutableSnapshot(), current.getImmutableStats());
+            for (CacheStatsHolder.Node child : current.children.values()) {
+                assertSumOfChildrenStats(child);
+            }
+        }
+    }
+
+    static void populateStatsHolderFromStatsValueMap(CacheStatsHolder cacheStatsHolder, Map<List<String>, CacheStats> statsMap) {
+        for (Map.Entry<List<String>, CacheStats> entry : statsMap.entrySet()) {
+            CacheStats stats = entry.getValue();
+            List<String> dims = entry.getKey();
+            for (int i = 0; i < stats.getHits(); i++) {
+                cacheStatsHolder.incrementHits(dims);
+            }
+            for (int i = 0; i < stats.getMisses(); i++) {
+                cacheStatsHolder.incrementMisses(dims);
+            }
+            for (int i = 0; i < stats.getEvictions(); i++) {
+                cacheStatsHolder.incrementEvictions(dims);
+            }
+            cacheStatsHolder.incrementSizeInBytes(dims, stats.getSizeInBytes());
+            for (int i = 0; i < stats.getEntries(); i++) {
+                cacheStatsHolder.incrementEntries(dims);
+            }
+        }
+    }
+}

--- a/server/src/test/java/org/opensearch/common/cache/stats/ImmutableCacheStatsHolderTests.java
+++ b/server/src/test/java/org/opensearch/common/cache/stats/ImmutableCacheStatsHolderTests.java
@@ -1,0 +1,88 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.cache.stats;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+import java.util.Map;
+
+public class ImmutableCacheStatsHolderTests extends OpenSearchTestCase {
+
+    public void testGet() throws Exception {
+        List<String> dimensionNames = List.of("dim1", "dim2", "dim3", "dim4");
+        CacheStatsHolder cacheStatsHolder = new CacheStatsHolder(dimensionNames);
+        Map<String, List<String>> usedDimensionValues = CacheStatsHolderTests.getUsedDimensionValues(cacheStatsHolder, 10);
+        Map<List<String>, CacheStats> expected = CacheStatsHolderTests.populateStats(cacheStatsHolder, usedDimensionValues, 1000, 10);
+        ImmutableCacheStatsHolder stats = cacheStatsHolder.getImmutableCacheStatsHolder();
+
+        // test the value in the map is as expected for each distinct combination of values
+        for (List<String> dimensionValues : expected.keySet()) {
+            CacheStats expectedCounter = expected.get(dimensionValues);
+
+            ImmutableCacheStats actualCacheStatsHolder = CacheStatsHolderTests.getNode(dimensionValues, cacheStatsHolder.getStatsRoot())
+                .getImmutableStats();
+            ImmutableCacheStats actualImmutableCacheStatsHolder = getNode(dimensionValues, stats.getStatsRoot()).getStats();
+
+            assertEquals(expectedCounter.immutableSnapshot(), actualCacheStatsHolder);
+            assertEquals(expectedCounter.immutableSnapshot(), actualImmutableCacheStatsHolder);
+        }
+
+        // test gets for total (this also checks sum-of-children logic)
+        CacheStats expectedTotal = new CacheStats();
+        for (List<String> dims : expected.keySet()) {
+            expectedTotal.add(expected.get(dims));
+        }
+        assertEquals(expectedTotal.immutableSnapshot(), stats.getTotalStats());
+
+        assertEquals(expectedTotal.getHits(), stats.getTotalHits());
+        assertEquals(expectedTotal.getMisses(), stats.getTotalMisses());
+        assertEquals(expectedTotal.getEvictions(), stats.getTotalEvictions());
+        assertEquals(expectedTotal.getSizeInBytes(), stats.getTotalSizeInBytes());
+        assertEquals(expectedTotal.getEntries(), stats.getTotalEntries());
+
+        assertSumOfChildrenStats(stats.getStatsRoot());
+    }
+
+    public void testEmptyDimsList() throws Exception {
+        // If the dimension list is empty, the tree should have only the root node containing the total stats.
+        CacheStatsHolder cacheStatsHolder = new CacheStatsHolder(List.of());
+        Map<String, List<String>> usedDimensionValues = CacheStatsHolderTests.getUsedDimensionValues(cacheStatsHolder, 100);
+        CacheStatsHolderTests.populateStats(cacheStatsHolder, usedDimensionValues, 10, 100);
+        ImmutableCacheStatsHolder stats = cacheStatsHolder.getImmutableCacheStatsHolder();
+
+        ImmutableCacheStatsHolder.Node statsRoot = stats.getStatsRoot();
+        assertEquals(0, statsRoot.children.size());
+        assertEquals(stats.getTotalStats(), statsRoot.getStats());
+    }
+
+    private ImmutableCacheStatsHolder.Node getNode(List<String> dimensionValues, ImmutableCacheStatsHolder.Node root) {
+        ImmutableCacheStatsHolder.Node current = root;
+        for (String dimensionValue : dimensionValues) {
+            current = current.getChildren().get(dimensionValue);
+            if (current == null) {
+                return null;
+            }
+        }
+        return current;
+    }
+
+    private void assertSumOfChildrenStats(ImmutableCacheStatsHolder.Node current) {
+        if (!current.children.isEmpty()) {
+            CacheStats expectedTotal = new CacheStats();
+            for (ImmutableCacheStatsHolder.Node child : current.children.values()) {
+                expectedTotal.add(child.getStats());
+            }
+            assertEquals(expectedTotal.immutableSnapshot(), current.getStats());
+            for (ImmutableCacheStatsHolder.Node child : current.children.values()) {
+                assertSumOfChildrenStats(child);
+            }
+        }
+    }
+}

--- a/server/src/test/java/org/opensearch/common/cache/stats/ImmutableCacheStatsTests.java
+++ b/server/src/test/java/org/opensearch/common/cache/stats/ImmutableCacheStatsTests.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.cache.stats;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.BytesStreamInput;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class ImmutableCacheStatsTests extends OpenSearchTestCase {
+    public void testSerialization() throws Exception {
+        ImmutableCacheStats immutableCacheStats = new ImmutableCacheStats(1, 2, 3, 4, 5);
+        BytesStreamOutput os = new BytesStreamOutput();
+        immutableCacheStats.writeTo(os);
+        BytesStreamInput is = new BytesStreamInput(BytesReference.toBytes(os.bytes()));
+        ImmutableCacheStats deserialized = new ImmutableCacheStats(is);
+
+        assertEquals(immutableCacheStats, deserialized);
+    }
+
+    public void testAddSnapshots() throws Exception {
+        ImmutableCacheStats ics1 = new ImmutableCacheStats(1, 2, 3, 4, 5);
+        ImmutableCacheStats ics2 = new ImmutableCacheStats(6, 7, 8, 9, 10);
+        ImmutableCacheStats expected = new ImmutableCacheStats(7, 9, 11, 13, 15);
+        assertEquals(expected, ImmutableCacheStats.addSnapshots(ics1, ics2));
+    }
+
+    public void testEqualsAndHash() throws Exception {
+        ImmutableCacheStats ics1 = new ImmutableCacheStats(1, 2, 3, 4, 5);
+        ImmutableCacheStats ics2 = new ImmutableCacheStats(1, 2, 3, 4, 5);
+        ImmutableCacheStats ics3 = new ImmutableCacheStats(0, 2, 3, 4, 5);
+
+        assertEquals(ics1, ics2);
+        assertNotEquals(ics1, ics3);
+        assertNotEquals(ics1, null);
+        assertNotEquals(ics1, "string");
+
+        assertEquals(ics1.hashCode(), ics2.hashCode());
+        assertNotEquals(ics1.hashCode(), ics3.hashCode());
+    }
+}

--- a/server/src/test/java/org/opensearch/common/cache/store/OpenSearchOnHeapCacheTests.java
+++ b/server/src/test/java/org/opensearch/common/cache/store/OpenSearchOnHeapCacheTests.java
@@ -1,0 +1,181 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.cache.store;
+
+import org.opensearch.common.Randomness;
+import org.opensearch.common.cache.CacheType;
+import org.opensearch.common.cache.ICache;
+import org.opensearch.common.cache.ICacheKey;
+import org.opensearch.common.cache.LoadAwareCacheLoader;
+import org.opensearch.common.cache.RemovalListener;
+import org.opensearch.common.cache.RemovalNotification;
+import org.opensearch.common.cache.stats.ImmutableCacheStats;
+import org.opensearch.common.cache.store.config.CacheConfig;
+import org.opensearch.common.cache.store.settings.OpenSearchOnHeapCacheSettings;
+import org.opensearch.common.metrics.CounterMetric;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.opensearch.common.cache.store.settings.OpenSearchOnHeapCacheSettings.MAXIMUM_SIZE_IN_BYTES_KEY;
+
+public class OpenSearchOnHeapCacheTests extends OpenSearchTestCase {
+    private final static long keyValueSize = 50;
+    private final static List<String> dimensionNames = List.of("dim1", "dim2", "dim3");
+
+    public void testStats() throws Exception {
+        MockRemovalListener<String, String> listener = new MockRemovalListener<>();
+        int maxKeys = between(10, 50);
+        int numEvicted = between(10, 20);
+        OpenSearchOnHeapCache<String, String> cache = getCache(maxKeys, listener);
+
+        List<ICacheKey<String>> keysAdded = new ArrayList<>();
+        int numAdded = maxKeys + numEvicted;
+        for (int i = 0; i < numAdded; i++) {
+            ICacheKey<String> key = getICacheKey(UUID.randomUUID().toString());
+            keysAdded.add(key);
+            cache.computeIfAbsent(key, getLoadAwareCacheLoader());
+
+            assertEquals(i + 1, cache.stats().getTotalMisses());
+            assertEquals(0, cache.stats().getTotalHits());
+            assertEquals(Math.min(maxKeys, i + 1), cache.stats().getTotalEntries());
+            assertEquals(Math.min(maxKeys, i + 1) * keyValueSize, cache.stats().getTotalSizeInBytes());
+            assertEquals(Math.max(0, i + 1 - maxKeys), cache.stats().getTotalEvictions());
+        }
+        // do gets from the last part of the list, which should be hits
+        for (int i = numAdded - maxKeys; i < numAdded; i++) {
+            cache.computeIfAbsent(keysAdded.get(i), getLoadAwareCacheLoader());
+            int numHits = i + 1 - (numAdded - maxKeys);
+
+            assertEquals(numAdded, cache.stats().getTotalMisses());
+            assertEquals(numHits, cache.stats().getTotalHits());
+            assertEquals(maxKeys, cache.stats().getTotalEntries());
+            assertEquals(maxKeys * keyValueSize, cache.stats().getTotalSizeInBytes());
+            assertEquals(numEvicted, cache.stats().getTotalEvictions());
+        }
+
+        // invalidate keys
+        for (int i = numAdded - maxKeys; i < numAdded; i++) {
+            cache.invalidate(keysAdded.get(i));
+            int numInvalidated = i + 1 - (numAdded - maxKeys);
+
+            assertEquals(numAdded, cache.stats().getTotalMisses());
+            assertEquals(maxKeys, cache.stats().getTotalHits());
+            assertEquals(maxKeys - numInvalidated, cache.stats().getTotalEntries());
+            assertEquals((maxKeys - numInvalidated) * keyValueSize, cache.stats().getTotalSizeInBytes());
+            assertEquals(numEvicted, cache.stats().getTotalEvictions());
+        }
+    }
+
+    private OpenSearchOnHeapCache<String, String> getCache(int maxSizeKeys, MockRemovalListener<String, String> listener) {
+        ICache.Factory onHeapCacheFactory = new OpenSearchOnHeapCache.OpenSearchOnHeapCacheFactory();
+        Settings settings = Settings.builder()
+            .put(
+                OpenSearchOnHeapCacheSettings.getSettingListForCacheType(CacheType.INDICES_REQUEST_CACHE)
+                    .get(MAXIMUM_SIZE_IN_BYTES_KEY)
+                    .getKey(),
+                maxSizeKeys * keyValueSize + "b"
+            )
+            .build();
+
+        CacheConfig<String, String> cacheConfig = new CacheConfig.Builder<String, String>().setKeyType(String.class)
+            .setValueType(String.class)
+            .setWeigher((k, v) -> keyValueSize)
+            .setRemovalListener(listener)
+            .setSettings(settings)
+            .setDimensionNames(dimensionNames)
+            .setMaxSizeInBytes(maxSizeKeys * keyValueSize)
+            .build();
+        return (OpenSearchOnHeapCache<String, String>) onHeapCacheFactory.create(cacheConfig, CacheType.INDICES_REQUEST_CACHE, null);
+    }
+
+    public void testInvalidateWithDropDimensions() throws Exception {
+        MockRemovalListener<String, String> listener = new MockRemovalListener<>();
+        int maxKeys = 50;
+        OpenSearchOnHeapCache<String, String> cache = getCache(maxKeys, listener);
+
+        List<ICacheKey<String>> keysAdded = new ArrayList<>();
+
+        for (int i = 0; i < maxKeys - 5; i++) {
+            ICacheKey<String> key = new ICacheKey<>(UUID.randomUUID().toString(), getRandomDimensions());
+            keysAdded.add(key);
+            cache.computeIfAbsent(key, getLoadAwareCacheLoader());
+        }
+
+        ICacheKey<String> keyToDrop = keysAdded.get(0);
+
+        ImmutableCacheStats snapshot = cache.stats().getStatsForDimensionValues(keyToDrop.dimensions);
+        assertNotNull(snapshot);
+
+        keyToDrop.setDropStatsForDimensions(true);
+        cache.invalidate(keyToDrop);
+
+        // Now assert the stats are gone for any key that has this combination of dimensions, but still there otherwise
+        for (ICacheKey<String> keyAdded : keysAdded) {
+            snapshot = cache.stats().getStatsForDimensionValues(keyAdded.dimensions);
+            if (keyAdded.dimensions.equals(keyToDrop.dimensions)) {
+                assertNull(snapshot);
+            } else {
+                assertNotNull(snapshot);
+            }
+        }
+    }
+
+    private List<String> getRandomDimensions() {
+        Random rand = Randomness.get();
+        int bound = 3;
+        List<String> result = new ArrayList<>();
+        for (String dimName : dimensionNames) {
+            result.add(String.valueOf(rand.nextInt(bound)));
+        }
+        return result;
+    }
+
+    private static class MockRemovalListener<K, V> implements RemovalListener<ICacheKey<K>, V> {
+        CounterMetric numRemovals;
+
+        MockRemovalListener() {
+            numRemovals = new CounterMetric();
+        }
+
+        @Override
+        public void onRemoval(RemovalNotification<ICacheKey<K>, V> notification) {
+            numRemovals.inc();
+        }
+    }
+
+    private ICacheKey<String> getICacheKey(String key) {
+        List<String> dims = new ArrayList<>();
+        for (String dimName : dimensionNames) {
+            dims.add("0");
+        }
+        return new ICacheKey<>(key, dims);
+    }
+
+    private LoadAwareCacheLoader<ICacheKey<String>, String> getLoadAwareCacheLoader() {
+        return new LoadAwareCacheLoader<>() {
+            boolean isLoaded = false;
+
+            @Override
+            public String load(ICacheKey<String> key) {
+                isLoaded = true;
+                return UUID.randomUUID().toString();
+            }
+
+            @Override
+            public boolean isLoaded() {
+                return isLoaded;
+            }
+        };
+    }
+}


### PR DESCRIPTION
**Original PR: https://github.com/opensearch-project/OpenSearch/pull/12531**

Signed-off-by: Peter Alfonsi <petealft@amazon.com>
Co-authored-by: Peter Alfonsi <petealft@amazon.com>
(cherry picked from commit cc22310145309b3f3dfca377a84f4e26579611be)

### Description
As part of [tiered caching stats](https://github.com/opensearch-project/OpenSearch/issues/12258), changes the common ICache interface to use ICacheKey as its key. This key contains dimensions (for example, shard ID, index name, or tier) that can be used to aggregate stats. Also changes the CacheStats interface to store the necessary cache stats, and to support getting stats either as a total or aggregated by these dimensions. 

Integrates these changes with OpenSearchOnHeapCache and EhcacheDiskCache. The stats implementation for the TieredSpilloverCache will be in a followup PR. 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [N/A] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
