### PR TITLE
Fix flat_object long field error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Client with Java 8 runtime and Apache HttpClient 5 Transport fails with java.lang.NoSuchMethodError: java.nio.ByteBuffer.flip()Ljava/nio/ByteBuffer ([#13100](https://github.com/opensearch-project/opensearch-java/pull/13100))
 - Fix implement mark() and markSupported() in class FilterStreamInput ([#13098](https://github.com/opensearch-project/OpenSearch/pull/13098))
 - Fix snapshot _status API to return correct status for partial snapshots ([#12812](https://github.com/opensearch-project/OpenSearch/pull/12812))
+- Fix flat_object long field error ([#13256](https://github.com/opensearch-project/OpenSearch/pull/13256))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/common/xcontent/JsonToStringXContentParser.java
+++ b/server/src/main/java/org/opensearch/common/xcontent/JsonToStringXContentParser.java
@@ -108,7 +108,7 @@ public class JsonToStringXContentParser extends AbstractXContentParser {
                 parseToken(path, currentFieldName);
                 int dotIndex = path.lastIndexOf(DOT_SYMBOL);
                 if (dotIndex != -1) {
-                    path.setLength(path.length() - currentFieldName.length() - 1);
+                    path.setLength(Math.max(0, path.length() - currentFieldName.length() - 1));
                 }
             } else {
                 if (!path.toString().contains(currentFieldName)) {

--- a/server/src/test/java/org/opensearch/index/mapper/FlatObjectFieldDataTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/FlatObjectFieldDataTests.java
@@ -54,6 +54,46 @@ public class FlatObjectFieldDataTests extends AbstractFieldDataTestCase {
         assertEquals(1, valueReaders.size());
     }
 
+    public void testLongFieldNameWithHashArray() throws Exception {
+        String mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("test")
+            .startObject("properties")
+            .startObject("field")
+            .field("type", FIELD_TYPE)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+        final DocumentMapper mapper = mapperService.documentMapperParser().parse("test", new CompressedXContent(mapping));
+
+        XContentBuilder json = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("field")
+            .startObject("detail")
+            .startArray("fooooooooooo")
+            .startObject().field("name", "baz").endObject()
+            .startObject().field("name", "baz").endObject()
+            .endArray()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        ParsedDocument d = mapper.parse(new SourceToParse("test", "1", BytesReference.bytes(json), MediaTypeRegistry.JSON));
+        writer.addDocument(d.rootDoc());
+        writer.commit();
+
+        IndexFieldData<?> fieldData = getForField("field");
+        List<LeafReaderContext> readers = refreshReader();
+        assertEquals(1, readers.size());
+
+        IndexFieldData<?> valueFieldData = getForField("field._value");
+        List<LeafReaderContext> valueReaders = refreshReader();
+        assertEquals(1, valueReaders.size());
+    }
+
+
     @Override
     protected String getFieldDataType() {
         return FIELD_TYPE;


### PR DESCRIPTION
### Description

Fixed an error `'Preview of field's value: 'null''` that occurred when using flat_object with long field names in OpenSearch version `2.12` and later.

### Related Issues

https://github.com/opensearch-project/OpenSearch/issues/13184


### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [ ] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
