### PR TITLE
Fix flat_object long field error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix snapshot _status API to return correct status for partial snapshots ([#12812](https://github.com/opensearch-project/OpenSearch/pull/12812))
 - Improve the error messages for _stats with closed indices ([#13012](https://github.com/opensearch-project/OpenSearch/pull/13012))
 - Ignore BaseRestHandler unconsumed content check as it's always consumed. ([#13290](https://github.com/opensearch-project/OpenSearch/pull/13290))
+- Fix mapper_parsing_exception when using flat_object fields with names longer than 11 characters ([#13259](https://github.com/opensearch-project/OpenSearch/pull/13259))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/common/xcontent/JsonToStringXContentParser.java
+++ b/server/src/main/java/org/opensearch/common/xcontent/JsonToStringXContentParser.java
@@ -119,7 +119,7 @@ public class JsonToStringXContentParser extends AbstractXContentParser {
                 this.valueList.add(parsedFields.toString());
                 this.valueAndPathList.add(path + EQUAL_SYMBOL + parsedFields);
                 int dotIndex = path.lastIndexOf(DOT_SYMBOL);
-                if (dotIndex != -1) {
+                if (dotIndex != -1 && path.length() > currentFieldName.length()) {
                     path.setLength(path.length() - currentFieldName.length() - 1);
                 }
             }

--- a/server/src/main/java/org/opensearch/common/xcontent/JsonToStringXContentParser.java
+++ b/server/src/main/java/org/opensearch/common/xcontent/JsonToStringXContentParser.java
@@ -106,7 +106,7 @@ public class JsonToStringXContentParser extends AbstractXContentParser {
                 // skip
             } else if (this.parser.currentToken() == Token.START_OBJECT) {
                 parseToken(path, currentFieldName);
-                int dotIndex = path.lastIndexOf(DOT_SYMBOL);
+                int dotIndex = path.lastIndexOf(DOT_SYMBOL, path.length());
 
                 if (dotIndex != -1 && path.length() > currentFieldName.length()) {
                     path.setLength(path.length() - currentFieldName.length() - 1);
@@ -118,7 +118,7 @@ public class JsonToStringXContentParser extends AbstractXContentParser {
                 parseValue(parsedFields);
                 this.valueList.add(parsedFields.toString());
                 this.valueAndPathList.add(path + EQUAL_SYMBOL + parsedFields);
-                int dotIndex = path.lastIndexOf(DOT_SYMBOL);
+                int dotIndex = path.lastIndexOf(DOT_SYMBOL, path.length());
                 if (dotIndex != -1 && path.length() > currentFieldName.length()) {
                     path.setLength(path.length() - currentFieldName.length() - 1);
                 }

--- a/server/src/main/java/org/opensearch/common/xcontent/JsonToStringXContentParser.java
+++ b/server/src/main/java/org/opensearch/common/xcontent/JsonToStringXContentParser.java
@@ -108,7 +108,8 @@ public class JsonToStringXContentParser extends AbstractXContentParser {
                 parseToken(path, currentFieldName);
                 int dotIndex = path.lastIndexOf(DOT_SYMBOL);
                 if (dotIndex != -1) {
-                    path.setLength(path.length() - currentFieldName.length() - 1);
+                    path.setLength(Math.max(0, path.length() - currentFieldName.length() - 1));
+
                 }
             } else {
                 if (!path.toString().contains(currentFieldName)) {

--- a/server/src/main/java/org/opensearch/common/xcontent/JsonToStringXContentParser.java
+++ b/server/src/main/java/org/opensearch/common/xcontent/JsonToStringXContentParser.java
@@ -109,7 +109,7 @@ public class JsonToStringXContentParser extends AbstractXContentParser {
                 int dotIndex = path.lastIndexOf(DOT_SYMBOL);
 
                 if (dotIndex != -1 && path.length() > currentFieldName.length()) {
-                   path.setLength(path.length() - currentFieldName.length() - 1);
+                    path.setLength(path.length() - currentFieldName.length() - 1);
                 }
             } else {
                 if (!path.toString().contains(currentFieldName)) {

--- a/server/src/main/java/org/opensearch/common/xcontent/JsonToStringXContentParser.java
+++ b/server/src/main/java/org/opensearch/common/xcontent/JsonToStringXContentParser.java
@@ -107,9 +107,9 @@ public class JsonToStringXContentParser extends AbstractXContentParser {
             } else if (this.parser.currentToken() == Token.START_OBJECT) {
                 parseToken(path, currentFieldName);
                 int dotIndex = path.lastIndexOf(DOT_SYMBOL);
-                if (dotIndex != -1) {
-                    path.setLength(Math.max(0, path.length() - currentFieldName.length() - 1));
 
+                if (dotIndex != -1 && path.length() > currentFieldName.length()) {
+                   path.setLength(path.length() - currentFieldName.length() - 1);
                 }
             } else {
                 if (!path.toString().contains(currentFieldName)) {


### PR DESCRIPTION
### Description

Fixed an error `'Preview of field's value: 'null'` that occurred when using flat_object with long field names in OpenSearch version `2.12` and later.

### Related Issues

https://github.com/opensearch-project/OpenSearch/issues/13184


### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
