### PR TITLE
Update supported version in yaml test file for the primary_only parameter in force-merge API

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.forcemerge/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.forcemerge/10_basic.yml
@@ -31,8 +31,8 @@
 ---
 "Test primary_only parameter":
   - skip:
-      version: " - 2.99.99"
-      reason: "primary_only is available in 3.0+"
+      version: " - 2.12.99"
+      reason: "primary_only was introduced in 2.13.0"
 
   - do:
       indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.forcemerge/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.forcemerge/10_basic.yml
@@ -32,7 +32,7 @@
 "Test primary_only parameter":
   - skip:
       version: " - 2.12.99"
-      reason: "primary_only was introduced in 2.13.0"
+      reason: "primary_only is available in 2.13.0+"
 
   - do:
       indices.create:


### PR DESCRIPTION
### Description

In 2.13.0, we added a new parameter `primary_only` for the force-merge API in this PR:https://github.com/opensearch-project/OpenSearch/pull/11269,  but I found that we omitted updating the supported version in a yaml test file when we updated the version check by this PR: https://github.com/opensearch-project/OpenSearch/pull/12657, so we need to update it.

Backport to 2.x is not needed, and changelog is also not needed.

### Related Issues

https://github.com/opensearch-project/OpenSearch/issues/8021

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
