### PR TITLE
Fix flakiness in testDontAllowSwitchingCompatibilityModeForClusterWit…

### DIFF
--- a/server/src/test/java/org/opensearch/action/support/clustermanager/TransportClusterManagerNodeActionTests.java
+++ b/server/src/test/java/org/opensearch/action/support/clustermanager/TransportClusterManagerNodeActionTests.java
@@ -91,8 +91,6 @@ import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.REMOTE_ST
 import static org.opensearch.node.remotestore.RemoteStoreNodeService.REMOTE_STORE_COMPATIBILITY_MODE_SETTING;
 import static org.opensearch.test.ClusterServiceUtils.createClusterService;
 import static org.opensearch.test.ClusterServiceUtils.setState;
-import static org.opensearch.test.VersionUtils.randomCompatibleVersion;
-import static org.opensearch.test.VersionUtils.randomOpenSearchVersion;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -826,10 +824,9 @@ public class TransportClusterManagerNodeActionTests extends OpenSearchTestCase {
         request.persistentSettings(intendedCompatibilityModeSettings);
 
         // two different but compatible open search versions for the discovery nodes
-        final Version version1 = randomOpenSearchVersion(random());
-        final Version version2 = randomCompatibleVersion(random(), version1);
+        final Version version1 = Version.V_2_13_0;
+        final Version version2 = Version.V_2_13_1;
 
-        assert version1.equals(version2) == false : "current nodes in the cluster must be of different versions";
         DiscoveryNode discoveryNode1 = new DiscoveryNode(
             UUIDs.base64UUID(),
             buildNewFakeTransportAddress(),


### PR DESCRIPTION
…hMultipleVersions

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
* Fixes the flakiness in `org.opensearch.action.support.clustermanager.TransportClusterManagerNodeActionTests.testDontAllowSwitchingCompatibilityModeForClusterWithMultipleVersions`.
* Was using `randomCompatibleVersion(random(), version1)` to pick `version2` which does not guarantee `version2` being different from `version1` leading to an assertion failure at `assert version1.equals(version2) == false`
* Now specifically using two compatible and different OpenSearch versions for the purpose of the test 

### Related Issues
Resolves #13240
<!-- List any other related issues here -->

### Check List
- [ ] ~New functionality includes testing.~
  - [ ] ~All tests pass~
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [ ] ~Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))~
- [x] Commits are signed per the DCO using --signoff
- [ ] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
