### PR TITLE
Server: add the opensearch product header to threadContext

### DIFF
--- a/.idea/runConfigurations/Debug_OpenSearch.xml
+++ b/.idea/runConfigurations/Debug_OpenSearch.xml
@@ -6,6 +6,10 @@
     <option name="HOST" value="localhost" />
     <option name="PORT" value="5005" />
     <option name="AUTO_RESTART" value="true" />
+    <RunnerSettings RunnerId="Debug">
+      <option name="DEBUG_PORT" value="5005" />
+      <option name="LOCAL" value="false" />
+    </RunnerSettings>
     <method v="2" />
   </configuration>
 </component>

--- a/.idea/runConfigurations/Debug_OpenSearch.xml
+++ b/.idea/runConfigurations/Debug_OpenSearch.xml
@@ -6,10 +6,6 @@
     <option name="HOST" value="localhost" />
     <option name="PORT" value="5005" />
     <option name="AUTO_RESTART" value="true" />
-    <RunnerSettings RunnerId="Debug">
-      <option name="DEBUG_PORT" value="5005" />
-      <option name="LOCAL" value="false" />
-    </RunnerSettings>
     <method v="2" />
   </configuration>
 </component>

--- a/server/src/main/java/org/opensearch/rest/RestController.java
+++ b/server/src/main/java/org/opensearch/rest/RestController.java
@@ -94,7 +94,7 @@ public class RestController implements HttpServerTransport.Dispatcher {
 
     private static final Logger logger = LogManager.getLogger(RestController.class);
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(RestController.class);
-    private static final String OPENSEARCH_PRODUCT_ORIGIN_HTTP_HEADER = "X-opensearch-product-origin";
+    protected static final String OPENSEARCH_PRODUCT_ORIGIN_HTTP_HEADER = "X-opensearch-product-origin";
 
     private static final BytesReference FAVICON_RESPONSE;
 

--- a/server/src/main/java/org/opensearch/rest/RestController.java
+++ b/server/src/main/java/org/opensearch/rest/RestController.java
@@ -330,6 +330,12 @@ public class RestController implements HttpServerTransport.Dispatcher {
                 // This header is intended for internal use only.
                 client.threadPool().getThreadContext().putHeader(SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY, Boolean.FALSE.toString());
             }
+            if (request.header(OPENSEARCH_PRODUCT_ORIGIN_HTTP_HEADER) != null) {
+                client.threadPool().getThreadContext().putHeader(
+                    OPENSEARCH_PRODUCT_ORIGIN_HTTP_HEADER,
+                    request.header(OPENSEARCH_PRODUCT_ORIGIN_HTTP_HEADER)
+                );
+            }
 
             handler.handleRequest(request, responseChannel, client);
         } catch (Exception e) {

--- a/server/src/main/java/org/opensearch/rest/RestController.java
+++ b/server/src/main/java/org/opensearch/rest/RestController.java
@@ -324,17 +324,13 @@ public class RestController implements HttpServerTransport.Dispatcher {
             if (handler.allowsUnsafeBuffers() == false) {
                 request.ensureSafeBuffers();
             }
-            if (handler.allowSystemIndexAccessByDefault() == false && request.header(OPENSEARCH_PRODUCT_ORIGIN_HTTP_HEADER) == null) {
+            if (request.header(OPENSEARCH_PRODUCT_ORIGIN_HTTP_HEADER) != null) {
+                client.threadPool().getThreadContext().putHeader(OPENSEARCH_PRODUCT_ORIGIN_HTTP_HEADER, Boolean.TRUE.toString());
+            } else if (handler.allowSystemIndexAccessByDefault() == false) {
                 // The OPENSEARCH_PRODUCT_ORIGIN_HTTP_HEADER indicates that the request is coming from an OpenSearch product with a plan
                 // to move away from direct access to system indices, and thus deprecation warnings should not be emitted.
                 // This header is intended for internal use only.
                 client.threadPool().getThreadContext().putHeader(SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY, Boolean.FALSE.toString());
-            }
-            if (request.header(OPENSEARCH_PRODUCT_ORIGIN_HTTP_HEADER) != null) {
-                client.threadPool().getThreadContext().putHeader(
-                    OPENSEARCH_PRODUCT_ORIGIN_HTTP_HEADER,
-                    request.header(OPENSEARCH_PRODUCT_ORIGIN_HTTP_HEADER)
-                );
             }
 
             handler.handleRequest(request, responseChannel, client);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

- As someone expand processing request or feature, etc., may want to know it is the context of the OpenSearch dashboard.
- ~~Requests from the Opensearch dashboard have the `X-opensearch-product-origin` header. So I added this to the ThreadContext header list.~~

---

- To distinguish whether the request comes from the opensearch dashboard.
- Requests that come from the Opensearch dashboard have the `x-opensearch-product-origin` header. The value is `opensearch-dashboards`.
- ~~Add the `isDashboardContext` method that returns `boolean` on OpenSearch `ThreadContext`.~~

---

- Add the opensearch product header to threadContext using boolean `TRUE` value.

### Related Issues
Resolves #13297 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
