### PR TITLE
Take shallow copy snapshot only when remote store compatibility mode is STRICT

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotemigration/RemoteStoreMigrationSettingsUpdateIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotemigration/RemoteStoreMigrationSettingsUpdateIT.java
@@ -8,28 +8,15 @@
 
 package org.opensearch.remotemigration;
 
-import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
 import org.opensearch.client.Client;
-import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.settings.SettingsException;
-import org.opensearch.core.rest.RestStatus;
-import org.opensearch.index.IndexSettings;
-import org.opensearch.indices.replication.common.ReplicationType;
-import org.opensearch.repositories.blobstore.BlobStoreRepository;
-import org.opensearch.snapshots.SnapshotInfo;
-import org.opensearch.snapshots.SnapshotState;
 import org.opensearch.test.InternalTestCluster;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
 import java.nio.file.Path;
 import java.util.Optional;
 
-import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REMOTE_SEGMENT_STORE_REPOSITORY;
-import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REMOTE_STORE_ENABLED;
-import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REMOTE_TRANSLOG_STORE_REPOSITORY;
-import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REPLICATION_TYPE;
-import static org.opensearch.index.IndexSettings.INDEX_REMOTE_TRANSLOG_BUFFER_INTERVAL_SETTING;
 import static org.opensearch.node.remotestore.RemoteStoreNodeService.CompatibilityMode.MIXED;
 import static org.opensearch.node.remotestore.RemoteStoreNodeService.CompatibilityMode.STRICT;
 import static org.opensearch.node.remotestore.RemoteStoreNodeService.Direction.REMOTE_STORE;
@@ -110,11 +97,12 @@ public class RemoteStoreMigrationSettingsUpdateIT extends RemoteStoreMigrationSh
 
         logger.info("Create snapshot of non remote stored backed index");
 
-        createSnapshot(snapshotRepoName, snapshotName);
+        createSnapshot(snapshotRepoName, snapshotName, TEST_INDEX);
 
         logger.info("Restore index from snapshot under NONE direction");
         String restoredIndexName1 = TEST_INDEX + "-restored1";
         restoreSnapshot(snapshotRepoName, snapshotName, restoredIndexName1);
+        ensureGreen(restoredIndexName1);
 
         logger.info("Verify that restored index is non remote-backed");
         assertNonRemoteStoreBackedIndex(restoredIndexName1);
@@ -123,6 +111,7 @@ public class RemoteStoreMigrationSettingsUpdateIT extends RemoteStoreMigrationSh
         setDirection(REMOTE_STORE.direction);
         String restoredIndexName2 = TEST_INDEX + "-restored2";
         restoreSnapshot(snapshotRepoName, snapshotName, restoredIndexName2);
+        ensureGreen(restoredIndexName2);
 
         logger.info("Verify that restored index is non remote-backed");
         assertRemoteStoreBackedIndex(restoredIndexName2);
@@ -157,116 +146,6 @@ public class RemoteStoreMigrationSettingsUpdateIT extends RemoteStoreMigrationSh
 
         logger.info("Attempt switching to strict mode");
         setClusterMode(STRICT.mode);
-    }
-
-    public void testNoShallowSnapshotInMixedMode() throws Exception {
-        logger.info("Initialize remote cluster");
-        initializeCluster(true);
-
-        logger.info("Add remote node");
-        String nodeName = internalCluster().startNode();
-        internalCluster().validateClusterFormed();
-        assertNodeInCluster(nodeName);
-
-        logger.info("Create remote backed index");
-        createIndex(TEST_INDEX, 0);
-        assertRemoteStoreBackedIndex(TEST_INDEX);
-
-        logger.info("Create shallow snapshot setting enabled repo");
-        String shallowSnapshotRepoName = "shallow-snapshot-repo-name";
-        Path shallowSnapshotRepoPath = randomRepoPath();
-        assertAcked(
-            clusterAdmin().preparePutRepository(shallowSnapshotRepoName)
-                .setType("fs")
-                .setSettings(
-                    Settings.builder()
-                        .put("location", shallowSnapshotRepoPath)
-                        .put(BlobStoreRepository.REMOTE_STORE_INDEX_SHALLOW_COPY.getKey(), Boolean.TRUE)
-                )
-        );
-
-        logger.info("Verify shallow snapshot creation");
-        final String snapshot1 = "snapshot1";
-        SnapshotInfo snapshotInfo1 = createSnapshot(shallowSnapshotRepoName, snapshot1);
-        assertEquals(snapshotInfo1.isRemoteStoreIndexShallowCopyEnabled(), true);
-
-        logger.info("Set MIXED compatibility mode");
-        setClusterMode(MIXED.mode);
-
-        logger.info("Verify that new snapshot is not shallow");
-        final String snapshot2 = "snapshot2";
-        SnapshotInfo snapshotInfo2 = createSnapshot(shallowSnapshotRepoName, snapshot2);
-        assertEquals(snapshotInfo2.isRemoteStoreIndexShallowCopyEnabled(), false);
-    }
-
-    // create a snapshot
-    private SnapshotInfo createSnapshot(String snapshotRepoName, String snapshotName) {
-        SnapshotInfo snapshotInfo = client().admin()
-            .cluster()
-            .prepareCreateSnapshot(snapshotRepoName, snapshotName)
-            .setIndices(TEST_INDEX)
-            .setWaitForCompletion(true)
-            .get()
-            .getSnapshotInfo();
-
-        assertEquals(SnapshotState.SUCCESS, snapshotInfo.state());
-        assertTrue(snapshotInfo.successfulShards() > 0);
-        assertEquals(0, snapshotInfo.failedShards());
-        return snapshotInfo;
-    }
-
-    // create new index
-    private void createIndex(String indexName, int replicaCount) {
-        assertAcked(
-            internalCluster().client()
-                .admin()
-                .indices()
-                .prepareCreate(indexName)
-                .setSettings(
-                    Settings.builder()
-                        .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-                        .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, replicaCount)
-                        .build()
-                )
-                .get()
-        );
-    }
-
-    // restore indices from a snapshot
-    private void restoreSnapshot(String snapshotRepoName, String snapshotName, String restoredIndexName) {
-        RestoreSnapshotResponse restoreSnapshotResponse = client.admin()
-            .cluster()
-            .prepareRestoreSnapshot(snapshotRepoName, snapshotName)
-            .setWaitForCompletion(false)
-            .setIndices(TEST_INDEX)
-            .setRenamePattern(TEST_INDEX)
-            .setRenameReplacement(restoredIndexName)
-            .get();
-
-        assertEquals(restoreSnapshotResponse.status(), RestStatus.ACCEPTED);
-        ensureGreen(restoredIndexName);
-    }
-
-    // verify that the created index is not remote store backed
-    private void assertNonRemoteStoreBackedIndex(String indexName) {
-        Settings indexSettings = client.admin().indices().prepareGetIndex().execute().actionGet().getSettings().get(indexName);
-        assertEquals(ReplicationType.DOCUMENT.toString(), indexSettings.get(SETTING_REPLICATION_TYPE));
-        assertNull(indexSettings.get(SETTING_REMOTE_STORE_ENABLED));
-        assertNull(indexSettings.get(SETTING_REMOTE_SEGMENT_STORE_REPOSITORY));
-        assertNull(indexSettings.get(SETTING_REMOTE_TRANSLOG_STORE_REPOSITORY));
-    }
-
-    // verify that the created index is remote store backed
-    private void assertRemoteStoreBackedIndex(String indexName) {
-        Settings indexSettings = client.admin().indices().prepareGetIndex().execute().actionGet().getSettings().get(indexName);
-        assertEquals(ReplicationType.SEGMENT.toString(), indexSettings.get(SETTING_REPLICATION_TYPE));
-        assertEquals("true", indexSettings.get(SETTING_REMOTE_STORE_ENABLED));
-        assertEquals(REPOSITORY_NAME, indexSettings.get(SETTING_REMOTE_SEGMENT_STORE_REPOSITORY));
-        assertEquals(REPOSITORY_2_NAME, indexSettings.get(SETTING_REMOTE_TRANSLOG_STORE_REPOSITORY));
-        assertEquals(
-            IndexSettings.DEFAULT_REMOTE_TRANSLOG_BUFFER_INTERVAL,
-            INDEX_REMOTE_TRANSLOG_BUFFER_INTERVAL_SETTING.get(indexSettings)
-        );
     }
 
     // bootstrap a cluster

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
@@ -131,6 +131,8 @@ import java.util.stream.Stream;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.unmodifiableList;
 import static org.opensearch.cluster.SnapshotsInProgress.completed;
+import static org.opensearch.node.remotestore.RemoteStoreNodeService.CompatibilityMode;
+import static org.opensearch.node.remotestore.RemoteStoreNodeService.REMOTE_STORE_COMPATIBILITY_MODE_SETTING;
 import static org.opensearch.repositories.blobstore.BlobStoreRepository.REMOTE_STORE_INDEX_SHALLOW_COPY;
 import static org.opensearch.snapshots.SnapshotUtils.validateSnapshotsBackingAnyIndex;
 
@@ -343,6 +345,15 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 }
 
                 boolean remoteStoreIndexShallowCopy = REMOTE_STORE_INDEX_SHALLOW_COPY.get(repository.getMetadata().settings());
+                logger.info("remote_store_index_shallow_copy setting is set as [{}]", remoteStoreIndexShallowCopy);
+                CompatibilityMode compatibilityMode = clusterService.getClusterSettings().get(REMOTE_STORE_COMPATIBILITY_MODE_SETTING);
+                if (remoteStoreIndexShallowCopy && compatibilityMode.equals(CompatibilityMode.STRICT) == false) {
+                    // don't allow shallow snapshots if compatibility mode is not strict
+                    logger.warn(
+                        "Shallow snapshots are not allowed during migration, thus overriding remote_store_index_shallow_copy to false"
+                    );
+                    remoteStoreIndexShallowCopy = false;
+                }
                 newEntry = SnapshotsInProgress.startedEntry(
                     new Snapshot(repositoryName, snapshotId),
                     request.includeGlobalState(),

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
@@ -345,13 +345,11 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 }
 
                 boolean remoteStoreIndexShallowCopy = REMOTE_STORE_INDEX_SHALLOW_COPY.get(repository.getMetadata().settings());
-                logger.info("remote_store_index_shallow_copy setting is set as [{}]", remoteStoreIndexShallowCopy);
-                CompatibilityMode compatibilityMode = clusterService.getClusterSettings().get(REMOTE_STORE_COMPATIBILITY_MODE_SETTING);
-                if (remoteStoreIndexShallowCopy && compatibilityMode.equals(CompatibilityMode.STRICT) == false) {
+                logger.debug("remote_store_index_shallow_copy setting is set as [{}]", remoteStoreIndexShallowCopy);
+                if (remoteStoreIndexShallowCopy
+                    && clusterService.getClusterSettings().get(REMOTE_STORE_COMPATIBILITY_MODE_SETTING).equals(CompatibilityMode.MIXED)) {
                     // don't allow shallow snapshots if compatibility mode is not strict
-                    logger.warn(
-                        "Shallow snapshots are not allowed during migration, thus overriding remote_store_index_shallow_copy to false"
-                    );
+                    logger.warn("Shallow snapshots are not supported during migration. Falling back to full snapshot.");
                     remoteStoreIndexShallowCopy = false;
                 }
                 newEntry = SnapshotsInProgress.startedEntry(


### PR DESCRIPTION
### Description
* This change ensures that when under remote-store/docrep migration, shallow snapshots are not taken as both remote-backed and non-remote-backed indices are present.
* For the `createSnapshot` operation, if the `remote_store_index_shallow_copy` setting is found to be `true` in the repository metadata settings but the cluster is in the `MIXED` compatibility mode, we override this setting to `false`. Thus, we do not honor the shallow snapshot setting and create full snapshots only.

### Related Issues
Resolves #13101

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [ ] ~Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))~
- [x] Commits are signed per the DCO using --signoff
- [ ] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
