### PR TITLE
Fix Flaky Test PersistentTasksExecutorFullRestartIT.testFullClusterRe…

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/persistent/PersistentTasksExecutorFullRestartIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/persistent/PersistentTasksExecutorFullRestartIT.java
@@ -43,6 +43,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -129,7 +130,7 @@ public class PersistentTasksExecutorFullRestartIT extends OpenSearchIntegTestCas
                     .custom(PersistentTasksCustomMetadata.TYPE)).tasks(),
                 empty()
             );
-        });
+        }, 20, TimeUnit.SECONDS);
 
     }
 }


### PR DESCRIPTION
### Description
Addresses fix for Flaky Test PersistentTasksExecutorFullRestartIT.testFullClusterRestart which is caused in scenarios of Cluster State not being able to remove all the Persistent Tasks as a part of the test in the default 10 seconds time limit. 

This change increases the time limit to 20 seconds

### Related Issues
Resolves #5145 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [ ] ~Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))~
- [x] Commits are signed per the DCO using --signoff
- [ ] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
