### PR TITLE
Using scheduleUnlessShuttingDown instead of schedule in retrying remote refresh calls

### DIFF
--- a/server/src/main/java/org/opensearch/index/shard/ReleasableRetryableRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/ReleasableRetryableRefreshListener.java
@@ -122,10 +122,10 @@ public abstract class ReleasableRetryableRefreshListener implements ReferenceMan
 
         boolean scheduled = false;
         try {
-            this.threadPool.schedule(
-                () -> runAfterRefreshWithPermit(didRefresh, () -> retryScheduled.set(false)),
+            this.threadPool.scheduleUnlessShuttingDown(
                 interval,
-                retryThreadPoolName
+                retryThreadPoolName,
+                () -> runAfterRefreshWithPermit(didRefresh, () -> retryScheduled.set(false))
             );
             scheduled = true;
             getLogger().info("Scheduled retry with didRefresh={}", didRefresh);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Details: https://github.com/opensearch-project/OpenSearch/issues/10902#issuecomment-2074118774

This should potentially fix all `OpenSearchRejectedExecutionException` coming up in ITs from the `ReleasableRetryableRefreshListener`

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/10902
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
