### PR TITLE
flaky test fix -  assert cluster stats on ClusterManager Node

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/discovery/ClusterManagerDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/discovery/ClusterManagerDisruptionIT.java
@@ -198,11 +198,15 @@ public class ClusterManagerDisruptionIT extends AbstractDisruptionTestCase {
                             + nodeState
                     );
                 }
-
             }
-            ClusterStateStats clusterStateStats = internalCluster().clusterService().getClusterManagerService().getClusterStateStats();
-            assertTrue(clusterStateStats.getUpdateFailed() > 0);
+
         });
+
+        ClusterStateStats clusterStateStats = internalCluster().clusterService(isolatedNode)
+            .getClusterManagerService()
+            .getClusterStateStats();
+        assertTrue(clusterStateStats.getUpdateFailed() > 0);
+
     }
 
     /**


### PR DESCRIPTION

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The fix is for flaky test ClusterManagerDisruptionIT#testIsolateClusterManagerAndVerifyClusterStateConsensus where the verification of ClusterStateStats was failing. The test was asserting on the ClusterStats which was retrieved from a random node in cluster. However ClusterStateStats is local to a node and has to be verified on node which was ClusterManager before the disruption was started.

```
  2> REPRODUCE WITH: ./gradlew ':server:internalClusterTest' --tests "org.opensearch.discovery.ClusterManagerDisruptionIT.testIsolateClusterManagerAndVerifyClusterStateConsensus" -Dtests.seed=3DFAFA04789EDE1A -Dtests.security.manager=true -Dtests.jvm.argline="-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m" -Dtests.locale=es-CU -Dtests.timezone=Asia/Katmandu -Druntime.java=21
  2> java.lang.AssertionError
        at __randomizedtesting.SeedInfo.seed([3DFAFA04789EDE1A:828A4C0EDAB2860B]:0)
        at org.junit.Assert.fail(Assert.java:87)
        at org.junit.Assert.assertTrue(Assert.java:42)
        at org.junit.Assert.assertTrue(Assert.java:53)
        at org.opensearch.discovery.ClusterManagerDisruptionIT.testIsolateClusterManagerAndVerifyClusterStateConsensus(ClusterManagerDisruptionIT.java:214)

```

### Related Issues
Resolves #[11063]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
