### PR TITLE
OpenJDK Update (April 2024 Patch releases)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 ### Dependencies
+- OpenJDK Update (April 2024 Patch releases), update to Eclipse Temurin 11.0.23+9 ([#13406](https://github.com/opensearch-project/OpenSearch/pull/13406))
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/buildSrc/src/main/java/org/opensearch/gradle/test/DistroTestPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/test/DistroTestPlugin.java
@@ -75,9 +75,9 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 public class DistroTestPlugin implements Plugin<Project> {
-    private static final String SYSTEM_JDK_VERSION = "8u402-b06";
+    private static final String SYSTEM_JDK_VERSION = "8u412-b08";
     private static final String SYSTEM_JDK_VENDOR = "adoptium";
-    private static final String GRADLE_JDK_VERSION = "11.0.22+7";
+    private static final String GRADLE_JDK_VERSION = "11.0.23+9";
     private static final String GRADLE_JDK_VENDOR = "adoptium";
 
     // all distributions used by distro tests. this is temporary until tests are per distribution

--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -2,7 +2,7 @@ opensearch        = 1.3.17
 lucene            = 8.10.1
 
 bundled_jdk_vendor = adoptium
-bundled_jdk = 11.0.22+7
+bundled_jdk = 11.0.23+9
 
 # optional dependencies
 spatial4j         = 0.7

--- a/server/src/test/java/org/opensearch/common/time/DateUtilsTests.java
+++ b/server/src/test/java/org/opensearch/common/time/DateUtilsTests.java
@@ -58,7 +58,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 public class DateUtilsTests extends OpenSearchTestCase {
-    private static final Set<String> IGNORE = new HashSet<>(Arrays.asList("America/Ciudad_Juarez"));
+    private static final Set<String> IGNORE = new HashSet<>(Arrays.asList("Antarctica/Vostok"));
 
     public void testTimezoneIds() {
         assertNull(DateUtils.dateTimeZoneToZoneId(null));


### PR DESCRIPTION
Backport https://github.com/opensearch-project/OpenSearch/commit/18aa5ad084b3ba0bc0603a84988699e71c461ae8 from https://github.com/opensearch-project/OpenSearch/pull/13389.