### PR TITLE
Switch to macos-13 runner for precommit and assemble github actions due to macos-latest is now arm64

### DIFF
--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11, 17, 21 ]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-13]
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}

--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -19,7 +19,8 @@ jobs:
       - name: Setup docker (missing on MacOS)
         if: runner.os == 'macos'
         uses: douglascamata/setup-docker-macos-action@main
-      - name: Test docker
+      - name: Test docker (missing on MacOS)
+        if: runner.os == 'macos'
         run: |
           colima start
           sudo ln -sf $HOME/.colima/default/docker.sock /var/run/docker.sock

--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -18,8 +18,9 @@ jobs:
           distribution: temurin
       - name: Setup docker (missing on MacOS)
         if: runner.os == 'macos'
+        with: douglascamata/setup-docker-macos-action@main
+      - name: Test docker
         run: |
-          brew install docker
           colima start
           sudo ln -sf $HOME/.colima/default/docker.sock /var/run/docker.sock
       - name: Run Gradle (assemble)

--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -19,11 +19,6 @@ jobs:
       - name: Setup docker (missing on MacOS)
         if: runner.os == 'macos'
         uses: douglascamata/setup-docker-macos-action@main
-      - name: Test docker (missing on MacOS)
-        if: runner.os == 'macos'
-        run: |
-          colima start
-          sudo ln -sf $HOME/.colima/default/docker.sock /var/run/docker.sock
       - name: Run Gradle (assemble)
         run: |
           ./gradlew assemble --parallel --no-build-cache -PDISABLE_BUILD_CACHE

--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -18,7 +18,7 @@ jobs:
           distribution: temurin
       - name: Setup docker (missing on MacOS)
         if: runner.os == 'macos'
-        with: douglascamata/setup-docker-macos-action@main
+        uses: douglascamata/setup-docker-macos-action@main
       - name: Test docker
         run: |
           colima start

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11, 17, 21 ]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-13]
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Ignoring unavailable shards during search request execution with ignore_available parameter ([#13298](https://github.com/opensearch-project/OpenSearch/pull/13298))
 - Refactoring globMatch using simpleMatchWithNormalizedStrings from Regex ([#13104](https://github.com/opensearch-project/OpenSearch/pull/13104))
 - [BWC and API enforcement] Reconsider the breaking changes check policy to detect breaking changes against released versions ([#13292](https://github.com/opensearch-project/OpenSearch/pull/13292))
+- Switch to macos-13 runner for precommit and assemble github actions due to macos-latest is now arm64 ([#13412](https://github.com/opensearch-project/OpenSearch/pull/13412))
 
 ### Deprecated
 


### PR DESCRIPTION
### Description
Switch to macos-13 runner for precommit and assemble github actions due to macos-latest is now arm64

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/13417


### Check List
- [ ] ~New functionality includes testing.~
  - [ ] ~All tests pass~
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [ ] ~Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))~
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).