### PR TITLE
[Backport 2.x] Add faster scaling composite hash value encoding for remote path

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteRestoreSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteRestoreSnapshotIT.java
@@ -59,7 +59,7 @@ import static org.opensearch.index.remote.RemoteStoreEnums.DataCategory.SEGMENTS
 import static org.opensearch.index.remote.RemoteStoreEnums.DataCategory.TRANSLOG;
 import static org.opensearch.index.remote.RemoteStoreEnums.DataType.DATA;
 import static org.opensearch.index.remote.RemoteStoreEnums.DataType.METADATA;
-import static org.opensearch.indices.IndicesService.CLUSTER_REMOTE_STORE_PATH_PREFIX_TYPE_SETTING;
+import static org.opensearch.indices.IndicesService.CLUSTER_REMOTE_STORE_PATH_TYPE_SETTING;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -229,7 +229,7 @@ public class RemoteRestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         client(clusterManagerNode).admin()
             .cluster()
             .prepareUpdateSettings()
-            .setTransientSettings(Settings.builder().put(CLUSTER_REMOTE_STORE_PATH_PREFIX_TYPE_SETTING.getKey(), PathType.FIXED))
+            .setTransientSettings(Settings.builder().put(CLUSTER_REMOTE_STORE_PATH_TYPE_SETTING.getKey(), PathType.FIXED))
             .get();
         createRepository(snapshotRepoName, "fs", getRepositorySettings(absolutePath1, true));
         Client client = client();
@@ -260,7 +260,7 @@ public class RemoteRestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         client(clusterManagerNode).admin()
             .cluster()
             .prepareUpdateSettings()
-            .setTransientSettings(Settings.builder().put(CLUSTER_REMOTE_STORE_PATH_PREFIX_TYPE_SETTING.getKey(), PathType.HASHED_PREFIX))
+            .setTransientSettings(Settings.builder().put(CLUSTER_REMOTE_STORE_PATH_TYPE_SETTING.getKey(), PathType.HASHED_PREFIX))
             .get();
 
         restoreSnapshotResponse = client.admin()
@@ -272,13 +272,13 @@ public class RemoteRestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
             .get();
         assertEquals(RestStatus.ACCEPTED, restoreSnapshotResponse.status());
         ensureGreen(restoredIndexName1version2);
-        validatePathType(restoredIndexName1version2, PathType.HASHED_PREFIX, PathHashAlgorithm.FNV_1A);
+        validatePathType(restoredIndexName1version2, PathType.HASHED_PREFIX, PathHashAlgorithm.FNV_1A_COMPOSITE_1);
 
-        // Create index with cluster setting cluster.remote_store.index.path.prefix.type as hashed_prefix.
+        // Create index with cluster setting cluster.remote_store.index.path.type as hashed_prefix.
         indexSettings = getIndexSettings(1, 0).build();
         createIndex(indexName2, indexSettings);
         ensureGreen(indexName2);
-        validatePathType(indexName2, PathType.HASHED_PREFIX, PathHashAlgorithm.FNV_1A);
+        validatePathType(indexName2, PathType.HASHED_PREFIX, PathHashAlgorithm.FNV_1A_COMPOSITE_1);
 
         // Validating that custom data has not changed for indexes which were created before the cluster setting got updated
         validatePathType(indexName1, PathType.FIXED);
@@ -294,7 +294,7 @@ public class RemoteRestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         client(clusterManagerNode).admin()
             .cluster()
             .prepareUpdateSettings()
-            .setTransientSettings(Settings.builder().put(CLUSTER_REMOTE_STORE_PATH_PREFIX_TYPE_SETTING.getKey(), PathType.FIXED))
+            .setTransientSettings(Settings.builder().put(CLUSTER_REMOTE_STORE_PATH_TYPE_SETTING.getKey(), PathType.FIXED))
             .get();
 
         // Close index 2
@@ -309,7 +309,7 @@ public class RemoteRestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         ensureGreen(indexName2);
 
         // Validating that custom data has not changed for testindex2 which was created before the cluster setting got updated
-        validatePathType(indexName2, PathType.HASHED_PREFIX, PathHashAlgorithm.FNV_1A);
+        validatePathType(indexName2, PathType.HASHED_PREFIX, PathHashAlgorithm.FNV_1A_COMPOSITE_1);
     }
 
     private void validatePathType(String index, PathType pathType) {

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -716,6 +716,8 @@ public final class ClusterSettings extends AbstractScopedSettings {
 
                 IndicesService.CLUSTER_REMOTE_INDEX_RESTRICT_ASYNC_DURABILITY_SETTING,
                 IndicesService.CLUSTER_INDEX_RESTRICT_REPLICATION_TYPE_SETTING,
+                IndicesService.CLUSTER_REMOTE_STORE_PATH_TYPE_SETTING,
+                IndicesService.CLUSTER_REMOTE_STORE_PATH_HASH_ALGORITHM_SETTING,
 
                 AdmissionControlSettings.ADMISSION_CONTROL_TRANSPORT_LAYER_MODE,
                 CpuBasedAdmissionControllerSettings.CPU_BASED_ADMISSION_CONTROLLER_TRANSPORT_LAYER_MODE,
@@ -731,9 +733,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 SearchService.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING,
 
                 RemoteStoreSettings.CLUSTER_REMOTE_INDEX_SEGMENT_METADATA_RETENTION_MAX_COUNT_SETTING,
-                RemoteStoreSettings.CLUSTER_REMOTE_TRANSLOG_BUFFER_INTERVAL_SETTING,
-                IndicesService.CLUSTER_REMOTE_STORE_PATH_PREFIX_TYPE_SETTING
-
+                RemoteStoreSettings.CLUSTER_REMOTE_TRANSLOG_BUFFER_INTERVAL_SETTING
             )
         )
     );

--- a/server/src/main/java/org/opensearch/index/remote/RemoteStoreEnums.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStoreEnums.java
@@ -9,6 +9,7 @@
 package org.opensearch.index.remote;
 
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.common.hash.FNV1a;
@@ -23,6 +24,8 @@ import java.util.Set;
 import static java.util.Collections.unmodifiableMap;
 import static org.opensearch.index.remote.RemoteStoreEnums.DataType.DATA;
 import static org.opensearch.index.remote.RemoteStoreEnums.DataType.METADATA;
+import static org.opensearch.index.remote.RemoteStoreUtils.longToCompositeBase64AndBinaryEncoding;
+import static org.opensearch.index.remote.RemoteStoreUtils.longToUrlBase64;
 
 /**
  * This class contains the different enums related to remote store like data categories and types, path types
@@ -30,12 +33,14 @@ import static org.opensearch.index.remote.RemoteStoreEnums.DataType.METADATA;
  *
  * @opensearch.api
  */
+@ExperimentalApi
 public class RemoteStoreEnums {
 
     /**
      * Categories of the data in Remote store.
      */
     @PublicApi(since = "2.14.0")
+    @ExperimentalApi
     public enum DataCategory {
         SEGMENTS("segments", Set.of(DataType.values())),
         TRANSLOG("translog", Set.of(DATA, METADATA));
@@ -61,6 +66,7 @@ public class RemoteStoreEnums {
      * Types of data in remote store.
      */
     @PublicApi(since = "2.14.0")
+    @ExperimentalApi
     public enum DataType {
         DATA("data"),
         METADATA("metadata"),
@@ -82,6 +88,7 @@ public class RemoteStoreEnums {
      * For more information, see <a href="https://github.com/opensearch-project/OpenSearch/issues/12567">Github issue #12567</a>.
      */
     @PublicApi(since = "2.14.0")
+    @ExperimentalApi
     public enum PathType {
         FIXED(0) {
             @Override
@@ -214,15 +221,29 @@ public class RemoteStoreEnums {
      * Type of hashes supported for path types that have hashing.
      */
     @PublicApi(since = "2.14.0")
+    @ExperimentalApi
     public enum PathHashAlgorithm {
 
-        FNV_1A(0) {
+        FNV_1A_BASE64(0) {
             @Override
             String hash(PathInput pathInput) {
                 String input = pathInput.indexUUID() + pathInput.shardId() + pathInput.dataCategory().getName() + pathInput.dataType()
                     .getName();
                 long hash = FNV1a.hash64(input);
-                return RemoteStoreUtils.longToUrlBase64(hash);
+                return longToUrlBase64(hash);
+            }
+        },
+        /**
+         * This hash algorithm will generate a hash value which will use 1st 6 bits to create bas64 character and next 14
+         * bits to create binary string.
+         */
+        FNV_1A_COMPOSITE_1(1) {
+            @Override
+            String hash(PathInput pathInput) {
+                String input = pathInput.indexUUID() + pathInput.shardId() + pathInput.dataCategory().getName() + pathInput.dataType()
+                    .getName();
+                long hash = FNV1a.hash64(input);
+                return longToCompositeBase64AndBinaryEncoding(hash, 20);
             }
         };
 

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -64,6 +64,7 @@ import org.opensearch.common.CheckedConsumer;
 import org.opensearch.common.CheckedFunction;
 import org.opensearch.common.CheckedSupplier;
 import org.opensearch.common.Nullable;
+import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.cache.policy.CachedQueryResult;
 import org.opensearch.common.cache.service.CacheService;
@@ -126,6 +127,7 @@ import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryRewriteContext;
 import org.opensearch.index.recovery.RecoveryStats;
 import org.opensearch.index.refresh.RefreshStats;
+import org.opensearch.index.remote.RemoteStoreEnums.PathHashAlgorithm;
 import org.opensearch.index.remote.RemoteStoreEnums.PathType;
 import org.opensearch.index.remote.RemoteStoreStatsTrackerFactory;
 import org.opensearch.index.search.stats.SearchStats;
@@ -309,13 +311,28 @@ public class IndicesService extends AbstractLifecycleComponent
     );
 
     /**
-     * This setting is used to set the remote store blob store path prefix strategy. This setting is effective only for
+     * This setting is used to set the remote store blob store path type strategy. This setting is effective only for
      * remote store enabled cluster.
      */
-    public static final Setting<PathType> CLUSTER_REMOTE_STORE_PATH_PREFIX_TYPE_SETTING = new Setting<>(
-        "cluster.remote_store.index.path.prefix.type",
+    @ExperimentalApi
+    public static final Setting<PathType> CLUSTER_REMOTE_STORE_PATH_TYPE_SETTING = new Setting<>(
+        "cluster.remote_store.index.path.type",
         PathType.FIXED.toString(),
         PathType::parseString,
+        Property.NodeScope,
+        Property.Dynamic
+    );
+
+    /**
+     * This setting is used to set the remote store blob store path hash algorithm strategy. This setting is effective only for
+     * remote store enabled cluster. This setting will come to effect if the {@link #CLUSTER_REMOTE_STORE_PATH_TYPE_SETTING}
+     * is either {@code HASHED_PREFIX} or {@code HASHED_INFIX}.
+     */
+    @ExperimentalApi
+    public static final Setting<PathHashAlgorithm> CLUSTER_REMOTE_STORE_PATH_HASH_ALGORITHM_SETTING = new Setting<>(
+        "cluster.remote_store.index.path.hash_algorithm",
+        PathHashAlgorithm.FNV_1A_COMPOSITE_1.toString(),
+        PathHashAlgorithm::parseString,
         Property.NodeScope,
         Property.Dynamic
     );

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -1720,7 +1720,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
         validateRemoteCustomData(
             indexMetadata.getCustomData(IndexMetadata.REMOTE_STORE_CUSTOM_KEY),
             PathHashAlgorithm.NAME,
-            PathHashAlgorithm.FNV_1A.name()
+            PathHashAlgorithm.FNV_1A_COMPOSITE_1.name()
         );
     }
 
@@ -1729,7 +1729,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
         if (remoteStoreEnabled) {
             settingsBuilder.put(NODE_ATTRIBUTES.getKey() + REMOTE_STORE_SEGMENT_REPOSITORY_NAME_ATTRIBUTE_KEY, "test");
         }
-        settingsBuilder.put(IndicesService.CLUSTER_REMOTE_STORE_PATH_PREFIX_TYPE_SETTING.getKey(), pathType.toString());
+        settingsBuilder.put(IndicesService.CLUSTER_REMOTE_STORE_PATH_TYPE_SETTING.getKey(), pathType.toString());
         Settings settings = settingsBuilder.build();
 
         ClusterService clusterService = mock(ClusterService.class);

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStoreEnumsTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStoreEnumsTests.java
@@ -25,7 +25,8 @@ import static org.opensearch.index.remote.RemoteStoreEnums.DataCategory.TRANSLOG
 import static org.opensearch.index.remote.RemoteStoreEnums.DataType.DATA;
 import static org.opensearch.index.remote.RemoteStoreEnums.DataType.LOCK_FILES;
 import static org.opensearch.index.remote.RemoteStoreEnums.DataType.METADATA;
-import static org.opensearch.index.remote.RemoteStoreEnums.PathHashAlgorithm.FNV_1A;
+import static org.opensearch.index.remote.RemoteStoreEnums.PathHashAlgorithm.FNV_1A_BASE64;
+import static org.opensearch.index.remote.RemoteStoreEnums.PathHashAlgorithm.FNV_1A_COMPOSITE_1;
 import static org.opensearch.index.remote.RemoteStoreEnums.PathType.FIXED;
 import static org.opensearch.index.remote.RemoteStoreEnums.PathType.HASHED_INFIX;
 import static org.opensearch.index.remote.RemoteStoreEnums.PathType.HASHED_PREFIX;
@@ -161,10 +162,10 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .dataCategory(dataCategory)
             .dataType(dataType)
             .build();
-        BlobPath result = HASHED_PREFIX.path(pathInput, FNV_1A);
+        BlobPath result = HASHED_PREFIX.path(pathInput, FNV_1A_BASE64);
         assertTrue(
             result.buildAsString()
-                .startsWith(String.join(SEPARATOR, FNV_1A.hash(pathInput), basePath, dataCategory.getName(), dataType.getName()))
+                .startsWith(String.join(SEPARATOR, FNV_1A_BASE64.hash(pathInput), basePath, dataCategory.getName(), dataType.getName()))
         );
 
         // assert with exact value for known base path
@@ -178,7 +179,7 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .dataCategory(dataCategory)
             .dataType(dataType)
             .build();
-        result = HASHED_PREFIX.path(pathInput, FNV_1A);
+        result = HASHED_PREFIX.path(pathInput, FNV_1A_BASE64);
         assertEquals("DgSI70IciXs/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/translog/data/", result.buildAsString());
 
         // Translog Metadata
@@ -190,10 +191,10 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .dataCategory(dataCategory)
             .dataType(dataType)
             .build();
-        result = HASHED_PREFIX.path(pathInput, FNV_1A);
+        result = HASHED_PREFIX.path(pathInput, FNV_1A_BASE64);
         assertTrue(
             result.buildAsString()
-                .startsWith(String.join(SEPARATOR, FNV_1A.hash(pathInput), basePath, dataCategory.getName(), dataType.getName()))
+                .startsWith(String.join(SEPARATOR, FNV_1A_BASE64.hash(pathInput), basePath, dataCategory.getName(), dataType.getName()))
         );
 
         // assert with exact value for known base path
@@ -204,7 +205,7 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .dataCategory(dataCategory)
             .dataType(dataType)
             .build();
-        result = HASHED_PREFIX.path(pathInput, FNV_1A);
+        result = HASHED_PREFIX.path(pathInput, FNV_1A_BASE64);
         assertEquals("oKU5SjILiy4/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/translog/metadata/", result.buildAsString());
 
         // Translog Lock files - This is a negative case where the assertion will trip.
@@ -238,10 +239,10 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .dataCategory(dataCategory)
             .dataType(dataType)
             .build();
-        result = HASHED_PREFIX.path(pathInput, FNV_1A);
+        result = HASHED_PREFIX.path(pathInput, FNV_1A_BASE64);
         assertTrue(
             result.buildAsString()
-                .startsWith(String.join(SEPARATOR, FNV_1A.hash(pathInput), basePath, dataCategory.getName(), dataType.getName()))
+                .startsWith(String.join(SEPARATOR, FNV_1A_BASE64.hash(pathInput), basePath, dataCategory.getName(), dataType.getName()))
         );
 
         // assert with exact value for known base path
@@ -252,7 +253,7 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .dataCategory(dataCategory)
             .dataType(dataType)
             .build();
-        result = HASHED_PREFIX.path(pathInput, FNV_1A);
+        result = HASHED_PREFIX.path(pathInput, FNV_1A_BASE64);
         assertEquals("AUBRfCIuWdk/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/segments/data/", result.buildAsString());
 
         // Segment Metadata
@@ -264,10 +265,10 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .dataCategory(dataCategory)
             .dataType(dataType)
             .build();
-        result = HASHED_PREFIX.path(pathInput, FNV_1A);
+        result = HASHED_PREFIX.path(pathInput, FNV_1A_BASE64);
         assertTrue(
             result.buildAsString()
-                .startsWith(String.join(SEPARATOR, FNV_1A.hash(pathInput), basePath, dataCategory.getName(), dataType.getName()))
+                .startsWith(String.join(SEPARATOR, FNV_1A_BASE64.hash(pathInput), basePath, dataCategory.getName(), dataType.getName()))
         );
 
         // assert with exact value for known base path
@@ -278,7 +279,7 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .dataCategory(dataCategory)
             .dataType(dataType)
             .build();
-        result = HASHED_PREFIX.path(pathInput, FNV_1A);
+        result = HASHED_PREFIX.path(pathInput, FNV_1A_BASE64);
         assertEquals("erwR-G735Uw/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/segments/metadata/", result.buildAsString());
 
         // Segment Lockfiles
@@ -290,10 +291,10 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .dataCategory(dataCategory)
             .dataType(dataType)
             .build();
-        result = HASHED_PREFIX.path(pathInput, FNV_1A);
+        result = HASHED_PREFIX.path(pathInput, FNV_1A_BASE64);
         assertTrue(
             result.buildAsString()
-                .startsWith(String.join(SEPARATOR, FNV_1A.hash(pathInput), basePath, dataCategory.getName(), dataType.getName()))
+                .startsWith(String.join(SEPARATOR, FNV_1A_BASE64.hash(pathInput), basePath, dataCategory.getName(), dataType.getName()))
         );
 
         // assert with exact value for known base path
@@ -304,8 +305,195 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .dataCategory(dataCategory)
             .dataType(dataType)
             .build();
-        result = HASHED_PREFIX.path(pathInput, FNV_1A);
+        result = HASHED_PREFIX.path(pathInput, FNV_1A_BASE64);
         assertEquals("KeYDIk0mJXI/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/segments/lock_files/", result.buildAsString());
+    }
+
+    public void testGeneratePathForHashedPrefixTypeAndFNVCompositeHashAlgorithm() {
+        BlobPath blobPath = new BlobPath();
+        List<String> pathList = getPathList();
+        for (String path : pathList) {
+            blobPath = blobPath.add(path);
+        }
+
+        String indexUUID = randomAlphaOfLength(10);
+        String shardId = String.valueOf(randomInt(100));
+        DataCategory dataCategory = TRANSLOG;
+        DataType dataType = DATA;
+
+        String basePath = getPath(pathList) + indexUUID + SEPARATOR + shardId;
+        // Translog Data
+        PathInput pathInput = PathInput.builder()
+            .basePath(blobPath)
+            .indexUUID(indexUUID)
+            .shardId(shardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        BlobPath result = HASHED_PREFIX.path(pathInput, FNV_1A_COMPOSITE_1);
+        assertTrue(
+            result.buildAsString()
+                .startsWith(
+                    String.join(SEPARATOR, FNV_1A_COMPOSITE_1.hash(pathInput), basePath, dataCategory.getName(), dataType.getName())
+                )
+        );
+
+        // assert with exact value for known base path
+        BlobPath fixedBlobPath = BlobPath.cleanPath().add("xjsdhj").add("ddjsha").add("yudy7sd").add("32hdhua7").add("89jdij");
+        String fixedIndexUUID = "k2ijhe877d7yuhx7";
+        String fixedShardId = "10";
+        pathInput = PathInput.builder()
+            .basePath(fixedBlobPath)
+            .indexUUID(fixedIndexUUID)
+            .shardId(fixedShardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        result = HASHED_PREFIX.path(pathInput, FNV_1A_COMPOSITE_1);
+        assertEquals("D10000001001000/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/translog/data/", result.buildAsString());
+
+        // Translog Metadata
+        dataType = METADATA;
+        pathInput = PathInput.builder()
+            .basePath(blobPath)
+            .indexUUID(indexUUID)
+            .shardId(shardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        result = HASHED_PREFIX.path(pathInput, FNV_1A_COMPOSITE_1);
+        assertTrue(
+            result.buildAsString()
+                .startsWith(
+                    String.join(SEPARATOR, FNV_1A_COMPOSITE_1.hash(pathInput), basePath, dataCategory.getName(), dataType.getName())
+                )
+        );
+
+        // assert with exact value for known base path
+        pathInput = PathInput.builder()
+            .basePath(fixedBlobPath)
+            .indexUUID(fixedIndexUUID)
+            .shardId(fixedShardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        result = HASHED_PREFIX.path(pathInput, FNV_1A_COMPOSITE_1);
+        assertEquals(
+            "o00101001010011/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/translog/metadata/",
+            result.buildAsString()
+        );
+
+        // Translog Lock files - This is a negative case where the assertion will trip.
+        dataType = LOCK_FILES;
+        PathInput finalPathInput = PathInput.builder()
+            .basePath(blobPath)
+            .indexUUID(indexUUID)
+            .shardId(shardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        assertThrows(AssertionError.class, () -> HASHED_PREFIX.path(finalPathInput, null));
+
+        // assert with exact value for known base path
+        pathInput = PathInput.builder()
+            .basePath(fixedBlobPath)
+            .indexUUID(fixedIndexUUID)
+            .shardId(fixedShardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        assertThrows(AssertionError.class, () -> HASHED_PREFIX.path(finalPathInput, null));
+
+        // Segment Data
+        dataCategory = SEGMENTS;
+        dataType = DATA;
+        pathInput = PathInput.builder()
+            .basePath(blobPath)
+            .indexUUID(indexUUID)
+            .shardId(shardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        result = HASHED_PREFIX.path(pathInput, FNV_1A_COMPOSITE_1);
+        assertTrue(
+            result.buildAsString()
+                .startsWith(
+                    String.join(SEPARATOR, FNV_1A_COMPOSITE_1.hash(pathInput), basePath, dataCategory.getName(), dataType.getName())
+                )
+        );
+
+        // assert with exact value for known base path
+        pathInput = PathInput.builder()
+            .basePath(fixedBlobPath)
+            .indexUUID(fixedIndexUUID)
+            .shardId(fixedShardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        result = HASHED_PREFIX.path(pathInput, FNV_1A_COMPOSITE_1);
+        assertEquals("A01010000000101/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/segments/data/", result.buildAsString());
+
+        // Segment Metadata
+        dataType = METADATA;
+        pathInput = PathInput.builder()
+            .basePath(blobPath)
+            .indexUUID(indexUUID)
+            .shardId(shardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        result = HASHED_PREFIX.path(pathInput, FNV_1A_COMPOSITE_1);
+        assertTrue(
+            result.buildAsString()
+                .startsWith(
+                    String.join(SEPARATOR, FNV_1A_COMPOSITE_1.hash(pathInput), basePath, dataCategory.getName(), dataType.getName())
+                )
+        );
+
+        // assert with exact value for known base path
+        pathInput = PathInput.builder()
+            .basePath(fixedBlobPath)
+            .indexUUID(fixedIndexUUID)
+            .shardId(fixedShardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        result = HASHED_PREFIX.path(pathInput, FNV_1A_COMPOSITE_1);
+        assertEquals(
+            "e10101111000001/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/segments/metadata/",
+            result.buildAsString()
+        );
+
+        // Segment Lockfiles
+        dataType = LOCK_FILES;
+        pathInput = PathInput.builder()
+            .basePath(blobPath)
+            .indexUUID(indexUUID)
+            .shardId(shardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        result = HASHED_PREFIX.path(pathInput, FNV_1A_COMPOSITE_1);
+        assertTrue(
+            result.buildAsString()
+                .startsWith(
+                    String.join(SEPARATOR, FNV_1A_COMPOSITE_1.hash(pathInput), basePath, dataCategory.getName(), dataType.getName())
+                )
+        );
+
+        // assert with exact value for known base path
+        pathInput = PathInput.builder()
+            .basePath(fixedBlobPath)
+            .indexUUID(fixedIndexUUID)
+            .shardId(fixedShardId)
+            .dataCategory(dataCategory)
+            .dataType(dataType)
+            .build();
+        result = HASHED_PREFIX.path(pathInput, FNV_1A_COMPOSITE_1);
+        assertEquals(
+            "K01111001100000/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/segments/lock_files/",
+            result.buildAsString()
+        );
     }
 
     public void testGeneratePathForHashedInfixType() {
@@ -330,7 +518,7 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .dataCategory(dataCategory)
             .dataType(dataType)
             .build();
-        BlobPath result = HASHED_INFIX.path(pathInput, FNV_1A);
+        BlobPath result = HASHED_INFIX.path(pathInput, FNV_1A_BASE64);
         String expected = derivePath(basePath, pathInput);
         String actual = result.buildAsString();
         assertTrue(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual.startsWith(expected));
@@ -346,7 +534,7 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .dataCategory(dataCategory)
             .dataType(dataType)
             .build();
-        result = HASHED_INFIX.path(pathInput, FNV_1A);
+        result = HASHED_INFIX.path(pathInput, FNV_1A_BASE64);
         expected = "xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/DgSI70IciXs/k2ijhe877d7yuhx7/10/translog/data/";
         actual = result.buildAsString();
         assertTrue(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual.startsWith(expected));
@@ -361,7 +549,7 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .dataType(dataType)
             .build();
 
-        result = HASHED_INFIX.path(pathInput, FNV_1A);
+        result = HASHED_INFIX.path(pathInput, FNV_1A_BASE64);
         expected = derivePath(basePath, pathInput);
         actual = result.buildAsString();
         assertTrue(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual.startsWith(expected));
@@ -374,7 +562,7 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .dataCategory(dataCategory)
             .dataType(dataType)
             .build();
-        result = HASHED_INFIX.path(pathInput, FNV_1A);
+        result = HASHED_INFIX.path(pathInput, FNV_1A_BASE64);
         expected = "xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/oKU5SjILiy4/k2ijhe877d7yuhx7/10/translog/metadata/";
         actual = result.buildAsString();
         assertTrue(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual.startsWith(expected));
@@ -410,7 +598,7 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .dataCategory(dataCategory)
             .dataType(dataType)
             .build();
-        result = HASHED_INFIX.path(pathInput, FNV_1A);
+        result = HASHED_INFIX.path(pathInput, FNV_1A_BASE64);
         expected = derivePath(basePath, pathInput);
         actual = result.buildAsString();
         assertTrue(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual.startsWith(expected));
@@ -423,7 +611,7 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .dataCategory(dataCategory)
             .dataType(dataType)
             .build();
-        result = HASHED_INFIX.path(pathInput, FNV_1A);
+        result = HASHED_INFIX.path(pathInput, FNV_1A_BASE64);
         expected = "xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/AUBRfCIuWdk/k2ijhe877d7yuhx7/10/segments/data/";
         actual = result.buildAsString();
         assertTrue(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual.startsWith(expected));
@@ -437,7 +625,7 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .dataCategory(dataCategory)
             .dataType(dataType)
             .build();
-        result = HASHED_INFIX.path(pathInput, FNV_1A);
+        result = HASHED_INFIX.path(pathInput, FNV_1A_BASE64);
         expected = derivePath(basePath, pathInput);
         actual = result.buildAsString();
         assertTrue(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual.startsWith(expected));
@@ -450,7 +638,7 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .dataCategory(dataCategory)
             .dataType(dataType)
             .build();
-        result = HASHED_INFIX.path(pathInput, FNV_1A);
+        result = HASHED_INFIX.path(pathInput, FNV_1A_BASE64);
         expected = "xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/erwR-G735Uw/k2ijhe877d7yuhx7/10/segments/metadata/";
         actual = result.buildAsString();
         assertTrue(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual.startsWith(expected));
@@ -464,7 +652,7 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .dataCategory(dataCategory)
             .dataType(dataType)
             .build();
-        result = HASHED_INFIX.path(pathInput, FNV_1A);
+        result = HASHED_INFIX.path(pathInput, FNV_1A_BASE64);
         expected = derivePath(basePath, pathInput);
         actual = result.buildAsString();
         assertTrue(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual.startsWith(expected));
@@ -477,7 +665,7 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .dataCategory(dataCategory)
             .dataType(dataType)
             .build();
-        result = HASHED_INFIX.path(pathInput, FNV_1A);
+        result = HASHED_INFIX.path(pathInput, FNV_1A_BASE64);
         expected = "xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/KeYDIk0mJXI/k2ijhe877d7yuhx7/10/segments/lock_files/";
         actual = result.buildAsString();
         assertTrue(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual.startsWith(expected));
@@ -487,7 +675,7 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
         return "".equals(basePath)
             ? String.join(
                 SEPARATOR,
-                FNV_1A.hash(pathInput),
+                FNV_1A_BASE64.hash(pathInput),
                 pathInput.indexUUID(),
                 pathInput.shardId(),
                 pathInput.dataCategory().getName(),
@@ -496,7 +684,7 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             : String.join(
                 SEPARATOR,
                 basePath,
-                FNV_1A.hash(pathInput),
+                FNV_1A_BASE64.hash(pathInput),
                 pathInput.indexUUID(),
                 pathInput.shardId(),
                 pathInput.dataCategory().getName(),

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStorePathStrategyResolverTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStorePathStrategyResolverTests.java
@@ -11,17 +11,17 @@ package org.opensearch.index.remote;
 import org.opensearch.Version;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.index.remote.RemoteStoreEnums.PathHashAlgorithm;
 import org.opensearch.index.remote.RemoteStoreEnums.PathType;
 import org.opensearch.test.OpenSearchTestCase;
 
-import static org.opensearch.indices.IndicesService.CLUSTER_REMOTE_STORE_PATH_PREFIX_TYPE_SETTING;
+import static org.opensearch.indices.IndicesService.CLUSTER_REMOTE_STORE_PATH_HASH_ALGORITHM_SETTING;
+import static org.opensearch.indices.IndicesService.CLUSTER_REMOTE_STORE_PATH_TYPE_SETTING;
 
 public class RemoteStorePathStrategyResolverTests extends OpenSearchTestCase {
 
     public void testGetMinVersionOlder() {
-        Settings settings = Settings.builder()
-            .put(CLUSTER_REMOTE_STORE_PATH_PREFIX_TYPE_SETTING.getKey(), randomFrom(PathType.values()))
-            .build();
+        Settings settings = Settings.builder().put(CLUSTER_REMOTE_STORE_PATH_TYPE_SETTING.getKey(), randomFrom(PathType.values())).build();
         ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         RemoteStorePathStrategyResolver resolver = new RemoteStorePathStrategyResolver(clusterSettings, () -> Version.V_2_13_0);
         assertEquals(PathType.FIXED, resolver.get().getType());
@@ -30,7 +30,7 @@ public class RemoteStorePathStrategyResolverTests extends OpenSearchTestCase {
 
     public void testGetMinVersionNewer() {
         PathType pathType = randomFrom(PathType.values());
-        Settings settings = Settings.builder().put(CLUSTER_REMOTE_STORE_PATH_PREFIX_TYPE_SETTING.getKey(), pathType).build();
+        Settings settings = Settings.builder().put(CLUSTER_REMOTE_STORE_PATH_TYPE_SETTING.getKey(), pathType).build();
         ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         RemoteStorePathStrategyResolver resolver = new RemoteStorePathStrategyResolver(clusterSettings, () -> Version.CURRENT);
         assertEquals(pathType, resolver.get().getType());
@@ -39,7 +39,100 @@ public class RemoteStorePathStrategyResolverTests extends OpenSearchTestCase {
         } else {
             assertNull(resolver.get().getHashAlgorithm());
         }
-
     }
 
+    public void testGetStrategy() {
+        // FIXED type
+        Settings settings = Settings.builder().put(CLUSTER_REMOTE_STORE_PATH_TYPE_SETTING.getKey(), PathType.FIXED).build();
+        ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        RemoteStorePathStrategyResolver resolver = new RemoteStorePathStrategyResolver(clusterSettings, () -> Version.CURRENT);
+        assertEquals(PathType.FIXED, resolver.get().getType());
+
+        // FIXED type with hash algorithm
+        settings = Settings.builder()
+            .put(CLUSTER_REMOTE_STORE_PATH_TYPE_SETTING.getKey(), PathType.FIXED)
+            .put(CLUSTER_REMOTE_STORE_PATH_HASH_ALGORITHM_SETTING.getKey(), randomFrom(PathHashAlgorithm.values()))
+            .build();
+        clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        resolver = new RemoteStorePathStrategyResolver(clusterSettings, () -> Version.CURRENT);
+        assertEquals(PathType.FIXED, resolver.get().getType());
+
+        // HASHED_PREFIX type with FNV_1A_COMPOSITE
+        settings = Settings.builder().put(CLUSTER_REMOTE_STORE_PATH_TYPE_SETTING.getKey(), PathType.HASHED_PREFIX).build();
+        clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        resolver = new RemoteStorePathStrategyResolver(clusterSettings, () -> Version.CURRENT);
+        assertEquals(PathType.HASHED_PREFIX, resolver.get().getType());
+        assertEquals(PathHashAlgorithm.FNV_1A_COMPOSITE_1, resolver.get().getHashAlgorithm());
+
+        // HASHED_PREFIX type with FNV_1A_COMPOSITE
+        settings = Settings.builder().put(CLUSTER_REMOTE_STORE_PATH_TYPE_SETTING.getKey(), PathType.HASHED_PREFIX).build();
+        clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        resolver = new RemoteStorePathStrategyResolver(clusterSettings, () -> Version.CURRENT);
+        assertEquals(PathType.HASHED_PREFIX, resolver.get().getType());
+        assertEquals(PathHashAlgorithm.FNV_1A_COMPOSITE_1, resolver.get().getHashAlgorithm());
+
+        // HASHED_PREFIX type with FNV_1A_BASE64
+        settings = Settings.builder()
+            .put(CLUSTER_REMOTE_STORE_PATH_TYPE_SETTING.getKey(), PathType.HASHED_PREFIX)
+            .put(CLUSTER_REMOTE_STORE_PATH_HASH_ALGORITHM_SETTING.getKey(), PathHashAlgorithm.FNV_1A_BASE64)
+            .build();
+        clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        resolver = new RemoteStorePathStrategyResolver(clusterSettings, () -> Version.CURRENT);
+        assertEquals(PathType.HASHED_PREFIX, resolver.get().getType());
+        assertEquals(PathHashAlgorithm.FNV_1A_BASE64, resolver.get().getHashAlgorithm());
+
+        // HASHED_PREFIX type with FNV_1A_BASE64
+        settings = Settings.builder()
+            .put(CLUSTER_REMOTE_STORE_PATH_TYPE_SETTING.getKey(), PathType.HASHED_PREFIX)
+            .put(CLUSTER_REMOTE_STORE_PATH_HASH_ALGORITHM_SETTING.getKey(), PathHashAlgorithm.FNV_1A_BASE64)
+            .build();
+        clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        resolver = new RemoteStorePathStrategyResolver(clusterSettings, () -> Version.CURRENT);
+        assertEquals(PathType.HASHED_PREFIX, resolver.get().getType());
+        assertEquals(PathHashAlgorithm.FNV_1A_BASE64, resolver.get().getHashAlgorithm());
+    }
+
+    public void testGetStrategyWithDynamicUpdate() {
+
+        // Default value
+        Settings settings = Settings.builder().build();
+        ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        RemoteStorePathStrategyResolver resolver = new RemoteStorePathStrategyResolver(clusterSettings, () -> Version.CURRENT);
+        assertEquals(PathType.FIXED, resolver.get().getType());
+        assertNull(resolver.get().getHashAlgorithm());
+
+        // Set HASHED_PREFIX with default hash algorithm
+        clusterSettings.applySettings(
+            Settings.builder().put(CLUSTER_REMOTE_STORE_PATH_TYPE_SETTING.getKey(), PathType.HASHED_PREFIX).build()
+        );
+        assertEquals(PathType.HASHED_PREFIX, resolver.get().getType());
+        assertEquals(PathHashAlgorithm.FNV_1A_COMPOSITE_1, resolver.get().getHashAlgorithm());
+
+        // Set HASHED_PREFIX with FNV_1A_BASE64 hash algorithm
+        clusterSettings.applySettings(
+            Settings.builder()
+                .put(CLUSTER_REMOTE_STORE_PATH_TYPE_SETTING.getKey(), PathType.HASHED_PREFIX)
+                .put(CLUSTER_REMOTE_STORE_PATH_HASH_ALGORITHM_SETTING.getKey(), PathHashAlgorithm.FNV_1A_BASE64)
+                .build()
+        );
+        assertEquals(PathType.HASHED_PREFIX, resolver.get().getType());
+        assertEquals(PathHashAlgorithm.FNV_1A_BASE64, resolver.get().getHashAlgorithm());
+
+        // Set HASHED_INFIX with default hash algorithm
+        clusterSettings.applySettings(
+            Settings.builder().put(CLUSTER_REMOTE_STORE_PATH_TYPE_SETTING.getKey(), PathType.HASHED_INFIX).build()
+        );
+        assertEquals(PathType.HASHED_INFIX, resolver.get().getType());
+        assertEquals(PathHashAlgorithm.FNV_1A_COMPOSITE_1, resolver.get().getHashAlgorithm());
+
+        // Set HASHED_INFIX with FNV_1A_BASE64 hash algorithm
+        clusterSettings.applySettings(
+            Settings.builder()
+                .put(CLUSTER_REMOTE_STORE_PATH_TYPE_SETTING.getKey(), PathType.HASHED_INFIX)
+                .put(CLUSTER_REMOTE_STORE_PATH_HASH_ALGORITHM_SETTING.getKey(), PathHashAlgorithm.FNV_1A_BASE64)
+                .build()
+        );
+        assertEquals(PathType.HASHED_INFIX, resolver.get().getType());
+        assertEquals(PathHashAlgorithm.FNV_1A_BASE64, resolver.get().getHashAlgorithm());
+    }
 }

--- a/server/src/test/java/org/opensearch/index/snapshots/blobstore/RemoteStoreShardShallowCopySnapshotTests.java
+++ b/server/src/test/java/org/opensearch/index/snapshots/blobstore/RemoteStoreShardShallowCopySnapshotTests.java
@@ -104,7 +104,7 @@ public class RemoteStoreShardShallowCopySnapshotTests extends OpenSearchTestCase
             + "\"test-repo-basepath\",\"file_names\":[\"file1\",\"file2\",\"file3\",\"file4\",\"file5\"],\"path_type\":0}";
         assert Objects.equals(actual, expectedXContent) : "xContent is " + actual;
 
-        // Case 3 - with just hashed prefix type and hash algorithm
+        // Case 3 - with just hashed prefix type and FNV_1A_BASE64 hash algorithm
         shardShallowCopySnapshot = new RemoteStoreShardShallowCopySnapshot(
             snapshot,
             indexVersion,
@@ -119,7 +119,7 @@ public class RemoteStoreShardShallowCopySnapshotTests extends OpenSearchTestCase
             repositoryBasePath,
             fileNames,
             PathType.HASHED_PREFIX,
-            PathHashAlgorithm.FNV_1A
+            PathHashAlgorithm.FNV_1A_BASE64
         );
         try (XContentBuilder builder = MediaTypeRegistry.JSON.contentBuilder()) {
             builder.startObject();
@@ -133,6 +133,99 @@ public class RemoteStoreShardShallowCopySnapshotTests extends OpenSearchTestCase
             + "\"test-rs-repository\",\"commit_generation\":5,\"primary_term\":3,\"remote_store_repository_base_path\":"
             + "\"test-repo-basepath\",\"file_names\":[\"file1\",\"file2\",\"file3\",\"file4\",\"file5\"],\"path_type\":1"
             + ",\"path_hash_algorithm\":0}";
+        assert Objects.equals(actual, expectedXContent) : "xContent is " + actual;
+
+        // Case 4 - with just hashed prefix type and FNV_1A_COMPOSITE hash algorithm
+        shardShallowCopySnapshot = new RemoteStoreShardShallowCopySnapshot(
+            snapshot,
+            indexVersion,
+            primaryTerm,
+            commitGeneration,
+            startTime,
+            time,
+            totalFileCount,
+            totalSize,
+            indexUUID,
+            remoteStoreRepository,
+            repositoryBasePath,
+            fileNames,
+            PathType.HASHED_PREFIX,
+            PathHashAlgorithm.FNV_1A_COMPOSITE_1
+        );
+        try (XContentBuilder builder = MediaTypeRegistry.JSON.contentBuilder()) {
+            builder.startObject();
+            shardShallowCopySnapshot.toXContent(builder, ToXContent.EMPTY_PARAMS);
+            builder.endObject();
+            actual = builder.toString();
+        }
+
+        expectedXContent = "{\"version\":\"2\",\"name\":\"test-snapshot\",\"index_version\":1,\"start_time\":123,\"time\":123,"
+            + "\"number_of_files\":5,\"total_size\":5,\"index_uuid\":\"syzhajds-ashdlfj\",\"remote_store_repository\":"
+            + "\"test-rs-repository\",\"commit_generation\":5,\"primary_term\":3,\"remote_store_repository_base_path\":"
+            + "\"test-repo-basepath\",\"file_names\":[\"file1\",\"file2\",\"file3\",\"file4\",\"file5\"],\"path_type\":1"
+            + ",\"path_hash_algorithm\":1}";
+        assert Objects.equals(actual, expectedXContent) : "xContent is " + actual;
+
+        // Case 5 - with just hashed infix type and FNV_1A_BASE64 hash algorithm
+        shardShallowCopySnapshot = new RemoteStoreShardShallowCopySnapshot(
+            snapshot,
+            indexVersion,
+            primaryTerm,
+            commitGeneration,
+            startTime,
+            time,
+            totalFileCount,
+            totalSize,
+            indexUUID,
+            remoteStoreRepository,
+            repositoryBasePath,
+            fileNames,
+            PathType.HASHED_INFIX,
+            PathHashAlgorithm.FNV_1A_BASE64
+        );
+        try (XContentBuilder builder = MediaTypeRegistry.JSON.contentBuilder()) {
+            builder.startObject();
+            shardShallowCopySnapshot.toXContent(builder, ToXContent.EMPTY_PARAMS);
+            builder.endObject();
+            actual = builder.toString();
+        }
+
+        expectedXContent = "{\"version\":\"2\",\"name\":\"test-snapshot\",\"index_version\":1,\"start_time\":123,\"time\":123,"
+            + "\"number_of_files\":5,\"total_size\":5,\"index_uuid\":\"syzhajds-ashdlfj\",\"remote_store_repository\":"
+            + "\"test-rs-repository\",\"commit_generation\":5,\"primary_term\":3,\"remote_store_repository_base_path\":"
+            + "\"test-repo-basepath\",\"file_names\":[\"file1\",\"file2\",\"file3\",\"file4\",\"file5\"],\"path_type\":2"
+            + ",\"path_hash_algorithm\":0}";
+        assert Objects.equals(actual, expectedXContent) : "xContent is " + actual;
+
+        // Case 6 - with just hashed infix type and FNV_1A_COMPOSITE hash algorithm
+        shardShallowCopySnapshot = new RemoteStoreShardShallowCopySnapshot(
+            snapshot,
+            indexVersion,
+            primaryTerm,
+            commitGeneration,
+            startTime,
+            time,
+            totalFileCount,
+            totalSize,
+            indexUUID,
+            remoteStoreRepository,
+            repositoryBasePath,
+            fileNames,
+            PathType.HASHED_INFIX,
+            PathHashAlgorithm.FNV_1A_COMPOSITE_1
+        );
+        try (XContentBuilder builder = MediaTypeRegistry.JSON.contentBuilder()) {
+            builder.startObject();
+            shardShallowCopySnapshot.toXContent(builder, ToXContent.EMPTY_PARAMS);
+            builder.endObject();
+            actual = builder.toString();
+        }
+
+        expectedXContent = "{\"version\":\"2\",\"name\":\"test-snapshot\",\"index_version\":1,\"start_time\":123,\"time\":123,"
+            + "\"number_of_files\":5,\"total_size\":5,\"index_uuid\":\"syzhajds-ashdlfj\",\"remote_store_repository\":"
+            + "\"test-rs-repository\",\"commit_generation\":5,\"primary_term\":3,\"remote_store_repository_base_path\":"
+            + "\"test-repo-basepath\",\"file_names\":[\"file1\",\"file2\",\"file3\",\"file4\",\"file5\"],\"path_type\":2"
+            + ",\"path_hash_algorithm\":1}";
         assert Objects.equals(actual, expectedXContent) : "xContent is " + actual;
     }
 
@@ -223,7 +316,88 @@ public class RemoteStoreShardShallowCopySnapshotTests extends OpenSearchTestCase
             repositoryBasePath,
             fileNames,
             PathType.HASHED_PREFIX,
-            PathHashAlgorithm.FNV_1A
+            PathHashAlgorithm.FNV_1A_BASE64
+        );
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, xContent)) {
+            RemoteStoreShardShallowCopySnapshot actualShardShallowCopySnapshot = RemoteStoreShardShallowCopySnapshot.fromXContent(parser);
+            assert Objects.equals(expectedShardShallowCopySnapshot, actualShardShallowCopySnapshot);
+        }
+
+        // with pathType=PathType.HASHED_PREFIX and pathHashAlgorithm=PathHashAlgorithm.FNV_1A_COMPOSITE
+        xContent = "{\"version\":\"2\",\"name\":\"test-snapshot\",\"index_version\":1,\"start_time\":123,\"time\":123,"
+            + "\"number_of_files\":5,\"total_size\":5,\"index_uuid\":\"syzhajds-ashdlfj\",\"remote_store_repository\":"
+            + "\"test-rs-repository\",\"commit_generation\":5,\"primary_term\":3,\"remote_store_repository_base_path\":"
+            + "\"test-repo-basepath\",\"file_names\":[\"file1\",\"file2\",\"file3\",\"file4\",\"file5\"],\"path_type\":1,\"path_hash_algorithm\":1}";
+        expectedShardShallowCopySnapshot = new RemoteStoreShardShallowCopySnapshot(
+            "2",
+            snapshot,
+            indexVersion,
+            primaryTerm,
+            commitGeneration,
+            startTime,
+            time,
+            totalFileCount,
+            totalSize,
+            indexUUID,
+            remoteStoreRepository,
+            repositoryBasePath,
+            fileNames,
+            PathType.HASHED_PREFIX,
+            PathHashAlgorithm.FNV_1A_COMPOSITE_1
+        );
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, xContent)) {
+            RemoteStoreShardShallowCopySnapshot actualShardShallowCopySnapshot = RemoteStoreShardShallowCopySnapshot.fromXContent(parser);
+            assert Objects.equals(expectedShardShallowCopySnapshot, actualShardShallowCopySnapshot);
+        }
+
+        // with pathType=PathType.HASHED_INFIX and pathHashAlgorithm=PathHashAlgorithm.FNV_1A
+        xContent = "{\"version\":\"2\",\"name\":\"test-snapshot\",\"index_version\":1,\"start_time\":123,\"time\":123,"
+            + "\"number_of_files\":5,\"total_size\":5,\"index_uuid\":\"syzhajds-ashdlfj\",\"remote_store_repository\":"
+            + "\"test-rs-repository\",\"commit_generation\":5,\"primary_term\":3,\"remote_store_repository_base_path\":"
+            + "\"test-repo-basepath\",\"file_names\":[\"file1\",\"file2\",\"file3\",\"file4\",\"file5\"],\"path_type\":2,\"path_hash_algorithm\":0}";
+        expectedShardShallowCopySnapshot = new RemoteStoreShardShallowCopySnapshot(
+            "2",
+            snapshot,
+            indexVersion,
+            primaryTerm,
+            commitGeneration,
+            startTime,
+            time,
+            totalFileCount,
+            totalSize,
+            indexUUID,
+            remoteStoreRepository,
+            repositoryBasePath,
+            fileNames,
+            PathType.HASHED_INFIX,
+            PathHashAlgorithm.FNV_1A_BASE64
+        );
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, xContent)) {
+            RemoteStoreShardShallowCopySnapshot actualShardShallowCopySnapshot = RemoteStoreShardShallowCopySnapshot.fromXContent(parser);
+            assert Objects.equals(expectedShardShallowCopySnapshot, actualShardShallowCopySnapshot);
+        }
+
+        // with pathType=PathType.HASHED_INFIX and pathHashAlgorithm=PathHashAlgorithm.FNV_1A_COMPOSITE
+        xContent = "{\"version\":\"2\",\"name\":\"test-snapshot\",\"index_version\":1,\"start_time\":123,\"time\":123,"
+            + "\"number_of_files\":5,\"total_size\":5,\"index_uuid\":\"syzhajds-ashdlfj\",\"remote_store_repository\":"
+            + "\"test-rs-repository\",\"commit_generation\":5,\"primary_term\":3,\"remote_store_repository_base_path\":"
+            + "\"test-repo-basepath\",\"file_names\":[\"file1\",\"file2\",\"file3\",\"file4\",\"file5\"],\"path_type\":2,\"path_hash_algorithm\":1}";
+        expectedShardShallowCopySnapshot = new RemoteStoreShardShallowCopySnapshot(
+            "2",
+            snapshot,
+            indexVersion,
+            primaryTerm,
+            commitGeneration,
+            startTime,
+            time,
+            totalFileCount,
+            totalSize,
+            indexUUID,
+            remoteStoreRepository,
+            repositoryBasePath,
+            fileNames,
+            PathType.HASHED_INFIX,
+            PathHashAlgorithm.FNV_1A_COMPOSITE_1
         );
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, xContent)) {
             RemoteStoreShardShallowCopySnapshot actualShardShallowCopySnapshot = RemoteStoreShardShallowCopySnapshot.fromXContent(parser);
@@ -232,7 +406,7 @@ public class RemoteStoreShardShallowCopySnapshotTests extends OpenSearchTestCase
     }
 
     public void testFromXContentInvalid() throws IOException {
-        final int iters = 14;
+        final int iters = 18;
         for (int iter = 0; iter < iters; iter++) {
             String snapshot = "test-snapshot";
             long indexVersion = 1;
@@ -296,21 +470,47 @@ public class RemoteStoreShardShallowCopySnapshotTests extends OpenSearchTestCase
                     break;
                 case 10:
                     version = "1";
-                    pathHashAlgorithm = PathHashAlgorithm.FNV_1A;
-                    failure = "Invalid combination of pathType=null pathHashAlgorithm=FNV_1A for version=1";
+                    pathHashAlgorithm = PathHashAlgorithm.FNV_1A_BASE64;
+                    failure = "Invalid combination of pathType=null pathHashAlgorithm=FNV_1A_BASE64 for version=1";
                     break;
                 case 11:
                     version = "2";
                     pathType = PathType.FIXED;
-                    pathHashAlgorithm = PathHashAlgorithm.FNV_1A;
-                    failure = "Invalid combination of pathType=FIXED pathHashAlgorithm=FNV_1A for version=2";
+                    pathHashAlgorithm = PathHashAlgorithm.FNV_1A_BASE64;
+                    failure = "Invalid combination of pathType=FIXED pathHashAlgorithm=FNV_1A_BASE64 for version=2";
                     break;
                 case 12:
-                    version = "2";
-                    pathType = PathType.HASHED_PREFIX;
-                    pathHashAlgorithm = PathHashAlgorithm.FNV_1A;
+                    version = "1";
+                    pathHashAlgorithm = PathHashAlgorithm.FNV_1A_COMPOSITE_1;
+                    failure = "Invalid combination of pathType=null pathHashAlgorithm=FNV_1A_COMPOSITE_1 for version=1";
                     break;
                 case 13:
+                    version = "2";
+                    pathType = PathType.FIXED;
+                    pathHashAlgorithm = PathHashAlgorithm.FNV_1A_COMPOSITE_1;
+                    failure = "Invalid combination of pathType=FIXED pathHashAlgorithm=FNV_1A_COMPOSITE_1 for version=2";
+                    break;
+                case 14:
+                    version = "2";
+                    pathType = PathType.HASHED_PREFIX;
+                    pathHashAlgorithm = PathHashAlgorithm.FNV_1A_BASE64;
+                    break;
+                case 15:
+                    version = "2";
+                    pathType = PathType.HASHED_PREFIX;
+                    pathHashAlgorithm = PathHashAlgorithm.FNV_1A_COMPOSITE_1;
+                    break;
+                case 16:
+                    version = "2";
+                    pathType = PathType.HASHED_INFIX;
+                    pathHashAlgorithm = PathHashAlgorithm.FNV_1A_BASE64;
+                    break;
+                case 17:
+                    version = "2";
+                    pathType = PathType.HASHED_INFIX;
+                    pathHashAlgorithm = PathHashAlgorithm.FNV_1A_COMPOSITE_1;
+                    break;
+                case 18:
                     break;
                 default:
                     fail("shouldn't be here");

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -706,7 +706,7 @@ public class RemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         ShardId shardId = new ShardId(Index.UNKNOWN_INDEX_NAME, indexUUID, Integer.parseInt("0"));
         RemoteStorePathStrategy pathStrategy = randomFrom(
             new RemoteStorePathStrategy(PathType.FIXED),
-            new RemoteStorePathStrategy(PathType.HASHED_PREFIX, PathHashAlgorithm.FNV_1A)
+            new RemoteStorePathStrategy(randomFrom(PathType.HASHED_INFIX, PathType.HASHED_PREFIX), randomFrom(PathHashAlgorithm.values()))
         );
 
         RemoteSegmentStoreDirectory.remoteDirectoryCleanup(

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
@@ -218,7 +218,7 @@ import static org.opensearch.index.IndexSettings.INDEX_DOC_ID_FUZZY_SET_ENABLED_
 import static org.opensearch.index.IndexSettings.INDEX_DOC_ID_FUZZY_SET_FALSE_POSITIVE_PROBABILITY_SETTING;
 import static org.opensearch.index.IndexSettings.INDEX_SOFT_DELETES_RETENTION_LEASE_PERIOD_SETTING;
 import static org.opensearch.index.query.QueryBuilders.matchAllQuery;
-import static org.opensearch.indices.IndicesService.CLUSTER_REMOTE_STORE_PATH_PREFIX_TYPE_SETTING;
+import static org.opensearch.indices.IndicesService.CLUSTER_REMOTE_STORE_PATH_TYPE_SETTING;
 import static org.opensearch.indices.IndicesService.CLUSTER_REPLICATION_TYPE_SETTING;
 import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.REMOTE_STORE_CLUSTER_STATE_REPOSITORY_NAME_ATTRIBUTE_KEY;
 import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_SETTINGS_ATTRIBUTE_KEY_PREFIX;
@@ -2637,7 +2637,7 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
             settings.put(segmentRepoSettingsAttributeKeyPrefix + "compress", randomBoolean())
                 .put(segmentRepoSettingsAttributeKeyPrefix + "chunk_size", 200, ByteSizeUnit.BYTES);
         }
-        settings.put(CLUSTER_REMOTE_STORE_PATH_PREFIX_TYPE_SETTING.getKey(), randomFrom(PathType.values()));
+        settings.put(CLUSTER_REMOTE_STORE_PATH_TYPE_SETTING.getKey(), randomFrom(PathType.values()));
         return settings.build();
     }
 


### PR DESCRIPTION
Backport https://github.com/opensearch-project/OpenSearch/commit/02f9d74ec7746ebe9f6e71fe86b127813a4e4daa from https://github.com/opensearch-project/OpenSearch/pull/13251.