### PR TITLE
[Backport 2.x] [Tiered Caching] Stats rework (2/4): Gates CacheStatsHolder logic behind FeatureFlags.PLUGGABLE_CACHE setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Streaming Indexing] Ensure support of the new transport by security plugin ([#13174](https://github.com/opensearch-project/OpenSearch/pull/13174))
 - Add cluster setting to dynamically configure the buckets for filter rewrite optimization. ([#13179](https://github.com/opensearch-project/OpenSearch/pull/13179))
 - Make search query counters dynamic to support all query types ([#12601](https://github.com/opensearch-project/OpenSearch/pull/12601))
+- [Tiered Caching] Gate new stats logic behind FeatureFlags.PLUGGABLE_CACHE ([#13238](https://github.com/opensearch-project/OpenSearch/pull/13238))
 - [Tiered Caching] Add a dynamic setting to disable/enable disk cache. ([#13373](https://github.com/opensearch-project/OpenSearch/pull/13373))
 
 ### Dependencies

--- a/plugins/cache-ehcache/src/main/java/org/opensearch/cache/store/disk/EhcacheDiskCache.java
+++ b/plugins/cache-ehcache/src/main/java/org/opensearch/cache/store/disk/EhcacheDiskCache.java
@@ -25,6 +25,7 @@ import org.opensearch.common.cache.RemovalReason;
 import org.opensearch.common.cache.serializer.ICacheKeySerializer;
 import org.opensearch.common.cache.serializer.Serializer;
 import org.opensearch.common.cache.stats.CacheStatsHolder;
+import org.opensearch.common.cache.stats.DefaultCacheStatsHolder;
 import org.opensearch.common.cache.stats.ImmutableCacheStatsHolder;
 import org.opensearch.common.cache.store.builders.ICacheBuilder;
 import org.opensearch.common.cache.store.config.CacheConfig;
@@ -162,7 +163,8 @@ public class EhcacheDiskCache<K, V> implements ICache<K, V> {
         this.ehCacheEventListener = new EhCacheEventListener(builder.getRemovalListener(), builder.getWeigher());
         this.cache = buildCache(Duration.ofMillis(expireAfterAccess.getMillis()), builder);
         List<String> dimensionNames = Objects.requireNonNull(builder.dimensionNames, "Dimension names can't be null");
-        this.cacheStatsHolder = new CacheStatsHolder(dimensionNames);
+        // If this cache is being used, FeatureFlags.PLUGGABLE_CACHE is already on, so we can always use the DefaultCacheStatsHolder.
+        this.cacheStatsHolder = new DefaultCacheStatsHolder(dimensionNames);
     }
 
     @SuppressWarnings({ "rawtypes" })

--- a/server/src/main/java/org/opensearch/common/cache/stats/CacheStatsHolder.java
+++ b/server/src/main/java/org/opensearch/common/cache/stats/CacheStatsHolder.java
@@ -8,288 +8,31 @@
 
 package org.opensearch.common.cache.stats;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-import java.util.function.Consumer;
 
 /**
- * A class ICache implementations use to internally keep track of their stats across multiple dimensions.
- * Not intended to be exposed outside the cache; for this, caches use getImmutableCacheStatsHolder() to create an immutable
- * copy of the current state of the stats.
- * Currently, in the IRC, the stats tracked in a CacheStatsHolder will not appear for empty shards that have had no cache
- * operations done on them yet. This might be changed in the future, by exposing a method to add empty nodes to the
- * tree in CacheStatsHolder in the ICache interface.
- *
- * @opensearch.experimental
+ * An interface extended by DefaultCacheStatsHolder and NoopCacheStatsHolder.
  */
-public class CacheStatsHolder {
+public interface CacheStatsHolder {
+    void incrementHits(List<String> dimensionValues);
 
-    // The list of permitted dimensions. Should be ordered from "outermost" to "innermost", as you would like to
-    // aggregate them in an API response.
-    private final List<String> dimensionNames;
-    // A tree structure based on dimension values, which stores stats values in its leaf nodes.
-    // Non-leaf nodes have stats matching the sum of their children.
-    // We use a tree structure, rather than a map with concatenated keys, to save on memory usage. If there are many leaf
-    // nodes that share a parent, that parent's dimension value will only be stored once, not many times.
-    private final Node statsRoot;
-    // To avoid sync problems, obtain a lock before creating or removing nodes in the stats tree.
-    // No lock is needed to edit stats on existing nodes.
-    private final Lock lock = new ReentrantLock();
+    void incrementMisses(List<String> dimensionValues);
 
-    public CacheStatsHolder(List<String> dimensionNames) {
-        this.dimensionNames = Collections.unmodifiableList(dimensionNames);
-        this.statsRoot = new Node("", true); // The root node has the empty string as its dimension value
-    }
+    void incrementEvictions(List<String> dimensionValues);
 
-    public List<String> getDimensionNames() {
-        return dimensionNames;
-    }
+    void incrementSizeInBytes(List<String> dimensionValues, long amountBytes);
 
-    // For all these increment functions, the dimensions list comes from the key, and contains all dimensions present in dimensionNames.
-    // The order has to match the order given in dimensionNames.
-    public void incrementHits(List<String> dimensionValues) {
-        internalIncrement(dimensionValues, Node::incrementHits, true);
-    }
+    void decrementSizeInBytes(List<String> dimensionValues, long amountBytes);
 
-    public void incrementMisses(List<String> dimensionValues) {
-        internalIncrement(dimensionValues, Node::incrementMisses, true);
-    }
+    void incrementEntries(List<String> dimensionValues);
 
-    public void incrementEvictions(List<String> dimensionValues) {
-        internalIncrement(dimensionValues, Node::incrementEvictions, true);
-    }
+    void decrementEntries(List<String> dimensionValues);
 
-    public void incrementSizeInBytes(List<String> dimensionValues, long amountBytes) {
-        internalIncrement(dimensionValues, (node) -> node.incrementSizeInBytes(amountBytes), true);
-    }
+    void reset();
 
-    // For decrements, we should not create nodes if they are absent. This protects us from erroneously decrementing values for keys
-    // which have been entirely deleted, for example in an async removal listener.
-    public void decrementSizeInBytes(List<String> dimensionValues, long amountBytes) {
-        internalIncrement(dimensionValues, (node) -> node.decrementSizeInBytes(amountBytes), false);
-    }
+    long count();
 
-    public void incrementEntries(List<String> dimensionValues) {
-        internalIncrement(dimensionValues, Node::incrementEntries, true);
-    }
+    void removeDimensions(List<String> dimensionValues);
 
-    public void decrementEntries(List<String> dimensionValues) {
-        internalIncrement(dimensionValues, Node::decrementEntries, false);
-    }
-
-    /**
-     * Reset number of entries and memory size when all keys leave the cache, but don't reset hit/miss/eviction numbers.
-     * This is in line with the behavior of the existing API when caches are cleared.
-     */
-    public void reset() {
-        resetHelper(statsRoot);
-    }
-
-    private void resetHelper(Node current) {
-        current.resetSizeAndEntries();
-        for (Node child : current.children.values()) {
-            resetHelper(child);
-        }
-    }
-
-    public long count() {
-        // Include this here so caches don't have to create an entire CacheStats object to run count().
-        return statsRoot.getEntries();
-    }
-
-    private void internalIncrement(List<String> dimensionValues, Consumer<Node> adder, boolean createNodesIfAbsent) {
-        assert dimensionValues.size() == dimensionNames.size();
-        // First try to increment without creating nodes
-        boolean didIncrement = internalIncrementHelper(dimensionValues, statsRoot, 0, adder, false);
-        // If we failed to increment, because nodes had to be created, obtain the lock and run again while creating nodes if needed
-        if (!didIncrement && createNodesIfAbsent) {
-            try {
-                lock.lock();
-                internalIncrementHelper(dimensionValues, statsRoot, 0, adder, true);
-            } finally {
-                lock.unlock();
-            }
-        }
-    }
-
-    /**
-     * Use the incrementer function to increment/decrement a value in the stats for a set of dimensions.
-     * If createNodesIfAbsent is true, and there is no stats for this set of dimensions, create one.
-     * Returns true if the increment was applied, false if not.
-     */
-    private boolean internalIncrementHelper(
-        List<String> dimensionValues,
-        Node node,
-        int depth, // Pass in the depth to avoid having to slice the list for each node.
-        Consumer<Node> adder,
-        boolean createNodesIfAbsent
-    ) {
-        if (depth == dimensionValues.size()) {
-            // This is the leaf node we are trying to reach
-            adder.accept(node);
-            return true;
-        }
-
-        Node child = node.getChild(dimensionValues.get(depth));
-        if (child == null) {
-            if (createNodesIfAbsent) {
-                boolean createMapInChild = depth < dimensionValues.size() - 1;
-                child = node.createChild(dimensionValues.get(depth), createMapInChild);
-            } else {
-                return false;
-            }
-        }
-        if (internalIncrementHelper(dimensionValues, child, depth + 1, adder, createNodesIfAbsent)) {
-            // Function returns true if the next node down was incremented
-            adder.accept(node);
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * Produce an immutable version of these stats.
-     */
-    public ImmutableCacheStatsHolder getImmutableCacheStatsHolder() {
-        return new ImmutableCacheStatsHolder(statsRoot.snapshot(), dimensionNames);
-    }
-
-    public void removeDimensions(List<String> dimensionValues) {
-        assert dimensionValues.size() == dimensionNames.size() : "Must specify a value for every dimension when removing from StatsHolder";
-        // As we are removing nodes from the tree, obtain the lock
-        lock.lock();
-        try {
-            removeDimensionsHelper(dimensionValues, statsRoot, 0);
-        } finally {
-            lock.unlock();
-        }
-    }
-
-    // Returns a CacheStatsCounterSnapshot object for the stats to decrement if the removal happened, null otherwise.
-    private ImmutableCacheStats removeDimensionsHelper(List<String> dimensionValues, Node node, int depth) {
-        if (depth == dimensionValues.size()) {
-            // Pass up a snapshot of the original stats to avoid issues when the original is decremented by other fn invocations
-            return node.getImmutableStats();
-        }
-        Node child = node.getChild(dimensionValues.get(depth));
-        if (child == null) {
-            return null;
-        }
-        ImmutableCacheStats statsToDecrement = removeDimensionsHelper(dimensionValues, child, depth + 1);
-        if (statsToDecrement != null) {
-            // The removal took place, decrement values and remove this node from its parent if it's now empty
-            node.decrementBySnapshot(statsToDecrement);
-            if (child.getChildren().isEmpty()) {
-                node.children.remove(child.getDimensionValue());
-            }
-        }
-        return statsToDecrement;
-    }
-
-    // pkg-private for testing
-    Node getStatsRoot() {
-        return statsRoot;
-    }
-
-    static class Node {
-        private final String dimensionValue;
-        // Map from dimensionValue to the DimensionNode for that dimension value.
-        final Map<String, Node> children;
-        // The stats for this node. If a leaf node, corresponds to the stats for this combination of dimensions; if not,
-        // contains the sum of its children's stats.
-        private CacheStats stats;
-
-        // Used for leaf nodes to avoid allocating many unnecessary maps
-        private static final Map<String, Node> EMPTY_CHILDREN_MAP = new HashMap<>();
-
-        Node(String dimensionValue, boolean createChildrenMap) {
-            this.dimensionValue = dimensionValue;
-            if (createChildrenMap) {
-                this.children = new ConcurrentHashMap<>();
-            } else {
-                this.children = EMPTY_CHILDREN_MAP;
-            }
-            this.stats = new CacheStats();
-        }
-
-        public String getDimensionValue() {
-            return dimensionValue;
-        }
-
-        protected Map<String, Node> getChildren() {
-            // We can safely iterate over ConcurrentHashMap without worrying about thread issues.
-            return children;
-        }
-
-        // Functions for modifying internal CacheStatsCounter without callers having to be aware of CacheStatsCounter
-
-        void incrementHits() {
-            this.stats.incrementHits();
-        }
-
-        void incrementMisses() {
-            this.stats.incrementMisses();
-        }
-
-        void incrementEvictions() {
-            this.stats.incrementEvictions();
-        }
-
-        void incrementSizeInBytes(long amountBytes) {
-            this.stats.incrementSizeInBytes(amountBytes);
-        }
-
-        void decrementSizeInBytes(long amountBytes) {
-            this.stats.decrementSizeInBytes(amountBytes);
-        }
-
-        void incrementEntries() {
-            this.stats.incrementEntries();
-        }
-
-        void decrementEntries() {
-            this.stats.decrementEntries();
-        }
-
-        long getEntries() {
-            return this.stats.getEntries();
-        }
-
-        ImmutableCacheStats getImmutableStats() {
-            return this.stats.immutableSnapshot();
-        }
-
-        void decrementBySnapshot(ImmutableCacheStats snapshot) {
-            this.stats.subtract(snapshot);
-        }
-
-        void resetSizeAndEntries() {
-            this.stats.resetSizeAndEntries();
-        }
-
-        Node getChild(String dimensionValue) {
-            return children.get(dimensionValue);
-        }
-
-        Node createChild(String dimensionValue, boolean createMapInChild) {
-            return children.computeIfAbsent(dimensionValue, (key) -> new Node(dimensionValue, createMapInChild));
-        }
-
-        ImmutableCacheStatsHolder.Node snapshot() {
-            TreeMap<String, ImmutableCacheStatsHolder.Node> snapshotChildren = null;
-            if (!children.isEmpty()) {
-                snapshotChildren = new TreeMap<>();
-                for (Node child : children.values()) {
-                    snapshotChildren.put(child.getDimensionValue(), child.snapshot());
-                }
-            }
-            return new ImmutableCacheStatsHolder.Node(dimensionValue, snapshotChildren, getImmutableStats());
-        }
-    }
+    ImmutableCacheStatsHolder getImmutableCacheStatsHolder();
 }

--- a/server/src/main/java/org/opensearch/common/cache/stats/DefaultCacheStatsHolder.java
+++ b/server/src/main/java/org/opensearch/common/cache/stats/DefaultCacheStatsHolder.java
@@ -1,0 +1,306 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.cache.stats;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
+
+/**
+ * A class ICache implementations use to internally keep track of their stats across multiple dimensions.
+ * Not intended to be exposed outside the cache; for this, caches use getImmutableCacheStatsHolder() to create an immutable
+ * copy of the current state of the stats.
+ * Currently, in the IRC, the stats tracked in a CacheStatsHolder will not appear for empty shards that have had no cache
+ * operations done on them yet. This might be changed in the future, by exposing a method to add empty nodes to the
+ * tree in CacheStatsHolder in the ICache interface.
+ *
+ * @opensearch.experimental
+ */
+public class DefaultCacheStatsHolder implements CacheStatsHolder {
+
+    // The list of permitted dimensions. Should be ordered from "outermost" to "innermost", as you would like to
+    // aggregate them in an API response.
+    private final List<String> dimensionNames;
+    // A tree structure based on dimension values, which stores stats values in its leaf nodes.
+    // Non-leaf nodes have stats matching the sum of their children.
+    // We use a tree structure, rather than a map with concatenated keys, to save on memory usage. If there are many leaf
+    // nodes that share a parent, that parent's dimension value will only be stored once, not many times.
+    private final Node statsRoot;
+    // To avoid sync problems, obtain a lock before creating or removing nodes in the stats tree.
+    // No lock is needed to edit stats on existing nodes.
+    private final Lock lock = new ReentrantLock();
+
+    public DefaultCacheStatsHolder(List<String> dimensionNames) {
+        this.dimensionNames = Collections.unmodifiableList(dimensionNames);
+        this.statsRoot = new Node("", true); // The root node has the empty string as its dimension value
+    }
+
+    public List<String> getDimensionNames() {
+        return dimensionNames;
+    }
+
+    // For all these increment functions, the dimensions list comes from the key, and contains all dimensions present in dimensionNames.
+    // The order has to match the order given in dimensionNames.
+    @Override
+    public void incrementHits(List<String> dimensionValues) {
+        internalIncrement(dimensionValues, Node::incrementHits, true);
+    }
+
+    @Override
+    public void incrementMisses(List<String> dimensionValues) {
+        internalIncrement(dimensionValues, Node::incrementMisses, true);
+    }
+
+    @Override
+    public void incrementEvictions(List<String> dimensionValues) {
+        internalIncrement(dimensionValues, Node::incrementEvictions, true);
+    }
+
+    @Override
+    public void incrementSizeInBytes(List<String> dimensionValues, long amountBytes) {
+        internalIncrement(dimensionValues, (node) -> node.incrementSizeInBytes(amountBytes), true);
+    }
+
+    // For decrements, we should not create nodes if they are absent. This protects us from erroneously decrementing values for keys
+    // which have been entirely deleted, for example in an async removal listener.
+    @Override
+    public void decrementSizeInBytes(List<String> dimensionValues, long amountBytes) {
+        internalIncrement(dimensionValues, (node) -> node.decrementSizeInBytes(amountBytes), false);
+    }
+
+    @Override
+    public void incrementEntries(List<String> dimensionValues) {
+        internalIncrement(dimensionValues, Node::incrementEntries, true);
+    }
+
+    @Override
+    public void decrementEntries(List<String> dimensionValues) {
+        internalIncrement(dimensionValues, Node::decrementEntries, false);
+    }
+
+    /**
+     * Reset number of entries and memory size when all keys leave the cache, but don't reset hit/miss/eviction numbers.
+     * This is in line with the behavior of the existing API when caches are cleared.
+     */
+    @Override
+    public void reset() {
+        resetHelper(statsRoot);
+    }
+
+    private void resetHelper(Node current) {
+        current.resetSizeAndEntries();
+        for (Node child : current.children.values()) {
+            resetHelper(child);
+        }
+    }
+
+    @Override
+    public long count() {
+        // Include this here so caches don't have to create an entire CacheStats object to run count().
+        return statsRoot.getEntries();
+    }
+
+    private void internalIncrement(List<String> dimensionValues, Consumer<Node> adder, boolean createNodesIfAbsent) {
+        assert dimensionValues.size() == dimensionNames.size();
+        // First try to increment without creating nodes
+        boolean didIncrement = internalIncrementHelper(dimensionValues, statsRoot, 0, adder, false);
+        // If we failed to increment, because nodes had to be created, obtain the lock and run again while creating nodes if needed
+        if (!didIncrement && createNodesIfAbsent) {
+            try {
+                lock.lock();
+                internalIncrementHelper(dimensionValues, statsRoot, 0, adder, true);
+            } finally {
+                lock.unlock();
+            }
+        }
+    }
+
+    /**
+     * Use the incrementer function to increment/decrement a value in the stats for a set of dimensions.
+     * If createNodesIfAbsent is true, and there is no stats for this set of dimensions, create one.
+     * Returns true if the increment was applied, false if not.
+     */
+    private boolean internalIncrementHelper(
+        List<String> dimensionValues,
+        Node node,
+        int depth, // Pass in the depth to avoid having to slice the list for each node.
+        Consumer<Node> adder,
+        boolean createNodesIfAbsent
+    ) {
+        if (depth == dimensionValues.size()) {
+            // This is the leaf node we are trying to reach
+            adder.accept(node);
+            return true;
+        }
+
+        Node child = node.getChild(dimensionValues.get(depth));
+        if (child == null) {
+            if (createNodesIfAbsent) {
+                boolean createMapInChild = depth < dimensionValues.size() - 1;
+                child = node.createChild(dimensionValues.get(depth), createMapInChild);
+            } else {
+                return false;
+            }
+        }
+        if (internalIncrementHelper(dimensionValues, child, depth + 1, adder, createNodesIfAbsent)) {
+            // Function returns true if the next node down was incremented
+            adder.accept(node);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Produce an immutable version of these stats.
+     */
+    @Override
+    public ImmutableCacheStatsHolder getImmutableCacheStatsHolder() {
+        return new ImmutableCacheStatsHolder(statsRoot.snapshot(), dimensionNames);
+    }
+
+    @Override
+    public void removeDimensions(List<String> dimensionValues) {
+        assert dimensionValues.size() == dimensionNames.size() : "Must specify a value for every dimension when removing from StatsHolder";
+        // As we are removing nodes from the tree, obtain the lock
+        lock.lock();
+        try {
+            removeDimensionsHelper(dimensionValues, statsRoot, 0);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    // Returns a CacheStatsCounterSnapshot object for the stats to decrement if the removal happened, null otherwise.
+    private ImmutableCacheStats removeDimensionsHelper(List<String> dimensionValues, Node node, int depth) {
+        if (depth == dimensionValues.size()) {
+            // Pass up a snapshot of the original stats to avoid issues when the original is decremented by other fn invocations
+            return node.getImmutableStats();
+        }
+        Node child = node.getChild(dimensionValues.get(depth));
+        if (child == null) {
+            return null;
+        }
+        ImmutableCacheStats statsToDecrement = removeDimensionsHelper(dimensionValues, child, depth + 1);
+        if (statsToDecrement != null) {
+            // The removal took place, decrement values and remove this node from its parent if it's now empty
+            node.decrementBySnapshot(statsToDecrement);
+            if (child.getChildren().isEmpty()) {
+                node.children.remove(child.getDimensionValue());
+            }
+        }
+        return statsToDecrement;
+    }
+
+    // pkg-private for testing
+    Node getStatsRoot() {
+        return statsRoot;
+    }
+
+    static class Node {
+        private final String dimensionValue;
+        // Map from dimensionValue to the DimensionNode for that dimension value.
+        final Map<String, Node> children;
+        // The stats for this node. If a leaf node, corresponds to the stats for this combination of dimensions; if not,
+        // contains the sum of its children's stats.
+        private CacheStats stats;
+
+        // Used for leaf nodes to avoid allocating many unnecessary maps
+        private static final Map<String, Node> EMPTY_CHILDREN_MAP = new HashMap<>();
+
+        Node(String dimensionValue, boolean createChildrenMap) {
+            this.dimensionValue = dimensionValue;
+            if (createChildrenMap) {
+                this.children = new ConcurrentHashMap<>();
+            } else {
+                this.children = EMPTY_CHILDREN_MAP;
+            }
+            this.stats = new CacheStats();
+        }
+
+        public String getDimensionValue() {
+            return dimensionValue;
+        }
+
+        protected Map<String, Node> getChildren() {
+            // We can safely iterate over ConcurrentHashMap without worrying about thread issues.
+            return children;
+        }
+
+        // Functions for modifying internal CacheStatsCounter without callers having to be aware of CacheStatsCounter
+
+        void incrementHits() {
+            this.stats.incrementHits();
+        }
+
+        void incrementMisses() {
+            this.stats.incrementMisses();
+        }
+
+        void incrementEvictions() {
+            this.stats.incrementEvictions();
+        }
+
+        void incrementSizeInBytes(long amountBytes) {
+            this.stats.incrementSizeInBytes(amountBytes);
+        }
+
+        void decrementSizeInBytes(long amountBytes) {
+            this.stats.decrementSizeInBytes(amountBytes);
+        }
+
+        void incrementEntries() {
+            this.stats.incrementEntries();
+        }
+
+        void decrementEntries() {
+            this.stats.decrementEntries();
+        }
+
+        long getEntries() {
+            return this.stats.getEntries();
+        }
+
+        ImmutableCacheStats getImmutableStats() {
+            return this.stats.immutableSnapshot();
+        }
+
+        void decrementBySnapshot(ImmutableCacheStats snapshot) {
+            this.stats.subtract(snapshot);
+        }
+
+        void resetSizeAndEntries() {
+            this.stats.resetSizeAndEntries();
+        }
+
+        Node getChild(String dimensionValue) {
+            return children.get(dimensionValue);
+        }
+
+        Node createChild(String dimensionValue, boolean createMapInChild) {
+            return children.computeIfAbsent(dimensionValue, (key) -> new Node(dimensionValue, createMapInChild));
+        }
+
+        ImmutableCacheStatsHolder.Node snapshot() {
+            TreeMap<String, ImmutableCacheStatsHolder.Node> snapshotChildren = null;
+            if (!children.isEmpty()) {
+                snapshotChildren = new TreeMap<>();
+                for (Node child : children.values()) {
+                    snapshotChildren.put(child.getDimensionValue(), child.snapshot());
+                }
+            }
+            return new ImmutableCacheStatsHolder.Node(dimensionValue, snapshotChildren, getImmutableStats());
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/common/cache/stats/NoopCacheStatsHolder.java
+++ b/server/src/main/java/org/opensearch/common/cache/stats/NoopCacheStatsHolder.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.cache.stats;
+
+import java.util.List;
+
+/**
+ * A dummy version of CacheStatsHolder, which cache implementations use when FeatureFlags.PLUGGABLE_CACHES is false.
+ * Returns all-zero stats when calling getImmutableCacheStatsHolder(). Always returns 0 for count().
+ * A singleton instance is used for memory purposes.
+ */
+public class NoopCacheStatsHolder implements CacheStatsHolder {
+    private static final NoopCacheStatsHolder singletonInstance = new NoopCacheStatsHolder();
+    private static final ImmutableCacheStatsHolder immutableCacheStatsHolder;
+    static {
+        ImmutableCacheStatsHolder.Node dummyNode = new ImmutableCacheStatsHolder.Node("", null, new ImmutableCacheStats(0, 0, 0, 0, 0));
+        immutableCacheStatsHolder = new ImmutableCacheStatsHolder(dummyNode, List.of());
+    }
+
+    private NoopCacheStatsHolder() {}
+
+    public static NoopCacheStatsHolder getInstance() {
+        return singletonInstance;
+    }
+
+    @Override
+    public void incrementHits(List<String> dimensionValues) {}
+
+    @Override
+    public void incrementMisses(List<String> dimensionValues) {}
+
+    @Override
+    public void incrementEvictions(List<String> dimensionValues) {}
+
+    @Override
+    public void incrementSizeInBytes(List<String> dimensionValues, long amountBytes) {}
+
+    @Override
+    public void decrementSizeInBytes(List<String> dimensionValues, long amountBytes) {}
+
+    @Override
+    public void incrementEntries(List<String> dimensionValues) {}
+
+    @Override
+    public void decrementEntries(List<String> dimensionValues) {}
+
+    @Override
+    public void reset() {}
+
+    @Override
+    public long count() {
+        return 0;
+    }
+
+    @Override
+    public void removeDimensions(List<String> dimensionValues) {}
+
+    @Override
+    public ImmutableCacheStatsHolder getImmutableCacheStatsHolder() {
+        return immutableCacheStatsHolder;
+    }
+}

--- a/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
@@ -801,13 +801,6 @@ public final class IndicesRequestCache implements RemovalListener<ICacheKey<Indi
     }
 
     /**
-     * Returns the current size in bytes of the cache
-     */
-    long getSizeInBytes() {
-        return cache.stats().getTotalSizeInBytes();
-    }
-
-    /**
      * Returns the current cache stats. Pkg-private for testing.
      */
     ImmutableCacheStatsHolder stats() {

--- a/server/src/test/java/org/opensearch/common/cache/stats/ImmutableCacheStatsHolderTests.java
+++ b/server/src/test/java/org/opensearch/common/cache/stats/ImmutableCacheStatsHolderTests.java
@@ -17,17 +17,24 @@ public class ImmutableCacheStatsHolderTests extends OpenSearchTestCase {
 
     public void testGet() throws Exception {
         List<String> dimensionNames = List.of("dim1", "dim2", "dim3", "dim4");
-        CacheStatsHolder cacheStatsHolder = new CacheStatsHolder(dimensionNames);
-        Map<String, List<String>> usedDimensionValues = CacheStatsHolderTests.getUsedDimensionValues(cacheStatsHolder, 10);
-        Map<List<String>, CacheStats> expected = CacheStatsHolderTests.populateStats(cacheStatsHolder, usedDimensionValues, 1000, 10);
+        DefaultCacheStatsHolder cacheStatsHolder = new DefaultCacheStatsHolder(dimensionNames);
+        Map<String, List<String>> usedDimensionValues = DefaultCacheStatsHolderTests.getUsedDimensionValues(cacheStatsHolder, 10);
+        Map<List<String>, CacheStats> expected = DefaultCacheStatsHolderTests.populateStats(
+            cacheStatsHolder,
+            usedDimensionValues,
+            1000,
+            10
+        );
         ImmutableCacheStatsHolder stats = cacheStatsHolder.getImmutableCacheStatsHolder();
 
         // test the value in the map is as expected for each distinct combination of values
         for (List<String> dimensionValues : expected.keySet()) {
             CacheStats expectedCounter = expected.get(dimensionValues);
 
-            ImmutableCacheStats actualCacheStatsHolder = CacheStatsHolderTests.getNode(dimensionValues, cacheStatsHolder.getStatsRoot())
-                .getImmutableStats();
+            ImmutableCacheStats actualCacheStatsHolder = DefaultCacheStatsHolderTests.getNode(
+                dimensionValues,
+                cacheStatsHolder.getStatsRoot()
+            ).getImmutableStats();
             ImmutableCacheStats actualImmutableCacheStatsHolder = getNode(dimensionValues, stats.getStatsRoot()).getStats();
 
             assertEquals(expectedCounter.immutableSnapshot(), actualCacheStatsHolder);
@@ -52,9 +59,9 @@ public class ImmutableCacheStatsHolderTests extends OpenSearchTestCase {
 
     public void testEmptyDimsList() throws Exception {
         // If the dimension list is empty, the tree should have only the root node containing the total stats.
-        CacheStatsHolder cacheStatsHolder = new CacheStatsHolder(List.of());
-        Map<String, List<String>> usedDimensionValues = CacheStatsHolderTests.getUsedDimensionValues(cacheStatsHolder, 100);
-        CacheStatsHolderTests.populateStats(cacheStatsHolder, usedDimensionValues, 10, 100);
+        DefaultCacheStatsHolder cacheStatsHolder = new DefaultCacheStatsHolder(List.of());
+        Map<String, List<String>> usedDimensionValues = DefaultCacheStatsHolderTests.getUsedDimensionValues(cacheStatsHolder, 100);
+        DefaultCacheStatsHolderTests.populateStats(cacheStatsHolder, usedDimensionValues, 10, 100);
         ImmutableCacheStatsHolder stats = cacheStatsHolder.getImmutableCacheStatsHolder();
 
         ImmutableCacheStatsHolder.Node statsRoot = stats.getStatsRoot();

--- a/server/src/test/java/org/opensearch/common/cache/store/OpenSearchOnHeapCacheTests.java
+++ b/server/src/test/java/org/opensearch/common/cache/store/OpenSearchOnHeapCacheTests.java
@@ -16,10 +16,12 @@ import org.opensearch.common.cache.LoadAwareCacheLoader;
 import org.opensearch.common.cache.RemovalListener;
 import org.opensearch.common.cache.RemovalNotification;
 import org.opensearch.common.cache.stats.ImmutableCacheStats;
+import org.opensearch.common.cache.stats.ImmutableCacheStatsHolder;
 import org.opensearch.common.cache.store.config.CacheConfig;
 import org.opensearch.common.cache.store.settings.OpenSearchOnHeapCacheSettings;
 import org.opensearch.common.metrics.CounterMetric;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.ArrayList;
@@ -37,7 +39,9 @@ public class OpenSearchOnHeapCacheTests extends OpenSearchTestCase {
         MockRemovalListener<String, String> listener = new MockRemovalListener<>();
         int maxKeys = between(10, 50);
         int numEvicted = between(10, 20);
-        OpenSearchOnHeapCache<String, String> cache = getCache(maxKeys, listener);
+        OpenSearchOnHeapCache<String, String> cache = getCache(maxKeys, listener, true);
+
+        // When the pluggable caches setting is on, we should get stats as expected from cache.stats().
 
         List<ICacheKey<String>> keysAdded = new ArrayList<>();
         int numAdded = maxKeys + numEvicted;
@@ -77,7 +81,34 @@ public class OpenSearchOnHeapCacheTests extends OpenSearchTestCase {
         }
     }
 
-    private OpenSearchOnHeapCache<String, String> getCache(int maxSizeKeys, MockRemovalListener<String, String> listener) {
+    public void testStatsWithoutPluggableCaches() throws Exception {
+        // When the pluggable caches setting is off, we should get all-zero stats from cache.stats(), but count() should still work.
+        MockRemovalListener<String, String> listener = new MockRemovalListener<>();
+        int maxKeys = between(10, 50);
+        int numEvicted = between(10, 20);
+        OpenSearchOnHeapCache<String, String> cache = getCache(maxKeys, listener, false);
+
+        List<ICacheKey<String>> keysAdded = new ArrayList<>();
+        int numAdded = maxKeys + numEvicted;
+        for (int i = 0; i < numAdded; i++) {
+            ICacheKey<String> key = getICacheKey(UUID.randomUUID().toString());
+            keysAdded.add(key);
+            cache.computeIfAbsent(key, getLoadAwareCacheLoader());
+
+            assertEquals(Math.min(maxKeys, i + 1), cache.count());
+            assertZeroStats(cache.stats());
+        }
+    }
+
+    private void assertZeroStats(ImmutableCacheStatsHolder stats) {
+        assertEquals(new ImmutableCacheStats(0, 0, 0, 0, 0), stats.getTotalStats());
+    }
+
+    private OpenSearchOnHeapCache<String, String> getCache(
+        int maxSizeKeys,
+        MockRemovalListener<String, String> listener,
+        boolean pluggableCachesSetting
+    ) {
         ICache.Factory onHeapCacheFactory = new OpenSearchOnHeapCache.OpenSearchOnHeapCacheFactory();
         Settings settings = Settings.builder()
             .put(
@@ -86,6 +117,7 @@ public class OpenSearchOnHeapCacheTests extends OpenSearchTestCase {
                     .getKey(),
                 maxSizeKeys * keyValueSize + "b"
             )
+            .put(FeatureFlags.PLUGGABLE_CACHE, pluggableCachesSetting)
             .build();
 
         CacheConfig<String, String> cacheConfig = new CacheConfig.Builder<String, String>().setKeyType(String.class)
@@ -102,7 +134,7 @@ public class OpenSearchOnHeapCacheTests extends OpenSearchTestCase {
     public void testInvalidateWithDropDimensions() throws Exception {
         MockRemovalListener<String, String> listener = new MockRemovalListener<>();
         int maxKeys = 50;
-        OpenSearchOnHeapCache<String, String> cache = getCache(maxKeys, listener);
+        OpenSearchOnHeapCache<String, String> cache = getCache(maxKeys, listener, true);
 
         List<ICacheKey<String>> keysAdded = new ArrayList<>();
 

--- a/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
@@ -51,6 +51,7 @@ import org.opensearch.common.cache.RemovalNotification;
 import org.opensearch.common.cache.RemovalReason;
 import org.opensearch.common.cache.module.CacheModule;
 import org.opensearch.common.cache.stats.ImmutableCacheStats;
+import org.opensearch.common.cache.stats.ImmutableCacheStatsHolder;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.lucene.index.OpenSearchDirectoryReader;
 import org.opensearch.common.settings.Settings;
@@ -812,8 +813,12 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
             assertNotNull(indexToKeep.getShard(i));
             assertNotNull(indexToClose.getShard(i));
         }
+
         threadPool = getThreadPool();
-        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.001%").build();
+        Settings settings = Settings.builder()
+            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.001%")
+            .put(FeatureFlags.PLUGGABLE_CACHE, true)
+            .build();
         cache = new IndicesRequestCache(settings, (shardId -> {
             IndexService indexService = null;
             try {
@@ -868,6 +873,7 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
                 ShardId shardId = indexService.getShard(i).shardId();
                 List<String> dimensionValues = List.of(shardId.getIndexName(), shardId.toString());
                 initialDimensionValues.add(dimensionValues);
+                ImmutableCacheStatsHolder holder = cache.stats();
                 ImmutableCacheStats snapshot = cache.stats().getStatsForDimensionValues(dimensionValues);
                 assertNotNull(snapshot);
                 // check the values are not empty by confirming entries != 0, this should always be true since the missed value is loaded
@@ -920,13 +926,14 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
             assertEquals("foo", value1.streamInput().readString());
             BytesReference value2 = cache.getOrCompute(getEntity(indexShard), getLoader(secondReader), secondReader, getTermBytes());
             assertEquals("bar", value2.streamInput().readString());
-            size = new ByteSizeValue(cache.getSizeInBytes());
+            size = indexShard.requestCache().stats().getMemorySize(); // Value from old API
             IOUtils.close(reader, secondReader, writer, dir, cache);
         }
         indexShard = createIndex("test1").getShard(0);
         IndicesRequestCache cache = new IndicesRequestCache(
-            // Add 5 instead of 1; the key size now depends on the length of dimension names and values so there's more variation
-            Settings.builder().put(IndicesRequestCache.INDICES_CACHE_QUERY_SIZE.getKey(), size.getBytes() + 5 + "b").build(),
+            // TODO: Add wiggle room to max size to allow for overhead of ICacheKey. This can be removed once API PR goes in, as it updates
+            // the old API to account for the ICacheKey overhead.
+            Settings.builder().put(IndicesRequestCache.INDICES_CACHE_QUERY_SIZE.getKey(), (int) (size.getBytes() * 1.2) + "b").build(),
             (shardId -> Optional.of(new IndicesService.IndexShardCacheEntity(indexShard))),
             new CacheModule(new ArrayList<>(), Settings.EMPTY).getCacheService(),
             threadPool,


### PR DESCRIPTION
[Original PR](https://github.com/opensearch-project/OpenSearch/pull/13238)

### Description
Part of [tiered caching stats](https://github.com/opensearch-project/OpenSearch/issues/12258). Tiered/pluggable caching is currently an experimental feature with the feature flag PLUGGABLE_CACHE. We want to gate the new CacheStatsHolder logic, which is run in the search path within cache implementations, behind this feature flag in case of any unexpected behavior. 

With this PR, if PLUGGABLE_CACHE is true, cache implementations use the existing CacheStatsHolder class to keep track of their stats. If it's false, they instead use a DummyCacheStatsHolder, which keeps track of count only. In this case, the new cache stats API exposed in [this PR](https://github.com/opensearch-project/OpenSearch/pull/13237) will return all-zero stats and not support aggregating by any levels.  

Because TieredSpilloverCache will store its own stats in https://github.com/opensearch-project/OpenSearch/pull/13236/, NoopCacheStatsHolder will also be used in the individual tiers of the TieredSpilloverCache to avoid storing redundant stats. 

### Related Issues
Follow up to https://github.com/opensearch-project/OpenSearch/pull/12531. 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
~- [N/A] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
