### PR TITLE
Fix flaky test CacheStatsAPIIndicesRequestCacheIT.testNullLevels()

### DIFF
--- a/server/src/main/java/org/opensearch/common/cache/stats/DefaultCacheStatsHolder.java
+++ b/server/src/main/java/org/opensearch/common/cache/stats/DefaultCacheStatsHolder.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -170,7 +171,8 @@ public class DefaultCacheStatsHolder implements CacheStatsHolder {
      */
     @Override
     public ImmutableCacheStatsHolder getImmutableCacheStatsHolder(String[] levels) {
-        return new ImmutableCacheStatsHolder(this.statsRoot, levels, dimensionNames, storeName);
+        String[] nonNullLevels = Objects.requireNonNullElseGet(levels, () -> new String[0]);
+        return new ImmutableCacheStatsHolder(this.statsRoot, nonNullLevels, dimensionNames, storeName);
     }
 
     @Override


### PR DESCRIPTION
### Description
I introduced CacheStatsAPIIndicesRequestCacheIT in [this recent PR](https://github.com/opensearch-project/OpenSearch/pull/13237) but I have found it to be flaky (example [here](https://build.ci.opensearch.org/job/gradle-check/38005/testReport/junit/org.opensearch.indices/CacheStatsAPIIndicesRequestCacheIT/testNullLevels__p0___opensearch_experimental_feature_pluggable_caching_enabled___true___/)).  

If `levels` is uninitialized in CommonStatsFlags, the String[] `levels` passed into DefaultCacheStatsHolder is usually an empty list. This is the expected behavior. But in some cases, DefaultCacheStatsHolder receives null instead of an empty list, and in this case, the XContent output derived from it has unexpected fields. To fix this we add an explicit null check when DefaultCacheStatsHolder constructs the object which produces XContent, and use an empty list if null is passed in. 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
~- [N/A] New functionality has been documented.~
  ~- [N/A] New functionality has javadoc added~
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
~- [N/A] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
~- [N/A] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
