### PR TITLE
[Tiered Caching] Bump versions for serialization in new cache stats API

### DIFF
--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodeStats.java
@@ -238,7 +238,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         } else {
             admissionControlStats = null;
         }
-        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_2_14_0)) {
             nodeCacheStats = in.readOptionalWriteable(NodeCacheStats::new);
         } else {
             nodeCacheStats = null;
@@ -522,7 +522,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         if (out.getVersion().onOrAfter(Version.V_2_12_0)) {
             out.writeOptionalWriteable(admissionControlStats);
         }
-        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_2_14_0)) {
             out.writeOptionalWriteable(nodeCacheStats);
         }
     }

--- a/server/src/main/java/org/opensearch/action/admin/indices/stats/CommonStatsFlags.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/stats/CommonStatsFlags.java
@@ -96,7 +96,7 @@ public class CommonStatsFlags implements Writeable, Cloneable {
         includeUnloadedSegments = in.readBoolean();
         includeAllShardIndexingPressureTrackers = in.readBoolean();
         includeOnlyTopIndexingPressureMetrics = in.readBoolean();
-        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_2_14_0)) {
             includeCaches = in.readEnumSet(CacheType.class);
             levels = in.readStringArray();
         }
@@ -120,7 +120,7 @@ public class CommonStatsFlags implements Writeable, Cloneable {
         out.writeBoolean(includeUnloadedSegments);
         out.writeBoolean(includeAllShardIndexingPressureTrackers);
         out.writeBoolean(includeOnlyTopIndexingPressureMetrics);
-        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_2_14_0)) {
             out.writeEnumSet(includeCaches);
             out.writeStringArrayNullable(levels);
         }

--- a/server/src/main/java/org/opensearch/index/cache/request/ShardRequestCache.java
+++ b/server/src/main/java/org/opensearch/index/cache/request/ShardRequestCache.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.index.cache.request;
 
+import org.apache.lucene.util.Accountable;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.metrics.CounterMetric;
 import org.opensearch.core.common.bytes.BytesReference;
@@ -61,6 +62,7 @@ public final class ShardRequestCache {
         missCount.inc();
     }
 
+    // Functions used to increment size by passing in the size directly, Used now, as we use ICacheKey<Key> in the IndicesRequestCache..
     public void onCached(long keyRamBytesUsed, BytesReference value) {
         totalMetric.inc(keyRamBytesUsed + value.ramBytesUsed());
     }
@@ -74,5 +76,23 @@ public final class ShardRequestCache {
             dec += value.ramBytesUsed();
         }
         totalMetric.dec(dec);
+    }
+
+    // Old functions which increment size by passing in an Accountable. Functional but no longer used.
+    public void onCached(Accountable key, BytesReference value) {
+        totalMetric.inc(key.ramBytesUsed() + value.ramBytesUsed());
+    }
+
+    public void onRemoval(Accountable key, BytesReference value, boolean evicted) {
+        if (evicted) {
+            evictionsMetric.inc();
+        }
+        long dec = 0;
+        if (key != null) {
+            dec += key.ramBytesUsed();
+        }
+        if (value != null) {
+            dec += value.ramBytesUsed();
+        }
     }
 }


### PR DESCRIPTION
### Description
Follows up to https://github.com/opensearch-project/OpenSearch/pull/13237 and its backport https://github.com/opensearch-project/OpenSearch/pull/13456. In the backport, we changed versions from V_3_0_0 to V_2_14_0, and re-added functions to ShardRequestCache that were required by the breaking-changes test. This PR brings those changes back to main so the two should be aligned. 

### Related Issues
Part of https://github.com/opensearch-project/OpenSearch/issues/12258

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
[] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
[] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
