### PR TITLE
FEATURE-13448: add use compound file setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 2.x]
 ### Added
+- Add useCompoundFile index setting ([#13478](https://github.com/opensearch-project/OpenSearch/pull/13478))
 - Constant Keyword Field ([#12285](https://github.com/opensearch-project/OpenSearch/pull/12285))
 - Convert ingest processor supports ip type ([#12818](https://github.com/opensearch-project/OpenSearch/pull/12818))
 - Add a counter to node stat api to track shard going from idle to non-idle ([#12768](https://github.com/opensearch-project/OpenSearch/pull/12768))

--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -198,6 +198,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 EngineConfig.INDEX_CODEC_SETTING,
                 EngineConfig.INDEX_CODEC_COMPRESSION_LEVEL_SETTING,
                 EngineConfig.INDEX_OPTIMIZE_AUTO_GENERATED_IDS,
+                EngineConfig.INDEX_USE_COMPOUND_FILE,
                 IndexMetadata.SETTING_WAIT_FOR_ACTIVE_SHARDS,
                 IndexSettings.DEFAULT_PIPELINE,
                 IndexSettings.FINAL_PIPELINE,

--- a/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
+++ b/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
@@ -159,6 +159,8 @@ public final class EngineConfig {
         }
     }, Property.IndexScope, Property.NodeScope);
 
+
+
     /**
      * Index setting to change the compression level of zstd and zstd_no_dict lucene codecs.
      * Compression Level gives a trade-off between compression ratio and speed. The higher compression level results in higher compression ratio but slower compression and decompression speeds.
@@ -231,6 +233,13 @@ public final class EngineConfig {
      */
     public static final Setting<Boolean> INDEX_OPTIMIZE_AUTO_GENERATED_IDS = Setting.boolSetting(
         "index.optimize_auto_generated_id",
+        true,
+        Property.IndexScope,
+        Property.Dynamic
+    );
+
+    public static final Setting<Boolean> INDEX_USE_COMPOUND_FILE = Setting.boolSetting(
+        "index.use_compound_file",
         true,
         Property.IndexScope,
         Property.Dynamic
@@ -492,6 +501,10 @@ public final class EngineConfig {
      */
     public boolean isReadOnlyReplica() {
         return indexSettings.isSegRepEnabledOrRemoteNode() && isReadOnlyReplica;
+    }
+
+    public boolean isUseCompoundFile() {
+        return indexSettings.getValue(INDEX_USE_COMPOUND_FILE);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
+++ b/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
@@ -159,8 +159,6 @@ public final class EngineConfig {
         }
     }, Property.IndexScope, Property.NodeScope);
 
-
-
     /**
      * Index setting to change the compression level of zstd and zstd_no_dict lucene codecs.
      * Compression Level gives a trade-off between compression ratio and speed. The higher compression level results in higher compression ratio but slower compression and decompression speeds.
@@ -241,8 +239,7 @@ public final class EngineConfig {
     public static final Setting<Boolean> INDEX_USE_COMPOUND_FILE = Setting.boolSetting(
         "index.use_compound_file",
         true,
-        Property.IndexScope,
-        Property.Dynamic
+        Property.IndexScope
     );
 
     private final TranslogConfig translogConfig;
@@ -503,7 +500,7 @@ public final class EngineConfig {
         return indexSettings.isSegRepEnabledOrRemoteNode() && isReadOnlyReplica;
     }
 
-    public boolean isUseCompoundFile() {
+    public boolean useCompoundFile() {
         return indexSettings.getValue(INDEX_USE_COMPOUND_FILE);
     }
 

--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -2341,7 +2341,7 @@ public class InternalEngine extends Engine {
         iwc.setSimilarity(engineConfig.getSimilarity());
         iwc.setRAMBufferSizeMB(engineConfig.getIndexingBufferSize().getMbFrac());
         iwc.setCodec(engineConfig.getCodec());
-        iwc.setUseCompoundFile(true); // always use compound on flush - reduces # of file-handles on refresh
+        iwc.setUseCompoundFile(engineConfig.isUseCompoundFile());
         if (config().getIndexSort() != null) {
             iwc.setIndexSort(config().getIndexSort());
         }

--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -2341,7 +2341,7 @@ public class InternalEngine extends Engine {
         iwc.setSimilarity(engineConfig.getSimilarity());
         iwc.setRAMBufferSizeMB(engineConfig.getIndexingBufferSize().getMbFrac());
         iwc.setCodec(engineConfig.getCodec());
-        iwc.setUseCompoundFile(engineConfig.isUseCompoundFile());
+        iwc.setUseCompoundFile(engineConfig.useCompoundFile());
         if (config().getIndexSort() != null) {
             iwc.setIndexSort(config().getIndexSort());
         }

--- a/server/src/test/java/org/opensearch/index/engine/EngineConfigTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/EngineConfigTests.java
@@ -36,7 +36,7 @@ public class EngineConfigTests extends OpenSearchTestCase {
         EngineConfig config = new EngineConfig.Builder().indexSettings(defaultIndexSettings)
             .retentionLeasesSupplier(() -> RetentionLeases.EMPTY)
             .build();
-        assertTrue(config.isUseCompoundFile());
+        assertTrue(config.useCompoundFile());
     }
 
     public void testEngineConfig_DefaultValueForReadOnlyEngine() {

--- a/server/src/test/java/org/opensearch/index/engine/EngineConfigTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/EngineConfigTests.java
@@ -32,6 +32,13 @@ public class EngineConfigTests extends OpenSearchTestCase {
         defaultIndexSettings = IndexSettingsModule.newIndexSettings("test", defaultIndexMetadata.getSettings());
     }
 
+    public void testEngineConfig_DefaultValueFoUseCompoundFile() {
+        EngineConfig config = new EngineConfig.Builder().indexSettings(defaultIndexSettings)
+            .retentionLeasesSupplier(() -> RetentionLeases.EMPTY)
+            .build();
+        assertTrue(config.isUseCompoundFile());
+    }
+
     public void testEngineConfig_DefaultValueForReadOnlyEngine() {
         EngineConfig config = new EngineConfig.Builder().indexSettings(defaultIndexSettings)
             .retentionLeasesSupplier(() -> RetentionLeases.EMPTY)

--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -349,7 +349,7 @@ public class InternalEngineTests extends EngineTestCase {
             engine.index(index);
             engine.flush();
             final List<Segment> segments = engine.segments(false);
-            assertThat(segments.size(), equalTo(1));
+            assertThat(segments, hasSize(1));
             assertTrue(segments.get(0).compound);
             boolean cfeCompoundFileFound = false;
             boolean cfsCompoundFileFound = false;
@@ -369,10 +369,7 @@ public class InternalEngineTests extends EngineTestCase {
     public void testSegmentsWithUseCompoundFileFlag_false() throws IOException {
         final IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(
             "test",
-            Settings.builder()
-                .put(defaultSettings.getSettings())
-                .put(EngineConfig.INDEX_USE_COMPOUND_FILE.getKey(), false)
-                .build()
+            Settings.builder().put(defaultSettings.getSettings()).put(EngineConfig.INDEX_USE_COMPOUND_FILE.getKey(), false).build()
         );
         try (Store store = createStore(); Engine engine = createEngine(indexSettings, store, createTempDir(), new TieredMergePolicy())) {
             ParsedDocument doc = testParsedDocument("1", null, testDocument(), B_1, null);
@@ -380,7 +377,7 @@ public class InternalEngineTests extends EngineTestCase {
             engine.index(index);
             engine.flush();
             final List<Segment> segments = engine.segments(false);
-            assertThat(segments.size(), equalTo(1));
+            assertThat(segments, hasSize(1));
             assertFalse(segments.get(0).compound);
             boolean cfeCompoundFileFound = false;
             boolean cfsCompoundFileFound = false;


### PR DESCRIPTION
### Description
Add `useCompoundFile` setting for the engine

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/13448

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
