### PR TITLE
Refactor implementations of query phase searcher, add empty QueryCollectorContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [BWC and API enforcement] Reconsider the breaking changes check policy to detect breaking changes against released versions ([#13292](https://github.com/opensearch-project/OpenSearch/pull/13292))
 - Switch to macos-13 runner for precommit and assemble github actions due to macos-latest is now arm64 ([#13412](https://github.com/opensearch-project/OpenSearch/pull/13412))
 - [Revert] Prevent unnecessary fetch sub phase processor initialization during fetch phase execution ([#12503](https://github.com/opensearch-project/OpenSearch/pull/12503))
+- Refactor implementations of query phase searcher, allow QueryCollectorContext to have zero collectors ([#13481](https://github.com/opensearch-project/OpenSearch/pull/13481))
 
 ### Deprecated
 

--- a/server/src/main/java/org/opensearch/search/query/ConcurrentQueryPhaseSearcher.java
+++ b/server/src/main/java/org/opensearch/search/query/ConcurrentQueryPhaseSearcher.java
@@ -84,10 +84,8 @@ public class ConcurrentQueryPhaseSearcher extends DefaultQueryPhaseSearcher {
         boolean hasFilterCollector,
         boolean timeoutSet
     ) throws IOException {
-        if (Objects.nonNull(queryCollectorContext)) {
-            // add the passed collector, the first collector context in the chain
-            collectorContexts.addFirst(queryCollectorContext);
-        }
+        // add the passed collector, the first collector context in the chain
+        collectorContexts.addFirst(Objects.requireNonNull(queryCollectorContext));
 
         final QuerySearchResult queryResult = searchContext.queryResult();
         final CollectorManager<?, ReduceableSearchResult> collectorManager;

--- a/server/src/main/java/org/opensearch/search/query/ConcurrentQueryPhaseSearcher.java
+++ b/server/src/main/java/org/opensearch/search/query/ConcurrentQueryPhaseSearcher.java
@@ -52,16 +52,7 @@ public class ConcurrentQueryPhaseSearcher extends DefaultQueryPhaseSearcher {
     ) throws IOException {
         // create the top docs collector
         final TopDocsCollectorContext topDocsFactory = createTopDocsCollectorContext(searchContext, hasFilterCollector);
-        return searchWithCollector(
-            searchContext,
-            searcher,
-            query,
-            collectors,
-            topDocsFactory,
-            hasFilterCollector,
-            hasTimeout,
-            topDocsFactory.shouldRescore()
-        );
+        return searchWithCollector(searchContext, searcher, query, collectors, topDocsFactory, hasFilterCollector, hasTimeout);
     }
 
     protected boolean searchWithCollector(
@@ -71,8 +62,7 @@ public class ConcurrentQueryPhaseSearcher extends DefaultQueryPhaseSearcher {
         LinkedList<QueryCollectorContext> collectors,
         QueryCollectorContext queryCollectorContext,
         boolean hasFilterCollector,
-        boolean hasTimeout,
-        boolean shouldRescore
+        boolean hasTimeout
     ) throws IOException {
         return searchWithCollectorManager(
             searchContext,
@@ -81,8 +71,7 @@ public class ConcurrentQueryPhaseSearcher extends DefaultQueryPhaseSearcher {
             collectors,
             queryCollectorContext,
             hasFilterCollector,
-            hasTimeout,
-            shouldRescore
+            hasTimeout
         );
     }
 
@@ -93,8 +82,7 @@ public class ConcurrentQueryPhaseSearcher extends DefaultQueryPhaseSearcher {
         LinkedList<QueryCollectorContext> collectorContexts,
         QueryCollectorContext queryCollectorContext,
         boolean hasFilterCollector,
-        boolean timeoutSet,
-        boolean shouldRescore
+        boolean timeoutSet
     ) throws IOException {
         if (Objects.nonNull(queryCollectorContext)) {
             // add the passed collector, the first collector context in the chain
@@ -131,7 +119,10 @@ public class ConcurrentQueryPhaseSearcher extends DefaultQueryPhaseSearcher {
             queryResult.terminatedEarly(false);
         }
 
-        return shouldRescore;
+        if (queryCollectorContext instanceof RescoringQueryCollectorContext) {
+            return ((RescoringQueryCollectorContext) queryCollectorContext).shouldRescore();
+        }
+        return false;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/query/ConcurrentQueryPhaseSearcher.java
+++ b/server/src/main/java/org/opensearch/search/query/ConcurrentQueryPhaseSearcher.java
@@ -23,6 +23,7 @@ import org.opensearch.search.query.QueryPhase.DefaultQueryPhaseSearcher;
 
 import java.io.IOException;
 import java.util.LinkedList;
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 
 import static org.opensearch.search.query.TopDocsCollectorContext.createTopDocsCollectorContext;
@@ -49,7 +50,40 @@ public class ConcurrentQueryPhaseSearcher extends DefaultQueryPhaseSearcher {
         boolean hasFilterCollector,
         boolean hasTimeout
     ) throws IOException {
-        return searchWithCollectorManager(searchContext, searcher, query, collectors, hasFilterCollector, hasTimeout);
+        // create the top docs collector
+        final TopDocsCollectorContext topDocsFactory = createTopDocsCollectorContext(searchContext, hasFilterCollector);
+        return searchWithCollector(
+            searchContext,
+            searcher,
+            query,
+            collectors,
+            topDocsFactory,
+            hasFilterCollector,
+            hasTimeout,
+            topDocsFactory.shouldRescore()
+        );
+    }
+
+    protected boolean searchWithCollector(
+        SearchContext searchContext,
+        ContextIndexSearcher searcher,
+        Query query,
+        LinkedList<QueryCollectorContext> collectors,
+        QueryCollectorContext queryCollectorContext,
+        boolean hasFilterCollector,
+        boolean hasTimeout,
+        boolean shouldRescore
+    ) throws IOException {
+        return searchWithCollectorManager(
+            searchContext,
+            searcher,
+            query,
+            collectors,
+            queryCollectorContext,
+            hasFilterCollector,
+            hasTimeout,
+            shouldRescore
+        );
     }
 
     private static boolean searchWithCollectorManager(
@@ -57,13 +91,15 @@ public class ConcurrentQueryPhaseSearcher extends DefaultQueryPhaseSearcher {
         ContextIndexSearcher searcher,
         Query query,
         LinkedList<QueryCollectorContext> collectorContexts,
+        QueryCollectorContext queryCollectorContext,
         boolean hasFilterCollector,
-        boolean timeoutSet
+        boolean timeoutSet,
+        boolean shouldRescore
     ) throws IOException {
-        // create the top docs collector last when the other collectors are known
-        final TopDocsCollectorContext topDocsFactory = createTopDocsCollectorContext(searchContext, hasFilterCollector);
-        // add the top docs collector, the first collector context in the chain
-        collectorContexts.addFirst(topDocsFactory);
+        if (Objects.nonNull(queryCollectorContext)) {
+            // add the passed collector, the first collector context in the chain
+            collectorContexts.addFirst(queryCollectorContext);
+        }
 
         final QuerySearchResult queryResult = searchContext.queryResult();
         final CollectorManager<?, ReduceableSearchResult> collectorManager;
@@ -95,7 +131,7 @@ public class ConcurrentQueryPhaseSearcher extends DefaultQueryPhaseSearcher {
             queryResult.terminatedEarly(false);
         }
 
-        return topDocsFactory.shouldRescore();
+        return shouldRescore;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/query/ConcurrentQueryPhaseSearcher.java
+++ b/server/src/main/java/org/opensearch/search/query/ConcurrentQueryPhaseSearcher.java
@@ -55,6 +55,7 @@ public class ConcurrentQueryPhaseSearcher extends DefaultQueryPhaseSearcher {
         return searchWithCollector(searchContext, searcher, query, collectors, topDocsFactory, hasFilterCollector, hasTimeout);
     }
 
+    @Override
     protected boolean searchWithCollector(
         SearchContext searchContext,
         ContextIndexSearcher searcher,

--- a/server/src/main/java/org/opensearch/search/query/ConcurrentQueryPhaseSearcher.java
+++ b/server/src/main/java/org/opensearch/search/query/ConcurrentQueryPhaseSearcher.java
@@ -26,8 +26,6 @@ import java.util.LinkedList;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 
-import static org.opensearch.search.query.TopDocsCollectorContext.createTopDocsCollectorContext;
-
 /**
  * The implementation of the {@link QueryPhaseSearcher} which attempts to use concurrent
  * search of Apache Lucene segments if it has been enabled.
@@ -40,20 +38,6 @@ public class ConcurrentQueryPhaseSearcher extends DefaultQueryPhaseSearcher {
      * Default constructor
      */
     public ConcurrentQueryPhaseSearcher() {}
-
-    @Override
-    protected boolean searchWithCollector(
-        SearchContext searchContext,
-        ContextIndexSearcher searcher,
-        Query query,
-        LinkedList<QueryCollectorContext> collectors,
-        boolean hasFilterCollector,
-        boolean hasTimeout
-    ) throws IOException {
-        // create the top docs collector
-        final TopDocsCollectorContext topDocsFactory = createTopDocsCollectorContext(searchContext, hasFilterCollector);
-        return searchWithCollector(searchContext, searcher, query, collectors, topDocsFactory, hasFilterCollector, hasTimeout);
-    }
 
     @Override
     protected boolean searchWithCollector(

--- a/server/src/main/java/org/opensearch/search/query/QueryCollectorContext.java
+++ b/server/src/main/java/org/opensearch/search/query/QueryCollectorContext.java
@@ -54,7 +54,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 import static org.opensearch.search.profile.query.CollectorResult.REASON_SEARCH_MIN_SCORE;
 import static org.opensearch.search.profile.query.CollectorResult.REASON_SEARCH_MULTI;
@@ -75,6 +74,29 @@ public abstract class QueryCollectorContext {
         @Override
         public ScoreMode scoreMode() {
             return ScoreMode.COMPLETE_NO_SCORES;
+        }
+    };
+
+    public static final QueryCollectorContext EMPTY_CONTEXT = new QueryCollectorContext("empty") {
+
+        @Override
+        Collector create(Collector in) throws IOException {
+            return EMPTY_COLLECTOR;
+        }
+
+        @Override
+        CollectorManager<?, ReduceableSearchResult> createManager(CollectorManager<?, ReduceableSearchResult> in) throws IOException {
+            return new CollectorManager<Collector, ReduceableSearchResult>() {
+                @Override
+                public Collector newCollector() throws IOException {
+                    return EMPTY_COLLECTOR;
+                }
+
+                @Override
+                public ReduceableSearchResult reduce(Collection<Collector> collectors) throws IOException {
+                    return result -> {};
+                }
+            };
         }
     };
 
@@ -249,9 +271,7 @@ public abstract class QueryCollectorContext {
                 CollectorManager<? extends Collector, ReduceableSearchResult> in
             ) throws IOException {
                 final List<CollectorManager<?, ReduceableSearchResult>> managers = new ArrayList<>();
-                if (Objects.nonNull(in)) {
-                    managers.add(in);
-                }
+                managers.add(in);
                 managers.addAll(subs);
                 return QueryCollectorManagerContext.createMultiCollectorManager(managers);
             }

--- a/server/src/main/java/org/opensearch/search/query/QueryCollectorContext.java
+++ b/server/src/main/java/org/opensearch/search/query/QueryCollectorContext.java
@@ -54,6 +54,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import static org.opensearch.search.profile.query.CollectorResult.REASON_SEARCH_MIN_SCORE;
 import static org.opensearch.search.profile.query.CollectorResult.REASON_SEARCH_MULTI;
@@ -248,7 +249,9 @@ public abstract class QueryCollectorContext {
                 CollectorManager<? extends Collector, ReduceableSearchResult> in
             ) throws IOException {
                 final List<CollectorManager<?, ReduceableSearchResult>> managers = new ArrayList<>();
-                managers.add(in);
+                if (Objects.nonNull(in)) {
+                    managers.add(in);
+                }
                 managers.addAll(subs);
                 return QueryCollectorManagerContext.createMultiCollectorManager(managers);
             }

--- a/server/src/main/java/org/opensearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/opensearch/search/query/QueryPhase.java
@@ -340,7 +340,7 @@ public class QueryPhase {
         boolean timeoutSet
     ) throws IOException {
         // add passed collector, the first collector context in the chain
-        collectors.addFirst(queryCollectorContext);
+        collectors.addFirst(Objects.requireNonNull(queryCollectorContext));
 
         final Collector queryCollector;
         if (searchContext.getProfilers() != null) {

--- a/server/src/main/java/org/opensearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/opensearch/search/query/QueryPhase.java
@@ -337,13 +337,10 @@ public class QueryPhase {
         LinkedList<QueryCollectorContext> collectors,
         QueryCollectorContext queryCollectorContext,
         boolean hasFilterCollector,
-        boolean timeoutSet,
-        boolean shouldRescore
+        boolean timeoutSet
     ) throws IOException {
-        if (Objects.nonNull(queryCollectorContext)) {
-            // add passed collector, the first collector context in the chain
-            collectors.addFirst(queryCollectorContext);
-        }
+        // add passed collector, the first collector context in the chain
+        collectors.addFirst(queryCollectorContext);
 
         final Collector queryCollector;
         if (searchContext.getProfilers() != null) {
@@ -372,7 +369,10 @@ public class QueryPhase {
         for (QueryCollectorContext ctx : collectors) {
             ctx.postProcess(queryResult);
         }
-        return shouldRescore;
+        if (queryCollectorContext instanceof RescoringQueryCollectorContext) {
+            return ((RescoringQueryCollectorContext) queryCollectorContext).shouldRescore();
+        }
+        return false;
     }
 
     /**
@@ -444,16 +444,7 @@ public class QueryPhase {
         ) throws IOException {
             // create the top docs collector last when the other collectors are known
             final TopDocsCollectorContext topDocsFactory = createTopDocsCollectorContext(searchContext, hasFilterCollector);
-            return searchWithCollector(
-                searchContext,
-                searcher,
-                query,
-                collectors,
-                topDocsFactory,
-                hasFilterCollector,
-                hasTimeout,
-                topDocsFactory.shouldRescore()
-            );
+            return searchWithCollector(searchContext, searcher, query, collectors, topDocsFactory, hasFilterCollector, hasTimeout);
         }
 
         protected boolean searchWithCollector(
@@ -463,8 +454,7 @@ public class QueryPhase {
             LinkedList<QueryCollectorContext> collectors,
             QueryCollectorContext queryCollectorContext,
             boolean hasFilterCollector,
-            boolean hasTimeout,
-            boolean shouldRescore
+            boolean hasTimeout
         ) throws IOException {
             return QueryPhase.searchWithCollector(
                 searchContext,
@@ -473,8 +463,7 @@ public class QueryPhase {
                 collectors,
                 queryCollectorContext,
                 hasFilterCollector,
-                hasTimeout,
-                shouldRescore
+                hasTimeout
             );
         }
     }

--- a/server/src/main/java/org/opensearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/opensearch/search/query/QueryPhase.java
@@ -335,13 +335,15 @@ public class QueryPhase {
         ContextIndexSearcher searcher,
         Query query,
         LinkedList<QueryCollectorContext> collectors,
+        QueryCollectorContext queryCollectorContext,
         boolean hasFilterCollector,
-        boolean timeoutSet
+        boolean timeoutSet,
+        boolean shouldRescore
     ) throws IOException {
-        // create the top docs collector last when the other collectors are known
-        final TopDocsCollectorContext topDocsFactory = createTopDocsCollectorContext(searchContext, hasFilterCollector);
-        // add the top docs collector, the first collector context in the chain
-        collectors.addFirst(topDocsFactory);
+        if (Objects.nonNull(queryCollectorContext)) {
+            // add passed collector, the first collector context in the chain
+            collectors.addFirst(queryCollectorContext);
+        }
 
         final Collector queryCollector;
         if (searchContext.getProfilers() != null) {
@@ -370,7 +372,7 @@ public class QueryPhase {
         for (QueryCollectorContext ctx : collectors) {
             ctx.postProcess(queryResult);
         }
-        return topDocsFactory.shouldRescore();
+        return shouldRescore;
     }
 
     /**
@@ -440,7 +442,40 @@ public class QueryPhase {
             boolean hasFilterCollector,
             boolean hasTimeout
         ) throws IOException {
-            return QueryPhase.searchWithCollector(searchContext, searcher, query, collectors, hasFilterCollector, hasTimeout);
+            // create the top docs collector last when the other collectors are known
+            final TopDocsCollectorContext topDocsFactory = createTopDocsCollectorContext(searchContext, hasFilterCollector);
+            return searchWithCollector(
+                searchContext,
+                searcher,
+                query,
+                collectors,
+                topDocsFactory,
+                hasFilterCollector,
+                hasTimeout,
+                topDocsFactory.shouldRescore()
+            );
+        }
+
+        protected boolean searchWithCollector(
+            SearchContext searchContext,
+            ContextIndexSearcher searcher,
+            Query query,
+            LinkedList<QueryCollectorContext> collectors,
+            QueryCollectorContext queryCollectorContext,
+            boolean hasFilterCollector,
+            boolean hasTimeout,
+            boolean shouldRescore
+        ) throws IOException {
+            return QueryPhase.searchWithCollector(
+                searchContext,
+                searcher,
+                query,
+                collectors,
+                queryCollectorContext,
+                hasFilterCollector,
+                hasTimeout,
+                shouldRescore
+            );
         }
     }
 }

--- a/server/src/main/java/org/opensearch/search/query/RescoringQueryCollectorContext.java
+++ b/server/src/main/java/org/opensearch/search/query/RescoringQueryCollectorContext.java
@@ -1,0 +1,27 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.query;
+
+import org.opensearch.common.annotation.PublicApi;
+
+/**
+ * Abstraction that allows indication of whether results should be rescored or not based on
+ * custom logic of exact {@link QueryCollectorContext} implementation.
+ *
+ * @opensearch.api
+ */
+@PublicApi(since = "2.15.0")
+public interface RescoringQueryCollectorContext {
+
+    /**
+     * Indicates if results from the query context should be rescored
+     * @return true if results must be rescored, false otherwise
+     */
+    boolean shouldRescore();
+}

--- a/server/src/main/java/org/opensearch/search/query/TopDocsCollectorContext.java
+++ b/server/src/main/java/org/opensearch/search/query/TopDocsCollectorContext.java
@@ -95,7 +95,7 @@ import static org.opensearch.search.profile.query.CollectorResult.REASON_SEARCH_
  *
  * @opensearch.internal
  */
-public abstract class TopDocsCollectorContext extends QueryCollectorContext {
+public abstract class TopDocsCollectorContext extends QueryCollectorContext implements RescoringQueryCollectorContext {
     protected final int numHits;
 
     TopDocsCollectorContext(String profilerName, int numHits) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Current implementations of query phase searcher (default and concurrent) alway adds `TopDocsCollector` collector to the collector context. In some scenario it's not the preferred behavior, for instance if in a plugin we're adding custom collector that collects doc scores in a different fashion. With current implementation there will be two collectors in the context, this will create a performance overhead. 

With this change we're not changing core functionality or implementation of query phase searcher. Instead we're adding overloaded `searchWith` method that child query phase search can override and pass empty `QueryPhaseSearcher`.


### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/13170

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [X] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
