### PR TITLE
Check changed files before running gradle check

### DIFF
--- a/.github/workflows/gradle-check.yml
+++ b/.github/workflows/gradle-check.yml
@@ -32,9 +32,20 @@ jobs:
         uses: tj-actions/changed-files@v44
         with:
           files_ignore: |
-            release-notes/**
+            release-notes/*.md
             .github/**
-            **.md
+            ADMINS.md
+            CHANGELOG-3.0.md
+            CHANGELOG.md
+            CODE_OF_CONDUCT.md
+            CONTRIBUTING.md
+            DEVELOPER_GUIDE.md
+            MAINTAINERS.md
+            README.md
+            RELEASING.md
+            SECURITY.md
+            TESTING.md
+            TRIAGING.md
 
       - name: Setup environment variables (PR)
         if: github.event_name == 'pull_request_target' && steps.changed-files-specific.outputs.any_changed == 'true'

--- a/.github/workflows/gradle-check.yml
+++ b/.github/workflows/gradle-check.yml
@@ -12,8 +12,25 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
-  gradle-check:
+  check-files:
     if: github.repository == 'opensearch-project/OpenSearch'
+    runs-on: ubuntu-latest
+    outputs: 
+      RUN_GRADLE_CHECK: ${{steps.changed-files-specific.outputs.any_changed}}
+    steps: 
+      - uses: actions/checkout@v3
+      - name: Get changed files in the docs folder
+        id: changed-files-specific
+        uses: tj-actions/changed-files@v44
+        with:
+          files_ignore: |
+            release-notes/**
+            .github/**
+            **.md
+    
+  gradle-check:
+    needs: check-files
+    if: github.repository == 'opensearch-project/OpenSearch' && needs.check-files.outputs.RUN_GRADLE_CHECK
     permissions:
       contents: read # to fetch code (actions/checkout)
       pull-requests: write # to create or update comment (peter-evans/create-or-update-comment)

--- a/.github/workflows/gradle-check.yml
+++ b/.github/workflows/gradle-check.yml
@@ -12,30 +12,13 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
-  check-files:
-    if: github.repository == 'opensearch-project/OpenSearch'
-    runs-on: ubuntu-latest
-    outputs: 
-      RUN_GRADLE_CHECK: ${{steps.changed-files-specific.outputs.any_changed}}
-    steps: 
-      - uses: actions/checkout@v3
-      - name: Get changed files in the docs folder
-        id: changed-files-specific
-        uses: tj-actions/changed-files@v44
-        with:
-          files_ignore: |
-            release-notes/**
-            .github/**
-            **.md
     
   gradle-check:
-    needs: check-files
-    if: github.repository == 'opensearch-project/OpenSearch' && needs.check-files.outputs.RUN_GRADLE_CHECK
+    if: github.repository == 'opensearch-project/OpenSearch'
     permissions:
       contents: read # to fetch code (actions/checkout)
       pull-requests: write # to create or update comment (peter-evans/create-or-update-comment)
       issues: write # To create an issue if check fails on push.
-
     runs-on: ubuntu-latest
     timeout-minutes: 130
     steps:
@@ -44,8 +27,17 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Get changed files
+        id: changed-files-specific
+        uses: tj-actions/changed-files@v44
+        with:
+          files_ignore: |
+            release-notes/**
+            .github/**
+            **.md
+
       - name: Setup environment variables (PR)
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request_target' && steps.changed-files-specific.outputs.any_changed == 'true'
         run: |
           echo "event_name=pull_request_target" >> $GITHUB_ENV
           echo "branch_name=$(jq --raw-output .pull_request.base.ref $GITHUB_EVENT_PATH)" >> $GITHUB_ENV
@@ -74,7 +66,7 @@ jobs:
             ).data[0];
 
       - name: Setup environment variables (Push)
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && steps.changed-files-specific.outputs.any_changed == 'true'
         run: |
           repo_url="https://github.com/opensearch-project/OpenSearch"
           ref_id=$(git rev-parse HEAD)
@@ -91,6 +83,7 @@ jobs:
           echo "post_merge_action=true" >> $GITHUB_ENV
 
       - name: Checkout opensearch-build repo
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
         uses: actions/checkout@v4
         with:
           repository: opensearch-project/opensearch-build
@@ -98,13 +91,14 @@ jobs:
           path: opensearch-build
 
       - name: Trigger jenkins workflow to run gradle check
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
         run: |
           set -e
           set -o pipefail
           bash opensearch-build/scripts/gradle/gradle-check.sh ${{ secrets.JENKINS_GRADLE_CHECK_GENERIC_WEBHOOK_TOKEN }} | tee -a gradle-check.log
 
       - name: Setup Result Status
-        if: always()
+        if: always() && steps.changed-files-specific.outputs.any_changed == 'true'
         run: |
           WORKFLOW_URL=`cat gradle-check.log | grep 'WORKFLOW_URL' | awk '{print $2}'`
           RESULT=`cat gradle-check.log | grep 'Result:' | awk '{print $2}'`
@@ -112,13 +106,13 @@ jobs:
           echo "result=$RESULT" >> $GITHUB_ENV
 
       - name: Upload Coverage Report
-        if: success()
+        if: success() && steps.changed-files-specific.outputs.any_changed == 'true'
         uses: codecov/codecov-action@v4
         with:
           files: ./codeCoverage.xml
 
       - name: Create Comment Success
-        if: ${{ github.event_name == 'pull_request_target' && success() && env.result == 'SUCCESS' }}
+        if: ${{ github.event_name == 'pull_request_target' && success() && env.result == 'SUCCESS' && steps.changed-files-specific.outputs.any_changed == 'true' }}
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ env.pr_number }}
@@ -126,7 +120,7 @@ jobs:
             :white_check_mark: Gradle check result for ${{ env.pr_from_sha }}: [${{ env.result }}](${{ env.workflow_url }})
 
       - name: Extract Test Failure
-        if: ${{ github.event_name == 'pull_request_target' && env.result != 'SUCCESS' }}
+        if: ${{ github.event_name == 'pull_request_target' && env.result != 'SUCCESS' }} && steps.changed-files-specific.outputs.any_changed == 'true'
         run: |
           TEST_FAILURES=`curl -s "${{ env.workflow_url }}/testReport/api/json?tree=suites\[cases\[status,className,name\]\]" | jq -r '.. | objects | select(.status=="FAILED",.status=="REGRESSION") | (.className + "." +  .name)' | uniq -c | sort -n -r | head -n 10`
           if [[ "$TEST_FAILURES" != "" ]]
@@ -141,7 +135,7 @@ jobs:
           fi
 
       - name: Create Comment Flaky
-        if: ${{ github.event_name == 'pull_request_target' && success() && env.result != 'SUCCESS' }}
+        if: ${{ github.event_name == 'pull_request_target' && success() && env.result != 'SUCCESS' && steps.changed-files-specific.outputs.any_changed == 'true' }}
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ env.pr_number }}
@@ -151,7 +145,7 @@ jobs:
             Please review all [flaky tests](https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md#flaky-tests) that succeeded after retry and create an issue if one does not already exist to track the flaky failure.
 
       - name: Create Comment Failure
-        if: ${{ github.event_name == 'pull_request_target' && failure() }}
+        if: ${{ github.event_name == 'pull_request_target' && failure() && steps.changed-files-specific.outputs.any_changed == 'true' }}
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ env.pr_number }}
@@ -161,7 +155,7 @@ jobs:
             Please examine the workflow log, locate, and copy-paste the failure(s) below, then iterate to green. Is the failure [a flaky test](https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md#flaky-tests) unrelated to your change?
 
       - name: Create Issue On Push Failure
-        if: ${{ github.event_name == 'push' && failure() }}
+        if: ${{ github.event_name == 'push' && failure() && steps.changed-files-specific.outputs.any_changed == 'true' }}
         uses: dblock/create-a-github-issue@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gradle-check.yml
+++ b/.github/workflows/gradle-check.yml
@@ -131,7 +131,7 @@ jobs:
             :white_check_mark: Gradle check result for ${{ env.pr_from_sha }}: [${{ env.result }}](${{ env.workflow_url }})
 
       - name: Extract Test Failure
-        if: ${{ github.event_name == 'pull_request_target' && env.result != 'SUCCESS' }} && steps.changed-files-specific.outputs.any_changed == 'true'
+        if: ${{ github.event_name == 'pull_request_target' && env.result != 'SUCCESS' && steps.changed-files-specific.outputs.any_changed == 'true' }}
         run: |
           TEST_FAILURES=`curl -s "${{ env.workflow_url }}/testReport/api/json?tree=suites\[cases\[status,className,name\]\]" | jq -r '.. | objects | select(.status=="FAILED",.status=="REGRESSION") | (.className + "." +  .name)' | uniq -c | sort -n -r | head -n 10`
           if [[ "$TEST_FAILURES" != "" ]]

--- a/.github/workflows/gradle-check.yml
+++ b/.github/workflows/gradle-check.yml
@@ -12,9 +12,24 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
+  check-files:
+    runs-on: ubuntu-latest
+    outputs: 
+      RUN_GRADLE_CHECK: ${{ steps.changed-files-specific.outputs.any_changed }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Get changed files
+      id: changed-files-specific
+      uses: tj-actions/changed-files@v44
+      with:
+        files_ignore: |
+          release-notes/*.md
+          .github/**
+          *.md
     
   gradle-check:
-    if: github.repository == 'opensearch-project/OpenSearch'
+    needs: check-files
+    if: github.repository == 'opensearch-project/OpenSearch' && needs.check-files.outputs.RUN_GRADLE_CHECK == 'true'
     permissions:
       contents: read # to fetch code (actions/checkout)
       pull-requests: write # to create or update comment (peter-evans/create-or-update-comment)
@@ -48,7 +63,7 @@ jobs:
             TRIAGING.md
 
       - name: Setup environment variables (PR)
-        if: github.event_name == 'pull_request_target' && steps.changed-files-specific.outputs.any_changed == 'true'
+        if: github.event_name == 'pull_request_target'
         run: |
           echo "event_name=pull_request_target" >> $GITHUB_ENV
           echo "branch_name=$(jq --raw-output .pull_request.base.ref $GITHUB_EVENT_PATH)" >> $GITHUB_ENV
@@ -77,7 +92,7 @@ jobs:
             ).data[0];
 
       - name: Setup environment variables (Push)
-        if: github.event_name == 'push' && steps.changed-files-specific.outputs.any_changed == 'true'
+        if: github.event_name == 'push'
         run: |
           repo_url="https://github.com/opensearch-project/OpenSearch"
           ref_id=$(git rev-parse HEAD)
@@ -94,7 +109,6 @@ jobs:
           echo "post_merge_action=true" >> $GITHUB_ENV
 
       - name: Checkout opensearch-build repo
-        if: steps.changed-files-specific.outputs.any_changed == 'true'
         uses: actions/checkout@v4
         with:
           repository: opensearch-project/opensearch-build
@@ -102,14 +116,13 @@ jobs:
           path: opensearch-build
 
       - name: Trigger jenkins workflow to run gradle check
-        if: steps.changed-files-specific.outputs.any_changed == 'true'
         run: |
           set -e
           set -o pipefail
           bash opensearch-build/scripts/gradle/gradle-check.sh ${{ secrets.JENKINS_GRADLE_CHECK_GENERIC_WEBHOOK_TOKEN }} | tee -a gradle-check.log
 
       - name: Setup Result Status
-        if: always() && steps.changed-files-specific.outputs.any_changed == 'true'
+        if: always()
         run: |
           WORKFLOW_URL=`cat gradle-check.log | grep 'WORKFLOW_URL' | awk '{print $2}'`
           RESULT=`cat gradle-check.log | grep 'Result:' | awk '{print $2}'`
@@ -117,13 +130,13 @@ jobs:
           echo "result=$RESULT" >> $GITHUB_ENV
 
       - name: Upload Coverage Report
-        if: success() && steps.changed-files-specific.outputs.any_changed == 'true'
+        if: success()
         uses: codecov/codecov-action@v4
         with:
           files: ./codeCoverage.xml
 
       - name: Create Comment Success
-        if: ${{ github.event_name == 'pull_request_target' && success() && env.result == 'SUCCESS' && steps.changed-files-specific.outputs.any_changed == 'true' }}
+        if: ${{ github.event_name == 'pull_request_target' && success() && env.result == 'SUCCESS' }}
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ env.pr_number }}
@@ -131,7 +144,7 @@ jobs:
             :white_check_mark: Gradle check result for ${{ env.pr_from_sha }}: [${{ env.result }}](${{ env.workflow_url }})
 
       - name: Extract Test Failure
-        if: ${{ github.event_name == 'pull_request_target' && env.result != 'SUCCESS' && steps.changed-files-specific.outputs.any_changed == 'true' }}
+        if: ${{ github.event_name == 'pull_request_target' && env.result != 'SUCCESS' }}
         run: |
           TEST_FAILURES=`curl -s "${{ env.workflow_url }}/testReport/api/json?tree=suites\[cases\[status,className,name\]\]" | jq -r '.. | objects | select(.status=="FAILED",.status=="REGRESSION") | (.className + "." +  .name)' | uniq -c | sort -n -r | head -n 10`
           if [[ "$TEST_FAILURES" != "" ]]
@@ -146,7 +159,7 @@ jobs:
           fi
 
       - name: Create Comment Flaky
-        if: ${{ github.event_name == 'pull_request_target' && success() && env.result != 'SUCCESS' && steps.changed-files-specific.outputs.any_changed == 'true' }}
+        if: ${{ github.event_name == 'pull_request_target' && success() && env.result != 'SUCCESS' }}
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ env.pr_number }}
@@ -156,7 +169,7 @@ jobs:
             Please review all [flaky tests](https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md#flaky-tests) that succeeded after retry and create an issue if one does not already exist to track the flaky failure.
 
       - name: Create Comment Failure
-        if: ${{ github.event_name == 'pull_request_target' && failure() && steps.changed-files-specific.outputs.any_changed == 'true' }}
+        if: ${{ github.event_name == 'pull_request_target' && failure() }}
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ env.pr_number }}
@@ -166,10 +179,19 @@ jobs:
             Please examine the workflow log, locate, and copy-paste the failure(s) below, then iterate to green. Is the failure [a flaky test](https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md#flaky-tests) unrelated to your change?
 
       - name: Create Issue On Push Failure
-        if: ${{ github.event_name == 'push' && failure() && steps.changed-files-specific.outputs.any_changed == 'true' }}
+        if: ${{ github.event_name == 'push' && failure() }}
         uses: dblock/create-a-github-issue@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           assignees: ${{ github.event.head_commit.author.username }}, ${{ github.triggering_actor }}
           filename: .github/ISSUE_TEMPLATE/failed_check.md
+
+  check-result:
+    needs: [check-files, gradle-check]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if gradle-check fails
+        if: ${{ needs.check-files.outputs.RUN_GRADLE_CHECK && needs.gradle-check.result == 'failure' }}
+        run: exit 1

--- a/.github/workflows/gradle-check.yml
+++ b/.github/workflows/gradle-check.yml
@@ -42,26 +42,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Get changed files
-        id: changed-files-specific
-        uses: tj-actions/changed-files@v44
-        with:
-          files_ignore: |
-            release-notes/*.md
-            .github/**
-            ADMINS.md
-            CHANGELOG-3.0.md
-            CHANGELOG.md
-            CODE_OF_CONDUCT.md
-            CONTRIBUTING.md
-            DEVELOPER_GUIDE.md
-            MAINTAINERS.md
-            README.md
-            RELEASING.md
-            SECURITY.md
-            TESTING.md
-            TRIAGING.md
-
       - name: Setup environment variables (PR)
         if: github.event_name == 'pull_request_target'
         run: |


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The repository requires the gradle check job status to pass before merging any PR. With `path-ignore` filter, this status check was skipped. However, GitHub does not resolve this conflict or allows to specify the requirement to be optional. See https://github.com/opensearch-project/OpenSearch/pull/13494 still waiting for gradle-check status to be set.
There are multiple discussions on GH community forums https://github.com/orgs/community/discussions/44490 and all of them requires work around as of now. This change adds one more step to gradle-check job to detect the files changed and accordingly decide whether to run the consecutive steps or not. See examples below:
1. Where gradle check runs for change in build.gradle https://github.com/gaiksaya/OpenSearch/pull/10
2. Gradle check steps are skipped for changes in md file https://github.com/gaiksaya/OpenSearch/pull/11

I set my fork requirements to mimic gradle check status as required and this satisfies both conditions


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
