### PR TITLE
Revert "Skip running gradle checks on release notes"

### DIFF
--- a/.github/workflows/gradle-check.yml
+++ b/.github/workflows/gradle-check.yml
@@ -7,10 +7,6 @@ on:
       - 'dependabot/**'
   pull_request_target:
     types: [opened, synchronize, reopened]
-    paths-ignore:
-      - 'release-notes/**'
-      - '.github/**'
-      - '**.md'
 
 permissions:
   contents: read # to fetch code (actions/checkout)


### PR DESCRIPTION
### Description
Reverts opensearch-project/OpenSearch#13477

We are seeing changes that are stalled because `gradle check` which is required by branch protections isn't being triggered, see stuck PR [1].  While we get an updated solution [2] in place, reverting this change.

- [1] https://github.com/opensearch-project/OpenSearch/pull/13494
- [2] https://github.com/opensearch-project/OpenSearch/pull/13498

### Check List
- [ ] ~New functionality includes testing.~
  - [ ] ~All tests pass~
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [X] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [ ] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~