### PR TITLE
Update Cluster Manager Node Timeout to 3mins for flaky test o.o.c.ClusterHealthIT.testHealthOnClusterManagerFailover

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/cluster/ClusterHealthIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/ClusterHealthIT.java
@@ -377,7 +377,7 @@ public class ClusterHealthIT extends OpenSearchIntegTestCase {
                     .prepareHealth()
                     .setWaitForEvents(Priority.LANGUID)
                     .setWaitForGreenStatus()
-                    .setClusterManagerNodeTimeout(TimeValue.timeValueMinutes(2))
+                    .setClusterManagerNodeTimeout(TimeValue.timeValueMinutes(3))
                     .execute()
             );
             internalCluster().restartNode(internalCluster().getClusterManagerName(), InternalTestCluster.EMPTY_CALLBACK);


### PR DESCRIPTION
### Description
Addresses fix for Flaky Test o.o.c.ClusterHealthIT.testHealthOnClusterManagerFailover which is caused in scenarios of master node not being able to bootup within 2 minutes occasionally

This change increases the time limit to 3 minutes which will reduce flakiness.
In 5k runs with previous setting of 2 minutes, saw 5 failures.
In 5k runs with new setting of 3 minutes, saw 0 failures

### Related Issues
Resolves #1828 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
