### PR TITLE
Query shape representation class structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add support for Azure Managed Identity in repository-azure ([#12423](https://github.com/opensearch-project/OpenSearch/issues/12423))
 - Add useCompoundFile index setting ([#13478](https://github.com/opensearch-project/OpenSearch/pull/13478))
 - Make outbound side of transport protocol dependent ([#13293](https://github.com/opensearch-project/OpenSearch/pull/13293))
+- Query shape class structure ([#13419](https://github.com/opensearch-project/OpenSearch/issues/13419))
 
 ### Dependencies
 - Bump `com.github.spullara.mustache.java:compiler` from 0.9.10 to 0.9.13 ([#13329](https://github.com/opensearch-project/OpenSearch/pull/13329), [#13559](https://github.com/opensearch-project/OpenSearch/pull/13559))

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/queryshape/aggregations/SumAggregationShape.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/queryshape/aggregations/SumAggregationShape.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.model.queryshape.aggregations;
+
+import org.opensearch.plugin.insights.rules.model.queryshape.misc.AggregationShape;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public class SumAggregationShape extends AggregationShape {
+    String fieldName;
+    List<? extends AggregationShape> subAggregations;
+
+    @Override
+    public int hashCode() {
+        if (subAggregations != null) {
+            Collections.sort(subAggregations);
+        }
+        return Objects.hash(fieldName, subAggregations);
+    }
+}

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/queryshape/aggregations/TermsAggregationShape.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/queryshape/aggregations/TermsAggregationShape.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.model.queryshape.aggregations;
+
+import org.opensearch.plugin.insights.rules.model.queryshape.misc.AggregationShape;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public class TermsAggregationShape extends AggregationShape {
+    String fieldName;
+    List<? extends AggregationShape> subAggregations;
+
+    @Override
+    public int hashCode() {
+        if (subAggregations != null) {
+            Collections.sort(subAggregations);
+        }
+        return Objects.hash(fieldName, subAggregations);
+    }
+}

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/queryshape/core/AggregationFullShape.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/queryshape/core/AggregationFullShape.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.model.queryshape.core;
+
+import org.opensearch.plugin.insights.rules.model.queryshape.misc.AggregationShape;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+class AggregationFullShape {
+    List<? extends AggregationShape> aggregations;
+
+    @Override
+    public int hashCode() {
+        Collections.sort(aggregations);
+        return Objects.hash(aggregations);
+    }
+}

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/queryshape/core/PipelineAggregationShape.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/queryshape/core/PipelineAggregationShape.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.model.queryshape.core;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+class PipelineAggregationShape {
+    List<String> pipelineAggregations;
+
+    @Override
+    public int hashCode() {
+        Collections.sort(pipelineAggregations);
+        return Objects.hash(pipelineAggregations);
+    }
+}

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/queryshape/core/QueryBuilderFullShape.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/queryshape/core/QueryBuilderFullShape.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.model.queryshape.core;
+
+import org.opensearch.plugin.insights.rules.model.queryshape.misc.QueryBuilderShape;
+
+import java.util.Objects;
+
+class QueryBuilderFullShape {
+    QueryBuilderShape queryBuilderShape;
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(queryBuilderShape);
+    }
+}

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/queryshape/core/QueryShape.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/queryshape/core/QueryShape.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.model.queryshape.core;
+
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.search.builder.SearchSourceBuilder;
+
+import java.util.Objects;
+
+/**
+ * Representation of a Query Shape primarily used to group Top N queries by latency and resource usage.
+ * https://github.com/opensearch-project/OpenSearch/issues/13357
+ * @opensearch.internal
+ */
+public class QueryShape {
+    private QueryBuilderFullShape queryBuilderFullShape;
+    private SortShape sortShape;
+    private AggregationFullShape aggregationFullShape;
+    private PipelineAggregationShape pipelineAggregationShape;
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(queryBuilderFullShape, sortShape, aggregationFullShape, pipelineAggregationShape);
+    }
+
+    public void parse(SearchSourceBuilder source) {
+        // Parse the QueryBuilder to QueryShape
+        // Populate QueryBuilderFullShape, SortShape, AggregationFullShape, PipelineAggregationShape
+    }
+
+    public String getStringQueryShape() {
+        // Provide the String Query Shape
+        return null;
+    }
+}

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/queryshape/core/SortShape.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/queryshape/core/SortShape.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.model.queryshape.core;
+
+import org.opensearch.plugin.insights.rules.model.queryshape.misc.SortShapeField;
+
+import java.util.List;
+import java.util.Objects;
+
+class SortShape {
+    List<SortShapeField> sortShapeFields;
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(sortShapeFields);
+    }
+}

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/queryshape/misc/AggregationShape.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/queryshape/misc/AggregationShape.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.model.queryshape.misc;
+
+public abstract class AggregationShape implements Comparable<AggregationShape> {
+    @Override
+    public int compareTo(AggregationShape other) {
+        return this.getClass().getName().compareTo(other.getClass().getName());
+    }
+}
+

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/queryshape/misc/QueryBuilderShape.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/queryshape/misc/QueryBuilderShape.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.model.queryshape.misc;
+
+public abstract class QueryBuilderShape implements Comparable<QueryBuilderShape> {
+
+    @Override
+    public int compareTo(QueryBuilderShape other) {
+        return this.getClass().getName().compareTo(other.getClass().getName());
+    }
+}

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/queryshape/misc/SortShapeField.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/queryshape/misc/SortShapeField.java
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.model.queryshape.misc;
+
+import java.util.Objects;
+
+public class SortShapeField {
+    String fieldName;
+    String sortOrder;
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fieldName, sortOrder);
+    }
+}

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/queryshape/queries/BoolQueryBuilderShape.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/queryshape/queries/BoolQueryBuilderShape.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.model.queryshape.queries;
+
+import org.opensearch.plugin.insights.rules.model.queryshape.misc.QueryBuilderShape;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public class BoolQueryBuilderShape extends QueryBuilderShape {
+    List<? extends QueryBuilderShape> filterClause;
+    List<? extends QueryBuilderShape> mustClause;
+    List<? extends QueryBuilderShape> mustNotClause;
+    List<? extends QueryBuilderShape> shouldClause;
+
+    @Override
+    public int hashCode() {
+        // Sort the lists before calculating the hash code
+        sortLists();
+        return Objects.hash(filterClause, mustClause, mustNotClause, shouldClause);
+    }
+
+    private void sortLists() {
+        if (filterClause != null) {
+            Collections.sort(filterClause);
+        }
+        if (mustClause != null) {
+            Collections.sort(mustClause);
+        }
+        if (mustNotClause != null) {
+            Collections.sort(mustNotClause);
+        }
+        if (shouldClause != null) {
+            Collections.sort(shouldClause);
+        }
+    }
+}

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/queryshape/queries/ExistsQueryBuilderShape.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/queryshape/queries/ExistsQueryBuilderShape.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.model.queryshape.queries;
+
+import org.opensearch.plugin.insights.rules.model.queryshape.misc.QueryBuilderShape;
+
+import java.util.Objects;
+
+public class ExistsQueryBuilderShape extends QueryBuilderShape {
+    String fieldName;
+    String fieldValue;
+    @Override
+    public int hashCode() {
+        return Objects.hash(fieldName, fieldValue);
+    }
+}

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/queryshape/queries/MatchQueryBuilderShape.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/queryshape/queries/MatchQueryBuilderShape.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.model.queryshape.queries;
+
+import org.opensearch.plugin.insights.rules.model.queryshape.misc.QueryBuilderShape;
+
+import java.util.Objects;
+
+public class MatchQueryBuilderShape extends QueryBuilderShape {
+    String fieldName;
+    String fieldValue;
+    @Override
+    public int hashCode() {
+        return Objects.hash(fieldName, fieldValue);
+    }
+}

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/queryshape/queries/MustQueryBuilderShape.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/queryshape/queries/MustQueryBuilderShape.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.model.queryshape.queries;
+
+import org.opensearch.plugin.insights.rules.model.queryshape.misc.QueryBuilderShape;
+
+import java.util.Objects;
+
+public class MustQueryBuilderShape extends QueryBuilderShape {
+    String fieldName;
+    String fieldValue;
+    @Override
+    public int hashCode() {
+        return Objects.hash(fieldName, fieldValue);
+    }
+}

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/queryshape/queries/TermQueryBuilderShape.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/queryshape/queries/TermQueryBuilderShape.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.model.queryshape.queries;
+
+import org.opensearch.plugin.insights.rules.model.queryshape.misc.QueryBuilderShape;
+
+import java.util.Objects;
+
+public class TermQueryBuilderShape extends QueryBuilderShape {
+    String fieldName;
+    String fieldValue;
+    @Override
+    public int hashCode() {
+        return Objects.hash(fieldName, fieldValue);
+    }
+}


### PR DESCRIPTION
Changes part of Grouping Top N queries by similarity (https://github.com/opensearch-project/OpenSearch/issues/13419), to create the query shape representation class structure.

RFC: https://github.com/opensearch-project/OpenSearch/issues/13357

### Description
As part of grouping Top N queries by similarity (https://github.com/opensearch-project/OpenSearch/issues/13357), the first set of changes are defining a class structure to represent the "Query Shape".

The following should be kept in mind when designing the class structure:
- Should be flexible and extensible in the future
- Should capture the 4 components of a query shape (https://github.com/opensearch-project/OpenSearch/issues/13357)
- Should be hashable taking required normalization into consideration 
- Should be easy to export the query shape as a string, json if required

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/13419

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
