### PR TITLE
Add toXContent and fromXContent for DiscoveryNode and DiscoveryNodes

### DIFF
--- a/libs/core/src/main/java/org/opensearch/core/common/transport/TransportAddress.java
+++ b/libs/core/src/main/java/org/opensearch/core/common/transport/TransportAddress.java
@@ -162,4 +162,14 @@ public final class TransportAddress implements Writeable, ToXContentFragment {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         return builder.value(toString());
     }
+
+    public static TransportAddress fromString(String address) throws UnknownHostException {
+        String[] addressSplit = address.split(":");
+        if (addressSplit.length != 2) {
+            throw new IllegalArgumentException("address must be of the form [hostname/ip]:[port]");
+        }
+        String hostname = addressSplit[0];
+        int port = Integer.parseInt(addressSplit[1]);
+        return new TransportAddress(InetAddress.getByName(hostname), port);
+    }
 }

--- a/libs/core/src/main/java/org/opensearch/core/common/transport/TransportAddress.java
+++ b/libs/core/src/main/java/org/opensearch/core/common/transport/TransportAddress.java
@@ -163,6 +163,11 @@ public final class TransportAddress implements Writeable, ToXContentFragment {
         return builder.value(toString());
     }
 
+    /**
+    * Converts a string in the format [hostname/ip]:[port] into a transport address.
+    * @throws UnknownHostException if the hostname or ip address is invalid
+    * @throws IllegalArgumentException if invalid string format provided
+    */
     public static TransportAddress fromString(String address) throws UnknownHostException {
         String[] addressSplit = address.split(":");
         if (addressSplit.length != 2) {

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
@@ -32,6 +32,8 @@
 
 package org.opensearch.cluster.node;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.Version;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.common.UUIDs;
@@ -85,6 +87,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
     static final String KEY_ATTRIBUTES = "attributes";
     static final String KEY_VERSION = "version";
     static final String KEY_ROLES = "roles";
+    private static final Logger logger = LogManager.getLogger(DiscoveryNode.class);
 
     public static boolean nodeRequiresLocalStorage(Settings settings) {
         boolean localStorageEnable = Node.NODE_LOCAL_STORAGE_SETTING.get(settings);
@@ -583,6 +586,10 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
         return builder;
     }
 
+    /**
+     * This method is able to parse either a complete XContentObject with start and end object
+     * or only a fragment with the key and value.
+     */
     public static DiscoveryNode fromXContent(XContentParser parser) throws IOException {
         if (parser.currentToken() == null) { // fresh parser? move to the first token
             parser.nextToken();
@@ -627,7 +634,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
                         version = Version.fromString(parser.text());
                         break;
                     default:
-                        throw new IllegalArgumentException("Unexpected field [ " + currentFieldName + " ]");
+                        logger.warn("unknown field [{}]", currentFieldName);
                 }
             } else if (token == XContentParser.Token.START_OBJECT) {
                 assert currentFieldName.equals(KEY_ATTRIBUTES) : "expecting field with name ["

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodes.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodes.java
@@ -45,7 +45,7 @@ import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.transport.TransportAddress;
-import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 
@@ -65,6 +65,7 @@ import java.util.stream.StreamSupport;
 
 import static org.opensearch.cluster.metadata.Metadata.CONTEXT_MODE_API;
 import static org.opensearch.cluster.metadata.Metadata.CONTEXT_MODE_PARAM;
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 
 /**
  * This class holds all {@link DiscoveryNode} in the cluster and provides convenience methods to
@@ -73,9 +74,11 @@ import static org.opensearch.cluster.metadata.Metadata.CONTEXT_MODE_PARAM;
  * @opensearch.api
  */
 @PublicApi(since = "1.0.0")
-public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements Iterable<DiscoveryNode>, ToXContentFragment {
+public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements Iterable<DiscoveryNode>, ToXContentObject {
 
     public static final DiscoveryNodes EMPTY_NODES = builder().build();
+    public static final String KEY_NODES = "nodes";
+    public static final String KEY_CLUSTER_MANAGER = "cluster_manager";
 
     private final Map<String, DiscoveryNode> nodes;
     private final Map<String, DiscoveryNode> dataNodes;
@@ -575,56 +578,54 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject("nodes");
+        builder.startObject();
+        innerToXContent(builder, params);
+        builder.endObject();
+        return builder;
+    }
+
+    public XContentBuilder innerToXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(KEY_NODES);
         for (DiscoveryNode node : this) {
             node.toXContent(builder, params);
         }
         builder.endObject();
         Metadata.XContentContext context = Metadata.XContentContext.valueOf(params.param(CONTEXT_MODE_PARAM, CONTEXT_MODE_API));
         if (context == Metadata.XContentContext.GATEWAY && clusterManagerNodeId != null) {
-            builder.field("cluster_manager", clusterManagerNodeId);
+            builder.field(KEY_CLUSTER_MANAGER, clusterManagerNodeId);
         }
         return builder;
     }
 
     public static DiscoveryNodes fromXContent(XContentParser parser) throws IOException {
         Builder builder = new Builder();
-        if (parser.currentToken() == null) {
+        if (parser.currentToken() == null) { // fresh parser? move to the first token
             parser.nextToken();
         }
-        if (parser.currentToken() == XContentParser.Token.START_OBJECT) {
-            parser.nextToken();
-        }
-        if (parser.currentToken() != XContentParser.Token.FIELD_NAME) {
-            throw new IllegalArgumentException("expected field name but got a " + parser.currentToken());
-        }
-        XContentParser.Token token;
-        String currentFieldName = parser.currentName();
+        XContentParser.Token token = parser.currentToken();
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, token, parser);
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-            if (token == XContentParser.Token.FIELD_NAME) {
-                currentFieldName = parser.currentName();
-            } else if (token == XContentParser.Token.START_OBJECT) {
-                if ("nodes".equals(currentFieldName)) {
-                    while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-                        if (token == XContentParser.Token.FIELD_NAME) {
-                            currentFieldName = parser.currentName();
-                        } else if (token == XContentParser.Token.START_OBJECT) {
-                            String nodeId = currentFieldName;
-                            DiscoveryNode node = DiscoveryNode.fromXContent(parser, nodeId);
-                            builder.add(node);
-                        }
-                    }
-                } else {
-                    throw new IllegalArgumentException("unexpected object field " + currentFieldName);
+            ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser);
+            String currentFieldName = parser.currentName();
+            token = parser.nextToken();
+            if (token == XContentParser.Token.START_OBJECT) {
+                assert currentFieldName.equals(KEY_NODES) : "expecting field with name ["
+                    + KEY_NODES
+                    + "] but found ["
+                    + currentFieldName
+                    + "]";
+                while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                    builder.add(DiscoveryNode.fromXContent(parser));
                 }
             } else if (token.isValue()) {
-                if ("cluster_manager".equals(currentFieldName)) {
-                    String clusterManagerNodeId = parser.text();
-                    if (clusterManagerNodeId != null) {
-                        builder.clusterManagerNodeId(clusterManagerNodeId);
-                    }
-                } else {
-                    throw new IllegalArgumentException("unexpected value field " + currentFieldName);
+                assert currentFieldName.equals(KEY_CLUSTER_MANAGER) : "expecting field with name ["
+                    + KEY_CLUSTER_MANAGER
+                    + "] but found ["
+                    + currentFieldName
+                    + "]";
+                String clusterManagerNodeId = parser.text();
+                if (clusterManagerNodeId != null) {
+                    builder.clusterManagerNodeId(clusterManagerNodeId);
                 }
             } else {
                 throw new IllegalArgumentException("unexpected token " + token);

--- a/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodeTests.java
+++ b/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodeTests.java
@@ -269,7 +269,7 @@ public class DiscoveryNodeTests extends OpenSearchTestCase {
         node.toXContent(builder, new ToXContent.MapParams(singletonMap(Metadata.CONTEXT_MODE_PARAM, CONTEXT_MODE_API)));
         builder.endObject();
 
-        String expectedNodeAPUXContent = "{\n"
+        String expectedNodeAPIXContent = "{\n"
             + "  \"node_1\" : {\n"
             + "    \"name\" : \""
             + node.getName()
@@ -282,7 +282,7 @@ public class DiscoveryNodeTests extends OpenSearchTestCase {
             + "  }\n"
             + "}";
 
-        assertEquals(expectedNodeAPUXContent, builder.toString());
+        assertEquals(expectedNodeAPIXContent, builder.toString());
     }
 
     public void testToXContentInGatewayMode() throws IOException {
@@ -296,7 +296,7 @@ public class DiscoveryNodeTests extends OpenSearchTestCase {
         node.toXContent(builder, new ToXContent.MapParams(singletonMap(Metadata.CONTEXT_MODE_PARAM, CONTEXT_MODE_GATEWAY)));
         builder.endObject();
 
-        String expectedNodeAPUXContent = "{\n"
+        String expectedNodeAPIXContent = "{\n"
             + "  \"node_1\" : {\n"
             + "    \"name\" : \""
             + node.getName()
@@ -320,7 +320,6 @@ public class DiscoveryNodeTests extends OpenSearchTestCase {
             + "  }\n"
             + "}";
 
-        assertEquals(expectedNodeAPUXContent, builder.toString());
-
+        assertEquals(expectedNodeAPIXContent, builder.toString());
     }
 }

--- a/server/src/test/java/org/opensearch/core/common/TransportAddressTests.java
+++ b/server/src/test/java/org/opensearch/core/common/TransportAddressTests.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.core.common;
+
+import org.opensearch.core.common.transport.TransportAddress;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.net.UnknownHostException;
+
+public class TransportAddressTests extends OpenSearchTestCase {
+    public void testFromString() throws UnknownHostException {
+        TransportAddress address = TransportAddress.fromString("127.0.0.1:9300");
+        assertEquals("127.0.0.1", address.getAddress());
+        assertEquals(9300, address.getPort());
+
+        address = TransportAddress.fromString("1080:0:0:0:8:800:200C:417A:9300");
+        assertEquals("1080::8:800:200c:417a", address.getAddress());
+        assertEquals(9300, address.getPort());
+
+        address = TransportAddress.fromString("FF01:0:0:0:0:0:0:101:9300");
+        assertEquals("ff01::101", address.getAddress());
+        assertEquals(9300, address.getPort());
+
+        address = TransportAddress.fromString("FEDC:BA98:7654:3210:FEDC:BA98:7654:3210:9200");
+        assertEquals("fedc:ba98:7654:3210:fedc:ba98:7654:3210", address.getAddress());
+        assertEquals(9200, address.getPort());
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
We need to upload the DiscoveryNodes object to remote to enable the cluster state publication flow from remote. To do that we need to parse DiscoveryNodes object to and from XContent.

### Related Issues
Resolves #13691 
Meta issue #13683 
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
