### PR TITLE
Fix parseToken array popping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix missing value of FieldSort for unsigned_long ([#14963](https://github.com/opensearch-project/OpenSearch/pull/14963))
 - Fix delete index template failed when the index template matches a data stream but is unused ([#15080](https://github.com/opensearch-project/OpenSearch/pull/15080))
 - Fix array_index_out_of_bounds_exception when indexing documents with field name containing only dot ([#15126](https://github.com/opensearch-project/OpenSearch/pull/15126))
+- Fixed array field name omission in flat_object function for nested JSON ([#13620](https://github.com/opensearch-project/OpenSearch/pull/13620))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/common/xcontent/JsonToStringXContentParser.java
+++ b/server/src/main/java/org/opensearch/common/xcontent/JsonToStringXContentParser.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.common.xcontent;
 
+import org.apache.logging.log4j.util.Strings;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.AbstractXContentParser;
@@ -23,6 +24,9 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.CharBuffer;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.LinkedList;
 
 /**
  * JsonToStringParser is the main parser class to transform JSON into stringFields in a XContentParser
@@ -46,7 +50,6 @@ public class JsonToStringXContentParser extends AbstractXContentParser {
 
     private static final String VALUE_AND_PATH_SUFFIX = "._valueAndPath";
     private static final String VALUE_SUFFIX = "._value";
-    private static final String DOT_SYMBOL = ".";
     private static final String EQUAL_SYMBOL = "=";
 
     public JsonToStringXContentParser(
@@ -65,7 +68,7 @@ public class JsonToStringXContentParser extends AbstractXContentParser {
     public XContentParser parseObject() throws IOException {
         builder.startObject();
         StringBuilder path = new StringBuilder(fieldTypeName);
-        parseToken(path, null, true);
+        parseToken(new LinkedList<>(Collections.singleton(fieldTypeName)));
         builder.field(this.fieldTypeName, keyList);
         builder.field(this.fieldTypeName + VALUE_SUFFIX, valueList);
         builder.field(this.fieldTypeName + VALUE_AND_PATH_SUFFIX, valueAndPathList);
@@ -74,79 +77,55 @@ public class JsonToStringXContentParser extends AbstractXContentParser {
         return JsonXContent.jsonXContent.createParser(this.xContentRegistry, this.deprecationHandler, String.valueOf(jString));
     }
 
-    private void parseToken(StringBuilder path, String currentFieldName, boolean popName) throws IOException {
-        while (this.parser.nextToken() != Token.END_OBJECT) {
-            if (this.parser.currentName() != null) {
-                currentFieldName = this.parser.currentName();
+    private void parseToken(Deque<String> path) throws IOException {
+        if (this.parser.currentToken() == Token.FIELD_NAME) {
+            String fieldName = this.parser.currentName();
+            path.addLast(fieldName); // Pushing onto the stack *must* be matched by pop
+            String parts = fieldName;
+            while (parts.contains(".")) { // Extract the intermediate keys maybe present in fieldName
+                int dotPos = parts.indexOf('.');
+                String part = parts.substring(0, dotPos);
+                this.keyList.add(part);
+                parts = parts.substring(dotPos + 1);
             }
-            StringBuilder parsedFields = new StringBuilder();
-
-            if (this.parser.currentToken() == Token.FIELD_NAME) {
-                path.append(DOT_SYMBOL).append(currentFieldName);
-                int dotIndex = currentFieldName.indexOf(DOT_SYMBOL);
-                String fieldNameSuffix = currentFieldName;
-                // The field name may be of the form foo.bar.baz
-                // If that's the case, each "part" is a key.
-                while (dotIndex >= 0) {
-                    String fieldNamePrefix = fieldNameSuffix.substring(0, dotIndex);
-                    if (!fieldNamePrefix.isEmpty()) {
-                        this.keyList.add(fieldNamePrefix);
-                    }
-                    fieldNameSuffix = fieldNameSuffix.substring(dotIndex + 1);
-                    dotIndex = fieldNameSuffix.indexOf(DOT_SYMBOL);
-                }
-                if (!fieldNameSuffix.isEmpty()) {
-                    this.keyList.add(fieldNameSuffix);
-                }
-            } else if (this.parser.currentToken() == Token.START_ARRAY) {
-                parseToken(path, currentFieldName, false);
-                break;
-            } else if (this.parser.currentToken() == Token.END_ARRAY) {
-                // skip
-            } else if (this.parser.currentToken() == Token.START_OBJECT) {
-                parseToken(path, currentFieldName, true);
-
-                if (popName) {
-                    int dotIndex = path.lastIndexOf(DOT_SYMBOL);
-                    if (dotIndex != -1) {
-                        path.setLength(path.length() - currentFieldName.length() - 1);
-                    }
-                }
-            } else {
-                if (!path.toString().contains(currentFieldName)) {
-                    path.append(DOT_SYMBOL).append(currentFieldName);
-                }
-                parseValue(parsedFields);
-                this.valueList.add(parsedFields.toString());
-                this.valueAndPathList.add(path + EQUAL_SYMBOL + parsedFields);
-
-                if (popName) {
-                    int dotIndex = path.lastIndexOf(DOT_SYMBOL);
-
-                    if (dotIndex != -1) {
-                        path.setLength(path.length() - currentFieldName.length() - 1);
-                    }
-                }
+            this.keyList.add(parts); // parts has no dot, so either it's the original fieldName or it's the last part
+            this.parser.nextToken(); // advance to the value of fieldName
+            parseToken(path); // parse the value for fieldName (which will be an array, an object, or a primitive value)
+            path.removeLast(); // Here is where we pop fieldName from the stack (since we're done with the value of fieldName)
+            // Note that whichever other branch we just passed through has already ended with nextToken(), so we
+            // don't need ot call it.
+        } else if (this.parser.currentToken() == Token.START_ARRAY) {
+            parser.nextToken();
+            while (this.parser.currentToken() != Token.END_ARRAY) {
+                parseToken(path);
             }
+            this.parser.nextToken();
+        } else if (this.parser.currentToken() == Token.START_OBJECT) {
+            parser.nextToken();
+            while (this.parser.currentToken() != Token.END_OBJECT) {
+                parseToken(path);
+            }
+            this.parser.nextToken();
+        } else if (this.parser.currentToken().isValue()) {
+            String parsedValue = parseValue();
+            if (parsedValue != null) {
+                this.valueList.add(parsedValue);
+                this.valueAndPathList.add(Strings.join(path, '.') + EQUAL_SYMBOL + parsedValue);
+            }
+            this.parser.nextToken();
         }
     }
 
-    private void parseValue(StringBuilder parsedFields) throws IOException {
+    private String parseValue() throws IOException {
         switch (this.parser.currentToken()) {
             case VALUE_BOOLEAN:
             case VALUE_NUMBER:
             case VALUE_STRING:
             case VALUE_NULL:
-                parsedFields.append(this.parser.textOrNull());
-                break;
+                return this.parser.textOrNull();
             // Handle other token types as needed
-            case FIELD_NAME:
-            case VALUE_EMBEDDED_OBJECT:
-            case END_ARRAY:
-            case START_ARRAY:
-                break;
             default:
-                throw new IOException("Unsupported token type [" + parser.currentToken() + "]");
+                throw new IOException("Unsupported value token type [" + parser.currentToken() + "]");
         }
     }
 

--- a/server/src/main/java/org/opensearch/common/xcontent/JsonToStringXContentParser.java
+++ b/server/src/main/java/org/opensearch/common/xcontent/JsonToStringXContentParser.java
@@ -8,8 +8,8 @@
 
 package org.opensearch.common.xcontent;
 
-import org.apache.logging.log4j.util.Strings;
 import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.AbstractXContentParser;
 import org.opensearch.core.xcontent.DeprecationHandler;
@@ -110,7 +110,7 @@ public class JsonToStringXContentParser extends AbstractXContentParser {
             String parsedValue = parseValue();
             if (parsedValue != null) {
                 this.valueList.add(parsedValue);
-                this.valueAndPathList.add(Strings.join(path, '.') + EQUAL_SYMBOL + parsedValue);
+                this.valueAndPathList.add(Strings.collectionToDelimitedString(path, ".") + EQUAL_SYMBOL + parsedValue);
             }
             this.parser.nextToken();
         }

--- a/server/src/main/java/org/opensearch/index/mapper/FlatObjectFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FlatObjectFieldMapper.java
@@ -568,6 +568,10 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
         if (context.externalValueSet()) {
             String value = context.externalValue().toString();
             parseValueAddFields(context, value, fieldType().name());
+        } else if (context.parser().currentToken() == XContentParser.Token.VALUE_NULL) {
+            context.parser().nextToken(); // This triggers an exception in DocumentParser.
+            // We could remove the above nextToken() call to skip the null value, but the existing
+            // behavior (since 2.7) throws the exception.
         } else {
             JsonToStringXContentParser jsonToStringParser = new JsonToStringXContentParser(
                 NamedXContentRegistry.EMPTY,
@@ -594,7 +598,6 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
                 }
 
             }
-
         }
 
     }

--- a/server/src/main/java/org/opensearch/index/mapper/FlatObjectFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FlatObjectFieldMapper.java
@@ -569,7 +569,7 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
             String value = context.externalValue().toString();
             parseValueAddFields(context, value, fieldType().name());
         } else {
-            JsonToStringXContentParser JsonToStringParser = new JsonToStringXContentParser(
+            JsonToStringXContentParser jsonToStringParser = new JsonToStringXContentParser(
                 NamedXContentRegistry.EMPTY,
                 DeprecationHandler.IGNORE_DEPRECATIONS,
                 context.parser(),
@@ -579,7 +579,7 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
               JsonToStringParser is the main parser class to transform JSON into stringFields in a XContentParser
               It reads the JSON object and parsed to a list of string
              */
-            XContentParser parser = JsonToStringParser.parseObject();
+            XContentParser parser = jsonToStringParser.parseObject();
 
             XContentParser.Token currentToken;
             while ((currentToken = parser.nextToken()) != XContentParser.Token.END_OBJECT) {

--- a/server/src/test/java/org/opensearch/common/xcontent/JsonToStringXContentParserTests.java
+++ b/server/src/test/java/org/opensearch/common/xcontent/JsonToStringXContentParserTests.java
@@ -111,23 +111,55 @@ public class JsonToStringXContentParserTests extends OpenSearchTestCase {
     }
 
     public void testArrayOfObjects() throws IOException {
-        String jsonExample ="{" +
-            "\"field\": {" +
-            "  \"detail\": {" +
-            "    \"foooooooooooo\": [" +
-            "      {\"name\":\"baz\"}," +
-            "      {\"name\":\"baz\"}" +
-            "    ]" +
-            "  }" +
-            "}}";
+        String jsonExample = "{"
+            + "\"field\": {"
+            + "  \"detail\": {"
+            + "    \"foooooooooooo\": ["
+            + "      {\"name\":\"baz\"},"
+            + "      {\"name\":\"baz\"}"
+            + "    ]"
+            + "  }"
+            + "}}";
 
-        assertEquals("{" +
-            "\"flat\":[\"field\",\"detail\",\"foooooooooooo\",\"name\",\"name\"]," +
-            "\"flat._value\":[\"baz\",\"baz\"]," +
-            "\"flat._valueAndPath\":[" +
-            "\"flat.field.detail.foooooooooooo.name=baz\"," +
-            "\"flat.field.detail.foooooooooooo.name=baz\"" +
-            "]}",
+        assertEquals(
+            "{"
+                + "\"flat\":[\"field\",\"detail\",\"foooooooooooo\",\"name\",\"name\"],"
+                + "\"flat._value\":[\"baz\",\"baz\"],"
+                + "\"flat._valueAndPath\":["
+                + "\"flat.field.detail.foooooooooooo.name=baz\","
+                + "\"flat.field.detail.foooooooooooo.name=baz\""
+                + "]}",
+            flattenJsonString("flat", jsonExample)
+        );
+    }
+
+    public void testArraysOfObjectsAndValues() throws IOException {
+        String jsonExample = "{"
+            + "\"field\": {"
+            + "  \"detail\": {"
+            + "    \"foooooooooooo\": ["
+            + "      {\"name\":\"baz\"},"
+            + "      {\"name\":\"baz\"}"
+            + "    ]"
+            + "  },"
+            + "  \"numbers\" : ["
+            + "    1,"
+            + "    2,"
+            + "    3"
+            + "  ]"
+            + "}}";
+
+        assertEquals(
+            "{"
+                + "\"flat\":[\"field\",\"detail\",\"foooooooooooo\",\"name\",\"name\",\"numbers\"],"
+                + "\"flat._value\":[\"baz\",\"baz\",\"1\",\"2\",\"3\"],"
+                + "\"flat._valueAndPath\":["
+                + "\"flat.field.detail.foooooooooooo.name=baz\","
+                + "\"flat.field.detail.foooooooooooo.name=baz\","
+                + "\"flat.field.numbers=1\","
+                + "\"flat.field.numbers=2\","
+                + "\"flat.field.numbers=3\""
+                + "]}",
             flattenJsonString("flat", jsonExample)
         );
     }

--- a/server/src/test/java/org/opensearch/common/xcontent/JsonToStringXContentParserTests.java
+++ b/server/src/test/java/org/opensearch/common/xcontent/JsonToStringXContentParserTests.java
@@ -110,4 +110,25 @@ public class JsonToStringXContentParserTests extends OpenSearchTestCase {
         );
     }
 
+    public void testArrayOfObjects() throws IOException {
+        String jsonExample ="{" +
+            "\"field\": {" +
+            "  \"detail\": {" +
+            "    \"foooooooooooo\": [" +
+            "      {\"name\":\"baz\"}," +
+            "      {\"name\":\"baz\"}" +
+            "    ]" +
+            "  }" +
+            "}}";
+
+        assertEquals("{" +
+            "\"flat\":[\"field\",\"detail\",\"foooooooooooo\",\"name\",\"name\"]," +
+            "\"flat._value\":[\"baz\",\"baz\"]," +
+            "\"flat._valueAndPath\":[" +
+            "\"flat.field.detail.foooooooooooo.name=baz\"," +
+            "\"flat.field.detail.foooooooooooo.name=baz\"" +
+            "]}",
+            flattenJsonString("flat", jsonExample)
+        );
+    }
 }

--- a/server/src/test/java/org/opensearch/common/xcontent/JsonToStringXContentParserTests.java
+++ b/server/src/test/java/org/opensearch/common/xcontent/JsonToStringXContentParserTests.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 public class JsonToStringXContentParserTests extends OpenSearchTestCase {
 
     private String flattenJsonString(String fieldName, String in) throws IOException {
-        String transformed;
         try (
             XContentParser parser = JsonXContent.jsonXContent.createParser(
                 xContentRegistry(),
@@ -33,10 +32,11 @@ public class JsonToStringXContentParserTests extends OpenSearchTestCase {
                 parser,
                 fieldName
             );
-            // Skip the START_OBJECT token:
+            // Point to the first token (should be START_OBJECT)
             jsonToStringXContentParser.nextToken();
 
             XContentParser transformedParser = jsonToStringXContentParser.parseObject();
+            assertSame(XContentParser.Token.END_OBJECT, jsonToStringXContentParser.currentToken());
             try (XContentBuilder jsonBuilder = XContentFactory.jsonBuilder()) {
                 jsonBuilder.copyCurrentStructure(transformedParser);
                 return jsonBuilder.toString();


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

Fixed an issue in the flat_object where array field names were incorrectly removed after processing the first object, leading to inaccurate key-paths in flattened JSON data.

### Related Issues

https://github.com/opensearch-project/OpenSearch/issues/13351

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
