### PR TITLE
Do not pass negative scores into function_score or script_score queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Remove handling of index.mapper.dynamic in AutoCreateIndex([#13067](https://github.com/opensearch-project/OpenSearch/pull/13067))
 
 ### Fixed
-- Fix negative RequestStats metric issue ([#13553](https://github.com/opensearch-project/OpenSearch/pull/13553))
 - Fix get field mapping API returns 404 error in mixed cluster with multiple versions ([#13624](https://github.com/opensearch-project/OpenSearch/pull/13624))
 - Allow clearing `remote_store.compatibility_mode` setting ([#13646](https://github.com/opensearch-project/OpenSearch/pull/13646))
+- Replace negative input scores to function/script score queries with zero to avoid downstream exception ([#13627](https://github.com/opensearch-project/OpenSearch/pull/13627))
 - Fix ReplicaShardBatchAllocator to batch shards without duplicates ([#13710](https://github.com/opensearch-project/OpenSearch/pull/13710))
 
 ### Security

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/30_search.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/30_search.yml
@@ -482,3 +482,79 @@
                         }]
     - match: { error.root_cause.0.type: "illegal_argument_exception" }
     - match: { error.root_cause.0.reason: "script score function must not produce negative scores, but got: [-9.0]"}
+
+---
+"Do not throw exception if input score is negative":
+  - do:
+      index:
+        index: test
+        id: 1
+        body: { "color" : "orange red yellow" }
+  - do:
+      index:
+        index: test
+        id: 2
+        body: { "color": "orange red purple", "shape": "red square" }
+  - do:
+      index:
+        index: test
+        id: 3
+        body: { "color" : "orange red yellow purple" }
+  - do:
+      indices.refresh: { }
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            function_score:
+              query:
+                multi_match:
+                  query: "red"
+                  type: "cross_fields"
+                  fields: [ "color", "shape^100"]
+                  tie_breaker: 0.1
+              functions: [{
+                "script_score": {
+                  "script": {
+                    "lang": "painless",
+                    "source": "_score"
+                  }
+                }
+              }]
+          explain: true
+  - match: { hits.total.value: 3 }
+  - match: { hits.hits.2._score: 0.0 }
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            function_score:
+              query:
+                multi_match:
+                  query: "red"
+                  type: "cross_fields"
+                  fields: [ "color", "shape^100"]
+                  tie_breaker: 0.1
+              weight: 1
+          explain: true
+  - match: { hits.total.value: 3 }
+  - match: { hits.hits.2._score: 0.0 }
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            script_score:
+              query:
+                multi_match:
+                  query: "red"
+                  type: "cross_fields"
+                  fields: [ "color", "shape^100"]
+                  tie_breaker: 0.1
+              script:
+                source: "_score"
+          explain: true
+  - match: { hits.total.value: 3 }
+  - match: { hits.hits.2._score: 0.0 }

--- a/server/src/main/java/org/opensearch/common/lucene/search/function/FunctionScoreQuery.java
+++ b/server/src/main/java/org/opensearch/common/lucene/search/function/FunctionScoreQuery.java
@@ -533,8 +533,10 @@ public class FunctionScoreQuery extends Query {
             int docId = docID();
             // Even if the weight is created with needsScores=false, it might
             // be costly to call score(), so we explicitly check if scores
-            // are needed
-            float subQueryScore = needsScores ? super.score() : 0f;
+            // are needed.
+            // While the function scorer should never turn a score negative, we
+            // must guard against the input score being negative.
+            float subQueryScore = needsScores ? Math.max(0f, super.score()) : 0f;
             if (leafFunctions.length == 0) {
                 return subQueryScore;
             }

--- a/server/src/main/java/org/opensearch/script/ScoreScript.java
+++ b/server/src/main/java/org/opensearch/script/ScoreScript.java
@@ -165,7 +165,9 @@ public abstract class ScoreScript {
     public void setScorer(Scorable scorer) {
         this.scoreSupplier = () -> {
             try {
-                return scorer.score();
+                // The ScoreScript is forbidden from returning a negative value.
+                // We should guard against receiving negative input.
+                return Math.max(0f, scorer.score());
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }

--- a/server/src/test/java/org/opensearch/index/query/NegativeBoostQuery.java
+++ b/server/src/test/java/org/opensearch/index/query/NegativeBoostQuery.java
@@ -1,0 +1,114 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.query;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Weight;
+
+import java.io.IOException;
+
+/**
+ * Similar to Lucene's BoostQuery, but will accept negative boost values (which is normally wrong, since scores
+ * should not be negative). Useful for testing that other query types guard against negative input scores.
+ */
+public class NegativeBoostQuery extends Query {
+    private final Query query;
+    private final float boost;
+
+    public NegativeBoostQuery(Query query, float boost) {
+        if (boost >= 0) {
+            throw new IllegalArgumentException("Expected negative boost. Use BoostQuery if boost is non-negative.");
+        }
+        this.boost = boost;
+        this.query = query;
+    }
+
+    @Override
+    public String toString(String field) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("(");
+        builder.append(query.toString(field));
+        builder.append(")");
+        builder.append("^");
+        builder.append(boost);
+        return builder.toString();
+    }
+
+    @Override
+    public void visit(QueryVisitor visitor) {
+        query.visit(visitor);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return sameClassAs(other) && equalsTo(getClass().cast(other));
+    }
+
+    private boolean equalsTo(NegativeBoostQuery other) {
+        return query.equals(other.query) && Float.floatToIntBits(boost) == Float.floatToIntBits(other.boost);
+    }
+
+    @Override
+    public int hashCode() {
+        int h = classHash();
+        h = 31 * h + query.hashCode();
+        h = 31 * h + Float.floatToIntBits(boost);
+        return h;
+    }
+
+    @Override
+    public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+        final float negativeBoost = this.boost;
+        Weight delegate = query.createWeight(searcher, scoreMode, boost);
+        return new Weight(this) {
+            @Override
+            public Explanation explain(LeafReaderContext context, int doc) throws IOException {
+                return delegate.explain(context, doc);
+            }
+
+            @Override
+            public Scorer scorer(LeafReaderContext context) throws IOException {
+                Scorer delegateScorer = delegate.scorer(context);
+                return new Scorer(this) {
+                    @Override
+                    public DocIdSetIterator iterator() {
+                        return delegateScorer.iterator();
+                    }
+
+                    @Override
+                    public float getMaxScore(int upTo) throws IOException {
+                        return delegateScorer.getMaxScore(upTo);
+                    }
+
+                    @Override
+                    public float score() throws IOException {
+                        return delegateScorer.score() * negativeBoost;
+                    }
+
+                    @Override
+                    public int docID() {
+                        return delegateScorer.docID();
+                    }
+                };
+            }
+
+            @Override
+            public boolean isCacheable(LeafReaderContext ctx) {
+                return delegate.isCacheable(ctx);
+            }
+        };
+    }
+}


### PR DESCRIPTION
In theory, Lucene scores should never go negative. To stop users from writing `function_score` and `script_score` queries that return negative values, we explicitly check their outputs and throw an exception when negative.

Unfortunately, due to a subtle, more complicated bug in multi_match queries, sometimes those might (incorrectly) return negative scores.

While that problem is also worth solving, we should protect function and script scoring from throwing an exception just for passing through a negative value that they had no hand in computing.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/7860

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] ~~New functionality has been documented.~~
  - [ ] ~~New functionality has javadoc added~~
- [ ] ~~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~~
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] ~~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
