### PR TITLE
Add to and from XContent to ClusterBlock and ClusterBlocks

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/block/ClusterBlock.java
+++ b/server/src/main/java/org/opensearch/cluster/block/ClusterBlock.java
@@ -32,19 +32,26 @@
 
 package org.opensearch.cluster.block;
 
+import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.annotation.PublicApi;
+import org.opensearch.common.util.set.Sets;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.ToXContentFragment;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.EnumSet;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Set;
+
+import static org.opensearch.cluster.metadata.Metadata.CONTEXT_MODE_API;
+import static org.opensearch.cluster.metadata.Metadata.CONTEXT_MODE_PARAM;
 
 /**
  * Blocks the cluster for concurrency
@@ -54,6 +61,20 @@ import java.util.Objects;
 @PublicApi(since = "1.0.0")
 public class ClusterBlock implements Writeable, ToXContentFragment {
 
+    static final String KEY_UUID = "uuid";
+    static final String KEY_DESCRIPTION = "description";
+    static final String KEY_RETRYABLE = "retryable";
+    static final String KEY_DISABLE_STATE_PERSISTENCE = "disable_state_persistence";
+    static final String KEY_LEVELS = "levels";
+    static final String KEY_STATUS = "status";
+    static final String KEY_ALLOW_RELEASE_RESOURCES = "allow_release_resources";
+    private static final Set<String> VALID_FIELDS = Sets.newHashSet(
+        KEY_UUID,
+        KEY_DESCRIPTION,
+        KEY_RETRYABLE,
+        KEY_DISABLE_STATE_PERSISTENCE,
+        KEY_LEVELS
+    );
     private final int id;
     @Nullable
     private final String uuid;
@@ -154,22 +175,97 @@ public class ClusterBlock implements Writeable, ToXContentFragment {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        Metadata.XContentContext context = Metadata.XContentContext.valueOf(params.param(CONTEXT_MODE_PARAM, CONTEXT_MODE_API));
         builder.startObject(Integer.toString(id));
         if (uuid != null) {
-            builder.field("uuid", uuid);
+            builder.field(KEY_UUID, uuid);
         }
-        builder.field("description", description);
-        builder.field("retryable", retryable);
+        builder.field(KEY_DESCRIPTION, description);
+        builder.field(KEY_RETRYABLE, retryable);
         if (disableStatePersistence) {
-            builder.field("disable_state_persistence", disableStatePersistence);
+            builder.field(KEY_DISABLE_STATE_PERSISTENCE, disableStatePersistence);
         }
-        builder.startArray("levels");
+        builder.startArray(KEY_LEVELS);
         for (ClusterBlockLevel level : levels) {
             builder.value(level.name().toLowerCase(Locale.ROOT));
         }
         builder.endArray();
+        if (context == Metadata.XContentContext.GATEWAY) {
+            builder.field(KEY_STATUS, status);
+            builder.field(KEY_ALLOW_RELEASE_RESOURCES, allowReleaseResources);
+        }
         builder.endObject();
         return builder;
+    }
+
+    public static ClusterBlock fromXContent(XContentParser parser, int id) throws IOException {
+        String uuid = null;
+        String description = null;
+        boolean retryable = false;
+        boolean disableStatePersistence = false;
+        RestStatus status = null;
+        boolean allowReleaseResources = false;
+        EnumSet<ClusterBlockLevel> levels = EnumSet.noneOf(ClusterBlockLevel.class);
+        String currentFieldName = skipBlockID(parser);
+        XContentParser.Token token;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (token.isValue()) {
+                switch (Objects.requireNonNull(currentFieldName)) {
+                    case KEY_UUID:
+                        uuid = parser.text();
+                        break;
+                    case KEY_DESCRIPTION:
+                        description = parser.text();
+                        break;
+                    case KEY_RETRYABLE:
+                        retryable = parser.booleanValue();
+                        break;
+                    case KEY_DISABLE_STATE_PERSISTENCE:
+                        disableStatePersistence = parser.booleanValue();
+                        break;
+                    case KEY_STATUS:
+                        status = RestStatus.valueOf(parser.text());
+                        break;
+                    case KEY_ALLOW_RELEASE_RESOURCES:
+                        allowReleaseResources = parser.booleanValue();
+                        break;
+                    default:
+                        throw new IllegalArgumentException("unknown field [" + currentFieldName + "]");
+                }
+            } else if (token == XContentParser.Token.START_ARRAY) {
+                if (currentFieldName.equals(KEY_LEVELS)) {
+                    while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                        levels.add(ClusterBlockLevel.fromString(parser.text(), Locale.ROOT));
+                    }
+                } else {
+                    throw new IllegalArgumentException("unknown field [" + currentFieldName + "]");
+                }
+            } else {
+                throw new IllegalArgumentException("unexpected token [" + token + "]");
+            }
+        }
+        return new ClusterBlock(id, uuid, description, retryable, disableStatePersistence, allowReleaseResources, status, levels);
+    }
+
+    private static String skipBlockID(XContentParser parser) throws IOException {
+        if (parser.currentToken() == null) {
+            parser.nextToken();
+        }
+        if (parser.currentToken() == XContentParser.Token.START_OBJECT) {
+            parser.nextToken();
+            if (parser.currentToken() == XContentParser.Token.FIELD_NAME) {
+                String currentFieldName = parser.currentName();
+                if (VALID_FIELDS.contains(currentFieldName)) {
+                    return currentFieldName;
+                } else {
+                    // we have hit block id, just move on
+                    parser.nextToken();
+                }
+            }
+        }
+        return null;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/cluster/block/ClusterBlock.java
+++ b/server/src/main/java/org/opensearch/cluster/block/ClusterBlock.java
@@ -32,6 +32,8 @@
 
 package org.opensearch.cluster.block;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.annotation.PublicApi;
@@ -60,7 +62,7 @@ import static org.opensearch.cluster.metadata.Metadata.CONTEXT_MODE_PARAM;
  */
 @PublicApi(since = "1.0.0")
 public class ClusterBlock implements Writeable, ToXContentFragment {
-
+    private static final Logger logger = LogManager.getLogger(ClusterBlock.class);
     static final String KEY_UUID = "uuid";
     static final String KEY_DESCRIPTION = "description";
     static final String KEY_RETRYABLE = "retryable";
@@ -232,7 +234,7 @@ public class ClusterBlock implements Writeable, ToXContentFragment {
                         allowReleaseResources = parser.booleanValue();
                         break;
                     default:
-                        throw new IllegalArgumentException("unknown field [" + currentFieldName + "]");
+                        logger.warn("unknown field [{}]", currentFieldName);
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if (currentFieldName.equals(KEY_LEVELS)) {
@@ -240,7 +242,7 @@ public class ClusterBlock implements Writeable, ToXContentFragment {
                         levels.add(ClusterBlockLevel.fromString(parser.text(), Locale.ROOT));
                     }
                 } else {
-                    throw new IllegalArgumentException("unknown field [" + currentFieldName + "]");
+                    logger.warn("unknown field [{}]", currentFieldName);
                 }
             } else {
                 throw new IllegalArgumentException("unexpected token [" + token + "]");

--- a/server/src/main/java/org/opensearch/cluster/block/ClusterBlockLevel.java
+++ b/server/src/main/java/org/opensearch/cluster/block/ClusterBlockLevel.java
@@ -35,6 +35,7 @@ package org.opensearch.cluster.block;
 import org.opensearch.common.annotation.PublicApi;
 
 import java.util.EnumSet;
+import java.util.Locale;
 
 /**
  * What level to block the cluster
@@ -51,4 +52,11 @@ public enum ClusterBlockLevel {
 
     public static final EnumSet<ClusterBlockLevel> ALL = EnumSet.allOf(ClusterBlockLevel.class);
     public static final EnumSet<ClusterBlockLevel> READ_WRITE = EnumSet.of(READ, WRITE);
+
+    /*
+    * This method is used to convert a string to a ClusterBlockLevel.
+    * */
+    public static ClusterBlockLevel fromString(String level, Locale locale) {
+        return ClusterBlockLevel.valueOf(level.toUpperCase(locale));
+    }
 }

--- a/server/src/main/java/org/opensearch/cluster/block/ClusterBlocks.java
+++ b/server/src/main/java/org/opensearch/cluster/block/ClusterBlocks.java
@@ -32,6 +32,8 @@
 
 package org.opensearch.cluster.block;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.cluster.AbstractDiffable;
 import org.opensearch.cluster.Diff;
 import org.opensearch.cluster.metadata.IndexMetadata;
@@ -68,6 +70,7 @@ import static java.util.stream.Collectors.toSet;
  */
 @PublicApi(since = "1.0.0")
 public class ClusterBlocks extends AbstractDiffable<ClusterBlocks> implements ToXContentFragment {
+    private static final Logger logger = LogManager.getLogger(ClusterBlocks.class);
     public static final ClusterBlocks EMPTY_CLUSTER_BLOCK = new ClusterBlocks(emptySet(), Map.of());
 
     private final Set<ClusterBlock> global;
@@ -368,6 +371,10 @@ public class ClusterBlocks extends AbstractDiffable<ClusterBlocks> implements To
         return new Builder();
     }
 
+    public static Builder builder(ClusterBlocks clusterBlocks) {
+        return new Builder(clusterBlocks);
+    }
+
     /**
      * Builder for cluster blocks.
      *
@@ -381,6 +388,11 @@ public class ClusterBlocks extends AbstractDiffable<ClusterBlocks> implements To
         private final Map<String, Set<ClusterBlock>> indices = new HashMap<>();
 
         public Builder() {}
+
+        public Builder(ClusterBlocks clusterBlocks) {
+            this.global.addAll(clusterBlocks.global());
+            this.indices.putAll(clusterBlocks.indices());
+        }
 
         public Builder blocks(ClusterBlocks blocks) {
             global.addAll(blocks.global());
@@ -555,7 +567,7 @@ public class ClusterBlocks extends AbstractDiffable<ClusterBlocks> implements To
                         }
                         break;
                     default:
-                        throw new IllegalArgumentException("unknown field [" + currentFieldName + "]");
+                        logger.warn("unknown field [{}]", currentFieldName);
                 }
             }
             return builder.build();

--- a/server/src/test/java/org/opensearch/cluster/block/ClusterBlockTests.java
+++ b/server/src/test/java/org/opensearch/cluster/block/ClusterBlockTests.java
@@ -33,18 +33,30 @@
 package org.opensearch.cluster.block;
 
 import org.opensearch.Version;
+import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.MediaType;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.XContentTestUtils;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
+import static java.util.Collections.singletonMap;
 import static java.util.EnumSet.copyOf;
+import static org.opensearch.cluster.metadata.Metadata.CONTEXT_MODE_GATEWAY;
 import static org.opensearch.test.VersionUtils.randomVersion;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -136,7 +148,119 @@ public class ClusterBlockTests extends OpenSearchTestCase {
         assertThat(builder.build().getIndexBlockWithId("index", randomValueOtherThan(blockId, OpenSearchTestCase::randomInt)), nullValue());
     }
 
-    private ClusterBlock randomClusterBlock() {
+    public void testToXContent_APIMode() throws IOException {
+        ClusterBlock clusterBlock = randomClusterBlock();
+        XContentBuilder builder = JsonXContent.contentBuilder().prettyPrint();
+        builder.startObject();
+        clusterBlock.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+
+        String expectedString = "{\n" + getExpectedXContentFragment(clusterBlock, "  ", false) + "\n}";
+
+        assertEquals(expectedString, builder.toString());
+    }
+
+    public void testToXContent_GatewayMode() throws IOException {
+        ClusterBlock clusterBlock = randomClusterBlock();
+        XContentBuilder builder = JsonXContent.contentBuilder().prettyPrint();
+        builder.startObject();
+        clusterBlock.toXContent(builder, new ToXContent.MapParams(singletonMap(Metadata.CONTEXT_MODE_PARAM, CONTEXT_MODE_GATEWAY)));
+        builder.endObject();
+
+        String expectedString = "{\n" + getExpectedXContentFragment(clusterBlock, "  ", true) + "\n}";
+
+        assertEquals(expectedString, builder.toString());
+    }
+
+    public void testFromXContent() throws IOException {
+        doFromXContentTestWithRandomFields(false);
+    }
+
+    public void testFromXContentWithRandomFields() throws IOException {
+        doFromXContentTestWithRandomFields(true);
+    }
+
+    private void doFromXContentTestWithRandomFields(boolean addRandomFields) throws IOException {
+        ClusterBlock clusterBlock = randomClusterBlock();
+        boolean humanReadable = randomBoolean();
+        final MediaType mediaType = MediaTypeRegistry.JSON;
+        BytesReference originalBytes = toShuffledXContent(clusterBlock, mediaType, ToXContent.EMPTY_PARAMS, humanReadable);
+
+        if (addRandomFields) {
+            String unsupportedField = "unsupported_field";
+            BytesReference mutated = BytesReference.bytes(
+                XContentTestUtils.insertIntoXContent(
+                    mediaType.xContent(),
+                    originalBytes,
+                    Collections.singletonList(Integer.toString(clusterBlock.id())),
+                    () -> unsupportedField,
+                    () -> randomAlphaOfLengthBetween(3, 10)
+                )
+            );
+            IllegalArgumentException e = expectThrows(
+                IllegalArgumentException.class,
+                () -> ClusterBlock.fromXContent(createParser(mediaType.xContent(), mutated), clusterBlock.id())
+            );
+            assertEquals(e.getMessage(), "unknown field [" + unsupportedField + "]");
+        } else {
+            ClusterBlock parsedBlock = ClusterBlock.fromXContent(createParser(mediaType.xContent(), originalBytes), clusterBlock.id());
+            assertEquals(clusterBlock, parsedBlock);
+            assertEquals(clusterBlock.description(), parsedBlock.description());
+            assertEquals(clusterBlock.retryable(), parsedBlock.retryable());
+            assertEquals(clusterBlock.disableStatePersistence(), parsedBlock.disableStatePersistence());
+            assertArrayEquals(clusterBlock.levels().toArray(), parsedBlock.levels().toArray());
+        }
+    }
+
+    static String getExpectedXContentFragment(ClusterBlock clusterBlock, String indent, boolean gatewayMode) {
+        return indent
+            + "\""
+            + clusterBlock.id()
+            + "\" : {\n"
+            + (clusterBlock.uuid() != null ? indent + "  \"uuid\" : \"" + clusterBlock.uuid() + "\",\n" : "")
+            + indent
+            + "  \"description\" : \""
+            + clusterBlock.description()
+            + "\",\n"
+            + indent
+            + "  \"retryable\" : "
+            + clusterBlock.retryable()
+            + ",\n"
+            + (clusterBlock.disableStatePersistence()
+                ? indent + "  \"disable_state_persistence\" : " + clusterBlock.disableStatePersistence() + ",\n"
+                : "")
+            + String.format(
+                Locale.ROOT,
+                indent + "  \"levels\" : [%s]",
+                clusterBlock.levels().isEmpty()
+                    ? " "
+                    : "\n"
+                        + String.join(
+                            ",\n",
+                            clusterBlock.levels()
+                                .stream()
+                                .map(level -> indent + "    \"" + level.name().toLowerCase(Locale.ROOT) + "\"")
+                                .toArray(String[]::new)
+                        )
+                        + "\n  "
+                        + indent
+            )
+            + (gatewayMode
+                ? ",\n"
+                    + indent
+                    + "  \"status\" : \""
+                    + clusterBlock.status()
+                    + "\",\n"
+                    + indent
+                    + "  \"allow_release_resources\" : "
+                    + clusterBlock.isAllowReleaseResources()
+                    + "\n"
+                : "\n")
+            + indent
+            + "}";
+    }
+
+    static ClusterBlock randomClusterBlock() {
         final String uuid = randomBoolean() ? UUIDs.randomBase64UUID() : null;
         final List<ClusterBlockLevel> levels = Arrays.asList(ClusterBlockLevel.values());
         return new ClusterBlock(

--- a/server/src/test/java/org/opensearch/cluster/block/ClusterBlocksTests.java
+++ b/server/src/test/java/org/opensearch/cluster/block/ClusterBlocksTests.java
@@ -1,0 +1,151 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.block;
+
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.MediaType;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.XContentTestUtils;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.opensearch.cluster.block.ClusterBlockTests.getExpectedXContentFragment;
+import static org.opensearch.cluster.block.ClusterBlockTests.randomClusterBlock;
+
+public class ClusterBlocksTests extends OpenSearchTestCase {
+    public void testToXContent() throws IOException {
+        ClusterBlocks clusterBlocks = randomClusterBlocks();
+        XContentBuilder builder = JsonXContent.contentBuilder().prettyPrint();
+        builder.startObject();
+        clusterBlocks.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+
+        String expectedXContent = "{\n"
+            + "  \"blocks\" : {\n"
+            + String.format(
+                Locale.ROOT,
+                "%s",
+                clusterBlocks.global().isEmpty()
+                    ? ""
+                    : "    \"global\" : {\n"
+                        + clusterBlocks.global()
+                            .stream()
+                            .map(clusterBlock -> getExpectedXContentFragment(clusterBlock, "      ", false))
+                            .collect(Collectors.joining(",\n"))
+                        + "\n    }"
+                        + (!clusterBlocks.indices().isEmpty() ? "," : "")
+                        + "\n"
+            )
+            + String.format(
+                Locale.ROOT,
+                "%s",
+                clusterBlocks.indices().isEmpty()
+                    ? ""
+                    : "    \"indices\" : {\n"
+                        + clusterBlocks.indices()
+                            .entrySet()
+                            .stream()
+                            .map(
+                                entry -> "      \""
+                                    + entry.getKey()
+                                    + "\" : {"
+                                    + (entry.getValue().isEmpty()
+                                        ? " }"
+                                        : "\n"
+                                            + entry.getValue()
+                                                .stream()
+                                                .map(clusterBlock -> getExpectedXContentFragment(clusterBlock, "        ", false))
+                                                .collect(Collectors.joining(",\n"))
+                                            + "\n      }")
+                            )
+                            .collect(Collectors.joining(",\n"))
+                        + "\n    }\n"
+            )
+            + "  }\n"
+            + "}";
+
+        assertEquals(expectedXContent, builder.toString());
+    }
+
+    public void testFromXContent() throws IOException {
+        doFromXContentTestWithRandomFields(false);
+    }
+
+    public void testFromXContentWithRandomFields() throws IOException {
+        doFromXContentTestWithRandomFields(true);
+    }
+
+    private void doFromXContentTestWithRandomFields(boolean addRandomFields) throws IOException {
+        ClusterBlocks clusterBlocks = randomClusterBlocks();
+        boolean humanReadable = randomBoolean();
+        final MediaType mediaType = MediaTypeRegistry.JSON;
+        BytesReference originalBytes = toShuffledXContent(clusterBlocks, mediaType, ToXContent.EMPTY_PARAMS, humanReadable);
+
+        if (addRandomFields) {
+            String unsupportedField = "unsupported_field";
+            BytesReference mutated = BytesReference.bytes(
+                XContentTestUtils.insertIntoXContent(
+                    mediaType.xContent(),
+                    originalBytes,
+                    Collections.singletonList("blocks"),
+                    () -> unsupportedField,
+                    () -> randomAlphaOfLengthBetween(3, 10)
+                )
+            );
+            IllegalArgumentException exception = expectThrows(
+                IllegalArgumentException.class,
+                () -> ClusterBlocks.fromXContent(createParser(mediaType.xContent(), mutated))
+            );
+            assertEquals("unknown field [" + unsupportedField + "]", exception.getMessage());
+        } else {
+            try (XContentParser parser = createParser(JsonXContent.jsonXContent, originalBytes)) {
+                ClusterBlocks parsedClusterBlocks = ClusterBlocks.fromXContent(parser);
+                assertEquals(clusterBlocks.global().size(), parsedClusterBlocks.global().size());
+                assertEquals(clusterBlocks.indices().size(), parsedClusterBlocks.indices().size());
+                clusterBlocks.global().forEach(clusterBlock -> assertTrue(parsedClusterBlocks.global().contains(clusterBlock)));
+                clusterBlocks.indices().forEach((key, value) -> {
+                    assertTrue(parsedClusterBlocks.indices().containsKey(key));
+                    value.forEach(clusterBlock -> assertTrue(parsedClusterBlocks.indices().get(key).contains(clusterBlock)));
+                });
+            }
+        }
+    }
+
+    private ClusterBlocks randomClusterBlocks() {
+        int randomGlobalBlocks = randomIntBetween(0, 10);
+        Set<ClusterBlock> globalBlocks = new HashSet<>();
+        for (int i = 0; i < randomGlobalBlocks; i++) {
+            globalBlocks.add(randomClusterBlock());
+        }
+
+        int randomIndices = randomIntBetween(0, 10);
+        Map<String, Set<ClusterBlock>> indexBlocks = new HashMap<>();
+        for (int i = 0; i < randomIndices; i++) {
+            int randomIndexBlocks = randomIntBetween(0, 10);
+            Set<ClusterBlock> blocks = new HashSet<>();
+            for (int j = 0; j < randomIndexBlocks; j++) {
+                blocks.add(randomClusterBlock());
+            }
+            indexBlocks.put("index-" + i, blocks);
+        }
+        return new ClusterBlocks(globalBlocks, indexBlocks);
+    }
+}


### PR DESCRIPTION
### Description
We need to upload the ClusterBlocks object to remote to enable the cluster state publication flow from remote. To do that we need to parse ClusterBlocks object to and from XContent.

### Related Issues
Resolves #13692 
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
~- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
