### PR TITLE
Skip unnecessary string format in ThrottlingAllocationDecider when not in debug mode

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/ThrottlingAllocationDecider.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/ThrottlingAllocationDecider.java
@@ -211,20 +211,9 @@ public class ThrottlingAllocationDecider extends AllocationDecider {
             allocation,
             currentInRecoveries,
             replicasInitialRecoveries,
-            (x, y) -> getInitialPrimaryNodeOutgoingRecoveries(x, y),
+            this::getInitialPrimaryNodeOutgoingRecoveries,
             replicasInitialRecoveries,
-            String.format(
-                Locale.ROOT,
-                "[%s=%d]",
-                CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_REPLICAS_RECOVERIES_SETTING.getKey(),
-                replicasInitialRecoveries
-            ),
-            String.format(
-                Locale.ROOT,
-                "[%s=%d]",
-                CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_REPLICAS_RECOVERIES_SETTING.getKey(),
-                replicasInitialRecoveries
-            )
+            true
         );
     }
 
@@ -238,22 +227,9 @@ public class ThrottlingAllocationDecider extends AllocationDecider {
             allocation,
             currentInRecoveries,
             concurrentIncomingRecoveries,
-            (x, y) -> getPrimaryNodeOutgoingRecoveries(x, y),
+            this::getPrimaryNodeOutgoingRecoveries,
             concurrentOutgoingRecoveries,
-            String.format(
-                Locale.ROOT,
-                "[%s=%d] (can also be set via [%s])",
-                CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_INCOMING_RECOVERIES_SETTING.getKey(),
-                concurrentIncomingRecoveries,
-                CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_RECOVERIES_SETTING.getKey()
-            ),
-            String.format(
-                Locale.ROOT,
-                "[%s=%d] (can also be set via [%s])",
-                CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_OUTGOING_RECOVERIES_SETTING.getKey(),
-                concurrentOutgoingRecoveries,
-                CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_RECOVERIES_SETTING.getKey()
-            )
+            false
         );
     }
 
@@ -274,18 +250,30 @@ public class ThrottlingAllocationDecider extends AllocationDecider {
         int inRecoveriesLimit,
         BiFunction<ShardRouting, RoutingAllocation, Integer> primaryNodeOutRecoveriesFunc,
         int outRecoveriesLimit,
-        String incomingRecoveriesSettingMsg,
-        String outGoingRecoveriesSettingMsg
+        boolean isInitialShardCopies
     ) {
         // Allocating a shard to this node will increase the incoming recoveries
         if (currentInRecoveries >= inRecoveriesLimit) {
-            return allocation.decision(
-                THROTTLE,
-                NAME,
-                "reached the limit of incoming shard recoveries [%d], cluster setting %s",
-                currentInRecoveries,
-                incomingRecoveriesSettingMsg
-            );
+            if (isInitialShardCopies) {
+                return allocation.decision(
+                    THROTTLE,
+                    NAME,
+                    "reached the limit of incoming shard recoveries [%d], cluster setting [%s=%d]",
+                    currentInRecoveries,
+                    CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_REPLICAS_RECOVERIES_SETTING.getKey(),
+                    inRecoveriesLimit
+                );
+            } else {
+                return allocation.decision(
+                    THROTTLE,
+                    NAME,
+                    "reached the limit of incoming shard recoveries [%d], cluster setting [%s=%d] (can also be set via [%s])",
+                    currentInRecoveries,
+                    CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_INCOMING_RECOVERIES_SETTING.getKey(),
+                    inRecoveriesLimit,
+                    CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_RECOVERIES_SETTING.getKey()
+                );
+            }
         } else {
             // search for corresponding recovery source (= primary shard) and check number of outgoing recoveries on that node
             ShardRouting primaryShard = allocation.routingNodes().activePrimary(shardRouting.shardId());
@@ -294,14 +282,28 @@ public class ThrottlingAllocationDecider extends AllocationDecider {
             }
             int primaryNodeOutRecoveries = primaryNodeOutRecoveriesFunc.apply(shardRouting, allocation);
             if (primaryNodeOutRecoveries >= outRecoveriesLimit) {
-                return allocation.decision(
-                    THROTTLE,
-                    NAME,
-                    "reached the limit of outgoing shard recoveries [%d] on the node [%s] which holds the primary, " + "cluster setting %s",
-                    primaryNodeOutRecoveries,
-                    primaryShard.currentNodeId(),
-                    outGoingRecoveriesSettingMsg
-                );
+                if (isInitialShardCopies) {
+                    return allocation.decision(
+                        THROTTLE,
+                        NAME,
+                        "reached the limit of outgoing shard recoveries [%d] on the node [%s] which holds the primary, " + "cluster setting [%s=%d]",
+                        primaryNodeOutRecoveries,
+                        primaryShard.currentNodeId(),
+                        CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_REPLICAS_RECOVERIES_SETTING.getKey(),
+                        inRecoveriesLimit
+                    );
+                } else {
+                    return allocation.decision(
+                        THROTTLE,
+                        NAME,
+                        "reached the limit of outgoing shard recoveries [%d] on the node [%s] which holds the primary, " + "cluster setting [%s=%d] (can also be set via [%s])",
+                        primaryNodeOutRecoveries,
+                        primaryShard.currentNodeId(),
+                        CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_OUTGOING_RECOVERIES_SETTING.getKey(),
+                        outRecoveriesLimit,
+                        CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_RECOVERIES_SETTING.getKey()
+                    );
+                }
             } else {
                 return allocation.decision(
                     YES,

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/ThrottlingAllocationDecider.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/ThrottlingAllocationDecider.java
@@ -44,7 +44,6 @@ import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.common.settings.Settings;
 
-import java.util.Locale;
 import java.util.function.BiFunction;
 
 import static org.opensearch.cluster.routing.allocation.decider.Decision.THROTTLE;
@@ -286,7 +285,8 @@ public class ThrottlingAllocationDecider extends AllocationDecider {
                     return allocation.decision(
                         THROTTLE,
                         NAME,
-                        "reached the limit of outgoing shard recoveries [%d] on the node [%s] which holds the primary, " + "cluster setting [%s=%d]",
+                        "reached the limit of outgoing shard recoveries [%d] on the node [%s] which holds the primary, "
+                            + "cluster setting [%s=%d]",
                         primaryNodeOutRecoveries,
                         primaryShard.currentNodeId(),
                         CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_REPLICAS_RECOVERIES_SETTING.getKey(),
@@ -296,7 +296,8 @@ public class ThrottlingAllocationDecider extends AllocationDecider {
                     return allocation.decision(
                         THROTTLE,
                         NAME,
-                        "reached the limit of outgoing shard recoveries [%d] on the node [%s] which holds the primary, " + "cluster setting [%s=%d] (can also be set via [%s])",
+                        "reached the limit of outgoing shard recoveries [%d] on the node [%s] which holds the primary, "
+                            + "cluster setting [%s=%d] (can also be set via [%s])",
                         primaryNodeOutRecoveries,
                         primaryShard.currentNodeId(),
                         CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_OUTGOING_RECOVERIES_SETTING.getKey(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Skip unnecessary string format in ThrottlingAllocationDecider when not in debug mode

### Related Issues
Resolves #13743 

### Check List
- ~[ ] New functionality includes testing.~
  - ~[ ] All tests pass~
- ~[ ] New functionality has been documented.~
  - ~[ ] New functionality has javadoc added~
- ~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- ~[ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
