### PR TITLE
Add Jay Deng as a maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # CODEOWNERS manages notifications, not PR approvals
-# For PR approvals see /.github/workflows/maintainer-approval.yml 
+# For PR approvals see /.github/workflows/maintainer-approval.yml
 
 # Files have a single rule applied, the last match decides the owner
 # If you would like to more specifically apply ownership, include existing owner in new sub fields
@@ -24,4 +24,4 @@
 
 /.github/ @peternied
 
-/MAINTAINERS.md @anasalkouz @andrross @Bukhtawar @CEHENKLE @dblock @dbwiddis @dreamer-89 @gbbafna @kotwanikunal @mch2 @msfroh @nknize @owaiskazi19 @peternied @reta @Rishikesh1159 @sachinpkale @saratvemulapalli @shwetathareja @sohami @tlfeng @VachaShah
+/MAINTAINERS.md @anasalkouz @andrross @Bukhtawar @CEHENKLE @dblock @dbwiddis @dreamer-89 @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @nknize @owaiskazi19 @peternied @reta @Rishikesh1159 @sachinpkale @saratvemulapalli @shwetathareja @sohami @tlfeng @VachaShah

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -14,6 +14,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Dan Widdis               | [dbwiddis](https://github.com/dbwiddis)                 | Amazon      |
 | Daniel "dB." Doubrovkine | [dblock](https://github.com/dblock)                     | Amazon      |
 | Gaurav Bafna             | [gbbafna](https://github.com/gbbafna)                   | Amazon      |
+| Jay Deng                 | [jed326](https://github.com/jed326)                     | Amazon      |
 | Kunal Kotwani            | [kotwanikunal](https://github.com/kotwanikunal)         | Amazon      |
 | Marc Handalian           | [mch2](https://github.com/mch2)                         | Amazon      |
 | Michael Froh             | [msfroh](https://github.com/msfroh)                     | Amazon      |


### PR DESCRIPTION
### Description
Jay has accepted the invitation to become a maintainer. Welcome Jay!

Jay is an active contributor of OpenSearch project and has extensively contributed in the concurrent segment search feature to make it GA for the users. Aside from this he proactively contributed to improve the documentations for different aggregations like term, sampler, diversified sampler, etc based on his learnings and is pretty active in the triage meetings and reviewing issues/PRs. Jay has contributed 56 pull requests to the project and reviewed close to 53 PRs. Some of his main contributions are:
 
**PRs:**
* Enabling parallel buildAggregation with concurrent search to further improve on agg performance https://github.com/opensearch-project/OpenSearch/issues/11673
* Doc count error computation at slice level: https://github.com/opensearch-project/OpenSearch/issues/11680
* New index_searcher threadpool and integrate it with Resource tracking framework. https://github.com/opensearch-project/OpenSearch/issues/7425
* New metrics related to concurrent search and wait time for search related threadpools.
** https://github.com/opensearch-project/OpenSearch/pull/9622
** https://github.com/opensearch-project/OpenSearch/pull/9681

* Dynamic way to enable/disable concurrent search. Followed by mechanism in the AggregationFactory to separate aggregations which supports concurrent search and determine at runtime if requests needs to be executed using concurrent vs non-concurrent path
** https://github.com/opensearch-project/OpenSearch/pull/7956
** https://github.com/opensearch-project/OpenSearch/pull/9469

**Issues:**
* Proactively followed up on a bug and facilitated the fix for that in 2.14 https://github.com/opensearch-project/OpenSearch/issues/13411

**Deep Dives:**
Evaluation to support force termination with terminate_after in concurrent search path https://github.com/opensearch-project/OpenSearch/issues/8371
Evaluation for Parent Join agg and Diversified Sampler for concurrent search support: https://github.com/opensearch-project/OpenSearch/issues/9316, https://github.com/opensearch-project/OpenSearch/issues/11075


The maintainers have voted and agreed to this nomination, following [the process here](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#nomination).

### Check List
- [ ] ~New functionality includes testing.~
  - [ ] ~All tests pass~
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [ ] ~Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))~
- [X] Commits are signed per the DCO using --signoff
- [ ] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
