### PR TITLE
[Bugfix] [Tiered Caching] Fixes issues when integrating tiered cache with disk cache

### DIFF
--- a/modules/cache-common/src/main/java/org/opensearch/cache/common/tier/TieredSpilloverCache.java
+++ b/modules/cache-common/src/main/java/org/opensearch/cache/common/tier/TieredSpilloverCache.java
@@ -119,6 +119,8 @@ public class TieredSpilloverCache<K, V> implements ICache<K, V> {
                 .setValueType(builder.cacheConfig.getValueType())
                 .setSettings(builder.cacheConfig.getSettings())
                 .setWeigher(builder.cacheConfig.getWeigher())
+                .setKeySerializer(builder.cacheConfig.getKeySerializer())
+                .setValueSerializer(builder.cacheConfig.getValueSerializer())
                 .setDimensionNames(builder.cacheConfig.getDimensionNames())
                 .setStatsTrackingEnabled(false)
                 .build(),

--- a/modules/cache-common/src/test/java/org/opensearch/cache/common/tier/MockDiskCache.java
+++ b/modules/cache-common/src/test/java/org/opensearch/cache/common/tier/MockDiskCache.java
@@ -141,6 +141,10 @@ public class MockDiskCache<K, V> implements ICache<K, V> {
         @Override
         @SuppressWarnings({ "unchecked" })
         public <K, V> ICache<K, V> create(CacheConfig<K, V> config, CacheType cacheType, Map<String, Factory> cacheFactories) {
+            // As we can't directly IT with the tiered cache and ehcache, check that we receive non-null serializers, as an ehcache disk
+            // cache would require.
+            assert config.getKeySerializer() != null;
+            assert config.getValueSerializer() != null;
             return new Builder<K, V>().setKeySerializer((Serializer<K, byte[]>) config.getKeySerializer())
                 .setValueSerializer((Serializer<V, byte[]>) config.getValueSerializer())
                 .setMaxSize(maxSize)

--- a/modules/cache-common/src/test/java/org/opensearch/cache/common/tier/TieredSpilloverCacheTests.java
+++ b/modules/cache-common/src/test/java/org/opensearch/cache/common/tier/TieredSpilloverCacheTests.java
@@ -16,6 +16,7 @@ import org.opensearch.common.cache.LoadAwareCacheLoader;
 import org.opensearch.common.cache.RemovalListener;
 import org.opensearch.common.cache.RemovalNotification;
 import org.opensearch.common.cache.policy.CachedQueryResult;
+import org.opensearch.common.cache.serializer.Serializer;
 import org.opensearch.common.cache.settings.CacheSettings;
 import org.opensearch.common.cache.stats.ImmutableCacheStats;
 import org.opensearch.common.cache.stats.ImmutableCacheStatsHolder;
@@ -32,6 +33,8 @@ import org.opensearch.test.OpenSearchTestCase;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -166,6 +169,8 @@ public class TieredSpilloverCacheTests extends OpenSearchTestCase {
                 .setKeyType(String.class)
                 .setWeigher((k, v) -> keyValueSize)
                 .setRemovalListener(removalListener)
+                .setKeySerializer(new StringSerializer())
+                .setValueSerializer(new StringSerializer())
                 .setSettings(settings)
                 .setDimensionNames(dimensionNames)
                 .setCachedResultParser(s -> new CachedQueryResult.PolicyValues(20_000_000L)) // Values will always appear to have taken
@@ -318,6 +323,8 @@ public class TieredSpilloverCacheTests extends OpenSearchTestCase {
             .setKeyType(String.class)
             .setWeigher((k, v) -> keyValueSize)
             .setRemovalListener(removalListener)
+            .setKeySerializer(new StringSerializer())
+            .setValueSerializer(new StringSerializer())
             .setDimensionNames(dimensionNames)
             .setSettings(
                 Settings.builder()
@@ -830,6 +837,8 @@ public class TieredSpilloverCacheTests extends OpenSearchTestCase {
             .setKeyType(String.class)
             .setWeigher((k, v) -> 150)
             .setRemovalListener(removalListener)
+            .setKeySerializer(new StringSerializer())
+            .setValueSerializer(new StringSerializer())
             .setSettings(
                 Settings.builder()
                     .put(
@@ -1014,6 +1023,8 @@ public class TieredSpilloverCacheTests extends OpenSearchTestCase {
                 .setKeyType(String.class)
                 .setWeigher((k, v) -> keyValueSize)
                 .setRemovalListener(removalListener)
+                .setKeySerializer(new StringSerializer())
+                .setValueSerializer(new StringSerializer())
                 .setSettings(settings)
                 .setMaxSizeInBytes(onHeapCacheSize * keyValueSize)
                 .setDimensionNames(dimensionNames)
@@ -1415,6 +1426,8 @@ public class TieredSpilloverCacheTests extends OpenSearchTestCase {
             .setSettings(settings)
             .setDimensionNames(dimensionNames)
             .setRemovalListener(removalListener)
+            .setKeySerializer(new StringSerializer())
+            .setValueSerializer(new StringSerializer())
             .setSettings(
                 Settings.builder()
                     .put(
@@ -1478,5 +1491,27 @@ public class TieredSpilloverCacheTests extends OpenSearchTestCase {
             // dimensions yet
         }
         return snapshot;
+    }
+
+    // Duplicated here from EhcacheDiskCacheTests.java, we can't add a dependency on that plugin
+    static class StringSerializer implements Serializer<String, byte[]> {
+        private final Charset charset = StandardCharsets.UTF_8;
+
+        @Override
+        public byte[] serialize(String object) {
+            return object.getBytes(charset);
+        }
+
+        @Override
+        public String deserialize(byte[] bytes) {
+            if (bytes == null) {
+                return null;
+            }
+            return new String(bytes, charset);
+        }
+
+        public boolean equals(String object, byte[] bytes) {
+            return object.equals(deserialize(bytes));
+        }
     }
 }

--- a/plugins/cache-ehcache/build.gradle
+++ b/plugins/cache-ehcache/build.gradle
@@ -24,6 +24,7 @@ versions << [
 
 dependencies {
   api "org.ehcache:ehcache:${versions.ehcache}"
+  api "org.slf4j:slf4j-api:${versions.slf4j}"
 }
 
 thirdPartyAudit {

--- a/plugins/cache-ehcache/build.gradle
+++ b/plugins/cache-ehcache/build.gradle
@@ -91,13 +91,3 @@ tasks.named("bundlePlugin").configure {
     into 'config'
   }
 }
-
-test {
-  // TODO: Adding permission in plugin-security.policy doesn't seem to work.
-  //systemProperty 'tests.security.manager', 'false'
-}
-
-internalClusterTest {
-  // TODO: Remove this later once we have a way.
-  //systemProperty 'tests.security.manager', 'false'
-}

--- a/plugins/cache-ehcache/build.gradle
+++ b/plugins/cache-ehcache/build.gradle
@@ -94,10 +94,10 @@ tasks.named("bundlePlugin").configure {
 
 test {
   // TODO: Adding permission in plugin-security.policy doesn't seem to work.
-  systemProperty 'tests.security.manager', 'false'
+  //systemProperty 'tests.security.manager', 'false'
 }
 
 internalClusterTest {
   // TODO: Remove this later once we have a way.
-  systemProperty 'tests.security.manager', 'false'
+  //systemProperty 'tests.security.manager', 'false'
 }

--- a/plugins/cache-ehcache/src/main/plugin-metadata/plugin-security.policy
+++ b/plugins/cache-ehcache/src/main/plugin-metadata/plugin-security.policy
@@ -12,7 +12,5 @@ grant {
   permission java.lang.RuntimePermission "accessDeclaredMembers";
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
   permission java.lang.RuntimePermission "getClassLoader";
-
-  permission java.io.FilePermission "${path.data}/nodes/{node.id}/-", "read, write";
 };
 

--- a/plugins/cache-ehcache/src/main/plugin-metadata/plugin-security.policy
+++ b/plugins/cache-ehcache/src/main/plugin-metadata/plugin-security.policy
@@ -9,5 +9,16 @@
 grant {
   permission java.lang.RuntimePermission "accessClassInPackage.sun.misc";
   permission java.lang.RuntimePermission "createClassLoader";
+  permission java.lang.RuntimePermission "accessDeclaredMembers";
+  permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
+  permission java.lang.RuntimePermission "getClassLoader";
+  permission java.io.FilePermission "/private/tmp/request_cache/-", "read";
+  permission java.io.FilePermission "/private/tmp/request_cache/-", "write"; // TODO: Where on earth is this /private prefix coming from?
+  permission java.io.FilePermission "/tmp/request_cache/-", "read";
+  permission java.io.FilePermission "/tmp/request_cache/-", "write";
+  permission java.io.FilePermission "/private/tmp/request_cache", "read";
+  permission java.io.FilePermission "/private/tmp/request_cache", "write";
+  permission java.io.FilePermission "/tmp/request_cache", "read";
+  permission java.io.FilePermission "/tmp/request_cache", "write";
 };
 

--- a/plugins/cache-ehcache/src/main/plugin-metadata/plugin-security.policy
+++ b/plugins/cache-ehcache/src/main/plugin-metadata/plugin-security.policy
@@ -12,13 +12,7 @@ grant {
   permission java.lang.RuntimePermission "accessDeclaredMembers";
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
   permission java.lang.RuntimePermission "getClassLoader";
-  permission java.io.FilePermission "/private/tmp/request_cache/-", "read";
-  permission java.io.FilePermission "/private/tmp/request_cache/-", "write"; // TODO: Where on earth is this /private prefix coming from?
-  permission java.io.FilePermission "/tmp/request_cache/-", "read";
-  permission java.io.FilePermission "/tmp/request_cache/-", "write";
-  permission java.io.FilePermission "/private/tmp/request_cache", "read";
-  permission java.io.FilePermission "/private/tmp/request_cache", "write";
-  permission java.io.FilePermission "/tmp/request_cache", "read";
-  permission java.io.FilePermission "/tmp/request_cache", "write";
+
+  permission java.io.FilePermission "${path.data}/nodes/{node.id}/-", "read, write";
 };
 


### PR DESCRIPTION
### Description
Fixes issues that prevented us from using the tiered spillover cache with EhcacheDiskCache as the disk cache: 

- TSC was not correctly passing serializers to its disk cache, broken since 2.14 
- Ehcache plugin was missing slf4j dependency in main, but had it in 2.x branch
- Ehcache plugin was missing permissions and wasn't properly using AccessController.doPrivileged to run its code that required those permissions. Broken since 2.13

These issues weren't caught in automated testing since the TSC lives in a module and the disk cache lives in a separate plugin, so we couldn't IT them together and the issues were only found during manual testing. Confirmed that after these fixes are in place, we can use the feature as desired using: 

```./gradlew run -Dtests.opensearch.opensearch.experimental.feature.pluggable.caching.enabled=true -Dtests.opensearch.indices.requests.cache.store.name=tiered_spillover -Dtests.opensearch.indices.requests.cache.tiered_spillover.onheap.store.name=opensearch_onheap -Dtests.opensearch.indices.requests.cache.tiered_spillover.disk.store.name=ehcache_disk -Dtests.opensearch.indices.requests.cache.tiered_spillover.disk.store.policies.took_time.threshold=0ms -PinstalledPlugins="['cache-ehcache']" -Dtests.opensearch.indices.requests.cache.ehcache_disk.storage.path="/Volumes/workplace/opensearch/OpenSearch/build/testclusters/runTask-0/data/nodes/0/indices/request_cache"```

I've bundled these bugfixes together, as we can't really confirm any one of the fixes works until the manual test runs correctly, which requires all of the fixes. 

### Related Issues
Part of [tiered caching](https://github.com/opensearch-project/OpenSearch/issues/10024)

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
~- [N/A] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
~- [N/A] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
~- [N/A] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
