### PR TITLE
[Remote Store] Add snapshot type information in repository data.

### DIFF
--- a/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
@@ -143,6 +143,7 @@ import org.opensearch.snapshots.SnapshotException;
 import org.opensearch.snapshots.SnapshotId;
 import org.opensearch.snapshots.SnapshotInfo;
 import org.opensearch.snapshots.SnapshotMissingException;
+import org.opensearch.snapshots.SnapshotType;
 import org.opensearch.snapshots.SnapshotsService;
 import org.opensearch.threadpool.ThreadPool;
 
@@ -1722,7 +1723,8 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                     Version.CURRENT,
                     shardGenerations,
                     indexMetas,
-                    indexMetaIdentifiers
+                    indexMetaIdentifiers,
+                    snapshotInfo.getSnapshotType()
                 );
                 writeIndexGen(
                     updatedRepositoryData,
@@ -2335,22 +2337,23 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
         // Step 2: Write new index-N blob to repository and update index.latest
         setPendingStep.whenComplete(newGen -> threadPool().executor(ThreadPool.Names.SNAPSHOT).execute(ActionRunnable.wrap(listener, l -> {
-            // BwC logic: Load snapshot version information if any snapshot is missing a version in RepositoryData so that the new
-            // RepositoryData contains a version for every snapshot
-            final List<SnapshotId> snapshotIdsWithoutVersion = repositoryData.getSnapshotIds()
+            // BwC logic: Load snapshot version or snapshot type information if any snapshot is missing a version or
+            // type in RepositoryData so that the new RepositoryData contains version and type for every snapshot
+            final List<SnapshotId> snapshotIdsWithoutVersionOrType = repositoryData.getSnapshotIds()
                 .stream()
                 .filter(snapshotId -> repositoryData.getVersion(snapshotId) == null)
                 .collect(Collectors.toList());
-            if (snapshotIdsWithoutVersion.isEmpty() == false) {
+            if (snapshotIdsWithoutVersionOrType.isEmpty() == false) {
                 final Map<SnapshotId, Version> updatedVersionMap = new ConcurrentHashMap<>();
-                final GroupedActionListener<Void> loadAllVersionsListener = new GroupedActionListener<>(
+                final Map<SnapshotId, SnapshotType> updatedSnapshotTypeMap = new ConcurrentHashMap<>();
+                final GroupedActionListener<Void> loadMissingDataListener = new GroupedActionListener<>(
                     ActionListener.runAfter(new ActionListener<Collection<Void>>() {
                         @Override
                         public void onResponse(Collection<Void> voids) {
                             logger.info(
-                                "Successfully loaded all snapshot's version information for {} from snapshot metadata",
+                                "Successfully loaded all snapshot's version and type information for {} from snapshot metadata",
                                 AllocationService.firstListElementsToCommaDelimitedString(
-                                    snapshotIdsWithoutVersion,
+                                    snapshotIdsWithoutVersionOrType,
                                     SnapshotId::toString,
                                     logger.isDebugEnabled()
                                 )
@@ -2359,19 +2362,20 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
                         @Override
                         public void onFailure(Exception e) {
-                            logger.warn("Failure when trying to load missing version information from snapshot metadata", e);
+                            logger.warn("Failure when trying to load missing version or type information from snapshot metadata", e);
                         }
-                    }, () -> filterRepositoryDataStep.onResponse(repositoryData.withVersions(updatedVersionMap))),
-                    snapshotIdsWithoutVersion.size()
+                    },
+                        () -> filterRepositoryDataStep.onResponse(
+                            repositoryData.withVersions(updatedVersionMap).withSnapshotTypes(updatedSnapshotTypeMap)
+                        )
+                    ),
+                    snapshotIdsWithoutVersionOrType.size()
                 );
-                for (SnapshotId snapshotId : snapshotIdsWithoutVersion) {
-                    threadPool().executor(ThreadPool.Names.SNAPSHOT)
-                        .execute(
-                            ActionRunnable.run(
-                                loadAllVersionsListener,
-                                () -> updatedVersionMap.put(snapshotId, getSnapshotInfo(snapshotId).version())
-                            )
-                        );
+                for (SnapshotId snapshotId : snapshotIdsWithoutVersionOrType) {
+                    threadPool().executor(ThreadPool.Names.SNAPSHOT).execute(ActionRunnable.run(loadMissingDataListener, () -> {
+                        updatedVersionMap.put(snapshotId, getSnapshotInfo(snapshotId).version());
+                        updatedSnapshotTypeMap.put(snapshotId, getSnapshotInfo(snapshotId).getSnapshotType());
+                    }));
                 }
             } else {
                 filterRepositoryDataStep.onResponse(repositoryData);

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotInfo.java
@@ -539,6 +539,13 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         return remoteStoreIndexShallowCopy;
     }
 
+    public SnapshotType getSnapshotType() {
+        if (remoteStoreIndexShallowCopy != null && remoteStoreIndexShallowCopy) {
+            return SnapshotType.SHALLOW_COPY;
+        }
+        return SnapshotType.FULL_COPY;
+    }
+
     /**
      * Returns shard failures; an empty list will be returned if there were no shard
      * failures, or if {@link #state()} returns {@code null}.

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotType.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotType.java
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.snapshots;
+
+import org.opensearch.common.annotation.PublicApi;
+
+@PublicApi(since = "2.15.0")
+public enum SnapshotType {
+    FULL_COPY("full_copy"),
+    SHALLOW_COPY("shallow_copy");
+
+    private final String text;
+
+    SnapshotType(String text) {
+        this.text = text;
+    }
+
+    @Override
+    public String toString() {
+        return text;
+    }
+
+    public static SnapshotType fromString(String string) {
+        for (SnapshotType type : values()) {
+            if (type.text.equals(string)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Invalid snapshot_type: " + string);
+    }
+}

--- a/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryTests.java
+++ b/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryTests.java
@@ -58,6 +58,7 @@ import org.opensearch.repositories.ShardGenerations;
 import org.opensearch.repositories.fs.FsRepository;
 import org.opensearch.snapshots.SnapshotId;
 import org.opensearch.snapshots.SnapshotState;
+import org.opensearch.snapshots.SnapshotType;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
 import java.nio.file.Path;
@@ -278,8 +279,12 @@ public class BlobStoreRepositoryTests extends BlobStoreRepositoryHelperTests {
     }
 
     private BlobStoreRepository setupRepo() {
-        final Client client = client();
         final Path location = OpenSearchIntegTestCase.randomRepoPath(node().settings());
+        return setupRepo(location);
+    }
+
+    private BlobStoreRepository setupRepo(Path location) {
+        final Client client = client();
         final String repositoryName = "test-repo";
 
         AcknowledgedResponse putRepositoryResponse = client.admin()
@@ -315,7 +320,8 @@ public class BlobStoreRepositoryTests extends BlobStoreRepositoryHelperTests {
                 Version.CURRENT,
                 shardGenerations,
                 indexLookup,
-                indexLookup.values().stream().collect(Collectors.toMap(Function.identity(), ignored -> UUIDs.randomBase64UUID(random())))
+                indexLookup.values().stream().collect(Collectors.toMap(Function.identity(), ignored -> UUIDs.randomBase64UUID(random()))),
+                randomFrom(SnapshotType.FULL_COPY, SnapshotType.SHALLOW_COPY)
             );
         }
         return repoData;

--- a/test/framework/src/main/java/org/opensearch/index/shard/RestoreOnlyRepository.java
+++ b/test/framework/src/main/java/org/opensearch/index/shard/RestoreOnlyRepository.java
@@ -112,7 +112,8 @@ public abstract class RestoreOnlyRepository extends AbstractLifecycleComponent i
                 Collections.emptyMap(),
                 Collections.singletonMap(indexId, emptyList()),
                 ShardGenerations.EMPTY,
-                IndexMetaDataGenerations.EMPTY
+                IndexMetaDataGenerations.EMPTY,
+                Collections.emptyMap()
             )
         );
     }


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
* While adding Shallow copy snapshots support, we introduced a new method `deleteSnapshotsAndReleaseLockFiles` (which also takes care of releasing remote store lock for the snapshot) in repository interface. We did not directly used this new method in snapshot service as it would be a breaking change for existing users who have implemented this interface differently or for those who do not have this method implemented in their repository implementation.
* Thus, during snapshot deletion we relied on `shallow_copy_snapshot_enabled` repository setting flag to decide if we need to use the old method `deleteSnapshots` or the new method `deleteSnapshotsAndReleaseLockFiles`.
* Now we will be supporting migration from remote store indices to docrep indices, we cannot rely on this repository setting as it would end up into dangling lock files in remote store.

### Related Issues
Resolves #8610 
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
