### PR TITLE
Custom toXContent implementations

### DIFF
--- a/libs/core/src/main/java/org/opensearch/core/xcontent/XContentParserUtils.java
+++ b/libs/core/src/main/java/org/opensearch/core/xcontent/XContentParserUtils.java
@@ -38,6 +38,8 @@ import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.xcontent.XContentParser.Token;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.function.Consumer;
 
@@ -177,5 +179,15 @@ public final class XContentParserUtils {
         } else {
             throw new ParsingException(parser.getTokenLocation(), "Failed to parse object: empty key");
         }
+    }
+
+    public static List<String> parseStringList(XContentParser parser) throws IOException {
+        List<String> valueList = new ArrayList<>();
+        ensureExpectedToken(Token.START_ARRAY, parser.currentToken(), parser);
+        while (parser.nextToken() != Token.END_ARRAY) {
+            ensureExpectedToken(Token.VALUE_STRING, parser.currentToken(), parser);
+            valueList.add(parser.text());
+        }
+        return valueList;
     }
 }

--- a/server/src/main/java/org/opensearch/cluster/RepositoryCleanupInProgress.java
+++ b/server/src/main/java/org/opensearch/cluster/RepositoryCleanupInProgress.java
@@ -133,7 +133,8 @@ public final class RepositoryCleanupInProgress extends AbstractNamedDiffable<Clu
                 if ("repository".equals(currentFieldName)) {
                     repository = parser.text();
                 } else if ("repository_state_id".equals(currentFieldName)) {
-                    // only XContent parsed with {@link Metadata.CONTEXT_MODE_GATEWAY} will have the repository state id and can be deserialized
+                    // only XContent parsed with {@link Metadata.CONTEXT_MODE_GATEWAY} will have the repository state id and can be
+                    // deserialized
                     repositoryStateId = parser.longValue();
                 } else {
                     throw new IllegalArgumentException("unknown field [" + currentFieldName + "]");

--- a/server/src/main/java/org/opensearch/cluster/RestoreInProgress.java
+++ b/server/src/main/java/org/opensearch/cluster/RestoreInProgress.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.cluster;
 
-import org.elasticsearch.snapshots.SnapshotId;
 import org.opensearch.Version;
 import org.opensearch.cluster.ClusterState.Custom;
 import org.opensearch.cluster.metadata.Metadata;
@@ -365,14 +364,23 @@ public class RestoreInProgress extends AbstractNamedDiffable<Custom> implements 
                                         throw new IllegalArgumentException("unknown field [" + currentFieldName + "]");
                                 }
                             }
-                            shards.put(new ShardId(indexName, indexUUID, shardId), new ShardRestoreStatus(nodeId, State.fromValue((byte) restoreState), reason));
+                            shards.put(
+                                new ShardId(indexName, indexUUID, shardId),
+                                new ShardRestoreStatus(nodeId, State.fromValue((byte) restoreState), reason)
+                            );
                         }
                         break;
                     default:
                         throw new IllegalArgumentException("unknown field [" + currentFieldName + "]");
                 }
             }
-            return new Entry(uuid, new Snapshot(snapshotRepository, new SnapshotId(snapshotName, snapshotUUID)), State.fromValue((byte) state), indices, shards);
+            return new Entry(
+                uuid,
+                new Snapshot(snapshotRepository, new SnapshotId(snapshotName, snapshotUUID)),
+                State.fromValue((byte) state),
+                indices,
+                shards
+            );
         }
     }
 
@@ -663,27 +671,3 @@ public class RestoreInProgress extends AbstractNamedDiffable<Custom> implements 
         entry.toXContent(builder, params);
     }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/server/src/main/java/org/opensearch/cluster/SnapshotDeletionsInProgress.java
+++ b/server/src/main/java/org/opensearch/cluster/SnapshotDeletionsInProgress.java
@@ -291,7 +291,6 @@ public class SnapshotDeletionsInProgress extends AbstractNamedDiffable<Custom> i
         return SnapshotDeletionsInProgress.of(entries);
     }
 
-
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder("SnapshotDeletionsInProgress[");

--- a/server/src/main/java/org/opensearch/cluster/SnapshotDeletionsInProgress.java
+++ b/server/src/main/java/org/opensearch/cluster/SnapshotDeletionsInProgress.java
@@ -34,12 +34,14 @@ package org.opensearch.cluster;
 
 import org.opensearch.Version;
 import org.opensearch.cluster.ClusterState.Custom;
+import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.repositories.RepositoryOperation;
 import org.opensearch.snapshots.SnapshotId;
 
@@ -51,6 +53,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureFieldName;
 
 /**
  * A class that represents the snapshot deletions that are in progress in the cluster.
@@ -72,7 +77,7 @@ public class SnapshotDeletionsInProgress extends AbstractNamedDiffable<Custom> i
         assert assertNoConcurrentDeletionsForSameRepository(entries);
     }
 
-    public static SnapshotDeletionsInProgress of(List<SnapshotDeletionsInProgress.Entry> entries) {
+    public static SnapshotDeletionsInProgress of(List<Entry> entries) {
         if (entries.isEmpty()) {
             return EMPTY;
         }
@@ -190,17 +195,91 @@ public class SnapshotDeletionsInProgress extends AbstractNamedDiffable<Custom> i
                 builder.field("repository", entry.repository());
                 builder.startArray("snapshots");
                 for (SnapshotId snapshot : entry.snapshots) {
-                    builder.value(snapshot.getName());
+                    if (params.param(Metadata.CONTEXT_MODE_PARAM, Metadata.CONTEXT_MODE_API).equals(Metadata.CONTEXT_MODE_GATEWAY)) {
+                        builder.startObject();
+                        builder.field("name", snapshot.getName());
+                        builder.field("uuid", snapshot.getUUID());
+                        builder.endObject();
+                    } else {
+                        builder.value(snapshot.getName());
+                    }
                 }
                 builder.endArray();
                 builder.humanReadableField("start_time_millis", "start_time", new TimeValue(entry.startTime));
                 builder.field("repository_state_id", entry.repositoryStateId);
+                if (params.param(Metadata.CONTEXT_MODE_PARAM, Metadata.CONTEXT_MODE_API).equals(Metadata.CONTEXT_MODE_GATEWAY)) {
+                    builder.field("state", entry.state().value);
+                } // else we don't serialize it
             }
             builder.endObject();
         }
         builder.endArray();
         return builder;
     }
+
+    public static SnapshotDeletionsInProgress fromXContent(XContentParser parser) throws IOException {
+        ensureFieldName(parser, parser.currentToken(), TYPE);
+        parser.nextToken();
+        ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
+        List<Entry> entries = new ArrayList<>();
+        while ((parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+            String repository = null;
+            long repositoryStateId = -1;
+            byte stateValue = -1;
+            List<SnapshotId> snapshotIds = new ArrayList<>();
+            TimeValue startTime = null;
+            while ((parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.currentToken(), parser);
+                final String fieldName = parser.currentName();
+                parser.nextToken();
+                switch (fieldName) {
+                    case "repository":
+                        repository = parser.text();
+                        break;
+                    case "snapshots":
+                        ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
+                        while ((parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                            String name = null;
+                            String uuid = null;
+                            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+                            while ((parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                                ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.currentToken(), parser);
+                                final String currentFieldName = parser.currentName();
+                                parser.nextToken();
+                                if ("name".equals(currentFieldName)) {
+                                    name = parser.text();
+                                } else if ("uuid".equals(currentFieldName)) {
+                                    uuid = parser.text();
+                                } else {
+                                    throw new IllegalArgumentException("unknown field [" + currentFieldName + "]");
+                                }
+                            }
+                            snapshotIds.add(new SnapshotId(name, uuid));
+                        }
+                        break;
+                    case "start_time_millis":
+                        startTime = TimeValue.timeValueMillis(parser.longValue());
+                        break;
+                    case "start_time":
+                        startTime = TimeValue.parseTimeValue(parser.text(), "start_time");
+                        break;
+                    case "repository_state_id":
+                        repositoryStateId = parser.longValue();
+                        break;
+                    case "state":
+                        stateValue = (byte) parser.intValue();
+                        break;
+                    default:
+                        throw new IllegalArgumentException("unknown field [" + fieldName + "]");
+                }
+            }
+            assert startTime != null;
+            entries.add(new Entry(snapshotIds, repository, startTime.millis(), repositoryStateId, State.fromValue(stateValue)));
+        }
+        return SnapshotDeletionsInProgress.of(entries);
+    }
+
 
     @Override
     public String toString() {
@@ -379,6 +458,17 @@ public class SnapshotDeletionsInProgress extends AbstractNamedDiffable<Custom> i
 
         public static State readFrom(StreamInput in) throws IOException {
             final byte value = in.readByte();
+            switch (value) {
+                case 0:
+                    return WAITING;
+                case 1:
+                    return STARTED;
+                default:
+                    throw new IllegalArgumentException("No snapshot delete state for value [" + value + "]");
+            }
+        }
+
+        public static State fromValue(byte value) {
             switch (value) {
                 case 0:
                     return WAITING;

--- a/server/src/main/java/org/opensearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/opensearch/cluster/SnapshotsInProgress.java
@@ -870,9 +870,12 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
                                         throw new IllegalArgumentException("unknown field [" + currentShardField + "]");
                                 }
                             }
-                            shards.put(new ShardId(index, shardId),
-                                reason != null ? new ShardSnapshotStatus(nodeId, shardState, reason, generation) :
-                                new ShardSnapshotStatus(nodeId, shardState, generation));
+                            shards.put(
+                                new ShardId(index, shardId),
+                                reason != null
+                                    ? new ShardSnapshotStatus(nodeId, shardState, reason, generation)
+                                    : new ShardSnapshotStatus(nodeId, shardState, generation)
+                            );
                         }
                         break;
                     case DATA_STREAMS:
@@ -927,9 +930,12 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
                                         throw new IllegalArgumentException("unknown field [" + currentFieldName + "]");
                                 }
                             }
-                            clones.put(new RepositoryShardId(new IndexId(index, indexId), shardId),
-                                reason != null ? new ShardSnapshotStatus(nodeId, ShardState.fromValue(snapshotShardStatus), reason, generation) :
-                                new ShardSnapshotStatus(nodeId, ShardState.fromValue(snapshotShardStatus), generation));
+                            clones.put(
+                                new RepositoryShardId(new IndexId(index, indexId), shardId),
+                                reason != null
+                                    ? new ShardSnapshotStatus(nodeId, ShardState.fromValue(snapshotShardStatus), reason, generation)
+                                    : new ShardSnapshotStatus(nodeId, ShardState.fromValue(snapshotShardStatus), generation)
+                            );
                         }
                         break;
                     case VERSION:
@@ -1202,7 +1208,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
         }
 
         public static State fromString(String value) {
-            switch(value) {
+            switch (value) {
                 case "INIT":
                     return INIT;
                 case "STARTED":

--- a/server/src/main/java/org/opensearch/repositories/IndexId.java
+++ b/server/src/main/java/org/opensearch/repositories/IndexId.java
@@ -138,7 +138,7 @@ public final class IndexId implements Writeable, ToXContentObject {
     }
 
     public static IndexId fromXContent(XContentParser parser) throws IOException {
-        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         String name = null;
         String id = null;
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {

--- a/server/src/main/java/org/opensearch/repositories/IndexId.java
+++ b/server/src/main/java/org/opensearch/repositories/IndexId.java
@@ -36,6 +36,7 @@ import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.ToXContentObject;
@@ -43,6 +44,8 @@ import org.opensearch.core.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.Objects;
+
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 
 /**
  * Represents a single snapshotted index in the repository.
@@ -132,5 +135,26 @@ public final class IndexId implements Writeable, ToXContentObject {
         builder.field(ID, id);
         builder.endObject();
         return builder;
+    }
+
+    public static IndexId fromXContent(XContentParser parser) throws IOException {
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+        String name = null;
+        String id = null;
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String currentFieldName = parser.currentName();
+            parser.nextToken();
+            switch (currentFieldName) {
+                case NAME:
+                    name = parser.text();
+                    break;
+                case ID:
+                    id = parser.text();
+                    break;
+                default:
+                    throw new IllegalArgumentException("unknown field [" + currentFieldName + "]");
+            }
+        }
+        return new IndexId(name, id);
     }
 }

--- a/server/src/main/java/org/opensearch/repositories/IndexId.java
+++ b/server/src/main/java/org/opensearch/repositories/IndexId.java
@@ -36,11 +36,11 @@ import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
-import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.Objects;

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotId.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotId.java
@@ -38,6 +38,8 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.core.xcontent.XContentParserUtils;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -144,5 +146,24 @@ public final class SnapshotId implements Comparable<SnapshotId>, Writeable, ToXC
         builder.field(UUID, uuid);
         builder.endObject();
         return builder;
+    }
+
+    public static SnapshotId fromXContent(XContentParser parser) throws IOException {
+        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        String name = null;
+        String uuid = null;
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            XContentParserUtils.ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.currentToken(), parser);
+            final String currentFieldName = parser.currentName();
+            parser.nextToken();
+            if (NAME.equals(currentFieldName)) {
+                name = parser.text();
+            } else if (UUID.equals(currentFieldName)) {
+                uuid = parser.text();
+            } else {
+                throw new IllegalArgumentException("unknown field [" + currentFieldName + "]");
+            }
+        }
+        return new SnapshotId(name, uuid);
     }
 }

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotId.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotId.java
@@ -149,6 +149,9 @@ public final class SnapshotId implements Comparable<SnapshotId>, Writeable, ToXC
     }
 
     public static SnapshotId fromXContent(XContentParser parser) throws IOException {
+        if (parser.currentToken() == null) { // fresh parser? move to next token
+            parser.nextToken();
+        }
         XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         String name = null;
         String uuid = null;

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotIdTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotIdTests.java
@@ -1,0 +1,74 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.snapshots;
+
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.MediaType;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.XContentTestUtils;
+
+import java.io.IOException;
+import java.util.Collections;
+
+public class SnapshotIdTests extends OpenSearchTestCase {
+    public void testToXContent() throws IOException {
+        SnapshotId snapshotId = new SnapshotId("repo", "snapshot");
+        XContentBuilder builder = JsonXContent.contentBuilder().prettyPrint();
+        snapshotId.toXContent(builder, null);
+        assertEquals("{\n" + "  \"name\" : \"repo\",\n" + "  \"uuid\" : \"snapshot\"\n" + "}", builder.toString());
+    }
+
+    public void testFromXContent() throws IOException {
+        doFromXContentTestWithRandomFields(false);
+    }
+
+    public void testFromXContentWithRandomField() throws IOException {
+        doFromXContentTestWithRandomFields(true);
+    }
+
+    private void doFromXContentTestWithRandomFields(boolean addRandomFields) throws IOException {
+        SnapshotId snapshotId = new SnapshotId(randomAlphaOfLengthBetween(5, 10), randomAlphaOfLengthBetween(5, 10));
+        boolean humanReadable = randomBoolean();
+        final MediaType mediaType = MediaTypeRegistry.JSON;
+        BytesReference originalBytes = toShuffledXContent(
+            snapshotId,
+            mediaType,
+            new ToXContent.MapParams(Collections.emptyMap()),
+            humanReadable
+        );
+
+        if (addRandomFields) {
+            String unsupportedField = "unsupported_field";
+            BytesReference mutated = BytesReference.bytes(
+                XContentTestUtils.insertIntoXContent(
+                    mediaType.xContent(),
+                    originalBytes,
+                    Collections.singletonList(""),
+                    () -> unsupportedField,
+                    () -> randomAlphaOfLengthBetween(3, 10)
+                )
+            );
+            IllegalArgumentException iae = expectThrows(
+                IllegalArgumentException.class,
+                () -> SnapshotId.fromXContent(createParser(mediaType.xContent(), mutated))
+            );
+            assertEquals("unknown field [" + unsupportedField + "]", iae.getMessage());
+        } else {
+            try (XContentParser parser = createParser(mediaType.xContent(), originalBytes)) {
+                SnapshotId parsedSnapshotId = SnapshotId.fromXContent(parser);
+                assertEquals(snapshotId, parsedSnapshotId);
+            }
+        }
+    }
+}

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotsInProgressSerializationTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotsInProgressSerializationTests.java
@@ -42,7 +42,6 @@ import org.opensearch.cluster.SnapshotsInProgress.Entry;
 import org.opensearch.cluster.SnapshotsInProgress.ShardState;
 import org.opensearch.cluster.SnapshotsInProgress.State;
 import org.opensearch.cluster.metadata.Metadata;
-import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.json.JsonXContent;
@@ -214,7 +213,13 @@ public class SnapshotsInProgressSerializationTests extends AbstractDiffableWireS
     }
 
     public void testToXContent_deletion() throws IOException {
-        SnapshotDeletionsInProgress.Entry entry = new SnapshotDeletionsInProgress.Entry(List.of(new SnapshotId("name1", "uuid1")), "repo", 10000000L, 10000L, SnapshotDeletionsInProgress.State.WAITING);
+        SnapshotDeletionsInProgress.Entry entry = new SnapshotDeletionsInProgress.Entry(
+            List.of(new SnapshotId("name1", "uuid1")),
+            "repo",
+            10000000L,
+            10000L,
+            SnapshotDeletionsInProgress.State.WAITING
+        );
         SnapshotDeletionsInProgress sdip = SnapshotDeletionsInProgress.of(List.of(entry));
         boolean humanReadable = false;
         XContentBuilder builder = JsonXContent.contentBuilder().prettyPrint();


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
