### PR TITLE
fix visitor pattern by calling visit instead of accept

### DIFF
--- a/server/src/main/java/org/opensearch/index/query/BoostingQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/BoostingQueryBuilder.java
@@ -258,10 +258,10 @@ public class BoostingQueryBuilder extends AbstractQueryBuilder<BoostingQueryBuil
     public void visit(QueryBuilderVisitor visitor) {
         visitor.accept(this);
         if (positiveQuery != null) {
-            visitor.getChildVisitor(BooleanClause.Occur.MUST).accept(positiveQuery);
+            positiveQuery.visit(visitor.getChildVisitor(BooleanClause.Occur.MUST));
         }
         if (negativeQuery != null) {
-            visitor.getChildVisitor(BooleanClause.Occur.SHOULD).accept(negativeQuery);
+            negativeQuery.visit(visitor.getChildVisitor(BooleanClause.Occur.SHOULD));
         }
     }
 }

--- a/server/src/main/java/org/opensearch/index/query/ConstantScoreQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/ConstantScoreQueryBuilder.java
@@ -188,7 +188,7 @@ public class ConstantScoreQueryBuilder extends AbstractQueryBuilder<ConstantScor
     @Override
     public void visit(QueryBuilderVisitor visitor) {
         visitor.accept(this);
-        visitor.getChildVisitor(BooleanClause.Occur.FILTER).accept(filterBuilder);
+        filterBuilder.visit(visitor.getChildVisitor(BooleanClause.Occur.FILTER));
     }
 
 }

--- a/server/src/main/java/org/opensearch/index/query/DisMaxQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/DisMaxQueryBuilder.java
@@ -254,7 +254,7 @@ public class DisMaxQueryBuilder extends AbstractQueryBuilder<DisMaxQueryBuilder>
         if (queries.isEmpty() == false) {
             QueryBuilderVisitor subVisitor = visitor.getChildVisitor(BooleanClause.Occur.SHOULD);
             for (QueryBuilder subQb : queries) {
-                subVisitor.accept(subQb);
+                subQb.visit(subVisitor);
             }
         }
     }

--- a/server/src/main/java/org/opensearch/index/query/FieldMaskingSpanQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/FieldMaskingSpanQueryBuilder.java
@@ -214,6 +214,6 @@ public class FieldMaskingSpanQueryBuilder extends AbstractQueryBuilder<FieldMask
     @Override
     public void visit(QueryBuilderVisitor visitor) {
         visitor.accept(this);
-        visitor.getChildVisitor(BooleanClause.Occur.MUST).accept(queryBuilder);
+        queryBuilder.visit(visitor.getChildVisitor(BooleanClause.Occur.MUST));
     }
 }

--- a/server/src/main/java/org/opensearch/index/query/SpanContainingQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/SpanContainingQueryBuilder.java
@@ -193,7 +193,7 @@ public class SpanContainingQueryBuilder extends AbstractQueryBuilder<SpanContain
     @Override
     public void visit(QueryBuilderVisitor visitor) {
         visitor.accept(this);
-        visitor.getChildVisitor(BooleanClause.Occur.MUST).accept(big);
-        visitor.getChildVisitor(BooleanClause.Occur.MUST).accept(little);
+        big.visit(visitor.getChildVisitor(BooleanClause.Occur.MUST));
+        little.visit(visitor.getChildVisitor(BooleanClause.Occur.MUST));
     }
 }

--- a/server/src/main/java/org/opensearch/index/query/SpanFirstQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/SpanFirstQueryBuilder.java
@@ -191,6 +191,6 @@ public class SpanFirstQueryBuilder extends AbstractQueryBuilder<SpanFirstQueryBu
     @Override
     public void visit(QueryBuilderVisitor visitor) {
         visitor.accept(this);
-        visitor.getChildVisitor(BooleanClause.Occur.MUST).accept(matchBuilder);
+        matchBuilder.visit(visitor.getChildVisitor(BooleanClause.Occur.MUST));
     }
 }

--- a/server/src/main/java/org/opensearch/index/query/SpanMultiTermQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/SpanMultiTermQueryBuilder.java
@@ -219,7 +219,7 @@ public class SpanMultiTermQueryBuilder extends AbstractQueryBuilder<SpanMultiTer
     public void visit(QueryBuilderVisitor visitor) {
         visitor.accept(this);
         if (multiTermQueryBuilder != null) {
-            visitor.getChildVisitor(BooleanClause.Occur.MUST).accept(multiTermQueryBuilder);
+            multiTermQueryBuilder.visit(visitor.getChildVisitor(BooleanClause.Occur.MUST));
         }
     }
 }

--- a/server/src/main/java/org/opensearch/index/query/SpanNearQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/SpanNearQueryBuilder.java
@@ -306,7 +306,7 @@ public class SpanNearQueryBuilder extends AbstractQueryBuilder<SpanNearQueryBuil
         if (this.clauses.isEmpty() == false) {
             QueryBuilderVisitor subVisitor = visitor.getChildVisitor(BooleanClause.Occur.MUST);
             for (QueryBuilder subQb : this.clauses) {
-                subVisitor.accept(subQb);
+                subQb.visit(subVisitor);
             }
         }
     }

--- a/server/src/main/java/org/opensearch/index/query/SpanNotQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/SpanNotQueryBuilder.java
@@ -290,11 +290,11 @@ public class SpanNotQueryBuilder extends AbstractQueryBuilder<SpanNotQueryBuilde
     public void visit(QueryBuilderVisitor visitor) {
         visitor.accept(this);
         if (include != null) {
-            visitor.getChildVisitor(BooleanClause.Occur.MUST).accept(include);
+            include.visit(visitor.getChildVisitor(BooleanClause.Occur.MUST));
         }
 
         if (exclude != null) {
-            visitor.getChildVisitor(BooleanClause.Occur.MUST_NOT).accept(exclude);
+            exclude.visit(visitor.getChildVisitor(BooleanClause.Occur.MUST_NOT));
         }
     }
 }

--- a/server/src/main/java/org/opensearch/index/query/SpanOrQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/SpanOrQueryBuilder.java
@@ -196,7 +196,7 @@ public class SpanOrQueryBuilder extends AbstractQueryBuilder<SpanOrQueryBuilder>
         if (clauses.isEmpty() == false) {
             QueryBuilderVisitor subVisitor = visitor.getChildVisitor(BooleanClause.Occur.SHOULD);
             for (QueryBuilder subQb : this.clauses) {
-                subVisitor.accept(subQb);
+                subQb.visit(subVisitor);
             }
         }
     }

--- a/server/src/main/java/org/opensearch/index/query/SpanWithinQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/SpanWithinQueryBuilder.java
@@ -202,7 +202,7 @@ public class SpanWithinQueryBuilder extends AbstractQueryBuilder<SpanWithinQuery
     @Override
     public void visit(QueryBuilderVisitor visitor) {
         visitor.accept(this);
-        visitor.getChildVisitor(BooleanClause.Occur.MUST).accept(big);
-        visitor.getChildVisitor(BooleanClause.Occur.MUST).accept(little);
+        big.visit(visitor.getChildVisitor(BooleanClause.Occur.MUST));
+        little.visit(visitor.getChildVisitor(BooleanClause.Occur.MUST));
     }
 }

--- a/server/src/test/java/org/opensearch/index/query/BoostingQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/BoostingQueryBuilderTests.java
@@ -158,13 +158,15 @@ public class BoostingQueryBuilderTests extends AbstractQueryTestCase<BoostingQue
 
     public void testVisit() {
         BoostingQueryBuilder builder = new BoostingQueryBuilder(
-            new TermQueryBuilder("unmapped_field", "value"),
+            new BoolQueryBuilder()
+                .must(new TermQueryBuilder("unmapped_field1", "value1"))
+                .filter(new TermQueryBuilder("unmapped_field2", "value2")),
             new TermQueryBuilder(KEYWORD_FIELD_NAME, "other_value")
         );
 
         List<QueryBuilder> visitedQueries = new ArrayList<>();
         builder.visit(createTestVisitor(visitedQueries));
 
-        assertEquals(3, visitedQueries.size());
+        assertEquals(5, visitedQueries.size());
     }
 }

--- a/server/src/test/java/org/opensearch/index/query/ConstantScoreQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/ConstantScoreQueryBuilderTests.java
@@ -137,10 +137,13 @@ public class ConstantScoreQueryBuilderTests extends AbstractQueryTestCase<Consta
     }
 
     public void testVisit() {
-        ConstantScoreQueryBuilder queryBuilder = new ConstantScoreQueryBuilder(new TermQueryBuilder("unmapped_field", "foo"));
+        ConstantScoreQueryBuilder queryBuilder = new ConstantScoreQueryBuilder(
+            new BoolQueryBuilder()
+                .must(new TermQueryBuilder("unmapped_field1", "value1"))
+                .filter(new TermQueryBuilder("unmapped_field2", "value2")));
         List<QueryBuilder> visitorQueries = new ArrayList<>();
         queryBuilder.visit(createTestVisitor(visitorQueries));
 
-        assertEquals(2, visitorQueries.size());
+        assertEquals(4, visitorQueries.size());
     }
 }

--- a/server/src/test/java/org/opensearch/index/query/DisMaxQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/DisMaxQueryBuilderTests.java
@@ -161,10 +161,13 @@ public class DisMaxQueryBuilderTests extends AbstractQueryTestCase<DisMaxQueryBu
     public void testVisit() {
         DisMaxQueryBuilder dismax = new DisMaxQueryBuilder();
         dismax.add(new WrapperQueryBuilder(new WrapperQueryBuilder(new MatchAllQueryBuilder().toString()).toString()));
+        dismax.add(new BoolQueryBuilder()
+            .must(new TermQueryBuilder("unmapped_field1", "value1"))
+            .filter(new TermQueryBuilder("unmapped_field2", "value2")));
 
         List<QueryBuilder> visitedQueries = new ArrayList<>();
         dismax.visit(createTestVisitor(visitedQueries));
 
-        assertEquals(2, visitedQueries.size());
+        assertEquals(5, visitedQueries.size());
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR aims to fix some bugs of the visitor pattern implemented before in this [PR](https://github.com/opensearch-project/OpenSearch/pull/10110). It should go down the tree by calling the `visit` methods of nested sub QueryBuilders, the `accept` should happen in sub QueryBuilders.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
https://github.com/opensearch-project/OpenSearch/issues/13812
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
