### PR TITLE
[Backport] [2.x] Bump com.google.code.gson:gson in /test/fixtures/hdfs-fixture (#13842)

### DIFF
--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -57,7 +57,7 @@ dependencies {
   api "commons-codec:commons-codec:${versions.commonscodec}"
   api "org.apache.logging.log4j:log4j-core:${versions.log4j}"
   api "io.netty:netty-all:${versions.netty}"
-  api 'com.google.code.gson:gson:2.9.0'
+  api 'com.google.code.gson:gson:2.11.0'
   api "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:${versions.jackson}"
   api "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
   api "com.fasterxml.woodstox:woodstox-core:${versions.woodstox}"


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/13842 to `2.x`