### PR TITLE
Remove conflicting static method from Metadata.Custom interface

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/Metadata.java
@@ -180,11 +180,6 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             // handling any Exception is caller's responsibility
             return parser.namedObject(Custom.class, name, null);
         }
-
-        static Custom fromXContent(XContentParser parser) throws IOException {
-            String currentFieldName = parser.currentName();
-            return fromXContent(parser, currentFieldName);
-        }
     }
 
     public static final Setting<Integer> DEFAULT_REPLICA_COUNT_SETTING = Setting.intSetting(

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -147,7 +147,7 @@ public class RemoteClusterStateService implements Closeable {
     public static final ChecksumBlobStoreFormat<Metadata.Custom> CUSTOM_METADATA_FORMAT = new ChecksumBlobStoreFormat<>(
         "custom",
         METADATA_NAME_FORMAT,
-        Metadata.Custom::fromXContent
+        null // no need of reader here, as this object is only used to write/serialize the object
     );
 
     /**


### PR DESCRIPTION
### Description
Removing the conflicting fromXContent method from Metadata.Custom which is also getting initialized in it's implementations, which was not getting used anywhere.


### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
