### PR TITLE
Painless: ensure type "UnmodifiableMap" for params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Allow clearing `remote_store.compatibility_mode` setting ([#13646](https://github.com/opensearch-project/OpenSearch/pull/13646))
 - Fix ReplicaShardBatchAllocator to batch shards without duplicates ([#13710](https://github.com/opensearch-project/OpenSearch/pull/13710))
 - Don't return negative scores from `multi_match` query with `cross_fields` type  ([#13829](https://github.com/opensearch-project/OpenSearch/pull/13829))
+- Painless: ensure type "UnmodifiableMap" for params ([#13885](https://github.com/opensearch-project/OpenSearch/pull/13885))
 - Pass parent filter to inner hit query ([#13903](https://github.com/opensearch-project/OpenSearch/pull/13903))
 - Fix NPE on restore searchable snapshot ([#13911](https://github.com/opensearch-project/OpenSearch/pull/13911))
 

--- a/modules/lang-painless/src/test/java/org/opensearch/painless/WhenThingsGoWrongTests.java
+++ b/modules/lang-painless/src/test/java/org/opensearch/painless/WhenThingsGoWrongTests.java
@@ -354,6 +354,9 @@ public class WhenThingsGoWrongTests extends ScriptTestCase {
         assertEquals(iae.getMessage(), "invalid assignment: cannot assign a value to addition operation [+]");
         iae = expectScriptThrows(IllegalArgumentException.class, () -> exec("Double.x() = 1;"));
         assertEquals(iae.getMessage(), "invalid assignment: cannot assign a value to method call [x/0]");
+
+        expectScriptThrows(UnsupportedOperationException.class, () -> exec("params['modifyingParamsMap'] = 2;"));
+        expectScriptThrows(UnsupportedOperationException.class, () -> exec("params.modifyingParamsMap = 2;"));
     }
 
     public void testCannotResolveSymbol() {

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/17_update_error.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/17_update_error.yml
@@ -13,3 +13,50 @@
   - match: { error.root_cause.0.position.offset: 13 }
   - match: { error.root_cause.0.position.start: 0 }
   - match: { error.root_cause.0.position.end: 38 }
+
+---
+"Test modifying params map from script leads to exception":
+  - skip:
+      features: "node_selector"
+
+  - do:
+      put_script:
+        id: "except"
+        body: {"script": {"lang": "painless", "source": "params.that = 3"}}
+
+  - do:
+      indices.create:
+        index: "test"
+        body:
+          settings:
+            index:
+              number_of_shards: 1
+              number_of_replicas: 0
+          mappings:
+            properties:
+              this:
+                type: "integer"
+              that:
+                type: "integer"
+
+  - do:
+      index:
+        index: "test"
+        id: 1
+        body: {"this": 1, "that": 2}
+
+  - do:
+      catch: /unsupported_operation_exception/
+      node_selector:
+        version: "2.15.0 - "
+      update:
+        index: "test"
+        id: 1
+        body:
+          script:
+            id: "except"
+            params: {"this": 2}
+
+  - match: { error.caused_by.position.offset: 6 }
+  - match: { error.caused_by.position.start: 0 }
+  - match: { error.caused_by.position.end: 15 }

--- a/server/src/main/java/org/opensearch/script/Script.java
+++ b/server/src/main/java/org/opensearch/script/Script.java
@@ -589,7 +589,7 @@ public final class Script implements ToXContentObject, Writeable {
         @SuppressWarnings("unchecked")
         Map<String, String> options = (Map<String, String>) (Map) in.readMap();
         this.options = options;
-        this.params = in.readMap();
+        this.params = Collections.unmodifiableMap(in.readMap());
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/script/UpdateScript.java
+++ b/server/src/main/java/org/opensearch/script/UpdateScript.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.script;
 
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -53,7 +54,7 @@ public abstract class UpdateScript {
     private final Map<String, Object> ctx;
 
     public UpdateScript(Map<String, Object> params, Map<String, Object> ctx) {
-        this.params = params;
+        this.params = Collections.unmodifiableMap(params);
         this.ctx = ctx;
     }
 


### PR DESCRIPTION
### Description

See comment here: https://github.com/opensearch-project/OpenSearch/issues/10561#issuecomment-2138270628

### Related Issues

Resolves #10561

### Check List
- [ ] ~New functionality includes testing.~
  - [ ] ~All tests pass~
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
