### PR TITLE
Revert "Pass parent filter to inner hit query (#13770)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix get field mapping API returns 404 error in mixed cluster with multiple versions ([#13624](https://github.com/opensearch-project/OpenSearch/pull/13624))
 - Allow clearing `remote_store.compatibility_mode` setting ([#13646](https://github.com/opensearch-project/OpenSearch/pull/13646))
 - Fix ReplicaShardBatchAllocator to batch shards without duplicates ([#13710](https://github.com/opensearch-project/OpenSearch/pull/13710))
-- Pass parent filter to inner hit query ([#13770](https://github.com/opensearch-project/OpenSearch/pull/13770))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/index/query/NestedQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/NestedQueryBuilder.java
@@ -401,32 +401,16 @@ public class NestedQueryBuilder extends AbstractQueryBuilder<NestedQueryBuilder>
                 }
             }
             String name = innerHitBuilder.getName() != null ? innerHitBuilder.getName() : nestedObjectMapper.fullPath();
-            ObjectMapper parentObjectMapper = queryShardContext.nestedScope().getObjectMapper();
-            BitSetProducer parentFilter;
-            if (parentObjectMapper == null) {
-                parentFilter = queryShardContext.bitsetFilter(Queries.newNonNestedFilter());
-            } else {
-                parentFilter = queryShardContext.bitsetFilter(parentObjectMapper.nestedTypeFilter());
-            }
-            BitSetProducer previousParentFilter = queryShardContext.getParentFilter();
-            try {
-                queryShardContext.setParentFilter(parentFilter);
-                queryShardContext.nestedScope().nextLevel(nestedObjectMapper);
-                try {
-                    NestedInnerHitSubContext nestedInnerHits = new NestedInnerHitSubContext(
-                        name,
-                        parentSearchContext,
-                        parentObjectMapper,
-                        nestedObjectMapper
-                    );
-                    setupInnerHitsContext(queryShardContext, nestedInnerHits);
-                    innerHitsContext.addInnerHitDefinition(nestedInnerHits);
-                } finally {
-                    queryShardContext.nestedScope().previousLevel();
-                }
-            } finally {
-                queryShardContext.setParentFilter(previousParentFilter);
-            }
+            ObjectMapper parentObjectMapper = queryShardContext.nestedScope().nextLevel(nestedObjectMapper);
+            NestedInnerHitSubContext nestedInnerHits = new NestedInnerHitSubContext(
+                name,
+                parentSearchContext,
+                parentObjectMapper,
+                nestedObjectMapper
+            );
+            setupInnerHitsContext(queryShardContext, nestedInnerHits);
+            queryShardContext.nestedScope().previousLevel();
+            innerHitsContext.addInnerHitDefinition(nestedInnerHits);
         }
     }
 

--- a/server/src/test/java/org/opensearch/index/query/NestedQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/NestedQueryBuilderTests.java
@@ -311,41 +311,6 @@ public class NestedQueryBuilderTests extends AbstractQueryTestCase<NestedQueryBu
         assertThat(innerHitBuilders.get(leafInnerHits.getName()), Matchers.notNullValue());
     }
 
-    public void testParentFilterFromInlineLeafInnerHitsNestedQuery() throws Exception {
-        QueryShardContext queryShardContext = createShardContext();
-        SearchContext searchContext = mock(SearchContext.class);
-        when(searchContext.getQueryShardContext()).thenReturn(queryShardContext);
-
-        MapperService mapperService = mock(MapperService.class);
-        IndexSettings settings = new IndexSettings(newIndexMeta("index", Settings.EMPTY), Settings.EMPTY);
-        when(mapperService.getIndexSettings()).thenReturn(settings);
-        when(searchContext.mapperService()).thenReturn(mapperService);
-
-        InnerHitBuilder leafInnerHits = randomNestedInnerHits();
-        leafInnerHits.setScriptFields(null);
-        leafInnerHits.setHighlightBuilder(null);
-
-        QueryBuilder innerQueryBuilder = spy(new MatchAllQueryBuilder());
-        when(innerQueryBuilder.toQuery(queryShardContext)).thenAnswer(invoke -> {
-            QueryShardContext context = invoke.getArgument(0);
-            if (context.getParentFilter() == null) {
-                throw new Exception("Expect parent filter to be non-null");
-            }
-            return invoke.callRealMethod();
-        });
-        NestedQueryBuilder query = new NestedQueryBuilder("nested1", innerQueryBuilder, ScoreMode.None);
-        query.innerHit(leafInnerHits);
-        final Map<String, InnerHitContextBuilder> innerHitBuilders = new HashMap<>();
-        final InnerHitsContext innerHitsContext = new InnerHitsContext();
-        query.extractInnerHitBuilders(innerHitBuilders);
-        assertThat(innerHitBuilders.size(), Matchers.equalTo(1));
-        assertTrue(innerHitBuilders.containsKey(leafInnerHits.getName()));
-        assertNull(queryShardContext.getParentFilter());
-        innerHitBuilders.get(leafInnerHits.getName()).build(searchContext, innerHitsContext);
-        assertNull(queryShardContext.getParentFilter());
-        verify(innerQueryBuilder).toQuery(queryShardContext);
-    }
-
     public void testInlineLeafInnerHitsNestedQueryViaBoolQuery() {
         InnerHitBuilder leafInnerHits = randomNestedInnerHits();
         NestedQueryBuilder nestedQueryBuilder = new NestedQueryBuilder("path", new MatchAllQueryBuilder(), ScoreMode.None).innerHit(


### PR DESCRIPTION
This reverts commit db5240e06dc08e7d7d03432595bb4d93b0e2e32d.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

Reverting due to flaky test failure. https://github.com/opensearch-project/OpenSearch/issues/13890

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)