### PR TITLE
Fix Flaky - testForceMergeWithSoftDeletesRetentionAndRecoverySource #5364

### DIFF
--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -1872,7 +1872,7 @@ public class InternalEngineTests extends EngineTestCase {
         try (
             Store store = createStore();
             InternalEngine engine = createEngine(
-                config(indexSettings, store, createTempDir(), newMergePolicy(), null, null, globalCheckpoint::get)
+                config(indexSettings, store, createTempDir(), newMergePolicy(random(), false), null, null, globalCheckpoint::get)
             )
         ) {
             int numDocs = scaledRandomIntBetween(10, 100);


### PR DESCRIPTION
### Description
Switching to a deterministic merge policy due to [Lucene-8962](https://issues.apache.org/jira/browse/LUCENE-8962)

The tests are also passing with the failed seeds
1. **C75D09DC5A0C3458**
<img width="1660" alt="Screenshot 2024-05-31 at 13 50 01" src="https://github.com/opensearch-project/OpenSearch/assets/25262500/3bb3bdfe-a3ad-4710-a0c4-a9af42d77058">


2. **1766E6A3B733A7AA**
<img width="1685" alt="Screenshot 2024-05-31 at 13 50 37" src="https://github.com/opensearch-project/OpenSearch/assets/25262500/f48c6307-942a-4192-94e0-219433d9dd35">


3. **1000 Iterations Passed**
<img width="1657" alt="Screenshot 2024-05-31 at 13 59 39" src="https://github.com/opensearch-project/OpenSearch/assets/25262500/da250b5a-ca1e-4a23-92a6-4f8725cc182d">


### Related Issues
Resolves #5364 



### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
