### PR TITLE
Revert "Remove deprecated constant META_FIELDS_BEFORE_7DOT8 (#13860)"

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -24,7 +24,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add task completion count in search backpressure stats API ([#10028](https://github.com/opensearch-project/OpenSearch/pull/10028/))
 - Deprecate CamelCase `PathHierarchy` tokenizer name in favor to lowercase `path_hierarchy` ([#10894](https://github.com/opensearch-project/OpenSearch/pull/10894))
 - Breaking change: Do not request "search_pipelines" metrics by default in NodesInfoRequest ([#12497](https://github.com/opensearch-project/OpenSearch/pull/12497))
-- Remove deprecated constant META_FIELDS_BEFORE_7DOT8 ([#13860](https://github.com/opensearch-project/OpenSearch/pull/13860))
 
 ### Deprecated
 

--- a/server/src/main/java/org/opensearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/opensearch/index/mapper/MapperService.java
@@ -73,6 +73,7 @@ import org.opensearch.script.ScriptService;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -199,6 +200,11 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         Property.Dynamic,
         Property.IndexScope,
         Property.Deprecated
+    );
+    // Deprecated set of meta-fields, for checking if a field is meta, use an instance method isMetadataField instead
+    @Deprecated
+    public static final Set<String> META_FIELDS_BEFORE_7DOT8 = Collections.unmodifiableSet(
+        new HashSet<>(Arrays.asList("_id", IgnoredFieldMapper.NAME, "_index", "_routing", "_size", "_timestamp", "_ttl", "_type"))
     );
 
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(MapperService.class);


### PR DESCRIPTION
This reverts commit 983297289325bdd1c832bfe18d105bd3e9727ab5.

### Description

Opening a PR to discuss this reversion. Removing this deprecated constant caused issues in the SQL Plugin which references the constant. See https://github.com/opensearch-project/sql/pull/2701 where they are working to adapt.

During Union operations, the SQL plugin relies on this list to differentiate between a metafield and a docfield. Ideally, the sql plugin can use [MapperService.isMetadataField](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/index/mapper/MapperService.java#L703-L709) to determine from the official registry of mappers if a field is a metafield, but getting an instance of the mapper service within a plugin is proving to be tricky.

The security plugin uses Guice, to get the IndicesService:

1. [GuiceHolder](https://github.com/opensearch-project/security/blob/main/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java#L2063-L2131)
2. [getGuiceServiceClasses](https://github.com/opensearch-project/security/blob/main/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java#L1975-L1985)

Security can then get the indicesService using [OpenSearchSecurityPlugin.GuiceHolder.getIndicesService()](https://github.com/opensearch-project/security/blob/main/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java#L334) which then allows it to get a handle on the [mapperService](https://github.com/opensearch-project/security/blob/main/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java#L410-L434).

This PR is to temporarily fix SQL's CI issues from this change until a strategic fix is implemented.

For extra context around the fields in this list: (Copying comment from [here](https://github.com/opensearch-project/sql/pull/2701#discussion_r1622675223))

7DOT8 is referring to ES 7.8.

"_ttl" and "_timestamp" were removed in ES6. See https://www.elastic.co/blog/elasticsearch-5-0-0-alpha4-released

"_type" was renamed to "_nested_path" in OS 2: https://github.com/opensearch-project/OpenSearch/pull/3196

"_size" is not a built-in metadata mapper, it comes from the mapper-size plugin which is not installed by default. Using mapperService.isMetadataField("_size") should return true if the mapper-size plugin is installed in the cluster.

The other values in this list still exist and are built-in metadata fields so mapperService.isMetadataField(<field>) should return true.

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
