### PR TITLE
[Feature] Add NestedField Visit Method

### DIFF
--- a/server/src/main/java/org/opensearch/index/query/NestedQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/NestedQueryBuilder.java
@@ -34,6 +34,7 @@ package org.opensearch.index.query;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.ReaderUtil;
+import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.MultiCollector;
 import org.apache.lucene.search.Query;
@@ -368,6 +369,14 @@ public class NestedQueryBuilder extends AbstractQueryBuilder<NestedQueryBuilder>
             InnerHitContextBuilder.extractInnerHits(query, children);
             InnerHitContextBuilder innerHitContextBuilder = new NestedInnerHitContextBuilder(path, query, innerHitBuilder, children);
             innerHits.put(name, innerHitContextBuilder);
+        }
+    }
+
+    @Override
+    public void visit(QueryBuilderVisitor visitor) {
+        visitor.accept(this);
+        if (query != null) {
+            query.visit(visitor.getChildVisitor(BooleanClause.Occur.MUST));
         }
     }
 

--- a/server/src/test/java/org/opensearch/index/query/NestedQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/NestedQueryBuilderTests.java
@@ -59,8 +59,10 @@ import org.opensearch.test.VersionUtils;
 import org.hamcrest.Matchers;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -538,6 +540,19 @@ public class NestedQueryBuilderTests extends AbstractQueryTestCase<NestedQueryBu
             Query depth2Query = depth2.toQuery(ctx);
             assertTrue(depth2Query instanceof OpenSearchToParentBlockJoinQuery);
         });
+    }
+
+    public void testVisit() {
+        NestedQueryBuilder queryBuilder = new NestedQueryBuilder(
+            "nested1",
+            new BoolQueryBuilder().must(new TermQueryBuilder("must_field1", "value1"))
+                .filter(new TermQueryBuilder("must_field2", "value2")),
+            ScoreMode.None
+        );
+        List<QueryBuilder> visitorQueries = new ArrayList<>();
+        queryBuilder.visit(createTestVisitor(visitorQueries));
+
+        assertEquals(4, visitorQueries.size());
     }
 
     void doWithDepth(int depth, ThrowingConsumer<QueryShardContext> test) throws Exception {


### PR DESCRIPTION
i use neural query in OpenSearch with nested field https://opensearch.org/docs/latest/search-plugins/semantic-search/#setting-a-default-model-on-an-index-or-field, but it can not calling model in search pipeline with `neural_query_enricher` processor like the doc shows. 

i think it is because NestedQueryBuilder do not support visit method like `boolean query` https://github.com/opensearch-project/OpenSearch/blob/581fcd2c3204f84ff93c626be41698ec35641680/server/src/main/java/org/opensearch/index/query/BoolQueryBuilder.java#L432-L439

it can not visit from processRequest like the following code do:
https://github.com/opensearch-project/neural-search/blob/2b21110be2d343e83f539e75104a8928522bf720/src/main/java/org/opensearch/neuralsearch/processor/NeuralQueryEnricherProcessor.java#L68-L75

BTW in #13837 i see it fixed many scenarios queries, but we still need `NestedQueryBuilder` to visit query builder.

so this pr i added a visit method.