### PR TITLE
[Backport 2.x] [Tiered Caching] Additional ITs for cache stats 

### DIFF
--- a/modules/cache-common/src/internalClusterTest/java/org/opensearch/cache/common/tier/TieredSpilloverCacheIT.java
+++ b/modules/cache-common/src/internalClusterTest/java/org/opensearch/cache/common/tier/TieredSpilloverCacheIT.java
@@ -65,7 +65,7 @@ public class TieredSpilloverCacheIT extends OpenSearchIntegTestCase {
         return Arrays.asList(TieredSpilloverCachePlugin.class, MockDiskCachePlugin.class);
     }
 
-    private Settings defaultSettings(String onHeapCacheSizeInBytesOrPecentage) {
+    static Settings defaultSettings(String onHeapCacheSizeInBytesOrPercentage) {
         return Settings.builder()
             .put(FeatureFlags.PLUGGABLE_CACHE, "true")
             .put(
@@ -88,7 +88,7 @@ public class TieredSpilloverCacheIT extends OpenSearchIntegTestCase {
                 OpenSearchOnHeapCacheSettings.getSettingListForCacheType(CacheType.INDICES_REQUEST_CACHE)
                     .get(MAXIMUM_SIZE_IN_BYTES_KEY)
                     .getKey(),
-                onHeapCacheSizeInBytesOrPecentage
+                onHeapCacheSizeInBytesOrPercentage
             )
             .build();
     }

--- a/modules/cache-common/src/internalClusterTest/java/org/opensearch/cache/common/tier/TieredSpilloverCacheStatsIT.java
+++ b/modules/cache-common/src/internalClusterTest/java/org/opensearch/cache/common/tier/TieredSpilloverCacheStatsIT.java
@@ -1,0 +1,501 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cache.common.tier;
+
+import org.opensearch.action.admin.cluster.node.stats.NodesStatsRequest;
+import org.opensearch.action.admin.cluster.node.stats.NodesStatsResponse;
+import org.opensearch.action.admin.indices.stats.CommonStatsFlags;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.client.Client;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.cache.CacheType;
+import org.opensearch.common.cache.service.NodeCacheStats;
+import org.opensearch.common.cache.stats.ImmutableCacheStats;
+import org.opensearch.common.cache.stats.ImmutableCacheStatsHolder;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.index.cache.request.RequestCacheStats;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.indices.IndicesRequestCache;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.test.hamcrest.OpenSearchAssertions;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.opensearch.cache.common.tier.TieredSpilloverCacheStatsHolder.TIER_DIMENSION_NAME;
+import static org.opensearch.cache.common.tier.TieredSpilloverCacheStatsHolder.TIER_DIMENSION_VALUE_DISK;
+import static org.opensearch.cache.common.tier.TieredSpilloverCacheStatsHolder.TIER_DIMENSION_VALUE_ON_HEAP;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertSearchResponse;
+
+// Use a single data node to simplify accessing cache stats across different shards.
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class TieredSpilloverCacheStatsIT extends OpenSearchIntegTestCase {
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Arrays.asList(TieredSpilloverCachePlugin.class, TieredSpilloverCacheIT.MockDiskCachePlugin.class);
+    }
+
+    private final String HEAP_CACHE_SIZE_STRING = "10000B";
+    private final int HEAP_CACHE_SIZE = 10_000;
+    private final String index1Name = "index1";
+    private final String index2Name = "index2";
+
+    /**
+     * Test aggregating by indices
+     */
+    public void testIndicesLevelAggregation() throws Exception {
+        internalCluster().startNodes(
+            1,
+            Settings.builder()
+                .put(TieredSpilloverCacheIT.defaultSettings(HEAP_CACHE_SIZE_STRING))
+                .put(
+                    TieredSpilloverCacheSettings.TOOK_TIME_POLICY_CONCRETE_SETTINGS_MAP.get(CacheType.INDICES_REQUEST_CACHE).getKey(),
+                    new TimeValue(0, TimeUnit.SECONDS)
+                )
+                .build()
+        );
+        Client client = client();
+        Map<String, Integer> values = setupCacheForAggregationTests(client);
+
+        ImmutableCacheStatsHolder allLevelsStatsHolder = getNodeCacheStatsResult(
+            client,
+            List.of(IndicesRequestCache.INDEX_DIMENSION_NAME, TIER_DIMENSION_NAME)
+        );
+        ImmutableCacheStatsHolder indicesOnlyStatsHolder = getNodeCacheStatsResult(
+            client,
+            List.of(IndicesRequestCache.INDEX_DIMENSION_NAME)
+        );
+
+        // Get values for indices alone, assert these match for statsHolders that have additional dimensions vs. a statsHolder that only has
+        // the indices dimension
+        ImmutableCacheStats index1ExpectedStats = returnNullIfAllZero(
+            new ImmutableCacheStats(
+                values.get("hitsOnHeapIndex1") + values.get("hitsOnDiskIndex1"),
+                values.get("itemsOnDiskIndex1AfterTest") + values.get("itemsOnHeapIndex1AfterTest"),
+                0,
+                (values.get("itemsOnDiskIndex1AfterTest") + values.get("itemsOnHeapIndex1AfterTest")) * values.get("singleSearchSize"),
+                values.get("itemsOnDiskIndex1AfterTest") + values.get("itemsOnHeapIndex1AfterTest")
+            )
+        );
+        ImmutableCacheStats index2ExpectedStats = returnNullIfAllZero(
+            new ImmutableCacheStats(
+                values.get("hitsOnHeapIndex2") + values.get("hitsOnDiskIndex2"),
+                values.get("itemsOnDiskIndex2AfterTest") + values.get("itemsOnHeapIndex2AfterTest"),
+                0,
+                (values.get("itemsOnDiskIndex2AfterTest") + values.get("itemsOnHeapIndex2AfterTest")) * values.get("singleSearchSize"),
+                values.get("itemsOnDiskIndex2AfterTest") + values.get("itemsOnHeapIndex2AfterTest")
+            )
+        );
+
+        for (ImmutableCacheStatsHolder statsHolder : List.of(allLevelsStatsHolder, indicesOnlyStatsHolder)) {
+            assertEquals(index1ExpectedStats, statsHolder.getStatsForDimensionValues(List.of(index1Name)));
+            assertEquals(index2ExpectedStats, statsHolder.getStatsForDimensionValues(List.of(index2Name)));
+        }
+    }
+
+    /**
+     * Test aggregating by indices and tier
+     */
+    public void testIndicesAndTierLevelAggregation() throws Exception {
+        internalCluster().startNodes(
+            1,
+            Settings.builder()
+                .put(TieredSpilloverCacheIT.defaultSettings(HEAP_CACHE_SIZE_STRING))
+                .put(
+                    TieredSpilloverCacheSettings.TOOK_TIME_POLICY_CONCRETE_SETTINGS_MAP.get(CacheType.INDICES_REQUEST_CACHE).getKey(),
+                    new TimeValue(0, TimeUnit.SECONDS)
+                )
+                .build()
+        );
+        Client client = client();
+        Map<String, Integer> values = setupCacheForAggregationTests(client);
+
+        ImmutableCacheStatsHolder allLevelsStatsHolder = getNodeCacheStatsResult(
+            client,
+            List.of(IndicesRequestCache.INDEX_DIMENSION_NAME, TIER_DIMENSION_NAME)
+        );
+
+        // Get values broken down by indices+tiers
+        ImmutableCacheStats index1HeapExpectedStats = returnNullIfAllZero(
+            new ImmutableCacheStats(
+                values.get("hitsOnHeapIndex1"),
+                values.get("itemsOnHeapIndex1AfterTest") + values.get("itemsOnDiskIndex1AfterTest") + values.get("hitsOnDiskIndex1"),
+                values.get("itemsOnDiskIndex1AfterTest"),
+                values.get("itemsOnHeapIndex1AfterTest") * values.get("singleSearchSize"),
+                values.get("itemsOnHeapIndex1AfterTest")
+            )
+        );
+        assertEquals(
+            index1HeapExpectedStats,
+            allLevelsStatsHolder.getStatsForDimensionValues(List.of(index1Name, TIER_DIMENSION_VALUE_ON_HEAP))
+        );
+
+        ImmutableCacheStats index2HeapExpectedStats = returnNullIfAllZero(
+            new ImmutableCacheStats(
+                values.get("hitsOnHeapIndex2"),
+                values.get("itemsOnHeapIndex2AfterTest") + values.get("itemsOnDiskIndex2AfterTest") + values.get("hitsOnDiskIndex2"),
+                values.get("itemsOnDiskIndex2AfterTest"),
+                values.get("itemsOnHeapIndex2AfterTest") * values.get("singleSearchSize"),
+                values.get("itemsOnHeapIndex2AfterTest")
+            )
+        );
+        assertEquals(
+            index2HeapExpectedStats,
+            allLevelsStatsHolder.getStatsForDimensionValues(List.of(index2Name, TIER_DIMENSION_VALUE_ON_HEAP))
+        );
+
+        ImmutableCacheStats index1DiskExpectedStats = returnNullIfAllZero(
+            new ImmutableCacheStats(
+                values.get("hitsOnDiskIndex1"),
+                values.get("itemsOnHeapIndex1AfterTest") + values.get("itemsOnDiskIndex1AfterTest"),
+                0,
+                values.get("itemsOnDiskIndex1AfterTest") * values.get("singleSearchSize"),
+                values.get("itemsOnDiskIndex1AfterTest")
+            )
+        );
+        assertEquals(
+            index1DiskExpectedStats,
+            allLevelsStatsHolder.getStatsForDimensionValues(List.of(index1Name, TIER_DIMENSION_VALUE_DISK))
+        );
+
+        ImmutableCacheStats index2DiskExpectedStats = returnNullIfAllZero(
+            new ImmutableCacheStats(
+                values.get("hitsOnDiskIndex2"),
+                values.get("itemsOnHeapIndex2AfterTest") + values.get("itemsOnDiskIndex2AfterTest"),
+                0,
+                values.get("itemsOnDiskIndex2AfterTest") * values.get("singleSearchSize"),
+                values.get("itemsOnDiskIndex2AfterTest")
+            )
+        );
+        assertEquals(
+            index2DiskExpectedStats,
+            allLevelsStatsHolder.getStatsForDimensionValues(List.of(index2Name, TIER_DIMENSION_VALUE_DISK))
+        );
+    }
+
+    /**
+     * Test aggregating by tier only
+     */
+    public void testTierLevelAggregation() throws Exception {
+        internalCluster().startNodes(
+            1,
+            Settings.builder()
+                .put(TieredSpilloverCacheIT.defaultSettings(HEAP_CACHE_SIZE_STRING))
+                .put(
+                    TieredSpilloverCacheSettings.TOOK_TIME_POLICY_CONCRETE_SETTINGS_MAP.get(CacheType.INDICES_REQUEST_CACHE).getKey(),
+                    new TimeValue(0, TimeUnit.SECONDS)
+                )
+                .build()
+        );
+        Client client = client();
+        Map<String, Integer> values = setupCacheForAggregationTests(client);
+
+        // Get values for tiers alone and check they add correctly across indices
+        ImmutableCacheStatsHolder tiersOnlyStatsHolder = getNodeCacheStatsResult(client, List.of(TIER_DIMENSION_NAME));
+        ImmutableCacheStats totalHeapExpectedStats = returnNullIfAllZero(
+            new ImmutableCacheStats(
+                values.get("hitsOnHeapIndex1") + values.get("hitsOnHeapIndex2"),
+                values.get("itemsOnHeapAfterTest") + values.get("itemsOnDiskAfterTest") + values.get("hitsOnDiskIndex1") + values.get(
+                    "hitsOnDiskIndex2"
+                ),
+                values.get("itemsOnDiskAfterTest"),
+                values.get("itemsOnHeapAfterTest") * values.get("singleSearchSize"),
+                values.get("itemsOnHeapAfterTest")
+            )
+        );
+        ImmutableCacheStats heapStats = tiersOnlyStatsHolder.getStatsForDimensionValues(List.of(TIER_DIMENSION_VALUE_ON_HEAP));
+        assertEquals(totalHeapExpectedStats, heapStats);
+        ImmutableCacheStats totalDiskExpectedStats = returnNullIfAllZero(
+            new ImmutableCacheStats(
+                values.get("hitsOnDiskIndex1") + values.get("hitsOnDiskIndex2"),
+                values.get("itemsOnHeapAfterTest") + values.get("itemsOnDiskAfterTest"),
+                0,
+                values.get("itemsOnDiskAfterTest") * values.get("singleSearchSize"),
+                values.get("itemsOnDiskAfterTest")
+            )
+        );
+        ImmutableCacheStats diskStats = tiersOnlyStatsHolder.getStatsForDimensionValues(List.of(TIER_DIMENSION_VALUE_DISK));
+        assertEquals(totalDiskExpectedStats, diskStats);
+    }
+
+    public void testInvalidLevelsAreIgnored() throws Exception {
+        internalCluster().startNodes(
+            1,
+            Settings.builder()
+                .put(TieredSpilloverCacheIT.defaultSettings(HEAP_CACHE_SIZE_STRING))
+                .put(
+                    TieredSpilloverCacheSettings.TOOK_TIME_POLICY_CONCRETE_SETTINGS_MAP.get(CacheType.INDICES_REQUEST_CACHE).getKey(),
+                    new TimeValue(0, TimeUnit.SECONDS)
+                )
+                .build()
+        );
+        Client client = client();
+        Map<String, Integer> values = setupCacheForAggregationTests(client);
+
+        ImmutableCacheStatsHolder allLevelsStatsHolder = getNodeCacheStatsResult(
+            client,
+            List.of(IndicesRequestCache.INDEX_DIMENSION_NAME, TIER_DIMENSION_NAME)
+        );
+        ImmutableCacheStatsHolder indicesOnlyStatsHolder = getNodeCacheStatsResult(
+            client,
+            List.of(IndicesRequestCache.INDEX_DIMENSION_NAME)
+        );
+
+        // Test invalid levels are ignored and permuting the order of levels in the request doesn't matter
+
+        // This should be equivalent to just "indices"
+        ImmutableCacheStatsHolder indicesEquivalentStatsHolder = getNodeCacheStatsResult(
+            client,
+            List.of(IndicesRequestCache.INDEX_DIMENSION_NAME, "unrecognized_dimension")
+        );
+        assertEquals(indicesOnlyStatsHolder, indicesEquivalentStatsHolder);
+
+        // This should be equivalent to "indices", "tier"
+        ImmutableCacheStatsHolder indicesAndTierEquivalentStatsHolder = getNodeCacheStatsResult(
+            client,
+            List.of(TIER_DIMENSION_NAME, "unrecognized_dimension_1", IndicesRequestCache.INDEX_DIMENSION_NAME, "unrecognized_dimension_2")
+        );
+        assertEquals(allLevelsStatsHolder, indicesAndTierEquivalentStatsHolder);
+
+        // This should be equivalent to no levels passed in
+        ImmutableCacheStatsHolder noLevelsEquivalentStatsHolder = getNodeCacheStatsResult(
+            client,
+            List.of("unrecognized_dimension_1", "unrecognized_dimension_2")
+        );
+        ImmutableCacheStatsHolder noLevelsStatsHolder = getNodeCacheStatsResult(client, List.of());
+        assertEquals(noLevelsStatsHolder, noLevelsEquivalentStatsHolder);
+    }
+
+    /**
+     * Check the new stats API returns the same values as the old stats API.
+     */
+    public void testStatsMatchOldApi() throws Exception {
+        internalCluster().startNodes(
+            1,
+            Settings.builder()
+                .put(TieredSpilloverCacheIT.defaultSettings(HEAP_CACHE_SIZE_STRING))
+                .put(
+                    TieredSpilloverCacheSettings.TOOK_TIME_POLICY_CONCRETE_SETTINGS_MAP.get(CacheType.INDICES_REQUEST_CACHE).getKey(),
+                    new TimeValue(0, TimeUnit.SECONDS)
+                )
+                .build()
+        );
+        String index = "index";
+        Client client = client();
+        startIndex(client, index);
+
+        // First search one time to see how big a single value will be
+        searchIndex(client, index, 0);
+        // get total stats
+        long singleSearchSize = getTotalStats(client).getSizeInBytes();
+        // Select numbers so we get some values on both heap and disk
+        int itemsOnHeap = HEAP_CACHE_SIZE / (int) singleSearchSize;
+        int itemsOnDisk = 1 + randomInt(30); // The first one we search (to get the size) always goes to disk
+        int expectedEntries = itemsOnHeap + itemsOnDisk;
+
+        for (int i = 1; i < expectedEntries; i++) {
+            // Cause misses
+            searchIndex(client, index, i);
+        }
+        int expectedMisses = itemsOnHeap + itemsOnDisk;
+
+        // Cause some hits
+        int expectedHits = randomIntBetween(itemsOnHeap, expectedEntries); // Select it so some hits come from both tiers
+        for (int i = 0; i < expectedHits; i++) {
+            searchIndex(client, index, i);
+        }
+
+        ImmutableCacheStats totalStats = getNodeCacheStatsResult(client, List.of()).getTotalStats();
+
+        // Check the new stats API values are as expected
+        assertEquals(
+            new ImmutableCacheStats(expectedHits, expectedMisses, 0, expectedEntries * singleSearchSize, expectedEntries),
+            totalStats
+        );
+        // Now check the new stats API values for the cache as a whole match the old stats API values
+        RequestCacheStats oldAPIStats = client.admin()
+            .indices()
+            .prepareStats(index)
+            .setRequestCache(true)
+            .get()
+            .getTotal()
+            .getRequestCache();
+        assertEquals(oldAPIStats.getHitCount(), totalStats.getHits());
+        assertEquals(oldAPIStats.getMissCount(), totalStats.getMisses());
+        assertEquals(oldAPIStats.getEvictions(), totalStats.getEvictions());
+        assertEquals(oldAPIStats.getMemorySizeInBytes(), totalStats.getSizeInBytes());
+    }
+
+    private void startIndex(Client client, String indexName) throws InterruptedException {
+        assertAcked(
+            client.admin()
+                .indices()
+                .prepareCreate(indexName)
+                .setMapping("k", "type=keyword")
+                .setSettings(
+                    Settings.builder()
+                        .put(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true)
+                        .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                        .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                        .build()
+                )
+                .get()
+        );
+        indexRandom(true, client.prepareIndex(indexName).setSource("k", "hello"));
+        ensureSearchable(indexName);
+    }
+
+    private Map<String, Integer> setupCacheForAggregationTests(Client client) throws Exception {
+        startIndex(client, index1Name);
+        startIndex(client, index2Name);
+
+        // First search one time to see how big a single value will be
+        searchIndex(client, index1Name, 0);
+        // get total stats
+        long singleSearchSize = getTotalStats(client).getSizeInBytes();
+        int itemsOnHeapAfterTest = HEAP_CACHE_SIZE / (int) singleSearchSize; // As the heap tier evicts, the items on it after the test will
+        // be the same as its max capacity
+        int itemsOnDiskAfterTest = 1 + randomInt(30); // The first one we search (to get the size) always goes to disk
+
+        // Put some values on heap and disk for each index
+        int itemsOnHeapIndex1AfterTest = randomInt(itemsOnHeapAfterTest);
+        int itemsOnHeapIndex2AfterTest = itemsOnHeapAfterTest - itemsOnHeapIndex1AfterTest;
+        int itemsOnDiskIndex1AfterTest = 1 + randomInt(itemsOnDiskAfterTest - 1);
+        // The first one we search (to get the size) always goes to disk
+        int itemsOnDiskIndex2AfterTest = itemsOnDiskAfterTest - itemsOnDiskIndex1AfterTest;
+        int hitsOnHeapIndex1 = randomInt(itemsOnHeapIndex1AfterTest);
+        int hitsOnDiskIndex1 = randomInt(itemsOnDiskIndex1AfterTest);
+        int hitsOnHeapIndex2 = randomInt(itemsOnHeapIndex2AfterTest);
+        int hitsOnDiskIndex2 = randomInt(itemsOnDiskIndex2AfterTest);
+
+        // Put these values into a map so tests can know what to expect in stats responses
+        Map<String, Integer> expectedValues = new HashMap<>();
+        expectedValues.put("itemsOnHeapIndex1AfterTest", itemsOnHeapIndex1AfterTest);
+        expectedValues.put("itemsOnHeapIndex2AfterTest", itemsOnHeapIndex2AfterTest);
+        expectedValues.put("itemsOnDiskIndex1AfterTest", itemsOnDiskIndex1AfterTest);
+        expectedValues.put("itemsOnDiskIndex2AfterTest", itemsOnDiskIndex2AfterTest);
+        expectedValues.put("hitsOnHeapIndex1", hitsOnHeapIndex1);
+        expectedValues.put("hitsOnDiskIndex1", hitsOnDiskIndex1);
+        expectedValues.put("hitsOnHeapIndex2", hitsOnHeapIndex2);
+        expectedValues.put("hitsOnDiskIndex2", hitsOnDiskIndex2);
+        expectedValues.put("singleSearchSize", (int) singleSearchSize);
+        expectedValues.put("itemsOnDiskAfterTest", itemsOnDiskAfterTest);
+        expectedValues.put("itemsOnHeapAfterTest", itemsOnHeapAfterTest); // Can only pass 10 keys in Map.of() constructor
+
+        // The earliest items (0 - itemsOnDiskAfterTest) are the ones which get evicted to disk
+        for (int i = 1; i < itemsOnDiskIndex1AfterTest; i++) { // Start at 1 as 0 has already been searched
+            searchIndex(client, index1Name, i);
+        }
+        for (int i = itemsOnDiskIndex1AfterTest; i < itemsOnDiskIndex1AfterTest + itemsOnDiskIndex2AfterTest; i++) {
+            searchIndex(client, index2Name, i);
+        }
+        // The remaining items stay on heap
+        for (int i = itemsOnDiskAfterTest; i < itemsOnDiskAfterTest + itemsOnHeapIndex1AfterTest; i++) {
+            searchIndex(client, index1Name, i);
+        }
+        for (int i = itemsOnDiskAfterTest + itemsOnHeapIndex1AfterTest; i < itemsOnDiskAfterTest + itemsOnHeapAfterTest; i++) {
+            searchIndex(client, index2Name, i);
+        }
+
+        // Get some hits on all combinations of indices and tiers
+        for (int i = itemsOnDiskAfterTest; i < itemsOnDiskAfterTest + hitsOnHeapIndex1; i++) {
+            // heap hits for index 1
+            searchIndex(client, index1Name, i);
+        }
+        for (int i = itemsOnDiskAfterTest + itemsOnHeapIndex1AfterTest; i < itemsOnDiskAfterTest + itemsOnHeapIndex1AfterTest
+            + hitsOnHeapIndex2; i++) {
+            // heap hits for index 2
+            searchIndex(client, index2Name, i);
+        }
+        for (int i = 0; i < hitsOnDiskIndex1; i++) {
+            // disk hits for index 1
+            searchIndex(client, index1Name, i);
+        }
+        for (int i = itemsOnDiskIndex1AfterTest; i < itemsOnDiskIndex1AfterTest + hitsOnDiskIndex2; i++) {
+            // disk hits for index 2
+            searchIndex(client, index2Name, i);
+        }
+        return expectedValues;
+    }
+
+    private ImmutableCacheStats returnNullIfAllZero(ImmutableCacheStats expectedStats) {
+        // If the randomly chosen numbers are such that the expected stats would be 0, we actually have not interacted with the cache for
+        // this index.
+        // In this case, we expect the stats holder to have no stats for this node, and therefore we should get null from
+        // statsHolder.getStatsForDimensionValues().
+        // We will not see it in the XContent response.
+        if (expectedStats.equals(new ImmutableCacheStats(0, 0, 0, 0, 0))) {
+            return null;
+        }
+        return expectedStats;
+    }
+
+    // Duplicated from CacheStatsAPIIndicesRequestCacheIT.java, as we can't add a dependency on server.internalClusterTest
+
+    private SearchResponse searchIndex(Client client, String index, int searchSuffix) {
+        SearchResponse resp = client.prepareSearch(index)
+            .setRequestCache(true)
+            .setQuery(QueryBuilders.termQuery("k", "hello" + padWithZeros(4, searchSuffix)))
+            // pad with zeros so request 0 and request 10 have the same size ("0000" and "0010" instead of "0" and "10")
+            .get();
+        assertSearchResponse(resp);
+        OpenSearchAssertions.assertAllSuccessful(resp);
+        return resp;
+    }
+
+    private String padWithZeros(int finalLength, int inputValue) {
+        // Avoid forbidden API String.format()
+        String input = String.valueOf(inputValue);
+        if (input.length() >= finalLength) {
+            return input;
+        }
+        StringBuilder sb = new StringBuilder();
+        while (sb.length() < finalLength - input.length()) {
+            sb.append('0');
+        }
+        sb.append(input);
+        return sb.toString();
+    }
+
+    private ImmutableCacheStats getTotalStats(Client client) throws IOException {
+        ImmutableCacheStatsHolder statsHolder = getNodeCacheStatsResult(client, List.of());
+        return statsHolder.getStatsForDimensionValues(List.of());
+    }
+
+    private static ImmutableCacheStatsHolder getNodeCacheStatsResult(Client client, List<String> aggregationLevels) throws IOException {
+        CommonStatsFlags statsFlags = new CommonStatsFlags();
+        statsFlags.includeAllCacheTypes();
+        String[] flagsLevels;
+        if (aggregationLevels == null) {
+            flagsLevels = null;
+        } else {
+            flagsLevels = aggregationLevels.toArray(new String[0]);
+        }
+        statsFlags.setLevels(flagsLevels);
+
+        NodesStatsResponse nodeStatsResponse = client.admin()
+            .cluster()
+            .prepareNodesStats("data:true")
+            .addMetric(NodesStatsRequest.Metric.CACHE_STATS.metricName())
+            .setIndices(statsFlags)
+            .get();
+        // Can always get the first data node as there's only one in this test suite
+        assertEquals(1, nodeStatsResponse.getNodes().size());
+        NodeCacheStats ncs = nodeStatsResponse.getNodes().get(0).getNodeCacheStats();
+        return ncs.getStatsByCache(CacheType.INDICES_REQUEST_CACHE);
+    }
+}

--- a/server/src/internalClusterTest/java/org/opensearch/indices/CacheStatsAPIIndicesRequestCacheIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/CacheStatsAPIIndicesRequestCacheIT.java
@@ -12,6 +12,7 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.opensearch.action.admin.cluster.node.stats.NodesStatsRequest;
 import org.opensearch.action.admin.cluster.node.stats.NodesStatsResponse;
+import org.opensearch.action.admin.indices.cache.clear.ClearIndicesCacheRequest;
 import org.opensearch.action.admin.indices.stats.CommonStatsFlags;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.Client;
@@ -20,7 +21,7 @@ import org.opensearch.common.Randomness;
 import org.opensearch.common.cache.CacheType;
 import org.opensearch.common.cache.service.NodeCacheStats;
 import org.opensearch.common.cache.stats.ImmutableCacheStats;
-import org.opensearch.common.cache.stats.ImmutableCacheStatsHolderTests;
+import org.opensearch.common.cache.stats.ImmutableCacheStatsHolder;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.common.xcontent.XContentFactory;
@@ -56,6 +57,10 @@ public class CacheStatsAPIIndicesRequestCacheIT extends ParameterizedStaticSetti
         return Arrays.<Object[]>asList(new Object[] { Settings.builder().put(FeatureFlags.PLUGGABLE_CACHE, "true").build() });
     }
 
+    /**
+     * Test aggregating by indices, indices+shards, shards, or no levels, and check the resulting stats
+     * are as we expect.
+     */
     public void testCacheStatsAPIWIthOnHeapCache() throws Exception {
         String index1Name = "index1";
         String index2Name = "index2";
@@ -73,84 +78,60 @@ public class CacheStatsAPIIndicesRequestCacheIT extends ParameterizedStaticSetti
         searchIndex(client, index2Name, "");
 
         // First, aggregate by indices only
-        Map<String, Object> xContentMap = getNodeCacheStatsXContentMap(client, List.of(IndicesRequestCache.INDEX_DIMENSION_NAME));
+        ImmutableCacheStatsHolder indicesStats = getNodeCacheStatsResult(client, List.of(IndicesRequestCache.INDEX_DIMENSION_NAME));
 
-        List<String> index1Keys = List.of(CacheType.INDICES_REQUEST_CACHE.getValue(), IndicesRequestCache.INDEX_DIMENSION_NAME, index1Name);
+        List<String> index1Dimensions = List.of(index1Name);
         // Since we searched twice, we expect to see 1 hit, 1 miss and 1 entry for index 1
         ImmutableCacheStats expectedStats = new ImmutableCacheStats(1, 1, 0, 0, 1);
-        checkCacheStatsAPIResponse(xContentMap, index1Keys, expectedStats, false, true);
+        checkCacheStatsAPIResponse(indicesStats, index1Dimensions, expectedStats, false, true);
         // Get the request size for one request, so we can reuse it for next index
-        int requestSize = (int) ((Map<String, Object>) ImmutableCacheStatsHolderTests.getValueFromNestedXContentMap(
-            xContentMap,
-            index1Keys
-        )).get(ImmutableCacheStats.Fields.SIZE_IN_BYTES);
+        long requestSize = indicesStats.getStatsForDimensionValues(List.of(index1Name)).getSizeInBytes();
         assertTrue(requestSize > 0);
 
-        List<String> index2Keys = List.of(CacheType.INDICES_REQUEST_CACHE.getValue(), IndicesRequestCache.INDEX_DIMENSION_NAME, index2Name);
+        List<String> index2Dimensions = List.of(index2Name);
         // We searched once in index 2, we expect 1 miss + 1 entry
         expectedStats = new ImmutableCacheStats(0, 1, 0, requestSize, 1);
-        checkCacheStatsAPIResponse(xContentMap, index2Keys, expectedStats, true, true);
+        checkCacheStatsAPIResponse(indicesStats, index2Dimensions, expectedStats, true, true);
 
         // The total stats for the node should be 1 hit, 2 misses, and 2 entries
         expectedStats = new ImmutableCacheStats(1, 2, 0, 2 * requestSize, 2);
-        List<String> totalStatsKeys = List.of(CacheType.INDICES_REQUEST_CACHE.getValue());
-        checkCacheStatsAPIResponse(xContentMap, totalStatsKeys, expectedStats, true, true);
+        List<String> totalStatsKeys = List.of();
+        checkCacheStatsAPIResponse(indicesStats, totalStatsKeys, expectedStats, true, true);
 
         // Aggregate by shards only
-        xContentMap = getNodeCacheStatsXContentMap(client, List.of(IndicesRequestCache.SHARD_ID_DIMENSION_NAME));
+        ImmutableCacheStatsHolder shardsStats = getNodeCacheStatsResult(client, List.of(IndicesRequestCache.SHARD_ID_DIMENSION_NAME));
 
-        List<String> index1Shard0Keys = List.of(
-            CacheType.INDICES_REQUEST_CACHE.getValue(),
-            IndicesRequestCache.SHARD_ID_DIMENSION_NAME,
-            "[" + index1Name + "][0]"
-        );
+        List<String> index1Shard0Dimensions = List.of("[" + index1Name + "][0]");
 
         expectedStats = new ImmutableCacheStats(1, 1, 0, requestSize, 1);
-        checkCacheStatsAPIResponse(xContentMap, index1Shard0Keys, expectedStats, true, true);
+        checkCacheStatsAPIResponse(shardsStats, index1Shard0Dimensions, expectedStats, true, true);
 
-        List<String> index2Shard0Keys = List.of(
-            CacheType.INDICES_REQUEST_CACHE.getValue(),
-            IndicesRequestCache.SHARD_ID_DIMENSION_NAME,
-            "[" + index2Name + "][0]"
-        );
+        List<String> index2Shard0Dimensions = List.of("[" + index2Name + "][0]");
         expectedStats = new ImmutableCacheStats(0, 1, 0, requestSize, 1);
-        checkCacheStatsAPIResponse(xContentMap, index2Shard0Keys, expectedStats, true, true);
+        checkCacheStatsAPIResponse(shardsStats, index2Shard0Dimensions, expectedStats, true, true);
 
         // Aggregate by indices and shards
-        xContentMap = getNodeCacheStatsXContentMap(
+        ImmutableCacheStatsHolder indicesAndShardsStats = getNodeCacheStatsResult(
             client,
             List.of(IndicesRequestCache.INDEX_DIMENSION_NAME, IndicesRequestCache.SHARD_ID_DIMENSION_NAME)
         );
 
-        index1Keys = List.of(
-            CacheType.INDICES_REQUEST_CACHE.getValue(),
-            IndicesRequestCache.INDEX_DIMENSION_NAME,
-            index1Name,
-            IndicesRequestCache.SHARD_ID_DIMENSION_NAME,
-            "[" + index1Name + "][0]"
-        );
+        index1Dimensions = List.of(index1Name, "[" + index1Name + "][0]");
 
         expectedStats = new ImmutableCacheStats(1, 1, 0, requestSize, 1);
-        checkCacheStatsAPIResponse(xContentMap, index1Keys, expectedStats, true, true);
+        checkCacheStatsAPIResponse(indicesAndShardsStats, index1Dimensions, expectedStats, true, true);
 
-        index2Keys = List.of(
-            CacheType.INDICES_REQUEST_CACHE.getValue(),
-            IndicesRequestCache.INDEX_DIMENSION_NAME,
-            index2Name,
-            IndicesRequestCache.SHARD_ID_DIMENSION_NAME,
-            "[" + index2Name + "][0]"
-        );
-
+        index2Dimensions = List.of(index2Name, "[" + index2Name + "][0]");
         expectedStats = new ImmutableCacheStats(0, 1, 0, requestSize, 1);
-        checkCacheStatsAPIResponse(xContentMap, index2Keys, expectedStats, true, true);
-
+        checkCacheStatsAPIResponse(indicesAndShardsStats, index2Dimensions, expectedStats, true, true);
     }
 
-    // TODO: Add testCacheStatsAPIWithTieredCache when TSC stats implementation PR is merged
-
+    /**
+     * Check the new stats API returns the same values as the old stats API. In particular,
+     * check that the new and old APIs are both correctly estimating memory size,
+     * using the logic that includes the overhead memory in ICacheKey.
+     */
     public void testStatsMatchOldApi() throws Exception {
-        // The main purpose of this test is to check that the new and old APIs are both correctly estimating memory size,
-        // using the logic that includes the overhead memory in ICacheKey.
         String index = "index";
         Client client = client();
         startIndex(client, index);
@@ -173,8 +154,7 @@ public class CacheStatsAPIIndicesRequestCacheIT extends ParameterizedStaticSetti
             .getRequestCache();
         assertNotEquals(0, oldApiStats.getMemorySizeInBytes());
 
-        List<String> xContentMapKeys = List.of(CacheType.INDICES_REQUEST_CACHE.getValue());
-        Map<String, Object> xContentMap = getNodeCacheStatsXContentMap(client, List.of());
+        ImmutableCacheStatsHolder statsHolder = getNodeCacheStatsResult(client, List.of());
         ImmutableCacheStats expected = new ImmutableCacheStats(
             oldApiStats.getHitCount(),
             oldApiStats.getMissCount(),
@@ -183,9 +163,13 @@ public class CacheStatsAPIIndicesRequestCacheIT extends ParameterizedStaticSetti
             0
         );
         // Don't check entries, as the old API doesn't track this
-        checkCacheStatsAPIResponse(xContentMap, xContentMapKeys, expected, true, false);
+        checkCacheStatsAPIResponse(statsHolder, List.of(), expected, true, false);
     }
 
+    /**
+     * Test the XContent in the response behaves correctly when we pass null levels.
+     * Only the total cache stats should be returned.
+     */
     public void testNullLevels() throws Exception {
         String index = "index";
         Client client = client();
@@ -194,9 +178,81 @@ public class CacheStatsAPIIndicesRequestCacheIT extends ParameterizedStaticSetti
         for (int i = 0; i < numKeys; i++) {
             searchIndex(client, index, String.valueOf(i));
         }
-        Map<String, Object> xContentMap = getNodeCacheStatsXContentMap(client, null);
+        Map<String, Object> xContentMap = getStatsXContent(getNodeCacheStatsResult(client, null));
         // Null levels should result in only the total cache stats being returned -> 6 fields inside the response.
-        assertEquals(6, ((Map<String, Object>) xContentMap.get("request_cache")).size());
+        assertEquals(6, xContentMap.size());
+    }
+
+    /**
+     * Test clearing the cache using API sets memory size and number of items to 0, but leaves other stats
+     * unaffected.
+     */
+    public void testCacheClear() throws Exception {
+        String index = "index";
+        Client client = client();
+
+        startIndex(client, index);
+
+        int expectedHits = 2;
+        int expectedMisses = 7;
+        // Search for the same doc to give hits
+        for (int i = 0; i < expectedHits + 1; i++) {
+            searchIndex(client, index, "");
+        }
+        // Search for new docs
+        for (int i = 0; i < expectedMisses - 1; i++) {
+            searchIndex(client, index, String.valueOf(i));
+        }
+
+        ImmutableCacheStats expectedTotal = new ImmutableCacheStats(expectedHits, expectedMisses, 0, 0, expectedMisses);
+        ImmutableCacheStatsHolder statsHolder = getNodeCacheStatsResult(client, List.of());
+        // Don't check the memory size, just assert it's nonzero
+        checkCacheStatsAPIResponse(statsHolder, List.of(), expectedTotal, false, true);
+        long originalMemorySize = statsHolder.getTotalSizeInBytes();
+        assertNotEquals(0, originalMemorySize);
+
+        // Clear cache
+        ClearIndicesCacheRequest clearIndicesCacheRequest = new ClearIndicesCacheRequest(index);
+        client.admin().indices().clearCache(clearIndicesCacheRequest).actionGet();
+
+        // Now size and items should be 0
+        expectedTotal = new ImmutableCacheStats(expectedHits, expectedMisses, 0, 0, 0);
+        statsHolder = getNodeCacheStatsResult(client, List.of());
+        checkCacheStatsAPIResponse(statsHolder, List.of(), expectedTotal, true, true);
+    }
+
+    /**
+     * Test the cache stats responses are in the expected place in XContent when we call the overall API
+     * GET /_nodes/stats. They should be at nodes.[node_id].caches.request_cache.
+     */
+    public void testNodesStatsResponse() throws Exception {
+        String index = "index";
+        Client client = client();
+
+        startIndex(client, index);
+
+        NodesStatsResponse nodeStatsResponse = client.admin()
+            .cluster()
+            .prepareNodesStats("data:true")
+            .all() // This mimics /_nodes/stats
+            .get();
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        Map<String, String> paramMap = new HashMap<>();
+        ToXContent.Params params = new ToXContent.MapParams(paramMap);
+
+        builder.startObject();
+        nodeStatsResponse.toXContent(builder, params);
+        builder.endObject();
+        Map<String, Object> xContentMap = XContentHelper.convertToMap(MediaTypeRegistry.JSON.xContent(), builder.toString(), true);
+        // Values should be at nodes.[node_id].caches.request_cache
+        // Get the node id
+        Map<String, Object> nodesResponse = (Map<String, Object>) xContentMap.get("nodes");
+        assertEquals(1, nodesResponse.size());
+        String nodeId = nodesResponse.keySet().toArray(String[]::new)[0];
+        Map<String, Object> cachesResponse = (Map<String, Object>) ((Map<String, Object>) nodesResponse.get(nodeId)).get("caches");
+        assertNotNull(cachesResponse);
+        // Request cache should be present in the response
+        assertTrue(cachesResponse.containsKey("request_cache"));
     }
 
     private void startIndex(Client client, String indexName) throws InterruptedException {
@@ -227,8 +283,7 @@ public class CacheStatsAPIIndicesRequestCacheIT extends ParameterizedStaticSetti
         return resp;
     }
 
-    private static Map<String, Object> getNodeCacheStatsXContentMap(Client client, List<String> aggregationLevels) throws IOException {
-
+    private static ImmutableCacheStatsHolder getNodeCacheStatsResult(Client client, List<String> aggregationLevels) throws IOException {
         CommonStatsFlags statsFlags = new CommonStatsFlags();
         statsFlags.includeAllCacheTypes();
         String[] flagsLevels;
@@ -248,16 +303,16 @@ public class CacheStatsAPIIndicesRequestCacheIT extends ParameterizedStaticSetti
         // Can always get the first data node as there's only one in this test suite
         assertEquals(1, nodeStatsResponse.getNodes().size());
         NodeCacheStats ncs = nodeStatsResponse.getNodes().get(0).getNodeCacheStats();
+        return ncs.getStatsByCache(CacheType.INDICES_REQUEST_CACHE);
+    }
 
+    private static Map<String, Object> getStatsXContent(ImmutableCacheStatsHolder statsHolder) throws IOException {
         XContentBuilder builder = XContentFactory.jsonBuilder();
         Map<String, String> paramMap = new HashMap<>();
-        if (aggregationLevels != null && !aggregationLevels.isEmpty()) {
-            paramMap.put("level", String.join(",", aggregationLevels));
-        }
         ToXContent.Params params = new ToXContent.MapParams(paramMap);
 
         builder.startObject();
-        ncs.toXContent(builder, params);
+        statsHolder.toXContent(builder, params);
         builder.endObject();
 
         String resultString = builder.toString();
@@ -265,27 +320,22 @@ public class CacheStatsAPIIndicesRequestCacheIT extends ParameterizedStaticSetti
     }
 
     private static void checkCacheStatsAPIResponse(
-        Map<String, Object> xContentMap,
-        List<String> xContentMapKeys,
+        ImmutableCacheStatsHolder statsHolder,
+        List<String> dimensionValues,
         ImmutableCacheStats expectedStats,
         boolean checkMemorySize,
         boolean checkEntries
     ) {
-        // Assumes the keys point to a level whose keys are the field values ("size_in_bytes", "evictions", etc) and whose values store
-        // those stats
-        Map<String, Object> aggregatedStatsResponse = (Map<String, Object>) ImmutableCacheStatsHolderTests.getValueFromNestedXContentMap(
-            xContentMap,
-            xContentMapKeys
-        );
+        ImmutableCacheStats aggregatedStatsResponse = statsHolder.getStatsForDimensionValues(dimensionValues);
         assertNotNull(aggregatedStatsResponse);
-        assertEquals(expectedStats.getHits(), (int) aggregatedStatsResponse.get(ImmutableCacheStats.Fields.HIT_COUNT));
-        assertEquals(expectedStats.getMisses(), (int) aggregatedStatsResponse.get(ImmutableCacheStats.Fields.MISS_COUNT));
-        assertEquals(expectedStats.getEvictions(), (int) aggregatedStatsResponse.get(ImmutableCacheStats.Fields.EVICTIONS));
+        assertEquals(expectedStats.getHits(), (int) aggregatedStatsResponse.getHits());
+        assertEquals(expectedStats.getMisses(), (int) aggregatedStatsResponse.getMisses());
+        assertEquals(expectedStats.getEvictions(), (int) aggregatedStatsResponse.getEvictions());
         if (checkMemorySize) {
-            assertEquals(expectedStats.getSizeInBytes(), (int) aggregatedStatsResponse.get(ImmutableCacheStats.Fields.SIZE_IN_BYTES));
+            assertEquals(expectedStats.getSizeInBytes(), (int) aggregatedStatsResponse.getSizeInBytes());
         }
         if (checkEntries) {
-            assertEquals(expectedStats.getItems(), (int) aggregatedStatsResponse.get(ImmutableCacheStats.Fields.ITEM_COUNT));
+            assertEquals(expectedStats.getItems(), (int) aggregatedStatsResponse.getItems());
         }
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/indices/stats/CommonStatsFlags.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/stats/CommonStatsFlags.java
@@ -149,7 +149,7 @@ public class CommonStatsFlags implements Writeable, Cloneable {
         includeUnloadedSegments = false;
         includeAllShardIndexingPressureTrackers = false;
         includeOnlyTopIndexingPressureMetrics = false;
-        includeCaches = EnumSet.noneOf(CacheType.class);
+        includeCaches = EnumSet.allOf(CacheType.class);
         levels = new String[0];
         return this;
     }

--- a/server/src/main/java/org/opensearch/common/cache/service/NodeCacheStats.java
+++ b/server/src/main/java/org/opensearch/common/cache/service/NodeCacheStats.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.common.cache.service;
 
+import org.opensearch.action.admin.cluster.node.stats.NodesStatsRequest;
 import org.opensearch.action.admin.indices.stats.CommonStatsFlags;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.cache.CacheType;
@@ -51,6 +52,7 @@ public class NodeCacheStats implements ToXContentFragment, Writeable {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(NodesStatsRequest.Metric.CACHE_STATS.metricName());
         for (CacheType type : statsByCache.keySet()) {
             if (flags.getIncludeCaches().contains(type)) {
                 builder.startObject(type.getValue());
@@ -58,6 +60,7 @@ public class NodeCacheStats implements ToXContentFragment, Writeable {
                 builder.endObject();
             }
         }
+        builder.endObject();
         return builder;
     }
 
@@ -76,5 +79,11 @@ public class NodeCacheStats implements ToXContentFragment, Writeable {
     @Override
     public int hashCode() {
         return Objects.hash(statsByCache, flags);
+    }
+
+    // Get the immutable cache stats for a given cache, used to avoid having to process XContent in tests.
+    // Safe to expose publicly as the ImmutableCacheStatsHolder can't be modified after its creation.
+    public ImmutableCacheStatsHolder getStatsByCache(CacheType cacheType) {
+        return statsByCache.get(cacheType);
     }
 }


### PR DESCRIPTION
## Original PR: https://github.com/opensearch-project/OpenSearch/pull/13655

### Description
Adds more ITs and UT coverage for cache stats in the tiered spillover cache. Also has 3 small bugfixes which were found during testing: 
- Cache clear API incorrectly wiped hits, misses, and eviction stats 
- Items evicted from the heap tier, but rejected from the disk tier due to policies, incorrectly weren't counted towards the total evictions for the cache
- `request_cache` object in XContent response for the cache stats API was incorrectly at nodes.[node_id].request_cache instead of nodes.[node_id].caches.request_cache

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/13455

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [ ] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
