### PR TITLE
Experimental Codec Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add getMetadataFields to MapperService ([#13819](https://github.com/opensearch-project/OpenSearch/pull/13819))
 - [Remote State] Add async remote state deletion task running on an interval, configurable by a setting ([#13131](https://github.com/opensearch-project/OpenSearch/pull/13131))
 - Allow setting query parameters on requests ([#13776](https://github.com/opensearch-project/OpenSearch/issues/13776))
+- Experimental support for codecs ([#13992](https://github.com/opensearch-project/OpenSearch/issues/13992))
 
 ### Dependencies
 - Bump `com.github.spullara.mustache.java:compiler` from 0.9.10 to 0.9.13 ([#13329](https://github.com/opensearch-project/OpenSearch/pull/13329), [#13559](https://github.com/opensearch-project/OpenSearch/pull/13559))

--- a/server/src/main/java/org/opensearch/index/codec/CodecSettings.java
+++ b/server/src/main/java/org/opensearch/index/codec/CodecSettings.java
@@ -18,4 +18,6 @@ import org.opensearch.common.settings.Setting;
  */
 public interface CodecSettings {
     boolean supports(Setting<?> setting);
+
+    boolean experimental();
 }

--- a/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
+++ b/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
@@ -140,7 +140,9 @@ public final class EngineConfig {
                 return s;
             default:
                 if (Codec.availableCodecs().contains(s)) {
-                    return s;
+                    if (!isExperimentalCodec(Codec.forName(s))) {
+                        return s;
+                    }
                 }
 
                 for (String codecName : Codec.availableCodecs()) {
@@ -148,7 +150,9 @@ public final class EngineConfig {
                     if (codec instanceof CodecAliases) {
                         CodecAliases codecWithAlias = (CodecAliases) codec;
                         if (codecWithAlias.aliases().contains(s)) {
-                            return s;
+                            if (!isExperimentalCodec(codec)) {
+                                return s;
+                            }
                         }
                     }
                 }
@@ -158,6 +162,21 @@ public final class EngineConfig {
                 );
         }
     }, Property.IndexScope, Property.NodeScope);
+
+    static boolean isExperimentalCodec(Codec codec) {
+        if (codec instanceof CodecSettings) {
+            CodecSettings codecWithSettings = (CodecSettings) codec;
+            if (!codecWithSettings.experimental()) {
+                return false;
+            } else {
+                throw new IllegalArgumentException(
+                    "experimental codecs are not enabled. value for [index.codec] must be one of [default, lz4, best_compression, zlib] but was: "
+                        + codec.getName()
+                );
+            }
+        }
+        return false;
+    }
 
     /**
      * Index setting to change the compression level of zstd and zstd_no_dict lucene codecs.


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
We currently do not have a way to mark and validate the codecs as experimental in OpenSearch. With this, we would be able to safely introduce experimental codecs for consumption.

### Related Issues
Resolves #13723 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
