### PR TITLE
Implement missing methods for EncryptedBlobStore and EncryptedBlobContainer

### DIFF
--- a/server/src/main/java/org/opensearch/common/blobstore/EncryptedBlobContainer.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/EncryptedBlobContainer.java
@@ -9,6 +9,7 @@
 package org.opensearch.common.blobstore;
 
 import org.opensearch.common.CheckedBiConsumer;
+import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.crypto.CryptoHandler;
 import org.opensearch.common.crypto.DecryptedRangedStreamProvider;
 import org.opensearch.common.crypto.EncryptedHeaderContentSupplier;
@@ -48,6 +49,14 @@ public class EncryptedBlobContainer<T, U> implements BlobContainer {
     public InputStream readBlob(String blobName) throws IOException {
         InputStream inputStream = blobContainer.readBlob(blobName);
         return cryptoHandler.createDecryptingStream(inputStream);
+    }
+
+    @ExperimentalApi
+    @Override
+    public InputStreamWithMetadata readBlobWithMetadata(String blobName) throws IOException {
+        InputStreamWithMetadata inputStreamWithMetadata = blobContainer.readBlobWithMetadata(blobName);
+        InputStream decryptInputStream = cryptoHandler.createDecryptingStream(inputStreamWithMetadata.getInputStream());
+        return new InputStreamWithMetadata(decryptInputStream, inputStreamWithMetadata.getMetadata());
     }
 
     EncryptedHeaderContentSupplier getEncryptedHeaderContentSupplier(String blobName) {

--- a/server/src/main/java/org/opensearch/common/blobstore/EncryptedBlobStore.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/EncryptedBlobStore.java
@@ -95,6 +95,11 @@ public class EncryptedBlobStore implements BlobStore {
         return blobStore.extendedStats();
     }
 
+    @Override
+    public boolean isBlobMetadataEnabled() {
+        return blobStore.isBlobMetadataEnabled();
+    }
+
     /**
      * Closes the EncryptedBlobStore by decrementing the reference count of the CryptoManager and closing the
      * underlying BlobStore. This ensures proper cleanup of resources.

--- a/server/src/test/java/org/opensearch/common/blobstore/EncryptedBlobContainerTests.java
+++ b/server/src/test/java/org/opensearch/common/blobstore/EncryptedBlobContainerTests.java
@@ -1,0 +1,41 @@
+
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.blobstore;
+
+import org.opensearch.common.crypto.CryptoHandler;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class EncryptedBlobContainerTests extends OpenSearchTestCase {
+
+    public void testBlobContainerReadBlobWithMetadata() throws IOException {
+        BlobContainer blobContainer = mock(BlobContainer.class);
+        CryptoHandler cryptoHandler = mock(CryptoHandler.class);
+        EncryptedBlobContainer encryptedBlobContainer = new EncryptedBlobContainer(blobContainer, cryptoHandler);
+        InputStreamWithMetadata inputStreamWithMetadata = new InputStreamWithMetadata(
+            new ByteArrayInputStream(new byte[0]),
+            new HashMap<>()
+        );
+        when(blobContainer.readBlobWithMetadata("test")).thenReturn(inputStreamWithMetadata);
+        InputStream decrypt = new ByteArrayInputStream(new byte[2]);
+        when(cryptoHandler.createDecryptingStream(inputStreamWithMetadata.getInputStream())).thenReturn(decrypt);
+        InputStreamWithMetadata result = encryptedBlobContainer.readBlobWithMetadata("test");
+        assertEquals(result.getInputStream(), decrypt);
+        assertEquals(result.getMetadata(), inputStreamWithMetadata.getMetadata());
+    }
+
+}

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStoreCustomMetadataResolverTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStoreCustomMetadataResolverTests.java
@@ -187,7 +187,7 @@ public class RemoteStoreCustomMetadataResolverTests extends OpenSearchTestCase {
         when(blobStoreMock.isBlobMetadataEnabled()).thenReturn(true);
         RemoteStoreCustomMetadataResolver resolver = new RemoteStoreCustomMetadataResolver(
             remoteStoreSettings,
-            () -> Version.CURRENT,
+            () -> Version.V_2_15_0,
             () -> repositoriesService,
             settings
         );
@@ -200,7 +200,7 @@ public class RemoteStoreCustomMetadataResolverTests extends OpenSearchTestCase {
         RemoteStoreSettings remoteStoreSettings = new RemoteStoreSettings(settings, clusterSettings);
         RemoteStoreCustomMetadataResolver resolver = new RemoteStoreCustomMetadataResolver(
             remoteStoreSettings,
-            () -> Version.CURRENT,
+            () -> Version.V_2_15_0,
             () -> repositoriesService,
             settings
         );

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStoreUtilsTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStoreUtilsTests.java
@@ -373,7 +373,7 @@ public class RemoteStoreUtilsTests extends OpenSearchTestCase {
             Settings.builder()
                 .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
                 .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
-                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.V_2_15_0)
                 .put(IndexMetadata.INDEX_REMOTE_STORE_ENABLED_SETTING.getKey(), true)
                 .put(IndexMetadata.INDEX_REMOTE_TRANSLOG_REPOSITORY_SETTING.getKey(), "dummy-tlog-repo")
                 .put(IndexMetadata.INDEX_REMOTE_SEGMENT_STORE_REPOSITORY_SETTING.getKey(), "dummy-segment-repo")


### PR DESCRIPTION
### Description
Implement missing methods IsBlobMetadataEnabled(), readBlobWithMetadata() for EncryptedBlobStore and EncryptedBlobContainer.  These methods were introduced as part of https://github.com/opensearch-project/OpenSearch/issues/13091

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- ~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
