### PR TITLE
Revert "[Remote Migration] Update checkpoint from remote nodes replicas"

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotemigration/MigrationBaseTestCase.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotemigration/MigrationBaseTestCase.java
@@ -186,11 +186,10 @@ public class MigrationBaseTestCase extends OpenSearchIntegTestCase {
                     indexSingleDoc(indexName);
                     long currentDocCount = indexedDocs.incrementAndGet();
                     if (currentDocCount > 0 && currentDocCount % refreshFrequency == 0) {
+                        logger.info("--> [iteration {}] flushing index", currentDocCount);
                         if (rarely()) {
-                            logger.info("--> [iteration {}] flushing index", currentDocCount);
                             client().admin().indices().prepareFlush(indexName).get();
                         } else {
-                            logger.info("--> [iteration {}] refreshing index", currentDocCount);
                             client().admin().indices().prepareRefresh(indexName).get();
                         }
                     }

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -523,6 +523,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     public Function<String, Boolean> isShardOnRemoteEnabledNode = nodeId -> {
         DiscoveryNode node = discoveryNodes.get(nodeId);
         if (node != null) {
+            logger.trace("Node {} has remote_enabled as {}", nodeId, node.isRemoteStoreNode());
             return node.isRemoteStoreNode();
         }
         return false;

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
@@ -384,7 +384,7 @@ public class SegmentReplicationTargetService extends AbstractLifecycleComponent 
     protected void updateVisibleCheckpoint(long replicationId, IndexShard replicaShard) {
         // Update replication checkpoint on source via transport call only supported for remote store integration. For node-
         // node communication, checkpoint update is piggy-backed to GET_SEGMENT_FILES transport call
-        if (replicaShard.indexSettings().isAssignedOnRemoteNode() == false) {
+        if (replicaShard.indexSettings().isRemoteStoreEnabled() == false) {
             return;
         }
         ShardRouting primaryShard = clusterService.state().routingTable().shardRoutingTable(replicaShard.shardId()).primaryShard();

--- a/server/src/main/java/org/opensearch/indices/replication/common/ReplicationTarget.java
+++ b/server/src/main/java/org/opensearch/indices/replication/common/ReplicationTarget.java
@@ -91,7 +91,7 @@ public abstract class ReplicationTarget extends AbstractRefCounted {
         // make sure the store is not released until we are done.
         this.cancellableThreads = new CancellableThreads();
         store.incRef();
-        if (indexShard.indexSettings().isAssignedOnRemoteNode()) {
+        if (indexShard.indexSettings().isRemoteStoreEnabled()) {
             indexShard.remoteStore().incRef();
         }
     }
@@ -284,7 +284,7 @@ public abstract class ReplicationTarget extends AbstractRefCounted {
         try {
             store.decRef();
         } finally {
-            if (indexShard.indexSettings().isAssignedOnRemoteNode()) {
+            if (indexShard.indexSettings().isRemoteStoreEnabled()) {
                 indexShard.remoteStore().decRef();
             }
         }


### PR DESCRIPTION
Reverts opensearch-project/OpenSearch#13888 
This PR introduced flaky tests that block a lot of 2.15 release items. Reverting it now.
Details:
https://github.com/opensearch-project/OpenSearch/issues/14055