### PR TITLE
Fix null values indexed as "null" strings in flat_object field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix indexing error when flat_object field is explicitly null ([#15375](https://github.com/opensearch-project/OpenSearch/pull/15375))
 - Fix split response processor not included in allowlist ([#15393](https://github.com/opensearch-project/OpenSearch/pull/15393))
 - Fix unchecked cast in dynamic action map getter ([#15394](https://github.com/opensearch-project/OpenSearch/pull/15394))
+- Fix null values indexed as "null" strings in flat_object field ([#14069](https://github.com/opensearch-project/OpenSearch/pull/14069))
 
 ### Security
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/91_flat_object_null_value.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/91_flat_object_null_value.yml
@@ -1,0 +1,401 @@
+---
+# The test setup includes:
+# - Create flat_object mapping for flat_object_null_value index
+# - Index 19 example documents related to null value
+# - Refresh the index so it is ready for search tests
+
+setup:
+  - skip:
+      version: " - 2.99.99"
+      reason: "null value in flat_object is processed in 3.0.0 "
+  - do:
+      indices.create:
+        index: flat_object_null_value
+        body:
+          mappings:
+            properties:
+              record:
+                type: "flat_object"
+  - do:
+      index:
+        index: flat_object_null_value
+        id: 1
+        body: {
+          "record": null
+        }
+
+  - do:
+      index:
+        index: flat_object_null_value
+        id: 2
+        body: {
+          "record": {
+            "name": null
+          }
+        }
+
+  - do:
+      index:
+        index: flat_object_null_value
+        id: 3
+        body: {
+          "record": {
+            "name": null,
+            "age":"5",
+            "name1": null
+          }
+        }
+
+  - do:
+      index:
+        index: flat_object_null_value
+        id: 4
+        body: {
+          "record": {
+            "name": [
+              null,
+              {
+                "d": {
+                  "name": "dsds"
+                }
+              }
+            ]
+          }
+        }
+
+  - do:
+      index:
+        index: flat_object_null_value
+        id: 5
+        body: {
+          "record": {
+            "name": [
+              {
+                "d": {
+                  "name": "dsds"
+                }
+              },
+              null
+            ]
+          }
+        }
+
+  - do:
+      index:
+        index: flat_object_null_value
+        id: 6
+        body: {
+          "record": {
+            "name": [
+              {
+                "name": "age1"
+              },
+              null,
+              {
+                "d": {
+                  "name": "dsds"
+                }
+              }
+            ]
+          }
+        }
+
+  - do:
+      index:
+        index: flat_object_null_value
+        id: 7
+        body: {
+          "record": {
+            "name": null,
+            "age":"3"
+          }
+        }
+
+  - do:
+      index:
+        index: flat_object_null_value
+        id: 8
+        body: {
+          "record": {
+            "age":"3",
+            "name": null
+          }
+        }
+
+  - do:
+      index:
+        index: flat_object_null_value
+        id: 9
+        body: {
+          "record": {
+            "name": [
+              null,
+              3
+            ],
+            "age": 4
+          }
+        }
+
+  - do:
+      index:
+        index: flat_object_null_value
+        id: 10
+        body: {
+          "record": {
+            "age": 4,
+            "name": [
+              null,
+              3
+            ]
+          }
+        }
+
+  - do:
+      index:
+        index: flat_object_null_value
+        id: 11
+        body: {
+          "record": {
+            "name": null
+          }
+        }
+
+  - do:
+      index:
+        index: flat_object_null_value
+        id: 12
+        body: {
+          "record": {
+            "r1": {
+              "labels": [
+                null
+              ]
+            }
+          }
+        }
+
+  - do:
+      index:
+        index: flat_object_null_value
+        id: 13
+        body: {
+          "record": {
+            "labels": [
+              null
+            ]
+          }
+        }
+
+  - do:
+      index:
+        index: flat_object_null_value
+        id: 14
+        body: {
+          "record": {
+            "r1": {
+              "name": null,
+              "labels": [
+                null
+              ]
+            }
+          }
+        }
+
+  - do:
+      index:
+        index: flat_object_null_value
+        id: 15
+        body: {
+          "record": {
+            "age": "4",
+            "labels": [
+              null
+            ]
+          }
+        }
+
+  - do:
+      index:
+        index: flat_object_null_value
+        id: 16
+        body: {
+          "record": {
+            "labels": [
+              null
+            ],
+            "age": "4"
+          }
+        }
+
+  - do:
+      index:
+        index: flat_object_null_value
+        id: 17
+        body: {
+          "record": {
+            "name": {
+              "name1": [
+                null,
+                "dsdsdsd"
+              ]
+            }
+          }
+        }
+
+  - do:
+      index:
+        index: flat_object_null_value
+        id: 18
+        body: {
+          "record": {
+            "name": {
+              "name1": {
+                "name2": null
+              }
+            }
+          }
+        }
+
+  - do:
+      index:
+        index: flat_object_null_value
+        id: 19
+        body: {
+          "record": {
+            "name": {
+              "name1": [
+                [],
+                [
+                  "dsdsdsd",
+                  null
+                ]
+              ]
+            }
+          }
+        }
+
+  - do:
+      indices.refresh:
+        index: flat_object_null_value
+---
+# Delete Index when connection is teardown
+teardown:
+  - do:
+      indices.delete:
+        index: flat_object_null_value
+
+
+---
+# Verify that mappings under the catalog field did not expand
+# and no dynamic fields were created.
+"Mappings":
+  - skip:
+      version: " - 2.99.99"
+      reason: "null value in flat_object is processed in 3.0.0"
+
+  - do:
+      indices.get_mapping:
+        index: flat_object_null_value
+  - is_true: flat_object_null_value.mappings
+  - match: { flat_object_null_value.mappings.properties.record.type: flat_object }
+  # https://github.com/opensearch-project/OpenSearch/tree/main/rest-api-spec/src/main/resources/rest-api-spec/test#length
+  - length: { flat_object_null_value.mappings.properties: 1 }
+
+
+---
+"Supported queries":
+  - skip:
+      version: " - 2.99.99"
+      reason: "null value in flat_object is processed in 3.0.0"
+
+  # Verify Document Count
+  - do:
+      search:
+        body: {
+          size: 30,
+          query: {
+            match_all: { }
+          }
+        }
+
+  - length: { hits.hits: 19 }
+
+  # Exists Query with no dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          size: 30,
+          query: {
+            exists: { "field": "record" }
+          }
+        }
+
+  - length: { hits.hits: 12 }
+  - match: { hits.hits.0._source.record: { "name": null, "age": "5", "name1": null } }
+  - match: { hits.hits.1._source.record.name: [ null, { "d": { "name": "dsds" } } ] }
+  - match: { hits.hits.2._source.record.name: [ { "d": { "name": "dsds" } }, null ] }
+  - match: { hits.hits.3._source.record.name: [ { "name": "age1" }, null, { "d": { "name": "dsds" } } ] }
+  - match: { hits.hits.4._source.record: { "name": null, "age": "3" } }
+  - match: { hits.hits.5._source.record: { "age": "3", "name": null } }
+  - match: { hits.hits.6._source.record: { "name": [ null, 3 ], "age": 4 } }
+  - match: { hits.hits.7._source.record: { "age": 4, "name": [ null, 3 ] } }
+  - match: { hits.hits.8._source.record: { "age": "4", "labels": [ null ] } }
+  - match: { hits.hits.9._source.record: { "labels": [ null ], "age": "4" } }
+  - match: { hits.hits.10._source.record.name: { "name1": [ null, "dsdsdsd" ] } }
+  - match: { hits.hits.11._source.record.name: { "name1": [ [], [ "dsdsdsd", null ] ] } }
+
+  # Exists Query with dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            exists: { "field": "record.d" }
+          }
+        }
+
+  - length: { hits.hits: 3 }
+  - match: { hits.hits.0._source.record.name: [ null, { "d": { "name": "dsds" } } ] }
+  - match: { hits.hits.1._source.record.name: [ { "d": { "name": "dsds" } }, null ] }
+  - match: { hits.hits.2._source.record.name: [ { "name": "age1" }, null, { "d": { "name": "dsds" } } ] }
+
+  # Term Query without exact dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            term: { record: "dsdsdsd" }
+          }
+        }
+
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._source.record.name: { "name1": [ null, "dsdsdsd" ] } }
+  - match: { hits.hits.1._source.record.name: { "name1": [ [], [ "dsdsdsd", null ] ] } }
+
+  # Term Query with exact dot path.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            term: { record.name.name1: "dsdsdsd" }
+          }
+        }
+
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._source.record.name: { "name1": [ null, "dsdsdsd" ] } }
+  - match: { hits.hits.1._source.record.name: { "name1": [ [], [ "dsdsdsd", null ] ] } }
+
+  # Test "null" string search.
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            term: { record: "null" }
+          }
+        }
+
+  - length: { hits.hits: 0 }

--- a/server/src/test/java/org/opensearch/common/xcontent/JsonToStringXContentParserTests.java
+++ b/server/src/test/java/org/opensearch/common/xcontent/JsonToStringXContentParserTests.java
@@ -49,9 +49,9 @@ public class JsonToStringXContentParserTests extends OpenSearchTestCase {
 
         assertEquals(
             "{"
-                + "\"flat\":[\"first\",\"second\",\"inner\",\"third\"],"
+                + "\"flat\":[\"third\",\"inner\",\"first\",\"second\"],"
                 + "\"flat._value\":[\"1\",\"2.0\",\"three\"],"
-                + "\"flat._valueAndPath\":[\"flat.first=1\",\"flat.second.inner=2.0\",\"flat.third=three\"]"
+                + "\"flat._valueAndPath\":[\"flat.second.inner=2.0\",\"flat.first=1\",\"flat.third=three\"]"
                 + "}",
             flattenJsonString("flat", jsonExample)
         );
@@ -64,9 +64,9 @@ public class JsonToStringXContentParserTests extends OpenSearchTestCase {
 
         assertEquals(
             "{"
-                + "\"flat\":[\"first\",\"second\",\"inner\",\"third\"],"
+                + "\"flat\":[\"third\",\"inner\",\"first\",\"second\"],"
                 + "\"flat._value\":[\"1\",\"2.0\",\"three\"],"
-                + "\"flat._valueAndPath\":[\"flat.first=1\",\"flat.second.inner=2.0\",\"flat.third=three\"]"
+                + "\"flat._valueAndPath\":[\"flat.second.inner=2.0\",\"flat.first=1\",\"flat.third=three\"]"
                 + "}",
             flattenJsonString("flat", jsonExample)
         );
@@ -83,7 +83,7 @@ public class JsonToStringXContentParserTests extends OpenSearchTestCase {
 
         assertEquals(
             "{"
-                + "\"flat\":[\"first\",\"second\",\"inner\",\"really_inner\",\"third\"],"
+                + "\"flat\":[\"really_inner\",\"third\",\"inner\",\"first\",\"second\"],"
                 + "\"flat._value\":[\"1\",\"2.0\",\"three\"],"
                 + "\"flat._valueAndPath\":[\"flat.first=1\",\"flat.second.inner.really_inner=2.0\",\"flat.third=three\"]"
                 + "}",
@@ -102,7 +102,7 @@ public class JsonToStringXContentParserTests extends OpenSearchTestCase {
 
         assertEquals(
             "{"
-                + "\"flat\":[\"first\",\"second\",\"inner\",\"totally\",\"absolutely\",\"inner\",\"third\"],"
+                + "\"flat\":[\"third\",\"absolutely\",\"totally\",\"inner\",\"first\",\"second\"],"
                 + "\"flat._value\":[\"1\",\"2.0\",\"three\"],"
                 + "\"flat._valueAndPath\":[\"flat.first=1\",\"flat.second.inner.totally.absolutely.inner=2.0\",\"flat.third=three\"]"
                 + "}",
@@ -123,10 +123,9 @@ public class JsonToStringXContentParserTests extends OpenSearchTestCase {
 
         assertEquals(
             "{"
-                + "\"flat\":[\"field\",\"detail\",\"foooooooooooo\",\"name\",\"name\"],"
-                + "\"flat._value\":[\"baz\",\"baz\"],"
+                + "\"flat\":[\"field\",\"name\",\"detail\",\"foooooooooooo\"],"
+                + "\"flat._value\":[\"baz\"],"
                 + "\"flat._valueAndPath\":["
-                + "\"flat.field.detail.foooooooooooo.name=baz\","
                 + "\"flat.field.detail.foooooooooooo.name=baz\""
                 + "]}",
             flattenJsonString("flat", jsonExample)
@@ -151,14 +150,13 @@ public class JsonToStringXContentParserTests extends OpenSearchTestCase {
 
         assertEquals(
             "{"
-                + "\"flat\":[\"field\",\"detail\",\"foooooooooooo\",\"name\",\"name\",\"numbers\"],"
-                + "\"flat._value\":[\"baz\",\"baz\",\"1\",\"2\",\"3\"],"
+                + "\"flat\":[\"field\",\"name\",\"numbers\",\"detail\",\"foooooooooooo\"],"
+                + "\"flat._value\":[\"1\",\"2\",\"3\",\"baz\"],"
                 + "\"flat._valueAndPath\":["
                 + "\"flat.field.detail.foooooooooooo.name=baz\","
-                + "\"flat.field.detail.foooooooooooo.name=baz\","
                 + "\"flat.field.numbers=1\","
-                + "\"flat.field.numbers=2\","
-                + "\"flat.field.numbers=3\""
+                + "\"flat.field.numbers=3\","
+                + "\"flat.field.numbers=2\""
                 + "]}",
             flattenJsonString("flat", jsonExample)
         );

--- a/server/src/test/java/org/opensearch/index/mapper/FlatObjectFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/FlatObjectFieldMapperTests.java
@@ -136,6 +136,254 @@ public class FlatObjectFieldMapperTests extends MapperTestCase {
         assertEquals(1, parsedDocument.docs().size());
         IndexableField[] fields = parsedDocument.rootDoc().getFields("field");
         assertEquals(0, fields.length);
+        ParsedDocument doc;
+        String json;
+        IndexableField[] fieldValues;
+        IndexableField[] fieldValueAndPaths;
+
+        {
+            // test1: {"field":null}
+            doc = mapper.parse(source(b -> b.nullField("field")));
+            assertArrayEquals(new IndexableField[0], doc.rootDoc().getFields("field"));
+            assertArrayEquals(new IndexableField[0], doc.rootDoc().getFields("field" + VALUE_SUFFIX));
+            assertArrayEquals(new IndexableField[0], doc.rootDoc().getFields("field" + VALUE_AND_PATH_SUFFIX));
+
+            // test2: {"field":{"age":3, "name": null}}
+            json = "{\"field\":{\"age\":3, \"name\": null}}";
+            doc = mapper.parse(source(json));
+            fields = doc.rootDoc().getFields("field");
+            assertEquals(2, fields.length);
+            assertEquals(new BytesRef("field.age"), fields[0].binaryValue());
+            fieldValues = doc.rootDoc().getFields("field" + VALUE_SUFFIX);
+            assertEquals(2, fieldValues.length);
+            assertEquals(new BytesRef("3"), fieldValues[0].binaryValue());
+            fieldValueAndPaths = doc.rootDoc().getFields("field" + VALUE_AND_PATH_SUFFIX);
+            assertEquals(2, fieldValueAndPaths.length);
+            assertEquals(new BytesRef("field.age=3"), fieldValueAndPaths[0].binaryValue());
+
+            // test3: {"field":{"name":null, "age":"5", "name1":null}}
+            json = "{\"field\":{\"name\":null, \"age\":\"5\", \"name1\":null}}";
+            doc = mapper.parse(source(json));
+            fields = doc.rootDoc().getFields("field");
+            assertEquals(2, fields.length);
+            assertEquals(new BytesRef("field.age"), fields[0].binaryValue());
+            fieldValues = doc.rootDoc().getFields("field" + VALUE_SUFFIX);
+            assertEquals(2, fieldValues.length);
+            assertEquals(new BytesRef("5"), fieldValues[0].binaryValue());
+            fieldValueAndPaths = doc.rootDoc().getFields("field" + VALUE_AND_PATH_SUFFIX);
+            assertEquals(2, fieldValueAndPaths.length);
+            assertEquals(new BytesRef("field.age=5"), fieldValueAndPaths[0].binaryValue());
+
+            // test4: {"field":{"name": {"name1": {"name2":null}}}}
+            json = "{\"field\":{\"name\": {\"name1\": {\"name2\":null}}}}";
+            doc = mapper.parse(source(json));
+            assertArrayEquals(new IndexableField[0], doc.rootDoc().getFields("field"));
+            assertArrayEquals(new IndexableField[0], doc.rootDoc().getFields("field" + VALUE_SUFFIX));
+            assertArrayEquals(new IndexableField[0], doc.rootDoc().getFields("field" + VALUE_AND_PATH_SUFFIX));
+
+        }
+
+        {
+            // test5: {"field":[null]}
+            doc = mapper.parse(source(b -> b.array("field", (String[]) null)));
+            assertArrayEquals(new IndexableField[0], doc.rootDoc().getFields("field"));
+            assertArrayEquals(new IndexableField[0], doc.rootDoc().getFields("field" + VALUE_SUFFIX));
+            assertArrayEquals(new IndexableField[0], doc.rootDoc().getFields("field" + VALUE_AND_PATH_SUFFIX));
+
+            // test6: {"field":{"labels": [null]}}
+            json = "{\"field\":{\"labels\": [null]}}";
+            doc = mapper.parse(source(json));
+            assertArrayEquals(new IndexableField[0], doc.rootDoc().getFields("field"));
+            assertArrayEquals(new IndexableField[0], doc.rootDoc().getFields("field" + VALUE_SUFFIX));
+            assertArrayEquals(new IndexableField[0], doc.rootDoc().getFields("field" + VALUE_AND_PATH_SUFFIX));
+
+            // test7: {"field":{"r1": {"labels": [null]}}}
+            json = "{\"field\":{\"r1\": {\"labels\": [null]}}}";
+            doc = mapper.parse(source(json));
+            assertArrayEquals(new IndexableField[0], doc.rootDoc().getFields("field"));
+            assertArrayEquals(new IndexableField[0], doc.rootDoc().getFields("field" + VALUE_SUFFIX));
+            assertArrayEquals(new IndexableField[0], doc.rootDoc().getFields("field" + VALUE_AND_PATH_SUFFIX));
+
+            // test8: {"field":{"r1": {"name": null,"labels": [null]}}}
+            json = "{\"field\":{\"r1\": {\"name\": null,\"labels\": [null]}}}";
+            doc = mapper.parse(source(json));
+            assertArrayEquals(new IndexableField[0], doc.rootDoc().getFields("field"));
+            assertArrayEquals(new IndexableField[0], doc.rootDoc().getFields("field" + VALUE_SUFFIX));
+            assertArrayEquals(new IndexableField[0], doc.rootDoc().getFields("field" + VALUE_AND_PATH_SUFFIX));
+
+            // test9: {"field":{"name": [null,3],"age":4}}
+            json = "{\"field\":{\"name\": [null,3],\"age\":4}}";
+            doc = mapper.parse(source(json));
+            fields = doc.rootDoc().getFields("field");
+            assertEquals(4, fields.length);
+            assertEquals(new BytesRef("field.name"), fields[0].binaryValue());
+            assertEquals(new BytesRef("field.age"), fields[2].binaryValue());
+            fieldValues = doc.rootDoc().getFields("field" + VALUE_SUFFIX);
+            assertEquals(4, fieldValues.length);
+            assertEquals(new BytesRef("3"), fieldValues[0].binaryValue());
+            assertEquals(new BytesRef("4"), fieldValues[2].binaryValue());
+            fieldValueAndPaths = doc.rootDoc().getFields("field" + VALUE_AND_PATH_SUFFIX);
+            assertEquals(4, fieldValueAndPaths.length);
+            assertEquals(new BytesRef("field.age=4"), fieldValueAndPaths[0].binaryValue());
+            assertEquals(new BytesRef("field.name=3"), fieldValueAndPaths[2].binaryValue());
+
+            // test10: {"field":{"age": 4,"name": [null,"3"]}}
+            json = "{\"field\":{\"age\": 4,\"name\": [null,\"3\"]}}";
+            doc = mapper.parse(source(json));
+            fields = doc.rootDoc().getFields("field");
+            assertEquals(4, fields.length);
+            assertEquals(new BytesRef("field.name"), fields[0].binaryValue());
+            assertEquals(new BytesRef("field.age"), fields[2].binaryValue());
+            fieldValues = doc.rootDoc().getFields("field" + VALUE_SUFFIX);
+            assertEquals(4, fieldValues.length);
+            assertEquals(new BytesRef("3"), fieldValues[0].binaryValue());
+            assertEquals(new BytesRef("4"), fieldValues[2].binaryValue());
+            fieldValueAndPaths = doc.rootDoc().getFields("field" + VALUE_AND_PATH_SUFFIX);
+            assertEquals(4, fieldValueAndPaths.length);
+            assertEquals(new BytesRef("field.age=4"), fieldValueAndPaths[0].binaryValue());
+            assertEquals(new BytesRef("field.name=3"), fieldValueAndPaths[2].binaryValue());
+
+            // test11: {"field":{"age":"4","labels": [null]}}
+            json = "{\"field\":{\"age\":\"4\",\"labels\": [null]}}";
+            doc = mapper.parse(source(json));
+            fields = doc.rootDoc().getFields("field");
+            assertEquals(2, fields.length);
+            assertEquals(new BytesRef("field.age"), fields[0].binaryValue());
+            fieldValues = doc.rootDoc().getFields("field" + VALUE_SUFFIX);
+            assertEquals(2, fieldValues.length);
+            assertEquals(new BytesRef("4"), fieldValues[0].binaryValue());
+            fieldValueAndPaths = doc.rootDoc().getFields("field" + VALUE_AND_PATH_SUFFIX);
+            assertEquals(2, fieldValueAndPaths.length);
+            assertEquals(new BytesRef("field.age=4"), fieldValueAndPaths[0].binaryValue());
+
+            // test12: {"field":{"labels": [null], "age":"4"}}
+            json = "{\"field\":{\"labels\": [null], \"age\":\"4\"}}";
+            doc = mapper.parse(source(json));
+            fields = doc.rootDoc().getFields("field");
+            assertEquals(2, fields.length);
+            assertEquals(new BytesRef("field.age"), fields[0].binaryValue());
+            fieldValues = doc.rootDoc().getFields("field" + VALUE_SUFFIX);
+            assertEquals(2, fieldValues.length);
+            assertEquals(new BytesRef("4"), fieldValues[0].binaryValue());
+            fieldValueAndPaths = doc.rootDoc().getFields("field" + VALUE_AND_PATH_SUFFIX);
+            assertEquals(2, fieldValueAndPaths.length);
+            assertEquals(new BytesRef("field.age=4"), fieldValueAndPaths[0].binaryValue());
+
+            // test13: {"field":{"name": [null, {"d":{"name":"dsds"}}]}}
+            json = "{\"field\":{\"name\": [null, {\"d\":{\"name\":\"dsds\"}}]}}";
+            doc = mapper.parse(source(json));
+            fields = doc.rootDoc().getFields("field");
+            assertEquals(4, fields.length);
+            assertEquals(new BytesRef("field.d"), fields[0].binaryValue());
+            assertEquals(new BytesRef("field.name"), fields[2].binaryValue());
+            fieldValues = doc.rootDoc().getFields("field" + VALUE_SUFFIX);
+            assertEquals(2, fieldValues.length);
+            assertEquals(new BytesRef("dsds"), fieldValues[0].binaryValue());
+            fieldValueAndPaths = doc.rootDoc().getFields("field" + VALUE_AND_PATH_SUFFIX);
+            assertEquals(2, fieldValueAndPaths.length);
+            assertEquals(new BytesRef("field.name.d.name=dsds"), fieldValueAndPaths[0].binaryValue());
+
+            // test14: {"field":{"name": [{"d":{"name":"dsds"}}, null]}}
+            json = "{\"field\":{\"name\": [{\"d\":{\"name\":\"dsds\"}}, null]}}";
+            doc = mapper.parse(source(json));
+            IndexableField[] fields1 = doc.rootDoc().getFields("field");
+            assertEquals(fields1.length, fields.length);
+            for (int i = 0; i < fields1.length; i++) {
+                assertEquals(fields[i].toString(), fields1[i].toString());
+            }
+            assertEquals(4, fields.length);
+            assertEquals(new BytesRef("field.d"), fields[0].binaryValue());
+            assertEquals(new BytesRef("field.name"), fields[2].binaryValue());
+            fieldValues = doc.rootDoc().getFields("field" + VALUE_SUFFIX);
+            assertEquals(2, fieldValues.length);
+            assertEquals(new BytesRef("dsds"), fieldValues[0].binaryValue());
+            fieldValueAndPaths = doc.rootDoc().getFields("field" + VALUE_AND_PATH_SUFFIX);
+            assertEquals(2, fieldValueAndPaths.length);
+            assertEquals(new BytesRef("field.name.d.name=dsds"), fieldValueAndPaths[0].binaryValue());
+
+            // test15: {"field":{"name": [{"name":"age1"}, null, {"d":{"name":"dsds"}}]}}
+            json = "{\"field\":{\"name\": [{\"name\":\"age1\"}, null, {\"d\":{\"name\":\"dsds\"}}]}}";
+            doc = mapper.parse(source(json));
+            fields = doc.rootDoc().getFields("field");
+            assertEquals(4, fields.length);
+            assertEquals(new BytesRef("field.d"), fields[0].binaryValue());
+            assertEquals(new BytesRef("field.name"), fields[2].binaryValue());
+            fieldValues = doc.rootDoc().getFields("field" + VALUE_SUFFIX);
+            assertEquals(4, fieldValues.length);
+            assertEquals(new BytesRef("dsds"), fieldValues[0].binaryValue());
+            assertEquals(new BytesRef("age1"), fieldValues[2].binaryValue());
+            fieldValueAndPaths = doc.rootDoc().getFields("field" + VALUE_AND_PATH_SUFFIX);
+            assertEquals(4, fieldValueAndPaths.length);
+            assertEquals(new BytesRef("field.name.name=age1"), fieldValueAndPaths[0].binaryValue());
+            assertEquals(new BytesRef("field.name.d.name=dsds"), fieldValueAndPaths[2].binaryValue());
+
+            // test16: {"field":{"name": {"name1": [null,"dsdsdsd"]}}}
+            json = "{\"field\":{\"name\": {\"name1\": [null,\"dsdsdsd\"]}}}";
+            doc = mapper.parse(source(json));
+            fields = doc.rootDoc().getFields("field");
+            assertEquals(4, fields.length);
+            assertEquals(new BytesRef("field.name"), fields[0].binaryValue());
+            assertEquals(new BytesRef("field.name1"), fields[2].binaryValue());
+            fieldValues = doc.rootDoc().getFields("field" + VALUE_SUFFIX);
+            assertEquals(2, fieldValues.length);
+            assertEquals(new BytesRef("dsdsdsd"), fieldValues[0].binaryValue());
+            fieldValueAndPaths = doc.rootDoc().getFields("field" + VALUE_AND_PATH_SUFFIX);
+            assertEquals(2, fieldValueAndPaths.length);
+            assertEquals(new BytesRef("field.name.name1=dsdsdsd"), fieldValueAndPaths[0].binaryValue());
+
+            // test17: {"field":{"name": {"name1": [[],["dsdsdsd", null]]}}}
+            json = "{\"field\":{\"name\": {\"name1\": [[],[\"dsdsdsd\", null]]}}}";
+            doc = mapper.parse(source(json));
+            fields = doc.rootDoc().getFields("field");
+            assertEquals(4, fields.length);
+            assertEquals(new BytesRef("field.name"), fields[0].binaryValue());
+            assertEquals(new BytesRef("field.name1"), fields[2].binaryValue());
+            fieldValues = doc.rootDoc().getFields("field" + VALUE_SUFFIX);
+            assertEquals(2, fieldValues.length);
+            assertEquals(new BytesRef("dsdsdsd"), fieldValues[0].binaryValue());
+            fieldValueAndPaths = doc.rootDoc().getFields("field" + VALUE_AND_PATH_SUFFIX);
+            assertEquals(2, fieldValueAndPaths.length);
+            assertEquals(new BytesRef("field.name.name1=dsdsdsd"), fieldValueAndPaths[0].binaryValue());
+        }
+    }
+
+    public void testInfiniteLoopWithNullValue() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        // test2: {"field":{"name": null,"age":3}}
+        String json = "{\"field\":{\"name\": null,\"age\":3}}";
+        ParsedDocument doc = mapper.parse(source(json));
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(2, fields.length);
+        assertEquals(new BytesRef("field.age"), fields[0].binaryValue());
+        IndexableField[] fieldValues = doc.rootDoc().getFields("field" + VALUE_SUFFIX);
+        assertEquals(2, fieldValues.length);
+        assertEquals(new BytesRef("3"), fieldValues[0].binaryValue());
+        IndexableField[] fieldValueAndPaths = doc.rootDoc().getFields("field" + VALUE_AND_PATH_SUFFIX);
+        assertEquals(2, fieldValueAndPaths.length);
+        assertEquals(new BytesRef("field.age=3"), fieldValueAndPaths[0].binaryValue());
+    }
+
+    // test deduplicationValue of keyList, valueList, valueAndPathList
+    public void testDeduplicationValue() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+
+        // test: {"field":{"age": 3,"labels": [null,"3"], "abc":{"abc":{"labels":"n"}}}}
+        String json = "{\"field\":{\"age\": 3,\"labels\": [null,\"3\"], \"abc\":{\"abc\":{\"labels\":\"n\"}}}}";
+        ParsedDocument doc = mapper.parse(source(json));
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(6, fields.length);
+        assertEquals(new BytesRef("field.abc"), fields[0].binaryValue());
+        assertEquals(new BytesRef("field.age"), fields[2].binaryValue());
+        assertEquals(new BytesRef("field.labels"), fields[4].binaryValue());
+        IndexableField[] fieldValues = doc.rootDoc().getFields("field" + VALUE_SUFFIX);
+        assertEquals(4, fieldValues.length);
+        assertEquals(new BytesRef("3"), fieldValues[0].binaryValue());
+        assertEquals(new BytesRef("n"), fieldValues[2].binaryValue());
+        IndexableField[] fieldValueAndPaths = doc.rootDoc().getFields("field" + VALUE_AND_PATH_SUFFIX);
+        assertEquals(6, fieldValueAndPaths.length);
+        assertEquals(new BytesRef("field.abc.abc.labels=n"), fieldValueAndPaths[0].binaryValue());
+        assertEquals(new BytesRef("field.age=3"), fieldValueAndPaths[2].binaryValue());
+        assertEquals(new BytesRef("field.labels=3"), fieldValueAndPaths[4].binaryValue());
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: kkewwei kkewwei@163.com

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The pr soloves three cases:

- fix null value case, I have test too many cases about null value, all of the tests are passed.
- deduplication the  value of fieldName, valueList, valueAndPathList, there is no need to store the duplicate values.
- fix infinite loop with null value ([comment](https://github.com/opensearch-project/OpenSearch/pull/13259#issuecomment-2312755190))

### Related Issues
Resolves #13880

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
