### PR TITLE
Remove redundant condition in jvmStats test

### DIFF
--- a/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -682,24 +682,22 @@ public class NodeStatsTests extends OpenSearchTestCase {
                 );
             }
             JvmStats.Classes classes = new JvmStats.Classes(randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong());
-            jvmStats = frequently()
-                ? new JvmStats(
+            jvmStats = new JvmStats(
+                randomNonNegativeLong(),
+                randomNonNegativeLong(),
+                new JvmStats.Mem(
                     randomNonNegativeLong(),
                     randomNonNegativeLong(),
-                    new JvmStats.Mem(
-                        randomNonNegativeLong(),
-                        randomNonNegativeLong(),
-                        randomNonNegativeLong(),
-                        randomNonNegativeLong(),
-                        randomNonNegativeLong(),
-                        memoryPools
-                    ),
-                    threads,
-                    garbageCollectors,
-                    randomBoolean() ? Collections.emptyList() : bufferPoolList,
-                    classes
-                )
-                : null;
+                    randomNonNegativeLong(),
+                    randomNonNegativeLong(),
+                    randomNonNegativeLong(),
+                    memoryPools
+                ),
+                threads,
+                garbageCollectors,
+                randomBoolean() ? Collections.emptyList() : bufferPoolList,
+                classes
+            );
         }
         ThreadPoolStats threadPoolStats = null;
         if (frequently()) {


### PR DESCRIPTION
### Description

Removing second use of the `frequentyl()` function. This function is alraedy used in the beginning of the testing block immediately after the declaration of `jvmStats` variable. The second use of the `frequently()` could cause all the other variables that were carefully prepared for the constructor to not be used at all.

### Related Issues

n/a

### Check List
- [x] Functionality includes testing.
~- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
~- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
