### PR TITLE
Mute all flaky IndicesRequestCacheIT tests

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/IndicesRequestCacheIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/IndicesRequestCacheIT.java
@@ -631,6 +631,7 @@ public class IndicesRequestCacheIT extends ParameterizedStaticSettingsOpenSearch
         assertCacheState(client, index, 2, 2);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/11374")
     public void testProfileDisableCache() throws Exception {
         Client client = client();
         String index = "index";
@@ -673,6 +674,7 @@ public class IndicesRequestCacheIT extends ParameterizedStaticSettingsOpenSearch
         }
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/12308")
     public void testCacheWithInvalidation() throws Exception {
         Client client = client();
         String index = "index";
@@ -758,6 +760,7 @@ public class IndicesRequestCacheIT extends ParameterizedStaticSettingsOpenSearch
     }
 
     // when staleness threshold is lower than staleness, it should clean the stale keys from cache
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/13540")
     public void testStaleKeysCleanupWithLowThreshold() throws Exception {
         int cacheCleanIntervalInMillis = 1;
         String node = internalCluster().startNode(
@@ -804,6 +807,7 @@ public class IndicesRequestCacheIT extends ParameterizedStaticSettingsOpenSearch
     }
 
     // when staleness threshold is equal to staleness, it should clean the stale keys from cache
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/13503")
     public void testCacheCleanupOnEqualStalenessAndThreshold() throws Exception {
         int cacheCleanIntervalInMillis = 1;
         String node = internalCluster().startNode(
@@ -982,6 +986,7 @@ public class IndicesRequestCacheIT extends ParameterizedStaticSettingsOpenSearch
     }
 
     // when cache cleaner interval setting is not set, cache cleaner is configured appropriately with the fall-back setting
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/13711")
     public void testCacheCleanupWithDefaultSettings() throws Exception {
         int cacheCleanIntervalInMillis = 1;
         String node = internalCluster().startNode(
@@ -1022,6 +1027,7 @@ public class IndicesRequestCacheIT extends ParameterizedStaticSettingsOpenSearch
     }
 
     // staleness threshold updates flows through to the cache cleaner
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/13949")
     public void testDynamicStalenessThresholdUpdate() throws Exception {
         int cacheCleanIntervalInMillis = 1;
         String node = internalCluster().startNode(
@@ -1169,6 +1175,7 @@ public class IndicesRequestCacheIT extends ParameterizedStaticSettingsOpenSearch
     }
 
     // when staleness threshold is lower than staleness, it should clean the cache from all indices having stale keys
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/13437")
     public void testStaleKeysCleanupWithMultipleIndices() throws Exception {
         int cacheCleanIntervalInMillis = 10;
         String node = internalCluster().startNode(
@@ -1223,6 +1230,7 @@ public class IndicesRequestCacheIT extends ParameterizedStaticSettingsOpenSearch
         }, cacheCleanIntervalInMillis * 2, TimeUnit.MILLISECONDS);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/13600")
     public void testDeleteAndCreateSameIndexShardOnSameNode() throws Exception {
         String node_1 = internalCluster().startNode(Settings.builder().build());
         Client client = client(node_1);


### PR DESCRIPTION
These are very frequent offenders and are causing a lot of pain in CI.

Related issues:
- https://github.com/opensearch-project/OpenSearch/issues/11374
- https://github.com/opensearch-project/OpenSearch/issues/12308
- https://github.com/opensearch-project/OpenSearch/issues/13540
- https://github.com/opensearch-project/OpenSearch/issues/13503
- https://github.com/opensearch-project/OpenSearch/issues/13711
- https://github.com/opensearch-project/OpenSearch/issues/13949
- https://github.com/opensearch-project/OpenSearch/issues/13437
- https://github.com/opensearch-project/OpenSearch/issues/13600

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Check List
- [ ] ~Functionality includes testing.~
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
