### PR TITLE
[Backport 2.x] Core and Plugin changes for query-level resource usages tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Move Remote Store Migration from DocRep to GA and modify remote migration settings name ([#14100](https://github.com/opensearch-project/OpenSearch/pull/14100))
 - [Remote State] Add async remote state deletion task running on an interval, configurable by a setting ([#13995](https://github.com/opensearch-project/OpenSearch/pull/13995))
 - Add remote routing table for remote state publication with experimental feature flag ([#13304](https://github.com/opensearch-project/OpenSearch/pull/13304))
+- Add support for query level resource usage tracking ([#13172](https://github.com/opensearch-project/OpenSearch/pull/13172))
 
 ### Dependencies
 - Bump `com.github.spullara.mustache.java:compiler` from 0.9.10 to 0.9.13 ([#13329](https://github.com/opensearch-project/OpenSearch/pull/13329), [#13559](https://github.com/opensearch-project/OpenSearch/pull/13559))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Remote State] Add async remote state deletion task running on an interval, configurable by a setting ([#13995](https://github.com/opensearch-project/OpenSearch/pull/13995))
 - Add remote routing table for remote state publication with experimental feature flag ([#13304](https://github.com/opensearch-project/OpenSearch/pull/13304))
 - Add support for query level resource usage tracking ([#13172](https://github.com/opensearch-project/OpenSearch/pull/13172))
+- [Query Insights] Add cpu and memory metrics to top n queries ([#13739](https://github.com/opensearch-project/OpenSearch/pull/13739))
 
 ### Dependencies
 - Bump `com.github.spullara.mustache.java:compiler` from 0.9.10 to 0.9.13 ([#13329](https://github.com/opensearch-project/OpenSearch/pull/13329), [#13559](https://github.com/opensearch-project/OpenSearch/pull/13559))

--- a/libs/core/src/main/java/org/opensearch/core/tasks/resourcetracker/ResourceUsageInfo.java
+++ b/libs/core/src/main/java/org/opensearch/core/tasks/resourcetracker/ResourceUsageInfo.java
@@ -104,6 +104,10 @@ public class ResourceUsageInfo {
             return endValue.get() - startValue;
         }
 
+        public long getStartValue() {
+            return startValue;
+        }
+
         @Override
         public String toString() {
             return String.valueOf(getTotalValue());

--- a/libs/core/src/main/java/org/opensearch/core/tasks/resourcetracker/TaskResourceInfo.java
+++ b/libs/core/src/main/java/org/opensearch/core/tasks/resourcetracker/TaskResourceInfo.java
@@ -1,0 +1,225 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.core.tasks.resourcetracker;
+
+import org.opensearch.common.annotation.PublicApi;
+import org.opensearch.core.ParseField;
+import org.opensearch.core.common.Strings;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ConstructingObjectParser;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import static org.opensearch.core.xcontent.ConstructingObjectParser.constructorArg;
+
+/**
+ * Task resource usage information with minimal information about the task
+ * <p>
+ * Writeable TaskResourceInfo objects are used to represent resource usage
+ * information of running tasks, which can be propagated to coordinator node
+ * to infer query-level resource usage
+ *
+ *  @opensearch.api
+ */
+@PublicApi(since = "2.15.0")
+public class TaskResourceInfo implements Writeable, ToXContentObject {
+    private final String action;
+    private final long taskId;
+    private final long parentTaskId;
+    private final String nodeId;
+    private final TaskResourceUsage taskResourceUsage;
+
+    private static final ParseField ACTION = new ParseField("action");
+    private static final ParseField TASK_ID = new ParseField("taskId");
+    private static final ParseField PARENT_TASK_ID = new ParseField("parentTaskId");
+    private static final ParseField NODE_ID = new ParseField("nodeId");
+    private static final ParseField TASK_RESOURCE_USAGE = new ParseField("taskResourceUsage");
+
+    public TaskResourceInfo(
+        final String action,
+        final long taskId,
+        final long parentTaskId,
+        final String nodeId,
+        final TaskResourceUsage taskResourceUsage
+    ) {
+        this.action = action;
+        this.taskId = taskId;
+        this.parentTaskId = parentTaskId;
+        this.nodeId = nodeId;
+        this.taskResourceUsage = taskResourceUsage;
+    }
+
+    public static final ConstructingObjectParser<TaskResourceInfo, Void> PARSER = new ConstructingObjectParser<>(
+        "task_resource_info",
+        a -> new Builder().setAction((String) a[0])
+            .setTaskId((Long) a[1])
+            .setParentTaskId((Long) a[2])
+            .setNodeId((String) a[3])
+            .setTaskResourceUsage((TaskResourceUsage) a[4])
+            .build()
+    );
+
+    static {
+        PARSER.declareString(constructorArg(), ACTION);
+        PARSER.declareLong(constructorArg(), TASK_ID);
+        PARSER.declareLong(constructorArg(), PARENT_TASK_ID);
+        PARSER.declareString(constructorArg(), NODE_ID);
+        PARSER.declareObject(constructorArg(), TaskResourceUsage.PARSER, TASK_RESOURCE_USAGE);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(ACTION.getPreferredName(), this.action);
+        builder.field(TASK_ID.getPreferredName(), this.taskId);
+        builder.field(PARENT_TASK_ID.getPreferredName(), this.parentTaskId);
+        builder.field(NODE_ID.getPreferredName(), this.nodeId);
+        builder.startObject(TASK_RESOURCE_USAGE.getPreferredName());
+        this.taskResourceUsage.toXContent(builder, params);
+        builder.endObject();
+        builder.endObject();
+        return builder;
+    }
+
+    /**
+     * Builder for {@link TaskResourceInfo}
+     */
+    public static class Builder {
+        private TaskResourceUsage taskResourceUsage;
+        private String action;
+        private long taskId;
+        private long parentTaskId;
+        private String nodeId;
+
+        public Builder setTaskResourceUsage(final TaskResourceUsage taskResourceUsage) {
+            this.taskResourceUsage = taskResourceUsage;
+            return this;
+        }
+
+        public Builder setAction(final String action) {
+            this.action = action;
+            return this;
+        }
+
+        public Builder setTaskId(final long taskId) {
+            this.taskId = taskId;
+            return this;
+        }
+
+        public Builder setParentTaskId(final long parentTaskId) {
+            this.parentTaskId = parentTaskId;
+            return this;
+        }
+
+        public Builder setNodeId(final String nodeId) {
+            this.nodeId = nodeId;
+            return this;
+        }
+
+        public TaskResourceInfo build() {
+            return new TaskResourceInfo(action, taskId, parentTaskId, nodeId, taskResourceUsage);
+        }
+    }
+
+    /**
+     * Read task info from a stream.
+     *
+     * @param in StreamInput to read
+     * @return {@link TaskResourceInfo}
+     * @throws IOException IOException
+     */
+    public static TaskResourceInfo readFromStream(StreamInput in) throws IOException {
+        return new TaskResourceInfo.Builder().setAction(in.readString())
+            .setTaskId(in.readLong())
+            .setParentTaskId(in.readLong())
+            .setNodeId(in.readString())
+            .setTaskResourceUsage(TaskResourceUsage.readFromStream(in))
+            .build();
+    }
+
+    /**
+     * Get TaskResourceUsage
+     *
+     * @return taskResourceUsage
+     */
+    public TaskResourceUsage getTaskResourceUsage() {
+        return taskResourceUsage;
+    }
+
+    /**
+     * Get parent task id
+     *
+     * @return parent task id
+     */
+    public long getParentTaskId() {
+        return parentTaskId;
+    }
+
+    /**
+     * Get task id
+     * @return task id
+     */
+    public long getTaskId() {
+        return taskId;
+    }
+
+    /**
+     * Get node id
+     * @return node id
+     */
+    public String getNodeId() {
+        return nodeId;
+    }
+
+    /**
+     * Get task action
+     * @return task action
+     */
+    public String getAction() {
+        return action;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(action);
+        out.writeLong(taskId);
+        out.writeLong(parentTaskId);
+        out.writeString(nodeId);
+        taskResourceUsage.writeTo(out);
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(MediaTypeRegistry.JSON, this);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null || obj.getClass() != TaskResourceInfo.class) {
+            return false;
+        }
+        TaskResourceInfo other = (TaskResourceInfo) obj;
+        return action.equals(other.action)
+            && taskId == other.taskId
+            && parentTaskId == other.parentTaskId
+            && Objects.equals(nodeId, other.nodeId)
+            && taskResourceUsage.equals(other.taskResourceUsage);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(action, taskId, parentTaskId, nodeId, taskResourceUsage);
+    }
+}

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/QueryInsightsPlugin.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/QueryInsightsPlugin.java
@@ -111,7 +111,15 @@ public class QueryInsightsPlugin extends Plugin implements ActionPlugin {
             QueryInsightsSettings.TOP_N_LATENCY_QUERIES_ENABLED,
             QueryInsightsSettings.TOP_N_LATENCY_QUERIES_SIZE,
             QueryInsightsSettings.TOP_N_LATENCY_QUERIES_WINDOW_SIZE,
-            QueryInsightsSettings.TOP_N_LATENCY_EXPORTER_SETTINGS
+            QueryInsightsSettings.TOP_N_LATENCY_EXPORTER_SETTINGS,
+            QueryInsightsSettings.TOP_N_CPU_QUERIES_ENABLED,
+            QueryInsightsSettings.TOP_N_CPU_QUERIES_SIZE,
+            QueryInsightsSettings.TOP_N_CPU_QUERIES_WINDOW_SIZE,
+            QueryInsightsSettings.TOP_N_CPU_EXPORTER_SETTINGS,
+            QueryInsightsSettings.TOP_N_MEMORY_QUERIES_ENABLED,
+            QueryInsightsSettings.TOP_N_MEMORY_QUERIES_SIZE,
+            QueryInsightsSettings.TOP_N_MEMORY_QUERIES_WINDOW_SIZE,
+            QueryInsightsSettings.TOP_N_MEMORY_EXPORTER_SETTINGS
         );
     }
 }

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/core/exporter/QueryInsightsExporterFactory.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/core/exporter/QueryInsightsExporterFactory.java
@@ -19,7 +19,7 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 
-import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.DEFAULT_TOP_N_LATENCY_QUERIES_INDEX_PATTERN;
+import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.DEFAULT_TOP_N_QUERIES_INDEX_PATTERN;
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.DEFAULT_TOP_QUERIES_EXPORTER_TYPE;
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.EXPORTER_TYPE;
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.EXPORT_INDEX;
@@ -71,7 +71,7 @@ public class QueryInsightsExporterFactory {
         }
         switch (type) {
             case LOCAL_INDEX:
-                final String indexPattern = settings.get(EXPORT_INDEX, DEFAULT_TOP_N_LATENCY_QUERIES_INDEX_PATTERN);
+                final String indexPattern = settings.get(EXPORT_INDEX, DEFAULT_TOP_N_QUERIES_INDEX_PATTERN);
                 if (indexPattern.length() == 0) {
                     throw new IllegalArgumentException("Empty index pattern configured for the exporter");
                 }

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/core/service/TopQueriesService.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/core/service/TopQueriesService.java
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.DEFAULT_TOP_N_LATENCY_QUERIES_INDEX_PATTERN;
+import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.DEFAULT_TOP_N_QUERIES_INDEX_PATTERN;
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.DEFAULT_TOP_QUERIES_EXPORTER_TYPE;
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.EXPORTER_TYPE;
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.EXPORT_INDEX;
@@ -218,10 +218,7 @@ public class TopQueriesService {
         if (settings.get(EXPORTER_TYPE) != null) {
             SinkType expectedType = SinkType.parse(settings.get(EXPORTER_TYPE, DEFAULT_TOP_QUERIES_EXPORTER_TYPE));
             if (exporter != null && expectedType == SinkType.getSinkTypeFromExporter(exporter)) {
-                queryInsightsExporterFactory.updateExporter(
-                    exporter,
-                    settings.get(EXPORT_INDEX, DEFAULT_TOP_N_LATENCY_QUERIES_INDEX_PATTERN)
-                );
+                queryInsightsExporterFactory.updateExporter(exporter, settings.get(EXPORT_INDEX, DEFAULT_TOP_N_QUERIES_INDEX_PATTERN));
             } else {
                 try {
                     queryInsightsExporterFactory.closeExporter(this.exporter);
@@ -230,7 +227,7 @@ public class TopQueriesService {
                 }
                 this.exporter = queryInsightsExporterFactory.createExporter(
                     SinkType.parse(settings.get(EXPORTER_TYPE, DEFAULT_TOP_QUERIES_EXPORTER_TYPE)),
-                    settings.get(EXPORT_INDEX, DEFAULT_TOP_N_LATENCY_QUERIES_INDEX_PATTERN)
+                    settings.get(EXPORT_INDEX, DEFAULT_TOP_N_QUERIES_INDEX_PATTERN)
                 );
             }
         } else {

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/Attribute.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/Attribute.java
@@ -45,6 +45,10 @@ public enum Attribute {
      */
     NODE_ID,
     /**
+     * Tasks level resource usages in this request
+     */
+    TASK_RESOURCE_USAGES,
+    /**
      * Custom search request labels
      */
     LABELS;

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/MetricType.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/rules/model/MetricType.java
@@ -35,7 +35,7 @@ public enum MetricType implements Comparator<Number> {
     /**
      * JVM heap usage metric type
      */
-    JVM;
+    MEMORY;
 
     /**
      * Read a MetricType from a StreamInput
@@ -93,10 +93,9 @@ public enum MetricType implements Comparator<Number> {
     public int compare(final Number a, final Number b) {
         switch (this) {
             case LATENCY:
-                return Long.compare(a.longValue(), b.longValue());
-            case JVM:
             case CPU:
-                return Double.compare(a.doubleValue(), b.doubleValue());
+            case MEMORY:
+                return Long.compare(a.longValue(), b.longValue());
         }
         return -1;
     }
@@ -110,10 +109,9 @@ public enum MetricType implements Comparator<Number> {
     Number parseValue(final Object o) {
         switch (this) {
             case LATENCY:
-                return (Long) o;
-            case JVM:
             case CPU:
-                return (Double) o;
+            case MEMORY:
+                return (Long) o;
             default:
                 return (Number) o;
         }

--- a/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
+++ b/plugins/query-insights/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
@@ -12,6 +12,7 @@ import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.plugin.insights.core.exporter.SinkType;
+import org.opensearch.plugin.insights.rules.model.MetricType;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -81,6 +82,10 @@ public class QueryInsightsSettings {
     public static final String TOP_N_QUERIES_SETTING_PREFIX = "search.insights.top_queries";
     /** Default prefix for top N queries by latency feature */
     public static final String TOP_N_LATENCY_QUERIES_PREFIX = TOP_N_QUERIES_SETTING_PREFIX + ".latency";
+    /** Default prefix for top N queries by cpu feature */
+    public static final String TOP_N_CPU_QUERIES_PREFIX = TOP_N_QUERIES_SETTING_PREFIX + ".cpu";
+    /** Default prefix for top N queries by memory feature */
+    public static final String TOP_N_MEMORY_QUERIES_PREFIX = TOP_N_QUERIES_SETTING_PREFIX + ".memory";
     /**
      * Boolean setting for enabling top queries by latency.
      */
@@ -112,6 +117,66 @@ public class QueryInsightsSettings {
     );
 
     /**
+     * Boolean setting for enabling top queries by cpu.
+     */
+    public static final Setting<Boolean> TOP_N_CPU_QUERIES_ENABLED = Setting.boolSetting(
+        TOP_N_CPU_QUERIES_PREFIX + ".enabled",
+        false,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Int setting to define the top n size for top queries by cpu.
+     */
+    public static final Setting<Integer> TOP_N_CPU_QUERIES_SIZE = Setting.intSetting(
+        TOP_N_CPU_QUERIES_PREFIX + ".top_n_size",
+        DEFAULT_TOP_N_SIZE,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Time setting to define the window size in seconds for top queries by cpu.
+     */
+    public static final Setting<TimeValue> TOP_N_CPU_QUERIES_WINDOW_SIZE = Setting.positiveTimeSetting(
+        TOP_N_CPU_QUERIES_PREFIX + ".window_size",
+        DEFAULT_WINDOW_SIZE,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
+     * Boolean setting for enabling top queries by memory.
+     */
+    public static final Setting<Boolean> TOP_N_MEMORY_QUERIES_ENABLED = Setting.boolSetting(
+        TOP_N_MEMORY_QUERIES_PREFIX + ".enabled",
+        false,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Int setting to define the top n size for top queries by memory.
+     */
+    public static final Setting<Integer> TOP_N_MEMORY_QUERIES_SIZE = Setting.intSetting(
+        TOP_N_MEMORY_QUERIES_PREFIX + ".top_n_size",
+        DEFAULT_TOP_N_SIZE,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Time setting to define the window size in seconds for top queries by memory.
+     */
+    public static final Setting<TimeValue> TOP_N_MEMORY_QUERIES_WINDOW_SIZE = Setting.positiveTimeSetting(
+        TOP_N_MEMORY_QUERIES_PREFIX + ".window_size",
+        DEFAULT_WINDOW_SIZE,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
      * Config key for exporter type
      */
     public static final String EXPORTER_TYPE = "type";
@@ -125,9 +190,17 @@ public class QueryInsightsSettings {
      */
     private static final String TOP_N_LATENCY_QUERIES_EXPORTER_PREFIX = TOP_N_LATENCY_QUERIES_PREFIX + ".exporter.";
     /**
-     * Default index pattern of top n queries by latency
+     * Prefix for top n queries by cpu exporters
      */
-    public static final String DEFAULT_TOP_N_LATENCY_QUERIES_INDEX_PATTERN = "'top_queries_by_latency-'YYYY.MM.dd";
+    private static final String TOP_N_CPU_QUERIES_EXPORTER_PREFIX = TOP_N_CPU_QUERIES_PREFIX + ".exporter.";
+    /**
+     * Prefix for top n queries by memory exporters
+     */
+    private static final String TOP_N_MEMORY_QUERIES_EXPORTER_PREFIX = TOP_N_MEMORY_QUERIES_PREFIX + ".exporter.";
+    /**
+     * Default index pattern of top n queries
+     */
+    public static final String DEFAULT_TOP_N_QUERIES_INDEX_PATTERN = "'top_queries-'YYYY.MM.dd";
     /**
      * Default exporter type of top queries
      */
@@ -141,6 +214,88 @@ public class QueryInsightsSettings {
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
+
+    /**
+     * Settings for the exporter of top cpu queries
+     */
+    public static final Setting<Settings> TOP_N_CPU_EXPORTER_SETTINGS = Setting.groupSetting(
+        TOP_N_CPU_QUERIES_EXPORTER_PREFIX,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Settings for the exporter of top cpu queries
+     */
+    public static final Setting<Settings> TOP_N_MEMORY_EXPORTER_SETTINGS = Setting.groupSetting(
+        TOP_N_MEMORY_QUERIES_EXPORTER_PREFIX,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Get the enabled setting based on type
+     * @param type MetricType
+     * @return enabled setting
+     */
+    public static Setting<Boolean> getTopNEnabledSetting(MetricType type) {
+        switch (type) {
+            case CPU:
+                return TOP_N_CPU_QUERIES_ENABLED;
+            case MEMORY:
+                return TOP_N_MEMORY_QUERIES_ENABLED;
+            default:
+                return TOP_N_LATENCY_QUERIES_ENABLED;
+        }
+    }
+
+    /**
+     * Get the top n size setting based on type
+     * @param type MetricType
+     * @return top n size setting
+     */
+    public static Setting<Integer> getTopNSizeSetting(MetricType type) {
+        switch (type) {
+            case CPU:
+                return TOP_N_CPU_QUERIES_SIZE;
+            case MEMORY:
+                return TOP_N_MEMORY_QUERIES_SIZE;
+            default:
+                return TOP_N_LATENCY_QUERIES_SIZE;
+        }
+    }
+
+    /**
+     * Get the window size setting based on type
+     * @param type MetricType
+     * @return top n queries window size setting
+     */
+    public static Setting<TimeValue> getTopNWindowSizeSetting(MetricType type) {
+        switch (type) {
+            case CPU:
+                return TOP_N_CPU_QUERIES_WINDOW_SIZE;
+            case MEMORY:
+                return TOP_N_MEMORY_QUERIES_WINDOW_SIZE;
+            default:
+                return TOP_N_LATENCY_QUERIES_WINDOW_SIZE;
+        }
+    }
+
+    /**
+     * Get the exporter settings based on type
+     * @param type MetricType
+     * @return exporter setting
+     */
+    public static Setting<Settings> getExporterSettings(MetricType type) {
+        switch (type) {
+            case CPU:
+                return TOP_N_CPU_EXPORTER_SETTINGS;
+            case MEMORY:
+                return TOP_N_MEMORY_EXPORTER_SETTINGS;
+            default:
+                return TOP_N_LATENCY_EXPORTER_SETTINGS;
+        }
+    }
 
     /**
      * Default constructor

--- a/plugins/query-insights/src/test/java/org/opensearch/plugin/insights/QueryInsightsPluginTests.java
+++ b/plugins/query-insights/src/test/java/org/opensearch/plugin/insights/QueryInsightsPluginTests.java
@@ -47,11 +47,7 @@ public class QueryInsightsPluginTests extends OpenSearchTestCase {
         Settings.Builder settingsBuilder = Settings.builder();
         Settings settings = settingsBuilder.build();
         ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_LATENCY_QUERIES_ENABLED);
-        clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_LATENCY_QUERIES_SIZE);
-        clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_LATENCY_QUERIES_WINDOW_SIZE);
-        clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_LATENCY_EXPORTER_SETTINGS);
-
+        QueryInsightsTestUtils.registerAllQueryInsightsSettings(clusterSettings);
         clusterService = ClusterServiceUtils.createClusterService(settings, clusterSettings, threadPool);
     }
 
@@ -61,7 +57,15 @@ public class QueryInsightsPluginTests extends OpenSearchTestCase {
                 QueryInsightsSettings.TOP_N_LATENCY_QUERIES_ENABLED,
                 QueryInsightsSettings.TOP_N_LATENCY_QUERIES_SIZE,
                 QueryInsightsSettings.TOP_N_LATENCY_QUERIES_WINDOW_SIZE,
-                QueryInsightsSettings.TOP_N_LATENCY_EXPORTER_SETTINGS
+                QueryInsightsSettings.TOP_N_LATENCY_EXPORTER_SETTINGS,
+                QueryInsightsSettings.TOP_N_CPU_QUERIES_ENABLED,
+                QueryInsightsSettings.TOP_N_CPU_QUERIES_SIZE,
+                QueryInsightsSettings.TOP_N_CPU_QUERIES_WINDOW_SIZE,
+                QueryInsightsSettings.TOP_N_CPU_EXPORTER_SETTINGS,
+                QueryInsightsSettings.TOP_N_MEMORY_QUERIES_ENABLED,
+                QueryInsightsSettings.TOP_N_MEMORY_QUERIES_SIZE,
+                QueryInsightsSettings.TOP_N_MEMORY_QUERIES_WINDOW_SIZE,
+                QueryInsightsSettings.TOP_N_MEMORY_EXPORTER_SETTINGS
             ),
             queryInsightsPlugin.getSettings()
         );

--- a/plugins/query-insights/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
+++ b/plugins/query-insights/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
@@ -10,6 +10,7 @@ package org.opensearch.plugin.insights;
 
 import org.opensearch.action.search.SearchType;
 import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.util.Maps;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -17,6 +18,7 @@ import org.opensearch.plugin.insights.rules.action.top_queries.TopQueries;
 import org.opensearch.plugin.insights.rules.model.Attribute;
 import org.opensearch.plugin.insights.rules.model.MetricType;
 import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
+import org.opensearch.plugin.insights.settings.QueryInsightsSettings;
 import org.opensearch.test.VersionUtils;
 
 import java.io.IOException;
@@ -36,7 +38,6 @@ import static org.opensearch.test.OpenSearchTestCase.buildNewFakeTransportAddres
 import static org.opensearch.test.OpenSearchTestCase.random;
 import static org.opensearch.test.OpenSearchTestCase.randomAlphaOfLengthBetween;
 import static org.opensearch.test.OpenSearchTestCase.randomArray;
-import static org.opensearch.test.OpenSearchTestCase.randomDouble;
 import static org.opensearch.test.OpenSearchTestCase.randomIntBetween;
 import static org.opensearch.test.OpenSearchTestCase.randomLong;
 import static org.opensearch.test.OpenSearchTestCase.randomLongBetween;
@@ -63,9 +64,9 @@ final public class QueryInsightsTestUtils {
                 MetricType.LATENCY,
                 randomLongBetween(1000, 10000),
                 MetricType.CPU,
-                randomDouble(),
-                MetricType.JVM,
-                randomDouble()
+                randomLongBetween(1000, 10000),
+                MetricType.MEMORY,
+                randomLongBetween(1000, 10000)
             );
 
             Map<String, Long> phaseLatencyMap = new HashMap<>();
@@ -185,5 +186,20 @@ final public class QueryInsightsTestUtils {
             }
         }
         return true;
+    }
+
+    public static void registerAllQueryInsightsSettings(ClusterSettings clusterSettings) {
+        clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_LATENCY_QUERIES_ENABLED);
+        clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_LATENCY_QUERIES_SIZE);
+        clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_LATENCY_QUERIES_WINDOW_SIZE);
+        clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_LATENCY_EXPORTER_SETTINGS);
+        clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_CPU_QUERIES_ENABLED);
+        clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_CPU_QUERIES_SIZE);
+        clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_CPU_QUERIES_WINDOW_SIZE);
+        clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_CPU_EXPORTER_SETTINGS);
+        clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_MEMORY_QUERIES_ENABLED);
+        clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_MEMORY_QUERIES_SIZE);
+        clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_MEMORY_QUERIES_WINDOW_SIZE);
+        clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_MEMORY_EXPORTER_SETTINGS);
     }
 }

--- a/plugins/query-insights/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
+++ b/plugins/query-insights/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
@@ -34,11 +34,11 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
         Settings.Builder settingsBuilder = Settings.builder();
         Settings settings = settingsBuilder.build();
         ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_LATENCY_EXPORTER_SETTINGS);
+        QueryInsightsTestUtils.registerAllQueryInsightsSettings(clusterSettings);
         queryInsightsService = new QueryInsightsService(clusterSettings, threadPool, client);
         queryInsightsService.enableCollection(MetricType.LATENCY, true);
         queryInsightsService.enableCollection(MetricType.CPU, true);
-        queryInsightsService.enableCollection(MetricType.JVM, true);
+        queryInsightsService.enableCollection(MetricType.MEMORY, true);
     }
 
     public void testAddRecordToLimitAndDrain() {

--- a/plugins/query-insights/src/test/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecordTests.java
+++ b/plugins/query-insights/src/test/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecordTests.java
@@ -39,7 +39,7 @@ public class SearchQueryRecordTests extends OpenSearchTestCase {
 
     public void testAllMetricTypes() {
         Set<MetricType> allMetrics = MetricType.allMetricTypes();
-        Set<MetricType> expected = new HashSet<>(Arrays.asList(MetricType.LATENCY, MetricType.CPU, MetricType.JVM));
+        Set<MetricType> expected = new HashSet<>(Arrays.asList(MetricType.LATENCY, MetricType.CPU, MetricType.MEMORY));
         assertEquals(expected, allMetrics);
     }
 

--- a/server/src/main/java/org/opensearch/action/search/FetchSearchPhase.java
+++ b/server/src/main/java/org/opensearch/action/search/FetchSearchPhase.java
@@ -240,6 +240,7 @@ final class FetchSearchPhase extends SearchPhase {
                     public void innerOnResponse(FetchSearchResult result) {
                         try {
                             progressListener.notifyFetchResult(shardIndex);
+                            context.setPhaseResourceUsages();
                             counter.onResult(result);
                         } catch (Exception e) {
                             context.onPhaseFailure(FetchSearchPhase.this, "", e);
@@ -254,6 +255,7 @@ final class FetchSearchPhase extends SearchPhase {
                                 e
                             );
                             progressListener.notifyFetchFailure(shardIndex, shardTarget, e);
+                            context.setPhaseResourceUsages();
                             counter.onFailure(shardIndex, shardTarget, e);
                         } finally {
                             // the search context might not be cleared on the node where the fetch was executed for example

--- a/server/src/main/java/org/opensearch/action/search/SearchPhaseContext.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchPhaseContext.java
@@ -150,4 +150,9 @@ public interface SearchPhaseContext extends Executor {
      * Registers a {@link Releasable} that will be closed when the search request finishes or fails.
      */
     void addReleasable(Releasable releasable);
+
+    /**
+     * Set the resource usage info for this phase
+     */
+    void setPhaseResourceUsages();
 }

--- a/server/src/main/java/org/opensearch/action/search/SearchRequestContext.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequestContext.java
@@ -8,13 +8,20 @@
 
 package org.opensearch.action.search;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.TotalHits;
 import org.opensearch.common.annotation.InternalApi;
+import org.opensearch.core.tasks.resourcetracker.TaskResourceInfo;
 
+import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.Supplier;
 
 /**
  * This class holds request-level context for search queries at the coordinator node
@@ -23,6 +30,7 @@ import java.util.Map;
  */
 @InternalApi
 public class SearchRequestContext {
+    private static final Logger logger = LogManager.getLogger();
     private final SearchRequestOperationsListener searchRequestOperationsListener;
     private long absoluteStartNanos;
     private final Map<String, Long> phaseTookMap;
@@ -30,13 +38,21 @@ public class SearchRequestContext {
     private final EnumMap<ShardStatsFieldNames, Integer> shardStats;
 
     private final SearchRequest searchRequest;
+    private final LinkedBlockingQueue<TaskResourceInfo> phaseResourceUsage;
+    private final Supplier<TaskResourceInfo> taskResourceUsageSupplier;
 
-    SearchRequestContext(final SearchRequestOperationsListener searchRequestOperationsListener, final SearchRequest searchRequest) {
+    SearchRequestContext(
+        final SearchRequestOperationsListener searchRequestOperationsListener,
+        final SearchRequest searchRequest,
+        final Supplier<TaskResourceInfo> taskResourceUsageSupplier
+    ) {
         this.searchRequestOperationsListener = searchRequestOperationsListener;
         this.absoluteStartNanos = System.nanoTime();
         this.phaseTookMap = new HashMap<>();
         this.shardStats = new EnumMap<>(ShardStatsFieldNames.class);
         this.searchRequest = searchRequest;
+        this.phaseResourceUsage = new LinkedBlockingQueue<>();
+        this.taskResourceUsageSupplier = taskResourceUsageSupplier;
     }
 
     SearchRequestOperationsListener getSearchRequestOperationsListener() {
@@ -106,6 +122,20 @@ public class SearchRequestContext {
                 shardStats.get(ShardStatsFieldNames.SEARCH_REQUEST_SLOWLOG_SHARD_FAILED)
             );
         }
+    }
+
+    public Supplier<TaskResourceInfo> getTaskResourceUsageSupplier() {
+        return taskResourceUsageSupplier;
+    }
+
+    public void recordPhaseResourceUsage(TaskResourceInfo usage) {
+        if (usage != null) {
+            this.phaseResourceUsage.add(usage);
+        }
+    }
+
+    public List<TaskResourceInfo> getPhaseResourceUsage() {
+        return new ArrayList<>(phaseResourceUsage);
     }
 
     public SearchRequest getRequest() {

--- a/server/src/main/java/org/opensearch/action/search/SearchRequestOperationsListener.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequestOperationsListener.java
@@ -51,6 +51,8 @@ public abstract class SearchRequestOperationsListener {
 
     protected void onRequestEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext) {}
 
+    protected void onRequestFailure(SearchPhaseContext context, SearchRequestContext searchRequestContext) {}
+
     protected boolean isEnabled(SearchRequest searchRequest) {
         return isEnabled();
     }
@@ -129,6 +131,17 @@ public abstract class SearchRequestOperationsListener {
                     listener.onRequestEnd(context, searchRequestContext);
                 } catch (Exception e) {
                     logger.warn(() -> new ParameterizedMessage("onRequestEnd listener [{}] failed", listener), e);
+                }
+            }
+        }
+
+        @Override
+        public void onRequestFailure(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
+            for (SearchRequestOperationsListener listener : listeners) {
+                try {
+                    listener.onRequestFailure(context, searchRequestContext);
+                } catch (Exception e) {
+                    logger.warn(() -> new ParameterizedMessage("onRequestFailure listener [{}] failed", listener), e);
                 }
             }
         }

--- a/server/src/main/java/org/opensearch/common/util/concurrent/ThreadContext.java
+++ b/server/src/main/java/org/opensearch/common/util/concurrent/ThreadContext.java
@@ -480,7 +480,7 @@ public final class ThreadContext implements Writeable {
      * @param value       the header value
      */
     public void addResponseHeader(final String key, final String value) {
-        updateResponseHeader(key, value, v -> v, false);
+        addResponseHeader(key, value, v -> v);
     }
 
     /**
@@ -490,7 +490,19 @@ public final class ThreadContext implements Writeable {
      * @param value       the header value
      */
     public void updateResponseHeader(final String key, final String value) {
-        updateResponseHeader(key, value, v -> v, true);
+        updateResponseHeader(key, value, v -> v);
+    }
+
+    /**
+     * Add the {@code value} for the specified {@code key} with the specified {@code uniqueValue} used for de-duplication. Any duplicate
+     * {@code value} after applying {@code uniqueValue} is ignored.
+     *
+     * @param key         the header name
+     * @param value       the header value
+     * @param uniqueValue the function that produces de-duplication values
+     */
+    public void addResponseHeader(final String key, final String value, final Function<String, String> uniqueValue) {
+        threadLocal.set(threadLocal.get().putResponse(key, value, uniqueValue, maxWarningHeaderCount, maxWarningHeaderSize, false));
     }
 
     /**
@@ -500,17 +512,9 @@ public final class ThreadContext implements Writeable {
      * @param key         the header name
      * @param value       the header value
      * @param uniqueValue the function that produces de-duplication values
-     * @param replaceExistingKey whether to replace the existing header if it already exists
      */
-    public void updateResponseHeader(
-        final String key,
-        final String value,
-        final Function<String, String> uniqueValue,
-        final boolean replaceExistingKey
-    ) {
-        threadLocal.set(
-            threadLocal.get().putResponse(key, value, uniqueValue, maxWarningHeaderCount, maxWarningHeaderSize, replaceExistingKey)
-        );
+    public void updateResponseHeader(final String key, final String value, final Function<String, String> uniqueValue) {
+        threadLocal.set(threadLocal.get().putResponse(key, value, uniqueValue, maxWarningHeaderCount, maxWarningHeaderSize, true));
     }
 
     /**

--- a/server/src/main/java/org/opensearch/common/util/concurrent/ThreadContext.java
+++ b/server/src/main/java/org/opensearch/common/util/concurrent/ThreadContext.java
@@ -480,28 +480,37 @@ public final class ThreadContext implements Writeable {
      * @param value       the header value
      */
     public void addResponseHeader(final String key, final String value) {
-        addResponseHeader(key, value, v -> v);
+        updateResponseHeader(key, value, v -> v, false);
     }
 
     /**
-     * Remove the {@code value} for the specified {@code key}.
+     * Update the {@code value} for the specified {@code key}
      *
      * @param key         the header name
+     * @param value       the header value
      */
-    public void removeResponseHeader(final String key) {
-        threadLocal.get().responseHeaders.remove(key);
+    public void updateResponseHeader(final String key, final String value) {
+        updateResponseHeader(key, value, v -> v, true);
     }
 
     /**
-     * Add the {@code value} for the specified {@code key} with the specified {@code uniqueValue} used for de-duplication. Any duplicate
+     * Update the {@code value} for the specified {@code key} with the specified {@code uniqueValue} used for de-duplication. Any duplicate
      * {@code value} after applying {@code uniqueValue} is ignored.
      *
      * @param key         the header name
      * @param value       the header value
      * @param uniqueValue the function that produces de-duplication values
+     * @param replaceExistingKey whether to replace the existing header if it already exists
      */
-    public void addResponseHeader(final String key, final String value, final Function<String, String> uniqueValue) {
-        threadLocal.set(threadLocal.get().putResponse(key, value, uniqueValue, maxWarningHeaderCount, maxWarningHeaderSize));
+    public void updateResponseHeader(
+        final String key,
+        final String value,
+        final Function<String, String> uniqueValue,
+        final boolean replaceExistingKey
+    ) {
+        threadLocal.set(
+            threadLocal.get().putResponse(key, value, uniqueValue, maxWarningHeaderCount, maxWarningHeaderSize, replaceExistingKey)
+        );
     }
 
     /**
@@ -726,7 +735,8 @@ public final class ThreadContext implements Writeable {
             final String value,
             final Function<String, String> uniqueValue,
             final int maxWarningHeaderCount,
-            final long maxWarningHeaderSize
+            final long maxWarningHeaderSize,
+            final boolean replaceExistingKey
         ) {
             assert value != null;
             long newWarningHeaderSize = warningHeadersSize;
@@ -768,8 +778,13 @@ public final class ThreadContext implements Writeable {
                 if (existingValues.contains(uniqueValue.apply(value))) {
                     return this;
                 }
-                // preserve insertion order
-                final Set<String> newValues = Stream.concat(existingValues.stream(), Stream.of(value)).collect(LINKED_HASH_SET_COLLECTOR);
+                Set<String> newValues;
+                if (replaceExistingKey) {
+                    newValues = Stream.of(value).collect(LINKED_HASH_SET_COLLECTOR);
+                } else {
+                    // preserve insertion order
+                    newValues = Stream.concat(existingValues.stream(), Stream.of(value)).collect(LINKED_HASH_SET_COLLECTOR);
+                }
                 newResponseHeaders = new HashMap<>(responseHeaders);
                 newResponseHeaders.put(key, Collections.unmodifiableSet(newValues));
             } else {

--- a/server/src/main/java/org/opensearch/common/util/concurrent/ThreadContext.java
+++ b/server/src/main/java/org/opensearch/common/util/concurrent/ThreadContext.java
@@ -484,6 +484,15 @@ public final class ThreadContext implements Writeable {
     }
 
     /**
+     * Remove the {@code value} for the specified {@code key}.
+     *
+     * @param key         the header name
+     */
+    public void removeResponseHeader(final String key) {
+        threadLocal.get().responseHeaders.remove(key);
+    }
+
+    /**
      * Add the {@code value} for the specified {@code key} with the specified {@code uniqueValue} used for de-duplication. Any duplicate
      * {@code value} after applying {@code uniqueValue} is ignored.
      *

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -1258,7 +1258,8 @@ public class Node implements Closeable {
                 searchModule.getFetchPhase(),
                 responseCollectorService,
                 circuitBreakerService,
-                searchModule.getIndexSearcherExecutor(threadPool)
+                searchModule.getIndexSearcherExecutor(threadPool),
+                taskResourceTrackingService
             );
 
             final List<PersistentTasksExecutor<?>> tasksExecutors = pluginsService.filterPlugins(PersistentTaskPlugin.class)
@@ -1901,7 +1902,8 @@ public class Node implements Closeable {
         FetchPhase fetchPhase,
         ResponseCollectorService responseCollectorService,
         CircuitBreakerService circuitBreakerService,
-        Executor indexSearcherExecutor
+        Executor indexSearcherExecutor,
+        TaskResourceTrackingService taskResourceTrackingService
     ) {
         return new SearchService(
             clusterService,
@@ -1913,7 +1915,8 @@ public class Node implements Closeable {
             fetchPhase,
             responseCollectorService,
             circuitBreakerService,
-            indexSearcherExecutor
+            indexSearcherExecutor,
+            taskResourceTrackingService
         );
     }
 

--- a/server/src/main/java/org/opensearch/tasks/Task.java
+++ b/server/src/main/java/org/opensearch/tasks/Task.java
@@ -476,6 +476,18 @@ public class Task {
         throw new IllegalStateException("cannot update final values if active thread resource entry is not present");
     }
 
+    public ThreadResourceInfo getActiveThreadResourceInfo(long threadId, ResourceStatsType statsType) {
+        final List<ThreadResourceInfo> threadResourceInfoList = resourceStats.get(threadId);
+        if (threadResourceInfoList != null) {
+            for (ThreadResourceInfo threadResourceInfo : threadResourceInfoList) {
+                if (threadResourceInfo.getStatsType() == statsType && threadResourceInfo.isActive()) {
+                    return threadResourceInfo;
+                }
+            }
+        }
+        return null;
+    }
+
     /**
      * Individual tasks can override this if they want to support task resource tracking. We just need to make sure that
      * the ThreadPool on which the task runs on have runnable wrapper similar to

--- a/server/src/main/java/org/opensearch/tasks/TaskResourceTrackingService.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskResourceTrackingService.java
@@ -322,10 +322,7 @@ public class TaskResourceTrackingService implements RunnableTaskExecutionListene
                 )
                 .build();
             // Remove the existing TASK_RESOURCE_USAGE header since it would have come from an earlier phase in the same request.
-            synchronized (this) {
-                threadPool.getThreadContext().removeResponseHeader(TASK_RESOURCE_USAGE);
-                threadPool.getThreadContext().addResponseHeader(TASK_RESOURCE_USAGE, taskResourceInfo.toString());
-            }
+            threadPool.getThreadContext().updateResponseHeader(TASK_RESOURCE_USAGE, taskResourceInfo.toString());
         } catch (Exception e) {
             logger.debug("Error during writing task resource usage: ", e);
         }

--- a/server/src/main/java/org/opensearch/tasks/TaskResourceTrackingService.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskResourceTrackingService.java
@@ -14,6 +14,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.ExceptionsHelper;
+import org.opensearch.action.search.SearchShardTask;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.settings.ClusterSettings;
@@ -22,12 +23,23 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ConcurrentCollections;
 import org.opensearch.common.util.concurrent.ConcurrentMapLong;
 import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.tasks.resourcetracker.ResourceStats;
+import org.opensearch.core.tasks.resourcetracker.ResourceStatsType;
+import org.opensearch.core.tasks.resourcetracker.ResourceUsageInfo;
 import org.opensearch.core.tasks.resourcetracker.ResourceUsageMetric;
+import org.opensearch.core.tasks.resourcetracker.TaskResourceInfo;
+import org.opensearch.core.tasks.resourcetracker.TaskResourceUsage;
 import org.opensearch.core.tasks.resourcetracker.ThreadResourceInfo;
+import org.opensearch.core.xcontent.DeprecationHandler;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.threadpool.RunnableTaskExecutionListener;
 import org.opensearch.threadpool.ThreadPool;
 
+import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -51,6 +63,7 @@ public class TaskResourceTrackingService implements RunnableTaskExecutionListene
         Setting.Property.NodeScope
     );
     public static final String TASK_ID = "TASK_ID";
+    public static final String TASK_RESOURCE_USAGE = "TASK_RESOURCE_USAGE";
 
     private static final ThreadMXBean threadMXBean = (ThreadMXBean) ManagementFactory.getThreadMXBean();
 
@@ -259,6 +272,89 @@ public class TaskResourceTrackingService implements RunnableTaskExecutionListene
         ThreadContext.StoredContext storedContext = threadContext.newStoredContext(true, Collections.singletonList(TASK_ID));
         threadContext.putTransient(TASK_ID, task.getId());
         return storedContext;
+    }
+
+    /**
+     * Get the current task level resource usage.
+     *
+     * @param task {@link SearchShardTask}
+     * @param nodeId the local nodeId
+     */
+    public void writeTaskResourceUsage(SearchShardTask task, String nodeId) {
+        try {
+            // Get resource usages from when the task started
+            ThreadResourceInfo threadResourceInfo = task.getActiveThreadResourceInfo(
+                Thread.currentThread().getId(),
+                ResourceStatsType.WORKER_STATS
+            );
+            if (threadResourceInfo == null) {
+                return;
+            }
+            Map<ResourceStats, ResourceUsageInfo.ResourceStatsInfo> startValues = threadResourceInfo.getResourceUsageInfo().getStatsInfo();
+            if (!(startValues.containsKey(ResourceStats.CPU) && startValues.containsKey(ResourceStats.MEMORY))) {
+                return;
+            }
+            // Get current resource usages
+            ResourceUsageMetric[] endValues = getResourceUsageMetricsForThread(Thread.currentThread().getId());
+            long cpu = -1, mem = -1;
+            for (ResourceUsageMetric endValue : endValues) {
+                if (endValue.getStats() == ResourceStats.MEMORY) {
+                    mem = endValue.getValue();
+                } else if (endValue.getStats() == ResourceStats.CPU) {
+                    cpu = endValue.getValue();
+                }
+            }
+            if (cpu == -1 || mem == -1) {
+                logger.debug("Invalid resource usage value, cpu [{}], memory [{}]: ", cpu, mem);
+                return;
+            }
+
+            // Build task resource usage info
+            TaskResourceInfo taskResourceInfo = new TaskResourceInfo.Builder().setAction(task.getAction())
+                .setTaskId(task.getId())
+                .setParentTaskId(task.getParentTaskId().getId())
+                .setNodeId(nodeId)
+                .setTaskResourceUsage(
+                    new TaskResourceUsage(
+                        cpu - startValues.get(ResourceStats.CPU).getStartValue(),
+                        mem - startValues.get(ResourceStats.MEMORY).getStartValue()
+                    )
+                )
+                .build();
+            // Remove the existing TASK_RESOURCE_USAGE header since it would have come from an earlier phase in the same request.
+            synchronized (this) {
+                threadPool.getThreadContext().removeResponseHeader(TASK_RESOURCE_USAGE);
+                threadPool.getThreadContext().addResponseHeader(TASK_RESOURCE_USAGE, taskResourceInfo.toString());
+            }
+        } catch (Exception e) {
+            logger.debug("Error during writing task resource usage: ", e);
+        }
+    }
+
+    /**
+     * Get the task resource usages from {@link ThreadContext}
+     *
+     * @return {@link TaskResourceInfo}
+     */
+    public TaskResourceInfo getTaskResourceUsageFromThreadContext() {
+        List<String> taskResourceUsages = threadPool.getThreadContext().getResponseHeaders().get(TASK_RESOURCE_USAGE);
+        if (taskResourceUsages != null && taskResourceUsages.size() > 0) {
+            String usage = taskResourceUsages.get(0);
+            try {
+                if (usage != null && !usage.isEmpty()) {
+                    XContentParser parser = XContentHelper.createParser(
+                        NamedXContentRegistry.EMPTY,
+                        DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                        new BytesArray(usage),
+                        MediaTypeRegistry.JSON
+                    );
+                    return TaskResourceInfo.PARSER.apply(parser, null);
+                }
+            } catch (IOException e) {
+                logger.debug("fail to parse phase resource usages: ", e);
+            }
+        }
+        return null;
     }
 
     /**

--- a/server/src/test/java/org/opensearch/action/search/CanMatchPreFilterSearchPhaseTests.java
+++ b/server/src/test/java/org/opensearch/action/search/CanMatchPreFilterSearchPhaseTests.java
@@ -170,7 +170,7 @@ public class CanMatchPreFilterSearchPhaseTests extends OpenSearchTestCase {
                 }
             },
             SearchResponse.Clusters.EMPTY,
-            new SearchRequestContext(searchRequestOperationsListener, searchRequest),
+            new SearchRequestContext(searchRequestOperationsListener, searchRequest, () -> null),
             NoopTracer.INSTANCE
         );
 
@@ -268,7 +268,7 @@ public class CanMatchPreFilterSearchPhaseTests extends OpenSearchTestCase {
                 }
             },
             SearchResponse.Clusters.EMPTY,
-            new SearchRequestContext(searchRequestOperationsListener, searchRequest),
+            new SearchRequestContext(searchRequestOperationsListener, searchRequest, () -> null),
             NoopTracer.INSTANCE
         );
 
@@ -366,7 +366,7 @@ public class CanMatchPreFilterSearchPhaseTests extends OpenSearchTestCase {
                         new ArraySearchPhaseResults<>(iter.size()),
                         randomIntBetween(1, 32),
                         SearchResponse.Clusters.EMPTY,
-                        new SearchRequestContext(searchRequestOperationsListener, searchRequest),
+                        new SearchRequestContext(searchRequestOperationsListener, searchRequest, () -> null),
                         NoopTracer.INSTANCE
                     ) {
                         @Override
@@ -396,7 +396,7 @@ public class CanMatchPreFilterSearchPhaseTests extends OpenSearchTestCase {
                 );
             },
             SearchResponse.Clusters.EMPTY,
-            new SearchRequestContext(searchRequestOperationsListener, searchRequest),
+            new SearchRequestContext(searchRequestOperationsListener, searchRequest, () -> null),
             NoopTracer.INSTANCE
         );
 
@@ -488,7 +488,7 @@ public class CanMatchPreFilterSearchPhaseTests extends OpenSearchTestCase {
                     }
                 },
                 SearchResponse.Clusters.EMPTY,
-                new SearchRequestContext(searchRequestOperationsListener, searchRequest),
+                new SearchRequestContext(searchRequestOperationsListener, searchRequest, () -> null),
                 NoopTracer.INSTANCE
             );
 
@@ -595,7 +595,7 @@ public class CanMatchPreFilterSearchPhaseTests extends OpenSearchTestCase {
                     }
                 },
                 SearchResponse.Clusters.EMPTY,
-                new SearchRequestContext(searchRequestOperationsListener, searchRequest),
+                new SearchRequestContext(searchRequestOperationsListener, searchRequest, () -> null),
                 NoopTracer.INSTANCE
             );
 
@@ -658,7 +658,8 @@ public class CanMatchPreFilterSearchPhaseTests extends OpenSearchTestCase {
         ExecutorService executor = OpenSearchExecutors.newDirectExecutorService();
         SearchRequestContext searchRequestContext = new SearchRequestContext(
             new SearchRequestOperationsListener.CompositeListener(List.of(assertingListener), LogManager.getLogger()),
-            searchRequest
+            searchRequest,
+            () -> null
         );
 
         SearchPhaseController controller = new SearchPhaseController(

--- a/server/src/test/java/org/opensearch/action/search/MockSearchPhaseContext.java
+++ b/server/src/test/java/org/opensearch/action/search/MockSearchPhaseContext.java
@@ -182,6 +182,14 @@ public final class MockSearchPhaseContext implements SearchPhaseContext {
         // Noop
     }
 
+    /**
+     * Set the resource usage info for this phase
+     */
+    @Override
+    public void setPhaseResourceUsages() {
+        // Noop
+    }
+
     @Override
     public void execute(Runnable command) {
         command.run();

--- a/server/src/test/java/org/opensearch/action/search/SearchAsyncActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchAsyncActionTests.java
@@ -162,7 +162,7 @@ public class SearchAsyncActionTests extends OpenSearchTestCase {
             new ArraySearchPhaseResults<>(shardsIter.size()),
             request.getMaxConcurrentShardRequests(),
             SearchResponse.Clusters.EMPTY,
-            new SearchRequestContext(searchRequestOperationsListener, request),
+            new SearchRequestContext(searchRequestOperationsListener, request, () -> null),
             NoopTracer.INSTANCE
         ) {
 
@@ -287,7 +287,7 @@ public class SearchAsyncActionTests extends OpenSearchTestCase {
             new ArraySearchPhaseResults<>(shardsIter.size()),
             request.getMaxConcurrentShardRequests(),
             SearchResponse.Clusters.EMPTY,
-            new SearchRequestContext(searchRequestOperationsListener, request),
+            new SearchRequestContext(searchRequestOperationsListener, request, () -> null),
             NoopTracer.INSTANCE
         ) {
 
@@ -409,7 +409,8 @@ public class SearchAsyncActionTests extends OpenSearchTestCase {
             SearchResponse.Clusters.EMPTY,
             new SearchRequestContext(
                 new SearchRequestOperationsListener.CompositeListener(List.of(assertingListener), LogManager.getLogger()),
-                request
+                request,
+                () -> null
             ),
             NoopTracer.INSTANCE
         ) {
@@ -537,7 +538,8 @@ public class SearchAsyncActionTests extends OpenSearchTestCase {
             SearchResponse.Clusters.EMPTY,
             new SearchRequestContext(
                 new SearchRequestOperationsListener.CompositeListener(List.of(assertingListener), LogManager.getLogger()),
-                request
+                request,
+                () -> null
             ),
             NoopTracer.INSTANCE
         ) {
@@ -657,7 +659,7 @@ public class SearchAsyncActionTests extends OpenSearchTestCase {
             new ArraySearchPhaseResults<>(shardsIter.size()),
             request.getMaxConcurrentShardRequests(),
             SearchResponse.Clusters.EMPTY,
-            new SearchRequestContext(searchRequestOperationsListener, request),
+            new SearchRequestContext(searchRequestOperationsListener, request, () -> null),
             NoopTracer.INSTANCE
         ) {
             @Override

--- a/server/src/test/java/org/opensearch/action/search/SearchQueryThenFetchAsyncActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchQueryThenFetchAsyncActionTests.java
@@ -240,7 +240,8 @@ public class SearchQueryThenFetchAsyncActionTests extends OpenSearchTestCase {
             SearchResponse.Clusters.EMPTY,
             new SearchRequestContext(
                 new SearchRequestOperationsListener.CompositeListener(List.of(assertingListener), LogManager.getLogger()),
-                searchRequest
+                searchRequest,
+                () -> null
             ),
             NoopTracer.INSTANCE
         ) {

--- a/server/src/test/java/org/opensearch/action/search/SearchRequestOperationsListenerSupport.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchRequestOperationsListenerSupport.java
@@ -25,7 +25,8 @@ public interface SearchRequestOperationsListenerSupport {
             context,
             new SearchRequestContext(
                 new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
-                new SearchRequest()
+                new SearchRequest(),
+                () -> null
             )
         );
     }

--- a/server/src/test/java/org/opensearch/action/search/SearchRequestSlowLogTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchRequestSlowLogTests.java
@@ -178,7 +178,8 @@ public class SearchRequestSlowLogTests extends OpenSearchTestCase {
         for (int i = 0; i < numRequests; i++) {
             SearchRequestContext searchRequestContext = new SearchRequestContext(
                 new SearchRequestOperationsListener.CompositeListener(searchListenersList, logger),
-                searchRequest
+                searchRequest,
+                () -> null
             );
             searchRequestContext.setAbsoluteStartNanos((i < numRequestsLogged) ? 0 : System.nanoTime());
             searchRequestContexts.add(searchRequestContext);
@@ -209,7 +210,8 @@ public class SearchRequestSlowLogTests extends OpenSearchTestCase {
         SearchPhaseContext searchPhaseContext = new MockSearchPhaseContext(1, searchRequest);
         SearchRequestContext searchRequestContext = new SearchRequestContext(
             new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
-            searchRequest
+            searchRequest,
+            () -> null
         );
         SearchRequestSlowLog.SearchRequestSlowLogMessage p = new SearchRequestSlowLog.SearchRequestSlowLogMessage(
             searchPhaseContext,
@@ -233,7 +235,8 @@ public class SearchRequestSlowLogTests extends OpenSearchTestCase {
         SearchPhaseContext searchPhaseContext = new MockSearchPhaseContext(1, searchRequest);
         SearchRequestContext searchRequestContext = new SearchRequestContext(
             new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
-            searchRequest
+            searchRequest,
+            () -> null
         );
         searchRequestContext.updatePhaseTookMap(SearchPhaseName.FETCH.getName(), 10L);
         searchRequestContext.updatePhaseTookMap(SearchPhaseName.QUERY.getName(), 50L);
@@ -262,7 +265,8 @@ public class SearchRequestSlowLogTests extends OpenSearchTestCase {
         SearchPhaseContext searchPhaseContext = new MockSearchPhaseContext(1, searchRequest);
         SearchRequestContext searchRequestContext = new SearchRequestContext(
             new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
-            searchRequest
+            searchRequest,
+            () -> null
         );
         searchRequestContext.updatePhaseTookMap(SearchPhaseName.FETCH.getName(), 10L);
         searchRequestContext.updatePhaseTookMap(SearchPhaseName.QUERY.getName(), 50L);
@@ -291,7 +295,8 @@ public class SearchRequestSlowLogTests extends OpenSearchTestCase {
         SearchPhaseContext searchPhaseContext = new MockSearchPhaseContext(1, searchRequest);
         SearchRequestContext searchRequestContext = new SearchRequestContext(
             new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
-            searchRequest
+            searchRequest,
+            () -> null
         );
         searchRequestContext.updatePhaseTookMap(SearchPhaseName.FETCH.getName(), 10L);
         searchRequestContext.updatePhaseTookMap(SearchPhaseName.QUERY.getName(), 50L);

--- a/server/src/test/java/org/opensearch/action/search/SearchRequestStatsTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchRequestStatsTests.java
@@ -60,7 +60,8 @@ public class SearchRequestStatsTests extends OpenSearchTestCase {
                 ctx,
                 new SearchRequestContext(
                     new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
-                    new SearchRequest()
+                    new SearchRequest(),
+                    () -> null
                 )
             );
             assertEquals(0, testRequestStats.getPhaseCurrent(searchPhaseName));
@@ -120,7 +121,8 @@ public class SearchRequestStatsTests extends OpenSearchTestCase {
                         ctx,
                         new SearchRequestContext(
                             new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
-                            new SearchRequest()
+                            new SearchRequest(),
+                            () -> null
                         )
                     );
                     countDownLatch.countDown();

--- a/server/src/test/java/org/opensearch/action/search/SearchResponseMergerTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchResponseMergerTests.java
@@ -137,7 +137,8 @@ public class SearchResponseMergerTests extends OpenSearchTestCase {
             SearchResponse.Clusters.EMPTY,
             new SearchRequestContext(
                 new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
-                new SearchRequest()
+                new SearchRequest(),
+                () -> null
             )
         );
         assertEquals(TimeUnit.NANOSECONDS.toMillis(currentRelativeTime), searchResponse.getTook().millis());
@@ -195,7 +196,8 @@ public class SearchResponseMergerTests extends OpenSearchTestCase {
             clusters,
             new SearchRequestContext(
                 new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
-                new SearchRequest()
+                new SearchRequest(),
+                () -> null
             )
         );
         assertSame(clusters, mergedResponse.getClusters());
@@ -252,7 +254,8 @@ public class SearchResponseMergerTests extends OpenSearchTestCase {
             clusters,
             new SearchRequestContext(
                 new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
-                new SearchRequest()
+                new SearchRequest(),
+                () -> null
             )
         );
         assertSame(clusters, mergedResponse.getClusters());
@@ -304,7 +307,8 @@ public class SearchResponseMergerTests extends OpenSearchTestCase {
             SearchResponse.Clusters.EMPTY,
             new SearchRequestContext(
                 new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
-                new SearchRequest()
+                new SearchRequest(),
+                () -> null
             )
         ).getShardFailures();
         assertThat(Arrays.asList(shardFailures), containsInAnyOrder(expectedFailures.toArray(ShardSearchFailure.EMPTY_ARRAY)));
@@ -344,7 +348,8 @@ public class SearchResponseMergerTests extends OpenSearchTestCase {
             clusters,
             new SearchRequestContext(
                 new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
-                new SearchRequest()
+                new SearchRequest(),
+                () -> null
             )
         );
         assertSame(clusters, mergedResponse.getClusters());
@@ -412,7 +417,8 @@ public class SearchResponseMergerTests extends OpenSearchTestCase {
             clusters,
             new SearchRequestContext(
                 new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
-                new SearchRequest()
+                new SearchRequest(),
+                () -> null
             )
         );
         assertSame(clusters, mergedResponse.getClusters());
@@ -490,7 +496,8 @@ public class SearchResponseMergerTests extends OpenSearchTestCase {
             clusters,
             new SearchRequestContext(
                 new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
-                new SearchRequest()
+                new SearchRequest(),
+                () -> null
             )
         );
         assertSame(clusters, mergedResponse.getClusters());
@@ -570,7 +577,8 @@ public class SearchResponseMergerTests extends OpenSearchTestCase {
             clusters,
             new SearchRequestContext(
                 new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
-                new SearchRequest()
+                new SearchRequest(),
+                () -> null
             )
         );
         assertSame(clusters, mergedResponse.getClusters());
@@ -733,7 +741,8 @@ public class SearchResponseMergerTests extends OpenSearchTestCase {
             clusters,
             new SearchRequestContext(
                 new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
-                new SearchRequest()
+                new SearchRequest(),
+                () -> null
             )
         );
 
@@ -799,7 +808,8 @@ public class SearchResponseMergerTests extends OpenSearchTestCase {
             clusters,
             new SearchRequestContext(
                 new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
-                new SearchRequest()
+                new SearchRequest(),
+                () -> null
             )
         );
         assertSame(clusters, response.getClusters());
@@ -878,7 +888,8 @@ public class SearchResponseMergerTests extends OpenSearchTestCase {
             clusters,
             new SearchRequestContext(
                 new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
-                new SearchRequest()
+                new SearchRequest(),
+                () -> null
             )
         );
         assertEquals(10, mergedResponse.getHits().getTotalHits().value);
@@ -926,7 +937,8 @@ public class SearchResponseMergerTests extends OpenSearchTestCase {
             clusters,
             new SearchRequestContext(
                 new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
-                new SearchRequest()
+                new SearchRequest(),
+                () -> null
             )
         );
         assertEquals(expectedTotalHits, mergedResponse.getHits().getTotalHits());

--- a/server/src/test/java/org/opensearch/action/search/TransportSearchActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/TransportSearchActionTests.java
@@ -487,7 +487,8 @@ public class TransportSearchActionTests extends OpenSearchTestCase {
                 (r, l) -> setOnce.set(Tuple.tuple(r, l)),
                 new SearchRequestContext(
                     new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
-                    searchRequest
+                    searchRequest,
+                    () -> null
                 )
             );
             if (localIndices == null) {
@@ -549,7 +550,8 @@ public class TransportSearchActionTests extends OpenSearchTestCase {
                     (r, l) -> setOnce.set(Tuple.tuple(r, l)),
                     new SearchRequestContext(
                         new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
-                        searchRequest
+                        searchRequest,
+                        () -> null
                     )
                 );
                 if (localIndices == null) {
@@ -590,7 +592,8 @@ public class TransportSearchActionTests extends OpenSearchTestCase {
                     (r, l) -> setOnce.set(Tuple.tuple(r, l)),
                     new SearchRequestContext(
                         new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
-                        searchRequest
+                        searchRequest,
+                        () -> null
                     )
                 );
                 if (localIndices == null) {
@@ -652,7 +655,8 @@ public class TransportSearchActionTests extends OpenSearchTestCase {
                     (r, l) -> setOnce.set(Tuple.tuple(r, l)),
                     new SearchRequestContext(
                         new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
-                        searchRequest
+                        searchRequest,
+                        () -> null
                     )
                 );
                 if (localIndices == null) {
@@ -696,7 +700,8 @@ public class TransportSearchActionTests extends OpenSearchTestCase {
                     (r, l) -> setOnce.set(Tuple.tuple(r, l)),
                     new SearchRequestContext(
                         new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
-                        searchRequest
+                        searchRequest,
+                        () -> null
                     )
                 );
                 if (localIndices == null) {
@@ -751,7 +756,8 @@ public class TransportSearchActionTests extends OpenSearchTestCase {
                     (r, l) -> setOnce.set(Tuple.tuple(r, l)),
                     new SearchRequestContext(
                         new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
-                        searchRequest
+                        searchRequest,
+                        () -> null
                     )
                 );
                 if (localIndices == null) {

--- a/server/src/test/java/org/opensearch/common/util/concurrent/ThreadContextTests.java
+++ b/server/src/test/java/org/opensearch/common/util/concurrent/ThreadContextTests.java
@@ -344,11 +344,16 @@ public class ThreadContextTests extends OpenSearchTestCase {
         }
 
         final String value = HeaderWarning.formatWarning("qux");
-        threadContext.addResponseHeader("baz", value, s -> HeaderWarning.extractWarningValueFromWarningHeader(s, false));
+        threadContext.updateResponseHeader("baz", value, s -> HeaderWarning.extractWarningValueFromWarningHeader(s, false), false);
         // pretend that another thread created the same response at a different time
         if (randomBoolean()) {
             final String duplicateValue = HeaderWarning.formatWarning("qux");
-            threadContext.addResponseHeader("baz", duplicateValue, s -> HeaderWarning.extractWarningValueFromWarningHeader(s, false));
+            threadContext.updateResponseHeader(
+                "baz",
+                duplicateValue,
+                s -> HeaderWarning.extractWarningValueFromWarningHeader(s, false),
+                false
+            );
         }
 
         threadContext.addResponseHeader("Warning", "One is the loneliest number");

--- a/server/src/test/java/org/opensearch/common/util/concurrent/ThreadContextTests.java
+++ b/server/src/test/java/org/opensearch/common/util/concurrent/ThreadContextTests.java
@@ -344,16 +344,11 @@ public class ThreadContextTests extends OpenSearchTestCase {
         }
 
         final String value = HeaderWarning.formatWarning("qux");
-        threadContext.updateResponseHeader("baz", value, s -> HeaderWarning.extractWarningValueFromWarningHeader(s, false), false);
+        threadContext.updateResponseHeader("baz", value, s -> HeaderWarning.extractWarningValueFromWarningHeader(s, false));
         // pretend that another thread created the same response at a different time
         if (randomBoolean()) {
             final String duplicateValue = HeaderWarning.formatWarning("qux");
-            threadContext.updateResponseHeader(
-                "baz",
-                duplicateValue,
-                s -> HeaderWarning.extractWarningValueFromWarningHeader(s, false),
-                false
-            );
+            threadContext.updateResponseHeader("baz", duplicateValue, s -> HeaderWarning.extractWarningValueFromWarningHeader(s, false));
         }
 
         threadContext.addResponseHeader("Warning", "One is the loneliest number");

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -2285,7 +2285,8 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                     new FetchPhase(Collections.emptyList()),
                     responseCollectorService,
                     new NoneCircuitBreakerService(),
-                    null
+                    null,
+                    new TaskResourceTrackingService(settings, clusterSettings, threadPool)
                 );
                 SearchPhaseController searchPhaseController = new SearchPhaseController(
                     writableRegistry(),
@@ -2320,7 +2321,8 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                         ),
                         NoopMetricsRegistry.INSTANCE,
                         searchRequestOperationsCompositeListenerFactory,
-                        NoopTracer.INSTANCE
+                        NoopTracer.INSTANCE,
+                        new TaskResourceTrackingService(settings, clusterSettings, threadPool)
                     )
                 );
                 actions.put(

--- a/server/src/test/java/org/opensearch/tasks/TaskResourceInfoTests.java
+++ b/server/src/test/java/org/opensearch/tasks/TaskResourceInfoTests.java
@@ -1,0 +1,106 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.tasks;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.tasks.resourcetracker.TaskResourceInfo;
+import org.opensearch.core.tasks.resourcetracker.TaskResourceUsage;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Locale;
+
+/**
+ * Test cases for TaskResourceInfo
+ */
+public class TaskResourceInfoTests extends OpenSearchTestCase {
+    private final Long cpuUsage = randomNonNegativeLong();
+    private final Long memoryUsage = randomNonNegativeLong();
+    private final String action = randomAlphaOfLengthBetween(1, 10);
+    private final Long taskId = randomNonNegativeLong();
+    private final Long parentTaskId = randomNonNegativeLong();
+    private final String nodeId = randomAlphaOfLengthBetween(1, 10);
+    private TaskResourceInfo taskResourceInfo;
+    private TaskResourceUsage taskResourceUsage;
+
+    @Before
+    public void setUpVariables() {
+        taskResourceUsage = new TaskResourceUsage(cpuUsage, memoryUsage);
+        taskResourceInfo = new TaskResourceInfo(action, taskId, parentTaskId, nodeId, taskResourceUsage);
+    }
+
+    public void testGetters() {
+        assertEquals(action, taskResourceInfo.getAction());
+        assertEquals(taskId.longValue(), taskResourceInfo.getTaskId());
+        assertEquals(parentTaskId.longValue(), taskResourceInfo.getParentTaskId());
+        assertEquals(nodeId, taskResourceInfo.getNodeId());
+        assertEquals(taskResourceUsage, taskResourceInfo.getTaskResourceUsage());
+    }
+
+    public void testEqualsAndHashCode() {
+        TaskResourceInfo taskResourceInfoCopy = new TaskResourceInfo(action, taskId, parentTaskId, nodeId, taskResourceUsage);
+        assertEquals(taskResourceInfo, taskResourceInfoCopy);
+        assertEquals(taskResourceInfo.hashCode(), taskResourceInfoCopy.hashCode());
+        TaskResourceInfo differentTaskResourceInfo = new TaskResourceInfo(
+            "differentAction",
+            taskId,
+            parentTaskId,
+            nodeId,
+            taskResourceUsage
+        );
+        assertNotEquals(taskResourceInfo, differentTaskResourceInfo);
+        assertNotEquals(taskResourceInfo.hashCode(), differentTaskResourceInfo.hashCode());
+    }
+
+    public void testSerialization() throws IOException {
+        BytesStreamOutput output = new BytesStreamOutput();
+        taskResourceInfo.writeTo(output);
+        StreamInput input = StreamInput.wrap(output.bytes().toBytesRef().bytes);
+        TaskResourceInfo deserializedTaskResourceInfo = TaskResourceInfo.readFromStream(input);
+        assertEquals(taskResourceInfo, deserializedTaskResourceInfo);
+    }
+
+    public void testToString() {
+        String expectedString = String.format(
+            Locale.ROOT,
+            "{\"action\":\"%s\",\"taskId\":%s,\"parentTaskId\":%s,\"nodeId\":\"%s\",\"taskResourceUsage\":{\"cpu_time_in_nanos\":%s,\"memory_in_bytes\":%s}}",
+            action,
+            taskId,
+            parentTaskId,
+            nodeId,
+            taskResourceUsage.getCpuTimeInNanos(),
+            taskResourceUsage.getMemoryInBytes()
+        );
+        assertTrue(expectedString.equals(taskResourceInfo.toString()));
+    }
+
+    public void testToXContent() throws IOException {
+        char[] expectedXcontent = String.format(
+            Locale.ROOT,
+            "{\"action\":\"%s\",\"taskId\":%s,\"parentTaskId\":%s,\"nodeId\":\"%s\",\"taskResourceUsage\":{\"cpu_time_in_nanos\":%s,\"memory_in_bytes\":%s}}",
+            action,
+            taskId,
+            parentTaskId,
+            nodeId,
+            taskResourceUsage.getCpuTimeInNanos(),
+            taskResourceUsage.getMemoryInBytes()
+        ).toCharArray();
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(MediaTypeRegistry.JSON);
+        char[] xContent = BytesReference.bytes(taskResourceInfo.toXContent(builder, ToXContent.EMPTY_PARAMS)).utf8ToString().toCharArray();
+        assertEquals(Arrays.hashCode(expectedXcontent), Arrays.hashCode(xContent));
+    }
+}

--- a/test/framework/src/main/java/org/opensearch/node/MockNode.java
+++ b/test/framework/src/main/java/org/opensearch/node/MockNode.java
@@ -60,6 +60,7 @@ import org.opensearch.search.MockSearchService;
 import org.opensearch.search.SearchService;
 import org.opensearch.search.fetch.FetchPhase;
 import org.opensearch.search.query.QueryPhase;
+import org.opensearch.tasks.TaskResourceTrackingService;
 import org.opensearch.telemetry.tracing.Tracer;
 import org.opensearch.test.MockHttpTransport;
 import org.opensearch.test.transport.MockTransportService;
@@ -155,7 +156,8 @@ public class MockNode extends Node {
         FetchPhase fetchPhase,
         ResponseCollectorService responseCollectorService,
         CircuitBreakerService circuitBreakerService,
-        Executor indexSearcherExecutor
+        Executor indexSearcherExecutor,
+        TaskResourceTrackingService taskResourceTrackingService
     ) {
         if (getPluginsService().filterPlugins(MockSearchService.TestPlugin.class).isEmpty()) {
             return super.newSearchService(
@@ -168,7 +170,8 @@ public class MockNode extends Node {
                 fetchPhase,
                 responseCollectorService,
                 circuitBreakerService,
-                indexSearcherExecutor
+                indexSearcherExecutor,
+                taskResourceTrackingService
             );
         }
         return new MockSearchService(
@@ -180,7 +183,8 @@ public class MockNode extends Node {
             queryPhase,
             fetchPhase,
             circuitBreakerService,
-            indexSearcherExecutor
+            indexSearcherExecutor,
+            taskResourceTrackingService
         );
     }
 

--- a/test/framework/src/main/java/org/opensearch/search/MockSearchService.java
+++ b/test/framework/src/main/java/org/opensearch/search/MockSearchService.java
@@ -42,6 +42,7 @@ import org.opensearch.script.ScriptService;
 import org.opensearch.search.fetch.FetchPhase;
 import org.opensearch.search.internal.ReaderContext;
 import org.opensearch.search.query.QueryPhase;
+import org.opensearch.tasks.TaskResourceTrackingService;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.util.HashMap;
@@ -96,7 +97,8 @@ public class MockSearchService extends SearchService {
         QueryPhase queryPhase,
         FetchPhase fetchPhase,
         CircuitBreakerService circuitBreakerService,
-        Executor indexSearcherExecutor
+        Executor indexSearcherExecutor,
+        TaskResourceTrackingService taskResourceTrackingService
     ) {
         super(
             clusterService,
@@ -108,7 +110,8 @@ public class MockSearchService extends SearchService {
             fetchPhase,
             null,
             circuitBreakerService,
-            indexSearcherExecutor
+            indexSearcherExecutor,
+            taskResourceTrackingService
         );
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This is a manual backport PR for Query-level resource usages tracking, and the query insights plugin support to consume the query level resource usage.


### Related Issues
Original PRs: 
https://github.com/opensearch-project/OpenSearch/pull/13172
https://github.com/opensearch-project/OpenSearch/pull/14084
https://github.com/opensearch-project/OpenSearch/pull/13739
https://github.com/opensearch-project/OpenSearch/pull/14147

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
