### PR TITLE
Fix the rewrite method for MatchOnlyText field query

### DIFF
--- a/server/src/main/java/org/opensearch/index/query/SourceFieldMatchQuery.java
+++ b/server/src/main/java/org/opensearch/index/query/SourceFieldMatchQuery.java
@@ -73,7 +73,7 @@ public class SourceFieldMatchQuery extends Query {
 
     @Override
     public Query rewrite(IndexSearcher indexSearcher) throws IOException {
-        Query rewritten = indexSearcher.rewrite(delegateQuery);
+        Query rewritten = delegateQuery.rewrite(indexSearcher);
         if (rewritten == delegateQuery) {
             return this;
         }

--- a/server/src/test/java/org/opensearch/search/query/QueryProfilePhaseTests.java
+++ b/server/src/test/java/org/opensearch/search/query/QueryProfilePhaseTests.java
@@ -35,6 +35,7 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.Pruning;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Sort;
@@ -48,12 +49,18 @@ import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.opensearch.action.search.SearchShardTask;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.index.Index;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.mapper.DocumentMapper;
+import org.opensearch.index.mapper.MatchOnlyTextFieldMapper;
 import org.opensearch.index.mapper.NumberFieldMapper.NumberFieldType;
 import org.opensearch.index.mapper.NumberFieldMapper.NumberType;
+import org.opensearch.index.mapper.SourceFieldMapper;
+import org.opensearch.index.mapper.TextSearchInfo;
 import org.opensearch.index.query.ParsedQuery;
 import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.index.query.SourceFieldMatchQuery;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.shard.IndexShardTestCase;
 import org.opensearch.lucene.queries.MinDocQuery;
@@ -62,6 +69,9 @@ import org.opensearch.search.collapse.CollapseBuilder;
 import org.opensearch.search.internal.ContextIndexSearcher;
 import org.opensearch.search.internal.ScrollContext;
 import org.opensearch.search.internal.SearchContext;
+import org.opensearch.search.lookup.LeafSearchLookup;
+import org.opensearch.search.lookup.SearchLookup;
+import org.opensearch.search.lookup.SourceLookup;
 import org.opensearch.search.profile.ProfileResult;
 import org.opensearch.search.profile.ProfileShardResult;
 import org.opensearch.search.profile.SearchProfileShardResults;
@@ -80,6 +90,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -94,6 +105,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -1510,6 +1522,90 @@ public class QueryProfilePhaseTests extends IndexShardTestCase {
             assertThat(collector.getProfiledChildren(), empty());
         });
 
+        reader.close();
+        dir.close();
+    }
+
+    public void testSourceFieldMatchQueryWithProfile() throws Exception {
+        Directory dir = newDirectory();
+        IndexWriterConfig iwc = newIndexWriterConfig();
+        RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
+        w.close();
+        IndexReader reader = DirectoryReader.open(dir);
+        QueryShardContext queryShardContext = mock(QueryShardContext.class);
+        DocumentMapper mockDocumentMapper = mock(DocumentMapper.class);
+        SourceFieldMapper mockSourceMapper = mock(SourceFieldMapper.class);
+        SearchLookup searchLookup = mock(SearchLookup.class);
+        LeafSearchLookup leafSearchLookup = mock(LeafSearchLookup.class);
+
+        when(queryShardContext.sourcePath("foo")).thenReturn(Set.of("bar"));
+        when(queryShardContext.index()).thenReturn(new Index("test_index", "uuid"));
+        when(searchLookup.getLeafSearchLookup(any())).thenReturn(leafSearchLookup);
+        when(leafSearchLookup.source()).thenReturn(new SourceLookup());
+        when(mockSourceMapper.enabled()).thenReturn(true);
+        when(mockDocumentMapper.sourceMapper()).thenReturn(mockSourceMapper);
+        when(queryShardContext.documentMapper(any())).thenReturn(mockDocumentMapper);
+        when(queryShardContext.lookup()).thenReturn(searchLookup);
+
+        TestSearchContext context = new TestSearchContext(queryShardContext, indexShard, newContextSearcher(reader, executor));
+        context.parsedQuery(
+            new ParsedQuery(
+                new SourceFieldMatchQuery(
+                    new TermQuery(new Term("foo", "bar")),
+                    new PhraseQuery("foo", "bar", "baz"),
+                    new MatchOnlyTextFieldMapper.MatchOnlyTextFieldType(
+                        "user",
+                        true,
+                        true,
+                        TextSearchInfo.WHITESPACE_MATCH_ONLY,
+                        Collections.emptyMap()
+                    ),
+                    queryShardContext
+                )
+            )
+        );
+
+        context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
+        context.setSize(1);
+        context.trackTotalHitsUpTo(5);
+        QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers(), queryPhaseSearcher);
+        assertProfileData(context, "SourceFieldMatchQuery", query -> {
+            assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+            assertThat(query.getTimeBreakdown().get("score"), equalTo(0L));
+            assertThat(query.getTimeBreakdown().get("score_count"), equalTo(0L));
+            if (executor != null) {
+                long maxScore = query.getTimeBreakdown().get("max_score");
+                long minScore = query.getTimeBreakdown().get("min_score");
+                long avgScore = query.getTimeBreakdown().get("avg_score");
+                long maxScoreCount = query.getTimeBreakdown().get("max_score_count");
+                long minScoreCount = query.getTimeBreakdown().get("min_score_count");
+                long avgScoreCount = query.getTimeBreakdown().get("avg_score_count");
+                assertThat(maxScore, equalTo(0L));
+                assertThat(minScore, equalTo(0L));
+                assertThat(avgScore, equalTo(0L));
+                assertThat(maxScore, equalTo(avgScore));
+                assertThat(avgScore, equalTo(minScore));
+                assertThat(maxScoreCount, equalTo(0L));
+                assertThat(minScoreCount, equalTo(0L));
+                assertThat(avgScoreCount, equalTo(0L));
+                assertThat(maxScoreCount, equalTo(avgScoreCount));
+                assertThat(avgScoreCount, equalTo(minScoreCount));
+            }
+            assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+            assertThat(query.getProfiledChildren(), empty());
+        }, collector -> {
+            assertThat(collector.getReason(), equalTo("search_top_hits"));
+            assertThat(collector.getTime(), greaterThan(0L));
+            if (collector.getName().contains("CollectorManager")) {
+                assertThat(collector.getReduceTime(), greaterThan(0L));
+            }
+            assertThat(collector.getMaxSliceTime(), greaterThan(0L));
+            assertThat(collector.getMinSliceTime(), greaterThan(0L));
+            assertThat(collector.getAvgSliceTime(), greaterThan(0L));
+            assertThat(collector.getSliceCount(), greaterThanOrEqualTo(1));
+            assertThat(collector.getProfiledChildren(), empty());
+        });
         reader.close();
         dir.close();
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Using `indexSearcher.rewrite(delegateQuery)` instead of `delegateQuery.rewrite(indexSearcher);`  can have side effects when `profile` is set to true, as it can start reusing the profile objects created in parent query and can interfere with timers if they were already started. Whereas,` query.rewrite(indexSearcher)` it just uses the lucene APIs and doesn't use the wrapped functionality in OpenSearch. 


In query phase, when rewrite is called

https://github.com/opensearch-project/OpenSearch/blob/5ff50a7e00698b0f448bc4840461c8518500d591/server/src/main/java/org/opensearch/search/query/QueryPhase.java#L127

the `ContextIndexSearch` will start the timer for the query and will start noting the `rewrite()` time for all clauses in the clauses for the complete query tree. 

But if we try to use `indexSearcher.rewrite(delegateQuery)` within rewrite of any of the query, it will try to initialize the profiler and timer again and will result in the assertion error here - 

https://github.com/opensearch-project/OpenSearch/blob/200ad5d28a577877be530ecab507601898025c5c/server/src/main/java/org/opensearch/search/profile/query/AbstractQueryProfileTree.java#L48

```
»  java.lang.AssertionError
»       at org.opensearch.search.profile.query.AbstractQueryProfileTree.startRewriteTime(AbstractQueryProfileTree.java:48)
»       at org.opensearch.search.profile.query.QueryProfiler.startRewriteTime(QueryProfiler.java:80)
»       at org.opensearch.search.internal.ContextIndexSearcher.rewrite(ContextIndexSearcher.java:192)
»       at org.opensearch.index.query.SourceFieldMatchQuery.rewrite(SourceFieldMatchQuery.java:76)
»       at org.apache.lucene.search.IndexSearcher.rewrite(IndexSearcher.java:777)
»       at org.opensearch.search.internal.ContextIndexSearcher.rewrite(ContextIndexSearcher.java:196)
»       at org.opensearch.search.DefaultSearchContext.preProcess(DefaultSearchContext.java:362)
»       at org.opensearch.search.query.QueryPhase.preProcess(QueryPhase.java:127)
»       at org.opensearch.search.SearchService.createContext(SearchService.java:1053)
```

### Related Issues
<!-- List any other related issues here -->
Fixes https://github.com/opensearch-project/OpenSearch/issues/14156

### Check List
- ~~[ ] Functionality includes testing.~~ There are already unit and integ tests present for `match_only_text` field. 
- ~~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~~
- ~~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
