### PR TITLE
`analysis-common`: make `UniqueTokenFilter` public

### DIFF
--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/UniqueTokenFilter.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/UniqueTokenFilter.java
@@ -44,7 +44,7 @@ import java.io.IOException;
  * A token filter that generates unique tokens. Can remove unique tokens only on the same
  * position increments as well.
  */
-class UniqueTokenFilter extends TokenFilter {
+public class UniqueTokenFilter extends TokenFilter {
 
     private final CharTermAttribute termAttribute = addAttribute(CharTermAttribute.class);
     private final PositionIncrementAttribute posIncAttribute = addAttribute(PositionIncrementAttribute.class);
@@ -52,11 +52,11 @@ class UniqueTokenFilter extends TokenFilter {
     private final CharArraySet previous = new CharArraySet(8, false);
     private final boolean onlyOnSamePosition;
 
-    UniqueTokenFilter(TokenStream in) {
+    public UniqueTokenFilter(TokenStream in) {
         this(in, false);
     }
 
-    UniqueTokenFilter(TokenStream in, boolean onlyOnSamePosition) {
+    public UniqueTokenFilter(TokenStream in, boolean onlyOnSamePosition) {
         super(in);
         this.onlyOnSamePosition = onlyOnSamePosition;
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
this way the filter can also be used from plugins which implement analyzers and want to use it.
the current workaround is that the plugin has to implement the usage from it in a package with the same name, which is just an ugly hack.

### Related Issues
no issue, but see [this discussion on slack](https://opensearch.slack.com/archives/C051D137M7G/p1717592052928849).

### Check List
(none applicable)

- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
