### PR TITLE
[Backport] [2.x] Java high-level REST client bulk() is not respecting the bulkRequest.requireAlias(true) method call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix NPE on restore searchable snapshot ([#13911](https://github.com/opensearch-project/OpenSearch/pull/13911))
 - Fix double invocation of postCollection when MultiBucketCollector is present ([#14015](https://github.com/opensearch-project/OpenSearch/pull/14015))
 - Fix ReplicaShardBatchAllocator to batch shards without duplicates ([#13710](https://github.com/opensearch-project/OpenSearch/pull/13710))
+- Java high-level REST client bulk() is not respecting the bulkRequest.requireAlias(true) method call ([#14146](https://github.com/opensearch-project/OpenSearch/pull/14146))
 
 ### Security
 

--- a/client/rest-high-level/src/main/java/org/opensearch/client/RequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/RequestConverters.java
@@ -154,6 +154,9 @@ final class RequestConverters {
         parameters.withRefreshPolicy(bulkRequest.getRefreshPolicy());
         parameters.withPipeline(bulkRequest.pipeline());
         parameters.withRouting(bulkRequest.routing());
+        if (bulkRequest.requireAlias() != null) {
+            parameters.withRequireAlias(bulkRequest.requireAlias());
+        }
         // Bulk API only supports newline delimited JSON or Smile. Before executing
         // the bulk, we need to check that all requests have the same content-type
         // and this content-type is supported by the Bulk API.
@@ -231,6 +234,10 @@ final class RequestConverters {
                         if (updateRequest.fetchSource() != null) {
                             metadata.field("_source", updateRequest.fetchSource());
                         }
+                    }
+
+                    if (action.isRequireAlias()) {
+                        metadata.field("require_alias", action.isRequireAlias());
                     }
                     metadata.endObject();
                 }

--- a/client/rest-high-level/src/test/java/org/opensearch/client/CrudIT.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/CrudIT.java
@@ -1299,4 +1299,61 @@ public class CrudIT extends OpenSearchRestHighLevelClientTestCase {
             }
         }
     }
+
+    public void testBulkWithRequireAlias() throws IOException {
+        {
+            String indexAliasName = "testindex-1";
+
+            BulkRequest bulkRequest = new BulkRequest(indexAliasName);
+            bulkRequest.requireAlias(true);
+            bulkRequest.add(new IndexRequest().id("1").source("{ \"name\": \"Biden\" }", XContentType.JSON));
+            bulkRequest.add(new IndexRequest().id("2").source("{ \"name\": \"Trump\" }", XContentType.JSON));
+
+            BulkResponse bulkResponse = execute(bulkRequest, highLevelClient()::bulk, highLevelClient()::bulkAsync, RequestOptions.DEFAULT);
+
+            assertFalse("Should not auto-create the '" + indexAliasName + "' index.", indexExists(indexAliasName));
+            assertTrue("Bulk response must have failures.", bulkResponse.hasFailures());
+        }
+        {
+            String indexAliasName = "testindex-2";
+
+            BulkRequest bulkRequest = new BulkRequest();
+            bulkRequest.requireAlias(true);
+            bulkRequest.add(new IndexRequest().index(indexAliasName).id("1").source("{ \"name\": \"Biden\" }", XContentType.JSON));
+            bulkRequest.add(new IndexRequest().index(indexAliasName).id("2").source("{ \"name\": \"Trump\" }", XContentType.JSON));
+
+            BulkResponse bulkResponse = execute(bulkRequest, highLevelClient()::bulk, highLevelClient()::bulkAsync, RequestOptions.DEFAULT);
+
+            assertFalse("Should not auto-create the '" + indexAliasName + "' index.", indexExists(indexAliasName));
+            assertTrue("Bulk response must have failures.", bulkResponse.hasFailures());
+        }
+        {
+            String indexAliasName = "testindex-3";
+
+            BulkRequest bulkRequest = new BulkRequest(indexAliasName);
+            bulkRequest.add(new IndexRequest().id("1").setRequireAlias(true).source("{ \"name\": \"Biden\" }", XContentType.JSON));
+            bulkRequest.add(new IndexRequest().id("2").setRequireAlias(true).source("{ \"name\": \"Trump\" }", XContentType.JSON));
+
+            BulkResponse bulkResponse = execute(bulkRequest, highLevelClient()::bulk, highLevelClient()::bulkAsync, RequestOptions.DEFAULT);
+
+            assertFalse("Should not auto-create the '" + indexAliasName + "' index.", indexExists(indexAliasName));
+            assertTrue("Bulk response must have failures.", bulkResponse.hasFailures());
+        }
+        {
+            String indexAliasName = "testindex-4";
+
+            BulkRequest bulkRequest = new BulkRequest();
+            bulkRequest.add(
+                new IndexRequest().index(indexAliasName).id("1").setRequireAlias(true).source("{ \"name\": \"Biden\" }", XContentType.JSON)
+            );
+            bulkRequest.add(
+                new IndexRequest().index(indexAliasName).id("2").setRequireAlias(true).source("{ \"name\": \"Trump\" }", XContentType.JSON)
+            );
+
+            BulkResponse bulkResponse = execute(bulkRequest, highLevelClient()::bulk, highLevelClient()::bulkAsync, RequestOptions.DEFAULT);
+
+            assertFalse("Should not auto-create the '" + indexAliasName + "' index.", indexExists(indexAliasName));
+            assertTrue("Bulk response must have failures.", bulkResponse.hasFailures());
+        }
+    }
 }


### PR DESCRIPTION
Backport of  https://github.com/opensearch-project/OpenSearch/pull/14146 to `2.x`