### PR TITLE
[Backport 2.x]Create Remote Object managers and use them in orchestration from Remo…

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/gateway/remote/RemoteClusterStateServiceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/gateway/remote/RemoteClusterStateServiceIT.java
@@ -26,13 +26,13 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.opensearch.gateway.remote.RemoteClusterStateService.COORDINATION_METADATA;
-import static org.opensearch.gateway.remote.RemoteClusterStateService.CUSTOM_METADATA;
-import static org.opensearch.gateway.remote.RemoteClusterStateService.DELIMITER;
-import static org.opensearch.gateway.remote.RemoteClusterStateService.METADATA_FILE_PREFIX;
 import static org.opensearch.gateway.remote.RemoteClusterStateService.REMOTE_CLUSTER_STATE_ENABLED_SETTING;
-import static org.opensearch.gateway.remote.RemoteClusterStateService.SETTING_METADATA;
-import static org.opensearch.gateway.remote.RemoteClusterStateService.TEMPLATES_METADATA;
+import static org.opensearch.gateway.remote.RemoteClusterStateUtils.DELIMITER;
+import static org.opensearch.gateway.remote.RemoteClusterStateUtils.METADATA_FILE_PREFIX;
+import static org.opensearch.gateway.remote.model.RemoteCoordinationMetadata.COORDINATION_METADATA;
+import static org.opensearch.gateway.remote.model.RemoteCustomMetadata.CUSTOM_METADATA;
+import static org.opensearch.gateway.remote.model.RemotePersistentSettingsMetadata.SETTING_METADATA;
+import static org.opensearch.gateway.remote.model.RemoteTemplatesMetadata.TEMPLATES_METADATA;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
 public class RemoteClusterStateServiceIT extends RemoteStoreBaseIntegTestCase {

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreClusterStateRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreClusterStateRestoreIT.java
@@ -57,6 +57,7 @@ import static org.opensearch.cluster.metadata.IndexMetadata.INDEX_READ_ONLY_SETT
 import static org.opensearch.cluster.metadata.Metadata.CLUSTER_READ_ONLY_BLOCK;
 import static org.opensearch.cluster.metadata.Metadata.SETTING_READ_ONLY_SETTING;
 import static org.opensearch.gateway.remote.RemoteClusterStateService.REMOTE_CLUSTER_STATE_ENABLED_SETTING;
+import static org.opensearch.gateway.remote.RemoteClusterStateUtils.encodeString;
 import static org.opensearch.indices.ShardLimitValidator.SETTING_CLUSTER_MAX_SHARDS_PER_NODE;
 import static org.opensearch.repositories.blobstore.BlobStoreRepository.SYSTEM_REPOSITORY_SETTING;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
@@ -326,9 +327,7 @@ public class RemoteStoreClusterStateRestoreIT extends BaseRemoteStoreRestoreIT {
         // Step - 3 Delete index metadata file in remote
         try {
             Files.move(
-                segmentRepoPath.resolve(
-                    RemoteClusterStateService.encodeString(clusterName) + "/cluster-state/" + prevClusterUUID + "/index"
-                ),
+                segmentRepoPath.resolve(encodeString(clusterName) + "/cluster-state/" + prevClusterUUID + "/index"),
                 segmentRepoPath.resolve("cluster-state/")
             );
         } catch (IOException e) {
@@ -354,10 +353,7 @@ public class RemoteStoreClusterStateRestoreIT extends BaseRemoteStoreRestoreIT {
         try {
             Files.move(
                 segmentRepoPath.resolve(
-                    RemoteClusterStateService.encodeString(clusterService().state().getClusterName().value())
-                        + "/cluster-state/"
-                        + prevClusterUUID
-                        + "/manifest"
+                    encodeString(clusterService().state().getClusterName().value()) + "/cluster-state/" + prevClusterUUID + "/manifest"
                 ),
                 segmentRepoPath.resolve("cluster-state/")
             );

--- a/server/src/main/java/org/opensearch/cluster/routing/remote/InternalRemoteRoutingTableService.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/remote/InternalRemoteRoutingTableService.java
@@ -33,7 +33,7 @@ import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.gateway.remote.ClusterMetadataManifest;
-import org.opensearch.gateway.remote.RemoteClusterStateService;
+import org.opensearch.gateway.remote.RemoteStateTransferException;
 import org.opensearch.gateway.remote.routingtable.RemoteIndexRoutingTable;
 import org.opensearch.index.remote.RemoteStoreEnums;
 import org.opensearch.index.remote.RemoteStorePathStrategy;
@@ -52,6 +52,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static org.opensearch.gateway.remote.RemoteClusterStateUtils.DELIMITER;
 import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.isRemoteRoutingTableEnabled;
 
 /**
@@ -87,7 +88,6 @@ public class InternalRemoteRoutingTableService extends AbstractLifecycleComponen
 
     public static final String INDEX_ROUTING_PATH_TOKEN = "index-routing";
     public static final String INDEX_ROUTING_FILE_PREFIX = "index_routing";
-    public static final String DELIMITER = "__";
     public static final String INDEX_ROUTING_METADATA_PREFIX = "indexRouting--";
 
     private static final Logger logger = LogManager.getLogger(InternalRemoteRoutingTableService.class);
@@ -175,10 +175,7 @@ public class InternalRemoteRoutingTableService extends AbstractLifecycleComponen
                 )
             ),
             ex -> latchedActionListener.onFailure(
-                new RemoteClusterStateService.RemoteStateTransferException(
-                    "Exception in writing index to remote store: " + indexRouting.getIndex().toString(),
-                    ex
-                )
+                new RemoteStateTransferException("Exception in writing index to remote store: " + indexRouting.getIndex().toString(), ex)
             )
         );
 

--- a/server/src/main/java/org/opensearch/common/remote/AbstractRemoteWritableBlobEntity.java
+++ b/server/src/main/java/org/opensearch/common/remote/AbstractRemoteWritableBlobEntity.java
@@ -42,6 +42,8 @@ public abstract class AbstractRemoteWritableBlobEntity<T> implements RemoteWrite
 
     public abstract BlobPathParameters getBlobPathParameters();
 
+    public abstract String getType();
+
     public String getFullBlobName() {
         return blobName;
     }

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -182,6 +182,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import static org.opensearch.gateway.remote.RemoteGlobalMetadataManager.GLOBAL_METADATA_UPLOAD_TIMEOUT_SETTING;
+import static org.opensearch.gateway.remote.RemoteIndexMetadataManager.INDEX_METADATA_UPLOAD_TIMEOUT_SETTING;
+import static org.opensearch.gateway.remote.RemoteManifestManager.METADATA_MANIFEST_UPLOAD_TIMEOUT_SETTING;
+
 /**
  * Encapsulates all valid cluster level settings.
  *
@@ -719,9 +723,9 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 // Remote cluster state settings
                 RemoteClusterStateCleanupManager.REMOTE_CLUSTER_STATE_CLEANUP_INTERVAL_SETTING,
                 RemoteClusterStateService.REMOTE_CLUSTER_STATE_ENABLED_SETTING,
-                RemoteClusterStateService.INDEX_METADATA_UPLOAD_TIMEOUT_SETTING,
-                RemoteClusterStateService.GLOBAL_METADATA_UPLOAD_TIMEOUT_SETTING,
-                RemoteClusterStateService.METADATA_MANIFEST_UPLOAD_TIMEOUT_SETTING,
+                INDEX_METADATA_UPLOAD_TIMEOUT_SETTING,
+                GLOBAL_METADATA_UPLOAD_TIMEOUT_SETTING,
+                METADATA_MANIFEST_UPLOAD_TIMEOUT_SETTING,
                 RemoteStoreNodeService.REMOTE_STORE_COMPATIBILITY_MODE_SETTING,
                 RemoteStoreNodeService.MIGRATION_DIRECTION_SETTING,
 

--- a/server/src/main/java/org/opensearch/gateway/remote/ClusterMetadataManifest.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/ClusterMetadataManifest.java
@@ -1158,8 +1158,7 @@ public class ClusterMetadataManifest implements Writeable, ToXContentFragment {
         }
 
         public String getUploadedFilename() {
-            String[] splitPath = uploadedFilename.split("/");
-            return splitPath[splitPath.length - 1];
+            return uploadedFilename;
         }
 
         public String getIndexName() {

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -11,14 +11,12 @@ package org.opensearch.gateway.remote;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.opensearch.Version;
 import org.opensearch.action.LatchedActionListener;
+import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.DiffableUtils;
-import org.opensearch.cluster.coordination.CoordinationMetadata;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.Metadata;
-import org.opensearch.cluster.metadata.TemplatesMetadata;
 import org.opensearch.cluster.routing.IndexRoutingTable;
 import org.opensearch.cluster.routing.remote.InternalRemoteRoutingTableService;
 import org.opensearch.cluster.routing.remote.RemoteRoutingTableService;
@@ -27,8 +25,6 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.CheckedRunnable;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.blobstore.BlobContainer;
-import org.opensearch.common.blobstore.BlobMetadata;
-import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.common.blobstore.BlobStore;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
@@ -41,41 +37,47 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.gateway.remote.ClusterMetadataManifest.UploadedIndexMetadata;
 import org.opensearch.gateway.remote.ClusterMetadataManifest.UploadedMetadataAttribute;
 import org.opensearch.gateway.remote.model.RemoteClusterStateManifestInfo;
-import org.opensearch.index.remote.RemoteStoreUtils;
+import org.opensearch.gateway.remote.model.RemoteCoordinationMetadata;
+import org.opensearch.gateway.remote.model.RemoteCustomMetadata;
+import org.opensearch.gateway.remote.model.RemotePersistentSettingsMetadata;
+import org.opensearch.gateway.remote.model.RemoteTemplatesMetadata;
 import org.opensearch.index.translog.transfer.BlobStoreTransferService;
 import org.opensearch.node.Node;
 import org.opensearch.node.remotestore.RemoteStoreNodeAttribute;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.repositories.Repository;
 import org.opensearch.repositories.blobstore.BlobStoreRepository;
-import org.opensearch.repositories.blobstore.ChecksumBlobStoreFormat;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import static java.util.Objects.requireNonNull;
 import static org.opensearch.gateway.PersistedClusterStateService.SLOW_WRITE_LOGGING_THRESHOLD;
-import static org.opensearch.gateway.remote.model.RemoteClusterMetadataManifest.MANIFEST_CURRENT_CODEC_VERSION;
+import static org.opensearch.gateway.remote.RemoteClusterStateUtils.DELIMITER;
+import static org.opensearch.gateway.remote.RemoteClusterStateUtils.UploadedMetadataResults;
+import static org.opensearch.gateway.remote.RemoteClusterStateUtils.clusterUUIDContainer;
+import static org.opensearch.gateway.remote.RemoteClusterStateUtils.getClusterMetadataBasePath;
+import static org.opensearch.gateway.remote.model.RemoteCoordinationMetadata.COORDINATION_METADATA;
+import static org.opensearch.gateway.remote.model.RemoteCustomMetadata.CUSTOM_DELIMITER;
+import static org.opensearch.gateway.remote.model.RemoteCustomMetadata.CUSTOM_METADATA;
+import static org.opensearch.gateway.remote.model.RemotePersistentSettingsMetadata.SETTING_METADATA;
+import static org.opensearch.gateway.remote.model.RemoteTemplatesMetadata.TEMPLATES_METADATA;
 import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.isRemoteStoreClusterStateEnabled;
 
 /**
@@ -85,98 +87,7 @@ import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.isRemoteS
  */
 public class RemoteClusterStateService implements Closeable {
 
-    public static final String METADATA_NAME_FORMAT = "%s.dat";
-
-    public static final String METADATA_MANIFEST_NAME_FORMAT = "%s";
-
-    public static final String DELIMITER = "__";
-    public static final String CUSTOM_DELIMITER = "--";
-
     private static final Logger logger = LogManager.getLogger(RemoteClusterStateService.class);
-
-    public static final TimeValue INDEX_METADATA_UPLOAD_TIMEOUT_DEFAULT = TimeValue.timeValueMillis(20000);
-
-    public static final TimeValue GLOBAL_METADATA_UPLOAD_TIMEOUT_DEFAULT = TimeValue.timeValueMillis(20000);
-
-    public static final TimeValue METADATA_MANIFEST_UPLOAD_TIMEOUT_DEFAULT = TimeValue.timeValueMillis(20000);
-
-    public static final Setting<TimeValue> INDEX_METADATA_UPLOAD_TIMEOUT_SETTING = Setting.timeSetting(
-        "cluster.remote_store.state.index_metadata.upload_timeout",
-        INDEX_METADATA_UPLOAD_TIMEOUT_DEFAULT,
-        Setting.Property.Dynamic,
-        Setting.Property.NodeScope
-    );
-
-    public static final Setting<TimeValue> GLOBAL_METADATA_UPLOAD_TIMEOUT_SETTING = Setting.timeSetting(
-        "cluster.remote_store.state.global_metadata.upload_timeout",
-        GLOBAL_METADATA_UPLOAD_TIMEOUT_DEFAULT,
-        Setting.Property.Dynamic,
-        Setting.Property.NodeScope
-    );
-
-    public static final Setting<TimeValue> METADATA_MANIFEST_UPLOAD_TIMEOUT_SETTING = Setting.timeSetting(
-        "cluster.remote_store.state.metadata_manifest.upload_timeout",
-        METADATA_MANIFEST_UPLOAD_TIMEOUT_DEFAULT,
-        Setting.Property.Dynamic,
-        Setting.Property.NodeScope
-    );
-
-    public static final ChecksumBlobStoreFormat<IndexMetadata> INDEX_METADATA_FORMAT = new ChecksumBlobStoreFormat<>(
-        "index-metadata",
-        METADATA_NAME_FORMAT,
-        IndexMetadata::fromXContent
-    );
-
-    public static final ChecksumBlobStoreFormat<Metadata> GLOBAL_METADATA_FORMAT = new ChecksumBlobStoreFormat<>(
-        "metadata",
-        METADATA_NAME_FORMAT,
-        Metadata::fromXContent
-    );
-
-    public static final ChecksumBlobStoreFormat<CoordinationMetadata> COORDINATION_METADATA_FORMAT = new ChecksumBlobStoreFormat<>(
-        "coordination",
-        METADATA_NAME_FORMAT,
-        CoordinationMetadata::fromXContent
-    );
-
-    public static final ChecksumBlobStoreFormat<Settings> SETTINGS_METADATA_FORMAT = new ChecksumBlobStoreFormat<>(
-        "settings",
-        METADATA_NAME_FORMAT,
-        Settings::fromXContent
-    );
-
-    public static final ChecksumBlobStoreFormat<TemplatesMetadata> TEMPLATES_METADATA_FORMAT = new ChecksumBlobStoreFormat<>(
-        "templates",
-        METADATA_NAME_FORMAT,
-        TemplatesMetadata::fromXContent
-    );
-
-    public static final ChecksumBlobStoreFormat<Metadata.Custom> CUSTOM_METADATA_FORMAT = new ChecksumBlobStoreFormat<>(
-        "custom",
-        METADATA_NAME_FORMAT,
-        null // no need to reader here, as this object is only used to write/serialize the object
-    );
-
-    /**
-     * Manifest format compatible with older codec v0, where codec version was missing.
-     */
-    public static final ChecksumBlobStoreFormat<ClusterMetadataManifest> CLUSTER_METADATA_MANIFEST_FORMAT_V0 =
-        new ChecksumBlobStoreFormat<>("cluster-metadata-manifest", METADATA_MANIFEST_NAME_FORMAT, ClusterMetadataManifest::fromXContentV0);
-
-    /**
-     * Manifest format compatible with older codec v1, where codec versions/global metadata was introduced.
-     */
-    public static final ChecksumBlobStoreFormat<ClusterMetadataManifest> CLUSTER_METADATA_MANIFEST_FORMAT_V1 =
-        new ChecksumBlobStoreFormat<>("cluster-metadata-manifest", METADATA_MANIFEST_NAME_FORMAT, ClusterMetadataManifest::fromXContentV1);
-
-    /**
-     * Manifest format compatible with codec v2, where global metadata file is replaced with multiple metadata attribute files
-     */
-    public static final ChecksumBlobStoreFormat<ClusterMetadataManifest> CLUSTER_METADATA_MANIFEST_FORMAT = new ChecksumBlobStoreFormat<>(
-        "cluster-metadata-manifest",
-        METADATA_MANIFEST_NAME_FORMAT,
-        ClusterMetadataManifest::fromXContent
-    );
 
     /**
      * Used to specify if cluster state metadata should be published to remote store
@@ -187,18 +98,6 @@ public class RemoteClusterStateService implements Closeable {
         Property.NodeScope,
         Property.Final
     );
-
-    public static final String CLUSTER_STATE_PATH_TOKEN = "cluster-state";
-    public static final String INDEX_PATH_TOKEN = "index";
-    public static final String GLOBAL_METADATA_PATH_TOKEN = "global-metadata";
-    public static final String MANIFEST_PATH_TOKEN = "manifest";
-    public static final String MANIFEST_FILE_PREFIX = "manifest";
-    public static final String METADATA_FILE_PREFIX = "metadata";
-    public static final String COORDINATION_METADATA = "coordination";
-    public static final String SETTING_METADATA = "settings";
-    public static final String TEMPLATES_METADATA = "templates";
-    public static final String CUSTOM_METADATA = "custom";
-    public static final int SPLITED_MANIFEST_FILE_LENGTH = 6; // file name manifest__term__version__C/P__timestamp__codecversion
 
     private final String nodeId;
     private final Supplier<RepositoriesService> repositoriesService;
@@ -211,17 +110,16 @@ public class RemoteClusterStateService implements Closeable {
     private final RemoteRoutingTableService remoteRoutingTableService;
     private volatile TimeValue slowWriteLoggingThreshold;
 
-    private volatile TimeValue indexMetadataUploadTimeout;
-    private volatile TimeValue globalMetadataUploadTimeout;
-    private volatile TimeValue metadataManifestUploadTimeout;
-    private RemoteClusterStateCleanupManager remoteClusterStateCleanupManager;
     private final RemotePersistenceStats remoteStateStats;
+    private RemoteClusterStateCleanupManager remoteClusterStateCleanupManager;
+    private RemoteIndexMetadataManager remoteIndexMetadataManager;
+    private RemoteGlobalMetadataManager remoteGlobalMetadataManager;
+    private RemoteManifestManager remoteManifestManager;
+    private ClusterSettings clusterSettings;
     private final String CLUSTER_STATE_UPLOAD_TIME_LOG_STRING = "writing cluster state for version [{}] took [{}ms]";
     private final String METADATA_UPDATE_LOG_STRING = "wrote metadata for [{}] indices and skipped [{}] unchanged "
         + "indices, coordination metadata updated : [{}], settings metadata updated : [{}], templates metadata "
         + "updated : [{}], custom metadata updated : [{}], indices routing updated : [{}]";
-    public static final int INDEX_METADATA_CURRENT_CODEC_VERSION = 1;
-    public static final int GLOBAL_METADATA_CURRENT_CODEC_VERSION = 2;
 
     // ToXContent Params with gateway mode.
     // We are using gateway context mode to persist all custom metadata.
@@ -248,15 +146,9 @@ public class RemoteClusterStateService implements Closeable {
         this.settings = settings;
         this.relativeTimeNanosSupplier = relativeTimeNanosSupplier;
         this.threadpool = threadPool;
-        ClusterSettings clusterSettings = clusterService.getClusterSettings();
+        clusterSettings = clusterService.getClusterSettings();
         this.slowWriteLoggingThreshold = clusterSettings.get(SLOW_WRITE_LOGGING_THRESHOLD);
-        this.indexMetadataUploadTimeout = clusterSettings.get(INDEX_METADATA_UPLOAD_TIMEOUT_SETTING);
-        this.globalMetadataUploadTimeout = clusterSettings.get(GLOBAL_METADATA_UPLOAD_TIMEOUT_SETTING);
-        this.metadataManifestUploadTimeout = clusterSettings.get(METADATA_MANIFEST_UPLOAD_TIMEOUT_SETTING);
         clusterSettings.addSettingsUpdateConsumer(SLOW_WRITE_LOGGING_THRESHOLD, this::setSlowWriteLoggingThreshold);
-        clusterSettings.addSettingsUpdateConsumer(INDEX_METADATA_UPLOAD_TIMEOUT_SETTING, this::setIndexMetadataUploadTimeout);
-        clusterSettings.addSettingsUpdateConsumer(GLOBAL_METADATA_UPLOAD_TIMEOUT_SETTING, this::setGlobalMetadataUploadTimeout);
-        clusterSettings.addSettingsUpdateConsumer(METADATA_MANIFEST_UPLOAD_TIMEOUT_SETTING, this::setMetadataManifestUploadTimeout);
         this.remoteStateStats = new RemotePersistenceStats();
         this.remoteClusterStateCleanupManager = new RemoteClusterStateCleanupManager(this, clusterService);
         this.indexMetadataUploadListeners = indexMetadataUploadListeners;
@@ -287,15 +179,10 @@ public class RemoteClusterStateService implements Closeable {
             true,
             remoteRoutingTableService.getIndicesRouting(clusterState.getRoutingTable())
         );
-        final RemoteClusterStateManifestInfo manifestDetails = uploadManifest(
+        final RemoteClusterStateManifestInfo manifestDetails = remoteManifestManager.uploadManifest(
             clusterState,
-            uploadedMetadataResults.uploadedIndexMetadata,
+            uploadedMetadataResults,
             previousClusterUUID,
-            uploadedMetadataResults.uploadedCoordinationMetadata,
-            uploadedMetadataResults.uploadedSettingsMetadata,
-            uploadedMetadataResults.uploadedTemplatesMetadata,
-            uploadedMetadataResults.uploadedCustomMetadataMap,
-            uploadedMetadataResults.uploadedIndicesRoutingMetadata,
             false
         );
         final long durationMillis = TimeValue.nsecToMSec(relativeTimeNanosSupplier.getAsLong() - startTimeNanos);
@@ -326,7 +213,7 @@ public class RemoteClusterStateService implements Closeable {
      * manifest. The new manifest file is created by using the unchanged metadata from the previous manifest and the new metadata changes from the current
      * cluster state.
      *
-     * @return The uploaded ClusterMetadataManifest file
+     * @return {@link RemoteClusterStateManifestInfo} object containing uploaded manifest detail
      */
     @Nullable
     public RemoteClusterStateManifestInfo writeIncrementalMetadata(
@@ -342,15 +229,16 @@ public class RemoteClusterStateService implements Closeable {
         assert previousClusterState.metadata().coordinationMetadata().term() == clusterState.metadata().coordinationMetadata().term();
 
         final Map<String, UploadedMetadataAttribute> customsToBeDeletedFromRemote = new HashMap<>(previousManifest.getCustomMetadataMap());
-        final Map<String, Metadata.Custom> customsToUpload = getUpdatedCustoms(clusterState, previousClusterState);
+        final Map<String, Metadata.Custom> customsToUpload = remoteGlobalMetadataManager.getUpdatedCustoms(
+            clusterState,
+            previousClusterState
+        );
         final Map<String, UploadedMetadataAttribute> allUploadedCustomMap = new HashMap<>(previousManifest.getCustomMetadataMap());
         for (final String custom : clusterState.metadata().customs().keySet()) {
             // remove all the customs which are present currently
             customsToBeDeletedFromRemote.remove(custom);
         }
-
         final Map<String, IndexMetadata> indicesToBeDeletedFromRemote = new HashMap<>(previousClusterState.metadata().indices());
-
         int numIndicesUpdated = 0;
         int numIndicesUnchanged = 0;
         final Map<String, ClusterMetadataManifest.UploadedIndexMetadata> allUploadedIndexMetadata = previousManifest.getIndices()
@@ -418,24 +306,30 @@ public class RemoteClusterStateService implements Closeable {
         customsToBeDeletedFromRemote.keySet().forEach(allUploadedCustomMap::remove);
         indicesToBeDeletedFromRemote.keySet().forEach(allUploadedIndexMetadata::remove);
 
+        if (!updateCoordinationMetadata) {
+            uploadedMetadataResults.uploadedCoordinationMetadata = previousManifest.getCoordinationMetadata();
+        }
+        if (!updateSettingsMetadata) {
+            uploadedMetadataResults.uploadedSettingsMetadata = previousManifest.getSettingsMetadata();
+        }
+        if (!updateTemplatesMetadata) {
+            uploadedMetadataResults.uploadedTemplatesMetadata = previousManifest.getTemplatesMetadata();
+        }
+        uploadedMetadataResults.uploadedCustomMetadataMap = allUploadedCustomMap;
+        uploadedMetadataResults.uploadedIndexMetadata = new ArrayList<>(allUploadedIndexMetadata.values());
+
         List<ClusterMetadataManifest.UploadedIndexMetadata> allUploadedIndicesRouting = new ArrayList<>();
         allUploadedIndicesRouting = remoteRoutingTableService.getAllUploadedIndicesRouting(
             previousManifest,
             uploadedMetadataResults.uploadedIndicesRoutingMetadata,
             routingTableDiff.getDeletes()
         );
+        uploadedMetadataResults.uploadedIndicesRoutingMetadata = allUploadedIndicesRouting;
 
-        final RemoteClusterStateManifestInfo manifestDetails = uploadManifest(
+        final RemoteClusterStateManifestInfo manifestDetails = remoteManifestManager.uploadManifest(
             clusterState,
-            new ArrayList<>(allUploadedIndexMetadata.values()),
+            uploadedMetadataResults,
             previousManifest.getPreviousClusterUUID(),
-            updateCoordinationMetadata ? uploadedMetadataResults.uploadedCoordinationMetadata : previousManifest.getCoordinationMetadata(),
-            updateSettingsMetadata ? uploadedMetadataResults.uploadedSettingsMetadata : previousManifest.getSettingsMetadata(),
-            updateTemplatesMetadata ? uploadedMetadataResults.uploadedTemplatesMetadata : previousManifest.getTemplatesMetadata(),
-            firstUploadForSplitGlobalMetadata || !customsToUpload.isEmpty()
-                ? allUploadedCustomMap
-                : previousManifest.getCustomMetadataMap(),
-            allUploadedIndicesRouting,
             false
         );
 
@@ -485,8 +379,8 @@ public class RemoteClusterStateService implements Closeable {
             + (uploadCoordinationMetadata ? 1 : 0) + (uploadSettingsMetadata ? 1 : 0) + (uploadTemplateMetadata ? 1 : 0)
             + indicesRoutingToUpload.size();
         CountDownLatch latch = new CountDownLatch(totalUploadTasks);
-        Map<String, CheckedRunnable<IOException>> uploadTasks = new HashMap<>(totalUploadTasks);
-        Map<String, ClusterMetadataManifest.UploadedMetadata> results = new HashMap<>(totalUploadTasks);
+        Map<String, CheckedRunnable<IOException>> uploadTasks = new ConcurrentHashMap<>(totalUploadTasks);
+        Map<String, ClusterMetadataManifest.UploadedMetadata> results = new ConcurrentHashMap<>(totalUploadTasks);
         List<Exception> exceptionList = Collections.synchronizedList(new ArrayList<>(totalUploadTasks));
 
         LatchedActionListener<ClusterMetadataManifest.UploadedMetadata> listener = new LatchedActionListener<>(
@@ -506,11 +400,14 @@ public class RemoteClusterStateService implements Closeable {
         if (uploadSettingsMetadata) {
             uploadTasks.put(
                 SETTING_METADATA,
-                getAsyncMetadataWriteAction(
-                    clusterState,
-                    SETTING_METADATA,
-                    SETTINGS_METADATA_FORMAT,
-                    clusterState.metadata().persistentSettings(),
+                remoteGlobalMetadataManager.getAsyncMetadataWriteAction(
+                    new RemotePersistentSettingsMetadata(
+                        clusterState.metadata().persistentSettings(),
+                        clusterState.metadata().version(),
+                        clusterState.metadata().clusterUUID(),
+                        blobStoreRepository.getCompressor(),
+                        blobStoreRepository.getNamedXContentRegistry()
+                    ),
                     listener
                 )
             );
@@ -518,11 +415,14 @@ public class RemoteClusterStateService implements Closeable {
         if (uploadCoordinationMetadata) {
             uploadTasks.put(
                 COORDINATION_METADATA,
-                getAsyncMetadataWriteAction(
-                    clusterState,
-                    COORDINATION_METADATA,
-                    COORDINATION_METADATA_FORMAT,
-                    clusterState.metadata().coordinationMetadata(),
+                remoteGlobalMetadataManager.getAsyncMetadataWriteAction(
+                    new RemoteCoordinationMetadata(
+                        clusterState.metadata().coordinationMetadata(),
+                        clusterState.metadata().version(),
+                        clusterState.metadata().clusterUUID(),
+                        blobStoreRepository.getCompressor(),
+                        blobStoreRepository.getNamedXContentRegistry()
+                    ),
                     listener
                 )
             );
@@ -530,11 +430,14 @@ public class RemoteClusterStateService implements Closeable {
         if (uploadTemplateMetadata) {
             uploadTasks.put(
                 TEMPLATES_METADATA,
-                getAsyncMetadataWriteAction(
-                    clusterState,
-                    TEMPLATES_METADATA,
-                    TEMPLATES_METADATA_FORMAT,
-                    clusterState.metadata().templatesMetadata(),
+                remoteGlobalMetadataManager.getAsyncMetadataWriteAction(
+                    new RemoteTemplatesMetadata(
+                        clusterState.metadata().templatesMetadata(),
+                        clusterState.metadata().version(),
+                        clusterState.metadata().clusterUUID(),
+                        blobStoreRepository.getCompressor(),
+                        blobStoreRepository.getNamedXContentRegistry()
+                    ),
                     listener
                 )
             );
@@ -543,11 +446,24 @@ public class RemoteClusterStateService implements Closeable {
             String customComponent = String.join(CUSTOM_DELIMITER, CUSTOM_METADATA, key);
             uploadTasks.put(
                 customComponent,
-                getAsyncMetadataWriteAction(clusterState, customComponent, CUSTOM_METADATA_FORMAT, value, listener)
+                remoteGlobalMetadataManager.getAsyncMetadataWriteAction(
+                    new RemoteCustomMetadata(
+                        value,
+                        key,
+                        clusterState.metadata().version(),
+                        clusterState.metadata().clusterUUID(),
+                        blobStoreRepository.getCompressor(),
+                        blobStoreRepository.getNamedXContentRegistry()
+                    ),
+                    listener
+                )
             );
         });
         indexToUpload.forEach(indexMetadata -> {
-            uploadTasks.put(indexMetadata.getIndex().getName(), getIndexMetadataAsyncAction(clusterState, indexMetadata, listener));
+            uploadTasks.put(
+                indexMetadata.getIndex().getName(),
+                remoteIndexMetadataManager.getAsyncIndexMetadataWriteAction(indexMetadata, clusterState.metadata().clusterUUID(), listener)
+            );
         });
 
         indicesRoutingToUpload.forEach(indexRoutingTable -> {
@@ -557,7 +473,11 @@ public class RemoteClusterStateService implements Closeable {
                     clusterState,
                     indexRoutingTable,
                     listener,
-                    getCusterMetadataBasePath(clusterState.getClusterName().value(), clusterState.metadata().clusterUUID())
+                    getClusterMetadataBasePath(
+                        blobStoreRepository,
+                        clusterState.getClusterName().value(),
+                        clusterState.metadata().clusterUUID()
+                    )
                 )
             );
         });
@@ -566,11 +486,10 @@ public class RemoteClusterStateService implements Closeable {
         for (CheckedRunnable<IOException> uploadTask : uploadTasks.values()) {
             uploadTask.run();
         }
-
         invokeIndexMetadataUploadListeners(indexToUpload, prevIndexMetadataByName, latch, exceptionList);
 
         try {
-            if (latch.await(getGlobalMetadataUploadTimeout().millis(), TimeUnit.MILLISECONDS) == false) {
+            if (latch.await(remoteGlobalMetadataManager.getGlobalMetadataUploadTimeout().millis(), TimeUnit.MILLISECONDS) == false) {
                 // TODO: We should add metrics where transfer is timing out. [Issue: #10687]
                 RemoteStateTransferException ex = new RemoteStateTransferException(
                     String.format(
@@ -611,7 +530,7 @@ public class RemoteClusterStateService implements Closeable {
             if (uploadedMetadata.getClass().equals(UploadedIndexMetadata.class)
                 && uploadedMetadata.getComponent().contains(InternalRemoteRoutingTableService.INDEX_ROUTING_METADATA_PREFIX)) {
                 response.uploadedIndicesRoutingMetadata.add((UploadedIndexMetadata) uploadedMetadata);
-            } else if (name.contains(CUSTOM_METADATA)) {
+            } else if (name.startsWith(CUSTOM_METADATA)) {
                 // component name for custom metadata will look like custom--<metadata-attribute>
                 String custom = name.split(DELIMITER)[0].split(CUSTOM_DELIMITER)[1];
                 response.uploadedCustomMetadataMap.put(
@@ -620,7 +539,7 @@ public class RemoteClusterStateService implements Closeable {
                 );
             } else if (COORDINATION_METADATA.equals(name)) {
                 response.uploadedCoordinationMetadata = (UploadedMetadataAttribute) uploadedMetadata;
-            } else if (SETTING_METADATA.equals(name)) {
+            } else if (RemotePersistentSettingsMetadata.SETTING_METADATA.equals(name)) {
                 response.uploadedSettingsMetadata = (UploadedMetadataAttribute) uploadedMetadata;
             } else if (TEMPLATES_METADATA.equals(name)) {
                 response.uploadedTemplatesMetadata = (UploadedMetadataAttribute) uploadedMetadata;
@@ -690,73 +609,8 @@ public class RemoteClusterStateService implements Closeable {
         );
     }
 
-    /**
-     * Allows async Upload of IndexMetadata to remote
-     *
-     * @param clusterState          current ClusterState
-     * @param indexMetadata         {@link IndexMetadata} to upload
-     * @param latchedActionListener listener to respond back on after upload finishes
-     */
-    private CheckedRunnable<IOException> getIndexMetadataAsyncAction(
-        ClusterState clusterState,
-        IndexMetadata indexMetadata,
-        LatchedActionListener<ClusterMetadataManifest.UploadedMetadata> latchedActionListener
-    ) {
-        final BlobContainer indexMetadataContainer = indexMetadataContainer(
-            clusterState.getClusterName().value(),
-            clusterState.metadata().clusterUUID(),
-            indexMetadata.getIndexUUID()
-        );
-        final String indexMetadataFilename = indexMetadataFileName(indexMetadata);
-        ActionListener<Void> completionListener = ActionListener.wrap(
-            resp -> latchedActionListener.onResponse(
-                new UploadedIndexMetadata(
-                    indexMetadata.getIndex().getName(),
-                    indexMetadata.getIndexUUID(),
-                    indexMetadataContainer.path().buildAsString() + indexMetadataFilename
-                )
-            ),
-            ex -> latchedActionListener.onFailure(new RemoteStateTransferException(indexMetadata.getIndex().toString(), ex))
-        );
-
-        return () -> INDEX_METADATA_FORMAT.writeAsyncWithUrgentPriority(
-            indexMetadata,
-            indexMetadataContainer,
-            indexMetadataFilename,
-            blobStoreRepository.getCompressor(),
-            completionListener,
-            FORMAT_PARAMS
-        );
-    }
-
-    /**
-     * Allows async upload of Metadata components to remote
-     */
-
-    private CheckedRunnable<IOException> getAsyncMetadataWriteAction(
-        ClusterState clusterState,
-        String component,
-        ChecksumBlobStoreFormat componentMetadataBlobStore,
-        ToXContent componentMetadata,
-        LatchedActionListener<ClusterMetadataManifest.UploadedMetadata> latchedActionListener
-    ) {
-        final BlobContainer globalMetadataContainer = globalMetadataContainer(
-            clusterState.getClusterName().value(),
-            clusterState.metadata().clusterUUID()
-        );
-        final String componentMetadataFilename = metadataAttributeFileName(component, clusterState.metadata().version());
-        ActionListener<Void> completionListener = ActionListener.wrap(
-            resp -> latchedActionListener.onResponse(new UploadedMetadataAttribute(component, componentMetadataFilename)),
-            ex -> latchedActionListener.onFailure(new RemoteStateTransferException(component, ex))
-        );
-        return () -> componentMetadataBlobStore.writeAsyncWithUrgentPriority(
-            componentMetadata,
-            globalMetadataContainer,
-            componentMetadataFilename,
-            blobStoreRepository.getCompressor(),
-            completionListener,
-            FORMAT_PARAMS
-        );
+    public RemoteManifestManager getRemoteManifestManager() {
+        return remoteManifestManager;
     }
 
     public RemoteClusterStateCleanupManager getCleanupManager() {
@@ -772,15 +626,24 @@ public class RemoteClusterStateService implements Closeable {
             return null;
         }
         assert previousManifest != null : "Last cluster metadata manifest is not set";
-        RemoteClusterStateManifestInfo committedManifestDetails = uploadManifest(
-            clusterState,
+        UploadedMetadataResults uploadedMetadataResults = new UploadedMetadataResults(
             previousManifest.getIndices(),
-            previousManifest.getPreviousClusterUUID(),
+            previousManifest.getCustomMetadataMap(),
             previousManifest.getCoordinationMetadata(),
             previousManifest.getSettingsMetadata(),
             previousManifest.getTemplatesMetadata(),
-            previousManifest.getCustomMetadataMap(),
+            previousManifest.getTransientSettingsMetadata(),
+            previousManifest.getDiscoveryNodesMetadata(),
+            previousManifest.getClusterBlocksMetadata(),
             previousManifest.getIndicesRouting(),
+            previousManifest.getHashesOfConsistentSettings(),
+            previousManifest.getClusterStateCustomMap()
+        );
+
+        RemoteClusterStateManifestInfo committedManifestDetails = remoteManifestManager.uploadManifest(
+            clusterState,
+            uploadedMetadataResults,
+            previousManifest.getPreviousClusterUUID(),
             true
         );
         if (!previousManifest.isClusterUUIDCommitted() && committedManifestDetails.getClusterMetadataManifest().isClusterUUIDCommitted()) {
@@ -788,6 +651,17 @@ public class RemoteClusterStateService implements Closeable {
         }
 
         return committedManifestDetails;
+    }
+
+    /**
+     * Fetch latest ClusterMetadataManifest from remote state store
+     *
+     * @param clusterUUID uuid of cluster state to refer to in remote
+     * @param clusterName name of the cluster
+     * @return ClusterMetadataManifest
+     */
+    public Optional<ClusterMetadataManifest> getLatestClusterMetadataManifest(String clusterName, String clusterUUID) {
+        return remoteManifestManager.getLatestClusterMetadataManifest(clusterName, clusterUUID);
     }
 
     @Override
@@ -808,189 +682,37 @@ public class RemoteClusterStateService implements Closeable {
         final Repository repository = repositoriesService.get().repository(remoteStoreRepo);
         assert repository instanceof BlobStoreRepository : "Repository should be instance of BlobStoreRepository";
         blobStoreRepository = (BlobStoreRepository) repository;
-        remoteClusterStateCleanupManager.start();
         this.remoteRoutingTableService.start();
-    }
+        blobStoreTransferService = new BlobStoreTransferService(getBlobStore(), threadpool);
+        String clusterName = ClusterName.CLUSTER_NAME_SETTING.get(settings).value();
 
-    private RemoteClusterStateManifestInfo uploadManifest(
-        ClusterState clusterState,
-        List<UploadedIndexMetadata> uploadedIndexMetadata,
-        String previousClusterUUID,
-        UploadedMetadataAttribute uploadedCoordinationMetadata,
-        UploadedMetadataAttribute uploadedSettingsMetadata,
-        UploadedMetadataAttribute uploadedTemplatesMetadata,
-        Map<String, UploadedMetadataAttribute> uploadedCustomMetadataMap,
-        List<UploadedIndexMetadata> uploadedIndicesRouting,
-        boolean committed
-    ) throws IOException {
-        synchronized (this) {
-            final String manifestFileName = getManifestFileName(
-                clusterState.term(),
-                clusterState.version(),
-                committed,
-                MANIFEST_CURRENT_CODEC_VERSION
-            );
-            final ClusterMetadataManifest manifest = ClusterMetadataManifest.builder()
-                .clusterTerm(clusterState.term())
-                .stateVersion(clusterState.getVersion())
-                .clusterUUID(clusterState.metadata().clusterUUID())
-                .stateUUID(clusterState.stateUUID())
-                .opensearchVersion(Version.CURRENT)
-                .nodeId(nodeId)
-                .committed(committed)
-                .codecVersion(MANIFEST_CURRENT_CODEC_VERSION)
-                .indices(uploadedIndexMetadata)
-                .previousClusterUUID(previousClusterUUID)
-                .clusterUUIDCommitted(clusterState.metadata().clusterUUIDCommitted())
-                .coordinationMetadata(uploadedCoordinationMetadata)
-                .settingMetadata(uploadedSettingsMetadata)
-                .templatesMetadata(uploadedTemplatesMetadata)
-                .customMetadataMap(uploadedCustomMetadataMap)
-                .routingTableVersion(clusterState.routingTable().version())
-                .indicesRouting(uploadedIndicesRouting)
-                .build();
-            writeMetadataManifest(clusterState.getClusterName().value(), clusterState.metadata().clusterUUID(), manifest, manifestFileName);
-            return new RemoteClusterStateManifestInfo(manifest, manifestFileName);
-        }
-    }
-
-    private void writeMetadataManifest(String clusterName, String clusterUUID, ClusterMetadataManifest uploadManifest, String fileName)
-        throws IOException {
-        AtomicReference<String> result = new AtomicReference<String>();
-        AtomicReference<Exception> exceptionReference = new AtomicReference<Exception>();
-
-        final BlobContainer metadataManifestContainer = manifestContainer(clusterName, clusterUUID);
-
-        // latch to wait until upload is not finished
-        CountDownLatch latch = new CountDownLatch(1);
-
-        LatchedActionListener completionListener = new LatchedActionListener<>(ActionListener.wrap(resp -> {
-            logger.trace(String.format(Locale.ROOT, "Manifest file uploaded successfully."));
-        }, ex -> { exceptionReference.set(ex); }), latch);
-
-        getClusterMetadataManifestBlobStoreFormat(fileName).writeAsyncWithUrgentPriority(
-            uploadManifest,
-            metadataManifestContainer,
-            fileName,
-            blobStoreRepository.getCompressor(),
-            completionListener,
-            FORMAT_PARAMS
+        remoteGlobalMetadataManager = new RemoteGlobalMetadataManager(
+            clusterSettings,
+            clusterName,
+            blobStoreRepository,
+            blobStoreTransferService,
+            threadpool
         );
-
-        try {
-            if (latch.await(getMetadataManifestUploadTimeout().millis(), TimeUnit.MILLISECONDS) == false) {
-                RemoteStateTransferException ex = new RemoteStateTransferException(
-                    String.format(Locale.ROOT, "Timed out waiting for transfer of manifest file to complete")
-                );
-                throw ex;
-            }
-        } catch (InterruptedException ex) {
-            RemoteStateTransferException exception = new RemoteStateTransferException(
-                String.format(Locale.ROOT, "Timed out waiting for transfer of manifest file to complete - %s"),
-                ex
-            );
-            Thread.currentThread().interrupt();
-            throw exception;
-        }
-        if (exceptionReference.get() != null) {
-            throw new RemoteStateTransferException(exceptionReference.get().getMessage(), exceptionReference.get());
-        }
-        logger.debug(
-            "Metadata manifest file [{}] written during [{}] phase. ",
-            fileName,
-            uploadManifest.isCommitted() ? "commit" : "publish"
+        remoteIndexMetadataManager = new RemoteIndexMetadataManager(
+            clusterSettings,
+            clusterName,
+            blobStoreRepository,
+            blobStoreTransferService,
+            threadpool
         );
-    }
-
-    ThreadPool getThreadpool() {
-        return threadpool;
-    }
-
-    BlobStore getBlobStore() {
-        return blobStoreRepository.blobStore();
-    }
-
-    private BlobContainer indexMetadataContainer(String clusterName, String clusterUUID, String indexUUID) {
-        // 123456789012_test-cluster/cluster-state/dsgYj10Nkso7/index/ftqsCnn9TgOX
-        return blobStoreRepository.blobStore()
-            .blobContainer(getCusterMetadataBasePath(clusterName, clusterUUID).add(INDEX_PATH_TOKEN).add(indexUUID));
-    }
-
-    private BlobContainer globalMetadataContainer(String clusterName, String clusterUUID) {
-        // 123456789012_test-cluster/cluster-state/dsgYj10Nkso7/global-metadata/
-        return blobStoreRepository.blobStore()
-            .blobContainer(getCusterMetadataBasePath(clusterName, clusterUUID).add(GLOBAL_METADATA_PATH_TOKEN));
-    }
-
-    private BlobContainer manifestContainer(String clusterName, String clusterUUID) {
-        // 123456789012_test-cluster/cluster-state/dsgYj10Nkso7/manifest
-        return blobStoreRepository.blobStore().blobContainer(getManifestFolderPath(clusterName, clusterUUID));
-    }
-
-    BlobPath getCusterMetadataBasePath(String clusterName, String clusterUUID) {
-        return blobStoreRepository.basePath().add(encodeString(clusterName)).add(CLUSTER_STATE_PATH_TOKEN).add(clusterUUID);
-    }
-
-    private BlobContainer clusterUUIDContainer(String clusterName) {
-        return blobStoreRepository.blobStore()
-            .blobContainer(
-                blobStoreRepository.basePath()
-                    .add(Base64.getUrlEncoder().withoutPadding().encodeToString(clusterName.getBytes(StandardCharsets.UTF_8)))
-                    .add(CLUSTER_STATE_PATH_TOKEN)
-            );
+        remoteManifestManager = new RemoteManifestManager(
+            clusterSettings,
+            clusterName,
+            nodeId,
+            blobStoreRepository,
+            blobStoreTransferService,
+            threadpool
+        );
+        remoteClusterStateCleanupManager.start();
     }
 
     private void setSlowWriteLoggingThreshold(TimeValue slowWriteLoggingThreshold) {
         this.slowWriteLoggingThreshold = slowWriteLoggingThreshold;
-    }
-
-    private void setIndexMetadataUploadTimeout(TimeValue newIndexMetadataUploadTimeout) {
-        this.indexMetadataUploadTimeout = newIndexMetadataUploadTimeout;
-    }
-
-    private void setGlobalMetadataUploadTimeout(TimeValue newGlobalMetadataUploadTimeout) {
-        this.globalMetadataUploadTimeout = newGlobalMetadataUploadTimeout;
-    }
-
-    private void setMetadataManifestUploadTimeout(TimeValue newMetadataManifestUploadTimeout) {
-        this.metadataManifestUploadTimeout = newMetadataManifestUploadTimeout;
-    }
-
-    private Map<String, Metadata.Custom> getUpdatedCustoms(ClusterState currentState, ClusterState previousState) {
-        if (Metadata.isCustomMetadataEqual(previousState.metadata(), currentState.metadata())) {
-            return new HashMap<>();
-        }
-        Map<String, Metadata.Custom> updatedCustom = new HashMap<>();
-        Set<String> currentCustoms = new HashSet<>(currentState.metadata().customs().keySet());
-        for (Map.Entry<String, Metadata.Custom> cursor : previousState.metadata().customs().entrySet()) {
-            if (cursor.getValue().context().contains(Metadata.XContentContext.GATEWAY)) {
-                if (currentCustoms.contains(cursor.getKey())
-                    && !cursor.getValue().equals(currentState.metadata().custom(cursor.getKey()))) {
-                    // If the custom metadata is updated, we need to upload the new version.
-                    updatedCustom.put(cursor.getKey(), currentState.metadata().custom(cursor.getKey()));
-                }
-                currentCustoms.remove(cursor.getKey());
-            }
-        }
-        for (String custom : currentCustoms) {
-            Metadata.Custom cursor = currentState.metadata().custom(custom);
-            if (cursor.context().contains(Metadata.XContentContext.GATEWAY)) {
-                updatedCustom.put(custom, cursor);
-            }
-        }
-        return updatedCustom;
-    }
-
-    public TimeValue getIndexMetadataUploadTimeout() {
-        return this.indexMetadataUploadTimeout;
-    }
-
-    public TimeValue getGlobalMetadataUploadTimeout() {
-        return this.globalMetadataUploadTimeout;
-    }
-
-    public TimeValue getMetadataManifestUploadTimeout() {
-        return this.metadataManifestUploadTimeout;
     }
 
     // Package private for unit test
@@ -998,105 +720,16 @@ public class RemoteClusterStateService implements Closeable {
         return this.remoteRoutingTableService;
     }
 
-    static String getManifestFileName(long term, long version, boolean committed, int codecVersion) {
-        // 123456789012_test-cluster/cluster-state/dsgYj10Nkso7/manifest/manifest__<inverted_term>__<inverted_version>__C/P__<inverted__timestamp>__<codec_version>
-        return String.join(
-            DELIMITER,
-            MANIFEST_PATH_TOKEN,
-            RemoteStoreUtils.invertLong(term),
-            RemoteStoreUtils.invertLong(version),
-            (committed ? "C" : "P"), // C for committed and P for published
-            RemoteStoreUtils.invertLong(System.currentTimeMillis()),
-            String.valueOf(codecVersion) // Keep the codec version at last place only, during read we reads last place to
-            // determine codec version.
-        );
+    ThreadPool getThreadpool() {
+        return threadpool;
     }
 
-    static String indexMetadataFileName(IndexMetadata indexMetadata) {
-        // 123456789012_test-cluster/cluster-state/dsgYj10Nkso7/index/<index_UUID>/metadata__<inverted_index_metadata_version>__<inverted__timestamp>__<codec
-        // version>
-        return String.join(
-            DELIMITER,
-            METADATA_FILE_PREFIX,
-            RemoteStoreUtils.invertLong(indexMetadata.getVersion()),
-            RemoteStoreUtils.invertLong(System.currentTimeMillis()),
-            String.valueOf(INDEX_METADATA_CURRENT_CODEC_VERSION) // Keep the codec version at last place only, during read we reads last
-            // place to determine codec version.
-        );
+    BlobStoreRepository getBlobStoreRepository() {
+        return blobStoreRepository;
     }
 
-    private static String globalMetadataFileName(Metadata metadata) {
-        // 123456789012_test-cluster/cluster-state/dsgYj10Nkso7/global-metadata/metadata__<inverted_metadata_version>__<inverted__timestamp>__<codec_version>
-        return String.join(
-            DELIMITER,
-            METADATA_FILE_PREFIX,
-            RemoteStoreUtils.invertLong(metadata.version()),
-            RemoteStoreUtils.invertLong(System.currentTimeMillis()),
-            String.valueOf(GLOBAL_METADATA_CURRENT_CODEC_VERSION)
-        );
-    }
-
-    private static String metadataAttributeFileName(String componentPrefix, Long metadataVersion) {
-        // 123456789012_test-cluster/cluster-state/dsgYj10Nkso7/global-metadata/<componentPrefix>__<inverted_metadata_version>__<inverted__timestamp>__<codec_version>
-        return String.join(
-            DELIMITER,
-            componentPrefix,
-            RemoteStoreUtils.invertLong(metadataVersion),
-            RemoteStoreUtils.invertLong(System.currentTimeMillis()),
-            String.valueOf(GLOBAL_METADATA_CURRENT_CODEC_VERSION)
-        );
-    }
-
-    BlobPath getManifestFolderPath(String clusterName, String clusterUUID) {
-        return getCusterMetadataBasePath(clusterName, clusterUUID).add(MANIFEST_PATH_TOKEN);
-    }
-
-    /**
-     * Fetch latest index metadata from remote cluster state
-     *
-     * @param clusterUUID             uuid of cluster state to refer to in remote
-     * @param clusterName             name of the cluster
-     * @param clusterMetadataManifest manifest file of cluster
-     * @return {@code Map<String, IndexMetadata>} latest IndexUUID to IndexMetadata map
-     */
-    private Map<String, IndexMetadata> getIndexMetadataMap(
-        String clusterName,
-        String clusterUUID,
-        ClusterMetadataManifest clusterMetadataManifest
-    ) {
-        assert Objects.equals(clusterUUID, clusterMetadataManifest.getClusterUUID())
-            : "Corrupt ClusterMetadataManifest found. Cluster UUID mismatch.";
-        Map<String, IndexMetadata> remoteIndexMetadata = new HashMap<>();
-        for (UploadedIndexMetadata uploadedIndexMetadata : clusterMetadataManifest.getIndices()) {
-            IndexMetadata indexMetadata = getIndexMetadata(clusterName, clusterUUID, uploadedIndexMetadata);
-            remoteIndexMetadata.put(uploadedIndexMetadata.getIndexUUID(), indexMetadata);
-        }
-        return remoteIndexMetadata;
-    }
-
-    /**
-     * Fetch index metadata from remote cluster state
-     *
-     * @param clusterUUID           uuid of cluster state to refer to in remote
-     * @param clusterName           name of the cluster
-     * @param uploadedIndexMetadata {@link UploadedIndexMetadata} contains details about remote location of index metadata
-     * @return {@link IndexMetadata}
-     */
-    private IndexMetadata getIndexMetadata(String clusterName, String clusterUUID, UploadedIndexMetadata uploadedIndexMetadata) {
-        BlobContainer blobContainer = indexMetadataContainer(clusterName, clusterUUID, uploadedIndexMetadata.getIndexUUID());
-        try {
-            String[] splitPath = uploadedIndexMetadata.getUploadedFilename().split("/");
-            return INDEX_METADATA_FORMAT.read(
-                blobContainer,
-                splitPath[splitPath.length - 1],
-                blobStoreRepository.getNamedXContentRegistry()
-            );
-        } catch (IOException e) {
-            throw new IllegalStateException(
-                String.format(Locale.ROOT, "Error while downloading IndexMetadata - %s", uploadedIndexMetadata.getUploadedFilename()),
-                e
-            );
-        }
+    BlobStore getBlobStore() {
+        return blobStoreRepository.blobStore();
     }
 
     /**
@@ -1107,7 +740,10 @@ public class RemoteClusterStateService implements Closeable {
      * @return {@link IndexMetadata}
      */
     public ClusterState getLatestClusterState(String clusterName, String clusterUUID) {
-        Optional<ClusterMetadataManifest> clusterMetadataManifest = getLatestClusterMetadataManifest(clusterName, clusterUUID);
+        Optional<ClusterMetadataManifest> clusterMetadataManifest = remoteManifestManager.getLatestClusterMetadataManifest(
+            clusterName,
+            clusterUUID
+        );
         if (clusterMetadataManifest.isEmpty()) {
             throw new IllegalStateException(
                 String.format(Locale.ROOT, "Latest cluster metadata manifest is not present for the provided clusterUUID: %s", clusterUUID)
@@ -1115,10 +751,10 @@ public class RemoteClusterStateService implements Closeable {
         }
 
         // Fetch Global Metadata
-        Metadata globalMetadata = getGlobalMetadata(clusterName, clusterUUID, clusterMetadataManifest.get());
+        Metadata globalMetadata = remoteGlobalMetadataManager.getGlobalMetadata(clusterUUID, clusterMetadataManifest.get());
 
         // Fetch Index Metadata
-        Map<String, IndexMetadata> indices = getIndexMetadataMap(clusterName, clusterUUID, clusterMetadataManifest.get());
+        Map<String, IndexMetadata> indices = remoteIndexMetadataManager.getIndexMetadataMap(clusterUUID, clusterMetadataManifest.get());
 
         Map<String, IndexMetadata> indexMetadataMap = new HashMap<>();
         indices.values().forEach(indexMetadata -> { indexMetadataMap.put(indexMetadata.getIndex().getName(), indexMetadata); });
@@ -1150,156 +786,7 @@ public class RemoteClusterStateService implements Closeable {
     }
 
     public ClusterMetadataManifest getClusterMetadataManifestByFileName(String clusterUUID, String manifestFileName) {
-        // TODO https://github.com/opensearch-project/OpenSearch/pull/14089
-        return null;
-    }
-
-    private Metadata getGlobalMetadata(String clusterName, String clusterUUID, ClusterMetadataManifest clusterMetadataManifest) {
-        String globalMetadataFileName = clusterMetadataManifest.getGlobalMetadataFileName();
-        try {
-            // Fetch Global metadata
-            if (globalMetadataFileName != null) {
-                String[] splitPath = globalMetadataFileName.split("/");
-                return GLOBAL_METADATA_FORMAT.read(
-                    globalMetadataContainer(clusterName, clusterUUID),
-                    splitPath[splitPath.length - 1],
-                    blobStoreRepository.getNamedXContentRegistry()
-                );
-            } else if (clusterMetadataManifest.hasMetadataAttributesFiles()) {
-                CoordinationMetadata coordinationMetadata = getCoordinationMetadata(
-                    clusterName,
-                    clusterUUID,
-                    clusterMetadataManifest.getCoordinationMetadata().getUploadedFilename()
-                );
-                Settings settingsMetadata = getSettingsMetadata(
-                    clusterName,
-                    clusterUUID,
-                    clusterMetadataManifest.getSettingsMetadata().getUploadedFilename()
-                );
-                TemplatesMetadata templatesMetadata = getTemplatesMetadata(
-                    clusterName,
-                    clusterUUID,
-                    clusterMetadataManifest.getTemplatesMetadata().getUploadedFilename()
-                );
-                Metadata.Builder builder = new Metadata.Builder();
-                builder.coordinationMetadata(coordinationMetadata);
-                builder.persistentSettings(settingsMetadata);
-                builder.templates(templatesMetadata);
-                clusterMetadataManifest.getCustomMetadataMap()
-                    .forEach(
-                        (key, value) -> builder.putCustom(
-                            key,
-                            getCustomsMetadata(clusterName, clusterUUID, value.getUploadedFilename(), key)
-                        )
-                    );
-                return builder.build();
-            } else {
-                return Metadata.EMPTY_METADATA;
-            }
-        } catch (IOException e) {
-            throw new IllegalStateException(
-                String.format(Locale.ROOT, "Error while downloading Global Metadata - %s", globalMetadataFileName),
-                e
-            );
-        }
-    }
-
-    private CoordinationMetadata getCoordinationMetadata(String clusterName, String clusterUUID, String coordinationMetadataFileName) {
-        try {
-            // Fetch Coordination metadata
-            if (coordinationMetadataFileName != null) {
-                String[] splitPath = coordinationMetadataFileName.split("/");
-                return COORDINATION_METADATA_FORMAT.read(
-                    globalMetadataContainer(clusterName, clusterUUID),
-                    splitPath[splitPath.length - 1],
-                    blobStoreRepository.getNamedXContentRegistry()
-                );
-            } else {
-                return CoordinationMetadata.EMPTY_METADATA;
-            }
-        } catch (IOException e) {
-            throw new IllegalStateException(
-                String.format(Locale.ROOT, "Error while downloading Coordination Metadata - %s", coordinationMetadataFileName),
-                e
-            );
-        }
-    }
-
-    private Settings getSettingsMetadata(String clusterName, String clusterUUID, String settingsMetadataFileName) {
-        try {
-            // Fetch Settings metadata
-            if (settingsMetadataFileName != null) {
-                String[] splitPath = settingsMetadataFileName.split("/");
-                return SETTINGS_METADATA_FORMAT.read(
-                    globalMetadataContainer(clusterName, clusterUUID),
-                    splitPath[splitPath.length - 1],
-                    blobStoreRepository.getNamedXContentRegistry()
-                );
-            } else {
-                return Settings.EMPTY;
-            }
-        } catch (IOException e) {
-            throw new IllegalStateException(
-                String.format(Locale.ROOT, "Error while downloading Settings Metadata - %s", settingsMetadataFileName),
-                e
-            );
-        }
-    }
-
-    private TemplatesMetadata getTemplatesMetadata(String clusterName, String clusterUUID, String templatesMetadataFileName) {
-        try {
-            // Fetch Templates metadata
-            if (templatesMetadataFileName != null) {
-                String[] splitPath = templatesMetadataFileName.split("/");
-                return TEMPLATES_METADATA_FORMAT.read(
-                    globalMetadataContainer(clusterName, clusterUUID),
-                    splitPath[splitPath.length - 1],
-                    blobStoreRepository.getNamedXContentRegistry()
-                );
-            } else {
-                return TemplatesMetadata.EMPTY_METADATA;
-            }
-        } catch (IOException e) {
-            throw new IllegalStateException(
-                String.format(Locale.ROOT, "Error while downloading Templates Metadata - %s", templatesMetadataFileName),
-                e
-            );
-        }
-    }
-
-    private Metadata.Custom getCustomsMetadata(String clusterName, String clusterUUID, String customMetadataFileName, String custom) {
-        requireNonNull(customMetadataFileName);
-        try {
-            // Fetch Custom metadata
-            String[] splitPath = customMetadataFileName.split("/");
-            ChecksumBlobStoreFormat<Metadata.Custom> customChecksumBlobStoreFormat = new ChecksumBlobStoreFormat<>(
-                "custom",
-                METADATA_NAME_FORMAT,
-                (parser -> Metadata.Custom.fromXContent(parser, custom))
-            );
-            return customChecksumBlobStoreFormat.read(
-                globalMetadataContainer(clusterName, clusterUUID),
-                splitPath[splitPath.length - 1],
-                blobStoreRepository.getNamedXContentRegistry()
-            );
-        } catch (IOException e) {
-            throw new IllegalStateException(
-                String.format(Locale.ROOT, "Error while downloading Custom Metadata - %s", customMetadataFileName),
-                e
-            );
-        }
-    }
-
-    /**
-     * Fetch latest ClusterMetadataManifest from remote state store
-     *
-     * @param clusterUUID uuid of cluster state to refer to in remote
-     * @param clusterName name of the cluster
-     * @return ClusterMetadataManifest
-     */
-    public Optional<ClusterMetadataManifest> getLatestClusterMetadataManifest(String clusterName, String clusterUUID) {
-        Optional<String> latestManifestFileName = getLatestManifestFileName(clusterName, clusterUUID);
-        return latestManifestFileName.map(s -> fetchRemoteClusterMetadataManifest(clusterName, clusterUUID, s));
+        return remoteManifestManager.getRemoteClusterMetadataManifestByFileName(clusterUUID, manifestFileName);
     }
 
     /**
@@ -1311,7 +798,10 @@ public class RemoteClusterStateService implements Closeable {
     public String getLastKnownUUIDFromRemote(String clusterName) {
         try {
             Set<String> clusterUUIDs = getAllClusterUUIDs(clusterName);
-            Map<String, ClusterMetadataManifest> latestManifests = getLatestManifestForAllClusterUUIDs(clusterName, clusterUUIDs);
+            Map<String, ClusterMetadataManifest> latestManifests = remoteManifestManager.getLatestManifestForAllClusterUUIDs(
+                clusterName,
+                clusterUUIDs
+            );
             List<String> validChain = createClusterChain(latestManifests, clusterName);
             if (validChain.isEmpty()) {
                 return ClusterState.UNKNOWN_UUID;
@@ -1326,7 +816,7 @@ public class RemoteClusterStateService implements Closeable {
     }
 
     Set<String> getAllClusterUUIDs(String clusterName) throws IOException {
-        Map<String, BlobContainer> clusterUUIDMetadata = clusterUUIDContainer(clusterName).children();
+        Map<String, BlobContainer> clusterUUIDMetadata = clusterUUIDContainer(blobStoreRepository, clusterName).children();
         if (clusterUUIDMetadata == null) {
             return Collections.emptySet();
         }
@@ -1427,7 +917,7 @@ public class RemoteClusterStateService implements Closeable {
             if (!ClusterState.UNKNOWN_UUID.equals(currentManifest.getPreviousClusterUUID())) {
                 ClusterMetadataManifest previousManifest = trimmedUUIDs.get(currentManifest.getPreviousClusterUUID());
                 if (isMetadataEqual(currentManifest, previousManifest, clusterName)
-                    && isGlobalMetadataEqual(currentManifest, previousManifest, clusterName)) {
+                    && remoteGlobalMetadataManager.isGlobalMetadataEqual(currentManifest, previousManifest, clusterName)) {
                     trimmedUUIDs.remove(clusterUUID);
                 }
             }
@@ -1442,14 +932,20 @@ public class RemoteClusterStateService implements Closeable {
         }
         final Map<String, UploadedIndexMetadata> secondIndices = second.getIndices()
             .stream()
-            .collect(Collectors.toMap(md -> md.getIndexName(), Function.identity()));
+            .collect(Collectors.toMap(UploadedIndexMetadata::getIndexName, Function.identity()));
         for (UploadedIndexMetadata uploadedIndexMetadata : first.getIndices()) {
-            final IndexMetadata firstIndexMetadata = getIndexMetadata(clusterName, first.getClusterUUID(), uploadedIndexMetadata);
+            final IndexMetadata firstIndexMetadata = remoteIndexMetadataManager.getIndexMetadata(
+                uploadedIndexMetadata,
+                first.getClusterUUID()
+            );
             final UploadedIndexMetadata secondUploadedIndexMetadata = secondIndices.get(uploadedIndexMetadata.getIndexName());
             if (secondUploadedIndexMetadata == null) {
                 return false;
             }
-            final IndexMetadata secondIndexMetadata = getIndexMetadata(clusterName, second.getClusterUUID(), secondUploadedIndexMetadata);
+            final IndexMetadata secondIndexMetadata = remoteIndexMetadataManager.getIndexMetadata(
+                secondUploadedIndexMetadata,
+                second.getClusterUUID()
+            );
             if (firstIndexMetadata.equals(secondIndexMetadata) == false) {
                 return false;
             }
@@ -1457,160 +953,15 @@ public class RemoteClusterStateService implements Closeable {
         return true;
     }
 
-    private boolean isGlobalMetadataEqual(ClusterMetadataManifest first, ClusterMetadataManifest second, String clusterName) {
-        Metadata secondGlobalMetadata = getGlobalMetadata(clusterName, second.getClusterUUID(), second);
-        Metadata firstGlobalMetadata = getGlobalMetadata(clusterName, first.getClusterUUID(), first);
-        return Metadata.isGlobalResourcesMetadataEquals(firstGlobalMetadata, secondGlobalMetadata);
-    }
-
     private boolean isValidClusterUUID(ClusterMetadataManifest manifest) {
         return manifest.isClusterUUIDCommitted();
-    }
-
-    /**
-     * Fetch ClusterMetadataManifest files from remote state store in order
-     *
-     * @param clusterUUID uuid of cluster state to refer to in remote
-     * @param clusterName name of the cluster
-     * @param limit       max no of files to fetch
-     * @return all manifest file names
-     */
-    private List<BlobMetadata> getManifestFileNames(String clusterName, String clusterUUID, int limit) throws IllegalStateException {
-        try {
-
-            /*
-              {@link BlobContainer#listBlobsByPrefixInSortedOrder} will list the latest manifest file first
-              as the manifest file name generated via {@link RemoteClusterStateService#getManifestFileName} ensures
-              when sorted in LEXICOGRAPHIC order the latest uploaded manifest file comes on top.
-             */
-            return manifestContainer(clusterName, clusterUUID).listBlobsByPrefixInSortedOrder(
-                MANIFEST_FILE_PREFIX + DELIMITER,
-                limit,
-                BlobContainer.BlobNameSortOrder.LEXICOGRAPHIC
-            );
-        } catch (IOException e) {
-            throw new IllegalStateException("Error while fetching latest manifest file for remote cluster state", e);
-        }
-    }
-
-    /**
-     * Fetch latest ClusterMetadataManifest file from remote state store
-     *
-     * @param clusterUUID uuid of cluster state to refer to in remote
-     * @param clusterName name of the cluster
-     * @return latest ClusterMetadataManifest filename
-     */
-    private Optional<String> getLatestManifestFileName(String clusterName, String clusterUUID) throws IllegalStateException {
-        List<BlobMetadata> manifestFilesMetadata = getManifestFileNames(clusterName, clusterUUID, 1);
-        if (manifestFilesMetadata != null && !manifestFilesMetadata.isEmpty()) {
-            return Optional.of(manifestFilesMetadata.get(0).name());
-        }
-        logger.info("No manifest file present in remote store for cluster name: {}, cluster UUID: {}", clusterName, clusterUUID);
-        return Optional.empty();
-    }
-
-    /**
-     * Fetch ClusterMetadataManifest from remote state store
-     *
-     * @param clusterUUID uuid of cluster state to refer to in remote
-     * @param clusterName name of the cluster
-     * @return ClusterMetadataManifest
-     */
-    ClusterMetadataManifest fetchRemoteClusterMetadataManifest(String clusterName, String clusterUUID, String filename)
-        throws IllegalStateException {
-        try {
-            return getClusterMetadataManifestBlobStoreFormat(filename).read(
-                manifestContainer(clusterName, clusterUUID),
-                filename,
-                blobStoreRepository.getNamedXContentRegistry()
-            );
-        } catch (IOException e) {
-            throw new IllegalStateException(String.format(Locale.ROOT, "Error while downloading cluster metadata - %s", filename), e);
-        }
-    }
-
-    private ChecksumBlobStoreFormat<ClusterMetadataManifest> getClusterMetadataManifestBlobStoreFormat(String fileName) {
-        long codecVersion = getManifestCodecVersion(fileName);
-        if (codecVersion == MANIFEST_CURRENT_CODEC_VERSION) {
-            return CLUSTER_METADATA_MANIFEST_FORMAT;
-        } else if (codecVersion == ClusterMetadataManifest.CODEC_V1) {
-            return CLUSTER_METADATA_MANIFEST_FORMAT_V1;
-        } else if (codecVersion == ClusterMetadataManifest.CODEC_V0) {
-            return CLUSTER_METADATA_MANIFEST_FORMAT_V0;
-        }
-
-        throw new IllegalArgumentException("Cluster metadata manifest file is corrupted, don't have valid codec version");
-    }
-
-    private int getManifestCodecVersion(String fileName) {
-        String[] splitName = fileName.split(DELIMITER);
-        if (splitName.length == SPLITED_MANIFEST_FILE_LENGTH) {
-            return Integer.parseInt(splitName[splitName.length - 1]); // Last value would be codec version.
-        } else if (splitName.length < SPLITED_MANIFEST_FILE_LENGTH) { // Where codec is not part of file name, i.e. default codec version 0
-            // is used.
-            return ClusterMetadataManifest.CODEC_V0;
-        } else {
-            throw new IllegalArgumentException("Manifest file name is corrupted");
-        }
-    }
-
-    public static String encodeString(String content) {
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(content.getBytes(StandardCharsets.UTF_8));
     }
 
     public void writeMetadataFailed() {
         getStats().stateFailed();
     }
 
-    /**
-     * Exception for Remote state transfer.
-     */
-    public static class RemoteStateTransferException extends RuntimeException {
-
-        public RemoteStateTransferException(String errorDesc) {
-            super(errorDesc);
-        }
-
-        public RemoteStateTransferException(String errorDesc, Throwable cause) {
-            super(errorDesc, cause);
-        }
-    }
-
     public RemotePersistenceStats getStats() {
         return remoteStateStats;
-    }
-
-    private static class UploadedMetadataResults {
-        List<UploadedIndexMetadata> uploadedIndexMetadata;
-        Map<String, UploadedMetadataAttribute> uploadedCustomMetadataMap;
-        UploadedMetadataAttribute uploadedCoordinationMetadata;
-        UploadedMetadataAttribute uploadedSettingsMetadata;
-        UploadedMetadataAttribute uploadedTemplatesMetadata;
-        List<UploadedIndexMetadata> uploadedIndicesRoutingMetadata;
-
-        public UploadedMetadataResults(
-            List<UploadedIndexMetadata> uploadedIndexMetadata,
-            Map<String, UploadedMetadataAttribute> uploadedCustomMetadataMap,
-            UploadedMetadataAttribute uploadedCoordinationMetadata,
-            UploadedMetadataAttribute uploadedSettingsMetadata,
-            UploadedMetadataAttribute uploadedTemplatesMetadata,
-            List<UploadedIndexMetadata> uploadedIndicesRoutingMetadata
-        ) {
-            this.uploadedIndexMetadata = uploadedIndexMetadata;
-            this.uploadedCustomMetadataMap = uploadedCustomMetadataMap;
-            this.uploadedCoordinationMetadata = uploadedCoordinationMetadata;
-            this.uploadedSettingsMetadata = uploadedSettingsMetadata;
-            this.uploadedTemplatesMetadata = uploadedTemplatesMetadata;
-            this.uploadedIndicesRoutingMetadata = uploadedIndicesRoutingMetadata;
-        }
-
-        public UploadedMetadataResults() {
-            this.uploadedIndexMetadata = new ArrayList<>();
-            this.uploadedCustomMetadataMap = new HashMap<>();
-            this.uploadedCoordinationMetadata = null;
-            this.uploadedSettingsMetadata = null;
-            this.uploadedTemplatesMetadata = null;
-            this.uploadedIndicesRoutingMetadata = new ArrayList<>();
-        }
     }
 }

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateUtils.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateUtils.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import static org.opensearch.gateway.remote.ClusterMetadataManifest.CODEC_V1;
+
 /**
  * Utility class for Remote Cluster State
  */
@@ -33,6 +35,7 @@ public class RemoteClusterStateUtils {
     public static final String GLOBAL_METADATA_PATH_TOKEN = "global-metadata";
     public static final String CLUSTER_STATE_EPHEMERAL_PATH_TOKEN = "ephemeral";
     public static final int GLOBAL_METADATA_CURRENT_CODEC_VERSION = 1;
+    public static final String METADATA_FILE_PREFIX = "metadata";
     public static final String CUSTOM_DELIMITER = "--";
     public static final String PATH_DELIMITER = "/";
     public static final String METADATA_NAME_PLAIN_FORMAT = "%s";
@@ -43,7 +46,7 @@ public class RemoteClusterStateUtils {
         Map.of(Metadata.CONTEXT_MODE_PARAM, Metadata.CONTEXT_MODE_GATEWAY)
     );
 
-    public static BlobPath getCusterMetadataBasePath(BlobStoreRepository blobStoreRepository, String clusterName, String clusterUUID) {
+    public static BlobPath getClusterMetadataBasePath(BlobStoreRepository blobStoreRepository, String clusterName, String clusterUUID) {
         return blobStoreRepository.basePath().add(encodeString(clusterName)).add(CLUSTER_STATE_PATH_TOKEN).add(clusterUUID);
     }
 
@@ -51,8 +54,11 @@ public class RemoteClusterStateUtils {
         return Base64.getUrlEncoder().withoutPadding().encodeToString(content.getBytes(StandardCharsets.UTF_8));
     }
 
-    public static String getFormattedFileName(String fileName, int codecVersion) {
-        if (codecVersion < ClusterMetadataManifest.CODEC_V2) {
+    public static String getFormattedIndexFileName(String fileName) {
+        String[] pathTokens = fileName.split(DELIMITER);
+        // last value added is the codec version in IndexMetadata file
+        int codecVersion = Integer.parseInt(pathTokens[pathTokens.length - 1]);
+        if (codecVersion == CODEC_V1) {
             return String.format(Locale.ROOT, METADATA_NAME_FORMAT, fileName);
         }
         return fileName;
@@ -88,8 +94,8 @@ public class RemoteClusterStateUtils {
             Map<String, ClusterMetadataManifest.UploadedMetadataAttribute> uploadedCustomMetadataMap,
             ClusterMetadataManifest.UploadedMetadataAttribute uploadedCoordinationMetadata,
             ClusterMetadataManifest.UploadedMetadataAttribute uploadedSettingsMetadata,
-            ClusterMetadataManifest.UploadedMetadataAttribute uploadedTransientSettingsMetadata,
             ClusterMetadataManifest.UploadedMetadataAttribute uploadedTemplatesMetadata,
+            ClusterMetadataManifest.UploadedMetadataAttribute uploadedTransientSettingsMetadata,
             ClusterMetadataManifest.UploadedMetadataAttribute uploadedDiscoveryNodes,
             ClusterMetadataManifest.UploadedMetadataAttribute uploadedClusterBlocks,
             List<ClusterMetadataManifest.UploadedIndexMetadata> uploadedIndicesRoutingMetadata,

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteGlobalMetadataManager.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteGlobalMetadataManager.java
@@ -1,0 +1,276 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.gateway.remote;
+
+import org.opensearch.action.LatchedActionListener;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.coordination.CoordinationMetadata;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.metadata.Metadata.Custom;
+import org.opensearch.cluster.metadata.TemplatesMetadata;
+import org.opensearch.common.CheckedRunnable;
+import org.opensearch.common.remote.AbstractRemoteWritableBlobEntity;
+import org.opensearch.common.remote.RemoteWritableEntityStore;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.compress.Compressor;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.gateway.remote.model.RemoteClusterStateBlobStore;
+import org.opensearch.gateway.remote.model.RemoteCoordinationMetadata;
+import org.opensearch.gateway.remote.model.RemoteCustomMetadata;
+import org.opensearch.gateway.remote.model.RemoteGlobalMetadata;
+import org.opensearch.gateway.remote.model.RemotePersistentSettingsMetadata;
+import org.opensearch.gateway.remote.model.RemoteTemplatesMetadata;
+import org.opensearch.index.translog.transfer.BlobStoreTransferService;
+import org.opensearch.repositories.blobstore.BlobStoreRepository;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import static org.opensearch.gateway.remote.RemoteClusterStateUtils.METADATA_NAME_FORMAT;
+
+/**
+ * A Manager which provides APIs to write and read Global Metadata attributes to remote store
+ *
+ * @opensearch.internal
+ */
+public class RemoteGlobalMetadataManager {
+
+    public static final TimeValue GLOBAL_METADATA_UPLOAD_TIMEOUT_DEFAULT = TimeValue.timeValueMillis(20000);
+
+    public static final Setting<TimeValue> GLOBAL_METADATA_UPLOAD_TIMEOUT_SETTING = Setting.timeSetting(
+        "cluster.remote_store.state.global_metadata.upload_timeout",
+        GLOBAL_METADATA_UPLOAD_TIMEOUT_DEFAULT,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    public static final int GLOBAL_METADATA_CURRENT_CODEC_VERSION = 1;
+
+    private volatile TimeValue globalMetadataUploadTimeout;
+    private Map<String, RemoteWritableEntityStore> remoteWritableEntityStores;
+    private final Compressor compressor;
+    private final NamedXContentRegistry namedXContentRegistry;
+
+    RemoteGlobalMetadataManager(
+        ClusterSettings clusterSettings,
+        String clusterName,
+        BlobStoreRepository blobStoreRepository,
+        BlobStoreTransferService blobStoreTransferService,
+        ThreadPool threadpool
+    ) {
+        this.globalMetadataUploadTimeout = clusterSettings.get(GLOBAL_METADATA_UPLOAD_TIMEOUT_SETTING);
+        this.compressor = blobStoreRepository.getCompressor();
+        this.namedXContentRegistry = blobStoreRepository.getNamedXContentRegistry();
+        this.remoteWritableEntityStores = new HashMap<>();
+        this.remoteWritableEntityStores.put(
+            RemoteGlobalMetadata.GLOBAL_METADATA,
+            new RemoteClusterStateBlobStore<>(
+                blobStoreTransferService,
+                blobStoreRepository,
+                clusterName,
+                threadpool,
+                ThreadPool.Names.REMOTE_STATE_READ
+            )
+        );
+        this.remoteWritableEntityStores.put(
+            RemoteCoordinationMetadata.COORDINATION_METADATA,
+            new RemoteClusterStateBlobStore<>(
+                blobStoreTransferService,
+                blobStoreRepository,
+                clusterName,
+                threadpool,
+                ThreadPool.Names.REMOTE_STATE_READ
+            )
+        );
+        this.remoteWritableEntityStores.put(
+            RemotePersistentSettingsMetadata.SETTING_METADATA,
+            new RemoteClusterStateBlobStore<>(
+                blobStoreTransferService,
+                blobStoreRepository,
+                clusterName,
+                threadpool,
+                ThreadPool.Names.REMOTE_STATE_READ
+            )
+        );
+        this.remoteWritableEntityStores.put(
+            RemoteTemplatesMetadata.TEMPLATES_METADATA,
+            new RemoteClusterStateBlobStore<>(
+                blobStoreTransferService,
+                blobStoreRepository,
+                clusterName,
+                threadpool,
+                ThreadPool.Names.REMOTE_STATE_READ
+            )
+        );
+        this.remoteWritableEntityStores.put(
+            RemoteCustomMetadata.CUSTOM_METADATA,
+            new RemoteClusterStateBlobStore<>(
+                blobStoreTransferService,
+                blobStoreRepository,
+                clusterName,
+                threadpool,
+                ThreadPool.Names.REMOTE_STATE_READ
+            )
+        );
+        clusterSettings.addSettingsUpdateConsumer(GLOBAL_METADATA_UPLOAD_TIMEOUT_SETTING, this::setGlobalMetadataUploadTimeout);
+    }
+
+    /**
+     * Allows async upload of Metadata components to remote
+     */
+    CheckedRunnable<IOException> getAsyncMetadataWriteAction(
+        AbstractRemoteWritableBlobEntity writeEntity,
+        LatchedActionListener<ClusterMetadataManifest.UploadedMetadata> latchedActionListener
+    ) {
+        return (() -> getStore(writeEntity).writeAsync(writeEntity, getActionListener(writeEntity, latchedActionListener)));
+    }
+
+    private RemoteWritableEntityStore getStore(AbstractRemoteWritableBlobEntity entity) {
+        RemoteWritableEntityStore remoteStore = remoteWritableEntityStores.get(entity.getType());
+        if (remoteStore == null) {
+            throw new IllegalArgumentException("Unknown entity type [" + entity.getType() + "]");
+        }
+        return remoteStore;
+    }
+
+    private ActionListener<Void> getActionListener(
+        AbstractRemoteWritableBlobEntity remoteBlobStoreObject,
+        LatchedActionListener<ClusterMetadataManifest.UploadedMetadata> latchedActionListener
+    ) {
+        return ActionListener.wrap(
+            resp -> latchedActionListener.onResponse(remoteBlobStoreObject.getUploadedMetadata()),
+            ex -> latchedActionListener.onFailure(new RemoteStateTransferException("Upload failed", ex))
+        );
+    }
+
+    Metadata getGlobalMetadata(String clusterUUID, ClusterMetadataManifest clusterMetadataManifest) {
+        String globalMetadataFileName = clusterMetadataManifest.getGlobalMetadataFileName();
+        try {
+            // Fetch Global metadata
+            if (globalMetadataFileName != null) {
+                RemoteGlobalMetadata remoteGlobalMetadata = new RemoteGlobalMetadata(
+                    String.format(Locale.ROOT, METADATA_NAME_FORMAT, globalMetadataFileName),
+                    clusterUUID,
+                    compressor,
+                    namedXContentRegistry
+                );
+                return (Metadata) getStore(remoteGlobalMetadata).read(remoteGlobalMetadata);
+            } else if (clusterMetadataManifest.hasMetadataAttributesFiles()) {
+                // from CODEC_V2, we have started uploading all the metadata in granular files instead of a single entity
+                Metadata.Builder builder = new Metadata.Builder();
+                if (clusterMetadataManifest.getCoordinationMetadata().getUploadedFilename() != null) {
+                    RemoteCoordinationMetadata remoteCoordinationMetadata = new RemoteCoordinationMetadata(
+                        clusterMetadataManifest.getCoordinationMetadata().getUploadedFilename(),
+                        clusterUUID,
+                        compressor,
+                        namedXContentRegistry
+                    );
+                    builder.coordinationMetadata(
+                        (CoordinationMetadata) getStore(remoteCoordinationMetadata).read(remoteCoordinationMetadata)
+                    );
+                }
+                if (clusterMetadataManifest.getTemplatesMetadata().getUploadedFilename() != null) {
+                    RemoteTemplatesMetadata remoteTemplatesMetadata = new RemoteTemplatesMetadata(
+                        clusterMetadataManifest.getTemplatesMetadata().getUploadedFilename(),
+                        clusterUUID,
+                        compressor,
+                        namedXContentRegistry
+                    );
+                    builder.templates((TemplatesMetadata) getStore(remoteTemplatesMetadata).read(remoteTemplatesMetadata));
+                }
+                if (clusterMetadataManifest.getSettingsMetadata().getUploadedFilename() != null) {
+                    RemotePersistentSettingsMetadata remotePersistentSettingsMetadata = new RemotePersistentSettingsMetadata(
+                        clusterMetadataManifest.getSettingsMetadata().getUploadedFilename(),
+                        clusterUUID,
+                        compressor,
+                        namedXContentRegistry
+                    );
+                    builder.persistentSettings(
+                        (Settings) getStore(remotePersistentSettingsMetadata).read(remotePersistentSettingsMetadata)
+                    );
+                }
+                builder.clusterUUID(clusterMetadataManifest.getClusterUUID());
+                builder.clusterUUIDCommitted(clusterMetadataManifest.isClusterUUIDCommitted());
+                clusterMetadataManifest.getCustomMetadataMap().forEach((key, value) -> {
+                    try {
+                        RemoteCustomMetadata remoteCustomMetadata = new RemoteCustomMetadata(
+                            value.getUploadedFilename(),
+                            key,
+                            clusterUUID,
+                            compressor,
+                            namedXContentRegistry
+                        );
+                        builder.putCustom(key, (Custom) getStore(remoteCustomMetadata).read(remoteCustomMetadata));
+                    } catch (IOException e) {
+                        throw new IllegalStateException(
+                            String.format(Locale.ROOT, "Error while downloading Custom Metadata - %s", value.getUploadedFilename()),
+                            e
+                        );
+                    }
+                });
+                return builder.build();
+            } else {
+                return Metadata.EMPTY_METADATA;
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException(
+                String.format(Locale.ROOT, "Error while downloading Global Metadata - %s", globalMetadataFileName),
+                e
+            );
+        }
+    }
+
+    Map<String, Metadata.Custom> getUpdatedCustoms(ClusterState currentState, ClusterState previousState) {
+        if (Metadata.isCustomMetadataEqual(previousState.metadata(), currentState.metadata())) {
+            return new HashMap<>();
+        }
+        Map<String, Metadata.Custom> updatedCustom = new HashMap<>();
+        Set<String> currentCustoms = new HashSet<>(currentState.metadata().customs().keySet());
+        for (Map.Entry<String, Metadata.Custom> cursor : previousState.metadata().customs().entrySet()) {
+            if (cursor.getValue().context().contains(Metadata.XContentContext.GATEWAY)) {
+                if (currentCustoms.contains(cursor.getKey())
+                    && !cursor.getValue().equals(currentState.metadata().custom(cursor.getKey()))) {
+                    // If the custom metadata is updated, we need to upload the new version.
+                    updatedCustom.put(cursor.getKey(), currentState.metadata().custom(cursor.getKey()));
+                }
+                currentCustoms.remove(cursor.getKey());
+            }
+        }
+        for (String custom : currentCustoms) {
+            Metadata.Custom cursor = currentState.metadata().custom(custom);
+            if (cursor.context().contains(Metadata.XContentContext.GATEWAY)) {
+                updatedCustom.put(custom, cursor);
+            }
+        }
+        return updatedCustom;
+    }
+
+    boolean isGlobalMetadataEqual(ClusterMetadataManifest first, ClusterMetadataManifest second, String clusterName) {
+        Metadata secondGlobalMetadata = getGlobalMetadata(second.getClusterUUID(), second);
+        Metadata firstGlobalMetadata = getGlobalMetadata(first.getClusterUUID(), first);
+        return Metadata.isGlobalResourcesMetadataEquals(firstGlobalMetadata, secondGlobalMetadata);
+    }
+
+    private void setGlobalMetadataUploadTimeout(TimeValue newGlobalMetadataUploadTimeout) {
+        this.globalMetadataUploadTimeout = newGlobalMetadataUploadTimeout;
+    }
+
+    public TimeValue getGlobalMetadataUploadTimeout() {
+        return this.globalMetadataUploadTimeout;
+    }
+}

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteIndexMetadataManager.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteIndexMetadataManager.java
@@ -1,0 +1,145 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.gateway.remote;
+
+import org.opensearch.action.LatchedActionListener;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.CheckedRunnable;
+import org.opensearch.common.remote.RemoteWritableEntityStore;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.compress.Compressor;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.gateway.remote.model.RemoteClusterStateBlobStore;
+import org.opensearch.gateway.remote.model.RemoteIndexMetadata;
+import org.opensearch.index.translog.transfer.BlobStoreTransferService;
+import org.opensearch.repositories.blobstore.BlobStoreRepository;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A Manager which provides APIs to write and read Index Metadata to remote store
+ *
+ * @opensearch.internal
+ */
+public class RemoteIndexMetadataManager {
+
+    public static final TimeValue INDEX_METADATA_UPLOAD_TIMEOUT_DEFAULT = TimeValue.timeValueMillis(20000);
+
+    public static final Setting<TimeValue> INDEX_METADATA_UPLOAD_TIMEOUT_SETTING = Setting.timeSetting(
+        "cluster.remote_store.state.index_metadata.upload_timeout",
+        INDEX_METADATA_UPLOAD_TIMEOUT_DEFAULT,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope,
+        Setting.Property.Deprecated
+    );
+
+    private final RemoteWritableEntityStore<IndexMetadata, RemoteIndexMetadata> indexMetadataBlobStore;
+    private final Compressor compressor;
+    private final NamedXContentRegistry namedXContentRegistry;
+
+    private volatile TimeValue indexMetadataUploadTimeout;
+
+    public RemoteIndexMetadataManager(
+        ClusterSettings clusterSettings,
+        String clusterName,
+        BlobStoreRepository blobStoreRepository,
+        BlobStoreTransferService blobStoreTransferService,
+        ThreadPool threadpool
+    ) {
+        this.indexMetadataBlobStore = new RemoteClusterStateBlobStore<>(
+            blobStoreTransferService,
+            blobStoreRepository,
+            clusterName,
+            threadpool,
+            ThreadPool.Names.REMOTE_STATE_READ
+        );
+        ;
+        this.namedXContentRegistry = blobStoreRepository.getNamedXContentRegistry();
+        this.compressor = blobStoreRepository.getCompressor();
+        this.indexMetadataUploadTimeout = clusterSettings.get(INDEX_METADATA_UPLOAD_TIMEOUT_SETTING);
+        clusterSettings.addSettingsUpdateConsumer(INDEX_METADATA_UPLOAD_TIMEOUT_SETTING, this::setIndexMetadataUploadTimeout);
+    }
+
+    /**
+     * Allows async Upload of IndexMetadata to remote
+     *
+     * @param indexMetadata {@link IndexMetadata} to upload
+     * @param latchedActionListener listener to respond back on after upload finishes
+     */
+    CheckedRunnable<IOException> getAsyncIndexMetadataWriteAction(
+        IndexMetadata indexMetadata,
+        String clusterUUID,
+        LatchedActionListener<ClusterMetadataManifest.UploadedMetadata> latchedActionListener
+    ) {
+        RemoteIndexMetadata remoteIndexMetadata = new RemoteIndexMetadata(indexMetadata, clusterUUID, compressor, namedXContentRegistry);
+        ActionListener<Void> completionListener = ActionListener.wrap(
+            resp -> latchedActionListener.onResponse(remoteIndexMetadata.getUploadedMetadata()),
+            ex -> latchedActionListener.onFailure(new RemoteStateTransferException(indexMetadata.getIndex().getName(), ex))
+        );
+        return () -> indexMetadataBlobStore.writeAsync(remoteIndexMetadata, completionListener);
+    }
+
+    /**
+     * Fetch index metadata from remote cluster state
+     *
+     * @param uploadedIndexMetadata {@link ClusterMetadataManifest.UploadedIndexMetadata} contains details about remote location of index metadata
+     * @return {@link IndexMetadata}
+     */
+    IndexMetadata getIndexMetadata(ClusterMetadataManifest.UploadedIndexMetadata uploadedIndexMetadata, String clusterUUID) {
+        RemoteIndexMetadata remoteIndexMetadata = new RemoteIndexMetadata(
+            RemoteClusterStateUtils.getFormattedIndexFileName(uploadedIndexMetadata.getUploadedFilename()),
+            clusterUUID,
+            compressor,
+            namedXContentRegistry
+        );
+        try {
+            return indexMetadataBlobStore.read(remoteIndexMetadata);
+        } catch (IOException e) {
+            throw new IllegalStateException(
+                String.format(Locale.ROOT, "Error while downloading IndexMetadata - %s", uploadedIndexMetadata.getUploadedFilename()),
+                e
+            );
+        }
+    }
+
+    /**
+     * Fetch latest index metadata from remote cluster state
+     *
+     * @param clusterMetadataManifest manifest file of cluster
+     * @param clusterUUID             uuid of cluster state to refer to in remote
+     * @return {@code Map<String, IndexMetadata>} latest IndexUUID to IndexMetadata map
+     */
+    Map<String, IndexMetadata> getIndexMetadataMap(String clusterUUID, ClusterMetadataManifest clusterMetadataManifest) {
+        assert Objects.equals(clusterUUID, clusterMetadataManifest.getClusterUUID())
+            : "Corrupt ClusterMetadataManifest found. Cluster UUID mismatch.";
+        Map<String, IndexMetadata> remoteIndexMetadata = new HashMap<>();
+        for (ClusterMetadataManifest.UploadedIndexMetadata uploadedIndexMetadata : clusterMetadataManifest.getIndices()) {
+            IndexMetadata indexMetadata = getIndexMetadata(uploadedIndexMetadata, clusterUUID);
+            remoteIndexMetadata.put(uploadedIndexMetadata.getIndexUUID(), indexMetadata);
+        }
+        return remoteIndexMetadata;
+    }
+
+    public TimeValue getIndexMetadataUploadTimeout() {
+        return this.indexMetadataUploadTimeout;
+    }
+
+    private void setIndexMetadataUploadTimeout(TimeValue newIndexMetadataUploadTimeout) {
+        this.indexMetadataUploadTimeout = newIndexMetadataUploadTimeout;
+    }
+
+}

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteManifestManager.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteManifestManager.java
@@ -1,0 +1,311 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.gateway.remote;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.Version;
+import org.opensearch.action.LatchedActionListener;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.common.blobstore.BlobContainer;
+import org.opensearch.common.blobstore.BlobMetadata;
+import org.opensearch.common.blobstore.BlobPath;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.compress.Compressor;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.gateway.remote.model.RemoteClusterMetadataManifest;
+import org.opensearch.gateway.remote.model.RemoteClusterStateBlobStore;
+import org.opensearch.gateway.remote.model.RemoteClusterStateManifestInfo;
+import org.opensearch.index.remote.RemoteStoreUtils;
+import org.opensearch.index.translog.transfer.BlobStoreTransferService;
+import org.opensearch.repositories.blobstore.BlobStoreRepository;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.opensearch.gateway.remote.RemoteClusterStateUtils.DELIMITER;
+
+/**
+ * A Manager which provides APIs to write and read {@link ClusterMetadataManifest} to remote store
+ *
+ * @opensearch.internal
+ */
+public class RemoteManifestManager {
+
+    public static final TimeValue METADATA_MANIFEST_UPLOAD_TIMEOUT_DEFAULT = TimeValue.timeValueMillis(20000);
+
+    public static final Setting<TimeValue> METADATA_MANIFEST_UPLOAD_TIMEOUT_SETTING = Setting.timeSetting(
+        "cluster.remote_store.state.metadata_manifest.upload_timeout",
+        METADATA_MANIFEST_UPLOAD_TIMEOUT_DEFAULT,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+    private static final Logger logger = LogManager.getLogger(RemoteManifestManager.class);
+
+    private volatile TimeValue metadataManifestUploadTimeout;
+    private final String nodeId;
+    private final RemoteClusterStateBlobStore<ClusterMetadataManifest, RemoteClusterMetadataManifest> manifestBlobStore;
+    private final Compressor compressor;
+    private final NamedXContentRegistry namedXContentRegistry;
+    // todo remove blobStorerepo from here
+    private final BlobStoreRepository blobStoreRepository;
+
+    RemoteManifestManager(
+        ClusterSettings clusterSettings,
+        String clusterName,
+        String nodeId,
+        BlobStoreRepository blobStoreRepository,
+        BlobStoreTransferService blobStoreTransferService,
+        ThreadPool threadpool
+    ) {
+        this.metadataManifestUploadTimeout = clusterSettings.get(METADATA_MANIFEST_UPLOAD_TIMEOUT_SETTING);
+        this.nodeId = nodeId;
+        this.manifestBlobStore = new RemoteClusterStateBlobStore<>(
+            blobStoreTransferService,
+            blobStoreRepository,
+            clusterName,
+            threadpool,
+            ThreadPool.Names.REMOTE_STATE_READ
+        );
+        ;
+        clusterSettings.addSettingsUpdateConsumer(METADATA_MANIFEST_UPLOAD_TIMEOUT_SETTING, this::setMetadataManifestUploadTimeout);
+        this.compressor = blobStoreRepository.getCompressor();
+        this.namedXContentRegistry = blobStoreRepository.getNamedXContentRegistry();
+        this.blobStoreRepository = blobStoreRepository;
+    }
+
+    RemoteClusterStateManifestInfo uploadManifest(
+        ClusterState clusterState,
+        RemoteClusterStateUtils.UploadedMetadataResults uploadedMetadataResult,
+        String previousClusterUUID,
+        boolean committed
+    ) {
+        synchronized (this) {
+            ClusterMetadataManifest.Builder manifestBuilder = ClusterMetadataManifest.builder();
+            manifestBuilder.clusterTerm(clusterState.term())
+                .stateVersion(clusterState.getVersion())
+                .clusterUUID(clusterState.metadata().clusterUUID())
+                .stateUUID(clusterState.stateUUID())
+                .opensearchVersion(Version.CURRENT)
+                .nodeId(nodeId)
+                .committed(committed)
+                .codecVersion(RemoteClusterMetadataManifest.MANIFEST_CURRENT_CODEC_VERSION)
+                .indices(uploadedMetadataResult.uploadedIndexMetadata)
+                .previousClusterUUID(previousClusterUUID)
+                .clusterUUIDCommitted(clusterState.metadata().clusterUUIDCommitted())
+                .coordinationMetadata(uploadedMetadataResult.uploadedCoordinationMetadata)
+                .settingMetadata(uploadedMetadataResult.uploadedSettingsMetadata)
+                .templatesMetadata(uploadedMetadataResult.uploadedTemplatesMetadata)
+                .customMetadataMap(uploadedMetadataResult.uploadedCustomMetadataMap)
+                .routingTableVersion(clusterState.getRoutingTable().version())
+                .indicesRouting(uploadedMetadataResult.uploadedIndicesRoutingMetadata);
+            final ClusterMetadataManifest manifest = manifestBuilder.build();
+            String manifestFileName = writeMetadataManifest(clusterState.metadata().clusterUUID(), manifest);
+            return new RemoteClusterStateManifestInfo(manifest, manifestFileName);
+        }
+    }
+
+    private String writeMetadataManifest(String clusterUUID, ClusterMetadataManifest uploadManifest) {
+        AtomicReference<String> result = new AtomicReference<String>();
+        AtomicReference<Exception> exceptionReference = new AtomicReference<Exception>();
+
+        // latch to wait until upload is not finished
+        CountDownLatch latch = new CountDownLatch(1);
+
+        LatchedActionListener completionListener = new LatchedActionListener<>(ActionListener.wrap(resp -> {
+            logger.trace(String.format(Locale.ROOT, "Manifest file uploaded successfully."));
+        }, ex -> { exceptionReference.set(ex); }), latch);
+
+        RemoteClusterMetadataManifest remoteClusterMetadataManifest = new RemoteClusterMetadataManifest(
+            uploadManifest,
+            clusterUUID,
+            compressor,
+            namedXContentRegistry
+        );
+        manifestBlobStore.writeAsync(remoteClusterMetadataManifest, completionListener);
+
+        try {
+            if (latch.await(getMetadataManifestUploadTimeout().millis(), TimeUnit.MILLISECONDS) == false) {
+                RemoteStateTransferException ex = new RemoteStateTransferException(
+                    String.format(Locale.ROOT, "Timed out waiting for transfer of manifest file to complete")
+                );
+                throw ex;
+            }
+        } catch (InterruptedException ex) {
+            RemoteStateTransferException exception = new RemoteStateTransferException(
+                String.format(Locale.ROOT, "Timed out waiting for transfer of manifest file to complete - %s"),
+                ex
+            );
+            Thread.currentThread().interrupt();
+            throw exception;
+        }
+        if (exceptionReference.get() != null) {
+            throw new RemoteStateTransferException(exceptionReference.get().getMessage(), exceptionReference.get());
+        }
+        logger.debug(
+            "Metadata manifest file [{}] written during [{}] phase. ",
+            remoteClusterMetadataManifest.getBlobFileName(),
+            uploadManifest.isCommitted() ? "commit" : "publish"
+        );
+        return remoteClusterMetadataManifest.getUploadedMetadata().getUploadedFilename();
+    }
+
+    /**
+     * Fetch latest ClusterMetadataManifest from remote state store
+     *
+     * @param clusterUUID uuid of cluster state to refer to in remote
+     * @param clusterName name of the cluster
+     * @return ClusterMetadataManifest
+     */
+    public Optional<ClusterMetadataManifest> getLatestClusterMetadataManifest(String clusterName, String clusterUUID) {
+        Optional<String> latestManifestFileName = getLatestManifestFileName(clusterName, clusterUUID);
+        return latestManifestFileName.map(s -> fetchRemoteClusterMetadataManifest(clusterName, clusterUUID, s));
+    }
+
+    public ClusterMetadataManifest getRemoteClusterMetadataManifestByFileName(String clusterUUID, String filename)
+        throws IllegalStateException {
+        try {
+            RemoteClusterMetadataManifest remoteClusterMetadataManifest = new RemoteClusterMetadataManifest(
+                filename,
+                clusterUUID,
+                compressor,
+                namedXContentRegistry
+            );
+            return manifestBlobStore.read(remoteClusterMetadataManifest);
+        } catch (IOException e) {
+            throw new IllegalStateException(String.format(Locale.ROOT, "Error while downloading cluster metadata - %s", filename), e);
+        }
+    }
+
+    /**
+     * Fetch ClusterMetadataManifest from remote state store
+     *
+     * @param clusterUUID uuid of cluster state to refer to in remote
+     * @param clusterName name of the cluster
+     * @return ClusterMetadataManifest
+     */
+    ClusterMetadataManifest fetchRemoteClusterMetadataManifest(String clusterName, String clusterUUID, String filename)
+        throws IllegalStateException {
+        try {
+            String fullBlobName = getManifestFolderPath(clusterName, clusterUUID).buildAsString() + filename;
+            RemoteClusterMetadataManifest remoteClusterMetadataManifest = new RemoteClusterMetadataManifest(
+                fullBlobName,
+                clusterUUID,
+                compressor,
+                namedXContentRegistry
+            );
+            return manifestBlobStore.read(remoteClusterMetadataManifest);
+        } catch (IOException e) {
+            throw new IllegalStateException(String.format(Locale.ROOT, "Error while downloading cluster metadata - %s", filename), e);
+        }
+    }
+
+    Map<String, ClusterMetadataManifest> getLatestManifestForAllClusterUUIDs(String clusterName, Set<String> clusterUUIDs) {
+        Map<String, ClusterMetadataManifest> manifestsByClusterUUID = new HashMap<>();
+        for (String clusterUUID : clusterUUIDs) {
+            try {
+                Optional<ClusterMetadataManifest> manifest = getLatestClusterMetadataManifest(clusterName, clusterUUID);
+                manifest.ifPresent(clusterMetadataManifest -> manifestsByClusterUUID.put(clusterUUID, clusterMetadataManifest));
+            } catch (Exception e) {
+                throw new IllegalStateException(
+                    String.format(Locale.ROOT, "Exception in fetching manifest for clusterUUID: %s", clusterUUID),
+                    e
+                );
+            }
+        }
+        return manifestsByClusterUUID;
+    }
+
+    private BlobContainer manifestContainer(String clusterName, String clusterUUID) {
+        // 123456789012_test-cluster/cluster-state/dsgYj10Nkso7/manifest
+        return blobStoreRepository.blobStore().blobContainer(getManifestFolderPath(clusterName, clusterUUID));
+    }
+
+    BlobPath getManifestFolderPath(String clusterName, String clusterUUID) {
+        return RemoteClusterStateUtils.getClusterMetadataBasePath(blobStoreRepository, clusterName, clusterUUID)
+            .add(RemoteClusterMetadataManifest.MANIFEST);
+    }
+
+    public TimeValue getMetadataManifestUploadTimeout() {
+        return this.metadataManifestUploadTimeout;
+    }
+
+    private void setMetadataManifestUploadTimeout(TimeValue newMetadataManifestUploadTimeout) {
+        this.metadataManifestUploadTimeout = newMetadataManifestUploadTimeout;
+    }
+
+    /**
+     * Fetch ClusterMetadataManifest files from remote state store in order
+     *
+     * @param clusterUUID uuid of cluster state to refer to in remote
+     * @param clusterName name of the cluster
+     * @param limit max no of files to fetch
+     * @return all manifest file names
+     */
+    private List<BlobMetadata> getManifestFileNames(String clusterName, String clusterUUID, String filePrefix, int limit)
+        throws IllegalStateException {
+        try {
+
+            /*
+              {@link BlobContainer#listBlobsByPrefixInSortedOrder} will list the latest manifest file first
+              as the manifest file name generated via {@link RemoteClusterStateService#getManifestFileName} ensures
+              when sorted in LEXICOGRAPHIC order the latest uploaded manifest file comes on top.
+             */
+            return manifestContainer(clusterName, clusterUUID).listBlobsByPrefixInSortedOrder(
+                filePrefix,
+                limit,
+                BlobContainer.BlobNameSortOrder.LEXICOGRAPHIC
+            );
+        } catch (IOException e) {
+            throw new IllegalStateException("Error while fetching latest manifest file for remote cluster state", e);
+        }
+    }
+
+    static String getManifestFilePrefixForTermVersion(long term, long version) {
+        return String.join(
+            DELIMITER,
+            RemoteClusterMetadataManifest.MANIFEST,
+            RemoteStoreUtils.invertLong(term),
+            RemoteStoreUtils.invertLong(version)
+        ) + DELIMITER;
+    }
+
+    /**
+     * Fetch latest ClusterMetadataManifest file from remote state store
+     *
+     * @param clusterUUID uuid of cluster state to refer to in remote
+     * @param clusterName name of the cluster
+     * @return latest ClusterMetadataManifest filename
+     */
+    private Optional<String> getLatestManifestFileName(String clusterName, String clusterUUID) throws IllegalStateException {
+        List<BlobMetadata> manifestFilesMetadata = getManifestFileNames(
+            clusterName,
+            clusterUUID,
+            RemoteClusterMetadataManifest.MANIFEST + DELIMITER,
+            1
+        );
+        if (manifestFilesMetadata != null && !manifestFilesMetadata.isEmpty()) {
+            return Optional.of(manifestFilesMetadata.get(0).name());
+        }
+        logger.info("No manifest file present in remote store for cluster name: {}, cluster UUID: {}", clusterName, clusterUUID);
+        return Optional.empty();
+    }
+}

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemoteClusterBlocks.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemoteClusterBlocks.java
@@ -56,6 +56,11 @@ public class RemoteClusterBlocks extends AbstractRemoteWritableBlobEntity<Cluste
     }
 
     @Override
+    public String getType() {
+        return CLUSTER_BLOCKS;
+    }
+
+    @Override
     public String generateBlobFileName() {
         // 123456789012_test-cluster/cluster-state/dsgYj10Nkso7/transient/<componentPrefix>__<inverted_state_version>__<inverted__timestamp>__<codec_version>
         String blobFileName = String.join(

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemoteClusterMetadataManifest.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemoteClusterMetadataManifest.java
@@ -87,6 +87,11 @@ public class RemoteClusterMetadataManifest extends AbstractRemoteWritableBlobEnt
     }
 
     @Override
+    public String getType() {
+        return MANIFEST;
+    }
+
+    @Override
     public String generateBlobFileName() {
         // 123456789012_test-cluster/cluster-state/dsgYj10Nkso7/manifest/manifest__<inverted_term>__<inverted_version>__C/P__<inverted__timestamp>__
         // <codec_version>
@@ -150,4 +155,5 @@ public class RemoteClusterMetadataManifest extends AbstractRemoteWritableBlobEnt
         }
         throw new IllegalArgumentException("Cluster metadata manifest file is corrupted, don't have valid codec version");
     }
+
 }

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemoteClusterStateCustoms.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemoteClusterStateCustoms.java
@@ -78,6 +78,11 @@ public class RemoteClusterStateCustoms extends AbstractRemoteWritableBlobEntity<
     }
 
     @Override
+    public String getType() {
+        return CLUSTER_STATE_CUSTOM;
+    }
+
+    @Override
     public String generateBlobFileName() {
         // 123456789012_test-cluster/cluster-state/dsgYj10Nkso7/ephemeral/<componentPrefix>__<inverted_state_version>__<inverted__timestamp>__<codec_version>
         String blobFileName = String.join(

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemoteCoordinationMetadata.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemoteCoordinationMetadata.java
@@ -71,6 +71,11 @@ public class RemoteCoordinationMetadata extends AbstractRemoteWritableBlobEntity
     }
 
     @Override
+    public String getType() {
+        return COORDINATION_METADATA;
+    }
+
+    @Override
     public String generateBlobFileName() {
         // 123456789012_test-cluster/cluster-state/dsgYj10Nkso7/global-metadata/<componentPrefix>__<inverted_metadata_version>__<inverted__timestamp>__<codec_version>
         String blobFileName = String.join(

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemoteCustomMetadata.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemoteCustomMetadata.java
@@ -86,6 +86,11 @@ public class RemoteCustomMetadata extends AbstractRemoteWritableBlobEntity<Custo
     }
 
     @Override
+    public String getType() {
+        return CUSTOM_METADATA;
+    }
+
+    @Override
     public String generateBlobFileName() {
         // 123456789012_test-cluster/cluster-state/dsgYj10Nkso7/global-metadata/<componentPrefix>__<inverted_metadata_version>__<inverted__timestamp>__
         // <codec_version>

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemoteDiscoveryNodes.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemoteDiscoveryNodes.java
@@ -61,6 +61,11 @@ public class RemoteDiscoveryNodes extends AbstractRemoteWritableBlobEntity<Disco
     }
 
     @Override
+    public String getType() {
+        return DISCOVERY_NODES;
+    }
+
+    @Override
     public String generateBlobFileName() {
         // 123456789012_test-cluster/cluster-state/dsgYj10Nkso7/ephemeral/<componentPrefix>__<inverted_state_version>__<inverted__timestamp>__<codec_version>
         String blobFileName = String.join(

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemoteGlobalMetadata.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemoteGlobalMetadata.java
@@ -26,6 +26,7 @@ import static org.opensearch.gateway.remote.RemoteClusterStateUtils.METADATA_NAM
  * Wrapper class for uploading/downloading global metadata ({@link Metadata}) to/from remote blob store
  */
 public class RemoteGlobalMetadata extends AbstractRemoteWritableBlobEntity<Metadata> {
+    public static final String GLOBAL_METADATA = "global_metadata";
 
     public static final ChecksumBlobStoreFormat<Metadata> GLOBAL_METADATA_FORMAT = new ChecksumBlobStoreFormat<>(
         "metadata",
@@ -46,6 +47,11 @@ public class RemoteGlobalMetadata extends AbstractRemoteWritableBlobEntity<Metad
     @Override
     public BlobPathParameters getBlobPathParameters() {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getType() {
+        return GLOBAL_METADATA;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemoteHashesOfConsistentSettings.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemoteHashesOfConsistentSettings.java
@@ -59,6 +59,11 @@ public class RemoteHashesOfConsistentSettings extends AbstractRemoteWritableBlob
     }
 
     @Override
+    public String getType() {
+        return HASHES_OF_CONSISTENT_SETTINGS;
+    }
+
+    @Override
     public String generateBlobFileName() {
         String blobFileName = String.join(
             DELIMITER,

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemoteIndexMetadata.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemoteIndexMetadata.java
@@ -31,14 +31,14 @@ import static org.opensearch.gateway.remote.RemoteClusterStateUtils.METADATA_NAM
  */
 public class RemoteIndexMetadata extends AbstractRemoteWritableBlobEntity<IndexMetadata> {
 
-    public static final int INDEX_METADATA_CURRENT_CODEC_VERSION = 1;
+    public static final int INDEX_METADATA_CURRENT_CODEC_VERSION = 2;
 
     public static final ChecksumBlobStoreFormat<IndexMetadata> INDEX_METADATA_FORMAT = new ChecksumBlobStoreFormat<>(
         "index-metadata",
         METADATA_NAME_PLAIN_FORMAT,
         IndexMetadata::fromXContent
     );
-    public static final String INDEX_PATH_TOKEN = "index";
+    public static final String INDEX = "index";
 
     private IndexMetadata indexMetadata;
 
@@ -64,7 +64,12 @@ public class RemoteIndexMetadata extends AbstractRemoteWritableBlobEntity<IndexM
 
     @Override
     public BlobPathParameters getBlobPathParameters() {
-        return new BlobPathParameters(List.of(INDEX_PATH_TOKEN, indexMetadata.getIndexUUID()), "metadata");
+        return new BlobPathParameters(List.of(INDEX, indexMetadata.getIndexUUID()), "metadata");
+    }
+
+    @Override
+    public String getType() {
+        return INDEX;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemotePersistentSettingsMetadata.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemotePersistentSettingsMetadata.java
@@ -26,7 +26,7 @@ import java.util.List;
 
 import static org.opensearch.gateway.remote.RemoteClusterStateUtils.DELIMITER;
 import static org.opensearch.gateway.remote.RemoteClusterStateUtils.GLOBAL_METADATA_CURRENT_CODEC_VERSION;
-import static org.opensearch.gateway.remote.RemoteClusterStateUtils.METADATA_NAME_FORMAT;
+import static org.opensearch.gateway.remote.RemoteClusterStateUtils.METADATA_NAME_PLAIN_FORMAT;
 
 /**
  * Wrapper class for uploading/downloading persistent {@link Settings} to/from remote blob store
@@ -37,7 +37,7 @@ public class RemotePersistentSettingsMetadata extends AbstractRemoteWritableBlob
 
     public static final ChecksumBlobStoreFormat<Settings> SETTINGS_METADATA_FORMAT = new ChecksumBlobStoreFormat<>(
         "settings",
-        METADATA_NAME_FORMAT,
+        METADATA_NAME_PLAIN_FORMAT,
         Settings::fromXContent
     );
 
@@ -69,6 +69,11 @@ public class RemotePersistentSettingsMetadata extends AbstractRemoteWritableBlob
     @Override
     public BlobPathParameters getBlobPathParameters() {
         return new BlobPathParameters(List.of("global-metadata"), SETTING_METADATA);
+    }
+
+    @Override
+    public String getType() {
+        return SETTING_METADATA;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemoteTemplatesMetadata.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemoteTemplatesMetadata.java
@@ -26,7 +26,7 @@ import java.util.List;
 
 import static org.opensearch.gateway.remote.RemoteClusterStateUtils.DELIMITER;
 import static org.opensearch.gateway.remote.RemoteClusterStateUtils.GLOBAL_METADATA_CURRENT_CODEC_VERSION;
-import static org.opensearch.gateway.remote.RemoteClusterStateUtils.METADATA_NAME_FORMAT;
+import static org.opensearch.gateway.remote.RemoteClusterStateUtils.METADATA_NAME_PLAIN_FORMAT;
 
 /**
  * Wrapper class for uploading/downloading {@link TemplatesMetadata} to/from remote blob store
@@ -37,7 +37,7 @@ public class RemoteTemplatesMetadata extends AbstractRemoteWritableBlobEntity<Te
 
     public static final ChecksumBlobStoreFormat<TemplatesMetadata> TEMPLATES_METADATA_FORMAT = new ChecksumBlobStoreFormat<>(
         "templates",
-        METADATA_NAME_FORMAT,
+        METADATA_NAME_PLAIN_FORMAT,
         TemplatesMetadata::fromXContent
     );
     private TemplatesMetadata templatesMetadata;
@@ -68,6 +68,11 @@ public class RemoteTemplatesMetadata extends AbstractRemoteWritableBlobEntity<Te
     @Override
     public BlobPathParameters getBlobPathParameters() {
         return new BlobPathParameters(List.of("global-metadata"), TEMPLATES_METADATA);
+    }
+
+    @Override
+    public String getType() {
+        return TEMPLATES_METADATA;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemoteTransientSettingsMetadata.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemoteTransientSettingsMetadata.java
@@ -73,6 +73,11 @@ public class RemoteTransientSettingsMetadata extends AbstractRemoteWritableBlobE
     }
 
     @Override
+    public String getType() {
+        return TRANSIENT_SETTING_METADATA;
+    }
+
+    @Override
     public String generateBlobFileName() {
         String blobFileName = String.join(
             DELIMITER,

--- a/server/src/main/java/org/opensearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/opensearch/threadpool/ThreadPool.java
@@ -114,6 +114,7 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         public static final String REMOTE_PURGE = "remote_purge";
         public static final String REMOTE_REFRESH_RETRY = "remote_refresh_retry";
         public static final String REMOTE_RECOVERY = "remote_recovery";
+        public static final String REMOTE_STATE_READ = "remote_state_read";
         public static final String INDEX_SEARCHER = "index_searcher";
     }
 
@@ -186,6 +187,7 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         map.put(Names.REMOTE_REFRESH_RETRY, ThreadPoolType.SCALING);
         map.put(Names.REMOTE_RECOVERY, ThreadPoolType.SCALING);
         map.put(Names.INDEX_SEARCHER, ThreadPoolType.FIXED_AUTO_QUEUE_SIZE);
+        map.put(Names.REMOTE_STATE_READ, ThreadPoolType.SCALING);
         THREAD_POOL_TYPES = Collections.unmodifiableMap(map);
     }
 
@@ -285,6 +287,15 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
             Names.REMOTE_RECOVERY,
             new ScalingExecutorBuilder(
                 Names.REMOTE_RECOVERY,
+                1,
+                twiceAllocatedProcessors(allocatedProcessors),
+                TimeValue.timeValueMinutes(5)
+            )
+        );
+        builders.put(
+            Names.REMOTE_STATE_READ,
+            new ScalingExecutorBuilder(
+                Names.REMOTE_STATE_READ,
                 1,
                 twiceAllocatedProcessors(allocatedProcessors),
                 TimeValue.timeValueMinutes(5)

--- a/server/src/test/java/org/opensearch/cluster/routing/remote/RemoteRoutingTableServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/remote/RemoteRoutingTableServiceTests.java
@@ -33,7 +33,7 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.index.Index;
 import org.opensearch.gateway.remote.ClusterMetadataManifest;
-import org.opensearch.gateway.remote.RemoteClusterStateService;
+import org.opensearch.gateway.remote.RemoteStateTransferException;
 import org.opensearch.index.remote.RemoteStoreEnums;
 import org.opensearch.index.remote.RemoteStorePathStrategy;
 import org.opensearch.index.remote.RemoteStoreUtils;
@@ -57,7 +57,7 @@ import org.mockito.ArgumentCaptor;
 import static org.opensearch.cluster.routing.remote.InternalRemoteRoutingTableService.INDEX_ROUTING_FILE_PREFIX;
 import static org.opensearch.cluster.routing.remote.InternalRemoteRoutingTableService.INDEX_ROUTING_PATH_TOKEN;
 import static org.opensearch.common.util.FeatureFlags.REMOTE_PUBLICATION_EXPERIMENTAL;
-import static org.opensearch.gateway.remote.RemoteClusterStateService.DELIMITER;
+import static org.opensearch.gateway.remote.RemoteClusterStateUtils.DELIMITER;
 import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.REMOTE_STORE_ROUTING_TABLE_REPOSITORY_NAME_ATTRIBUTE_KEY;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -352,7 +352,7 @@ public class RemoteRoutingTableServiceTests extends OpenSearchTestCase {
             RemoteStoreUtils.invertLong(clusterState.version())
         );
         verify(blobContainer, times(1)).writeBlob(startsWith(expectedFilePrefix), any(StreamInput.class), anyLong(), eq(true));
-        verify(listener, times(1)).onFailure(any(RemoteClusterStateService.RemoteStateTransferException.class));
+        verify(listener, times(1)).onFailure(any(RemoteStateTransferException.class));
     }
 
     public void testGetIndexRoutingAsyncActionAsyncRepo() throws IOException {
@@ -419,7 +419,7 @@ public class RemoteRoutingTableServiceTests extends OpenSearchTestCase {
         );
         assertNotNull(runnable);
         runnable.run();
-        verify(listener, times(1)).onFailure(any(RemoteClusterStateService.RemoteStateTransferException.class));
+        verify(listener, times(1)).onFailure(any(RemoteStateTransferException.class));
     }
 
     public void testGetAllUploadedIndicesRouting() {

--- a/server/src/test/java/org/opensearch/gateway/remote/ClusterMetadataManifestTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/ClusterMetadataManifestTests.java
@@ -37,8 +37,12 @@ import static org.opensearch.gateway.remote.ClusterMetadataManifest.CODEC_V0;
 import static org.opensearch.gateway.remote.ClusterMetadataManifest.CODEC_V1;
 import static org.opensearch.gateway.remote.RemoteClusterStateAttributesManager.CLUSTER_BLOCKS;
 import static org.opensearch.gateway.remote.RemoteClusterStateAttributesManager.DISCOVERY_NODES;
-import static org.opensearch.gateway.remote.RemoteClusterStateServiceTests.generateClusterStateWithOneIndex;
+import static org.opensearch.gateway.remote.model.RemoteCoordinationMetadata.COORDINATION_METADATA;
+import static org.opensearch.gateway.remote.model.RemoteCustomMetadata.CUSTOM_DELIMITER;
+import static org.opensearch.gateway.remote.model.RemoteCustomMetadata.CUSTOM_METADATA;
 import static org.opensearch.gateway.remote.model.RemoteHashesOfConsistentSettings.HASHES_OF_CONSISTENT_SETTINGS;
+import static org.opensearch.gateway.remote.model.RemotePersistentSettingsMetadata.SETTING_METADATA;
+import static org.opensearch.gateway.remote.model.RemoteTemplatesMetadata.TEMPLATES_METADATA;
 import static org.opensearch.gateway.remote.model.RemoteTransientSettingsMetadata.TRANSIENT_SETTING_METADATA;
 
 public class ClusterMetadataManifestTests extends OpenSearchTestCase {
@@ -110,24 +114,22 @@ public class ClusterMetadataManifestTests extends OpenSearchTestCase {
             .indices(Collections.singletonList(uploadedIndexMetadata))
             .previousClusterUUID("prev-cluster-uuid")
             .clusterUUIDCommitted(true)
-            .coordinationMetadata(new UploadedMetadataAttribute(RemoteClusterStateService.COORDINATION_METADATA, "coordination-file"))
-            .settingMetadata(new UploadedMetadataAttribute(RemoteClusterStateService.SETTING_METADATA, "setting-file"))
-            .templatesMetadata(new UploadedMetadataAttribute(RemoteClusterStateService.TEMPLATES_METADATA, "templates-file"))
+            .coordinationMetadata(new UploadedMetadataAttribute(COORDINATION_METADATA, "coordination-file"))
+            .settingMetadata(new UploadedMetadataAttribute(SETTING_METADATA, "setting-file"))
+            .templatesMetadata(new UploadedMetadataAttribute(TEMPLATES_METADATA, "templates-file"))
             .customMetadataMap(
                 Collections.unmodifiableList(
                     Arrays.asList(
                         new UploadedMetadataAttribute(
-                            RemoteClusterStateService.CUSTOM_METADATA + RemoteClusterStateService.CUSTOM_DELIMITER
-                                + RepositoriesMetadata.TYPE,
+                            CUSTOM_METADATA + CUSTOM_DELIMITER + RepositoriesMetadata.TYPE,
                             "custom--repositories-file"
                         ),
                         new UploadedMetadataAttribute(
-                            RemoteClusterStateService.CUSTOM_METADATA + RemoteClusterStateService.CUSTOM_DELIMITER + IndexGraveyard.TYPE,
+                            CUSTOM_METADATA + CUSTOM_DELIMITER + IndexGraveyard.TYPE,
                             "custom--index_graveyard-file"
                         ),
                         new UploadedMetadataAttribute(
-                            RemoteClusterStateService.CUSTOM_METADATA + RemoteClusterStateService.CUSTOM_DELIMITER
-                                + WeightedRoutingMetadata.TYPE,
+                            CUSTOM_METADATA + CUSTOM_DELIMITER + WeightedRoutingMetadata.TYPE,
                             "custom--weighted_routing_netadata-file"
                         )
                     )
@@ -159,24 +161,22 @@ public class ClusterMetadataManifestTests extends OpenSearchTestCase {
             .indices(randomUploadedIndexMetadataList())
             .previousClusterUUID("yfObdx8KSMKKrXf8UyHhM")
             .clusterUUIDCommitted(true)
-            .coordinationMetadata(new UploadedMetadataAttribute(RemoteClusterStateService.COORDINATION_METADATA, "coordination-file"))
-            .settingMetadata(new UploadedMetadataAttribute(RemoteClusterStateService.SETTING_METADATA, "setting-file"))
-            .templatesMetadata(new UploadedMetadataAttribute(RemoteClusterStateService.TEMPLATES_METADATA, "templates-file"))
+            .coordinationMetadata(new UploadedMetadataAttribute(COORDINATION_METADATA, "coordination-file"))
+            .settingMetadata(new UploadedMetadataAttribute(SETTING_METADATA, "setting-file"))
+            .templatesMetadata(new UploadedMetadataAttribute(TEMPLATES_METADATA, "templates-file"))
             .customMetadataMap(
                 Collections.unmodifiableList(
                     Arrays.asList(
                         new UploadedMetadataAttribute(
-                            RemoteClusterStateService.CUSTOM_METADATA + RemoteClusterStateService.CUSTOM_DELIMITER
-                                + RepositoriesMetadata.TYPE,
+                            CUSTOM_METADATA + CUSTOM_DELIMITER + RepositoriesMetadata.TYPE,
                             "custom--repositories-file"
                         ),
                         new UploadedMetadataAttribute(
-                            RemoteClusterStateService.CUSTOM_METADATA + RemoteClusterStateService.CUSTOM_DELIMITER + IndexGraveyard.TYPE,
+                            CUSTOM_METADATA + CUSTOM_DELIMITER + IndexGraveyard.TYPE,
                             "custom--index_graveyard-file"
                         ),
                         new UploadedMetadataAttribute(
-                            RemoteClusterStateService.CUSTOM_METADATA + RemoteClusterStateService.CUSTOM_DELIMITER
-                                + WeightedRoutingMetadata.TYPE,
+                            CUSTOM_METADATA + CUSTOM_DELIMITER + WeightedRoutingMetadata.TYPE,
                             "custom--weighted_routing_netadata-file"
                         )
                     )
@@ -188,7 +188,12 @@ public class ClusterMetadataManifestTests extends OpenSearchTestCase {
             .transientSettingsMetadata(new UploadedMetadataAttribute(TRANSIENT_SETTING_METADATA, "transient-settings-file"))
             .hashesOfConsistentSettings(new UploadedMetadataAttribute(HASHES_OF_CONSISTENT_SETTINGS, "hashes-of-consistent-settings-file"))
             .clusterStateCustomMetadataMap(Collections.emptyMap())
-            .diffManifest(new ClusterStateDiffManifest(generateClusterStateWithOneIndex().build(), ClusterState.EMPTY_STATE))
+            .diffManifest(
+                new ClusterStateDiffManifest(
+                    RemoteClusterStateServiceTests.generateClusterStateWithOneIndex().build(),
+                    ClusterState.EMPTY_STATE
+                )
+            )
             .build();
         {  // Mutate Cluster Term
             EqualsHashCodeTestUtils.checkEqualsAndHashCode(
@@ -494,17 +499,15 @@ public class ClusterMetadataManifestTests extends OpenSearchTestCase {
                 Collections.unmodifiableList(
                     Arrays.asList(
                         new UploadedMetadataAttribute(
-                            RemoteClusterStateService.CUSTOM_METADATA + RemoteClusterStateService.CUSTOM_DELIMITER
-                                + RepositoriesMetadata.TYPE,
+                            CUSTOM_METADATA + CUSTOM_DELIMITER + RepositoriesMetadata.TYPE,
                             "custom--repositories-file"
                         ),
                         new UploadedMetadataAttribute(
-                            RemoteClusterStateService.CUSTOM_METADATA + RemoteClusterStateService.CUSTOM_DELIMITER + IndexGraveyard.TYPE,
+                            CUSTOM_METADATA + CUSTOM_DELIMITER + IndexGraveyard.TYPE,
                             "custom--index_graveyard-file"
                         ),
                         new UploadedMetadataAttribute(
-                            RemoteClusterStateService.CUSTOM_METADATA + RemoteClusterStateService.CUSTOM_DELIMITER
-                                + WeightedRoutingMetadata.TYPE,
+                            CUSTOM_METADATA + CUSTOM_DELIMITER + WeightedRoutingMetadata.TYPE,
                             "custom--weighted_routing_netadata-file"
                         )
                     )
@@ -517,7 +520,12 @@ public class ClusterMetadataManifestTests extends OpenSearchTestCase {
             .transientSettingsMetadata(uploadedMetadataAttribute)
             .hashesOfConsistentSettings(uploadedMetadataAttribute)
             .clusterStateCustomMetadataMap(Collections.emptyMap())
-            .diffManifest(new ClusterStateDiffManifest(generateClusterStateWithOneIndex().build(), ClusterState.EMPTY_STATE))
+            .diffManifest(
+                new ClusterStateDiffManifest(
+                    RemoteClusterStateServiceTests.generateClusterStateWithOneIndex().build(),
+                    ClusterState.EMPTY_STATE
+                )
+            )
             .build();
         final XContentBuilder builder = JsonXContent.contentBuilder();
         builder.startObject();
@@ -558,17 +566,15 @@ public class ClusterMetadataManifestTests extends OpenSearchTestCase {
                 Collections.unmodifiableList(
                     Arrays.asList(
                         new UploadedMetadataAttribute(
-                            RemoteClusterStateService.CUSTOM_METADATA + RemoteClusterStateService.CUSTOM_DELIMITER
-                                + RepositoriesMetadata.TYPE,
+                            CUSTOM_METADATA + CUSTOM_DELIMITER + RepositoriesMetadata.TYPE,
                             "custom--repositories-file"
                         ),
                         new UploadedMetadataAttribute(
-                            RemoteClusterStateService.CUSTOM_METADATA + RemoteClusterStateService.CUSTOM_DELIMITER + IndexGraveyard.TYPE,
+                            CUSTOM_METADATA + CUSTOM_DELIMITER + IndexGraveyard.TYPE,
                             "custom--index_graveyard-file"
                         ),
                         new UploadedMetadataAttribute(
-                            RemoteClusterStateService.CUSTOM_METADATA + RemoteClusterStateService.CUSTOM_DELIMITER
-                                + WeightedRoutingMetadata.TYPE,
+                            CUSTOM_METADATA + CUSTOM_DELIMITER + WeightedRoutingMetadata.TYPE,
                             "custom--weighted_routing_netadata-file"
                         )
                     )

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateCleanupManagerTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateCleanupManagerTests.java
@@ -54,18 +54,15 @@ import static org.opensearch.gateway.remote.RemoteClusterStateCleanupManager.CLU
 import static org.opensearch.gateway.remote.RemoteClusterStateCleanupManager.REMOTE_CLUSTER_STATE_CLEANUP_INTERVAL_SETTING;
 import static org.opensearch.gateway.remote.RemoteClusterStateCleanupManager.RETAINED_MANIFESTS;
 import static org.opensearch.gateway.remote.RemoteClusterStateCleanupManager.SKIP_CLEANUP_STATE_CHANGES;
-import static org.opensearch.gateway.remote.RemoteClusterStateService.CLUSTER_STATE_PATH_TOKEN;
-import static org.opensearch.gateway.remote.RemoteClusterStateService.COORDINATION_METADATA;
-import static org.opensearch.gateway.remote.RemoteClusterStateService.DELIMITER;
-import static org.opensearch.gateway.remote.RemoteClusterStateService.GLOBAL_METADATA_PATH_TOKEN;
-import static org.opensearch.gateway.remote.RemoteClusterStateService.INDEX_PATH_TOKEN;
-import static org.opensearch.gateway.remote.RemoteClusterStateService.MANIFEST_FILE_PREFIX;
-import static org.opensearch.gateway.remote.RemoteClusterStateService.MANIFEST_PATH_TOKEN;
-import static org.opensearch.gateway.remote.RemoteClusterStateService.SETTING_METADATA;
-import static org.opensearch.gateway.remote.RemoteClusterStateService.TEMPLATES_METADATA;
-import static org.opensearch.gateway.remote.RemoteClusterStateService.encodeString;
-import static org.opensearch.gateway.remote.RemoteClusterStateServiceTests.generateClusterStateWithOneIndex;
-import static org.opensearch.gateway.remote.RemoteClusterStateServiceTests.nodesWithLocalNodeClusterManager;
+import static org.opensearch.gateway.remote.RemoteClusterStateUtils.CLUSTER_STATE_PATH_TOKEN;
+import static org.opensearch.gateway.remote.RemoteClusterStateUtils.DELIMITER;
+import static org.opensearch.gateway.remote.RemoteClusterStateUtils.GLOBAL_METADATA_PATH_TOKEN;
+import static org.opensearch.gateway.remote.RemoteClusterStateUtils.encodeString;
+import static org.opensearch.gateway.remote.RemoteClusterStateUtils.getFormattedIndexFileName;
+import static org.opensearch.gateway.remote.model.RemoteClusterMetadataManifest.MANIFEST;
+import static org.opensearch.gateway.remote.model.RemoteCoordinationMetadata.COORDINATION_METADATA;
+import static org.opensearch.gateway.remote.model.RemotePersistentSettingsMetadata.SETTING_METADATA;
+import static org.opensearch.gateway.remote.model.RemoteTemplatesMetadata.TEMPLATES_METADATA;
 import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.REMOTE_STORE_CLUSTER_STATE_REPOSITORY_NAME_ATTRIBUTE_KEY;
 import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_SETTINGS_ATTRIBUTE_KEY_PREFIX;
 import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_TYPE_ATTRIBUTE_KEY_FORMAT;
@@ -92,6 +89,7 @@ public class RemoteClusterStateCleanupManagerTests extends OpenSearchTestCase {
     private ClusterState clusterState;
     private Metadata metadata;
     private RemoteClusterStateService remoteClusterStateService;
+    private RemoteManifestManager remoteManifestManager;
     private final ThreadPool threadPool = new TestThreadPool(getClass().getName());
 
     @Before
@@ -135,10 +133,13 @@ public class RemoteClusterStateCleanupManagerTests extends OpenSearchTestCase {
         when(blobStoreRepository.blobStore()).thenReturn(blobStore);
         when(repositoriesService.repository("remote_store_repository")).thenReturn(blobStoreRepository);
 
+        remoteManifestManager = mock(RemoteManifestManager.class);
         remoteClusterStateService = mock(RemoteClusterStateService.class);
+        when(remoteClusterStateService.getRemoteManifestManager()).thenReturn(remoteManifestManager);
         when(remoteClusterStateService.getStats()).thenReturn(new RemotePersistenceStats());
         when(remoteClusterStateService.getThreadpool()).thenReturn(threadPool);
         when(remoteClusterStateService.getBlobStore()).thenReturn(blobStore);
+        when(remoteClusterStateService.getBlobStoreRepository()).thenReturn(blobStoreRepository);
         remoteClusterStateCleanupManager = new RemoteClusterStateCleanupManager(remoteClusterStateService, clusterService);
     }
 
@@ -161,9 +162,9 @@ public class RemoteClusterStateCleanupManagerTests extends OpenSearchTestCase {
             new PlainBlobMetadata("manifest4.dat", 1L),
             new PlainBlobMetadata("manifest5.dat", 1L)
         );
-        UploadedIndexMetadata index1Metadata = new UploadedIndexMetadata("index1", "indexUUID1", "index_metadata1");
-        UploadedIndexMetadata index2Metadata = new UploadedIndexMetadata("index2", "indexUUID2", "index_metadata2");
-        UploadedIndexMetadata index1UpdatedMetadata = new UploadedIndexMetadata("index1", "indexUUID1", "index_metadata1_updated");
+        UploadedIndexMetadata index1Metadata = new UploadedIndexMetadata("index1", "indexUUID1", "index_metadata1__1");
+        UploadedIndexMetadata index2Metadata = new UploadedIndexMetadata("index2", "indexUUID2", "index_metadata2__2");
+        UploadedIndexMetadata index1UpdatedMetadata = new UploadedIndexMetadata("index1", "indexUUID1", "index_metadata1_updated__2");
         UploadedMetadataAttribute coordinationMetadata = new UploadedMetadataAttribute(COORDINATION_METADATA, "coordination_metadata");
         UploadedMetadataAttribute templateMetadata = new UploadedMetadataAttribute(TEMPLATES_METADATA, "template_metadata");
         UploadedMetadataAttribute settingMetadata = new UploadedMetadataAttribute(SETTING_METADATA, "settings_metadata");
@@ -205,39 +206,44 @@ public class RemoteClusterStateCleanupManagerTests extends OpenSearchTestCase {
             .build();
         ClusterMetadataManifest manifest5 = ClusterMetadataManifest.builder(manifest4).templatesMetadata(templateMetadataUpdated).build();
 
-        when(remoteClusterStateService.fetchRemoteClusterMetadataManifest(eq(clusterName), eq(clusterUUID), any())).thenReturn(
+        when(remoteManifestManager.fetchRemoteClusterMetadataManifest(eq(clusterName), eq(clusterUUID), any())).thenReturn(
             manifest4,
             manifest5,
             manifest1,
             manifest2,
             manifest3
         );
+        when(remoteManifestManager.getManifestFolderPath(eq(clusterName), eq(clusterUUID))).thenReturn(
+            new BlobPath().add(encodeString(clusterName)).add(CLUSTER_STATE_PATH_TOKEN).add(clusterUUID).add(MANIFEST)
+        );
         BlobContainer container = mock(BlobContainer.class);
         when(blobStore.blobContainer(any())).thenReturn(container);
         doNothing().when(container).deleteBlobsIgnoringIfNotExists(any());
-
+        remoteClusterStateCleanupManager.start();
         remoteClusterStateCleanupManager.deleteClusterMetadata(clusterName, clusterUUID, activeBlobs, inactiveBlobs);
         verify(container).deleteBlobsIgnoringIfNotExists(
             List.of(
-                new BlobPath().add(GLOBAL_METADATA_PATH_TOKEN).buildAsString() + coordinationMetadata.getUploadedFilename() + ".dat",
-                new BlobPath().add(GLOBAL_METADATA_PATH_TOKEN).buildAsString() + settingMetadata.getUploadedFilename() + ".dat",
+                // coordination/setting metadata is from CODEC_V2, the uploaded filename with contain the complete path
+                coordinationMetadata.getUploadedFilename(),
+                settingMetadata.getUploadedFilename(),
                 new BlobPath().add(GLOBAL_METADATA_PATH_TOKEN).buildAsString() + "global_metadata.dat"
             )
         );
-        verify(container).deleteBlobsIgnoringIfNotExists(
-            List.of(
-                new BlobPath().add(INDEX_PATH_TOKEN).add(index1Metadata.getIndexUUID()).buildAsString()
-                    + index1Metadata.getUploadedFilePath()
-                    + ".dat"
+        verify(container).deleteBlobsIgnoringIfNotExists(List.of(getFormattedIndexFileName(index1Metadata.getUploadedFilePath())));
+        Set<String> staleManifest = new HashSet<>();
+        inactiveBlobs.forEach(
+            blob -> staleManifest.add(
+                remoteClusterStateService.getRemoteManifestManager().getManifestFolderPath(clusterName, clusterUUID).buildAsString() + blob
+                    .name()
             )
         );
-        Set<String> staleManifest = new HashSet<>();
-        inactiveBlobs.forEach(blob -> staleManifest.add(new BlobPath().add(MANIFEST_PATH_TOKEN).buildAsString() + blob.name()));
         verify(container).deleteBlobsIgnoringIfNotExists(new ArrayList<>(staleManifest));
     }
 
     public void testDeleteStaleClusterUUIDs() throws IOException {
-        final ClusterState clusterState = generateClusterStateWithOneIndex().nodes(nodesWithLocalNodeClusterManager()).build();
+        final ClusterState clusterState = RemoteClusterStateServiceTests.generateClusterStateWithOneIndex()
+            .nodes(RemoteClusterStateServiceTests.nodesWithLocalNodeClusterManager())
+            .build();
         ClusterMetadataManifest clusterMetadataManifest = ClusterMetadataManifest.builder()
             .indices(List.of())
             .clusterTerm(1L)
@@ -268,25 +274,21 @@ public class RemoteClusterStateCleanupManagerTests extends OpenSearchTestCase {
         });
         when(
             manifest2Container.listBlobsByPrefixInSortedOrder(
-                MANIFEST_FILE_PREFIX + DELIMITER,
+                MANIFEST + DELIMITER,
                 Integer.MAX_VALUE,
                 BlobContainer.BlobNameSortOrder.LEXICOGRAPHIC
             )
         ).thenReturn(List.of(new PlainBlobMetadata("mainfest2", 1L)));
         when(
             manifest3Container.listBlobsByPrefixInSortedOrder(
-                MANIFEST_FILE_PREFIX + DELIMITER,
+                MANIFEST + DELIMITER,
                 Integer.MAX_VALUE,
                 BlobContainer.BlobNameSortOrder.LEXICOGRAPHIC
             )
         ).thenReturn(List.of(new PlainBlobMetadata("mainfest3", 1L)));
         Set<String> uuids = new HashSet<>(Arrays.asList("cluster-uuid1", "cluster-uuid2", "cluster-uuid3"));
         when(remoteClusterStateService.getAllClusterUUIDs(any())).thenReturn(uuids);
-        when(remoteClusterStateService.getCusterMetadataBasePath(any(), any())).then(
-            invocationOnMock -> blobPath.add(encodeString(invocationOnMock.getArgument(0)))
-                .add(CLUSTER_STATE_PATH_TOKEN)
-                .add((String) invocationOnMock.getArgument(1))
-        );
+        when(blobStoreRepository.basePath()).thenReturn(blobPath);
         remoteClusterStateCleanupManager.start();
         remoteClusterStateCleanupManager.deleteStaleClusterUUIDs(clusterState, clusterMetadataManifest);
         try {
@@ -306,11 +308,11 @@ public class RemoteClusterStateCleanupManagerTests extends OpenSearchTestCase {
         BlobPath blobPath = new BlobPath().add("random-path");
         when((blobStoreRepository.basePath())).thenReturn(blobPath);
         remoteClusterStateCleanupManager.start();
-        remoteClusterStateCleanupManager.deleteStaleUUIDsClusterMetadata("cluster1", List.of("cluster-uuid1"));
+        remoteClusterStateCleanupManager.deleteStaleUUIDsClusterMetadata("cluster1", Arrays.asList("cluster-uuid1"));
         try {
             assertBusy(() -> {
                 // wait for stats to get updated
-                assertNotNull(remoteClusterStateCleanupManager.getStats());
+                assertTrue(remoteClusterStateCleanupManager.getStats() != null);
                 assertEquals(0, remoteClusterStateCleanupManager.getStats().getSuccessCount());
                 assertEquals(1, remoteClusterStateCleanupManager.getStats().getCleanupAttemptFailedCount());
             });

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteGlobalMetadataManagerTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteGlobalMetadataManagerTests.java
@@ -1,0 +1,85 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.gateway.remote;
+
+import org.opensearch.cluster.ClusterModule;
+import org.opensearch.common.network.NetworkModule;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.compress.Compressor;
+import org.opensearch.core.compress.NoneCompressor;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.index.translog.transfer.BlobStoreTransferService;
+import org.opensearch.indices.IndicesModule;
+import org.opensearch.repositories.blobstore.BlobStoreRepository;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RemoteGlobalMetadataManagerTests extends OpenSearchTestCase {
+    private RemoteGlobalMetadataManager remoteGlobalMetadataManager;
+    private ClusterSettings clusterSettings;
+    private BlobStoreRepository blobStoreRepository;
+    private final ThreadPool threadPool = new TestThreadPool(getClass().getName());
+
+    @Before
+    public void setup() {
+        clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        blobStoreRepository = mock(BlobStoreRepository.class);
+        BlobStoreTransferService blobStoreTransferService = mock(BlobStoreTransferService.class);
+        NamedXContentRegistry xContentRegistry = new NamedXContentRegistry(
+            Stream.of(
+                NetworkModule.getNamedXContents().stream(),
+                IndicesModule.getNamedXContents().stream(),
+                ClusterModule.getNamedXWriteables().stream()
+            ).flatMap(Function.identity()).collect(toList())
+        );
+        Compressor compressor = new NoneCompressor();
+        when(blobStoreRepository.getCompressor()).thenReturn(compressor);
+        when(blobStoreRepository.getNamedXContentRegistry()).thenReturn(xContentRegistry);
+        remoteGlobalMetadataManager = new RemoteGlobalMetadataManager(
+            clusterSettings,
+            "test-cluster",
+            blobStoreRepository,
+            blobStoreTransferService,
+            threadPool
+        );
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+        threadPool.shutdown();
+    }
+
+    public void testGlobalMetadataUploadWaitTimeSetting() {
+        // verify default value
+        assertEquals(
+            RemoteGlobalMetadataManager.GLOBAL_METADATA_UPLOAD_TIMEOUT_DEFAULT,
+            remoteGlobalMetadataManager.getGlobalMetadataUploadTimeout()
+        );
+
+        // verify update global metadata upload timeout
+        int globalMetadataUploadTimeout = randomIntBetween(1, 10);
+        Settings newSettings = Settings.builder()
+            .put("cluster.remote_store.state.global_metadata.upload_timeout", globalMetadataUploadTimeout + "s")
+            .build();
+        clusterSettings.applySettings(newSettings);
+        assertEquals(globalMetadataUploadTimeout, remoteGlobalMetadataManager.getGlobalMetadataUploadTimeout().seconds());
+    }
+}

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteManifestManagerTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteManifestManagerTests.java
@@ -1,0 +1,129 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.gateway.remote;
+
+import org.opensearch.cluster.ClusterModule;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.common.blobstore.BlobContainer;
+import org.opensearch.common.blobstore.BlobPath;
+import org.opensearch.common.blobstore.BlobStore;
+import org.opensearch.common.network.NetworkModule;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.compress.Compressor;
+import org.opensearch.core.compress.NoneCompressor;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.index.translog.transfer.BlobStoreTransferService;
+import org.opensearch.indices.IndicesModule;
+import org.opensearch.repositories.blobstore.BlobStoreRepository;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+import static org.opensearch.gateway.remote.RemoteClusterStateUtils.DELIMITER;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RemoteManifestManagerTests extends OpenSearchTestCase {
+    private RemoteManifestManager remoteManifestManager;
+    private ClusterSettings clusterSettings;
+    private BlobStoreRepository blobStoreRepository;
+    private BlobStore blobStore;
+    private BlobStoreTransferService blobStoreTransferService;
+    private ThreadPool threadPool;
+
+    @Before
+    public void setup() {
+        clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        blobStoreRepository = mock(BlobStoreRepository.class);
+        NamedXContentRegistry xContentRegistry = new NamedXContentRegistry(
+            Stream.of(
+                NetworkModule.getNamedXContents().stream(),
+                IndicesModule.getNamedXContents().stream(),
+                ClusterModule.getNamedXWriteables().stream()
+            ).flatMap(Function.identity()).collect(toList())
+        );
+        blobStoreTransferService = mock(BlobStoreTransferService.class);
+        blobStore = mock(BlobStore.class);
+        when(blobStoreRepository.blobStore()).thenReturn(blobStore);
+        threadPool = new TestThreadPool("test");
+        Compressor compressor = new NoneCompressor();
+        when(blobStoreRepository.getCompressor()).thenReturn(compressor);
+        when(blobStoreRepository.getNamedXContentRegistry()).thenReturn(xContentRegistry);
+        remoteManifestManager = new RemoteManifestManager(
+            clusterSettings,
+            "test-cluster-name",
+            "test-node-id",
+            blobStoreRepository,
+            blobStoreTransferService,
+            threadPool
+        );
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+        threadPool.shutdown();
+    }
+
+    public void testMetadataManifestUploadWaitTimeSetting() {
+        // verify default value
+        assertEquals(
+            RemoteManifestManager.METADATA_MANIFEST_UPLOAD_TIMEOUT_DEFAULT,
+            remoteManifestManager.getMetadataManifestUploadTimeout()
+        );
+
+        // verify update metadata manifest upload timeout
+        int metadataManifestUploadTimeout = randomIntBetween(1, 10);
+        Settings newSettings = Settings.builder()
+            .put("cluster.remote_store.state.metadata_manifest.upload_timeout", metadataManifestUploadTimeout + "s")
+            .build();
+        clusterSettings.applySettings(newSettings);
+        assertEquals(metadataManifestUploadTimeout, remoteManifestManager.getMetadataManifestUploadTimeout().seconds());
+    }
+
+    public void testReadLatestMetadataManifestFailedIOException() throws IOException {
+        final ClusterState clusterState = RemoteClusterStateServiceTests.generateClusterStateWithOneIndex()
+            .nodes(RemoteClusterStateServiceTests.nodesWithLocalNodeClusterManager())
+            .build();
+
+        BlobContainer blobContainer = mockBlobStoreObjects();
+        when(blobContainer.listBlobsByPrefixInSortedOrder("manifest" + DELIMITER, 1, BlobContainer.BlobNameSortOrder.LEXICOGRAPHIC))
+            .thenThrow(IOException.class);
+
+        Exception e = assertThrows(
+            IllegalStateException.class,
+            () -> remoteManifestManager.getLatestClusterMetadataManifest(
+                clusterState.getClusterName().value(),
+                clusterState.metadata().clusterUUID()
+            )
+        );
+        assertEquals(e.getMessage(), "Error while fetching latest manifest file for remote cluster state");
+    }
+
+    private BlobContainer mockBlobStoreObjects() {
+        final BlobPath blobPath = mock(BlobPath.class);
+        when((blobStoreRepository.basePath())).thenReturn(blobPath);
+        when(blobPath.add(anyString())).thenReturn(blobPath);
+        when(blobPath.buildAsString()).thenReturn("/blob/path/");
+        final BlobContainer blobContainer = mock(BlobContainer.class);
+        when(blobContainer.path()).thenReturn(blobPath);
+        when(blobStore.blobContainer(any())).thenReturn(blobContainer);
+        return blobContainer;
+    }
+}

--- a/server/src/test/java/org/opensearch/gateway/remote/model/RemoteClusterBlocksTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/model/RemoteClusterBlocksTests.java
@@ -138,14 +138,14 @@ public class RemoteClusterBlocksTests extends OpenSearchTestCase {
 
     static ClusterBlocks randomClusterBlocks() {
         ClusterBlocks.Builder builder = ClusterBlocks.builder();
-        int randomGlobalBlocks = randomIntBetween(0, 10);
+        int randomGlobalBlocks = randomIntBetween(1, 10);
         for (int i = 0; i < randomGlobalBlocks; i++) {
             builder.addGlobalBlock(randomClusterBlock());
         }
 
-        int randomIndices = randomIntBetween(0, 10);
+        int randomIndices = randomIntBetween(1, 10);
         for (int i = 0; i < randomIndices; i++) {
-            int randomIndexBlocks = randomIntBetween(0, 10);
+            int randomIndexBlocks = randomIntBetween(1, 10);
             for (int j = 0; j < randomIndexBlocks; j++) {
                 builder.addIndexBlock("index-" + i, randomClusterBlock());
             }

--- a/server/src/test/java/org/opensearch/gateway/remote/model/RemoteGlobalMetadataTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/model/RemoteGlobalMetadataTests.java
@@ -205,6 +205,5 @@ public class RemoteGlobalMetadataTests extends OpenSearchTestCase {
                     .build()
             )
             .build();
-
     }
 }

--- a/server/src/test/java/org/opensearch/gateway/remote/model/RemoteIndexMetadataTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/model/RemoteIndexMetadataTests.java
@@ -40,8 +40,8 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
+import static org.opensearch.gateway.remote.model.RemoteIndexMetadata.INDEX;
 import static org.opensearch.gateway.remote.model.RemoteIndexMetadata.INDEX_METADATA_CURRENT_CODEC_VERSION;
-import static org.opensearch.gateway.remote.model.RemoteIndexMetadata.INDEX_PATH_TOKEN;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -137,7 +137,7 @@ public class RemoteIndexMetadataTests extends OpenSearchTestCase {
         IndexMetadata indexMetadata = getIndexMetadata();
         RemoteIndexMetadata remoteObjectForUpload = new RemoteIndexMetadata(indexMetadata, clusterUUID, compressor, namedXContentRegistry);
         BlobPathParameters params = remoteObjectForUpload.getBlobPathParameters();
-        assertThat(params.getPathTokens(), is(List.of(INDEX_PATH_TOKEN, indexMetadata.getIndexUUID())));
+        assertThat(params.getPathTokens(), is(List.of(INDEX, indexMetadata.getIndexUUID())));
         assertThat(params.getFilePrefix(), is("metadata"));
     }
 
@@ -156,12 +156,9 @@ public class RemoteIndexMetadataTests extends OpenSearchTestCase {
         IndexMetadata indexMetadata = getIndexMetadata();
         RemoteIndexMetadata remoteObjectForUpload = new RemoteIndexMetadata(indexMetadata, clusterUUID, compressor, namedXContentRegistry);
         assertThrows(AssertionError.class, remoteObjectForUpload::getUploadedMetadata);
-
-        try (InputStream inputStream = remoteObjectForUpload.serialize()) {
-            remoteObjectForUpload.setFullBlobName(new BlobPath().add(TEST_BLOB_PATH));
-            UploadedMetadata uploadedMetadata = remoteObjectForUpload.getUploadedMetadata();
-            assertThat(uploadedMetadata.getUploadedFilename(), is(remoteObjectForUpload.getBlobFileName()));
-        }
+        remoteObjectForUpload.setFullBlobName(new BlobPath().add(TEST_BLOB_PATH));
+        UploadedMetadata uploadedMetadata = remoteObjectForUpload.getUploadedMetadata();
+        assertEquals(uploadedMetadata.getUploadedFilename(), remoteObjectForUpload.getFullBlobName());
     }
 
     public void testSerDe() throws IOException {

--- a/server/src/test/java/org/opensearch/index/remote/RemoteIndexPathUploaderTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteIndexPathUploaderTests.java
@@ -22,7 +22,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.gateway.remote.RemoteClusterStateService;
-import org.opensearch.gateway.remote.RemoteClusterStateService.RemoteStateTransferException;
+import org.opensearch.gateway.remote.RemoteStateTransferException;
 import org.opensearch.index.remote.RemoteStoreEnums.PathHashAlgorithm;
 import org.opensearch.index.remote.RemoteStoreEnums.PathType;
 import org.opensearch.node.Node;
@@ -46,6 +46,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.mockito.Mockito;
 
+import static org.opensearch.gateway.remote.RemoteGlobalMetadataManager.GLOBAL_METADATA_UPLOAD_TIMEOUT_SETTING;
 import static org.opensearch.index.remote.RemoteStoreEnums.PathType.FIXED;
 import static org.opensearch.index.remote.RemoteStoreEnums.PathType.HASHED_INFIX;
 import static org.opensearch.index.remote.RemoteStoreEnums.PathType.HASHED_PREFIX;
@@ -276,7 +277,7 @@ public class RemoteIndexPathUploaderTests extends OpenSearchTestCase {
 
         Settings settings = Settings.builder()
             .put(this.settings)
-            .put(RemoteClusterStateService.INDEX_METADATA_UPLOAD_TIMEOUT_SETTING.getKey(), TimeValue.ZERO)
+            .put(GLOBAL_METADATA_UPLOAD_TIMEOUT_SETTING.getKey(), TimeValue.ZERO)
             .build();
         clusterSettings.applySettings(settings);
         SetOnce<Exception> exceptionSetOnce = new SetOnce<>();
@@ -306,7 +307,7 @@ public class RemoteIndexPathUploaderTests extends OpenSearchTestCase {
         remoteIndexPathUploader.start();
         Settings settings = Settings.builder()
             .put(this.settings)
-            .put(RemoteClusterStateService.INDEX_METADATA_UPLOAD_TIMEOUT_SETTING.getKey(), TimeValue.timeValueSeconds(1))
+            .put(GLOBAL_METADATA_UPLOAD_TIMEOUT_SETTING.getKey(), TimeValue.timeValueSeconds(1))
             .build();
         clusterSettings.applySettings(settings);
         SetOnce<Exception> exceptionSetOnce = new SetOnce<>();

--- a/server/src/test/java/org/opensearch/threadpool/ScalingThreadPoolTests.java
+++ b/server/src/test/java/org/opensearch/threadpool/ScalingThreadPoolTests.java
@@ -155,6 +155,7 @@ public class ScalingThreadPoolTests extends OpenSearchThreadPoolTestCase {
         sizes.put(ThreadPool.Names.REMOTE_PURGE, ThreadPool::halfAllocatedProcessors);
         sizes.put(ThreadPool.Names.REMOTE_REFRESH_RETRY, ThreadPool::halfAllocatedProcessors);
         sizes.put(ThreadPool.Names.REMOTE_RECOVERY, ThreadPool::twiceAllocatedProcessors);
+        sizes.put(ThreadPool.Names.REMOTE_STATE_READ, ThreadPool::twiceAllocatedProcessors);
         return sizes.get(threadPoolName).apply(numberOfProcessors);
     }
 


### PR DESCRIPTION
* Create Remote Object managers and use them in orchestration from RemoteClusterStateService

Backport from https://github.com/opensearch-project/OpenSearch/pull/13924