### PR TITLE
Demonstrate that arrays of `geo_shape` can no longer be ingested

### DIFF
--- a/modules/geo/src/yamlRestTest/resources/rest-api-spec/test/geo_shape/300_array_of_geo_shapes.yml
+++ b/modules/geo/src/yamlRestTest/resources/rest-api-spec/test/geo_shape/300_array_of_geo_shapes.yml
@@ -1,0 +1,67 @@
+setup:
+  - do:
+      indices.create:
+        index: test
+        body:
+          settings:
+            number_of_replicas: 0
+          mappings:
+            properties:
+              location:
+                type: "geo_shape"
+
+---
+"Single shape":
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - index:
+              _index: test
+              _id: 1
+          - location:
+              type: "polygon"
+              coordinates: [
+                [
+                  [ -87.0, 41.0 ],
+                  [ -88.0, 41.0 ],
+                  [ -88.0, 42.0 ],
+                  [ -87.0, 42.0 ],
+                  [ -87.0, 41.0 ],
+                ]
+              ]
+
+  - match: {errors: false}
+
+---
+"Array of shapes":
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - index:
+              _index: test
+              _id: 1
+          - location:
+              - type: "polygon"
+                coordinates: [
+                  [
+                    [ -87.0, 41.0 ],
+                    [ -88.0, 41.0 ],
+                    [ -88.0, 42.0 ],
+                    [ -87.0, 42.0 ],
+                    [ -87.0, 41.0 ],
+                  ]
+                ]
+              - type: "polygon"
+                coordinates: [
+                  [
+                    [ -97.0, 41.0 ],
+                    [ -98.0, 41.0 ],
+                    [ -98.0, 42.0 ],
+                    [ -97.0, 42.0 ],
+                    [ -97.0, 41.0 ],
+                  ]
+                ]
+
+  - match: {errors: false}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

> [!NOTE]
>
> This PR is not intended for merging as-is. It demonstrates issue #14193, which reports a regression in OpenSearch introduced in #4266 and #8301, and released in v2.9.0 and higher.
>
> It is expected that OpenSearch maintainers can fetch this branch, add fix commits to the branch to resolve the underlying bug, and push directly to this PR. Thank you!

### Related Issues
Resolves #14193 

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
