### PR TITLE
[Flaky Test] Set refresh interval to -1 to only have 1 segment

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/10_histogram.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/10_histogram.yml
@@ -658,6 +658,7 @@ setup:
           settings:
             number_of_replicas: 0
             number_of_shards: 1
+            refresh_interval: -1
           mappings:
             properties:
               date:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite.yml
@@ -1083,6 +1083,7 @@ setup:
           settings:
             number_of_replicas: 0
             number_of_shards: 1
+            refresh_interval: -1
           mappings:
             properties:
               date:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/330_auto_date_histogram.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/330_auto_date_histogram.yml
@@ -107,7 +107,35 @@ setup:
       reason: debug info for filter rewrite added in 3.0.0 (to be backported to 2.14.0)
 
   - do:
+      indices.create:
+        index: test_profile
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+            refresh_interval: -1
+          mappings:
+            properties:
+              date:
+                type: date
+
+  - do:
+      bulk:
+        index: test_profile
+        refresh: true
+        body:
+          - '{"index": {}}'
+          - '{"date": "2020-03-01", "v": 1}'
+          - '{"index": {}}'
+          - '{"date": "2020-03-02", "v": 2}'
+          - '{"index": {}}'
+          - '{"date": "2020-03-08", "v": 3}'
+          - '{"index": {}}'
+          - '{"date": "2020-03-09", "v": 4}'
+
+  - do:
       search:
+        index: test_profile
         body:
           profile: true
           size: 0


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

Failed 3 times in gradle check after merging in the change on [5/2](https://github.com/opensearch-project/OpenSearch/pull/13317) [Metric Dashboard Link](https://metrics.opensearch.org/_dashboards/app/dashboards#/view/e5e64d40-ed31-11ee-be99-69d1dbc75083?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-6M,to:now))&_a=(description:'',filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'2e729590-eb26-11ee-b008-6583d3dd450c',key:test_class,negate:!f,params:(query:ClientYamlTestSuiteIT),type:phrase),query:(match_phrase:(test_class:ClientYamlTestSuiteIT)))),fullScreenMode:!f,options:(hidePanelTitles:!f,useMargins:!t),query:(language:lucene,query:'test_name:%20*filter*rewrite*info*'),timeRestore:!t,title:'OpenSearch%20Gradle%20Check%20Report',viewMode:view))

Example Failure

https://build.ci.opensearch.org/job/gradle-check/39719/testReport/junit/org.opensearch.test.rest/ClientYamlTestSuiteIT/test__p0_search_aggregation_230_composite_composite_aggregation_date_histogram_profile_shows_filter_rewrite_info__2/

We can see the flaky is because sometime there are 2 segments instead of 1 though we are bulk indexing just 4 documents. After discussing with @mch2 , this could because the background refresh race in. So we are setting refresh_interval to -1 now to eliminate that.

### Related Issues
Resolves #13971 

### Check List
- [x] Functionality includes testing.
- ~~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~~
- ~~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
