### PR TITLE
[Backport 2.x] Read write ephemeral objects for remote publication of cluster state

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/RepositoryCleanupInProgress.java
+++ b/server/src/main/java/org/opensearch/cluster/RepositoryCleanupInProgress.java
@@ -45,6 +45,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Information passed during repository cleanup
@@ -118,6 +119,24 @@ public final class RepositoryCleanupInProgress extends AbstractNamedDiffable<Clu
         return LegacyESVersion.V_7_4_0;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        RepositoryCleanupInProgress that = (RepositoryCleanupInProgress) o;
+        return entries.equals(that.entries);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 + entries.hashCode();
+    }
+
     /**
      * Entry in the collection.
      *
@@ -153,6 +172,23 @@ public final class RepositoryCleanupInProgress extends AbstractNamedDiffable<Clu
         public void writeTo(StreamOutput out) throws IOException {
             out.writeString(repository);
             out.writeLong(repositoryStateId);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            RepositoryCleanupInProgress.Entry that = (RepositoryCleanupInProgress.Entry) o;
+            return repository.equals(that.repository) && repositoryStateId == that.repositoryStateId;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(repository, repositoryStateId);
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/Metadata.java
@@ -978,6 +978,10 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         return metadata1.templates.equals(metadata2.templates);
     }
 
+    public static boolean isHashesOfConsistentSettingsEqual(Metadata metadata1, Metadata metadata2) {
+        return metadata1.hashesOfConsistentSettings.equals(metadata2.hashesOfConsistentSettings);
+    }
+
     public static boolean isCustomMetadataEqual(Metadata metadata1, Metadata metadata2) {
         int customCount1 = 0;
         for (Map.Entry<String, Custom> cursor : metadata1.customs.entrySet()) {

--- a/server/src/main/java/org/opensearch/cluster/routing/RoutingTable.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RoutingTable.java
@@ -79,7 +79,7 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
     // index to IndexRoutingTable map
     private final Map<String, IndexRoutingTable> indicesRouting;
 
-    private RoutingTable(long version, final Map<String, IndexRoutingTable> indicesRouting) {
+    public RoutingTable(long version, final Map<String, IndexRoutingTable> indicesRouting) {
         this.version = version;
         this.indicesRouting = Collections.unmodifiableMap(indicesRouting);
     }

--- a/server/src/main/java/org/opensearch/cluster/routing/remote/NoopRemoteRoutingTableService.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/remote/NoopRemoteRoutingTableService.java
@@ -16,6 +16,7 @@ import org.opensearch.cluster.routing.RoutingTable;
 import org.opensearch.common.CheckedRunnable;
 import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.common.lifecycle.AbstractLifecycleComponent;
+import org.opensearch.core.index.Index;
 import org.opensearch.gateway.remote.ClusterMetadataManifest;
 
 import java.io.IOException;
@@ -57,6 +58,26 @@ public class NoopRemoteRoutingTableService extends AbstractLifecycleComponent im
         List<ClusterMetadataManifest.UploadedIndexMetadata> indicesRoutingUploaded,
         List<String> indicesRoutingToDelete
     ) {
+        // noop
+        return List.of();
+    }
+
+    @Override
+    public CheckedRunnable<IOException> getAsyncIndexRoutingReadAction(
+        String uploadedFilename,
+        Index index,
+        LatchedActionListener<IndexRoutingTable> latchedActionListener
+    ) {
+        // noop
+        return () -> {};
+    }
+
+    @Override
+    public List<ClusterMetadataManifest.UploadedIndexMetadata> getUpdatedIndexRoutingTableMetadata(
+        List<String> updatedIndicesRouting,
+        List<ClusterMetadataManifest.UploadedIndexMetadata> allIndicesRouting
+    ) {
+        // noop
         return List.of();
     }
 

--- a/server/src/main/java/org/opensearch/cluster/routing/remote/RemoteRoutingTableService.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/remote/RemoteRoutingTableService.java
@@ -18,6 +18,7 @@ import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.common.lifecycle.LifecycleComponent;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.index.Index;
 import org.opensearch.gateway.remote.ClusterMetadataManifest;
 
 import java.io.IOException;
@@ -25,7 +26,9 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Interface for RemoteRoutingTableService. Exposes methods to orchestrate upload and download of routing table from remote store.
+ * A Service which provides APIs to upload and download routing table from remote store.
+ *
+ * @opensearch.internal
  */
 public interface RemoteRoutingTableService extends LifecycleComponent {
     public static final DiffableUtils.NonDiffableValueSerializer<String, IndexRoutingTable> CUSTOM_ROUTING_TABLE_VALUE_SERIALIZER =
@@ -42,6 +45,17 @@ public interface RemoteRoutingTableService extends LifecycleComponent {
         };
 
     List<IndexRoutingTable> getIndicesRouting(RoutingTable routingTable);
+
+    CheckedRunnable<IOException> getAsyncIndexRoutingReadAction(
+        String uploadedFilename,
+        Index index,
+        LatchedActionListener<IndexRoutingTable> latchedActionListener
+    );
+
+    List<ClusterMetadataManifest.UploadedIndexMetadata> getUpdatedIndexRoutingTableMetadata(
+        List<String> updatedIndicesRouting,
+        List<ClusterMetadataManifest.UploadedIndexMetadata> allIndicesRouting
+    );
 
     DiffableUtils.MapDiff<String, IndexRoutingTable, Map<String, IndexRoutingTable>> getIndicesRoutingMapDiff(
         RoutingTable before,

--- a/server/src/main/java/org/opensearch/cluster/routing/remote/RemoteRoutingTableServiceFactory.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/remote/RemoteRoutingTableServiceFactory.java
@@ -11,6 +11,7 @@ package org.opensearch.cluster.routing.remote;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.repositories.RepositoriesService;
+import org.opensearch.threadpool.ThreadPool;
 
 import java.util.function.Supplier;
 
@@ -26,15 +27,17 @@ public class RemoteRoutingTableServiceFactory {
      * @param repositoriesService repositoriesService
      * @param settings settings
      * @param clusterSettings clusterSettings
+     * @param threadPool threadPool
      * @return RemoteRoutingTableService
      */
     public static RemoteRoutingTableService getService(
         Supplier<RepositoriesService> repositoriesService,
         Settings settings,
-        ClusterSettings clusterSettings
+        ClusterSettings clusterSettings,
+        ThreadPool threadPool
     ) {
         if (isRemoteRoutingTableEnabled(settings)) {
-            return new InternalRemoteRoutingTableService(repositoriesService, settings, clusterSettings);
+            return new InternalRemoteRoutingTableService(repositoriesService, settings, clusterSettings, threadPool);
         }
         return new NoopRemoteRoutingTableService();
     }

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -726,6 +726,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 INDEX_METADATA_UPLOAD_TIMEOUT_SETTING,
                 GLOBAL_METADATA_UPLOAD_TIMEOUT_SETTING,
                 METADATA_MANIFEST_UPLOAD_TIMEOUT_SETTING,
+                RemoteClusterStateService.REMOTE_STATE_READ_TIMEOUT_SETTING,
                 RemoteStoreNodeService.REMOTE_STORE_COMPATIBILITY_MODE_SETTING,
                 RemoteStoreNodeService.MIGRATION_DIRECTION_SETTING,
 

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateAttributesManager.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateAttributesManager.java
@@ -10,21 +10,20 @@ package org.opensearch.gateway.remote;
 
 import org.opensearch.action.LatchedActionListener;
 import org.opensearch.cluster.ClusterState;
-import org.opensearch.cluster.ClusterState.Custom;
-import org.opensearch.cluster.block.ClusterBlocks;
-import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.common.CheckedRunnable;
 import org.opensearch.common.remote.AbstractRemoteWritableBlobEntity;
+import org.opensearch.common.remote.RemoteWritableEntityStore;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
-import org.opensearch.core.compress.Compressor;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.gateway.remote.model.RemoteClusterBlocks;
 import org.opensearch.gateway.remote.model.RemoteClusterStateBlobStore;
 import org.opensearch.gateway.remote.model.RemoteClusterStateCustoms;
 import org.opensearch.gateway.remote.model.RemoteDiscoveryNodes;
 import org.opensearch.gateway.remote.model.RemoteReadResult;
+import org.opensearch.index.translog.transfer.BlobStoreTransferService;
+import org.opensearch.repositories.blobstore.BlobStoreRepository;
+import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -42,27 +41,48 @@ public class RemoteClusterStateAttributesManager {
     public static final String DISCOVERY_NODES = "nodes";
     public static final String CLUSTER_BLOCKS = "blocks";
     public static final int CLUSTER_STATE_ATTRIBUTES_CURRENT_CODEC_VERSION = 1;
-    private final RemoteClusterStateBlobStore<ClusterBlocks, RemoteClusterBlocks> clusterBlocksBlobStore;
-    private final RemoteClusterStateBlobStore<DiscoveryNodes, RemoteDiscoveryNodes> discoveryNodesBlobStore;
-    private final RemoteClusterStateBlobStore<Custom, RemoteClusterStateCustoms> customsBlobStore;
-    private final Compressor compressor;
-    private final NamedXContentRegistry namedXContentRegistry;
+    private final Map<String, RemoteWritableEntityStore> remoteWritableEntityStores;
     private final NamedWriteableRegistry namedWriteableRegistry;
 
     RemoteClusterStateAttributesManager(
-        RemoteClusterStateBlobStore<ClusterBlocks, RemoteClusterBlocks> clusterBlocksBlobStore,
-        RemoteClusterStateBlobStore<DiscoveryNodes, RemoteDiscoveryNodes> discoveryNodesBlobStore,
-        RemoteClusterStateBlobStore<Custom, RemoteClusterStateCustoms> customsBlobStore,
-        Compressor compressor,
-        NamedXContentRegistry namedXContentRegistry,
-        NamedWriteableRegistry namedWriteableRegistry
+        String clusterName,
+        BlobStoreRepository blobStoreRepository,
+        BlobStoreTransferService blobStoreTransferService,
+        NamedWriteableRegistry namedWriteableRegistry,
+        ThreadPool threadpool
     ) {
-        this.clusterBlocksBlobStore = clusterBlocksBlobStore;
-        this.discoveryNodesBlobStore = discoveryNodesBlobStore;
-        this.customsBlobStore = customsBlobStore;
-        this.compressor = compressor;
-        this.namedXContentRegistry = namedXContentRegistry;
         this.namedWriteableRegistry = namedWriteableRegistry;
+        this.remoteWritableEntityStores = new HashMap<>();
+        this.remoteWritableEntityStores.put(
+            RemoteDiscoveryNodes.DISCOVERY_NODES,
+            new RemoteClusterStateBlobStore<>(
+                blobStoreTransferService,
+                blobStoreRepository,
+                clusterName,
+                threadpool,
+                ThreadPool.Names.REMOTE_STATE_READ
+            )
+        );
+        this.remoteWritableEntityStores.put(
+            RemoteClusterBlocks.CLUSTER_BLOCKS,
+            new RemoteClusterStateBlobStore<>(
+                blobStoreTransferService,
+                blobStoreRepository,
+                clusterName,
+                threadpool,
+                ThreadPool.Names.REMOTE_STATE_READ
+            )
+        );
+        this.remoteWritableEntityStores.put(
+            RemoteClusterStateCustoms.CLUSTER_STATE_CUSTOM,
+            new RemoteClusterStateBlobStore<>(
+                blobStoreTransferService,
+                blobStoreRepository,
+                clusterName,
+                threadpool,
+                ThreadPool.Names.REMOTE_STATE_READ
+            )
+        );
     }
 
     /**
@@ -71,10 +91,9 @@ public class RemoteClusterStateAttributesManager {
     CheckedRunnable<IOException> getAsyncMetadataWriteAction(
         String component,
         AbstractRemoteWritableBlobEntity blobEntity,
-        RemoteClusterStateBlobStore remoteEntityStore,
         LatchedActionListener<ClusterMetadataManifest.UploadedMetadata> latchedActionListener
     ) {
-        return () -> remoteEntityStore.writeAsync(blobEntity, getActionListener(component, blobEntity, latchedActionListener));
+        return () -> getStore(blobEntity).writeAsync(blobEntity, getActionListener(component, blobEntity, latchedActionListener));
     }
 
     private ActionListener<Void> getActionListener(
@@ -88,17 +107,24 @@ public class RemoteClusterStateAttributesManager {
         );
     }
 
+    private RemoteWritableEntityStore getStore(AbstractRemoteWritableBlobEntity entity) {
+        RemoteWritableEntityStore remoteStore = remoteWritableEntityStores.get(entity.getType());
+        if (remoteStore == null) {
+            throw new IllegalArgumentException("Unknown entity type [" + entity.getType() + "]");
+        }
+        return remoteStore;
+    }
+
     public CheckedRunnable<IOException> getAsyncMetadataReadAction(
         String component,
         AbstractRemoteWritableBlobEntity blobEntity,
-        RemoteClusterStateBlobStore remoteEntityStore,
         LatchedActionListener<RemoteReadResult> listener
     ) {
         final ActionListener actionListener = ActionListener.wrap(
             response -> listener.onResponse(new RemoteReadResult((ToXContent) response, CLUSTER_STATE_ATTRIBUTE, component)),
             listener::onFailure
         );
-        return () -> remoteEntityStore.readAsync(blobEntity, actionListener);
+        return () -> getStore(blobEntity).readAsync(blobEntity, actionListener);
     }
 
     public Map<String, ClusterState.Custom> getUpdatedCustoms(ClusterState clusterState, ClusterState previousClusterState) {

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteManifestManager.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteManifestManager.java
@@ -96,6 +96,7 @@ public class RemoteManifestManager {
         ClusterState clusterState,
         RemoteClusterStateUtils.UploadedMetadataResults uploadedMetadataResult,
         String previousClusterUUID,
+        ClusterStateDiffManifest clusterDiffManifest,
         boolean committed
     ) {
         synchronized (this) {
@@ -116,7 +117,14 @@ public class RemoteManifestManager {
                 .templatesMetadata(uploadedMetadataResult.uploadedTemplatesMetadata)
                 .customMetadataMap(uploadedMetadataResult.uploadedCustomMetadataMap)
                 .routingTableVersion(clusterState.getRoutingTable().version())
-                .indicesRouting(uploadedMetadataResult.uploadedIndicesRoutingMetadata);
+                .indicesRouting(uploadedMetadataResult.uploadedIndicesRoutingMetadata)
+                .discoveryNodesMetadata(uploadedMetadataResult.uploadedDiscoveryNodes)
+                .clusterBlocksMetadata(uploadedMetadataResult.uploadedClusterBlocks)
+                .diffManifest(clusterDiffManifest)
+                .metadataVersion(clusterState.metadata().version())
+                .transientSettingsMetadata(uploadedMetadataResult.uploadedTransientSettingsMetadata)
+                .clusterStateCustomMetadataMap(uploadedMetadataResult.uploadedClusterStateCustomMetadataMap)
+                .hashesOfConsistentSettings(uploadedMetadataResult.uploadedHashesOfConsistentSettings);
             final ClusterMetadataManifest manifest = manifestBuilder.build();
             String manifestFileName = writeMetadataManifest(clusterState.metadata().clusterUUID(), manifest);
             return new RemoteClusterStateManifestInfo(manifest, manifestFileName);

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemoteClusterBlocks.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemoteClusterBlocks.java
@@ -10,21 +10,18 @@ package org.opensearch.gateway.remote.model;
 
 import org.opensearch.cluster.block.ClusterBlocks;
 import org.opensearch.common.io.Streams;
-import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.remote.AbstractRemoteWritableBlobEntity;
 import org.opensearch.common.remote.BlobPathParameters;
-import org.opensearch.core.common.io.stream.BytesStreamInput;
-import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.compress.Compressor;
 import org.opensearch.gateway.remote.ClusterMetadataManifest.UploadedMetadata;
 import org.opensearch.gateway.remote.ClusterMetadataManifest.UploadedMetadataAttribute;
 import org.opensearch.index.remote.RemoteStoreUtils;
+import org.opensearch.repositories.blobstore.ChecksumWritableBlobStoreFormat;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
-import static org.opensearch.core.common.bytes.BytesReference.toBytes;
 import static org.opensearch.gateway.remote.RemoteClusterStateAttributesManager.CLUSTER_STATE_ATTRIBUTES_CURRENT_CODEC_VERSION;
 import static org.opensearch.gateway.remote.RemoteClusterStateUtils.CLUSTER_STATE_EPHEMERAL_PATH_TOKEN;
 import static org.opensearch.gateway.remote.RemoteClusterStateUtils.DELIMITER;
@@ -35,6 +32,10 @@ import static org.opensearch.gateway.remote.RemoteClusterStateUtils.DELIMITER;
 public class RemoteClusterBlocks extends AbstractRemoteWritableBlobEntity<ClusterBlocks> {
 
     public static final String CLUSTER_BLOCKS = "blocks";
+    public static final ChecksumWritableBlobStoreFormat<ClusterBlocks> CLUSTER_BLOCKS_FORMAT = new ChecksumWritableBlobStoreFormat<>(
+        "blocks",
+        ClusterBlocks::readFrom
+    );
 
     private ClusterBlocks clusterBlocks;
     private long stateVersion;
@@ -82,20 +83,11 @@ public class RemoteClusterBlocks extends AbstractRemoteWritableBlobEntity<Cluste
 
     @Override
     public InputStream serialize() throws IOException {
-        try (BytesStreamOutput bytesStreamOutput = new BytesStreamOutput()) {
-            clusterBlocks.writeTo(bytesStreamOutput);
-            return bytesStreamOutput.bytes().streamInput();
-        } catch (IOException e) {
-            throw new IOException("Failed to serialize remote cluster blocks", e);
-        }
+        return CLUSTER_BLOCKS_FORMAT.serialize(clusterBlocks, generateBlobFileName(), getCompressor()).streamInput();
     }
 
     @Override
     public ClusterBlocks deserialize(final InputStream inputStream) throws IOException {
-        try (StreamInput in = new BytesStreamInput(toBytes(Streams.readFully(inputStream)))) {
-            return ClusterBlocks.readFrom(in);
-        } catch (IOException e) {
-            throw new IOException("Failed to deserialize remote cluster blocks", e);
-        }
+        return CLUSTER_BLOCKS_FORMAT.deserialize(blobName, Streams.readFully(inputStream));
     }
 }

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemoteDiscoveryNodes.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemoteDiscoveryNodes.java
@@ -10,21 +10,18 @@ package org.opensearch.gateway.remote.model;
 
 import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.common.io.Streams;
-import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.remote.AbstractRemoteWritableBlobEntity;
 import org.opensearch.common.remote.BlobPathParameters;
-import org.opensearch.core.common.io.stream.BytesStreamInput;
-import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.compress.Compressor;
 import org.opensearch.gateway.remote.ClusterMetadataManifest.UploadedMetadata;
 import org.opensearch.gateway.remote.ClusterMetadataManifest.UploadedMetadataAttribute;
 import org.opensearch.index.remote.RemoteStoreUtils;
+import org.opensearch.repositories.blobstore.ChecksumWritableBlobStoreFormat;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
-import static org.opensearch.core.common.bytes.BytesReference.toBytes;
 import static org.opensearch.gateway.remote.RemoteClusterStateAttributesManager.CLUSTER_STATE_ATTRIBUTES_CURRENT_CODEC_VERSION;
 import static org.opensearch.gateway.remote.RemoteClusterStateUtils.CLUSTER_STATE_EPHEMERAL_PATH_TOKEN;
 import static org.opensearch.gateway.remote.RemoteClusterStateUtils.DELIMITER;
@@ -35,6 +32,10 @@ import static org.opensearch.gateway.remote.RemoteClusterStateUtils.DELIMITER;
 public class RemoteDiscoveryNodes extends AbstractRemoteWritableBlobEntity<DiscoveryNodes> {
 
     public static final String DISCOVERY_NODES = "nodes";
+    public static final ChecksumWritableBlobStoreFormat<DiscoveryNodes> DISCOVERY_NODES_FORMAT = new ChecksumWritableBlobStoreFormat<>(
+        "nodes",
+        is -> DiscoveryNodes.readFrom(is, null)
+    );
 
     private DiscoveryNodes discoveryNodes;
     private long stateVersion;
@@ -87,20 +88,11 @@ public class RemoteDiscoveryNodes extends AbstractRemoteWritableBlobEntity<Disco
 
     @Override
     public InputStream serialize() throws IOException {
-        try (BytesStreamOutput outputStream = new BytesStreamOutput()) {
-            discoveryNodes.writeTo(outputStream);
-            return outputStream.bytes().streamInput();
-        } catch (IOException e) {
-            throw new IOException("Failed to serialize remote discovery nodes", e);
-        }
+        return DISCOVERY_NODES_FORMAT.serialize(discoveryNodes, generateBlobFileName(), getCompressor()).streamInput();
     }
 
     @Override
     public DiscoveryNodes deserialize(final InputStream inputStream) throws IOException {
-        try (StreamInput streamInput = new BytesStreamInput(toBytes(Streams.readFully(inputStream)))) {
-            return DiscoveryNodes.readFrom(streamInput, null);
-        } catch (IOException e) {
-            throw new IOException("Failed to deserialize remote discovery nodes", e);
-        }
+        return DISCOVERY_NODES_FORMAT.deserialize(blobName, Streams.readFully(inputStream));
     }
 }

--- a/server/src/main/java/org/opensearch/index/recovery/RemoteStoreRestoreService.java
+++ b/server/src/main/java/org/opensearch/index/recovery/RemoteStoreRestoreService.java
@@ -152,7 +152,11 @@ public class RemoteStoreRestoreService {
                     throw new IllegalArgumentException("clusterUUID to restore from should be different from current cluster UUID");
                 }
                 logger.info("Restoring cluster state from remote store from cluster UUID : [{}]", restoreClusterUUID);
-                remoteState = remoteClusterStateService.getLatestClusterState(currentState.getClusterName().value(), restoreClusterUUID);
+                remoteState = remoteClusterStateService.getLatestClusterState(
+                    currentState.getClusterName().value(),
+                    restoreClusterUUID,
+                    false
+                );
                 remoteState.getMetadata().getIndices().values().forEach(indexMetadata -> {
                     indexMetadataMap.put(indexMetadata.getIndex().getName(), new Tuple<>(true, indexMetadata));
                 });

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -768,7 +768,8 @@ public class Node implements Closeable {
                     clusterService,
                     threadPool::preciseRelativeTimeInNanos,
                     threadPool,
-                    List.of(remoteIndexPathUploader)
+                    List.of(remoteIndexPathUploader),
+                    namedWriteableRegistry
                 );
                 remoteClusterStateCleanupManager = remoteClusterStateService.getCleanupManager();
             } else {

--- a/server/src/test/java/org/opensearch/cluster/routing/remote/RemoteRoutingTableServiceFactoryTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/remote/RemoteRoutingTableServiceFactoryTests.java
@@ -14,6 +14,9 @@ import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.repositories.fs.FsRepository;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+import org.junit.After;
 
 import java.util.function.Supplier;
 
@@ -23,13 +26,21 @@ import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.REMOTE_ST
 public class RemoteRoutingTableServiceFactoryTests extends OpenSearchTestCase {
 
     Supplier<RepositoriesService> repositoriesService;
+    private ThreadPool threadPool = new TestThreadPool(getClass().getName());
+
+    @After
+    public void teardown() throws Exception {
+        super.tearDown();
+        threadPool.shutdown();
+    }
 
     public void testGetServiceWhenRemoteRoutingDisabled() {
         Settings settings = Settings.builder().build();
         RemoteRoutingTableService service = RemoteRoutingTableServiceFactory.getService(
             repositoriesService,
             settings,
-            new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+            new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+            threadPool
         );
         assertTrue(service instanceof NoopRemoteRoutingTableService);
     }
@@ -44,8 +55,10 @@ public class RemoteRoutingTableServiceFactoryTests extends OpenSearchTestCase {
         RemoteRoutingTableService service = RemoteRoutingTableServiceFactory.getService(
             repositoriesService,
             settings,
-            new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+            new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+            threadPool
         );
         assertTrue(service instanceof InternalRemoteRoutingTableService);
     }
+
 }

--- a/server/src/test/java/org/opensearch/gateway/GatewayMetaStatePersistedStateTests.java
+++ b/server/src/test/java/org/opensearch/gateway/GatewayMetaStatePersistedStateTests.java
@@ -489,7 +489,8 @@ public class GatewayMetaStatePersistedStateTests extends OpenSearchTestCase {
                         clusterService,
                         () -> 0L,
                         threadPool,
-                        List.of(new RemoteIndexPathUploader(threadPool, settings, repositoriesServiceSupplier, clusterSettings))
+                        List.of(new RemoteIndexPathUploader(threadPool, settings, repositoriesServiceSupplier, clusterSettings)),
+                        writableRegistry()
                     );
                 } else {
                     return null;

--- a/server/src/test/java/org/opensearch/gateway/remote/ClusterMetadataManifestTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/ClusterMetadataManifestTests.java
@@ -593,7 +593,7 @@ public class ClusterMetadataManifestTests extends OpenSearchTestCase {
         }
     }
 
-    private List<UploadedIndexMetadata> randomUploadedIndexMetadataList() {
+    public static List<UploadedIndexMetadata> randomUploadedIndexMetadataList() {
         final int size = randomIntBetween(1, 10);
         final List<UploadedIndexMetadata> uploadedIndexMetadataList = new ArrayList<>(size);
         while (uploadedIndexMetadataList.size() < size) {
@@ -602,7 +602,7 @@ public class ClusterMetadataManifestTests extends OpenSearchTestCase {
         return uploadedIndexMetadataList;
     }
 
-    private UploadedIndexMetadata randomUploadedIndexMetadata() {
+    private static UploadedIndexMetadata randomUploadedIndexMetadata() {
         return new UploadedIndexMetadata(randomAlphaOfLength(10), randomAlphaOfLength(10), randomAlphaOfLength(10));
     }
 

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteGlobalMetadataManagerTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteGlobalMetadataManagerTests.java
@@ -57,6 +57,7 @@ public class RemoteGlobalMetadataManagerTests extends OpenSearchTestCase {
             "test-cluster",
             blobStoreRepository,
             blobStoreTransferService,
+            writableRegistry(),
             threadPool
         );
     }

--- a/server/src/test/java/org/opensearch/gateway/remote/model/RemoteDiscoveryNodesTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/model/RemoteDiscoveryNodesTests.java
@@ -145,7 +145,6 @@ public class RemoteDiscoveryNodesTests extends OpenSearchTestCase {
         RemoteDiscoveryNodes remoteObjectForUpload = new RemoteDiscoveryNodes(nodes, METADATA_VERSION, clusterUUID, compressor);
         doThrow(new IOException("mock-exception")).when(nodes).writeTo(any());
         IOException iea = assertThrows(IOException.class, remoteObjectForUpload::serialize);
-        assertEquals("Failed to serialize remote discovery nodes", iea.getMessage());
     }
 
     public void testExceptionDuringDeserialize() throws IOException {
@@ -155,7 +154,6 @@ public class RemoteDiscoveryNodesTests extends OpenSearchTestCase {
         String uploadedFile = "user/local/opensearch/discovery-nodes";
         RemoteDiscoveryNodes remoteObjectForDownload = new RemoteDiscoveryNodes(uploadedFile, clusterUUID, compressor);
         IOException ioe = assertThrows(IOException.class, () -> remoteObjectForDownload.deserialize(in));
-        assertEquals("Failed to deserialize remote discovery nodes", ioe.getMessage());
     }
 
     private DiscoveryNodes getDiscoveryNodes() {


### PR DESCRIPTION
* Read and write ephemeral objects for remote publication

Backport of #14089