### PR TITLE
[Tiered Caching] [Bug Fix] Use concurrentMap instead of HashMap to fix Concurrent Modification Exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 ### Fixed
+- Fix Concurrent Modification Exception in Indices Request Cache([#14032](https://github.com/opensearch-project/OpenSearch/pull/14221))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 ### Fixed
-- Fix Concurrent Modification Exception in Indices Request Cache([#14032](https://github.com/opensearch-project/OpenSearch/pull/14221))
 
 ### Security
 

--- a/release-notes/opensearch.release-notes-2.15.0.md
+++ b/release-notes/opensearch.release-notes-2.15.0.md
@@ -71,3 +71,4 @@
 - Fix ReplicaShardBatchAllocator to batch shards without duplicates ([#13710](https://github.com/opensearch-project/OpenSearch/pull/13710))
 - Java high-level REST client bulk() is not respecting the bulkRequest.requireAlias(true) method call ([#14146](https://github.com/opensearch-project/OpenSearch/pull/14146))
 - Fix ShardNotFoundException during request cache clean up ([#14219](https://github.com/opensearch-project/OpenSearch/pull/14219))
+- Fix Concurrent Modification Exception in Indices Request Cache([#14032](https://github.com/opensearch-project/OpenSearch/pull/14221))

--- a/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
@@ -61,6 +61,7 @@ import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.RatioValue;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.common.util.concurrent.ConcurrentCollections;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -75,7 +76,6 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -176,7 +176,8 @@ public final class IndicesRequestCache implements RemovalListener<ICacheKey<Indi
         this.cacheCleanupManager = new IndicesRequestCacheCleanupManager(
             threadPool,
             INDICES_REQUEST_CACHE_CLEANUP_INTERVAL_SETTING.get(settings),
-            getStalenessThreshold(settings)
+            getStalenessThreshold(settings),
+            FeatureFlags.PLUGGABLE_CACHE_SETTING.get(settings)
         );
         this.cacheEntityLookup = cacheEntityFunction;
         this.clusterService = clusterService;
@@ -507,17 +508,24 @@ public final class IndicesRequestCache implements RemovalListener<ICacheKey<Indi
      * */
     class IndicesRequestCacheCleanupManager implements Closeable {
         private final Set<CleanupKey> keysToClean;
-        private final ConcurrentMap<ShardId, HashMap<String, Integer>> cleanupKeyToCountMap;
+        private final ConcurrentMap<ShardId, ConcurrentMap<String, Integer>> cleanupKeyToCountMap;
         private final AtomicInteger staleKeysCount;
         private volatile double stalenessThreshold;
         private final IndicesRequestCacheCleaner cacheCleaner;
+        private final boolean pluggableCacheEnabled;
 
-        IndicesRequestCacheCleanupManager(ThreadPool threadpool, TimeValue cleanInterval, double stalenessThreshold) {
+        IndicesRequestCacheCleanupManager(
+            ThreadPool threadpool,
+            TimeValue cleanInterval,
+            double stalenessThreshold,
+            boolean pluggableCacheEnabled
+        ) {
             this.stalenessThreshold = stalenessThreshold;
             this.keysToClean = ConcurrentCollections.newConcurrentSet();
             this.cleanupKeyToCountMap = ConcurrentCollections.newConcurrentMap();
             this.staleKeysCount = new AtomicInteger(0);
             this.cacheCleaner = new IndicesRequestCacheCleaner(this, threadpool, cleanInterval);
+            this.pluggableCacheEnabled = pluggableCacheEnabled;
             threadpool.schedule(cacheCleaner, cleanInterval, ThreadPool.Names.SAME);
         }
 
@@ -556,7 +564,7 @@ public final class IndicesRequestCache implements RemovalListener<ICacheKey<Indi
          * @param cleanupKey the CleanupKey to be updated in the map
          */
         private void updateStaleCountOnCacheInsert(CleanupKey cleanupKey) {
-            if (cleanupKey.entity == null) {
+            if (pluggableCacheEnabled || cleanupKey.entity == null) {
                 return;
             }
             IndexShard indexShard = (IndexShard) cleanupKey.entity.getCacheIdentity();
@@ -568,7 +576,13 @@ public final class IndicesRequestCache implements RemovalListener<ICacheKey<Indi
 
             // If the key doesn't exist, it's added with a value of 1.
             // If the key exists, its value is incremented by 1.
-            cleanupKeyToCountMap.computeIfAbsent(shardId, k -> new HashMap<>()).merge(cleanupKey.readerCacheKeyId, 1, Integer::sum);
+            addToCleanupKeyToCountMap(shardId, cleanupKey.readerCacheKeyId);
+        }
+
+        // pkg-private for testing
+        void addToCleanupKeyToCountMap(ShardId shardId, String readerCacheKeyId) {
+            cleanupKeyToCountMap.computeIfAbsent(shardId, k -> ConcurrentCollections.newConcurrentMap())
+                .merge(readerCacheKeyId, 1, Integer::sum);
         }
 
         /**
@@ -587,7 +601,7 @@ public final class IndicesRequestCache implements RemovalListener<ICacheKey<Indi
             CleanupKey cleanupKey,
             RemovalNotification<ICacheKey<Key>, BytesReference> notification
         ) {
-            if (notification.getRemovalReason() == RemovalReason.REPLACED) {
+            if (pluggableCacheEnabled || notification.getRemovalReason() == RemovalReason.REPLACED) {
                 // The reason of the notification is REPLACED when a cache entry's value is updated, since replacing an entry
                 // does not affect the staleness count, we skip such notifications.
                 return;
@@ -647,7 +661,7 @@ public final class IndicesRequestCache implements RemovalListener<ICacheKey<Indi
          * @param cleanupKey the CleanupKey that has been marked for cleanup
          */
         private void incrementStaleKeysCount(CleanupKey cleanupKey) {
-            if (cleanupKey.entity == null) {
+            if (pluggableCacheEnabled || cleanupKey.entity == null) {
                 return;
             }
             IndexShard indexShard = (IndexShard) cleanupKey.entity.getCacheIdentity();
@@ -789,7 +803,7 @@ public final class IndicesRequestCache implements RemovalListener<ICacheKey<Indi
          * @return true if the cache cleanup process can be skipped, false otherwise.
          */
         private synchronized boolean canSkipCacheCleanup(double cleanThresholdPercent) {
-            if (cleanThresholdPercent == 0.0) {
+            if (pluggableCacheEnabled || cleanThresholdPercent == 0.0) {
                 return false;
             }
             double staleKeysInCachePercentage = staleKeysInCachePercentage();
@@ -826,7 +840,7 @@ public final class IndicesRequestCache implements RemovalListener<ICacheKey<Indi
         }
 
         // for testing
-        ConcurrentMap<ShardId, HashMap<String, Integer>> getCleanupKeyToCountMap() {
+        ConcurrentMap<ShardId, ConcurrentMap<String, Integer>> getCleanupKeyToCountMap() {
             return cleanupKeyToCountMap;
         }
 

--- a/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
@@ -61,7 +61,6 @@ import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.RatioValue;
 import org.opensearch.common.unit.TimeValue;
-import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.common.util.concurrent.ConcurrentCollections;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -176,8 +175,7 @@ public final class IndicesRequestCache implements RemovalListener<ICacheKey<Indi
         this.cacheCleanupManager = new IndicesRequestCacheCleanupManager(
             threadPool,
             INDICES_REQUEST_CACHE_CLEANUP_INTERVAL_SETTING.get(settings),
-            getStalenessThreshold(settings),
-            FeatureFlags.PLUGGABLE_CACHE_SETTING.get(settings)
+            getStalenessThreshold(settings)
         );
         this.cacheEntityLookup = cacheEntityFunction;
         this.clusterService = clusterService;
@@ -512,20 +510,13 @@ public final class IndicesRequestCache implements RemovalListener<ICacheKey<Indi
         private final AtomicInteger staleKeysCount;
         private volatile double stalenessThreshold;
         private final IndicesRequestCacheCleaner cacheCleaner;
-        private final boolean pluggableCacheEnabled;
 
-        IndicesRequestCacheCleanupManager(
-            ThreadPool threadpool,
-            TimeValue cleanInterval,
-            double stalenessThreshold,
-            boolean pluggableCacheEnabled
-        ) {
+        IndicesRequestCacheCleanupManager(ThreadPool threadpool, TimeValue cleanInterval, double stalenessThreshold) {
             this.stalenessThreshold = stalenessThreshold;
             this.keysToClean = ConcurrentCollections.newConcurrentSet();
             this.cleanupKeyToCountMap = ConcurrentCollections.newConcurrentMap();
             this.staleKeysCount = new AtomicInteger(0);
             this.cacheCleaner = new IndicesRequestCacheCleaner(this, threadpool, cleanInterval);
-            this.pluggableCacheEnabled = pluggableCacheEnabled;
             threadpool.schedule(cacheCleaner, cleanInterval, ThreadPool.Names.SAME);
         }
 
@@ -564,7 +555,7 @@ public final class IndicesRequestCache implements RemovalListener<ICacheKey<Indi
          * @param cleanupKey the CleanupKey to be updated in the map
          */
         private void updateStaleCountOnCacheInsert(CleanupKey cleanupKey) {
-            if (!pluggableCacheEnabled || cleanupKey.entity == null) {
+            if (cleanupKey.entity == null) {
                 return;
             }
             IndexShard indexShard = (IndexShard) cleanupKey.entity.getCacheIdentity();
@@ -601,7 +592,7 @@ public final class IndicesRequestCache implements RemovalListener<ICacheKey<Indi
             CleanupKey cleanupKey,
             RemovalNotification<ICacheKey<Key>, BytesReference> notification
         ) {
-            if (!pluggableCacheEnabled || notification.getRemovalReason() == RemovalReason.REPLACED) {
+            if (notification.getRemovalReason() == RemovalReason.REPLACED) {
                 // The reason of the notification is REPLACED when a cache entry's value is updated, since replacing an entry
                 // does not affect the staleness count, we skip such notifications.
                 return;
@@ -661,7 +652,7 @@ public final class IndicesRequestCache implements RemovalListener<ICacheKey<Indi
          * @param cleanupKey the CleanupKey that has been marked for cleanup
          */
         private void incrementStaleKeysCount(CleanupKey cleanupKey) {
-            if (!pluggableCacheEnabled || cleanupKey.entity == null) {
+            if (cleanupKey.entity == null) {
                 return;
             }
             IndexShard indexShard = (IndexShard) cleanupKey.entity.getCacheIdentity();
@@ -803,7 +794,7 @@ public final class IndicesRequestCache implements RemovalListener<ICacheKey<Indi
          * @return true if the cache cleanup process can be skipped, false otherwise.
          */
         private synchronized boolean canSkipCacheCleanup(double cleanThresholdPercent) {
-            if (!pluggableCacheEnabled || cleanThresholdPercent == 0.0) {
+            if (cleanThresholdPercent == 0.0) {
                 return false;
             }
             double staleKeysInCachePercentage = staleKeysInCachePercentage();

--- a/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
@@ -564,7 +564,7 @@ public final class IndicesRequestCache implements RemovalListener<ICacheKey<Indi
          * @param cleanupKey the CleanupKey to be updated in the map
          */
         private void updateStaleCountOnCacheInsert(CleanupKey cleanupKey) {
-            if (pluggableCacheEnabled || cleanupKey.entity == null) {
+            if (!pluggableCacheEnabled || cleanupKey.entity == null) {
                 return;
             }
             IndexShard indexShard = (IndexShard) cleanupKey.entity.getCacheIdentity();
@@ -601,7 +601,7 @@ public final class IndicesRequestCache implements RemovalListener<ICacheKey<Indi
             CleanupKey cleanupKey,
             RemovalNotification<ICacheKey<Key>, BytesReference> notification
         ) {
-            if (pluggableCacheEnabled || notification.getRemovalReason() == RemovalReason.REPLACED) {
+            if (!pluggableCacheEnabled || notification.getRemovalReason() == RemovalReason.REPLACED) {
                 // The reason of the notification is REPLACED when a cache entry's value is updated, since replacing an entry
                 // does not affect the staleness count, we skip such notifications.
                 return;
@@ -661,7 +661,7 @@ public final class IndicesRequestCache implements RemovalListener<ICacheKey<Indi
          * @param cleanupKey the CleanupKey that has been marked for cleanup
          */
         private void incrementStaleKeysCount(CleanupKey cleanupKey) {
-            if (pluggableCacheEnabled || cleanupKey.entity == null) {
+            if (!pluggableCacheEnabled || cleanupKey.entity == null) {
                 return;
             }
             IndexShard indexShard = (IndexShard) cleanupKey.entity.getCacheIdentity();
@@ -803,7 +803,7 @@ public final class IndicesRequestCache implements RemovalListener<ICacheKey<Indi
          * @return true if the cache cleanup process can be skipped, false otherwise.
          */
         private synchronized boolean canSkipCacheCleanup(double cleanThresholdPercent) {
-            if (pluggableCacheEnabled || cleanThresholdPercent == 0.0) {
+            if (!pluggableCacheEnabled || cleanThresholdPercent == 0.0) {
                 return false;
             }
             double staleKeysInCachePercentage = staleKeysInCachePercentage();

--- a/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
@@ -394,7 +394,10 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
     // when staleness count is higher than stale threshold, stale keys should be cleaned up.
     public void testCacheCleanupBasedOnStaleThreshold_StalenessHigherThanThreshold() throws Exception {
         threadPool = getThreadPool();
-        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.49").build();
+        Settings settings = Settings.builder()
+            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.49")
+            .put(FeatureFlags.PLUGGABLE_CACHE, true)
+            .build();
         cache = getIndicesRequestCache(settings);
 
         writer.addDocument(newDoc(0, "foo"));
@@ -429,7 +432,10 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
     // when staleness count equal to stale threshold, stale keys should be cleaned up.
     public void testCacheCleanupBasedOnStaleThreshold_StalenessEqualToThreshold() throws Exception {
         threadPool = getThreadPool();
-        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.5").build();
+        Settings settings = Settings.builder()
+            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.5")
+            .put(FeatureFlags.PLUGGABLE_CACHE, true)
+            .build();
         cache = getIndicesRequestCache(settings);
         writer.addDocument(newDoc(0, "foo"));
         DirectoryReader reader = getReader(writer, indexShard.shardId());
@@ -461,7 +467,10 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
     // when a cache entry that is Stale is evicted for any reason, we have to deduct the count from our staleness count
     public void testStaleCount_OnRemovalNotificationOfStaleKey_DecrementsStaleCount() throws Exception {
         threadPool = getThreadPool();
-        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.51").build();
+        Settings settings = Settings.builder()
+            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.51")
+            .put(FeatureFlags.PLUGGABLE_CACHE, true)
+            .build();
         cache = getIndicesRequestCache(settings);
         writer.addDocument(newDoc(0, "foo"));
         ShardId shardId = indexShard.shardId();
@@ -523,7 +532,10 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
     // when a cache entry that is NOT Stale is evicted for any reason, staleness count should NOT be deducted
     public void testStaleCount_OnRemovalNotificationOfNonStaleKey_DoesNotDecrementsStaleCount() throws Exception {
         threadPool = getThreadPool();
-        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.51").build();
+        Settings settings = Settings.builder()
+            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.51")
+            .put(FeatureFlags.PLUGGABLE_CACHE, true)
+            .build();
         cache = getIndicesRequestCache(settings);
         writer.addDocument(newDoc(0, "foo"));
         ShardId shardId = indexShard.shardId();
@@ -584,7 +596,10 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
     // when a cache entry that is NOT Stale is evicted WITHOUT its reader closing, we should NOT deduct it from staleness count
     public void testStaleCount_WithoutReaderClosing_DecrementsStaleCount() throws Exception {
         threadPool = getThreadPool();
-        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.51").build();
+        Settings settings = Settings.builder()
+            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.51")
+            .put(FeatureFlags.PLUGGABLE_CACHE, true)
+            .build();
         cache = getIndicesRequestCache(settings);
 
         writer.addDocument(newDoc(0, "foo"));
@@ -623,7 +638,10 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
     // test staleness count based on removal notifications
     public void testStaleCount_OnRemovalNotifications() throws Exception {
         threadPool = getThreadPool();
-        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.51").build();
+        Settings settings = Settings.builder()
+            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.51")
+            .put(FeatureFlags.PLUGGABLE_CACHE, true)
+            .build();
         cache = getIndicesRequestCache(settings);
 
         writer.addDocument(newDoc(0, "foo"));
@@ -677,7 +695,10 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
     // when staleness count less than the stale threshold, stale keys should NOT be cleaned up.
     public void testCacheCleanupBasedOnStaleThreshold_StalenessLesserThanThreshold() throws Exception {
         threadPool = getThreadPool();
-        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "51%").build();
+        Settings settings = Settings.builder()
+            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "51%")
+            .put(FeatureFlags.PLUGGABLE_CACHE, true)
+            .build();
         cache = getIndicesRequestCache(settings);
 
         writer.addDocument(newDoc(0, "foo"));
@@ -710,7 +731,10 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
     // test the cleanupKeyToCountMap are set appropriately when both readers are closed
     public void testCleanupKeyToCountMapAreSetAppropriately() throws Exception {
         threadPool = getThreadPool();
-        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.51").build();
+        Settings settings = Settings.builder()
+            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.51")
+            .put(FeatureFlags.PLUGGABLE_CACHE, true)
+            .build();
         cache = getIndicesRequestCache(settings);
 
         writer.addDocument(newDoc(0, "foo"));
@@ -798,7 +822,10 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
     // test adding to cleanupKeyToCountMap with multiple threads
     public void testAddToCleanupKeyToCountMap() throws Exception {
         threadPool = getThreadPool();
-        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "51%").build();
+        Settings settings = Settings.builder()
+            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "51%")
+            .put(FeatureFlags.PLUGGABLE_CACHE, true)
+            .build();
         cache = getIndicesRequestCache(settings);
 
         int numberOfThreads = 10;
@@ -1008,7 +1035,10 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
 
     public void testCacheCleanupBasedOnStaleThreshold_thresholdUpdate() throws Exception {
         threadPool = getThreadPool();
-        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "51%").build();
+        Settings settings = Settings.builder()
+            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "51%")
+            .put(FeatureFlags.PLUGGABLE_CACHE, true)
+            .build();
         cache = getIndicesRequestCache(settings);
 
         writer.addDocument(newDoc(0, "foo"));

--- a/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
@@ -795,57 +795,6 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
         IOUtils.close(secondReader);
     }
 
-    // test adding to cleanupKeyToCountMap with multiple threads
-    public void testAddToCleanupKeyToCountMap() throws InterruptedException {
-        threadPool = getThreadPool();
-        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "51%").build();
-        cache = getIndicesRequestCache(settings);
-
-        int numberOfThreads = 10;
-        int numberOfIterations = 1000;
-        Phaser phaser = new Phaser(numberOfThreads + 1); // +1 for the main thread
-        AtomicBoolean exceptionDetected = new AtomicBoolean(false);
-
-        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
-
-        for (int i = 0; i < numberOfThreads; i++) {
-            executorService.submit(() -> {
-                phaser.arriveAndAwaitAdvance(); // Ensure all threads start at the same time
-                try {
-                    for (int j = 0; j < numberOfIterations; j++) {
-                        cache.cacheCleanupManager.addToCleanupKeyToCountMap(indexShard.shardId(), UUID.randomUUID().toString());
-                    }
-                } catch (ConcurrentModificationException e) {
-                    e.printStackTrace();
-                    exceptionDetected.set(true); // Set flag if exception is detected
-                }
-            });
-        }
-        phaser.arriveAndAwaitAdvance(); // Start all threads
-
-        // Main thread iterates over the map
-        executorService.submit(() -> {
-            try {
-                for (int j = 0; j < numberOfIterations; j++) {
-                    cache.cacheCleanupManager.getCleanupKeyToCountMap().forEach((k, v) -> {
-                        v.forEach((k1, v1) -> {
-                            // Accessing the map to create contention
-                            v.get(k1);
-                        });
-                    });
-                }
-            } catch (ConcurrentModificationException e) {
-                e.printStackTrace();
-                exceptionDetected.set(true); // Set flag if exception is detected
-            }
-        });
-
-        executorService.shutdown();
-        executorService.awaitTermination(60, TimeUnit.SECONDS);
-
-        assertFalse(exceptionDetected.get());
-    }
-
     private IndicesRequestCache getIndicesRequestCache(Settings settings) {
         IndicesService indicesService = getInstanceFromNode(IndicesService.class);
         return new IndicesRequestCache(settings, (shardId -> {

--- a/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
@@ -795,6 +795,56 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
         IOUtils.close(secondReader);
     }
 
+    // test adding to cleanupKeyToCountMap with multiple threads
+    public void testAddToCleanupKeyToCountMap() throws Exception {
+        threadPool = getThreadPool();
+        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "51%").build();
+        cache = getIndicesRequestCache(settings);
+
+        int numberOfThreads = 10;
+        int numberOfIterations = 1000;
+        Phaser phaser = new Phaser(numberOfThreads + 1); // +1 for the main thread
+        AtomicBoolean exceptionDetected = new AtomicBoolean(false);
+
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            executorService.submit(() -> {
+                phaser.arriveAndAwaitAdvance(); // Ensure all threads start at the same time
+                try {
+                    for (int j = 0; j < numberOfIterations; j++) {
+                        cache.cacheCleanupManager.addToCleanupKeyToCountMap(indexShard.shardId(), UUID.randomUUID().toString());
+                    }
+                } catch (ConcurrentModificationException e) {
+                    logger.error("ConcurrentModificationException detected in thread : " + e.getMessage());
+                    exceptionDetected.set(true); // Set flag if exception is detected
+                }
+            });
+        }
+        phaser.arriveAndAwaitAdvance(); // Start all threads
+
+        // Main thread iterates over the map
+        executorService.submit(() -> {
+            try {
+                for (int j = 0; j < numberOfIterations; j++) {
+                    cache.cacheCleanupManager.getCleanupKeyToCountMap().forEach((k, v) -> {
+                        v.forEach((k1, v1) -> {
+                            // Accessing the map to create contention
+                            v.get(k1);
+                        });
+                    });
+                }
+            } catch (ConcurrentModificationException e) {
+                logger.error("ConcurrentModificationException detected in main thread : " + e.getMessage());
+                exceptionDetected.set(true); // Set flag if exception is detected
+            }
+        });
+
+        executorService.shutdown();
+        executorService.awaitTermination(60, TimeUnit.SECONDS);
+        assertFalse(exceptionDetected.get());
+    }
+
     private IndicesRequestCache getIndicesRequestCache(Settings settings) {
         IndicesService indicesService = getInstanceFromNode(IndicesService.class);
         return new IndicesRequestCache(

--- a/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
@@ -95,7 +95,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.ConcurrentModificationException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -105,7 +105,9 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Phaser;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Collections.emptyMap;
@@ -489,7 +491,7 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
             indexShard.hashCode()
         );
         // test the mapping
-        ConcurrentMap<ShardId, HashMap<String, Integer>> cleanupKeyToCountMap = cache.cacheCleanupManager.getCleanupKeyToCountMap();
+        ConcurrentMap<ShardId, ConcurrentMap<String, Integer>> cleanupKeyToCountMap = cache.cacheCleanupManager.getCleanupKeyToCountMap();
         // shard id should exist
         assertTrue(cleanupKeyToCountMap.containsKey(shardId));
         // reader CacheKeyId should NOT exist
@@ -552,7 +554,7 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
         );
 
         // test the mapping
-        ConcurrentMap<ShardId, HashMap<String, Integer>> cleanupKeyToCountMap = cache.cacheCleanupManager.getCleanupKeyToCountMap();
+        ConcurrentMap<ShardId, ConcurrentMap<String, Integer>> cleanupKeyToCountMap = cache.cacheCleanupManager.getCleanupKeyToCountMap();
         // shard id should exist
         assertTrue(cleanupKeyToCountMap.containsKey(shardId));
         // reader CacheKeyId should NOT exist
@@ -720,7 +722,7 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
         cache.getOrCompute(getEntity(indexShard), getLoader(reader), reader, getTermBytes());
         assertEquals(1, cache.count());
         // test the mappings
-        ConcurrentMap<ShardId, HashMap<String, Integer>> cleanupKeyToCountMap = cache.cacheCleanupManager.getCleanupKeyToCountMap();
+        ConcurrentMap<ShardId, ConcurrentMap<String, Integer>> cleanupKeyToCountMap = cache.cacheCleanupManager.getCleanupKeyToCountMap();
         assertEquals(1, (int) cleanupKeyToCountMap.get(shardId).get(getReaderCacheKeyId(reader)));
 
         cache.getOrCompute(getEntity(indexShard), getLoader(secondReader), secondReader, getTermBytes());
@@ -793,8 +795,55 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
         IOUtils.close(secondReader);
     }
 
-    private DirectoryReader getReader(IndexWriter writer, ShardId shardId) throws IOException {
-        return OpenSearchDirectoryReader.wrap(DirectoryReader.open(writer), shardId);
+    // test adding to cleanupKeyToCountMap with multiple threads
+    public void testAddToCleanupKeyToCountMap() throws InterruptedException {
+        threadPool = getThreadPool();
+        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "51%").build();
+        cache = getIndicesRequestCache(settings);
+
+        int numberOfThreads = 10;
+        int numberOfIterations = 1000;
+        Phaser phaser = new Phaser(numberOfThreads + 1); // +1 for the main thread
+        AtomicBoolean exceptionDetected = new AtomicBoolean(false);
+
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            executorService.submit(() -> {
+                phaser.arriveAndAwaitAdvance(); // Ensure all threads start at the same time
+                try {
+                    for (int j = 0; j < numberOfIterations; j++) {
+                        cache.cacheCleanupManager.addToCleanupKeyToCountMap(indexShard.shardId(), UUID.randomUUID().toString());
+                    }
+                } catch (ConcurrentModificationException e) {
+                    e.printStackTrace();
+                    exceptionDetected.set(true); // Set flag if exception is detected
+                }
+            });
+        }
+        phaser.arriveAndAwaitAdvance(); // Start all threads
+
+        // Main thread iterates over the map
+        executorService.submit(() -> {
+            try {
+                for (int j = 0; j < numberOfIterations; j++) {
+                    cache.cacheCleanupManager.getCleanupKeyToCountMap().forEach((k, v) -> {
+                        v.forEach((k1, v1) -> {
+                            // Accessing the map to create contention
+                            v.get(k1);
+                        });
+                    });
+                }
+            } catch (ConcurrentModificationException e) {
+                e.printStackTrace();
+                exceptionDetected.set(true); // Set flag if exception is detected
+            }
+        });
+
+        executorService.shutdown();
+        executorService.awaitTermination(60, TimeUnit.SECONDS);
+
+        assertFalse(exceptionDetected.get());
     }
 
     private IndicesRequestCache getIndicesRequestCache(Settings settings) {
@@ -806,6 +855,10 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
             threadPool,
             ClusterServiceUtils.createClusterService(threadPool)
         );
+    }
+
+    private DirectoryReader getReader(IndexWriter writer, ShardId shardId) throws IOException {
+        return OpenSearchDirectoryReader.wrap(DirectoryReader.open(writer), shardId);
     }
 
     private Loader getLoader(DirectoryReader reader) {

--- a/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
@@ -394,7 +394,10 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
     // when staleness count is higher than stale threshold, stale keys should be cleaned up.
     public void testCacheCleanupBasedOnStaleThreshold_StalenessHigherThanThreshold() throws Exception {
         threadPool = getThreadPool();
-        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.49").build();
+        Settings settings = Settings.builder()
+            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.49")
+            .put(FeatureFlags.PLUGGABLE_CACHE, true)
+            .build();
         cache = getIndicesRequestCache(settings);
 
         writer.addDocument(newDoc(0, "foo"));
@@ -429,7 +432,10 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
     // when staleness count equal to stale threshold, stale keys should be cleaned up.
     public void testCacheCleanupBasedOnStaleThreshold_StalenessEqualToThreshold() throws Exception {
         threadPool = getThreadPool();
-        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.5").build();
+        Settings settings = Settings.builder()
+            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.5")
+            .put(FeatureFlags.PLUGGABLE_CACHE, true)
+            .build();
         cache = getIndicesRequestCache(settings);
         writer.addDocument(newDoc(0, "foo"));
         DirectoryReader reader = getReader(writer, indexShard.shardId());
@@ -461,7 +467,10 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
     // when a cache entry that is Stale is evicted for any reason, we have to deduct the count from our staleness count
     public void testStaleCount_OnRemovalNotificationOfStaleKey_DecrementsStaleCount() throws Exception {
         threadPool = getThreadPool();
-        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.51").build();
+        Settings settings = Settings.builder()
+            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.51")
+            .put(FeatureFlags.PLUGGABLE_CACHE, true)
+            .build();
         cache = getIndicesRequestCache(settings);
         writer.addDocument(newDoc(0, "foo"));
         ShardId shardId = indexShard.shardId();
@@ -523,7 +532,10 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
     // when a cache entry that is NOT Stale is evicted for any reason, staleness count should NOT be deducted
     public void testStaleCount_OnRemovalNotificationOfNonStaleKey_DoesNotDecrementsStaleCount() throws Exception {
         threadPool = getThreadPool();
-        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.51").build();
+        Settings settings = Settings.builder()
+            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.51")
+            .put(FeatureFlags.PLUGGABLE_CACHE, true)
+            .build();
         cache = getIndicesRequestCache(settings);
         writer.addDocument(newDoc(0, "foo"));
         ShardId shardId = indexShard.shardId();
@@ -584,7 +596,10 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
     // when a cache entry that is NOT Stale is evicted WITHOUT its reader closing, we should NOT deduct it from staleness count
     public void testStaleCount_WithoutReaderClosing_DecrementsStaleCount() throws Exception {
         threadPool = getThreadPool();
-        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.51").build();
+        Settings settings = Settings.builder()
+            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.51")
+            .put(FeatureFlags.PLUGGABLE_CACHE, true)
+            .build();
         cache = getIndicesRequestCache(settings);
 
         writer.addDocument(newDoc(0, "foo"));
@@ -623,7 +638,10 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
     // test staleness count based on removal notifications
     public void testStaleCount_OnRemovalNotifications() throws Exception {
         threadPool = getThreadPool();
-        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.51").build();
+        Settings settings = Settings.builder()
+            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.51")
+            .put(FeatureFlags.PLUGGABLE_CACHE, true)
+            .build();
         cache = getIndicesRequestCache(settings);
 
         writer.addDocument(newDoc(0, "foo"));
@@ -677,7 +695,10 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
     // when staleness count less than the stale threshold, stale keys should NOT be cleaned up.
     public void testCacheCleanupBasedOnStaleThreshold_StalenessLesserThanThreshold() throws Exception {
         threadPool = getThreadPool();
-        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "51%").build();
+        Settings settings = Settings.builder()
+            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "51%")
+            .put(FeatureFlags.PLUGGABLE_CACHE, true)
+            .build();
         cache = getIndicesRequestCache(settings);
 
         writer.addDocument(newDoc(0, "foo"));
@@ -710,7 +731,10 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
     // test the cleanupKeyToCountMap are set appropriately when both readers are closed
     public void testCleanupKeyToCountMapAreSetAppropriately() throws Exception {
         threadPool = getThreadPool();
-        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.51").build();
+        Settings settings = Settings.builder()
+            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.51")
+            .put(FeatureFlags.PLUGGABLE_CACHE, true)
+            .build();
         cache = getIndicesRequestCache(settings);
 
         writer.addDocument(newDoc(0, "foo"));
@@ -798,7 +822,10 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
     // test adding to cleanupKeyToCountMap with multiple threads
     public void testAddToCleanupKeyToCountMap() throws Exception {
         threadPool = getThreadPool();
-        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "51%").build();
+        Settings settings = Settings.builder()
+            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "51%")
+            .put(FeatureFlags.PLUGGABLE_CACHE, true)
+            .build();
         cache = getIndicesRequestCache(settings);
 
         int numberOfThreads = 10;
@@ -1002,7 +1029,10 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
 
     public void testCacheCleanupBasedOnStaleThreshold_thresholdUpdate() throws Exception {
         threadPool = getThreadPool();
-        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "51%").build();
+        Settings settings = Settings.builder()
+            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "51%")
+            .put(FeatureFlags.PLUGGABLE_CACHE, true)
+            .build();
         cache = getIndicesRequestCache(settings);
 
         writer.addDocument(newDoc(0, "foo"));

--- a/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
@@ -195,58 +195,6 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
         assertEquals(0, cache.numRegisteredCloseListeners());
     }
 
-    public void testBasicOperationsCacheWithFeatureFlag() throws Exception {
-        threadPool = getThreadPool();
-        Settings settings = Settings.builder().put(super.featureFlagSettings()).put(FeatureFlags.PLUGGABLE_CACHE, "true").build();
-        cache = getIndicesRequestCache(settings);
-        writer.addDocument(newDoc(0, "foo"));
-        DirectoryReader reader = getReader(writer, indexShard.shardId());
-
-        // initial cache
-        IndicesService.IndexShardCacheEntity entity = new IndicesService.IndexShardCacheEntity(indexShard);
-        Loader loader = new Loader(reader, 0);
-        BytesReference value = cache.getOrCompute(entity, loader, reader, getTermBytes());
-        assertEquals("foo", value.streamInput().readString());
-        ShardRequestCache requestCacheStats = indexShard.requestCache();
-        assertEquals(0, requestCacheStats.stats().getHitCount());
-        assertEquals(1, requestCacheStats.stats().getMissCount());
-        assertEquals(0, requestCacheStats.stats().getEvictions());
-        assertFalse(loader.loadedFromCache);
-        assertEquals(1, cache.count());
-
-        // cache hit
-        entity = new IndicesService.IndexShardCacheEntity(indexShard);
-        loader = new Loader(reader, 0);
-        value = cache.getOrCompute(entity, loader, reader, getTermBytes());
-        assertEquals("foo", value.streamInput().readString());
-        requestCacheStats = indexShard.requestCache();
-        assertEquals(1, requestCacheStats.stats().getHitCount());
-        assertEquals(1, requestCacheStats.stats().getMissCount());
-        assertEquals(0, requestCacheStats.stats().getEvictions());
-        assertTrue(loader.loadedFromCache);
-        assertEquals(1, cache.count());
-        assertTrue(requestCacheStats.stats().getMemorySize().bytesAsInt() > value.length());
-        assertEquals(1, cache.numRegisteredCloseListeners());
-
-        // Closing the cache doesn't modify an already returned CacheEntity
-        if (randomBoolean()) {
-            reader.close();
-        } else {
-            indexShard.close("test", true, true); // closed shard but reader is still open
-            cache.clear(entity);
-        }
-        cache.cacheCleanupManager.cleanCache();
-        assertEquals(1, requestCacheStats.stats().getHitCount());
-        assertEquals(1, requestCacheStats.stats().getMissCount());
-        assertEquals(0, requestCacheStats.stats().getEvictions());
-        assertTrue(loader.loadedFromCache);
-        assertEquals(0, cache.count());
-        assertEquals(0, requestCacheStats.stats().getMemorySize().bytesAsInt());
-
-        IOUtils.close(reader);
-        assertEquals(0, cache.numRegisteredCloseListeners());
-    }
-
     public void testCacheDifferentReaders() throws Exception {
         threadPool = getThreadPool();
         cache = getIndicesRequestCache(Settings.EMPTY);
@@ -391,44 +339,10 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
         IOUtils.close(secondReader);
     }
 
-    // when the feature flag is disabled, stale keys should be cleaned up every time cache cleaner is invoked.
-    public void testCacheCleanupWhenFeatureFlagIsDisabled() throws Exception {
-        threadPool = getThreadPool();
-        Settings settings = Settings.builder()
-            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0%")
-            .put(FeatureFlags.PLUGGABLE_CACHE, false)
-            .build();
-        cache = getIndicesRequestCache(settings);
-        writer.addDocument(newDoc(0, "foo"));
-        DirectoryReader reader = getReader(writer, indexShard.shardId());
-        DirectoryReader secondReader = getReader(writer, indexShard.shardId());
-
-        // Get 2 entries into the cache
-        cache.getOrCompute(getEntity(indexShard), getLoader(reader), reader, getTermBytes());
-        assertEquals(1, cache.count());
-
-        cache.getOrCompute(getEntity(indexShard), getLoader(secondReader), secondReader, getTermBytes());
-        assertEquals(2, cache.count());
-
-        // Close the reader, to be enqueued for cleanup
-        // 1 out of 2 keys ie 50% are now stale.
-        reader.close();
-        // cache count should not be affected
-        assertEquals(2, cache.count());
-        // clean cache with 0% staleness threshold
-        cache.cacheCleanupManager.cleanCache();
-        // cleanup should remove the stale-key
-        assertEquals(1, cache.count());
-        IOUtils.close(secondReader);
-    }
-
     // when staleness count is higher than stale threshold, stale keys should be cleaned up.
     public void testCacheCleanupBasedOnStaleThreshold_StalenessHigherThanThreshold() throws Exception {
         threadPool = getThreadPool();
-        Settings settings = Settings.builder()
-            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.49")
-            .put(FeatureFlags.PLUGGABLE_CACHE, true)
-            .build();
+        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.49").build();
         cache = getIndicesRequestCache(settings);
 
         writer.addDocument(newDoc(0, "foo"));
@@ -463,10 +377,7 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
     // when staleness count equal to stale threshold, stale keys should be cleaned up.
     public void testCacheCleanupBasedOnStaleThreshold_StalenessEqualToThreshold() throws Exception {
         threadPool = getThreadPool();
-        Settings settings = Settings.builder()
-            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.5")
-            .put(FeatureFlags.PLUGGABLE_CACHE, true)
-            .build();
+        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.5").build();
         cache = getIndicesRequestCache(settings);
         writer.addDocument(newDoc(0, "foo"));
         DirectoryReader reader = getReader(writer, indexShard.shardId());
@@ -498,10 +409,7 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
     // when a cache entry that is Stale is evicted for any reason, we have to deduct the count from our staleness count
     public void testStaleCount_OnRemovalNotificationOfStaleKey_DecrementsStaleCount() throws Exception {
         threadPool = getThreadPool();
-        Settings settings = Settings.builder()
-            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.51")
-            .put(FeatureFlags.PLUGGABLE_CACHE, true)
-            .build();
+        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.51").build();
         cache = getIndicesRequestCache(settings);
         writer.addDocument(newDoc(0, "foo"));
         ShardId shardId = indexShard.shardId();
@@ -563,10 +471,7 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
     // when a cache entry that is NOT Stale is evicted for any reason, staleness count should NOT be deducted
     public void testStaleCount_OnRemovalNotificationOfNonStaleKey_DoesNotDecrementsStaleCount() throws Exception {
         threadPool = getThreadPool();
-        Settings settings = Settings.builder()
-            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.51")
-            .put(FeatureFlags.PLUGGABLE_CACHE, true)
-            .build();
+        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.51").build();
         cache = getIndicesRequestCache(settings);
         writer.addDocument(newDoc(0, "foo"));
         ShardId shardId = indexShard.shardId();
@@ -627,10 +532,7 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
     // when a cache entry that is NOT Stale is evicted WITHOUT its reader closing, we should NOT deduct it from staleness count
     public void testStaleCount_WithoutReaderClosing_DecrementsStaleCount() throws Exception {
         threadPool = getThreadPool();
-        Settings settings = Settings.builder()
-            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.51")
-            .put(FeatureFlags.PLUGGABLE_CACHE, true)
-            .build();
+        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.51").build();
         cache = getIndicesRequestCache(settings);
 
         writer.addDocument(newDoc(0, "foo"));
@@ -669,10 +571,7 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
     // test staleness count based on removal notifications
     public void testStaleCount_OnRemovalNotifications() throws Exception {
         threadPool = getThreadPool();
-        Settings settings = Settings.builder()
-            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.51")
-            .put(FeatureFlags.PLUGGABLE_CACHE, true)
-            .build();
+        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.51").build();
         cache = getIndicesRequestCache(settings);
 
         writer.addDocument(newDoc(0, "foo"));
@@ -726,10 +625,7 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
     // when staleness count less than the stale threshold, stale keys should NOT be cleaned up.
     public void testCacheCleanupBasedOnStaleThreshold_StalenessLesserThanThreshold() throws Exception {
         threadPool = getThreadPool();
-        Settings settings = Settings.builder()
-            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "51%")
-            .put(FeatureFlags.PLUGGABLE_CACHE, true)
-            .build();
+        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "51%").build();
         cache = getIndicesRequestCache(settings);
 
         writer.addDocument(newDoc(0, "foo"));
@@ -762,10 +658,7 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
     // test the cleanupKeyToCountMap are set appropriately when both readers are closed
     public void testCleanupKeyToCountMapAreSetAppropriately() throws Exception {
         threadPool = getThreadPool();
-        Settings settings = Settings.builder()
-            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.51")
-            .put(FeatureFlags.PLUGGABLE_CACHE, true)
-            .build();
+        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.51").build();
         cache = getIndicesRequestCache(settings);
 
         writer.addDocument(newDoc(0, "foo"));
@@ -850,70 +743,10 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
         IOUtils.close(secondReader);
     }
 
-    // test the cleanupKeyToCountMap stays empty when the pluggable cache feature flag is disabled
-    public void testCleanupKeyToCountMapAreSetAppropriatelyWhenFeatureFlagIsDisabled() throws Exception {
-        threadPool = getThreadPool();
-        Settings settings = Settings.builder()
-            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "0.51")
-            .put(FeatureFlags.PLUGGABLE_CACHE, false)
-            .build();
-        cache = getIndicesRequestCache(settings);
-
-        writer.addDocument(newDoc(0, "foo"));
-        ShardId shardId = indexShard.shardId();
-        DirectoryReader reader = getReader(writer, shardId);
-        DirectoryReader secondReader = getReader(writer, shardId);
-
-        // Get 2 entries into the cache from 2 different readers
-        cache.getOrCompute(getEntity(indexShard), getLoader(reader), reader, getTermBytes());
-        assertEquals(1, cache.count());
-        // test the mappings
-        ConcurrentMap<ShardId, ConcurrentMap<String, Integer>> cleanupKeyToCountMap = cache.cacheCleanupManager.getCleanupKeyToCountMap();
-        assertTrue(cleanupKeyToCountMap.isEmpty());
-
-        cache.getOrCompute(getEntity(indexShard), getLoader(secondReader), secondReader, getTermBytes());
-        // test the mapping
-        assertEquals(2, cache.count());
-        assertTrue(cleanupKeyToCountMap.isEmpty());
-        // create another entry for the second reader
-        cache.getOrCompute(getEntity(indexShard), getLoader(secondReader), secondReader, getTermBytes("id", "1"));
-        // test the mapping
-        assertEquals(3, cache.count());
-        assertTrue(cleanupKeyToCountMap.isEmpty());
-
-        // Close the reader, to create stale entries
-        reader.close();
-        // cache count should not be affected
-        assertEquals(3, cache.count());
-        // test the mapping, cleanupKeyToCountMap should be empty
-        assertTrue(cleanupKeyToCountMap.isEmpty());
-        // send removal notification for first reader
-        IndicesRequestCache.Key key = new IndicesRequestCache.Key(
-            indexShard.shardId(),
-            getTermBytes(),
-            getReaderCacheKeyId(reader),
-            indexShard.hashCode()
-        );
-        cache.onRemoval(
-            new RemovalNotification<ICacheKey<IndicesRequestCache.Key>, BytesReference>(
-                new ICacheKey<>(key),
-                getTermBytes(),
-                RemovalReason.EVICTED
-            )
-        );
-        // test the mapping, it should stay the same
-        assertTrue(cleanupKeyToCountMap.isEmpty());
-
-        IOUtils.close(secondReader);
-    }
-
     // test adding to cleanupKeyToCountMap with multiple threads
     public void testAddToCleanupKeyToCountMap() throws Exception {
         threadPool = getThreadPool();
-        Settings settings = Settings.builder()
-            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "51%")
-            .put(FeatureFlags.PLUGGABLE_CACHE, true)
-            .build();
+        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "51%").build();
         cache = getIndicesRequestCache(settings);
 
         int numberOfThreads = 10;
@@ -1123,10 +956,7 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
 
     public void testCacheCleanupBasedOnStaleThreshold_thresholdUpdate() throws Exception {
         threadPool = getThreadPool();
-        Settings settings = Settings.builder()
-            .put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "51%")
-            .put(FeatureFlags.PLUGGABLE_CACHE, true)
-            .build();
+        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "51%").build();
         cache = getIndicesRequestCache(settings);
 
         writer.addDocument(newDoc(0, "foo"));

--- a/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
@@ -847,15 +847,9 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
 
     private IndicesRequestCache getIndicesRequestCache(Settings settings) {
         IndicesService indicesService = getInstanceFromNode(IndicesService.class);
-        return new IndicesRequestCache(settings, (shardId -> {
-            IndexService indexService = null;
-            try {
-                indexService = indicesService.indexServiceSafe(shardId.getIndex());
-            } catch (IndexNotFoundException ex) {
-                return Optional.empty();
-            }
-            return Optional.of(new IndicesService.IndexShardCacheEntity(indexService.getShard(shardId.id())));
-        }),
+        return new IndicesRequestCache(
+            settings,
+            indicesService.indicesRequestCache.cacheEntityLookup,
             new CacheModule(new ArrayList<>(), Settings.EMPTY).getCacheService(),
             threadPool,
             ClusterServiceUtils.createClusterService(threadPool)
@@ -1470,6 +1464,55 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
         assertEquals(0, cache.count());
 
         IOUtils.close(reader, writer, dir, cache);
+    }
+
+    public void testIndexShardClosedAndVerifyCacheCleanUpWorksSuccessfully() throws Exception {
+        threadPool = getThreadPool();
+        String indexName = "test1";
+        // Create a shard
+        IndexService indexService = createIndex(
+            indexName,
+            Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0).build()
+        );
+        IndexShard indexShard = indexService.getShard(0);
+        Directory dir = newDirectory();
+        IndexWriter writer = new IndexWriter(dir, newIndexWriterConfig());
+        writer.addDocument(newDoc(0, "foo"));
+        writer.addDocument(newDoc(1, "hack"));
+        DirectoryReader reader = OpenSearchDirectoryReader.wrap(DirectoryReader.open(writer), indexShard.shardId());
+        Loader loader = new Loader(reader, 0);
+
+        // Set clean interval to a high value as we will do it manually here.
+        IndicesRequestCache cache = getIndicesRequestCache(
+            Settings.builder()
+                .put(IndicesRequestCache.INDICES_REQUEST_CACHE_CLEANUP_INTERVAL_SETTING_KEY, TimeValue.timeValueMillis(100000))
+                .build()
+        );
+        IndicesService.IndexShardCacheEntity cacheEntity = new IndicesService.IndexShardCacheEntity(indexShard);
+        TermQueryBuilder termQuery = new TermQueryBuilder("id", "bar");
+
+        // Cache some values for indexShard
+        BytesReference value = cache.getOrCompute(cacheEntity, loader, reader, getTermBytes());
+
+        // Verify response and stats.
+        assertEquals("foo", value.streamInput().readString());
+        RequestCacheStats stats = indexShard.requestCache().stats();
+        assertEquals("foo", value.streamInput().readString());
+        assertEquals(1, cache.count());
+        assertEquals(1, stats.getMissCount());
+        assertTrue(stats.getMemorySizeInBytes() > 0);
+
+        // Remove the shard making its cache entries stale
+        IOUtils.close(reader, writer, dir);
+        indexService.removeShard(0, "force");
+
+        assertBusy(() -> { assertEquals(IndexShardState.CLOSED, indexShard.state()); }, 1, TimeUnit.SECONDS);
+
+        // Trigger clean up of cache. Should not throw any exception.
+        cache.cacheCleanupManager.cleanCache();
+        // Verify all cleared up.
+        assertEquals(0, cache.count());
+        IOUtils.close(cache);
     }
 
     public static String generateString(int length) {

--- a/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
@@ -795,6 +795,56 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
         IOUtils.close(secondReader);
     }
 
+    // test adding to cleanupKeyToCountMap with multiple threads
+    public void testAddToCleanupKeyToCountMap() throws Exception {
+        threadPool = getThreadPool();
+        Settings settings = Settings.builder().put(INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING.getKey(), "51%").build();
+        cache = getIndicesRequestCache(settings);
+
+        int numberOfThreads = 10;
+        int numberOfIterations = 1000;
+        Phaser phaser = new Phaser(numberOfThreads + 1); // +1 for the main thread
+        AtomicBoolean exceptionDetected = new AtomicBoolean(false);
+
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            executorService.submit(() -> {
+                phaser.arriveAndAwaitAdvance(); // Ensure all threads start at the same time
+                try {
+                    for (int j = 0; j < numberOfIterations; j++) {
+                        cache.cacheCleanupManager.addToCleanupKeyToCountMap(indexShard.shardId(), UUID.randomUUID().toString());
+                    }
+                } catch (ConcurrentModificationException e) {
+                    logger.error("ConcurrentModificationException detected in thread : " + e.getMessage());
+                    exceptionDetected.set(true); // Set flag if exception is detected
+                }
+            });
+        }
+        phaser.arriveAndAwaitAdvance(); // Start all threads
+
+        // Main thread iterates over the map
+        executorService.submit(() -> {
+            try {
+                for (int j = 0; j < numberOfIterations; j++) {
+                    cache.cacheCleanupManager.getCleanupKeyToCountMap().forEach((k, v) -> {
+                        v.forEach((k1, v1) -> {
+                            // Accessing the map to create contention
+                            v.get(k1);
+                        });
+                    });
+                }
+            } catch (ConcurrentModificationException e) {
+                logger.error("ConcurrentModificationException detected in main thread : " + e.getMessage());
+                exceptionDetected.set(true); // Set flag if exception is detected
+            }
+        });
+
+        executorService.shutdown();
+        executorService.awaitTermination(60, TimeUnit.SECONDS);
+        assertFalse(exceptionDetected.get());
+    }
+
     private IndicesRequestCache getIndicesRequestCache(Settings settings) {
         IndicesService indicesService = getInstanceFromNode(IndicesService.class);
         return new IndicesRequestCache(settings, (shardId -> {


### PR DESCRIPTION
### Description
https://github.com/opensearch-project/OpenSearch/issues/14032 reported msearches failing with a Concurrent Modification Exception, though they were not able to repro it consistently they were able to attach a debugger and find out the line throwing the exception, which was https://github.com/opensearch-project/OpenSearch/blob/5b93f2e429996f6324248cb0bc5e2dd3a2150dbb/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java#L571

We are using a HashMap (not thread safe) for the inner map of the cleanupKeyToCountMap and hence it throws a Concurrent Modification Exception when the map is getting updated by multiple threads concurrently. 

The fix is to use a thread safe Concurrent Map instead. 

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/14032

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
