### PR TITLE
Update Gradle check workflow to remove the `Create Issue On Push Failure` section.

### DIFF
--- a/.github/ISSUE_TEMPLATE/failed_check.md
+++ b/.github/ISSUE_TEMPLATE/failed_check.md
@@ -1,8 +1,0 @@
----
-title: '[AUTOCUT] Gradle Check Failure on push to {{ env.branch_name }}'
-labels: '>test-failure, bug, autocut'
----
-
-Gradle check has failed on push of your commit {{ env.pr_from_sha }}.
-Please examine the workflow log {{ env.workflow_url }}.
-Is the failure [a flaky test](https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md#flaky-tests) unrelated to your change?

--- a/.github/workflows/gradle-check.yml
+++ b/.github/workflows/gradle-check.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   check-files:
     runs-on: ubuntu-latest
-    outputs: 
+    outputs:
       RUN_GRADLE_CHECK: ${{ steps.changed-files-specific.outputs.any_changed }}
     steps:
     - uses: actions/checkout@v4
@@ -26,7 +26,7 @@ jobs:
           release-notes/*.md
           .github/**
           *.md
-    
+
   gradle-check:
     needs: check-files
     if: github.repository == 'opensearch-project/OpenSearch' && needs.check-files.outputs.RUN_GRADLE_CHECK == 'true'
@@ -157,15 +157,6 @@ jobs:
             :x: Gradle check result for ${{ env.pr_from_sha }}: [${{ env.result }}](${{ env.workflow_url }})
 
             Please examine the workflow log, locate, and copy-paste the failure(s) below, then iterate to green. Is the failure [a flaky test](https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md#flaky-tests) unrelated to your change?
-
-      - name: Create Issue On Push Failure
-        if: ${{ github.event_name == 'push' && failure() }}
-        uses: dblock/create-a-github-issue@v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          assignees: ${{ github.event.head_commit.author.username }}, ${{ github.triggering_actor }}
-          filename: .github/ISSUE_TEMPLATE/failed_check.md
 
   check-result:
     needs: [check-files, gradle-check]


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Remove this job `Create Issue On Push Failure` from workflow as we have an automation to detect the Gradle Check flaky failures and auto create an issue. 

Related Jenkins job: https://build.ci.opensearch.org/job/gradle-check-flaky-test-detector 
Library Used: `gradleCheckFlakyTestChecker`
Library Code: https://github.com/opensearch-project/opensearch-build-libraries/pull/436
The AUTOCUT issues created: [link](https://github.com/issues?q=is%3Aissue+label%3Auntriaged+repo%3Aopensearch-project%2Fopensearch+%5BAUTOCUT%5D+Gradle+Check+Flaky+Test+Report+for+in%3Atitle)


### Related Issues
Part of https://github.com/opensearch-project/OpenSearch/issues/13950


### Check List
- [ ] ~Functionality includes testing.~
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
