### PR TITLE
Use remote publication flag to decide which custom objects to upload

### DIFF
--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateAttributesManager.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateAttributesManager.java
@@ -130,11 +130,11 @@ public class RemoteClusterStateAttributesManager {
     public DiffableUtils.MapDiff<String, ClusterState.Custom, Map<String, ClusterState.Custom>> getUpdatedCustoms(
         ClusterState clusterState,
         ClusterState previousClusterState,
-        boolean isWriteFull,
-        boolean firstUploadForEphemeralMetadata
+        boolean isRemotePublicationEnabled,
+        boolean isFirstUpload
     ) {
-        if (!isWriteFull) {
-            // When isWriteFull is false, we do not want store any custom objects
+        if (!isRemotePublicationEnabled) {
+            // When isRemotePublicationEnabled is false, we do not want store any custom objects
             return DiffableUtils.diff(
                 Collections.emptyMap(),
                 Collections.emptyMap(),
@@ -142,7 +142,7 @@ public class RemoteClusterStateAttributesManager {
                 NonDiffableValueSerializer.getAbstractInstance()
             );
         }
-        if (firstUploadForEphemeralMetadata) {
+        if (isFirstUpload) {
             // For first upload of ephemeral metadata, we want to upload all customs
             return DiffableUtils.diff(
                 Collections.emptyMap(),

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateAttributesManager.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateAttributesManager.java
@@ -130,11 +130,11 @@ public class RemoteClusterStateAttributesManager {
     public DiffableUtils.MapDiff<String, ClusterState.Custom, Map<String, ClusterState.Custom>> getUpdatedCustoms(
         ClusterState clusterState,
         ClusterState previousClusterState,
-        boolean includeEphemeral,
+        boolean isWriteFull,
         boolean firstUploadForEphemeralMetadata
     ) {
-        if (!includeEphemeral) {
-            // When includeEphemeral is false, we do not want store any custom objects
+        if (!isWriteFull) {
+            // When isWriteFull is false, we do not want store any custom objects
             return DiffableUtils.diff(
                 Collections.emptyMap(),
                 Collections.emptyMap(),

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateAttributesManager.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateAttributesManager.java
@@ -143,7 +143,7 @@ public class RemoteClusterStateAttributesManager {
             );
         }
         if (firstUploadForEphemeralMetadata) {
-            // For first split global metadata upload, we want to upload all customs
+            // For first upload of ephemeral metadata, we want to upload all customs
             return DiffableUtils.diff(
                 Collections.emptyMap(),
                 clusterState.customs(),

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateAttributesManager.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateAttributesManager.java
@@ -10,6 +10,8 @@ package org.opensearch.gateway.remote;
 
 import org.opensearch.action.LatchedActionListener;
 import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.DiffableUtils;
+import org.opensearch.cluster.DiffableUtils.NonDiffableValueSerializer;
 import org.opensearch.common.CheckedRunnable;
 import org.opensearch.common.remote.AbstractRemoteWritableBlobEntity;
 import org.opensearch.common.remote.RemoteWritableEntityStore;
@@ -25,10 +27,9 @@ import org.opensearch.repositories.blobstore.BlobStoreRepository;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * A Manager which provides APIs to upload and download attributes of ClusterState to the {@link RemoteClusterStateBlobStore}
@@ -126,18 +127,35 @@ public class RemoteClusterStateAttributesManager {
         return () -> getStore(blobEntity).readAsync(blobEntity, actionListener);
     }
 
-    public Map<String, ClusterState.Custom> getUpdatedCustoms(ClusterState clusterState, ClusterState previousClusterState) {
-        Map<String, ClusterState.Custom> updatedCustoms = new HashMap<>();
-        Set<String> currentCustoms = new HashSet<>(clusterState.customs().keySet());
-        for (Map.Entry<String, ClusterState.Custom> entry : previousClusterState.customs().entrySet()) {
-            if (currentCustoms.contains(entry.getKey()) && !entry.getValue().equals(clusterState.customs().get(entry.getKey()))) {
-                updatedCustoms.put(entry.getKey(), clusterState.customs().get(entry.getKey()));
-            }
-            currentCustoms.remove(entry.getKey());
+    public DiffableUtils.MapDiff<String, ClusterState.Custom, Map<String, ClusterState.Custom>> getUpdatedCustoms(
+        ClusterState clusterState,
+        ClusterState previousClusterState,
+        boolean includeEphemeral,
+        boolean firstUploadForSplitGlobalMetadata
+    ) {
+        if (!includeEphemeral) {
+            // When includeEphemeral is false, we do not want store any custom objects
+            return DiffableUtils.diff(
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                DiffableUtils.getStringKeySerializer(),
+                NonDiffableValueSerializer.getAbstractInstance()
+            );
         }
-        for (String custom : currentCustoms) {
-            updatedCustoms.put(custom, clusterState.customs().get(custom));
+        if (firstUploadForSplitGlobalMetadata) {
+            // For first split global metadata upload, we want to upload all customs
+            return DiffableUtils.diff(
+                Collections.emptyMap(),
+                clusterState.customs(),
+                DiffableUtils.getStringKeySerializer(),
+                NonDiffableValueSerializer.getAbstractInstance()
+            );
         }
-        return updatedCustoms;
+        return DiffableUtils.diff(
+            previousClusterState.customs(),
+            clusterState.customs(),
+            DiffableUtils.getStringKeySerializer(),
+            NonDiffableValueSerializer.getAbstractInstance()
+        );
     }
 }

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateAttributesManager.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateAttributesManager.java
@@ -131,7 +131,7 @@ public class RemoteClusterStateAttributesManager {
         ClusterState clusterState,
         ClusterState previousClusterState,
         boolean includeEphemeral,
-        boolean firstUploadForSplitGlobalMetadata
+        boolean firstUploadForEphemeralMetadata
     ) {
         if (!includeEphemeral) {
             // When includeEphemeral is false, we do not want store any custom objects
@@ -142,7 +142,7 @@ public class RemoteClusterStateAttributesManager {
                 NonDiffableValueSerializer.getAbstractInstance()
             );
         }
-        if (firstUploadForSplitGlobalMetadata) {
+        if (firstUploadForEphemeralMetadata) {
             // For first split global metadata upload, we want to upload all customs
             return DiffableUtils.diff(
                 Collections.emptyMap(),

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -292,7 +292,7 @@ public class RemoteClusterStateService implements Closeable {
         assert previousClusterState.metadata().coordinationMetadata().term() == clusterState.metadata().coordinationMetadata().term();
 
         boolean firstUploadForSplitGlobalMetadata = !previousManifest.hasMetadataAttributesFiles();
-        boolean firstUploadForEphemeralMetadata = previousManifest.getDiscoveryNodesMetadata() != null;
+        boolean firstUploadForEphemeralMetadata = previousManifest.getDiscoveryNodesMetadata() == null;
 
         final DiffableUtils.MapDiff<String, Metadata.Custom, Map<String, Metadata.Custom>> customsDiff = remoteGlobalMetadataManager
             .getCustomsDiff(clusterState, previousClusterState, firstUploadForSplitGlobalMetadata, isPublicationEnabled);

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -292,15 +292,16 @@ public class RemoteClusterStateService implements Closeable {
         assert previousClusterState.metadata().coordinationMetadata().term() == clusterState.metadata().coordinationMetadata().term();
 
         boolean firstUploadForSplitGlobalMetadata = !previousManifest.hasMetadataAttributesFiles();
+        boolean firstUploadForEphemeralMetadata = previousManifest.getDiscoveryNodesMetadata() != null;
 
         final DiffableUtils.MapDiff<String, Metadata.Custom, Map<String, Metadata.Custom>> customsDiff = remoteGlobalMetadataManager
-            .getCustomsDiff(clusterState, previousClusterState, isPublicationEnabled, firstUploadForSplitGlobalMetadata);
+            .getCustomsDiff(clusterState, previousClusterState, firstUploadForSplitGlobalMetadata, isPublicationEnabled);
         final DiffableUtils.MapDiff<String, ClusterState.Custom, Map<String, ClusterState.Custom>> clusterStateCustomsDiff =
             remoteClusterStateAttributesManager.getUpdatedCustoms(
                 clusterState,
                 previousClusterState,
                 isPublicationEnabled,
-                firstUploadForSplitGlobalMetadata
+                firstUploadForEphemeralMetadata
             );
         final Map<String, UploadedMetadataAttribute> allUploadedCustomMap = new HashMap<>(previousManifest.getCustomMetadataMap());
         final Map<String, UploadedMetadataAttribute> allUploadedClusterStateCustomsMap = new HashMap<>(
@@ -350,7 +351,7 @@ public class RemoteClusterStateService implements Closeable {
         ;
         boolean updateSettingsMetadata = firstUploadForSplitGlobalMetadata
             || Metadata.isSettingsMetadataEqual(previousClusterState.metadata(), clusterState.metadata()) == false;
-        boolean updateTransientSettingsMetadata = firstUploadForSplitGlobalMetadata
+        boolean updateTransientSettingsMetadata = firstUploadForEphemeralMetadata
             || Metadata.isTransientSettingsMetadataEqual(previousClusterState.metadata(), clusterState.metadata()) == false;
         boolean updateTemplatesMetadata = firstUploadForSplitGlobalMetadata
             || Metadata.isTemplatesMetadataEqual(previousClusterState.metadata(), clusterState.metadata()) == false;
@@ -358,7 +359,7 @@ public class RemoteClusterStateService implements Closeable {
         final boolean updateDiscoveryNodes = isPublicationEnabled
             && clusterState.getNodes().delta(previousClusterState.getNodes()).hasChanges();
         final boolean updateClusterBlocks = isPublicationEnabled && !clusterState.blocks().equals(previousClusterState.blocks());
-        final boolean updateHashesOfConsistentSettings = isPublicationEnabled && firstUploadForSplitGlobalMetadata
+        final boolean updateHashesOfConsistentSettings = isPublicationEnabled && firstUploadForEphemeralMetadata
             || Metadata.isHashesOfConsistentSettingsEqual(previousClusterState.metadata(), clusterState.metadata()) == false;
 
         uploadedMetadataResults = writeMetadataInParallel(
@@ -400,13 +401,13 @@ public class RemoteClusterStateService implements Closeable {
         if (!updateTemplatesMetadata) {
             uploadedMetadataResults.uploadedTemplatesMetadata = previousManifest.getTemplatesMetadata();
         }
-        if (!updateDiscoveryNodes && !firstUploadForSplitGlobalMetadata) {
+        if (!updateDiscoveryNodes && !firstUploadForEphemeralMetadata) {
             uploadedMetadataResults.uploadedDiscoveryNodes = previousManifest.getDiscoveryNodesMetadata();
         }
-        if (!updateClusterBlocks && !firstUploadForSplitGlobalMetadata) {
+        if (!updateClusterBlocks && !firstUploadForEphemeralMetadata) {
             uploadedMetadataResults.uploadedClusterBlocks = previousManifest.getClusterBlocksMetadata();
         }
-        if (!updateHashesOfConsistentSettings && !firstUploadForSplitGlobalMetadata) {
+        if (!updateHashesOfConsistentSettings && !firstUploadForEphemeralMetadata) {
             uploadedMetadataResults.uploadedHashesOfConsistentSettings = previousManifest.getHashesOfConsistentSettings();
         }
         uploadedMetadataResults.uploadedCustomMetadataMap = allUploadedCustomMap;

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -39,6 +39,7 @@ import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
@@ -88,6 +89,7 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
+import static org.opensearch.common.util.FeatureFlags.REMOTE_PUBLICATION_EXPERIMENTAL;
 import static org.opensearch.gateway.PersistedClusterStateService.SLOW_WRITE_LOGGING_THRESHOLD;
 import static org.opensearch.gateway.remote.ClusterMetadataManifest.CODEC_V2;
 import static org.opensearch.gateway.remote.RemoteClusterStateAttributesManager.CLUSTER_BLOCKS;
@@ -159,6 +161,7 @@ public class RemoteClusterStateService implements Closeable {
     private final String METADATA_UPDATE_LOG_STRING = "wrote metadata for [{}] indices and skipped [{}] unchanged "
         + "indices, coordination metadata updated : [{}], settings metadata updated : [{}], templates metadata "
         + "updated : [{}], custom metadata updated : [{}], indices routing updated : [{}]";
+    private final boolean isPublicationEnabled;
 
     // ToXContent Params with gateway mode.
     // We are using gateway context mode to persist all custom metadata.
@@ -201,6 +204,9 @@ public class RemoteClusterStateService implements Closeable {
             threadPool
         );
         this.remoteClusterStateCleanupManager = new RemoteClusterStateCleanupManager(this, clusterService, remoteRoutingTableService);
+        this.isPublicationEnabled = FeatureFlags.isEnabled(REMOTE_PUBLICATION_EXPERIMENTAL)
+            && RemoteStoreNodeAttribute.isRemoteStoreClusterStateEnabled(settings)
+            && RemoteStoreNodeAttribute.isRemoteRoutingTableEnabled(settings);
     }
 
     /**
@@ -221,15 +227,15 @@ public class RemoteClusterStateService implements Closeable {
             clusterState,
             new ArrayList<>(clusterState.metadata().indices().values()),
             emptyMap(),
-            clusterState.metadata().customs(),
+            RemoteGlobalMetadataManager.filterCustoms(clusterState.metadata().customs(), isPublicationEnabled),
             true,
             true,
             true,
-            true,
-            true,
-            true,
-            clusterState.customs(),
-            true,
+            isPublicationEnabled,
+            isPublicationEnabled,
+            isPublicationEnabled,
+            isPublicationEnabled ? clusterState.customs() : Collections.emptyMap(),
+            isPublicationEnabled,
             remoteRoutingTableService.getIndicesRouting(clusterState.getRoutingTable())
         );
         final RemoteClusterStateManifestInfo manifestDetails = remoteManifestManager.uploadManifest(
@@ -285,28 +291,22 @@ public class RemoteClusterStateService implements Closeable {
         }
         assert previousClusterState.metadata().coordinationMetadata().term() == clusterState.metadata().coordinationMetadata().term();
 
-        final Map<String, UploadedMetadataAttribute> customsToBeDeletedFromRemote = new HashMap<>(previousManifest.getCustomMetadataMap());
-        final Map<String, Metadata.Custom> customsToUpload = remoteGlobalMetadataManager.getUpdatedCustoms(
-            clusterState,
-            previousClusterState
-        );
-        final Map<String, UploadedMetadataAttribute> clusterStateCustomsToBeDeleted = new HashMap<>(
+        boolean firstUploadForSplitGlobalMetadata = !previousManifest.hasMetadataAttributesFiles();
+
+        final DiffableUtils.MapDiff<String, Metadata.Custom, Map<String, Metadata.Custom>> customsDiff = remoteGlobalMetadataManager
+            .getCustomsDiff(clusterState, previousClusterState, isPublicationEnabled, firstUploadForSplitGlobalMetadata);
+        final DiffableUtils.MapDiff<String, ClusterState.Custom, Map<String, ClusterState.Custom>> clusterStateCustomsDiff =
+            remoteClusterStateAttributesManager.getUpdatedCustoms(
+                clusterState,
+                previousClusterState,
+                isPublicationEnabled,
+                firstUploadForSplitGlobalMetadata
+            );
+        final Map<String, UploadedMetadataAttribute> allUploadedCustomMap = new HashMap<>(previousManifest.getCustomMetadataMap());
+        final Map<String, UploadedMetadataAttribute> allUploadedClusterStateCustomsMap = new HashMap<>(
             previousManifest.getClusterStateCustomMap()
         );
-        final Map<String, ClusterState.Custom> clusterStateCustomsToUpload = remoteClusterStateAttributesManager.getUpdatedCustoms(
-            clusterState,
-            previousClusterState
-        );
-        final Map<String, UploadedMetadataAttribute> allUploadedCustomMap = new HashMap<>(previousManifest.getCustomMetadataMap());
-        for (final String custom : clusterState.metadata().customs().keySet()) {
-            // remove all the customs which are present currently
-            customsToBeDeletedFromRemote.remove(custom);
-        }
         final Map<String, IndexMetadata> indicesToBeDeletedFromRemote = new HashMap<>(previousClusterState.metadata().indices());
-        for (final String custom : clusterState.customs().keySet()) {
-            // remove all the custom which are present currently
-            clusterStateCustomsToBeDeleted.remove(custom);
-        }
         int numIndicesUpdated = 0;
         int numIndicesUnchanged = 0;
         final Map<String, ClusterMetadataManifest.UploadedIndexMetadata> allUploadedIndexMetadata = previousManifest.getIndices()
@@ -337,15 +337,14 @@ public class RemoteClusterStateService implements Closeable {
             indicesToBeDeletedFromRemote.remove(indexMetadata.getIndex().getName());
         }
 
-        DiffableUtils.MapDiff<String, IndexRoutingTable, Map<String, IndexRoutingTable>> routingTableDiff = remoteRoutingTableService
+        final DiffableUtils.MapDiff<String, IndexRoutingTable, Map<String, IndexRoutingTable>> routingTableDiff = remoteRoutingTableService
             .getIndicesRoutingMapDiff(previousClusterState.getRoutingTable(), clusterState.getRoutingTable());
-        List<IndexRoutingTable> indicesRoutingToUpload = new ArrayList<>();
+        final List<IndexRoutingTable> indicesRoutingToUpload = new ArrayList<>();
         routingTableDiff.getUpserts().forEach((k, v) -> indicesRoutingToUpload.add(v));
 
         UploadedMetadataResults uploadedMetadataResults;
         // For migration case from codec V0 or V1 to V2, we have added null check on metadata attribute files,
         // If file is empty and codec is 1 then write global metadata.
-        boolean firstUploadForSplitGlobalMetadata = !previousManifest.hasMetadataAttributesFiles();
         boolean updateCoordinationMetadata = firstUploadForSplitGlobalMetadata
             || Metadata.isCoordinationMetadataEqual(previousClusterState.metadata(), clusterState.metadata()) == false;
         ;
@@ -355,24 +354,25 @@ public class RemoteClusterStateService implements Closeable {
             || Metadata.isTransientSettingsMetadataEqual(previousClusterState.metadata(), clusterState.metadata()) == false;
         boolean updateTemplatesMetadata = firstUploadForSplitGlobalMetadata
             || Metadata.isTemplatesMetadataEqual(previousClusterState.metadata(), clusterState.metadata()) == false;
-        // ToDo: check if these needs to be updated or not
-        final boolean updateDiscoveryNodes = clusterState.getNodes().delta(previousClusterState.getNodes()).hasChanges();
-        final boolean updateClusterBlocks = !clusterState.blocks().equals(previousClusterState.blocks());
-        final boolean updateHashesOfConsistentSettings = firstUploadForSplitGlobalMetadata
+
+        final boolean updateDiscoveryNodes = isPublicationEnabled
+            && clusterState.getNodes().delta(previousClusterState.getNodes()).hasChanges();
+        final boolean updateClusterBlocks = isPublicationEnabled && !clusterState.blocks().equals(previousClusterState.blocks());
+        final boolean updateHashesOfConsistentSettings = isPublicationEnabled && firstUploadForSplitGlobalMetadata
             || Metadata.isHashesOfConsistentSettingsEqual(previousClusterState.metadata(), clusterState.metadata()) == false;
 
         uploadedMetadataResults = writeMetadataInParallel(
             clusterState,
             toUpload,
             prevIndexMetadataByName,
-            firstUploadForSplitGlobalMetadata ? clusterState.metadata().customs() : customsToUpload,
+            customsDiff.getUpserts(),
             updateCoordinationMetadata,
             updateSettingsMetadata,
             updateTemplatesMetadata,
             updateDiscoveryNodes,
             updateClusterBlocks,
             updateTransientSettingsMetadata,
-            clusterStateCustomsToUpload,
+            clusterStateCustomsDiff.getUpserts(),
             updateHashesOfConsistentSettings,
             indicesRoutingToUpload
         );
@@ -382,10 +382,11 @@ public class RemoteClusterStateService implements Closeable {
             uploadedIndexMetadata -> allUploadedIndexMetadata.put(uploadedIndexMetadata.getIndexName(), uploadedIndexMetadata)
         );
         allUploadedCustomMap.putAll(uploadedMetadataResults.uploadedCustomMetadataMap);
+        allUploadedClusterStateCustomsMap.putAll(uploadedMetadataResults.uploadedClusterStateCustomMetadataMap);
         // remove the data for removed custom/indices
-        customsToBeDeletedFromRemote.keySet().forEach(allUploadedCustomMap::remove);
+        customsDiff.getDeletes().forEach(allUploadedCustomMap::remove);
         indicesToBeDeletedFromRemote.keySet().forEach(allUploadedIndexMetadata::remove);
-        clusterStateCustomsToBeDeleted.keySet().forEach(allUploadedCustomMap::remove);
+        clusterStateCustomsDiff.getDeletes().forEach(allUploadedClusterStateCustomsMap::remove);
 
         if (!updateCoordinationMetadata) {
             uploadedMetadataResults.uploadedCoordinationMetadata = previousManifest.getCoordinationMetadata();
@@ -408,22 +409,15 @@ public class RemoteClusterStateService implements Closeable {
         if (!updateHashesOfConsistentSettings && !firstUploadForSplitGlobalMetadata) {
             uploadedMetadataResults.uploadedHashesOfConsistentSettings = previousManifest.getHashesOfConsistentSettings();
         }
-        if (!firstUploadForSplitGlobalMetadata && customsToUpload.isEmpty()) {
-            uploadedMetadataResults.uploadedCustomMetadataMap = previousManifest.getCustomMetadataMap();
-        }
-        if (!firstUploadForSplitGlobalMetadata && clusterStateCustomsToUpload.isEmpty()) {
-            uploadedMetadataResults.uploadedClusterStateCustomMetadataMap = previousManifest.getClusterStateCustomMap();
-        }
         uploadedMetadataResults.uploadedCustomMetadataMap = allUploadedCustomMap;
+        uploadedMetadataResults.uploadedClusterStateCustomMetadataMap = allUploadedClusterStateCustomsMap;
         uploadedMetadataResults.uploadedIndexMetadata = new ArrayList<>(allUploadedIndexMetadata.values());
 
-        List<ClusterMetadataManifest.UploadedIndexMetadata> allUploadedIndicesRouting = new ArrayList<>();
-        allUploadedIndicesRouting = remoteRoutingTableService.getAllUploadedIndicesRouting(
+        uploadedMetadataResults.uploadedIndicesRoutingMetadata = remoteRoutingTableService.getAllUploadedIndicesRouting(
             previousManifest,
             uploadedMetadataResults.uploadedIndicesRoutingMetadata,
             routingTableDiff.getDeletes()
         );
-        uploadedMetadataResults.uploadedIndicesRoutingMetadata = allUploadedIndicesRouting;
 
         final RemoteClusterStateManifestInfo manifestDetails = remoteManifestManager.uploadManifest(
             clusterState,
@@ -448,7 +442,7 @@ public class RemoteClusterStateService implements Closeable {
             updateCoordinationMetadata,
             updateSettingsMetadata,
             updateTemplatesMetadata,
-            customsToUpload.size(),
+            customsDiff.getUpserts().size(),
             indicesRoutingToUpload.size()
         );
         if (durationMillis >= slowWriteLoggingThreshold.getMillis()) {
@@ -464,7 +458,7 @@ public class RemoteClusterStateService implements Closeable {
                 updateCoordinationMetadata,
                 updateSettingsMetadata,
                 updateTemplatesMetadata,
-                customsToUpload.size()
+                customsDiff.getUpserts().size()
             );
         } else {
             logger.info("{}; {}", clusterStateUploadTimeMessage, metadataUpdateMessage);
@@ -479,7 +473,7 @@ public class RemoteClusterStateService implements Closeable {
                 updateCoordinationMetadata,
                 updateSettingsMetadata,
                 updateTemplatesMetadata,
-                customsToUpload.size()
+                customsDiff.getUpserts().size()
             );
         }
         return manifestDetails;

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteGlobalMetadataManager.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteGlobalMetadataManager.java
@@ -284,27 +284,27 @@ public class RemoteGlobalMetadataManager {
         ClusterState currentState,
         ClusterState previousState,
         boolean firstUploadForSplitGlobalMetadata,
-        boolean includeEphemeral
+        boolean isRemotePublicationEnabled
     ) {
         if (firstUploadForSplitGlobalMetadata) {
             // For first split global metadata upload, we want to upload all customs
             return DiffableUtils.diff(
                 Collections.emptyMap(),
-                filterCustoms(currentState.metadata().customs(), includeEphemeral),
+                filterCustoms(currentState.metadata().customs(), isRemotePublicationEnabled),
                 DiffableUtils.getStringKeySerializer(),
                 NonDiffableValueSerializer.getAbstractInstance()
             );
         }
         return DiffableUtils.diff(
-            filterCustoms(previousState.metadata().customs(), includeEphemeral),
-            filterCustoms(currentState.metadata().customs(), includeEphemeral),
+            filterCustoms(previousState.metadata().customs(), isRemotePublicationEnabled),
+            filterCustoms(currentState.metadata().customs(), isRemotePublicationEnabled),
             DiffableUtils.getStringKeySerializer(),
             NonDiffableValueSerializer.getAbstractInstance()
         );
     }
 
-    public static Map<String, Metadata.Custom> filterCustoms(Map<String, Metadata.Custom> customs, boolean includeEphemeral) {
-        if (includeEphemeral) {
+    public static Map<String, Metadata.Custom> filterCustoms(Map<String, Metadata.Custom> customs, boolean isRemotePublicationEnabled) {
+        if (isRemotePublicationEnabled) {
             return customs;
         }
         return customs.entrySet()

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteGlobalMetadataManager.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteGlobalMetadataManager.java
@@ -10,9 +10,12 @@ package org.opensearch.gateway.remote;
 
 import org.opensearch.action.LatchedActionListener;
 import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.DiffableUtils;
+import org.opensearch.cluster.DiffableUtils.NonDiffableValueSerializer;
 import org.opensearch.cluster.coordination.CoordinationMetadata;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.metadata.Metadata.Custom;
+import org.opensearch.cluster.metadata.Metadata.XContentContext;
 import org.opensearch.cluster.metadata.TemplatesMetadata;
 import org.opensearch.common.CheckedRunnable;
 import org.opensearch.common.remote.AbstractRemoteWritableBlobEntity;
@@ -39,11 +42,12 @@ import org.opensearch.repositories.blobstore.BlobStoreRepository;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 import static org.opensearch.gateway.remote.RemoteClusterStateUtils.METADATA_NAME_FORMAT;
 
@@ -276,29 +280,37 @@ public class RemoteGlobalMetadataManager {
         }
     }
 
-    Map<String, Metadata.Custom> getUpdatedCustoms(ClusterState currentState, ClusterState previousState) {
-        if (Metadata.isCustomMetadataEqual(previousState.metadata(), currentState.metadata())) {
-            return new HashMap<>();
+    DiffableUtils.MapDiff<String, Metadata.Custom, Map<String, Metadata.Custom>> getCustomsDiff(
+        ClusterState currentState,
+        ClusterState previousState,
+        boolean firstUploadForSplitGlobalMetadata,
+        boolean includeEphemeral
+    ) {
+        if (firstUploadForSplitGlobalMetadata) {
+            // For first split global metadata upload, we want to upload all customs
+            return DiffableUtils.diff(
+                Collections.emptyMap(),
+                filterCustoms(currentState.metadata().customs(), includeEphemeral),
+                DiffableUtils.getStringKeySerializer(),
+                NonDiffableValueSerializer.getAbstractInstance()
+            );
         }
-        Map<String, Metadata.Custom> updatedCustom = new HashMap<>();
-        Set<String> currentCustoms = new HashSet<>(currentState.metadata().customs().keySet());
-        for (Map.Entry<String, Metadata.Custom> cursor : previousState.metadata().customs().entrySet()) {
-            if (cursor.getValue().context().contains(Metadata.XContentContext.GATEWAY)) {
-                if (currentCustoms.contains(cursor.getKey())
-                    && !cursor.getValue().equals(currentState.metadata().custom(cursor.getKey()))) {
-                    // If the custom metadata is updated, we need to upload the new version.
-                    updatedCustom.put(cursor.getKey(), currentState.metadata().custom(cursor.getKey()));
-                }
-                currentCustoms.remove(cursor.getKey());
-            }
+        return DiffableUtils.diff(
+            filterCustoms(previousState.metadata().customs(), includeEphemeral),
+            filterCustoms(currentState.metadata().customs(), includeEphemeral),
+            DiffableUtils.getStringKeySerializer(),
+            NonDiffableValueSerializer.getAbstractInstance()
+        );
+    }
+
+    public static Map<String, Metadata.Custom> filterCustoms(Map<String, Metadata.Custom> customs, boolean includeEphemeral) {
+        if (includeEphemeral) {
+            return customs;
         }
-        for (String custom : currentCustoms) {
-            Metadata.Custom cursor = currentState.metadata().custom(custom);
-            if (cursor.context().contains(Metadata.XContentContext.GATEWAY)) {
-                updatedCustom.put(custom, cursor);
-            }
-        }
-        return updatedCustom;
+        return customs.entrySet()
+            .stream()
+            .filter(e -> e.getValue().context().contains(XContentContext.GATEWAY))
+            .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
     }
 
     boolean isGlobalMetadataEqual(ClusterMetadataManifest first, ClusterMetadataManifest second, String clusterName) {

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemoteClusterStateBlobStore.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemoteClusterStateBlobStore.java
@@ -72,7 +72,9 @@ public class RemoteClusterStateBlobStore<T, U extends AbstractRemoteWritableBlob
     public T read(final U entity) throws IOException {
         // TODO Add timing logs and tracing
         assert entity.getFullBlobName() != null;
-        return entity.deserialize(transferService.downloadBlob(getBlobPathForDownload(entity), entity.getBlobFileName()));
+        try (InputStream inputStream = transferService.downloadBlob(getBlobPathForDownload(entity), entity.getBlobFileName())) {
+            return entity.deserialize(inputStream);
+        }
     }
 
     @Override

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateAttributesManagerTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateAttributesManagerTests.java
@@ -8,7 +8,16 @@
 
 package org.opensearch.gateway.remote;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.opensearch.Version;
 import org.opensearch.action.LatchedActionListener;
+import org.opensearch.cluster.AbstractNamedDiffable;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.ClusterState.Custom;
+import org.opensearch.cluster.DiffableUtils;
 import org.opensearch.cluster.block.ClusterBlocks;
 import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.common.CheckedRunnable;
@@ -16,8 +25,11 @@ import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.compress.Compressor;
 import org.opensearch.core.compress.NoneCompressor;
+import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.gateway.remote.model.RemoteClusterBlocks;
 import org.opensearch.gateway.remote.model.RemoteDiscoveryNodes;
 import org.opensearch.gateway.remote.model.RemoteReadResult;
@@ -45,13 +57,14 @@ import static org.mockito.ArgumentMatchers.anyIterable;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.hamcrest.Matchers.is;
 
 public class RemoteClusterStateAttributesManagerTests extends OpenSearchTestCase {
     private RemoteClusterStateAttributesManager remoteClusterStateAttributesManager;
     private BlobStoreTransferService blobStoreTransferService;
     private BlobStoreRepository blobStoreRepository;
     private Compressor compressor;
-    private ThreadPool threadpool = new TestThreadPool(RemoteClusterStateAttributesManagerTests.class.getName());
+    private ThreadPool threadPool = new TestThreadPool(RemoteClusterStateAttributesManagerTests.class.getName());
 
     @Before
     public void setup() throws Exception {
@@ -65,15 +78,15 @@ public class RemoteClusterStateAttributesManagerTests extends OpenSearchTestCase
             "test-cluster",
             blobStoreRepository,
             blobStoreTransferService,
-            namedWriteableRegistry,
-            threadpool
+            writableRegistry(),
+            threadPool
         );
     }
 
     @After
     public void tearDown() throws Exception {
         super.tearDown();
-        threadpool.shutdown();
+        threadPool.shutdown();
     }
 
     public void testGetAsyncMetadataReadAction_DiscoveryNodes() throws IOException {
@@ -136,6 +149,171 @@ public class RemoteClusterStateAttributesManagerTests extends OpenSearchTestCase
             }
         } catch (Exception e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    public void testGetUpdatedCustoms() {
+        Map<String, ClusterState.Custom> previousCustoms = Map.of(
+            TestCustom1.TYPE,
+            new TestCustom1("data1"),
+            TestCustom2.TYPE,
+            new TestCustom2("data2"),
+            TestCustom3.TYPE,
+            new TestCustom3("data3")
+        );
+        ClusterState previousState = ClusterState.builder(new ClusterName("test-cluster")).customs(previousCustoms).build();
+
+        Map<String, Custom> currentCustoms = Map.of(
+            TestCustom2.TYPE,
+            new TestCustom2("data2"),
+            TestCustom3.TYPE,
+            new TestCustom3("data3-changed"),
+            TestCustom4.TYPE,
+            new TestCustom4("data4")
+        );
+
+        ClusterState currentState = ClusterState.builder(new ClusterName("test-cluster")).customs(currentCustoms).build();
+
+        DiffableUtils.MapDiff<String, ClusterState.Custom, Map<String, ClusterState.Custom>> customsDiff =
+            remoteClusterStateAttributesManager.getUpdatedCustoms(currentState, previousState, false, randomBoolean());
+        assertThat(customsDiff.getUpserts(), is(Collections.emptyMap()));
+        assertThat(customsDiff.getDeletes(), is(Collections.emptyList()));
+
+        customsDiff = remoteClusterStateAttributesManager.getUpdatedCustoms(currentState, previousState, true, true);
+        assertThat(customsDiff.getUpserts(), is(currentCustoms));
+        assertThat(customsDiff.getDeletes(), is(Collections.emptyList()));
+
+        Map<String, ClusterState.Custom> expectedCustoms = Map.of(
+            TestCustom3.TYPE,
+            new TestCustom3("data3-changed"),
+            TestCustom4.TYPE,
+            new TestCustom4("data4")
+        );
+
+        customsDiff = remoteClusterStateAttributesManager.getUpdatedCustoms(currentState, previousState, true, false);
+        assertThat(customsDiff.getUpserts(), is(expectedCustoms));
+        assertThat(customsDiff.getDeletes(), is(List.of(TestCustom1.TYPE)));
+    }
+
+    private static abstract class AbstractTestCustom extends AbstractNamedDiffable<Custom> implements ClusterState.Custom {
+
+        private final String value;
+
+        AbstractTestCustom(String value) {
+            this.value = value;
+        }
+
+        AbstractTestCustom(StreamInput in) throws IOException {
+            this.value = in.readString();
+        }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.CURRENT;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(value);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            return builder;
+        }
+
+        @Override
+        public boolean isPrivate() {
+            return true;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            AbstractTestCustom that = (AbstractTestCustom) o;
+
+            if (!value.equals(that.value)) return false;
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            return value.hashCode();
+        }
+    }
+
+    private static class TestCustom1 extends AbstractTestCustom {
+
+        private static final String TYPE = "custom_1";
+
+        TestCustom1(String value) {
+            super(value);
+        }
+
+        TestCustom1(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        @Override
+        public String getWriteableName() {
+            return TYPE;
+        }
+    }
+
+    private static class TestCustom2 extends AbstractTestCustom {
+
+        private static final String TYPE = "custom_2";
+
+        TestCustom2(String value) {
+            super(value);
+        }
+
+        TestCustom2(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        @Override
+        public String getWriteableName() {
+            return TYPE;
+        }
+    }
+
+    private static class TestCustom3 extends AbstractTestCustom {
+
+        private static final String TYPE = "custom_3";
+
+        TestCustom3(String value) {
+            super(value);
+        }
+
+        TestCustom3(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        @Override
+        public String getWriteableName() {
+            return TYPE;
+        }
+    }
+
+    private static class TestCustom4 extends AbstractTestCustom {
+
+        private static final String TYPE = "custom_4";
+
+        TestCustom4(String value) {
+            super(value);
+        }
+
+        TestCustom4(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        @Override
+        public String getWriteableName() {
+            return TYPE;
         }
     }
 }

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateAttributesManagerTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateAttributesManagerTests.java
@@ -8,9 +8,6 @@
 
 package org.opensearch.gateway.remote;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 import org.opensearch.Version;
 import org.opensearch.action.LatchedActionListener;
 import org.opensearch.cluster.AbstractNamedDiffable;
@@ -43,6 +40,9 @@ import org.junit.Assert;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -53,11 +53,11 @@ import static org.opensearch.gateway.remote.model.RemoteClusterBlocks.CLUSTER_BL
 import static org.opensearch.gateway.remote.model.RemoteClusterBlocksTests.randomClusterBlocks;
 import static org.opensearch.gateway.remote.model.RemoteDiscoveryNodes.DISCOVERY_NODES_FORMAT;
 import static org.opensearch.gateway.remote.model.RemoteDiscoveryNodesTests.getDiscoveryNodes;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.anyIterable;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.hamcrest.Matchers.is;
 
 public class RemoteClusterStateAttributesManagerTests extends OpenSearchTestCase {
     private RemoteClusterStateAttributesManager remoteClusterStateAttributesManager;

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteGlobalMetadataManagerTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteGlobalMetadataManagerTests.java
@@ -117,7 +117,7 @@ public class RemoteGlobalMetadataManagerTests extends OpenSearchTestCase {
             CustomMetadata4.TYPE,
             new CustomMetadata4("data4"),
             CustomMetadata5.TYPE,
-            new CustomMetadata5("data4")
+            new CustomMetadata5("data5")
         );
         ClusterState currentState = ClusterState.builder(new ClusterName("test-cluster"))
             .metadata(Metadata.builder().customs(currentCustoms))

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteGlobalMetadataManagerTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteGlobalMetadataManagerTests.java
@@ -8,7 +8,14 @@
 
 package org.opensearch.gateway.remote;
 
+import org.opensearch.Version;
 import org.opensearch.cluster.ClusterModule;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.DiffableUtils;
+import org.opensearch.cluster.metadata.IndexGraveyard;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.metadata.Metadata.XContentContext;
 import org.opensearch.common.network.NetworkModule;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
@@ -19,15 +26,20 @@ import org.opensearch.index.translog.transfer.BlobStoreTransferService;
 import org.opensearch.indices.IndicesModule;
 import org.opensearch.repositories.blobstore.BlobStoreRepository;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.TestCustomMetadata;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 import org.junit.After;
 import org.junit.Before;
 
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -82,5 +94,202 @@ public class RemoteGlobalMetadataManagerTests extends OpenSearchTestCase {
             .build();
         clusterSettings.applySettings(newSettings);
         assertEquals(globalMetadataUploadTimeout, remoteGlobalMetadataManager.getGlobalMetadataUploadTimeout().seconds());
+    }
+
+    public void testGetUpdatedCustoms() {
+        Map<String, Metadata.Custom> previousCustoms = Map.of(
+            CustomMetadata1.TYPE,
+            new CustomMetadata1("data1"),
+            CustomMetadata2.TYPE,
+            new CustomMetadata2("data2"),
+            CustomMetadata3.TYPE,
+            new CustomMetadata3("data3")
+        );
+        ClusterState previousState = ClusterState.builder(new ClusterName("test-cluster"))
+            .metadata(Metadata.builder().customs(previousCustoms))
+            .build();
+
+        Map<String, Metadata.Custom> currentCustoms = Map.of(
+            CustomMetadata2.TYPE,
+            new CustomMetadata2("data2"),
+            CustomMetadata3.TYPE,
+            new CustomMetadata3("data3-changed"),
+            CustomMetadata4.TYPE,
+            new CustomMetadata4("data4"),
+            CustomMetadata5.TYPE,
+            new CustomMetadata5("data4")
+        );
+        ClusterState currentState = ClusterState.builder(new ClusterName("test-cluster"))
+            .metadata(Metadata.builder().customs(currentCustoms))
+            .build();
+
+        DiffableUtils.MapDiff<String, Metadata.Custom, Map<String, Metadata.Custom>> customsDiff = remoteGlobalMetadataManager
+            .getCustomsDiff(currentState, previousState, true, false);
+        Map<String, Metadata.Custom> expectedUpserts = Map.of(
+            CustomMetadata2.TYPE,
+            new CustomMetadata2("data2"),
+            CustomMetadata3.TYPE,
+            new CustomMetadata3("data3-changed"),
+            CustomMetadata4.TYPE,
+            new CustomMetadata4("data4"),
+            IndexGraveyard.TYPE,
+            IndexGraveyard.builder().build()
+        );
+        assertThat(customsDiff.getUpserts(), is(expectedUpserts));
+        assertThat(customsDiff.getDeletes(), is(List.of()));
+
+        customsDiff = remoteGlobalMetadataManager.getCustomsDiff(currentState, previousState, false, false);
+        expectedUpserts = Map.of(
+            CustomMetadata3.TYPE,
+            new CustomMetadata3("data3-changed"),
+            CustomMetadata4.TYPE,
+            new CustomMetadata4("data4")
+        );
+        assertThat(customsDiff.getUpserts(), is(expectedUpserts));
+        assertThat(customsDiff.getDeletes(), is(List.of(CustomMetadata1.TYPE)));
+
+        customsDiff = remoteGlobalMetadataManager.getCustomsDiff(currentState, previousState, true, true);
+        expectedUpserts = Map.of(
+            CustomMetadata2.TYPE,
+            new CustomMetadata2("data2"),
+            CustomMetadata3.TYPE,
+            new CustomMetadata3("data3-changed"),
+            CustomMetadata4.TYPE,
+            new CustomMetadata4("data4"),
+            CustomMetadata5.TYPE,
+            new CustomMetadata5("data5"),
+            IndexGraveyard.TYPE,
+            IndexGraveyard.builder().build()
+        );
+        assertThat(customsDiff.getUpserts(), is(expectedUpserts));
+        assertThat(customsDiff.getDeletes(), is(List.of()));
+
+        customsDiff = remoteGlobalMetadataManager.getCustomsDiff(currentState, previousState, false, true);
+        expectedUpserts = Map.of(
+            CustomMetadata3.TYPE,
+            new CustomMetadata3("data3-changed"),
+            CustomMetadata4.TYPE,
+            new CustomMetadata4("data4"),
+            CustomMetadata5.TYPE,
+            new CustomMetadata5("data5")
+        );
+        assertThat(customsDiff.getUpserts(), is(expectedUpserts));
+        assertThat(customsDiff.getDeletes(), is(List.of(CustomMetadata1.TYPE)));
+
+    }
+
+    private static class CustomMetadata1 extends TestCustomMetadata {
+        public static final String TYPE = "custom_md_1";
+
+        CustomMetadata1(String data) {
+            super(data);
+        }
+
+        @Override
+        public String getWriteableName() {
+            return TYPE;
+        }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.CURRENT;
+        }
+
+        @Override
+        public EnumSet<XContentContext> context() {
+            return EnumSet.of(Metadata.XContentContext.GATEWAY);
+        }
+    }
+
+    private static class CustomMetadata2 extends TestCustomMetadata {
+        public static final String TYPE = "custom_md_2";
+
+        CustomMetadata2(String data) {
+            super(data);
+        }
+
+        @Override
+        public String getWriteableName() {
+            return TYPE;
+        }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.CURRENT;
+        }
+
+        @Override
+        public EnumSet<Metadata.XContentContext> context() {
+            return EnumSet.of(Metadata.XContentContext.GATEWAY);
+        }
+    }
+
+    private static class CustomMetadata3 extends TestCustomMetadata {
+        public static final String TYPE = "custom_md_3";
+
+        CustomMetadata3(String data) {
+            super(data);
+        }
+
+        @Override
+        public String getWriteableName() {
+            return TYPE;
+        }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.CURRENT;
+        }
+
+        @Override
+        public EnumSet<Metadata.XContentContext> context() {
+            return EnumSet.of(Metadata.XContentContext.GATEWAY);
+        }
+    }
+
+    private static class CustomMetadata4 extends TestCustomMetadata {
+        public static final String TYPE = "custom_md_4";
+
+        CustomMetadata4(String data) {
+            super(data);
+        }
+
+        @Override
+        public String getWriteableName() {
+            return TYPE;
+        }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.CURRENT;
+        }
+
+        @Override
+        public EnumSet<Metadata.XContentContext> context() {
+            return EnumSet.of(Metadata.XContentContext.GATEWAY);
+        }
+    }
+
+    private static class CustomMetadata5 extends TestCustomMetadata {
+        public static final String TYPE = "custom_md_5";
+
+        CustomMetadata5(String data) {
+            super(data);
+        }
+
+        @Override
+        public String getWriteableName() {
+            return TYPE;
+        }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.CURRENT;
+        }
+
+        @Override
+        public EnumSet<Metadata.XContentContext> context() {
+            return EnumSet.of(XContentContext.API);
+        }
     }
 }


### PR DESCRIPTION
### Description
This PR addresses the following:
- Cluster state customs should only be uploaded when remote publication is enabled.
- All metadata customs when remote publication is enabled while customs with context as GATEWAY should be uploaded otherwise
- simplify the logic of computing the updated customs
- Fix bug where metadata customs map was being used to remove cluster state customs to be deleted.
- Close input stream while reading blob

### Related Issues
NA

### Check List
- [X] Functionality includes testing.
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
