### PR TITLE
[Bugfix] Fix incorrect document order when there's exception during batch ingest 

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/ingest/IngestClientIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/ingest/IngestClientIT.java
@@ -162,6 +162,14 @@ public class IngestClientIT extends ParameterizedStaticSettingsOpenSearchIntegTe
     }
 
     public void testBulkWithIngestFailures() throws Exception {
+        runBulkTestWithRandomDocs(false);
+    }
+
+    public void testBulkWithIngestFailuresWithBatchSize() throws Exception {
+        runBulkTestWithRandomDocs(true);
+    }
+
+    private void runBulkTestWithRandomDocs(boolean shouldSetBatchSize) throws Exception {
         createIndex("index");
 
         BytesReference source = BytesReference.bytes(
@@ -180,7 +188,9 @@ public class IngestClientIT extends ParameterizedStaticSettingsOpenSearchIntegTe
 
         int numRequests = scaledRandomIntBetween(32, 128);
         BulkRequest bulkRequest = new BulkRequest();
-        bulkRequest.batchSize(numRequests);
+        if (shouldSetBatchSize) {
+            bulkRequest.batchSize(numRequests);
+        }
         for (int i = 0; i < numRequests; i++) {
             IndexRequest indexRequest = new IndexRequest("index").id(Integer.toString(i)).setPipeline("_id");
             indexRequest.source(Requests.INDEX_CONTENT_TYPE, "field", "value", "fail", i % 2 == 0);

--- a/server/src/internalClusterTest/java/org/opensearch/ingest/IngestClientIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/ingest/IngestClientIT.java
@@ -60,15 +60,18 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
+import org.hamcrest.MatcherAssert;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.opensearch.test.NodeRoles.nonIngestNode;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
@@ -177,6 +180,7 @@ public class IngestClientIT extends ParameterizedStaticSettingsOpenSearchIntegTe
 
         int numRequests = scaledRandomIntBetween(32, 128);
         BulkRequest bulkRequest = new BulkRequest();
+        bulkRequest.batchSize(numRequests);
         for (int i = 0; i < numRequests; i++) {
             IndexRequest indexRequest = new IndexRequest("index").id(Integer.toString(i)).setPipeline("_id");
             indexRequest.source(Requests.INDEX_CONTENT_TYPE, "field", "value", "fail", i % 2 == 0);
@@ -203,6 +207,103 @@ public class IngestClientIT extends ParameterizedStaticSettingsOpenSearchIntegTe
                 assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
             }
         }
+
+        // cleanup
+        AcknowledgedResponse deletePipelineResponse = client().admin().cluster().prepareDeletePipeline("_id").get();
+        assertTrue(deletePipelineResponse.isAcknowledged());
+    }
+
+    public void testBulkWithIngestFailuresBatch() throws Exception {
+        createIndex("index");
+
+        BytesReference source = BytesReference.bytes(
+            jsonBuilder().startObject()
+                .field("description", "my_pipeline")
+                .startArray("processors")
+                .startObject()
+                .startObject("test")
+                .endObject()
+                .endObject()
+                .endArray()
+                .endObject()
+        );
+        PutPipelineRequest putPipelineRequest = new PutPipelineRequest("_id", source, MediaTypeRegistry.JSON);
+        client().admin().cluster().putPipeline(putPipelineRequest).get();
+
+        BulkRequest bulkRequest = new BulkRequest();
+        bulkRequest.batchSize(2);
+        bulkRequest.add(
+            new IndexRequest("index").id("_fail").setPipeline("_id").source(Requests.INDEX_CONTENT_TYPE, "field", "value", "fail", true)
+        );
+        bulkRequest.add(
+            new IndexRequest("index").id("_success").setPipeline("_id").source(Requests.INDEX_CONTENT_TYPE, "field", "value", "fail", false)
+        );
+
+        BulkResponse response = client().bulk(bulkRequest).actionGet();
+        MatcherAssert.assertThat(response.getItems().length, equalTo(bulkRequest.requests().size()));
+
+        Map<String, BulkItemResponse> results = Arrays.stream(response.getItems())
+            .collect(Collectors.toMap(BulkItemResponse::getId, r -> r));
+
+        MatcherAssert.assertThat(results.keySet(), containsInAnyOrder("_fail", "_success"));
+        assertNotNull(results.get("_fail").getFailure());
+        assertNull(results.get("_success").getFailure());
+
+        // verify field of successful doc
+        Map<String, Object> successDoc = client().prepareGet("index", "_success").get().getSourceAsMap();
+        assertThat(successDoc.get("processed"), equalTo(true));
+
+        // cleanup
+        AcknowledgedResponse deletePipelineResponse = client().admin().cluster().prepareDeletePipeline("_id").get();
+        assertTrue(deletePipelineResponse.isAcknowledged());
+    }
+
+    public void testBulkWithIngestFailuresAndDropBatch() throws Exception {
+        createIndex("index");
+
+        BytesReference source = BytesReference.bytes(
+            jsonBuilder().startObject()
+                .field("description", "my_pipeline")
+                .startArray("processors")
+                .startObject()
+                .startObject("test")
+                .endObject()
+                .endObject()
+                .endArray()
+                .endObject()
+        );
+        PutPipelineRequest putPipelineRequest = new PutPipelineRequest("_id", source, MediaTypeRegistry.JSON);
+        client().admin().cluster().putPipeline(putPipelineRequest).get();
+
+        BulkRequest bulkRequest = new BulkRequest();
+        bulkRequest.batchSize(3);
+        bulkRequest.add(
+            new IndexRequest("index").id("_fail").setPipeline("_id").source(Requests.INDEX_CONTENT_TYPE, "field", "value", "fail", true)
+        );
+        bulkRequest.add(
+            new IndexRequest("index").id("_success").setPipeline("_id").source(Requests.INDEX_CONTENT_TYPE, "field", "value", "fail", false)
+        );
+        bulkRequest.add(
+            new IndexRequest("index").id("_drop").setPipeline("_id").source(Requests.INDEX_CONTENT_TYPE, "field", "value", "drop", true)
+        );
+
+        BulkResponse response = client().bulk(bulkRequest).actionGet();
+        MatcherAssert.assertThat(response.getItems().length, equalTo(bulkRequest.requests().size()));
+
+        Map<String, BulkItemResponse> results = Arrays.stream(response.getItems())
+            .collect(Collectors.toMap(BulkItemResponse::getId, r -> r));
+
+        MatcherAssert.assertThat(results.keySet(), containsInAnyOrder("_fail", "_success", "_drop"));
+        assertNotNull(results.get("_fail").getFailure());
+        assertNull(results.get("_success").getFailure());
+        assertNull(results.get("_drop").getFailure());
+
+        // verify dropped doc not in index
+        assertNull(client().prepareGet("index", "_drop").get().getSourceAsMap());
+
+        // verify field of successful doc
+        Map<String, Object> successDoc = client().prepareGet("index", "_success").get().getSourceAsMap();
+        assertThat(successDoc.get("processed"), equalTo(true));
 
         // cleanup
         AcknowledgedResponse deletePipelineResponse = client().admin().cluster().prepareDeletePipeline("_id").get();

--- a/server/src/main/java/org/opensearch/ingest/IngestService.java
+++ b/server/src/main/java/org/opensearch/ingest/IngestService.java
@@ -1096,13 +1096,11 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
                 if (!dropped.isEmpty()) {
                     dropped.forEach(t -> itemDroppedHandler.accept(t.getSlot()));
                 }
-                if (!succeeded.isEmpty()) {
-                    for (IngestDocumentWrapper ingestDocumentWrapper : succeeded) {
-                        updateIndexRequestWithIngestDocument(
-                            slotToindexRequestMap.get(ingestDocumentWrapper.getSlot()),
-                            ingestDocumentWrapper.getIngestDocument()
-                        );
-                    }
+                for (IngestDocumentWrapper ingestDocumentWrapper : succeeded) {
+                    updateIndexRequestWithIngestDocument(
+                        slotToindexRequestMap.get(ingestDocumentWrapper.getSlot()),
+                        ingestDocumentWrapper.getIngestDocument()
+                    );
                 }
                 handler.accept(allResults);
             }

--- a/server/src/main/java/org/opensearch/ingest/IngestService.java
+++ b/server/src/main/java/org/opensearch/ingest/IngestService.java
@@ -775,7 +775,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
                                 ),
                                 results.get(i).getException()
                             );
-                            onFailure.accept(slots.get(i), results.get(i).getException());
+                            onFailure.accept(results.get(i).getSlot(), results.get(i).getException());
                         }
                     }
 
@@ -1092,9 +1092,11 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
                 }
                 if (!exceptions.isEmpty()) {
                     totalMetrics.failedN(exceptions.size());
-                } else if (!dropped.isEmpty()) {
+                }
+                if (!dropped.isEmpty()) {
                     dropped.forEach(t -> itemDroppedHandler.accept(t.getSlot()));
-                } else {
+                }
+                if (!succeeded.isEmpty()) {
                     for (IngestDocumentWrapper ingestDocumentWrapper : succeeded) {
                         updateIndexRequestWithIngestDocument(
                             slotToindexRequestMap.get(ingestDocumentWrapper.getSlot()),


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This is to fix a document incorrect order bug with batch ingestion when some docs run into exception.

bug is described here: https://github.com/opensearch-project/OpenSearch/issues/14336
the integration test here https://github.com/opensearch-project/OpenSearch/pull/14335 was also added. 

**Skip changelog** and **backport to 2.x**

### Related Issues
- https://github.com/opensearch-project/OpenSearch/issues/14336
- https://github.com/opensearch-project/OpenSearch/pull/14335

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
