### PR TITLE
Optimize global ordinal includes/excludes for prefix matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - Add lower limit for primary and replica batch allocators timeout ([#14979](https://github.com/opensearch-project/OpenSearch/pull/14979))
+- Optimize regexp-based include/exclude on aggregations when pattern matches prefixes ([#14371](https://github.com/opensearch-project/OpenSearch/pull/14371))
 - Replace and block usages of org.apache.logging.log4j.util.Strings ([#15238](https://github.com/opensearch-project/OpenSearch/pull/15238))
 
 ### Deprecated

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/IncludeExclude.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/IncludeExclude.java
@@ -480,7 +480,12 @@ public class IncludeExclude implements Writeable, ToXContentFragment {
         @Override
         public LongBitSet acceptedGlobalOrdinals(SortedSetDocValues globalOrdinals) throws IOException {
             LongBitSet accept = new LongBitSet(globalOrdinals.getValueCount());
-            process(globalOrdinals, accept.length(), includePrefixes, accept::set);
+            if (includePrefixes.isEmpty()) {
+                // Exclude-only
+                accept.set(0, accept.length());
+            } else {
+                process(globalOrdinals, accept.length(), includePrefixes, accept::set);
+            }
             process(globalOrdinals, accept.length(), excludePrefixes, accept::clear);
             return accept;
         }
@@ -872,7 +877,7 @@ public class IncludeExclude implements Writeable, ToXContentFragment {
         }
     }
 
-    private static SortedSet<BytesRef> extractPrefixes(String pattern, int maxRegexLength) {
+    static SortedSet<BytesRef> extractPrefixes(String pattern, int maxRegexLength) {
         if (pattern == null) {
             return Collections.emptySortedSet();
         }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/IncludeExclude.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/IncludeExclude.java
@@ -429,16 +429,12 @@ public class IncludeExclude implements Writeable, ToXContentFragment {
             return next;
         }
 
-        private interface LongLongBiconsumer {
+        private interface LongBiConsumer {
             void accept(long a, long b);
         }
 
-        private static void process(
-            SortedSetDocValues globalOrdinals,
-            long length,
-            SortedSet<BytesRef> prefixes,
-            LongLongBiconsumer consumer
-        ) throws IOException {
+        private static void process(SortedSetDocValues globalOrdinals, long length, SortedSet<BytesRef> prefixes, LongBiConsumer consumer)
+            throws IOException {
             for (BytesRef prefix : prefixes) {
                 long startOrd = globalOrdinals.lookupTerm(prefix);
                 if (startOrd < 0) {

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/IncludeExclude.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/IncludeExclude.java
@@ -480,11 +480,11 @@ public class IncludeExclude implements Writeable, ToXContentFragment {
         @Override
         public LongBitSet acceptedGlobalOrdinals(SortedSetDocValues globalOrdinals) throws IOException {
             LongBitSet accept = new LongBitSet(globalOrdinals.getValueCount());
-            if (includePrefixes.isEmpty()) {
+            if (!includePrefixes.isEmpty()) {
+                process(globalOrdinals, accept.length(), includePrefixes, accept::set);
+            } else if (accept.length() > 0) {
                 // Exclude-only
                 accept.set(0, accept.length());
-            } else {
-                process(globalOrdinals, accept.length(), includePrefixes, accept::set);
             }
             process(globalOrdinals, accept.length(), excludePrefixes, accept::clear);
             return accept;


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
If an aggregration specifies includes or excludes based on a regular expression, and the regular expression has a finite expansion followed by .*, then we can optimize the global ordinal filter.

Specifically, in this case, we can expand the matching prefixes, then include/exclude the range of global ordinals that start with each prefix.

### Related Issues
Resolves #14368

### Check List
- [x] Functionality includes testing.
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
