### PR TITLE
Add missing data types to IngestDocument deep copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 ### Fixed
+- Fix handling of Short and Byte data types in ScriptProcessor ingest pipeline ([#14379](https://github.com/opensearch-project/OpenSearch/issues/14379))
 
 ### Security
 

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/190_script_processor.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/190_script_processor.yml
@@ -278,3 +278,78 @@ teardown:
         body: {source_field: "fooBar", foo: {foo: "bar"}}
   - match: { error.root_cause.0.type: "illegal_argument_exception" }
   - match: { error.root_cause.0.reason: "Iterable object is self-referencing itself (ingest script)" }
+
+---
+"Test painless data types":
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body:  >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "script" : {
+                  "source" : "ctx.byte = (byte)127;ctx.short = (short)32767;ctx.int = (int)2147483647;ctx.long = (long)9223372036854775807L;ctx.float = (float)0.1;ctx.double = (double)0.1;ctx.boolean = (boolean)true"
+                }
+              },
+              {
+                "script" : {
+                  "source" : "ctx.other_field = 'other_field'"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test
+        id: 1
+        pipeline: "my_pipeline"
+        body: {source_field: "FooBar"}
+
+  - do:
+      get:
+        index: test
+        id: 1
+  - match: { _source.byte: 127 }
+  - match: { _source.int: 2147483647 }
+  - match: { _source.long: 9223372036854775807 }
+  - gt: { _source.float: 0.0 }
+  - lt: { _source.float: 0.2 }
+  - gt: { _source.double: 0.0 }
+  - lt: { _source.double: 0.2 }
+  - match: { _source.boolean: true }
+
+---
+"Test char type fails":
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body:  >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "script" : {
+                  "source" : "ctx.char = (char)'a'"
+                }
+              },
+              {
+                "script" : {
+                  "source" : "ctx.other_field = 'other_field'"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      catch: bad_request
+      index:
+        index: test
+        id: 1
+        pipeline: "my_pipeline"
+        body: {source_field: "FooBar"}
+  - match: { error.root_cause.0.type: "illegal_argument_exception" }

--- a/server/src/main/java/org/opensearch/ingest/IngestDocument.java
+++ b/server/src/main/java/org/opensearch/ingest/IngestDocument.java
@@ -776,6 +776,9 @@ public final class IngestDocument {
             byte[] bytes = (byte[]) value;
             return Arrays.copyOf(bytes, bytes.length);
         } else if (value == null
+            || value instanceof Byte
+            || value instanceof Character
+            || value instanceof Short
             || value instanceof String
             || value instanceof Integer
             || value instanceof Long


### PR DESCRIPTION
PR #11725 added a new deep copy in the ScriptProcessor flow. If a script uses a Short or Byte data type then this new deep copy introduced a regression. This commit fixes that regression.

However, it appears there has been an existing bug where using a Character type in the same way will fail (this failed before PR 11725). The failure is different, and appears to be related to something deeping in the XContent serialization layer. For now, I have fixed the regression but not yet dug into the failure with the Character data type. I have added a test that expects this failure.

Resolves #14379

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
