### PR TITLE
Add perms for remote snapshot cache eviction on scripted query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix NPE in ReplicaShardAllocator ([#14385](https://github.com/opensearch-project/OpenSearch/pull/14385))
 - Fix constant_keyword field type used when creating index ([#14807](https://github.com/opensearch-project/OpenSearch/pull/14807))
 - Use circuit breaker in InternalHistogram when adding empty buckets ([#14754](https://github.com/opensearch-project/OpenSearch/pull/14754))
+- Fix searchable snapshot failure with scripted fields ([#14411](https://github.com/opensearch-project/OpenSearch/pull/14411))
 
 ### Security
 


### PR DESCRIPTION
### Description
Scripted queries require elevated permissions to write to a remote snapshot local file cache. Since accessing the file cache can trigger an eviction the AccessController doPrivileged call needs to move up the call stack so we have permissions to perform file deletions for these evictions.

Reproduced and verified fix with OSB StackOverflow workload:
1. Run OSB StackOverflow workload.
2. Create snapshot from so index.
3. Restore from remote snapshot.
4. Query with a scripted field. 
```
curl -X POST "http://localhost:9200/so/_search?pretty" -H 'Content-Type: application/json' -d'
{
  "query": {
    "match": {
      "body": "java"
    }
  },
  "script_fields": {
    "combined_field": {
      "script": {
        "source": "params[\"_source\"][\"user\"] + \" \" + params[\"_source\"][\"body\"]"
      }
    }
  },
  "size": 100
}
'
```

```
{
  "error" : {
    "root_cause" : [
      {
        "type" : "parse_exception",
        "reason" : "failed to parse / load source"
      }
    ],
    "type" : "search_phase_execution_exception",
    "reason" : "all shards failed",
    "phase" : "query",
    "grouped" : true,
    "failed_shards" : [
      {
        "shard" : 0,
        "index" : "so",
        "node" : "Q87dFmoFQ4ivpVr0ng82NQ",
        "reason" : {
          "type" : "script_exception",
          "reason" : "runtime error",
          "script_stack" : [
            "org.opensearch.search.lookup.SourceLookup.loadSourceIfNeeded(SourceLookup.java:115)",
            "org.opensearch.script.FieldScript.lambda$static$2(FieldScript.java:72)",
            "org.opensearch.script.DynamicMap.get(DynamicMap.java:84)",
            "params[\"_source\"][\"user\"] + \" \" + params[\"_source\"][\"body\"]",
            "       ^---- HERE"
          ],
          "script" : "params[\"_source\"][\"user\"] + \" \" + params[\"_source\"][\"body\"]",
          "lang" : "painless",
          "position" : {
            "offset" : 7,
            "start" : 0,
            "end" : 59
          },
          "caused_by" : {
            "type" : "parse_exception",
            "reason" : "failed to parse / load source",
            "caused_by" : {
              "type" : "access_control_exception",
              "reason" : "access denied (\"java.io.FilePermission\" \"/local/home/carrofin/DEBUG/STORES/DATA/nodes/0/cache/nI-w4Uy5QzeP73xjaqu4SQ/0/RemoteLocalStore/_nd.fdt.87\" \"delete\")"
            }
          }
        }
      }
    ],
    "caused_by" : {
      "type" : "parse_exception",
      "reason" : "failed to parse / load source",
      "caused_by" : {
        "type" : "access_control_exception",
        "reason" : "access denied (\"java.io.FilePermission\" \"/local/home/carrofin/DEBUG/STORES/DATA/nodes/0/cache/nI-w4Uy5QzeP73xjaqu4SQ/0/RemoteLocalStore/_nd.fdt.87\" \"delete\")"
      }
    }
  },
  "status" : 400
}
```
### Related Issues
Resolves #14268

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
