### PR TITLE
Normalize URI paths in RestClient

### DIFF
--- a/client/rest/src/main/java/org/opensearch/client/RestClient.java
+++ b/client/rest/src/main/java/org/opensearch/client/RestClient.java
@@ -674,19 +674,7 @@ public class RestClient implements Closeable {
     static URI buildUri(String pathPrefix, String path, Map<String, String> params) {
         Objects.requireNonNull(path, "path must not be null");
         try {
-            String fullPath;
-            if (pathPrefix != null && pathPrefix.isEmpty() == false) {
-                if (pathPrefix.endsWith("/") && path.startsWith("/")) {
-                    fullPath = pathPrefix.substring(0, pathPrefix.length() - 1) + path;
-                } else if (pathPrefix.endsWith("/") || path.startsWith("/")) {
-                    fullPath = pathPrefix + path;
-                } else {
-                    fullPath = pathPrefix + "/" + path;
-                }
-            } else {
-                fullPath = path;
-            }
-
+            String fullPath = buildUriPath(pathPrefix, path);
             URIBuilder uriBuilder = new URIBuilder(fullPath);
             for (Map.Entry<String, String> param : params.entrySet()) {
                 uriBuilder.addParameter(param.getKey(), param.getValue());
@@ -700,6 +688,28 @@ public class RestClient implements Closeable {
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException(e.getMessage(), e);
         }
+    }
+
+    private static String buildUriPath(String pathPrefix, String path) {
+        pathPrefix = pathPrefix != null ? trimSlashes(pathPrefix) : "";
+        path = path != null ? trimSlashes(path) : "";
+
+        if (!pathPrefix.isEmpty()) {
+            if (!path.isEmpty()) {
+                return "/" + pathPrefix + "/" + path;
+            }
+            return "/" + pathPrefix;
+        }
+
+        return "/" + path;
+    }
+
+    private static String trimSlashes(String str) {
+        int start = 0;
+        int end = str.length();
+        while (start < end && str.charAt(start) == '/') ++start;
+        while (end > start && str.charAt(end - 1) == '/') --end;
+        return str.substring(start, end);
     }
 
     /**

--- a/client/rest/src/test/java/org/opensearch/client/RestClientTests.java
+++ b/client/rest/src/test/java/org/opensearch/client/RestClientTests.java
@@ -145,11 +145,11 @@ public class RestClientTests extends RestClientTestCase {
         }
         {
             URI uri = RestClient.buildUri(null, "*", emptyMap);
-            assertEquals("*", uri.getPath());
+            assertEquals("/*", uri.getPath());
         }
         {
             URI uri = RestClient.buildUri("", "*", emptyMap);
-            assertEquals("*", uri.getPath());
+            assertEquals("/*", uri.getPath());
         }
         {
             URI uri = RestClient.buildUri(null, "/*", emptyMap);


### PR DESCRIPTION
### Description
There are a sprinkling of locations such as this [line](https://github.com/opensearch-project/OpenSearch/blob/2.x/client/rest-high-level/src/main/java/org/opensearch/client/RequestConverters.java#L543) that construct a RestClient request with a non-absolute path (ie. no leading `/`). This is being passed verbatim to the HTTP request which results in a [technically invalid request start-line](https://developer.mozilla.org/en-US/docs/Web/HTTP/Messages#request_line) of `GET _render/template HTTP/1.1` which should be `GET /_render/template HTTP/1.1`. OpenSearch itself is lenient and happily serves this request, however in cases of stricter intermediaries such as proxies or load-balances as in Amazon OpenSearch Service, this request ends up denied with a `400 Bad Request`.

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
