### PR TITLE
Fix flaky test : RemoteMigrationIndexMetadataUpdateIT.testRemoteIndexPathFileExistsAfterMigration

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotemigration/RemoteMigrationIndexMetadataUpdateIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotemigration/RemoteMigrationIndexMetadataUpdateIT.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.remotemigration;
 
+import org.opensearch.action.admin.cluster.configuration.AddVotingConfigExclusionsAction;
+import org.opensearch.action.admin.cluster.configuration.AddVotingConfigExclusionsRequest;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.health.ClusterHealthStatus;
 import org.opensearch.cluster.metadata.IndexMetadata;
@@ -471,7 +473,6 @@ public class RemoteMigrationIndexMetadataUpdateIT extends MigrationBaseTestCase 
      * exclude docrep nodes, assert that remote index path file exists
      * when shards start relocating to the remote nodes.
      */
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/13939")
     public void testRemoteIndexPathFileExistsAfterMigration() throws Exception {
         String docrepClusterManager = internalCluster().startClusterManagerOnlyNode();
 
@@ -518,7 +519,11 @@ public class RemoteMigrationIndexMetadataUpdateIT extends MigrationBaseTestCase 
                 .isAcknowledged()
         );
 
-        internalCluster().stopRandomNode(InternalTestCluster.nameFilter(docrepClusterManager));
+        // elect cluster manager with remote-cluster state enabled
+        internalCluster().client()
+            .execute(AddVotingConfigExclusionsAction.INSTANCE, new AddVotingConfigExclusionsRequest(docrepClusterManager))
+            .get();
+
         internalCluster().validateClusterFormed();
 
         logger.info("---> Excluding docrep nodes from allocation");


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
- In `RemoteMigrationIndexMetadataUpdateIT.testRemoteIndexPathFileExistsAfterMigration` test we validate if remote index path file exists on the migrated index on remote node.
- In test, we are first creating a DocRep cluster with 1 cluster manager , 2 Data nodes. After that we add 1 remote cluster manager node and 2 remote nodes.
- So previously in order to elect remote cluster manager as active master we were terminating docRep cluster manager, due to which we were running into issue `NodeClosedException` when other nodes try to join the cluster.
- To avoid the issue we will be using voting config exclusion to elect the remote cluster manager instead of terminating it.
- With the fix, the flaky test ran for 5500+ iterations without failing locally.

### Related Issues
Resolves #13939


### Check List
- ~[ ] Functionality includes testing.~
- ~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
