### PR TITLE
Adjusting TESTING.md for a single test run

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -88,16 +88,14 @@ This will instruct all JVMs (including any that run cli tools such as creating t
 
 ## Test case filtering
 
--   `tests.class` is a class-filtering shell-like glob pattern
--   `tests.method` is a method-filtering glob pattern.
-
 To be able to run a single test you need to specify the module where you're running the tests from.
 
-Example: `./gradlew server:test --tests "*.ReplicaShardBatchAllocatorTests"`
+Example: `./gradlew server:test --tests "*.ReplicaShardBatchAllocatorTests.testNoAsyncFetchData"`
 
 Run a single test case (variants)
 
     ./gradlew module:test --tests org.opensearch.package.ClassName
+    ./gradlew module:test --tests org.opensearch.package.ClassName.testName
     ./gradlew module:test --tests "*.ClassName"
 
 Run all tests in a package and its sub-packages
@@ -110,7 +108,7 @@ Run any test methods that contain *esi* (e.g.: .r*esi*ze.)
 
 Run all tests that are waiting for a bugfix (disabled by default)
 
-    ./gradlew test -Dtests.filter=@awaitsfix
+    ./gradlew module:test --tests "*@awaitsfix"
 
 ## Seed and repetitions
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -108,7 +108,7 @@ Run any test methods that contain *esi* (e.g.: .r*esi*ze.)
 
 Run all tests that are waiting for a bugfix (disabled by default)
 
-./gradlew test -Dtests.filter=@awaitsfix
+    ./gradlew test "-Dtests.method=*esi*"
 
 ## Seed and repetitions
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -108,7 +108,7 @@ Run any test methods that contain *esi* (e.g.: .r*esi*ze.)
 
 Run all tests that are waiting for a bugfix (disabled by default)
 
-    ./gradlew module:test --tests "*@awaitsfix"
+./gradlew test -Dtests.filter=@awaitsfix
 
 ## Seed and repetitions
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -108,7 +108,7 @@ Run any test methods that contain *esi* (e.g.: .r*esi*ze.)
 
 Run all tests that are waiting for a bugfix (disabled by default)
 
-    ./gradlew test "-Dtests.method=*esi*"
+    ./gradlew test -Dtests.filter=@awaitsfix
 
 ## Seed and repetitions
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -91,18 +91,22 @@ This will instruct all JVMs (including any that run cli tools such as creating t
 -   `tests.class` is a class-filtering shell-like glob pattern
 -   `tests.method` is a method-filtering glob pattern.
 
+To be able to run a single test you need to specify the module where you're running the tests from.
+
+Example: `./gradlew server:test --tests "*.ReplicaShardBatchAllocatorTests"`
+
 Run a single test case (variants)
 
-    ./gradlew test -Dtests.class=org.opensearch.package.ClassName
-    ./gradlew test "-Dtests.class=*.ClassName"
+    ./gradlew module:test --tests org.opensearch.package.ClassName
+    ./gradlew module:test --tests "*.ClassName"
 
 Run all tests in a package and its sub-packages
 
-    ./gradlew test "-Dtests.class=org.opensearch.package.*"
+    ./gradlew module:test --tests "org.opensearch.package.*"
 
 Run any test methods that contain *esi* (e.g.: .r*esi*ze.)
 
-    ./gradlew test "-Dtests.method=*esi*"
+    ./gradlew module:test --tests "*esi*"
 
 Run all tests that are waiting for a bugfix (disabled by default)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Adjusting the gradle commands for running a single test and running the filtered tests.
According a Gradle [docs](https://docs.gradle.org/current/userguide/intro_multi_project_builds.html#sec:multiproject_build_and_test) for multi modules projects.

Below the screenshots of how it worked on my machine: 
1. Without specifying a module name ❌ 
<img width="1344" alt="Screenshot 2024-06-18 at 23 07 21" src="https://github.com/opensearch-project/OpenSearch/assets/23433684/3e15c335-d0a8-474b-83ad-29888a0a3b47">
2. With specifying a module name ✅ 
<img width="1350" alt="Screenshot 2024-06-18 at 23 07 54" src="https://github.com/opensearch-project/OpenSearch/assets/23433684/91e1e0c3-10fb-47c0-84c8-e6dfe7888b4f">


### Related Issues
Resolves #14014


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
