### PR TITLE
Fix a race condition in Derived Field parsing from search request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Remote Store] Rate limiter for remote store low priority uploads ([#14374](https://github.com/opensearch-project/OpenSearch/pull/14374/))
 - Apply the date histogram rewrite optimization to range aggregation ([#13865](https://github.com/opensearch-project/OpenSearch/pull/13865))
 - [Writable Warm] Add composite directory implementation and integrate it with FileCache ([12782](https://github.com/opensearch-project/OpenSearch/pull/12782))
+- Fix race condition while parsing derived fields from search definition ([14445](https://github.com/opensearch-project/OpenSearch/pull/14445))
 
 ### Dependencies
 - Bump `org.gradle.test-retry` from 1.5.8 to 1.5.9 ([#13442](https://github.com/opensearch-project/OpenSearch/pull/13442))

--- a/server/src/main/java/org/opensearch/index/mapper/DefaultDerivedFieldResolver.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DefaultDerivedFieldResolver.java
@@ -15,6 +15,8 @@ import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.script.Script;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -189,9 +191,10 @@ public class DefaultDerivedFieldResolver implements DerivedFieldResolver {
 
     private Map<String, DerivedFieldType> getAllDerivedFieldTypeFromObject(Map<String, Object> derivedFieldObject) {
         Map<String, DerivedFieldType> derivedFieldTypes = new HashMap<>();
+        // deep copy of derivedFieldObject is required as DocumentMapperParser modifies the map
         DocumentMapper documentMapper = queryShardContext.getMapperService()
             .documentMapperParser()
-            .parse(DerivedFieldMapper.CONTENT_TYPE, derivedFieldObject);
+            .parse(DerivedFieldMapper.CONTENT_TYPE, (Map) deepCopy(derivedFieldObject));
         if (documentMapper != null && documentMapper.mappers() != null) {
             for (Mapper mapper : documentMapper.mappers()) {
                 if (mapper instanceof DerivedFieldMapper) {
@@ -225,5 +228,28 @@ public class DefaultDerivedFieldResolver implements DerivedFieldResolver {
             }
         }
         return null;
+    }
+
+    private static Object deepCopy(Object value) {
+        if (value instanceof Map) {
+            Map<?, ?> mapValue = (Map<?, ?>) value;
+            Map<Object, Object> copy = new HashMap<>(mapValue.size());
+            for (Map.Entry<?, ?> entry : mapValue.entrySet()) {
+                copy.put(entry.getKey(), deepCopy(entry.getValue()));
+            }
+            return copy;
+        } else if (value instanceof List) {
+            List<?> listValue = (List<?>) value;
+            List<Object> copy = new ArrayList<>(listValue.size());
+            for (Object itemValue : listValue) {
+                copy.add(deepCopy(itemValue));
+            }
+            return copy;
+        } else if (value instanceof byte[]) {
+            byte[] bytes = (byte[]) value;
+            return Arrays.copyOf(bytes, bytes.length);
+        } else {
+            return value;
+        }
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[flaky test](https://build.ci.opensearch.org/job/gradle-check/41269/testReport/junit/org.opensearch.painless/LangPainlessClientYamlTestSuiteIT/test__yaml_painless_derived_fields_30_derived_field_search_definition_Test_derived_field_supported_type_using_search_definition_/) was introduced because of a race condition in derived fields when defined within search request.
Since derived fields are created per `QueryShardContext` and `QueryShardContext` instance can be created multiple times for a search request, there is a race condition hitting [here](https://github.com/opensearch-project/OpenSearch/blob/9da6170fc38653284cfeee0e5c1800d41999ba08/server/src/main/java/org/opensearch/index/mapper/DefaultDerivedFieldResolver.java#L194). Since we are reusing the parsing logic of mapper for derived fields defined in search requests too, it tries to modify the map passed to it where it tries to remove all keys it has parsed.

```
  1> Caused by: java.util.ConcurrentModificationException
  1>    at java.base/java.util.HashMap$HashIterator.remove(HashMap.java:1619)
  1>    at org.opensearch.index.mapper.ParametrizedFieldMapper$Builder.parse(ParametrizedFieldMapper.java:732)
  1>    at org.opensearch.index.mapper.ParametrizedFieldMapper$TypeParser.parse(ParametrizedFieldMapper.java:769)
  1>    at org.opensearch.index.mapper.ParametrizedFieldMapper$TypeParser.parse(ParametrizedFieldMapper.java:754)
  1>    at org.opensearch.index.mapper.ObjectMapper$TypeParser.parseDerived(ObjectMapper.java:384)
  1>    at org.opensearch.index.mapper.ObjectMapper$TypeParser.parseObjectOrDocumentTypeProperties(ObjectMapper.java:298)
  1>    at org.opensearch.index.mapper.RootObjectMapper$TypeParser.parse(RootObjectMapper.java:184)
  1>    at org.opensearch.index.mapper.DocumentMapperParser.parse(DocumentMapperParser.java:143)
  1>    at org.opensearch.index.mapper.DefaultDerivedFieldResolver.getAllDerivedFieldTypeFromObject(DefaultDerivedFieldResolver.java:194)
  1>    at org.opensearch.index.mapper.DefaultDerivedFieldResolver.initDerivedFieldTypes(DefaultDerivedFieldResolver.java:181)
  1>    at org.opensearch.index.mapper.DefaultDerivedFieldResolver.<init>(DefaultDerivedFieldResolver.java:64)
  1>    at org.opensearch.index.mapper.DefaultDerivedFieldResolver.<init>(DefaultDerivedFieldResolver.java:45)
  1>    at org.opensearch.index.mapper.DerivedFieldResolverFactory.createResolver(DerivedFieldResolverFactory.java:49)
  1>    at org.opensearch.search.SearchService.createSearchContext(SearchService.java:1121)
  1>    at 
```

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/14444
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- ~~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~~
- ~~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
