### PR TITLE
Adding number of routing shards to index settings before passing into…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix fs info reporting negative available size ([#11573](https://github.com/opensearch-project/OpenSearch/pull/11573))
 - Add ListPitInfo::getKeepAlive() getter ([#14495](https://github.com/opensearch-project/OpenSearch/pull/14495))
 - Fix FuzzyQuery in keyword field will use IndexOrDocValuesQuery when both of index and doc_value are true ([#14378](https://github.com/opensearch-project/OpenSearch/pull/14378))
+- Updated GET {index}/_settings to return `number_of_routing_shards` ([#14446](https://github.com/opensearch-project/OpenSearch/pull/14446))
 
 ### Security
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_settings/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_settings/10_basic.yml
@@ -171,3 +171,42 @@ setup:
 
  - is_true: test_1
  - is_true: test_2
+
+---
+"Test number of routing shards returned":
+  - skip:
+      version: " - 2.99.99"
+      reason: "introduced in 3.0.0"
+
+  - do:
+      indices.create:
+        index: test_3
+        body:
+          settings:
+            number_of_shards: 3
+            number_of_replicas: 0
+            number_of_routing_shards: 6
+
+  - do:
+      indices.get_settings: {}
+
+  - match: { test_3.settings.index.number_of_shards: "3"}
+  - match: { test_3.settings.index.number_of_replicas: "0"}
+  - match: { test_3.settings.index.number_of_routing_shards: "6"}
+
+  - do:
+      indices.get_settings:
+        index: test_3
+
+  - match: { test_3.settings.index.number_of_shards: "3"}
+  - match: { test_3.settings.index.number_of_replicas: "0"}
+  - match: { test_3.settings.index.number_of_routing_shards: "6"}
+
+  - do:
+      indices.get_settings:
+        index: test_3
+        name:  _all
+
+  - match: { test_3.settings.index.number_of_shards: "3"}
+  - match: { test_3.settings.index.number_of_replicas: "0"}
+  - match: { test_3.settings.index.number_of_routing_shards: "6"}

--- a/server/src/main/java/org/opensearch/action/admin/indices/settings/get/TransportGetSettingsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/settings/get/TransportGetSettingsAction.java
@@ -121,7 +121,12 @@ public class TransportGetSettingsAction extends TransportClusterManagerNodeReadA
                 continue;
             }
 
-            Settings indexSettings = settingsFilter.filter(indexMetadata.getSettings());
+            Settings indexSettingsWithRoutingShards = Settings.builder()
+                .put(indexMetadata.getSettings())
+                .put(IndexMetadata.INDEX_NUMBER_OF_ROUTING_SHARDS_SETTING.getKey(), indexMetadata.getRoutingNumShards())
+                .build();
+
+            Settings indexSettings = settingsFilter.filter(indexSettingsWithRoutingShards);
             if (request.humanReadable()) {
                 indexSettings = IndexMetadata.addHumanReadableSettings(indexSettings);
             }

--- a/server/src/test/java/org/opensearch/action/admin/indices/settings/get/GetSettingsActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/settings/get/GetSettingsActionTests.java
@@ -165,6 +165,16 @@ public class GetSettingsActionTests extends OpenSearchTestCase {
         }, exception -> { throw new AssertionError(exception); }));
     }
 
+    public void testShouldReturnNumberOfRoutingShards() {
+        GetSettingsRequest noDefaultsRequest = new GetSettingsRequest().indices(indexName);
+        getSettingsAction.execute(null, noDefaultsRequest, ActionListener.wrap(noDefaultsResponse -> {
+            assertNotNull(
+                "index.number_of_routing_shards should be set",
+                noDefaultsResponse.getSetting(indexName, "index.number_of_routing_shards")
+            );
+        }, exception -> { throw new AssertionError(exception); }));
+    }
+
     static class Resolver extends IndexNameExpressionResolver {
         Resolver() {
             super(new ThreadContext(Settings.EMPTY));


### PR DESCRIPTION
… GetSettingsResponse

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Adds `number_of_routing_shards` into indexSettings before passing into `GetSettingsResponse`. Alternative solution to [PR-4443](https://github.com/opensearch-project/OpenSearch/pull/14443).

### Related Issues
Resolves #14199 
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
