### PR TITLE
Adding params for enabling and disabling mapping_stats and analysis_s…

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/stats/ClusterStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/stats/ClusterStatsIT.java
@@ -288,7 +288,12 @@ public class ClusterStatsIT extends OpenSearchIntegTestCase {
     public void testFieldTypes() {
         internalCluster().startNode();
         ensureGreen();
-        ClusterStatsResponse response = client().admin().cluster().prepareClusterStats().get();
+        ClusterStatsResponse response = client().admin()
+            .cluster()
+            .prepareClusterStats()
+            .includeAnalysisStats(true)
+            .includeMappingStats(true)
+            .get();
         assertThat(response.getStatus(), Matchers.equalTo(ClusterHealthStatus.GREEN));
         assertTrue(response.getIndicesStats().getMappings().getFieldTypeStats().isEmpty());
 
@@ -301,7 +306,7 @@ public class ClusterStatsIT extends OpenSearchIntegTestCase {
                     + "\"eggplant\":{\"type\":\"integer\"}}}}}"
             )
             .get();
-        response = client().admin().cluster().prepareClusterStats().get();
+        response = client().admin().cluster().prepareClusterStats().includeMappingStats(true).includeAnalysisStats(true).get();
         assertThat(response.getIndicesStats().getMappings().getFieldTypeStats().size(), equalTo(3));
         Set<IndexFeatureStats> stats = response.getIndicesStats().getMappings().getFieldTypeStats();
         for (IndexFeatureStats stat : stats) {

--- a/server/src/main/java/org/opensearch/action/ActionModule.java
+++ b/server/src/main/java/org/opensearch/action/ActionModule.java
@@ -808,7 +808,7 @@ public class ActionModule extends AbstractModule {
         registerHandler.accept(new RestNodesUsageAction());
         registerHandler.accept(new RestNodesHotThreadsAction());
         registerHandler.accept(new RestClusterAllocationExplainAction());
-        registerHandler.accept(new RestClusterStatsAction());
+        registerHandler.accept(new RestClusterStatsAction(settings, clusterSettings));
         registerHandler.accept(new RestClusterStateAction(settingsFilter));
         registerHandler.accept(new RestClusterHealthAction());
         registerHandler.accept(new RestClusterUpdateSettingsAction());

--- a/server/src/main/java/org/opensearch/action/admin/cluster/stats/ClusterStatsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/stats/ClusterStatsRequest.java
@@ -47,8 +47,27 @@ import java.io.IOException;
 @PublicApi(since = "1.0.0")
 public class ClusterStatsRequest extends BaseNodesRequest<ClusterStatsRequest> {
 
+    private boolean includeMappingStats;
+    private boolean includeAnalysisStats;
+
     public ClusterStatsRequest(StreamInput in) throws IOException {
         super(in);
+    }
+
+    public void setIncludeMappingStats(boolean bool) {
+        this.includeMappingStats = bool;
+    }
+
+    public boolean isIncludeMappingStats() {
+        return includeMappingStats;
+    }
+
+    public void setIncludeAnalysisStats(boolean bool) {
+        this.includeAnalysisStats = bool;
+    }
+
+    public boolean isIncludeAnalysisStats() {
+        return includeAnalysisStats;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/action/admin/cluster/stats/ClusterStatsRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/stats/ClusterStatsRequestBuilder.java
@@ -50,4 +50,14 @@ public class ClusterStatsRequestBuilder extends NodesOperationRequestBuilder<
     public ClusterStatsRequestBuilder(OpenSearchClient client, ClusterStatsAction action) {
         super(client, action, new ClusterStatsRequest());
     }
+
+    public ClusterStatsRequestBuilder includeMappingStats(boolean value) {
+        request.setIncludeMappingStats(value);
+        return this;
+    }
+
+    public ClusterStatsRequestBuilder includeAnalysisStats(boolean value) {
+        request.setIncludeAnalysisStats(value);
+        return this;
+    }
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/stats/ClusterStatsResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/stats/ClusterStatsResponse.java
@@ -105,6 +105,35 @@ public class ClusterStatsResponse extends BaseNodesResponse<ClusterStatsNodeResp
         this.status = status;
     }
 
+    public ClusterStatsResponse(
+        long timestamp,
+        String clusterUUID,
+        ClusterName clusterName,
+        List<ClusterStatsNodeResponse> nodes,
+        List<FailedNodeException> failures,
+        ClusterState state,
+        ClusterStatsRequest request
+    ) {
+        super(clusterName, nodes, failures);
+        this.clusterUUID = clusterUUID;
+        this.timestamp = timestamp;
+        nodesStats = new ClusterStatsNodes(nodes);
+        indicesStats = new ClusterStatsIndices(
+            nodes,
+            request.isIncludeMappingStats() ? MappingStats.of(state) : null,
+            request.isIncludeAnalysisStats() ? AnalysisStats.of(state) : null
+        );
+        ClusterHealthStatus status = null;
+        for (ClusterStatsNodeResponse response : nodes) {
+            // only the cluster-manager node populates the status
+            if (response.clusterStatus() != null) {
+                status = response.clusterStatus();
+                break;
+            }
+        }
+        this.status = status;
+    }
+
     public String getClusterUUID() {
         return this.clusterUUID;
     }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -129,7 +129,8 @@ public class TransportClusterStatsAction extends TransportNodesAction<
             clusterService.getClusterName(),
             responses,
             failures,
-            state
+            state,
+            request
         );
     }
 

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -149,6 +149,7 @@ import org.opensearch.ratelimitting.admissioncontrol.settings.CpuBasedAdmissionC
 import org.opensearch.ratelimitting.admissioncontrol.settings.IoBasedAdmissionControllerSettings;
 import org.opensearch.repositories.fs.FsRepository;
 import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.action.admin.cluster.RestClusterStatsAction;
 import org.opensearch.script.ScriptService;
 import org.opensearch.search.SearchModule;
 import org.opensearch.search.SearchService;
@@ -749,7 +750,9 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 RemoteStoreSettings.CLUSTER_REMOTE_STORE_PATH_HASH_ALGORITHM_SETTING,
                 RemoteStoreSettings.CLUSTER_REMOTE_MAX_TRANSLOG_READERS,
                 RemoteStoreSettings.CLUSTER_REMOTE_STORE_TRANSLOG_METADATA,
-                SearchService.CLUSTER_ALLOW_DERIVED_FIELD_SETTING
+                SearchService.CLUSTER_ALLOW_DERIVED_FIELD_SETTING,
+
+                RestClusterStatsAction.CLUSTER_STATS_LEVEL_SETTING
             )
         )
     );


### PR DESCRIPTION
…tats with flags

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The current implementation of the cluster stats API includes mapping and analysis stats by default. While this does not cause any significant overhead for small and medium clusters, iterating over the entire cluster state on the coordinator node to generate these stats can incur significant overhead in large clusters, especially with complex mappings or a large cluster state. 

![image](https://github.com/opensearch-project/OpenSearch/assets/55992439/f34a792b-01f0-4cd4-bee6-d2dd8104cc07)

This pull request proposes introducing a new experimental flag, `opensearch.experimental.optimization.cluster_stats.response_level` (default: 2), to control the inclusion of mapping and analysis stats in the cluster stats response:

| Response Level | Mapping Stats | Analysis Stats | 
| -- | -- | -- |
| 1 | No | No |
| 2 | Yes | Yes |

Benefits:

1. Reduced Overhead: Users managing large clusters can choose response level 1 to exclude mapping and analysis stats, improving the performance of the cluster stats API call.
2. Fine-Grained Control: Users can tailor the response to their specific needs, reducing unnecessary data transfer and processing.

For users who still require mapping and analysis stats at response level 1, the following parameters can be included in the REST call:

`include_mapping_stats` -> To include mapping stats
`include_analysis_stats` -> To include analysis stats


My Take on Response Levels:
While the introduction of response levels is an experimental step in this PR, it might be beneficial to explore further granularity in the future. Providing additional parameters within the REST API to allow users to choose specific layers of ClusterStats response would offer even finer control over the response content and minimize data transfer for various use cases.


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
