### PR TITLE
Added Eco-CI

### DIFF
--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -1,5 +1,6 @@
 name: Gradle Assemble
-on: [pull_request]
+on:
+  pull_request:
 
 jobs:
   assemble:
@@ -10,12 +11,38 @@ jobs:
         java: [ 11, 17, 21 ]
         os: [ubuntu-latest, windows-latest, macos-13]
     steps:
+      - name: Eco CI Energy Estimation - Initialize
+        if: matrix.os == 'ubuntu-latest'
+        uses: green-coding-solutions/eco-ci-energy-estimation@v4.0-rc3
+        with:
+          task: start-measurement
+        continue-on-error: true
+
       - uses: actions/checkout@v4
+
+      - name: Eco CI Energy Estimation - Get Measurement
+        if: matrix.os == 'ubuntu-latest'
+        uses: green-coding-solutions/eco-ci-energy-estimation@v4.0-rc3
+        with:
+          task: get-measurement
+          label: 'checkout'
+        continue-on-error: true
+
+
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: temurin
+
+      - name: Eco CI Energy Estimation - Get Measurement
+        if: matrix.os == 'ubuntu-latest'
+        uses: green-coding-solutions/eco-ci-energy-estimation@v4.0-rc3
+        with:
+          task: get-measurement
+          label: 'set up JDK'
+        continue-on-error: true
+
       - name: Setup docker (missing on MacOS)
         id: setup_docker
         if: runner.os == 'macos'
@@ -24,6 +51,7 @@ jobs:
         with:
           upgrade-qemu: true
           colima:  v0.6.8
+
       - name: Run Gradle (assemble)
         if: runner.os == 'macos' && steps.setup_docker.outcome != 'success'
         run: |
@@ -33,7 +61,24 @@ jobs:
         if: runner.os != 'macos'
         run: |
           ./gradlew assemble --parallel --no-build-cache -PDISABLE_BUILD_CACHE
+
       - name: Run Gradle (assemble)
         if: runner.os == 'macos' && steps.setup_docker.outcome == 'success'
         run: |
           ./gradlew assemble --parallel --no-build-cache -PDISABLE_BUILD_CACHE
+
+      - name: Eco CI Energy Estimation - Get Measurement
+        if: matrix.os == 'ubuntu-latest'
+        uses: green-coding-solutions/eco-ci-energy-estimation@v4.0-rc3
+        with:
+          task: get-measurement
+          label: 'gradlew assemble'
+        continue-on-error: true
+
+      - name: Eco CI Energy Estimation - End Measurement
+        if: matrix.os == 'ubuntu-latest'
+        uses: green-coding-solutions/eco-ci-energy-estimation@v4.0-rc3
+        with:
+          task: display-results
+          send-data: true
+        continue-on-error: true


### PR DESCRIPTION
### Description
This pull requests is a bit out of the ordinary ... I hope :)

I mainly follows up on a discussion with the [CNCF TAG ENV](https://github.com/cncf-tags/green-reviews-tooling/issues/55) where @wbeckler encouraged us to integrate to make a PR here. But now for the details:

I work for an open source company called Green Coding Solutions in Germany and we started with the mission to increase awareness and actionability around digital CO2 emissions.

We have recently created an open source CI/CD plugin called Eco-CI. 
- [Project page](https://www.green-coding.io/projects/eco-ci/)
- [Github Page](https://github.com/green-coding-solutions/eco-ci-energy-estimation)

It integrates into the Github Actions pipeline and estimates the energy and CO2 consumption of the pipeline by utilizing a Machine Learning model trained on real server energy data from [SPECpower](https://www.spec.org/power_ssj2008/results/)

The tool creates awareness of the energy cost and carbon emissions of CI/CD pipelines and empoweres developers to create action for more sustainability.
It can separate steps of the pipeline and create detailed drill-downs which step has increased / decreased in carbon emissions and provider great insights into pipeline performance in general.

Since OpenSearch is a CNCF project and some members from your TAG ENV are active here I hope you find it adjacent to your work :)

In this PR I have made a sample integration into the `.github/workflows/assemble.yml` pipeline. It will show the current pipline energy cost and CO2 emissions (only for linux though atm) and will also provide an aggregate view on https://metrics.green-coding.io/ci-index.html

I hope this PR and the information that Eco-CI provides is interesting for you and I am super interested in your feedback on  it. 

## Changelog

- Added Eco-CI into the `.github/workflows/assemble.yml` pipeline
- Activated the `send-data: true` flag. This will send data to be used as historical data view on https://metrics.green-coding.io/ci-index.html . If this is not desired it must be set to false.
- Nothing to be documented in the OpenSearch Changelog as it is only a CI change

## Demo

- An example of where we have run it before making the PR in the forked repository to verify that the pipeline works
  - https://github.com/green-coding-solutions/OpenSearch/actions/runs/9566625147 (Since your pipeline skips some workflows it shows this status. Linux ran fine though)

- A possible upgrade could also be to show the energy and CO2 cost in every PR as message. See an example here: https://github.com/green-coding-solutions/green-metrics-tool/pull/816#issuecomment-2177937727
  - Since this requires to set an additional permission to the workflow I omitted this for now. Let me know if you want to bring this in 
 

@ribalba @MichelleGruene @wbeckler @by-d-sign @leonardpahlke @nikimanoledaki

### Related Issues
- None
- 
### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
I have also signed my commit.