### PR TITLE
Add unit tests for read flow of RemoteClusterStateService and bug fix for transient settings

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/coordination/PublicationTransportHandler.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/PublicationTransportHandler.java
@@ -284,7 +284,6 @@ public class PublicationTransportHandler {
                 )
             );
             ClusterState clusterState = remoteClusterStateService.getClusterStateUsingDiff(
-                request.getClusterName(),
                 manifest,
                 lastSeen,
                 transportService.getLocalNode().getId()

--- a/server/src/main/java/org/opensearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/Metadata.java
@@ -1286,6 +1286,11 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             return this;
         }
 
+        public Builder removeAllTemplates() {
+            templates.clear();
+            return this;
+        }
+
         public Builder templates(TemplatesMetadata templatesMetadata) {
             this.templates.clear();
             this.templates.putAll(templatesMetadata.getTemplates());

--- a/server/src/main/java/org/opensearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/Metadata.java
@@ -1286,11 +1286,6 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             return this;
         }
 
-        public Builder removeAllTemplates() {
-            templates.clear();
-            return this;
-        }
-
         public Builder templates(TemplatesMetadata templatesMetadata) {
             this.templates.clear();
             this.templates.putAll(templatesMetadata.getTemplates());

--- a/server/src/main/java/org/opensearch/gateway/remote/ClusterStateDiffManifest.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/ClusterStateDiffManifest.java
@@ -25,6 +25,7 @@ import org.opensearch.core.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -152,17 +153,17 @@ public class ClusterStateDiffManifest implements ToXContentFragment, Writeable {
         this.settingsMetadataUpdated = settingsMetadataUpdated;
         this.transientSettingsMetadataUpdated = transientSettingsMetadataUpdate;
         this.templatesMetadataUpdated = templatesMetadataUpdated;
-        this.customMetadataUpdated = customMetadataUpdated;
-        this.customMetadataDeleted = customMetadataDeleted;
-        this.indicesUpdated = indicesUpdated;
-        this.indicesDeleted = indicesDeleted;
+        this.customMetadataUpdated = Collections.unmodifiableList(customMetadataUpdated);
+        this.customMetadataDeleted = Collections.unmodifiableList(customMetadataDeleted);
+        this.indicesUpdated = Collections.unmodifiableList(indicesUpdated);
+        this.indicesDeleted = Collections.unmodifiableList(indicesDeleted);
         this.clusterBlocksUpdated = clusterBlocksUpdated;
         this.discoveryNodesUpdated = discoveryNodesUpdated;
-        this.indicesRoutingUpdated = indicesRoutingUpdated;
-        this.indicesRoutingDeleted = indicesRoutingDeleted;
+        this.indicesRoutingUpdated = Collections.unmodifiableList(indicesRoutingUpdated);
+        this.indicesRoutingDeleted = Collections.unmodifiableList(indicesRoutingDeleted);
         this.hashesOfConsistentSettingsUpdated = hashesOfConsistentSettingsUpdated;
-        this.clusterStateCustomUpdated = clusterStateCustomUpdated;
-        this.clusterStateCustomDeleted = clusterStateCustomDeleted;
+        this.clusterStateCustomUpdated = Collections.unmodifiableList(clusterStateCustomUpdated);
+        this.clusterStateCustomDeleted = Collections.unmodifiableList(clusterStateCustomDeleted);
     }
 
     public ClusterStateDiffManifest(StreamInput in) throws IOException {
@@ -563,7 +564,16 @@ public class ClusterStateDiffManifest implements ToXContentFragment, Writeable {
         private List<String> clusterStateCustomUpdated;
         private List<String> clusterStateCustomDeleted;
 
-        public Builder() {}
+        public Builder() {
+            customMetadataUpdated = Collections.emptyList();
+            customMetadataDeleted = Collections.emptyList();
+            indicesUpdated = Collections.emptyList();
+            indicesDeleted = Collections.emptyList();
+            indicesRoutingUpdated = Collections.emptyList();
+            indicesRoutingDeleted = Collections.emptyList();
+            clusterStateCustomUpdated = Collections.emptyList();
+            clusterStateCustomDeleted = Collections.emptyList();
+        }
 
         public Builder fromStateUUID(String fromStateUUID) {
             this.fromStateUUID = fromStateUUID;

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -1234,8 +1234,6 @@ public class RemoteClusterStateService implements Closeable {
                     metadataBuilder.transientSettings((Settings) remoteReadResult.getObj());
                     break;
                 case TEMPLATES_METADATA:
-                    // we need to remove the older templates, as the templates will be refreshed from remote file
-                    metadataBuilder.removeAllTemplates();
                     metadataBuilder.templates((TemplatesMetadata) remoteReadResult.getObj());
                     break;
                 case HASHES_OF_CONSISTENT_SETTINGS:

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateAttributesManagerTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateAttributesManagerTests.java
@@ -8,9 +8,7 @@
 
 package org.opensearch.gateway.remote;
 
-import org.opensearch.Version;
 import org.opensearch.action.LatchedActionListener;
-import org.opensearch.cluster.AbstractNamedDiffable;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.ClusterState.Custom;
@@ -23,11 +21,8 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.TestCapturingListener;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
-import org.opensearch.core.common.io.stream.StreamInput;
-import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.compress.Compressor;
 import org.opensearch.core.compress.NoneCompressor;
-import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.gateway.remote.model.RemoteClusterBlocks;
 import org.opensearch.gateway.remote.model.RemoteClusterStateCustoms;
 import org.opensearch.gateway.remote.model.RemoteDiscoveryNodes;
@@ -51,6 +46,10 @@ import static org.opensearch.common.blobstore.stream.write.WritePriority.URGENT;
 import static org.opensearch.gateway.remote.RemoteClusterStateAttributesManager.CLUSTER_STATE_ATTRIBUTE;
 import static org.opensearch.gateway.remote.RemoteClusterStateAttributesManager.CLUSTER_STATE_ATTRIBUTES_CURRENT_CODEC_VERSION;
 import static org.opensearch.gateway.remote.RemoteClusterStateAttributesManager.DISCOVERY_NODES;
+import static org.opensearch.gateway.remote.RemoteClusterStateTestUtils.TestClusterStateCustom1;
+import static org.opensearch.gateway.remote.RemoteClusterStateTestUtils.TestClusterStateCustom2;
+import static org.opensearch.gateway.remote.RemoteClusterStateTestUtils.TestClusterStateCustom3;
+import static org.opensearch.gateway.remote.RemoteClusterStateTestUtils.TestClusterStateCustom4;
 import static org.opensearch.gateway.remote.RemoteClusterStateUtils.CLUSTER_STATE_EPHEMERAL_PATH_TOKEN;
 import static org.opensearch.gateway.remote.RemoteClusterStateUtils.CLUSTER_STATE_PATH_TOKEN;
 import static org.opensearch.gateway.remote.RemoteClusterStateUtils.CUSTOM_DELIMITER;
@@ -338,22 +337,22 @@ public class RemoteClusterStateAttributesManagerTests extends OpenSearchTestCase
 
     public void testGetUpdatedCustoms() {
         Map<String, ClusterState.Custom> previousCustoms = Map.of(
-            TestCustom1.TYPE,
-            new TestCustom1("data1"),
-            TestCustom2.TYPE,
-            new TestCustom2("data2"),
-            TestCustom3.TYPE,
-            new TestCustom3("data3")
+            TestClusterStateCustom1.TYPE,
+            new TestClusterStateCustom1("data1"),
+            TestClusterStateCustom2.TYPE,
+            new TestClusterStateCustom2("data2"),
+            TestClusterStateCustom3.TYPE,
+            new TestClusterStateCustom3("data3")
         );
         ClusterState previousState = ClusterState.builder(new ClusterName("test-cluster")).customs(previousCustoms).build();
 
         Map<String, Custom> currentCustoms = Map.of(
-            TestCustom2.TYPE,
-            new TestCustom2("data2"),
-            TestCustom3.TYPE,
-            new TestCustom3("data3-changed"),
-            TestCustom4.TYPE,
-            new TestCustom4("data4")
+            TestClusterStateCustom2.TYPE,
+            new TestClusterStateCustom2("data2"),
+            TestClusterStateCustom3.TYPE,
+            new TestClusterStateCustom3("data3-changed"),
+            TestClusterStateCustom4.TYPE,
+            new TestClusterStateCustom4("data4")
         );
 
         ClusterState currentState = ClusterState.builder(new ClusterName("test-cluster")).customs(currentCustoms).build();
@@ -368,136 +367,14 @@ public class RemoteClusterStateAttributesManagerTests extends OpenSearchTestCase
         assertThat(customsDiff.getDeletes(), is(Collections.emptyList()));
 
         Map<String, ClusterState.Custom> expectedCustoms = Map.of(
-            TestCustom3.TYPE,
-            new TestCustom3("data3-changed"),
-            TestCustom4.TYPE,
-            new TestCustom4("data4")
+            TestClusterStateCustom3.TYPE,
+            new TestClusterStateCustom3("data3-changed"),
+            TestClusterStateCustom4.TYPE,
+            new TestClusterStateCustom4("data4")
         );
 
         customsDiff = remoteClusterStateAttributesManager.getUpdatedCustoms(currentState, previousState, true, false);
         assertThat(customsDiff.getUpserts(), is(expectedCustoms));
-        assertThat(customsDiff.getDeletes(), is(List.of(TestCustom1.TYPE)));
-    }
-
-    private static abstract class AbstractTestCustom extends AbstractNamedDiffable<Custom> implements ClusterState.Custom {
-
-        private final String value;
-
-        AbstractTestCustom(String value) {
-            this.value = value;
-        }
-
-        AbstractTestCustom(StreamInput in) throws IOException {
-            this.value = in.readString();
-        }
-
-        @Override
-        public Version getMinimalSupportedVersion() {
-            return Version.CURRENT;
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            out.writeString(value);
-        }
-
-        @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            return builder;
-        }
-
-        @Override
-        public boolean isPrivate() {
-            return true;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-
-            AbstractTestCustom that = (AbstractTestCustom) o;
-
-            if (!value.equals(that.value)) return false;
-
-            return true;
-        }
-
-        @Override
-        public int hashCode() {
-            return value.hashCode();
-        }
-    }
-
-    private static class TestCustom1 extends AbstractTestCustom {
-
-        private static final String TYPE = "custom_1";
-
-        TestCustom1(String value) {
-            super(value);
-        }
-
-        TestCustom1(StreamInput in) throws IOException {
-            super(in);
-        }
-
-        @Override
-        public String getWriteableName() {
-            return TYPE;
-        }
-    }
-
-    private static class TestCustom2 extends AbstractTestCustom {
-
-        private static final String TYPE = "custom_2";
-
-        TestCustom2(String value) {
-            super(value);
-        }
-
-        TestCustom2(StreamInput in) throws IOException {
-            super(in);
-        }
-
-        @Override
-        public String getWriteableName() {
-            return TYPE;
-        }
-    }
-
-    private static class TestCustom3 extends AbstractTestCustom {
-
-        private static final String TYPE = "custom_3";
-
-        TestCustom3(String value) {
-            super(value);
-        }
-
-        TestCustom3(StreamInput in) throws IOException {
-            super(in);
-        }
-
-        @Override
-        public String getWriteableName() {
-            return TYPE;
-        }
-    }
-
-    private static class TestCustom4 extends AbstractTestCustom {
-
-        private static final String TYPE = "custom_4";
-
-        TestCustom4(String value) {
-            super(value);
-        }
-
-        TestCustom4(StreamInput in) throws IOException {
-            super(in);
-        }
-
-        @Override
-        public String getWriteableName() {
-            return TYPE;
-        }
+        assertThat(customsDiff.getDeletes(), is(List.of(TestClusterStateCustom1.TYPE)));
     }
 }

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
@@ -536,12 +536,8 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
                 anyList()
             )
         ).thenReturn(new RemoteClusterStateUtils.UploadedMetadataResults());
-        try {
-            spiedService.writeFullMetadata(clusterState, randomAlphaOfLength(10));
-        } catch (Exception e) {
-            assertTrue(e instanceof RemoteStateTransferException);
-            assertTrue(e.getMessage().contains("Timed out waiting for transfer of manifest file to complete"));
-        }
+        RemoteStateTransferException ex = expectThrows(RemoteStateTransferException.class, () -> spiedService.writeFullMetadata(clusterState, randomAlphaOfLength(10)));
+        assertTrue(ex.getMessage().contains("Timed out waiting for transfer of manifest file to complete"));
     }
 
     public void testWriteFullMetadataInParallelFailureForIndexMetadata() throws IOException {
@@ -835,9 +831,9 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
         remoteClusterStateService.setRemoteIndexMetadataManager(mockedIndexManager);
         remoteClusterStateService.setRemoteGlobalMetadataManager(mockedGlobalMetadataManager);
         remoteClusterStateService.setRemoteClusterStateAttributesManager(mockedClusterStateAttributeManager);
-        RemoteClusterStateService mockService = spy(remoteClusterStateService);
-        mockService.getClusterStateForManifest(ClusterName.DEFAULT.value(), manifest, NODE_ID, false);
-        verify(mockService, times(1)).readClusterStateInParallel(
+        RemoteClusterStateService spiedService = spy(remoteClusterStateService);
+        spiedService.getClusterStateForManifest(ClusterName.DEFAULT.value(), manifest, NODE_ID, false);
+        verify(spiedService, times(1)).readClusterStateInParallel(
             any(),
             eq(manifest),
             eq(manifest.getClusterUUID()),

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
@@ -536,7 +536,10 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
                 anyList()
             )
         ).thenReturn(new RemoteClusterStateUtils.UploadedMetadataResults());
-        RemoteStateTransferException ex = expectThrows(RemoteStateTransferException.class, () -> spiedService.writeFullMetadata(clusterState, randomAlphaOfLength(10)));
+        RemoteStateTransferException ex = expectThrows(
+            RemoteStateTransferException.class,
+            () -> spiedService.writeFullMetadata(clusterState, randomAlphaOfLength(10))
+        );
         assertTrue(ex.getMessage().contains("Timed out waiting for transfer of manifest file to complete"));
     }
 

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateTestUtils.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateTestUtils.java
@@ -1,0 +1,227 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.gateway.remote;
+
+import org.opensearch.Version;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.test.TestClusterStateCustom;
+import org.opensearch.test.TestCustomMetadata;
+
+import java.io.IOException;
+import java.util.EnumSet;
+
+public class RemoteClusterStateTestUtils {
+    public static class CustomMetadata1 extends TestCustomMetadata {
+        public static final String TYPE = "custom_md_1";
+
+        public CustomMetadata1(String data) {
+            super(data);
+        }
+
+        public CustomMetadata1(StreamInput in) throws IOException {
+            super(in.readString());
+        }
+
+        @Override
+        public String getWriteableName() {
+            return TYPE;
+        }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.CURRENT;
+        }
+
+        @Override
+        public EnumSet<Metadata.XContentContext> context() {
+            return EnumSet.of(Metadata.XContentContext.GATEWAY);
+        }
+    }
+
+    public static class CustomMetadata2 extends TestCustomMetadata {
+        public static final String TYPE = "custom_md_2";
+
+        public CustomMetadata2(String data) {
+            super(data);
+        }
+
+        public CustomMetadata2(StreamInput in) throws IOException {
+            super(in.readString());
+        }
+
+        @Override
+        public String getWriteableName() {
+            return TYPE;
+        }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.CURRENT;
+        }
+
+        @Override
+        public EnumSet<Metadata.XContentContext> context() {
+            return EnumSet.of(Metadata.XContentContext.GATEWAY);
+        }
+    }
+
+    public static class CustomMetadata3 extends TestCustomMetadata {
+        public static final String TYPE = "custom_md_3";
+
+        public CustomMetadata3(String data) {
+            super(data);
+        }
+
+        public CustomMetadata3(StreamInput in) throws IOException {
+            super(in.readString());
+        }
+
+        @Override
+        public String getWriteableName() {
+            return TYPE;
+        }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.CURRENT;
+        }
+
+        @Override
+        public EnumSet<Metadata.XContentContext> context() {
+            return EnumSet.of(Metadata.XContentContext.GATEWAY);
+        }
+    }
+
+    public static class CustomMetadata4 extends TestCustomMetadata {
+        public static final String TYPE = "custom_md_4";
+
+        public CustomMetadata4(String data) {
+            super(data);
+        }
+
+        public CustomMetadata4(StreamInput in) throws IOException {
+            super(in.readString());
+        }
+
+        @Override
+        public String getWriteableName() {
+            return TYPE;
+        }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.CURRENT;
+        }
+
+        @Override
+        public EnumSet<Metadata.XContentContext> context() {
+            return EnumSet.of(Metadata.XContentContext.GATEWAY);
+        }
+    }
+
+    public static class CustomMetadata5 extends TestCustomMetadata {
+        public static final String TYPE = "custom_md_5";
+
+        public CustomMetadata5(String data) {
+            super(data);
+        }
+
+        public CustomMetadata5(StreamInput in) throws IOException {
+            super(in.readString());
+        }
+
+        @Override
+        public String getWriteableName() {
+            return TYPE;
+        }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.CURRENT;
+        }
+
+        @Override
+        public EnumSet<Metadata.XContentContext> context() {
+            return EnumSet.of(Metadata.XContentContext.API);
+        }
+    }
+
+    public static class TestClusterStateCustom1 extends TestClusterStateCustom {
+
+        public static final String TYPE = "custom_1";
+
+        public TestClusterStateCustom1(String value) {
+            super(value);
+        }
+
+        public TestClusterStateCustom1(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        @Override
+        public String getWriteableName() {
+            return TYPE;
+        }
+    }
+
+    public static class TestClusterStateCustom2 extends TestClusterStateCustom {
+
+        public static final String TYPE = "custom_2";
+
+        public TestClusterStateCustom2(String value) {
+            super(value);
+        }
+
+        public TestClusterStateCustom2(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        @Override
+        public String getWriteableName() {
+            return TYPE;
+        }
+    }
+
+    public static class TestClusterStateCustom3 extends TestClusterStateCustom {
+
+        public static final String TYPE = "custom_3";
+
+        public TestClusterStateCustom3(String value) {
+            super(value);
+        }
+
+        public TestClusterStateCustom3(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        @Override
+        public String getWriteableName() {
+            return TYPE;
+        }
+    }
+
+    public static class TestClusterStateCustom4 extends TestClusterStateCustom {
+
+        public static final String TYPE = "custom_4";
+
+        public TestClusterStateCustom4(String value) {
+            super(value);
+        }
+
+        public TestClusterStateCustom4(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        @Override
+        public String getWriteableName() {
+            return TYPE;
+        }
+    }
+}

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteGlobalMetadataManagerTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteGlobalMetadataManagerTests.java
@@ -8,7 +8,6 @@
 
 package org.opensearch.gateway.remote;
 
-import org.opensearch.Version;
 import org.opensearch.action.LatchedActionListener;
 import org.opensearch.cluster.ClusterModule;
 import org.opensearch.cluster.ClusterName;
@@ -18,7 +17,6 @@ import org.opensearch.cluster.coordination.CoordinationMetadata;
 import org.opensearch.cluster.metadata.DiffableStringMap;
 import org.opensearch.cluster.metadata.IndexGraveyard;
 import org.opensearch.cluster.metadata.Metadata;
-import org.opensearch.cluster.metadata.Metadata.XContentContext;
 import org.opensearch.cluster.metadata.TemplatesMetadata;
 import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.common.network.NetworkModule;
@@ -43,7 +41,6 @@ import org.opensearch.index.translog.transfer.BlobStoreTransferService;
 import org.opensearch.indices.IndicesModule;
 import org.opensearch.repositories.blobstore.BlobStoreRepository;
 import org.opensearch.test.OpenSearchTestCase;
-import org.opensearch.test.TestCustomMetadata;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 import org.junit.After;
@@ -51,7 +48,6 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -61,6 +57,11 @@ import java.util.stream.Stream;
 import static java.util.stream.Collectors.toList;
 import static org.opensearch.cluster.metadata.Metadata.isGlobalStateEquals;
 import static org.opensearch.common.blobstore.stream.write.WritePriority.URGENT;
+import static org.opensearch.gateway.remote.RemoteClusterStateTestUtils.CustomMetadata1;
+import static org.opensearch.gateway.remote.RemoteClusterStateTestUtils.CustomMetadata2;
+import static org.opensearch.gateway.remote.RemoteClusterStateTestUtils.CustomMetadata3;
+import static org.opensearch.gateway.remote.RemoteClusterStateTestUtils.CustomMetadata4;
+import static org.opensearch.gateway.remote.RemoteClusterStateTestUtils.CustomMetadata5;
 import static org.opensearch.gateway.remote.RemoteClusterStateUtils.CLUSTER_STATE_PATH_TOKEN;
 import static org.opensearch.gateway.remote.RemoteClusterStateUtils.CUSTOM_DELIMITER;
 import static org.opensearch.gateway.remote.RemoteClusterStateUtils.DELIMITER;
@@ -699,121 +700,5 @@ public class RemoteGlobalMetadataManagerTests extends OpenSearchTestCase {
         );
         assertThat(customsDiff.getUpserts(), is(expectedUpserts));
         assertThat(customsDiff.getDeletes(), is(List.of(CustomMetadata1.TYPE)));
-
-    }
-
-    private static class CustomMetadata1 extends TestCustomMetadata {
-        public static final String TYPE = "custom_md_1";
-
-        CustomMetadata1(String data) {
-            super(data);
-        }
-
-        @Override
-        public String getWriteableName() {
-            return TYPE;
-        }
-
-        @Override
-        public Version getMinimalSupportedVersion() {
-            return Version.CURRENT;
-        }
-
-        @Override
-        public EnumSet<XContentContext> context() {
-            return EnumSet.of(Metadata.XContentContext.GATEWAY);
-        }
-    }
-
-    private static class CustomMetadata2 extends TestCustomMetadata {
-        public static final String TYPE = "custom_md_2";
-
-        CustomMetadata2(String data) {
-            super(data);
-        }
-
-        @Override
-        public String getWriteableName() {
-            return TYPE;
-        }
-
-        @Override
-        public Version getMinimalSupportedVersion() {
-            return Version.CURRENT;
-        }
-
-        @Override
-        public EnumSet<Metadata.XContentContext> context() {
-            return EnumSet.of(Metadata.XContentContext.GATEWAY);
-        }
-    }
-
-    private static class CustomMetadata3 extends TestCustomMetadata {
-        public static final String TYPE = "custom_md_3";
-
-        CustomMetadata3(String data) {
-            super(data);
-        }
-
-        @Override
-        public String getWriteableName() {
-            return TYPE;
-        }
-
-        @Override
-        public Version getMinimalSupportedVersion() {
-            return Version.CURRENT;
-        }
-
-        @Override
-        public EnumSet<Metadata.XContentContext> context() {
-            return EnumSet.of(Metadata.XContentContext.GATEWAY);
-        }
-    }
-
-    private static class CustomMetadata4 extends TestCustomMetadata {
-        public static final String TYPE = "custom_md_4";
-
-        CustomMetadata4(String data) {
-            super(data);
-        }
-
-        @Override
-        public String getWriteableName() {
-            return TYPE;
-        }
-
-        @Override
-        public Version getMinimalSupportedVersion() {
-            return Version.CURRENT;
-        }
-
-        @Override
-        public EnumSet<Metadata.XContentContext> context() {
-            return EnumSet.of(Metadata.XContentContext.GATEWAY);
-        }
-    }
-
-    private static class CustomMetadata5 extends TestCustomMetadata {
-        public static final String TYPE = "custom_md_5";
-
-        CustomMetadata5(String data) {
-            super(data);
-        }
-
-        @Override
-        public String getWriteableName() {
-            return TYPE;
-        }
-
-        @Override
-        public Version getMinimalSupportedVersion() {
-            return Version.CURRENT;
-        }
-
-        @Override
-        public EnumSet<Metadata.XContentContext> context() {
-            return EnumSet.of(XContentContext.API);
-        }
     }
 }

--- a/test/framework/src/main/java/org/opensearch/test/TestClusterStateCustom.java
+++ b/test/framework/src/main/java/org/opensearch/test/TestClusterStateCustom.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.test;
+
+import org.opensearch.Version;
+import org.opensearch.cluster.AbstractNamedDiffable;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+public abstract class TestClusterStateCustom extends AbstractNamedDiffable<ClusterState.Custom> implements ClusterState.Custom {
+
+    private final String value;
+
+    protected TestClusterStateCustom(String value) {
+        this.value = value;
+    }
+
+    protected TestClusterStateCustom(StreamInput in) throws IOException {
+        this.value = in.readString();
+    }
+
+    @Override
+    public Version getMinimalSupportedVersion() {
+        return Version.CURRENT;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(value);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        return builder;
+    }
+
+    @Override
+    public boolean isPrivate() {
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        TestClusterStateCustom that = (TestClusterStateCustom) o;
+
+        if (!value.equals(that.value)) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+}


### PR DESCRIPTION
### Description
For newly added flows for write of ephemeral objects and read of all cluster state objects in #14089, the PR lacked in coverage. Adding more tests in this flow.
Removed unused parameter from `getClusterStateUsingDiff` method.

Also, fixed a bug where we were reading transient settings from remote store even if includeEphemeral was sent as false, which is not expected here.

### Related Issues


### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
