### PR TITLE
[Remote State] Fix component name for ClusterState custom

### DIFF
--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -1160,7 +1160,8 @@ public class RemoteClusterStateService implements Closeable {
         for (Map.Entry<String, UploadedMetadataAttribute> entry : clusterStateCustomToRead.entrySet()) {
             asyncMetadataReadActions.add(
                 remoteClusterStateAttributesManager.getAsyncMetadataReadAction(
-                    CLUSTER_STATE_CUSTOM,
+                    // pass component name as cluster-state-custom--<custom_name>, so that we can interpret it later
+                    String.join(CUSTOM_DELIMITER, CLUSTER_STATE_CUSTOM, entry.getKey()),
                     new RemoteClusterStateCustoms(
                         entry.getValue().getUploadedFilename(),
                         entry.getValue().getAttributeName(),


### PR DESCRIPTION
### Description
We are expecting component name for ClusterState.Custom to be of `cluster-state-custom--<custom_name>`. This was missed during refactoring while PR review and there were no test to catch this change. For tests, I am already working on more tests in #14476.


### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
