### PR TITLE
[Flaky Test] Fix flaky test in range aggregation yaml test

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/40_range.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/40_range.yml
@@ -544,6 +544,7 @@ setup:
         body:
           settings:
             number_of_replicas: 0
+            number_of_shards: 1
             refresh_interval: -1
           mappings:
             properties:


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

The newly added yaml test `Double range profiler shows filter rewrite info` is flaky

It's a supprise to me one bulk request with 3 documents can index into 2 shards. 

Based on the profile API result, we can see 2 shards, and the optimization algorithm related profiling entry `"optimized_segments": 1` and `"inner_visited": 1` shows both shards have documents.

profile API result
```
{
  "body": {
    "took": 38,
    "timed_out": false,
    "_shards": {
      "total": 2,
      "successful": 2,
      "skipped": 0,
      "failed": 0
    },
    "hits": {
      "total": {
        "value": 3,
        "relation": "eq"
      },
      "max_score": null,
      "hits": []
    },
    "aggregations": {
      "double_range": {
        "buckets": [
          {
            "key": "*-50.0",
            "to": 50.0,
            "doc_count": 1
          },
          {
            "key": "50.0-150.0",
            "from": 50.0,
            "to": 150.0,
            "doc_count": 2
          },
          {
            "key": "150.0-*",
            "from": 150.0,
            "doc_count": 0
          }
        ]
      }
    },
    "profile": {
      "shards": [
        {
          "id": "[1c8HW1JTTFafkVnpxeWY4Q][test_profile][0]",
          "inbound_network_time_in_millis": 0,
          "outbound_network_time_in_millis": 0,
          "searches": [
            {
              "query": [
                {
                  "type": "ConstantScoreQuery",
                  "description": "ConstantScore(*:*)",
                  "time_in_nanos": 332625,
                  "breakdown": {
                    "set_min_competitive_score_count": 0,
                    "match_count": 0,
                    "shallow_advance_count": 0,
                    "next_doc": 0,
                    "score_count": 0,
                    "compute_max_score_count": 0,
                    "advance": 0,
                    "advance_count": 0,
                    "score": 0,
                    "shallow_advance": 0,
                    "create_weight_count": 1,
                    "build_scorer": 0,
                    "set_min_competitive_score": 0,
                    "match": 0,
                    "next_doc_count": 0,
                    "compute_max_score": 0,
                    "build_scorer_count": 0,
                    "create_weight": 332625
                  },
                  "children": [
                    {
                      "type": "MatchAllDocsQuery",
                      "description": "*:*",
                      "time_in_nanos": 212334,
                      "breakdown": {
                        "set_min_competitive_score_count": 0,
                        "match_count": 0,
                        "shallow_advance_count": 0,
                        "next_doc": 0,
                        "score_count": 0,
                        "compute_max_score_count": 0,
                        "advance": 0,
                        "advance_count": 0,
                        "score": 0,
                        "shallow_advance": 0,
                        "create_weight_count": 1,
                        "build_scorer": 0,
                        "set_min_competitive_score": 0,
                        "match": 0,
                        "next_doc_count": 0,
                        "compute_max_score": 0,
                        "build_scorer_count": 0,
                        "create_weight": 212334
                      }
                    }
                  ]
                }
              ],
              "rewrite_time": 12042,
              "collector": [
                {
                  "name": "MultiCollector",
                  "reason": "search_multi",
                  "time_in_nanos": 2047167,
                  "children": [
                    {
                      "name": "EarlyTerminatingCollector",
                      "reason": "search_count",
                      "time_in_nanos": 9292
                    },
                    {
                      "name": "ProfilingAggregator: [double_range]",
                      "reason": "aggregation",
                      "time_in_nanos": 2048874
                    }
                  ]
                }
              ]
            }
          ],
          "aggregations": [
            {
              "type": "RangeAggregator",
              "description": "double_range",
              "time_in_nanos": 2882125,
              "breakdown": {
                "reduce": 0,
                "build_aggregation_count": 1,
                "post_collection": 2708,
                "initialize_count": 1,
                "reduce_count": 0,
                "collect_count": 0,
                "post_collection_count": 1,
                "build_leaf_collector": 2029083,
                "build_aggregation": 838209,
                "build_leaf_collector_count": 1,
                "initialize": 12125,
                "collect": 0
              },
              "debug": {
                "optimized_segments": 1,
                "unoptimized_segments": 0,
                "inner_visited": 1,
                "leaf_visited": 0
              }
            }
          ]
        },
        {
          "id": "[1c8HW1JTTFafkVnpxeWY4Q][test_profile][1]",
          "inbound_network_time_in_millis": 0,
          "outbound_network_time_in_millis": 0,
          "searches": [
            {
              "query": [
                {
                  "type": "ConstantScoreQuery",
                  "description": "ConstantScore(*:*)",
                  "time_in_nanos": 340417,
                  "breakdown": {
                    "set_min_competitive_score_count": 0,
                    "match_count": 0,
                    "shallow_advance_count": 0,
                    "next_doc": 0,
                    "score_count": 0,
                    "compute_max_score_count": 0,
                    "advance": 0,
                    "advance_count": 0,
                    "score": 0,
                    "shallow_advance": 0,
                    "create_weight_count": 1,
                    "build_scorer": 0,
                    "set_min_competitive_score": 0,
                    "match": 0,
                    "next_doc_count": 0,
                    "compute_max_score": 0,
                    "build_scorer_count": 0,
                    "create_weight": 340417
                  },
                  "children": [
                    {
                      "type": "MatchAllDocsQuery",
                      "description": "*:*",
                      "time_in_nanos": 225292,
                      "breakdown": {
                        "set_min_competitive_score_count": 0,
                        "match_count": 0,
                        "shallow_advance_count": 0,
                        "next_doc": 0,
                        "score_count": 0,
                        "compute_max_score_count": 0,
                        "advance": 0,
                        "advance_count": 0,
                        "score": 0,
                        "shallow_advance": 0,
                        "create_weight_count": 1,
                        "build_scorer": 0,
                        "set_min_competitive_score": 0,
                        "match": 0,
                        "next_doc_count": 0,
                        "compute_max_score": 0,
                        "build_scorer_count": 0,
                        "create_weight": 225292
                      }
                    }
                  ]
                }
              ],
              "rewrite_time": 11292,
              "collector": [
                {
                  "name": "MultiCollector",
                  "reason": "search_multi",
                  "time_in_nanos": 2071709,
                  "children": [
                    {
                      "name": "EarlyTerminatingCollector",
                      "reason": "search_count",
                      "time_in_nanos": 16208
                    },
                    {
                      "name": "ProfilingAggregator: [double_range]",
                      "reason": "aggregation",
                      "time_in_nanos": 2066710
                    }
                  ]
                }
              ]
            }
          ],
          "aggregations": [
            {
              "type": "RangeAggregator",
              "description": "double_range",
              "time_in_nanos": 2876917,
              "breakdown": {
                "reduce": 0,
                "build_aggregation_count": 1,
                "post_collection": 542,
                "initialize_count": 1,
                "reduce_count": 0,
                "collect_count": 0,
                "post_collection_count": 1,
                "build_leaf_collector": 2045625,
                "build_aggregation": 818625,
                "build_leaf_collector_count": 1,
                "initialize": 12125,
                "collect": 0
              },
              "debug": {
                "optimized_segments": 1,
                "unoptimized_segments": 0,
                "inner_visited": 1,
                "leaf_visited": 0
              }
            }
          ]
        }
      ]
    }
  }
}
```

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/pull/13865#issuecomment-2181727724

### Check List
- ~~[ ] Functionality includes testing.~~
- ~~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~~
- ~~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
