### PR TITLE
Use set for shard routings in batch check.

### DIFF
--- a/server/src/main/java/org/opensearch/gateway/ReplicaShardBatchAllocator.java
+++ b/server/src/main/java/org/opensearch/gateway/ReplicaShardBatchAllocator.java
@@ -28,10 +28,11 @@ import org.opensearch.indices.store.TransportNodesListShardStoreMetadataHelper.S
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 /**
  * Allocates replica shards in a batch mode
@@ -117,6 +118,7 @@ public abstract class ReplicaShardBatchAllocator extends ReplicaShardAllocator {
      * @param allocation    the allocation state container object
      */
     public void allocateUnassignedBatch(List<ShardRouting> shardRoutings, RoutingAllocation allocation) {
+        logger.trace("Starting shard allocation execution for unassigned replica shards: {}", shardRoutings.size());
         List<ShardRouting> eligibleShards = new ArrayList<>();
         List<ShardRouting> ineligibleShards = new ArrayList<>();
         Map<ShardRouting, AllocateUnassignedDecision> ineligibleShardAllocationDecisions = new HashMap<>();
@@ -135,7 +137,11 @@ public abstract class ReplicaShardBatchAllocator extends ReplicaShardAllocator {
         // only fetch data for eligible shards
         final FetchResult<NodeStoreFilesMetadataBatch> shardsState = fetchData(eligibleShards, ineligibleShards, allocation);
 
-        List<ShardId> shardIdsFromBatch = shardRoutings.stream().map(shardRouting -> shardRouting.shardId()).collect(Collectors.toList());
+        Set<ShardId> shardIdsFromBatch = new HashSet<>();
+        for (ShardRouting shardRouting : shardRoutings) {
+            ShardId shardId = shardRouting.shardId();
+            shardIdsFromBatch.add(shardId);
+        }
         RoutingNodes.UnassignedShards.UnassignedIterator iterator = allocation.routingNodes().unassigned().iterator();
         while (iterator.hasNext()) {
             ShardRouting unassignedShard = iterator.next();
@@ -159,6 +165,7 @@ public abstract class ReplicaShardBatchAllocator extends ReplicaShardAllocator {
                 executeDecision(unassignedShard, allocateUnassignedDecision, allocation, iterator);
             }
         }
+        logger.trace("Finished shard allocation execution for unassigned replica shards: {}", shardRoutings.size());
     }
 
     private AllocateUnassignedDecision getUnassignedShardAllocationDecision(

--- a/server/src/test/java/org/opensearch/gateway/PrimaryShardBatchAllocatorTests.java
+++ b/server/src/test/java/org/opensearch/gateway/PrimaryShardBatchAllocatorTests.java
@@ -85,7 +85,10 @@ public class PrimaryShardBatchAllocatorTests extends OpenSearchAllocationTestCas
         final RoutingNodes.UnassignedShards.UnassignedIterator iterator = allocation.routingNodes().unassigned().iterator();
         List<ShardRouting> shardsToBatch = new ArrayList<>();
         while (iterator.hasNext()) {
-            shardsToBatch.add(iterator.next());
+            ShardRouting unassignedShardRouting = iterator.next();
+            if (unassignedShardRouting.primary()) {
+                shardsToBatch.add(unassignedShardRouting);
+            }
         }
         batchAllocator.allocateUnassignedBatch(shardsToBatch, allocation);
     }
@@ -180,6 +183,35 @@ public class PrimaryShardBatchAllocatorTests extends OpenSearchAllocationTestCas
         assertEquals(2, routingAllocation.routingNodes().getInitialPrimariesIncomingRecoveries(node1.getId()));
     }
 
+    public void testInitializeOnlyPrimaryUnassignedShardsIgnoreReplicaShards() {
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        AllocationDeciders allocationDeciders = randomAllocationDeciders(Settings.builder().build(), clusterSettings, random());
+        setUpShards(1);
+        final RoutingAllocation routingAllocation = routingAllocationWithOnePrimary(allocationDeciders, CLUSTER_RECOVERED, "allocId-0");
+
+        for (ShardId shardId : shardsInBatch) {
+            batchAllocator.addShardData(
+                node1,
+                "allocId-0",
+                shardId,
+                true,
+                new ReplicationCheckpoint(shardId, 20, 101, 1, Codec.getDefault().getName()),
+                null
+            );
+        }
+
+        allocateAllUnassignedBatch(routingAllocation);
+
+        List<ShardRouting> initializingShards = routingAllocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING);
+        assertEquals(1, initializingShards.size());
+        assertTrue(shardsInBatch.contains(initializingShards.get(0).shardId()));
+        assertTrue(initializingShards.get(0).primary());
+        assertEquals(1, routingAllocation.routingNodes().getInitialPrimariesIncomingRecoveries(node1.getId()));
+        List<ShardRouting> unassignedShards = routingAllocation.routingNodes().shardsWithState(ShardRoutingState.UNASSIGNED);
+        assertEquals(1, unassignedShards.size());
+        assertTrue(!unassignedShards.get(0).primary());
+    }
+
     public void testAllocateUnassignedBatchThrottlingAllocationDeciderIsHonoured() {
         ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         AllocationDeciders allocationDeciders = randomAllocationDeciders(
@@ -258,7 +290,7 @@ public class PrimaryShardBatchAllocatorTests extends OpenSearchAllocationTestCas
             .routingTable(routingTableBuilder.build())
             .nodes(DiscoveryNodes.builder().add(node1).add(node2).add(node3))
             .build();
-        return new RoutingAllocation(deciders, new RoutingNodes(state, false), state, null, null, System.nanoTime());
+        return new RoutingAllocation(deciders, new RoutingNodes(state, false), state, ClusterInfo.EMPTY, null, System.nanoTime());
     }
 
     private RoutingAllocation routingAllocationWithMultiplePrimaries(


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
PrimaryShardsBatchAllocator and ReplicaShardsBatchAllocator both use list data structure to check if a unassigned shard is a shard from the batch being executed. This is in-efficient way and can make recovery significantly slow for clusters with higher shard count. Using set data structure will be more efficient to have constant performance.

Reroute duration reduced by 14.5 minutes for a cluster with 500K unassigned shards

Performance before fix for reroute:
```
[2024-06-24T17:46:18,646][DEBUG][o.o.c.r.a.AllocationService] [c7b768cc312193a718de31bd65dc23c7] ASF-AS reroute started, unassigned shards: 502366, initializing shards: 0, ignored shards: 0
[2024-06-24T18:04:33,158][DEBUG][o.o.c.r.a.AllocationService] [c7b768cc312193a718de31bd65dc23c7] ASF-AS after primaries before replica, unassigned shards: 254178, initializing shards: 248188, ignored shards: 0
[2024-06-24T18:04:33,158][DEBUG][o.o.c.r.a.AllocationService] [c7b768cc312193a718de31bd65dc23c7] ASF-AS replica, unassigned shards: 254178, initializing shards: 248188, ignored shards: 0
[2024-06-24T18:07:45,037][DEBUG][o.o.c.r.a.AllocationService] [c7b768cc312193a718de31bd65dc23c7] ASF-AS reroute finished, unassigned shards: 0, initializing shards: 248188, ignored shards: 254178
```

Performance after fix for reroute:

```
[2024-06-25T15:17:11,584][DEBUG][o.o.c.r.a.AllocationService] [cce76896e008802de8384c1a0cea2d6a] ASF-AS reroute started, unassigned shards: 502366, initializing shards: 0, ignored shards: 0
[2024-06-25T15:21:04,918][DEBUG][o.o.c.r.a.AllocationService] [cce76896e008802de8384c1a0cea2d6a] ASF-AS after primaries before replica, unassigned shards: 254178, initializing shards: 248188, ignored shards: 0
[2024-06-25T15:21:04,918][DEBUG][o.o.c.r.a.AllocationService] [cce76896e008802de8384c1a0cea2d6a] ASF-AS replica, unassigned shards: 254178, initializing shards: 248188, ignored shards: 0
[2024-06-25T15:22:41,146][DEBUG][o.o.c.r.a.AllocationService] [cce76896e008802de8384c1a0cea2d6a] ASF-AS reroute finished, unassigned shards: 0, initializing shards: 248188, ignored shards: 254178
```



### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
https://github.com/opensearch-project/OpenSearch/issues/14532

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
