### PR TITLE
Use `CODECOV_TOKEN` for `codecov/codecov-action`.

### DIFF
--- a/.github/workflows/gradle-check.yml
+++ b/.github/workflows/gradle-check.yml
@@ -113,6 +113,7 @@ jobs:
         if: success()
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./codeCoverage.xml
 
       - name: Create Comment Success


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Use `CODECOV_TOKEN` for `codecov/codecov-action`.

### Related Issues

Fixes the error `Error: Codecov token not found. Please provide Codecov token with -t flag.` https://github.com/opensearch-project/OpenSearch/actions/runs/9549676092/job/26319805993. Without the Codecov token, the Codecov report is missing for a few commits. For example, the commit 61dbcd0795c9bfe9b81e5762175414bc38bbcadf in this repository is used in [2.15.0 RC](https://github.com/opensearch-project/opensearch-build/blob/main/manifests/2.15.0/opensearch-2.15.0.yml#L13C10-L13C50). Codecov report for that commit is missing [here](https://app.codecov.io/gh/opensearch-project/opensearch/commit/61dbcd0795c9bfe9b81e5762175414bc38bbcadf).

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
