### PR TITLE
Fix flaky test TieredSpilloverCacheTests.testComputeIfAbsentConcurrently

### DIFF
--- a/modules/cache-common/src/main/java/org/opensearch/cache/common/tier/TieredSpilloverCache.java
+++ b/modules/cache-common/src/main/java/org/opensearch/cache/common/tier/TieredSpilloverCache.java
@@ -249,20 +249,18 @@ public class TieredSpilloverCache<K, V> implements ICache<K, V> {
             if (pair != null) {
                 try (ReleasableLock ignore = writeLock.acquire()) {
                     onHeapCache.put(pair.v1(), pair.v2());
-                    completableFutureMap.remove(key);// Remove key from map as not needed anymore.
                 } catch (Exception e) {
                     // TODO: Catch specific exceptions to know whether this resulted from cache or underlying removal
                     // listeners/stats. Needs better exception handling at underlying layers.For now swallowing
                     // exception.
                     logger.warn("Exception occurred while putting item onto heap cache", e);
-                    completableFutureMap.remove(key);// Remove key from map as not needed anymore.
                 }
             } else {
                 if (ex != null) {
                     logger.warn("Exception occurred while trying to compute the value", ex);
                 }
-                completableFutureMap.remove(key);// Remove key from map as not needed anymore.
             }
+            completableFutureMap.remove(key);// Remove key from map as not needed anymore.
             return null;
         };
         V value = null;

--- a/modules/cache-common/src/main/java/org/opensearch/cache/common/tier/TieredSpilloverCache.java
+++ b/modules/cache-common/src/main/java/org/opensearch/cache/common/tier/TieredSpilloverCache.java
@@ -195,7 +195,16 @@ public class TieredSpilloverCache<K, V> implements ICache<K, V> {
         // and it only has to be loaded one time, we should report one miss and the rest hits. But, if we do stats in
         // getValueFromTieredCache(),
         // we will see all misses. Instead, handle stats in computeIfAbsent().
-        Tuple<V, String> cacheValueTuple = getValueFromTieredCache(false).apply(key);
+        Tuple<V, String> cacheValueTuple;
+        CompletableFuture<Tuple<ICacheKey<K>, V>> future = null;
+        try (ReleasableLock ignore = readLock.acquire()) {
+            cacheValueTuple = getValueFromTieredCache(false).apply(key);
+            if (cacheValueTuple == null) {
+                // Only one of the threads will succeed putting a future into map for the same key.
+                // Rest will fetch existing future and wait on that to complete.
+                future = completableFutureMap.putIfAbsent(key, new CompletableFuture<>());
+            }
+        }
         List<String> heapDimensionValues = statsHolder.getDimensionsWithTierValue(key.dimensions, TIER_DIMENSION_VALUE_ON_HEAP);
         List<String> diskDimensionValues = statsHolder.getDimensionsWithTierValue(key.dimensions, TIER_DIMENSION_VALUE_DISK);
 
@@ -203,7 +212,7 @@ public class TieredSpilloverCache<K, V> implements ICache<K, V> {
             // Add the value to the onHeap cache. We are calling computeIfAbsent which does another get inside.
             // This is needed as there can be many requests for the same key at the same time and we only want to load
             // the value once.
-            V value = compute(key, loader);
+            V value = compute(key, loader, future);
             // Handle stats
             if (loader.isLoaded()) {
                 // The value was just computed and added to the cache by this thread. Register a miss for the heap cache, and the disk cache
@@ -232,28 +241,28 @@ public class TieredSpilloverCache<K, V> implements ICache<K, V> {
         return cacheValueTuple.v1();
     }
 
-    private V compute(ICacheKey<K> key, LoadAwareCacheLoader<ICacheKey<K>, V> loader) throws Exception {
-        // Only one of the threads will succeed putting a future into map for the same key.
-        // Rest will fetch existing future and wait on that to complete.
-        CompletableFuture<Tuple<ICacheKey<K>, V>> future = completableFutureMap.putIfAbsent(key, new CompletableFuture<>());
+    private V compute(ICacheKey<K> key, LoadAwareCacheLoader<ICacheKey<K>, V> loader, CompletableFuture<Tuple<ICacheKey<K>, V>> future)
+        throws Exception {
         // Handler to handle results post processing. Takes a tuple<key, value> or exception as an input and returns
         // the value. Also before returning value, puts the value in cache.
         BiFunction<Tuple<ICacheKey<K>, V>, Throwable, Void> handler = (pair, ex) -> {
             if (pair != null) {
                 try (ReleasableLock ignore = writeLock.acquire()) {
                     onHeapCache.put(pair.v1(), pair.v2());
+                    completableFutureMap.remove(key);// Remove key from map as not needed anymore.
                 } catch (Exception e) {
                     // TODO: Catch specific exceptions to know whether this resulted from cache or underlying removal
                     // listeners/stats. Needs better exception handling at underlying layers.For now swallowing
                     // exception.
                     logger.warn("Exception occurred while putting item onto heap cache", e);
+                    completableFutureMap.remove(key);// Remove key from map as not needed anymore.
                 }
             } else {
                 if (ex != null) {
                     logger.warn("Exception occurred while trying to compute the value", ex);
                 }
+                completableFutureMap.remove(key);// Remove key from map as not needed anymore.
             }
-            completableFutureMap.remove(key); // Remove key from map as not needed anymore.
             return null;
         };
         V value = null;

--- a/modules/cache-common/src/test/java/org/opensearch/cache/common/tier/TieredSpilloverCacheTests.java
+++ b/modules/cache-common/src/test/java/org/opensearch/cache/common/tier/TieredSpilloverCacheTests.java
@@ -760,7 +760,7 @@ public class TieredSpilloverCacheTests extends OpenSearchTestCase {
     }
 
     public void testComputeIfAbsentConcurrently() throws Exception {
-        int onHeapCacheSize = randomIntBetween(100, 300);
+        int onHeapCacheSize = randomIntBetween(500, 700);
         int diskCacheSize = randomIntBetween(200, 400);
         int keyValueSize = 50;
 
@@ -782,7 +782,7 @@ public class TieredSpilloverCacheTests extends OpenSearchTestCase {
             0
         );
 
-        int numberOfSameKeys = randomIntBetween(10, onHeapCacheSize - 1);
+        int numberOfSameKeys = randomIntBetween(400, onHeapCacheSize - 1);
         ICacheKey<String> key = getICacheKey(UUID.randomUUID().toString());
         String value = UUID.randomUUID().toString();
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fixes flaky test.
We had added the logic as part of https://github.com/opensearch-project/OpenSearch/pull/14187 to move query recompute logic outside write lock. We used a `Map<Key, Future>` so that the first thread adds a future to the map, loads the value and rest threads wait on the future via `future.get()`. And then we remove the key from the map from the thread which was responsible to load the value.

After this change `testComputeIfAbsentConcurrently` became flaky and fails in certain scenarios where we expected that the value was loaded only once but in actual it was more than more. This happened in below scenario:

1. Thread 1 puts the future into map `completeableFutureMap` for key A
2. Thread 1 loads the value, takes write lock and puts the value onto onHeap cache. Release the lock.
3. Now Thread 2 comes with request for key A, tries a get() and finds null value. 
4. Meanwhile Thread 1 removes the key A from map `completeableFutureMap`
5. Thread 2 doesn't find key A in `completeableFutureMap` and again loads the value. Test fails after this point.


I reproduced this by running `testComputeIfAbsentConcurrently` 100 times and saw it failing pretty often. To verify the fix, again ran it 100 times and it passed in all cases.

### Solution
The fix is to put the future for key A inside read lock. And remove it inside write lock.
So that above scenario never occurs and Thread 2 will find the value in `get()` itself.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/14544

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- ~[] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
