### PR TITLE
Add Ashish Singh as maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,4 +24,4 @@
 
 /.github/ @peternied
 
-/MAINTAINERS.md @anasalkouz @andrross @Bukhtawar @CEHENKLE @dblock @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @nknize @owaiskazi19 @peternied @reta @Rishikesh1159 @sachinpkale @saratvemulapalli @shwetathareja @sohami @VachaShah
+/MAINTAINERS.md @anasalkouz @andrross @ashking94 @Bukhtawar @CEHENKLE @dblock @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @nknize @owaiskazi19 @peternied @reta @Rishikesh1159 @sachinpkale @saratvemulapalli @shwetathareja @sohami @VachaShah

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,6 +9,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Anas Alkouz              | [anasalkouz](https://github.com/anasalkouz)             | Amazon      |
 | Andrew Ross              | [andrross](https://github.com/andrross)                 | Amazon      |
 | Andriy Redko             | [reta](https://github.com/reta)                         | Aiven       |
+| Ashish Singh             | [ashking94](https://github.com/ashking94)               | Amazon      |
 | Bukhtawar Khan           | [Bukhtawar](https://github.com/Bukhtawar)               | Amazon      |
 | Charlotte Henkle         | [CEHENKLE](https://github.com/CEHENKLE)                 | Amazon      |
 | Dan Widdis               | [dbwiddis](https://github.com/dbwiddis)                 | Amazon      |


### PR DESCRIPTION
I have nominated, and maintainers have agreed to add Ashish Singh (@ashking94) as a co-maintainer, who kindly accepted.

Ashish is an active contributor of OpenSearch project and has extensively contributed in various [remote-backed storage](https://opensearch.org/blog/remote-backed-storage/) features which has been launched successfully for users, with most of his recent works focused on improving performance, resiliency and scalability of the remote store and it’s interactions. Apart from this, he has proactively contributed to identifying critical bugs, resolving them and improving documentations around the same. Ashish is pretty active in the OpenSearch Storage bi-weekly triages and has consistently exercised sound judgement in triaging and prioritising the issues.
 
Ashish, has [authored](https://github.com/opensearch-project/OpenSearch/pulls?q=is%3Apr+author%3Aashking94) 147 pull requests, [reviewed](https://github.com/opensearch-project/OpenSearch/pulls?q=is%3Apr+reviewed-by%3Aashking94) 179 pull requests and [created](https://github.com/issues?q=is%3Aissue+author%3Aashking94+archived%3Afalse+is%3Aclosed+user%3Aopensearch-project) 184 issues in the OpenSearch repo last 18 months, with nearly 47 of them being [contributed](https://github.com/search?q=repo%3Aopensearch-project%2FOpenSearch+involves%3Aashking94+created%3A%3E2024-03-15+&type=pullrequests) in the last 3 months. Apart from this, Ashish has [contributed](https://github.com/search?q=repo%3Aopensearch-project%2Fdocumentation-website+involves%3Aashking94&type=pullrequests) to 10 PRs to the documentation website and [contributed](https://github.com/issues?q=is%3Aissue+author%3Aashking94+archived%3Afalse+is%3Aclosed+user%3Aopensearch-project) another 5 PRs to the opensearch-build repo. Based on his historical contributions, I am reasonably confident, that Ashish will be a valuable addition as a maintainer of OpenSearch and will help to contribute to our success going forward.

 
### Notable Proposals
1. Primary term validation with remote store for replicas (No-op replication):
a) https://github.com/opensearch-project/OpenSearch/issues/4507
b) https://github.com/opensearch-project/OpenSearch/issues/5033
c) https://github.com/opensearch-project/OpenSearch/issues/3706#issuecomment-1185617653
d) https://github.com/opensearch-project/OpenSearch/issues/6737
e) https://github.com/opensearch-project/OpenSearch/issues/6354
f) https://github.com/opensearch-project/OpenSearch/issues/6851
g) https://github.com/opensearch-project/OpenSearch/issues/7225
h) https://github.com/opensearch-project/OpenSearch/issues/7477
i) https://github.com/opensearch-project/OpenSearch/issues/9024
j) https://github.com/opensearch-project/OpenSearch/issues/9790
k) https://github.com/opensearch-project/OpenSearch/issues/10013
l) https://github.com/opensearch-project/OpenSearch/issues/12567
m) https://github.com/opensearch-project/OpenSearch/issues/12589.

### Notable Pull-requests
1. Primary term validation & updated peer recovery flows:
a) https://github.com/opensearch-project/OpenSearch/pull/4318
b) https://github.com/opensearch-project/OpenSearch/pull/4954
c) https://github.com/opensearch-project/OpenSearch/pull/5616
d) https://github.com/opensearch-project/OpenSearch/pull/5282
2. Performance optimisation for remote store:
a) https://github.com/opensearch-project/OpenSearch/pull/10135
b) https://github.com/opensearch-project/OpenSearch/pull/5854
c) https://github.com/opensearch-project/OpenSearch/pull/7905
3. Remote store segments upload backpressure:
a) https://github.com/opensearch-project/OpenSearch/pull/7227
b) https://github.com/opensearch-project/OpenSearch/pull/7400
c) https://github.com/opensearch-project/OpenSearch/pull/7459
d) https://github.com/opensearch-project/OpenSearch/pull/7720
e) https://github.com/opensearch-project/OpenSearch/pull/8758
4. Remote store relocation & peer recovery:
a) https://github.com/opensearch-project/OpenSearch/pull/11330
b) https://github.com/opensearch-project/OpenSearch/pull/10761
c) https://github.com/opensearch-project/OpenSearch/pull/8683
d) https://github.com/opensearch-project/OpenSearch/pull/6314
5. Optimised prefix pattern per shard for remote store data and metadata files for higher throughput:
a) https://github.com/opensearch-project/OpenSearch/pull/12986
b) https://github.com/opensearch-project/OpenSearch/pull/12988
c) https://github.com/opensearch-project/OpenSearch/pull/13103
d) https://github.com/opensearch-project/OpenSearch/pull/13150

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
