### PR TITLE
Segment Replication stats throwing NPE when shards are unassigned or are in delayed allocation phase

### DIFF
--- a/server/src/main/java/org/opensearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/opensearch/index/seqno/ReplicationTracker.java
@@ -1254,8 +1254,9 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
 
     // skip any shard that is a relocating primary or search only replica (not tracked by primary)
     private boolean shouldSkipReplicationTimer(String allocationId) {
-        Optional<ShardRouting> shardRouting = routingTable.shards()
+        Optional<ShardRouting> shardRouting = routingTable.assignedShards()
             .stream()
+            .filter(routing -> Objects.nonNull(routing.allocationId()))
             .filter(routing -> routing.allocationId().getId().equals(allocationId))
             .findAny();
         return shardRouting.isPresent() && (shardRouting.get().primary() || shardRouting.get().isSearchOnly());


### PR DESCRIPTION
### Description
Fixes segment Replication stats throwing NPE when shards are unassigned or are in delayed allocation phase

### Related Issues
Resolves #11945

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
