### PR TITLE
Fix assertion failure while deleting remote backed index

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotemigration/RemoteMigrationIndexMetadataUpdateIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotemigration/RemoteMigrationIndexMetadataUpdateIT.java
@@ -275,7 +275,6 @@ public class RemoteMigrationIndexMetadataUpdateIT extends MigrationBaseTestCase 
      * After shard relocation completes, shuts down the docrep nodes and asserts remote
      * index settings are applied even when the index is in YELLOW state
      */
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/13737")
     public void testIndexSettingsUpdatedEvenForMisconfiguredReplicas() throws Exception {
         internalCluster().startClusterManagerOnlyNode();
 
@@ -332,7 +331,6 @@ public class RemoteMigrationIndexMetadataUpdateIT extends MigrationBaseTestCase 
      * After shard relocation completes, restarts the docrep node holding extra replica shard copy
      * and asserts remote index settings are applied as soon as the docrep replica copy is unassigned
      */
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/13871")
     public void testIndexSettingsUpdatedWhenDocrepNodeIsRestarted() throws Exception {
         internalCluster().startClusterManagerOnlyNode();
 

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
@@ -132,7 +132,7 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
         );
     }
 
-    public void testRemoteStoreIndexCreationAndDeletion() throws InterruptedException, ExecutionException {
+    public void testRemoteStoreIndexCreationAndDeletionWithReferencedStore() throws InterruptedException, ExecutionException {
         String dataNode = internalCluster().startNodes(1).get(0);
         createIndex(INDEX_NAME, remoteStoreIndexSettings(0));
         ensureYellowAndNoInitializingShards(INDEX_NAME);
@@ -140,6 +140,8 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
 
         IndexShard indexShard = getIndexShard(dataNode, INDEX_NAME);
 
+        // Simulating a condition where store is already in use by increasing ref count, this helps in testing index
+        // deletion when refresh is in-progress.
         indexShard.store().incRef();
         assertAcked(client().admin().indices().prepareDelete(INDEX_NAME));
         indexShard.store().decRef();

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
@@ -65,7 +65,6 @@ import static org.opensearch.index.remote.RemoteStoreEnums.DataType.DATA;
 import static org.opensearch.index.remote.RemoteStoreEnums.DataType.METADATA;
 import static org.opensearch.index.shard.IndexShardTestCase.getTranslog;
 import static org.opensearch.indices.RemoteStoreSettings.CLUSTER_REMOTE_TRANSLOG_BUFFER_INTERVAL_SETTING;
-import static org.opensearch.test.OpenSearchTestCase.getShardLevelBlobPath;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.comparesEqualTo;
@@ -131,6 +130,19 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
             30,
             TimeUnit.SECONDS
         );
+    }
+
+    public void testRemoteStoreIndexCreationAndDeletion() throws InterruptedException, ExecutionException {
+        String dataNode = internalCluster().startNodes(1).get(0);
+        createIndex(INDEX_NAME, remoteStoreIndexSettings(0));
+        ensureYellowAndNoInitializingShards(INDEX_NAME);
+        ensureGreen(INDEX_NAME);
+
+        IndexShard indexShard = getIndexShard(dataNode, INDEX_NAME);
+
+        indexShard.store().incRef();
+        assertAcked(client().admin().indices().prepareDelete(INDEX_NAME));
+        indexShard.store().decRef();
     }
 
     public void testPeerRecoveryWithRemoteStoreAndRemoteTranslogNoDataFlush() throws Exception {

--- a/server/src/main/java/org/opensearch/index/IndexService.java
+++ b/server/src/main/java/org/opensearch/index/IndexService.java
@@ -597,14 +597,21 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                         this.indexSettings.getRemoteStorePathStrategy()
                     );
                 }
-                remoteStore = new Store(
-                    shardId,
-                    this.indexSettings,
-                    remoteDirectory,
-                    getRemoteStoreLock(shardId),
-                    Store.OnClose.EMPTY,
-                    path
-                );
+                // When an instance of Store is created, a shardlock is created which is released on closing the instance of store.
+                // Currently, we create 2 instances of store for remote store backed indices: store and remoteStore.
+                // As there can be only one shardlock acquired for a given shard, the lock is shared between store and remoteStore.
+                // This creates an issue when we are deleting the index as it results in closing both store and remoteStore.
+                // Sample test failure: https://github.com/opensearch-project/OpenSearch/issues/13871
+                // The following method provides ShardLock that is not maintained by NodeEnvironment.
+                // As part of https://github.com/opensearch-project/OpenSearch/issues/13075, we want to move away from keeping 2
+                // store instances.
+                ShardLock remoteStoreLock = new ShardLock(shardId) {
+                    @Override
+                    protected void closeInternal() {
+                        // Do nothing for shard lock on remote store
+                    }
+                };
+                remoteStore = new Store(shardId, this.indexSettings, remoteDirectory, remoteStoreLock, Store.OnClose.EMPTY, path);
             } else {
                 // Disallow shards with remote store based settings to be created on non-remote store enabled nodes
                 // Even though we have `RemoteStoreMigrationAllocationDecider` in place to prevent something like this from happening at the
@@ -627,7 +634,6 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             } else {
                 directory = directoryFactory.newDirectory(this.indexSettings, path);
             }
-
             store = new Store(
                 shardId,
                 this.indexSettings,
@@ -683,23 +689,6 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                 closeShard("initialization failed", shardId, indexShard, store, eventListener);
             }
         }
-    }
-
-    // When an instance of Store is created, a shardlock is created which is released on closing the instance of store.
-    // Currently, we create 2 instances of store for remote store backed indices: store and remoteStore.
-    // As there can be only one shardlock acquired for a given shard, the lock is shared between store and remoteStore.
-    // This creates an issue when we are deleting the index as it results in closing both store and remoteStore.
-    // Sample test failure: https://github.com/opensearch-project/OpenSearch/issues/13871
-    // The following method provides ShardLock that is not maintained by NodeEnvironment.
-    // As part of https://github.com/opensearch-project/OpenSearch/issues/13075, we want to move away from keeping 2
-    // store instances.
-    private ShardLock getRemoteStoreLock(ShardId shardId) {
-        return new ShardLock(shardId) {
-            @Override
-            protected void closeInternal() {
-                // Ignore for remote store
-            }
-        };
     }
 
     /*


### PR DESCRIPTION
### Description
- When an instance of Store is created, a `shardlock` is created which is released on closing the instance of store.
- Currently, we create 2 instances of store for remote store backed indices: `store` and `remoteStore`.
- As there can be only one `shardlock` acquired for a given shard, the lock is shared between `store` and `remoteStore`.
- This creates an issue when we are deleting the index as it results in closing both `store` and `remoteStore`.
- In this PR, we create a different lock for remoteStore. As part of https://github.com/opensearch-project/OpenSearch/issues/13075, we want to move away from keeping 2 store instances.
- To reproduce the issue (without the change in this PR), we need to keep following sequence:
  - Refresh Started and increased `store.ref`
  - Store.close - will not release shardLock as refCount is not 0
  - RemoteStore.close - will release shardLock as the refCount is 0
  - Refresh ended - will decrease `store.ref`, closes it and close fail as it finds that shard is not locked


### Related Issues
- https://github.com/opensearch-project/OpenSearch/issues/13871
- https://github.com/opensearch-project/OpenSearch/issues/13737

### Check List
- [x] Functionality includes testing.
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
