### PR TITLE
Removing String format in RemoteStoreMigrationAllocationDecider

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/RemoteStoreMigrationAllocationDecider.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/RemoteStoreMigrationAllocationDecider.java
@@ -44,8 +44,6 @@ import org.opensearch.node.remotestore.RemoteStoreNodeService;
 import org.opensearch.node.remotestore.RemoteStoreNodeService.CompatibilityMode;
 import org.opensearch.node.remotestore.RemoteStoreNodeService.Direction;
 
-import java.util.Locale;
-
 /**
  * A new allocation decider for migration of document replication clusters to remote store backed clusters:
  * - For STRICT compatibility mode, the decision is always YES
@@ -101,7 +99,7 @@ public class RemoteStoreMigrationAllocationDecider extends AllocationDecider {
         if (migrationDirection.equals(Direction.NONE)) {
             // remote backed indices on docrep nodes and non remote backed indices on remote nodes are not allowed
             boolean isNoDecision = remoteSettingsBackedIndex ^ targetNode.isRemoteStoreNode();
-            String reason = String.format(Locale.ROOT, " for %sremote store backed index", remoteSettingsBackedIndex ? "" : "non ");
+            String reason = " for " + (remoteSettingsBackedIndex ? "" : "non ") + "remote store backed index";
             return allocation.decision(
                 isNoDecision ? Decision.NO : Decision.YES,
                 NAME,
@@ -114,11 +112,9 @@ public class RemoteStoreMigrationAllocationDecider extends AllocationDecider {
             // check for remote store backed indices
             if (remoteSettingsBackedIndex && targetNode.isRemoteStoreNode() == false) {
                 // allocations and relocations must be to a remote node
-                String reason = String.format(
-                    Locale.ROOT,
-                    " because a remote store backed index's shard copy can only be %s to a remote node",
-                    ((shardRouting.assignedToNode() == false) ? "allocated" : "relocated")
-                );
+                String reason = new StringBuilder(" because a remote store backed index's shard copy can only be ").append(
+                    (shardRouting.assignedToNode() == false) ? "allocated" : "relocated"
+                ).append(" to a remote node").toString();
                 return allocation.decision(Decision.NO, NAME, getDecisionDetails(false, shardRouting, targetNode, reason));
             }
 
@@ -168,16 +164,18 @@ public class RemoteStoreMigrationAllocationDecider extends AllocationDecider {
 
     // get detailed reason for the decision
     private String getDecisionDetails(boolean isYes, ShardRouting shardRouting, DiscoveryNode targetNode, String reason) {
-        return String.format(
-            Locale.ROOT,
-            "[%s migration_direction]: %s shard copy %s be %s to a %s node%s",
-            migrationDirection.direction,
-            (shardRouting.primary() ? "primary" : "replica"),
-            (isYes ? "can" : "can not"),
-            ((shardRouting.assignedToNode() == false) ? "allocated" : "relocated"),
-            (targetNode.isRemoteStoreNode() ? "remote" : "non-remote"),
-            reason
-        );
+        return new StringBuilder("[").append(migrationDirection.direction)
+            .append(" migration_direction]: ")
+            .append(shardRouting.primary() ? "primary" : "replica")
+            .append(" shard copy ")
+            .append(isYes ? "can" : "can not")
+            .append(" be ")
+            .append((shardRouting.assignedToNode() == false) ? "allocated" : "relocated")
+            .append(" to a ")
+            .append(targetNode.isRemoteStoreNode() ? "remote" : "non-remote")
+            .append(" node")
+            .append(reason)
+            .toString();
     }
 
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

## Description
`String.format` is a relatively expensive operation for concatenating strings. Inside `RemoteStoreMigrationAllocationDecider`,  the function calls to `String.format` stands out as the most resource-intensive operation in terms of latency.

<img width="1723" alt="Screenshot 2024-06-27 at 7 04 26 PM" src="https://github.com/opensearch-project/OpenSearch/assets/6240205/7b52168e-b347-49bd-86ab-15e0e045f9ae">
       


This PR improves the latency of RemoteStoreMigrationAllocationDecider by replacing calls to String.format with more efficient StringBuilder for string concatenation.

### Latency improvements

For initialising 225K shards on 500 nodes, we are observing an improvement of 31 seconds with above change.

#### Before the change
391,940.31 ms

#### After the change
360,279.58 ms

## Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
